### PR TITLE
Revise “Configure a Pod to Use a ConfigMap” task

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -8,10 +8,13 @@ card:
 ---
 
 <!-- overview -->
-Many applications rely on configuration which is used during either application initialization or runtime.
-Most of the times there is a requirement to adjust values assigned to configuration parameters.
-ConfigMaps are the Kubernetes way to inject application pods with configuration data.
-ConfigMaps allow you to decouple configuration artifacts from image content to keep containerized applications portable. This page provides a series of usage examples demonstrating how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
+Many applications rely on configuration which is used during either application initialization
+or runtime. Most of the times there is a requirement to adjust values assigned to configuration
+parameters.
+ConfigMaps are the Kubernetes way to inject application pods with configuration
+data. ConfigMaps allow you to decouple configuration artifacts from image content to keep
+containerized applications portable. This page provides a series of usage examples demonstrating
+how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
 
 
 ## {{% heading "prerequisites" %}}
@@ -25,21 +28,27 @@ ConfigMaps allow you to decouple configuration artifacts from image content to k
 
 
 ## Create a ConfigMap
-You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml` to create a ConfigMap. Note that `kubectl` starts to support `kustomization.yaml` since 1.14.
+
+You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml`
+to create a ConfigMap. Note that `kubectl` starts to support `kustomization.yaml` since 1.14.
 
 ### Create a ConfigMap Using kubectl create configmap
 
-Use the `kubectl create configmap` command to create ConfigMaps from [directories](#create-configmaps-from-directories), [files](#create-configmaps-from-files), or [literal values](#create-configmaps-from-literal-values):
+Use the `kubectl create configmap` command to create ConfigMaps from
+[directories](#create-configmaps-from-directories), [files](#create-configmaps-from-files),
+or [literal values](#create-configmaps-from-literal-values):
 
 ```shell
 kubectl create configmap <map-name> <data-source>
 ```
 
-where \<map-name> is the name you want to assign to the ConfigMap and \<data-source> is the directory, file, or literal value to draw the data from.
+where \<map-name> is the name you want to assign to the ConfigMap and \<data-source> is the
+directory, file, or literal value to draw the data from.
 The name of a ConfigMap object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
-When you are creating a ConfigMap based on a file, the key in the \<data-source> defaults to the basename of the file, and the value defaults to the file content.
+When you are creating a ConfigMap based on a file, the key in the \<data-source> defaults to
+the basename of the file, and the value defaults to the file content.
 
 You can use [`kubectl describe`](/docs/reference/generated/kubectl/kubectl-commands/#describe) or
 [`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) to retrieve information
@@ -47,7 +56,11 @@ about a ConfigMap.
 
 #### Create ConfigMaps from directories
 
-You can use `kubectl create configmap` to create a ConfigMap from multiple files in the same directory. When you are creating a ConfigMap based on a directory, kubectl identifies files whose basename is a valid key in the directory and packages each of those files into the new ConfigMap. Any directory entries except regular files are ignored (e.g. subdirectories, symlinks, devices, pipes, etc).
+You can use `kubectl create configmap` to create a ConfigMap from multiple files in the same
+directory. When you are creating a ConfigMap based on a directory, kubectl identifies files
+whose basename is a valid key in the directory and packages each of those files into the
+new ConfigMap. Any directory entries except regular files are ignored (e.g. subdirectories,
+symlinks, devices, pipes, etc).
 
 For example:
 
@@ -63,7 +76,9 @@ wget https://kubernetes.io/examples/configmap/ui.properties -O configure-pod-con
 kubectl create configmap game-config --from-file=configure-pod-container/configmap/
 ```
 
-The above command packages each file, in this case, `game.properties` and `ui.properties` in the `configure-pod-container/configmap/` directory into the game-config ConfigMap. You can display details of the ConfigMap using the following command:
+The above command packages each file, in this case, `game.properties` and `ui.properties`
+in the `configure-pod-container/configmap/` directory into the game-config ConfigMap. You can
+display details of the ConfigMap using the following command:
 
 ```shell
 kubectl describe configmaps game-config
@@ -95,7 +110,8 @@ allow.textmode=true
 how.nice.to.look=fairlyNice
 ```
 
-The `game.properties` and `ui.properties` files in the `configure-pod-container/configmap/` directory are represented in the `data` section of the ConfigMap.
+The `game.properties` and `ui.properties` files in the `configure-pod-container/configmap/`
+directory are represented in the `data` section of the ConfigMap.
 
 ```shell
 kubectl get configmaps game-config -o yaml
@@ -129,7 +145,8 @@ data:
 
 #### Create ConfigMaps from files
 
-You can use `kubectl create configmap` to create a ConfigMap from an individual file, or from multiple files.
+You can use `kubectl create configmap` to create a ConfigMap from an individual file, or from
+multiple files.
 
 For example,
 
@@ -164,7 +181,8 @@ secret.code.allowed=true
 secret.code.lives=30
 ```
 
-You can pass in the `--from-file` argument multiple times to create a ConfigMap from multiple data sources.
+You can pass in the `--from-file` argument multiple times to create a ConfigMap from multiple
+data sources.
 
 ```shell
 kubectl create configmap game-config-2 --from-file=configure-pod-container/configmap/game.properties --from-file=configure-pod-container/configmap/ui.properties
@@ -203,8 +221,10 @@ allow.textmode=true
 how.nice.to.look=fairlyNice
 ```
 
-When `kubectl` creates a ConfigMap from inputs that are not ASCII or UTF-8, the tool puts these into the `binaryData` field of the ConfigMap, and not in `data`. Both text and binary data sources can be combined in one ConfigMap.
-If you want to view the `binaryData` keys (and their values) in a ConfigMap, you can run `kubectl get configmap -o jsonpath='{.binaryData}' <name>`.
+When `kubectl` creates a ConfigMap from inputs that are not ASCII or UTF-8, the tool puts these
+into the `binaryData` field of the ConfigMap, and not in `data`. Both text and binary data
+sources can be combined in one ConfigMap. If you want to view the `binaryData` keys (and their
+values) in a ConfigMap, you can run `kubectl get configmap -o jsonpath='{.binaryData}' <name>`.
 
 Use the option `--from-env-file` to create a ConfigMap from an env-file, for example:
 
@@ -292,13 +312,15 @@ data:
 
 #### Define the key to use when creating a ConfigMap from a file
 
-You can define a key other than the file name to use in the `data` section of your ConfigMap when using the `--from-file` argument:
+You can define a key other than the file name to use in the `data` section of your ConfigMap
+when using the `--from-file` argument:
 
 ```shell
 kubectl create configmap game-config-3 --from-file=<my-key-name>=<path-to-file>
 ```
 
-where `<my-key-name>` is the key you want to use in the ConfigMap and `<path-to-file>` is the location of the data source file you want the key to represent.
+where `<my-key-name>` is the key you want to use in the ConfigMap and `<path-to-file>` is the
+location of the data source file you want the key to represent.
 
 For example:
 
@@ -334,13 +356,15 @@ data:
 
 #### Create ConfigMaps from literal values
 
-You can use `kubectl create configmap` with the `--from-literal` argument to define a literal value from the command line:
+You can use `kubectl create configmap` with the `--from-literal` argument to define a literal
+value from the command line:
 
 ```shell
 kubectl create configmap special-config --from-literal=special.how=very --from-literal=special.type=charm
 ```
 
-You can pass in multiple key-value pairs. Each pair provided on the command line is represented as a separate entry in the `data` section of the ConfigMap.
+You can pass in multiple key-value pairs. Each pair provided on the command line is represented
+as a separate entry in the `data` section of the ConfigMap.
 
 ```shell
 kubectl get configmaps special-config -o yaml
@@ -414,10 +438,11 @@ secret.code.lives=30
 Events:  <none>
 ```
 
-Note that the generated ConfigMap name has a suffix appended by hashing the contents. This ensures that a
-new ConfigMap is generated each time the content is modified.
+Note that the generated ConfigMap name has a suffix appended by hashing the contents. This
+ensures that a new ConfigMap is generated each time the content is modified.
 
 #### Define the key to use when generating a ConfigMap from a file
+
 You can define a key other than the file name to use in the ConfigMap generator.
 For example, to generate a ConfigMap from files `configure-pod-container/configmap/game.properties`
 with the key `game-special-key`
@@ -439,6 +464,7 @@ configmap/game-config-5-m67dt67794 created
 ```
 
 #### Generate ConfigMaps from Literals
+
 To generate a ConfigMap from literals `special.type=charm` and `special.how=very`,
 you can specify the ConfigMap generator in `kustomization.yaml` as
 ```shell
@@ -515,7 +541,8 @@ configmap/special-config-2-c92b5mmcf2 created
   kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
   ```
 
-* Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
+* Use `envFrom` to define all of the ConfigMap's data as container environment variables. The
+  key from the ConfigMap becomes the environment variable name in the Pod.
 
   {{< codenew file="pods/pod-configmap-envFrom.yaml" >}}
 
@@ -530,7 +557,8 @@ configmap/special-config-2-c92b5mmcf2 created
 
 ## Use ConfigMap-defined environment variables in Pod commands
 
-You can use ConfigMap-defined environment variables in the `command` and `args` of a container using the `$(VAR_NAME)` Kubernetes substitution syntax.
+You can use ConfigMap-defined environment variables in the `command` and `args` of a container
+using the `$(VAR_NAME)` Kubernetes substitution syntax.
 
 For example, the following Pod specification
 
@@ -550,7 +578,9 @@ very charm
 
 ## Add ConfigMap data to a Volume
 
-As explained in [Create ConfigMaps from files](#create-configmaps-from-files), when you create a ConfigMap using ``--from-file``, the filename becomes a key stored in the `data` section of the ConfigMap. The file contents become the key's value.
+As explained in [Create ConfigMaps from files](#create-configmaps-from-files), when you create
+a ConfigMap using ``--from-file``, the filename becomes a key stored in the `data` section of
+the ConfigMap. The file contents become the key's value.
 
 The examples in this section refer to a ConfigMap named special-config, shown below.
 
@@ -565,8 +595,9 @@ kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.y
 ### Populate a Volume with data stored in a ConfigMap
 
 Add the ConfigMap name under the `volumes` section of the Pod specification.
-This adds the ConfigMap data to the directory specified as `volumeMounts.mountPath` (in this case, `/etc/config`).
-The `command` section lists directory files with names that match the keys in ConfigMap.
+This adds the ConfigMap data to the directory specified as `volumeMounts.mountPath` (in this
+case, `/etc/config`). The `command` section lists directory files with names that match the
+keys in ConfigMap.
 
 {{< codenew file="pods/pod-configmap-volume.yaml" >}}
 
@@ -588,7 +619,8 @@ If there are some files in the `/etc/config/` directory, they will be deleted.
 {{< /caution >}}
 
 {{< note >}}
-Text data is exposed as files using the UTF-8 character encoding. To use some other character encoding, use binaryData.
+Text data is exposed as files using the UTF-8 character encoding. To use some other character
+encoding, use binaryData.
 {{< /note >}}
 
 ### Add ConfigMap data to a specific path in the Volume
@@ -617,7 +649,8 @@ Like before, all previous files in the `/etc/config/` directory will be deleted.
 ### Project keys to specific paths and file permissions
 
 You can project keys to specific paths and specific permissions on a per-file
-basis. The [Secrets](/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod) user guide explains the syntax.
+basis. The [Secrets](/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod)
+user guide explains the syntax.
 
 
 
@@ -625,13 +658,22 @@ basis. The [Secrets](/docs/concepts/configuration/secret/#using-secrets-as-files
 
 ## Understanding ConfigMaps and Pods
 
-The ConfigMap API resource stores configuration data as key-value pairs. The data can be consumed in pods or provide the configurations for system components such as controllers. ConfigMap is similar to [Secrets](/docs/concepts/configuration/secret/), but provides a means of working with strings that don't contain sensitive information. Users and system components alike can store configuration data in ConfigMap.
+The ConfigMap API resource stores configuration data as key-value pairs. The data can be consumed
+in pods or provide the configurations for system components such as controllers. ConfigMap is
+similar to [Secrets](/docs/concepts/configuration/secret/), but provides a means of working
+with strings that don't contain sensitive information. Users and system components alike can
+store configuration data in ConfigMap.
 
 {{< note >}}
-ConfigMaps should reference properties files, not replace them. Think of the ConfigMap as representing something similar to the Linux `/etc` directory and its contents. For example, if you create a [Kubernetes Volume](/docs/concepts/storage/volumes/) from a ConfigMap, each data item in the ConfigMap is represented by an individual file in the volume.
+ConfigMaps should reference properties files, not replace them. Think of the ConfigMap as
+representing something similar to the Linux `/etc` directory and its contents. For example,
+if you create a [Kubernetes Volume](/docs/concepts/storage/volumes/) from a ConfigMap, each
+data item in the ConfigMap is represented by an individual file in the volume.
 {{< /note >}}
 
-The ConfigMap's `data` field contains the configuration data. As shown in the example below, this can be simple -- like individual properties defined using `--from-literal` -- or complex -- like configuration files or JSON blobs defined using `--from-file`.
+The ConfigMap's `data` field contains the configuration data. As shown in the example below,
+this can be simple -- like individual properties defined using `--from-literal` -- or complex --
+like configuration files or JSON blobs defined using `--from-file`.
 
 ```yaml
 apiVersion: v1
@@ -653,9 +695,17 @@ data:
 
 ### Restrictions
 
-- You must create the `ConfigMap` object before you reference it in a Pod specification. Alternatively, mark the ConfigMap reference as `optional` in the Pod spec (see [Optional ConfigMaps](#optional-configmaps)). If you reference a ConfigMap that doesn't exist and you don't mark the reference as `optional`, the Pod won't start. Similarly, references to keys that don't exist in the ConfigMap will also prevent the Pod from starting, unless you mark the key references as `optional`.
+- You must create the `ConfigMap` object before you reference it in a Pod
+  specification. Alternatively, mark the ConfigMap reference as `optional` in the Pod spec (see
+  [Optional ConfigMaps](#optional-configmaps)). If you reference a ConfigMap that doesn't exist
+  and you don't mark the reference as `optional`, the Pod won't start. Similarly, references
+  to keys that don't exist in the ConfigMap will also prevent the Pod from starting, unless
+  you mark the key references as `optional`.
 
-- If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
+- If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered
+  invalid will be skipped. The pod will be allowed to start, but the invalid names will be
+  recorded in the event log (`InvalidVariableNames`). The log message lists each skipped
+  key. For example:
 
   ```shell
   kubectl get events
@@ -674,10 +724,12 @@ data:
 ### Optional ConfigMaps
 
 You can mark a reference to a ConfigMap as _optional_ in a Pod specification.
-If the ConfigMap doesn't exist, the configuration for which it provides data in the Pod (e.g. environment variable, mounted volume) will be empty.
+If the ConfigMap doesn't exist, the configuration for which it provides data in the Pod
+(e.g. environment variable, mounted volume) will be empty.
 If the ConfigMap exists, but the referenced key is non-existent the data is also empty.
 
-For example, the following Pod specification marks an environment variable from a ConfigMap as optional:
+For example, the following Pod specification marks an environment variable from a ConfigMap
+as optional:
 
 ```yaml
 apiVersion: v1
@@ -704,8 +756,9 @@ If you run this pod, and there is a ConfigMap named `a-config` but that ConfigMa
 a key named `akey`, the output is also empty. If you do set a value for `akey` in the `a-config`
 ConfigMap, this pod prints that value and then terminates.
 
-You can also mark the volumes and files provided by a ConfigMap as optional. Kubernetes always creates the mount paths for the volume, even if the referenced ConfigMap or key doesn't exist. For example, the following
-Pod specification marks a volume that references a ConfigMap as optional:
+You can also mark the volumes and files provided by a ConfigMap as optional. Kubernetes always
+creates the mount paths for the volume, even if the referenced ConfigMap or key doesn't exist. For
+example, the following Pod specification marks a volume that references a ConfigMap as optional:
 
 ```yaml
 apiVersion: v1
@@ -730,12 +783,15 @@ spec:
 
 ### Mounted ConfigMaps are updated automatically
 
-When a mounted ConfigMap is updated, the projected content is eventually updated too.  This applies in the case where an optionally referenced ConfigMap comes into
-existence after a pod has started.
+When a mounted ConfigMap is updated, the projected content is eventually updated too.
+This applies in the case where an optionally referenced ConfigMap comes into existence after
+a pod has started.
 
-The kubelet checks whether the mounted ConfigMap is fresh on every periodic sync. However, it uses its local TTL-based cache for getting the current value of the
-ConfigMap. As a result, the total delay from the moment when the ConfigMap is updated to the moment when new keys are projected to the pod can be as long as
-kubelet sync period (1 minute by default) + TTL of ConfigMaps cache (1 minute by default) in kubelet.
+The kubelet checks whether the mounted ConfigMap is fresh on every periodic sync. However, it
+uses its local TTL-based cache for getting the current value of the ConfigMap. As a result,
+the total delay from the moment when the ConfigMap is updated to the moment when new keys
+are projected to the pod can be as long as kubelet sync period (1 minute by default) + TTL of
+ConfigMaps cache (1 minute by default) in kubelet.
 
 {{< note >}}
 A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath) volume will not receive ConfigMap updates.
@@ -743,4 +799,5 @@ A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#usi
 
 ## {{% heading "whatsnext" %}}
 
-* Follow a real world example of [Configuring Redis using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/).
+* Follow a real world example of
+  [Configuring Redis using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/).

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -8,21 +8,25 @@ card:
 ---
 
 <!-- overview -->
-Many applications rely on configuration which is used during either application initialization
-or runtime. Most of the times there is a requirement to adjust values assigned to configuration
-parameters.
-ConfigMaps are the Kubernetes way to inject application pods with configuration
-data. ConfigMaps allow you to decouple configuration artifacts from image content to keep
-containerized applications portable. This page provides a series of usage examples demonstrating
-how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
+Many applications rely on configuration which is used during either application initialization or runtime.
+Most times, there is a requirement to adjust values assigned to configuration parameters.
+ConfigMaps are a Kubernetes mechanism that let you inject configuration data into application
+{{< glossary_tooltip text="pods" term_id="pod" >}}.
 
+The ConfigMap concept allow you to decouple configuration artifacts from image content to
+keep containerized applications portable. For example, you can download and run the same
+{{< glossary_tooltip text="container image" term_id="image" >}} to spin up containers for the purposes of local development, system test, or running a live end-user workload.
+
+This page provides a series of usage examples demonstrating how to create ConfigMaps and
+configure Pods using data stored in ConfigMaps.
 
 ## {{% heading "prerequisites" %}}
 
+{{< include "task-tutorial-prereqs.md" >}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-
+You need to have the `wget` tool installed. If you have a different tool
+such as `curl`, and you do not have `wget`, you will need to adapt the
+step that downloads example data.
 
 <!-- steps -->
 
@@ -30,9 +34,9 @@ how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
 ## Create a ConfigMap
 
 You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml`
-to create a ConfigMap. Note that `kubectl` starts to support `kustomization.yaml` since 1.14.
+to create a ConfigMap.
 
-### Create a ConfigMap Using kubectl create configmap
+### Create a ConfigMap using `kubectl create configmap`
 
 Use the `kubectl create configmap` command to create ConfigMaps from
 [directories](#create-configmaps-from-directories), [files](#create-configmaps-from-files),
@@ -54,25 +58,28 @@ You can use [`kubectl describe`](/docs/reference/generated/kubectl/kubectl-comma
 [`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) to retrieve information
 about a ConfigMap.
 
-#### Create ConfigMaps from directories
+#### Create a ConfigMap from a directory {#create-configmaps-from-directories}
 
 You can use `kubectl create configmap` to create a ConfigMap from multiple files in the same
 directory. When you are creating a ConfigMap based on a directory, kubectl identifies files
-whose basename is a valid key in the directory and packages each of those files into the
-new ConfigMap. Any directory entries except regular files are ignored (e.g. subdirectories,
-symlinks, devices, pipes, etc).
+whose basename is a valid key in the directory and packages each of those files into the new
+ConfigMap. Any directory entries except regular files are ignored (for example: subdirectories,
+symlinks, devices, pipes, and more).
 
-For example:
+Create the local directory:
 
 ```shell
-# Create the local directory
 mkdir -p configure-pod-container/configmap/
+```
 
+Now, download the sample configuration and create the ConfigMap:
+
+```shell
 # Download the sample files into `configure-pod-container/configmap/` directory
 wget https://kubernetes.io/examples/configmap/game.properties -O configure-pod-container/configmap/game.properties
 wget https://kubernetes.io/examples/configmap/ui.properties -O configure-pod-container/configmap/ui.properties
 
-# Create the configmap
+# Create the ConfigMap
 kubectl create configmap game-config --from-file=configure-pod-container/configmap/
 ```
 
@@ -122,7 +129,7 @@ The output is similar to this:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2016-02-18T18:52:05Z
+  creationTimestamp: 2022-02-18T18:52:05Z
   name: game-config
   namespace: default
   resourceVersion: "516"
@@ -221,11 +228,6 @@ allow.textmode=true
 how.nice.to.look=fairlyNice
 ```
 
-When `kubectl` creates a ConfigMap from inputs that are not ASCII or UTF-8, the tool puts these
-into the `binaryData` field of the ConfigMap, and not in `data`. Both text and binary data
-sources can be combined in one ConfigMap. If you want to view the `binaryData` keys (and their
-values) in a ConfigMap, you can run `kubectl get configmap -o jsonpath='{.binaryData}' <name>`.
-
 Use the option `--from-env-file` to create a ConfigMap from an env-file, for example:
 
 ```shell
@@ -254,18 +256,18 @@ kubectl create configmap game-config-env-file \
        --from-env-file=configure-pod-container/configmap/game-env-file.properties
 ```
 
-would produce the following ConfigMap:
+would produce a ConfigMap. View the ConfigMap:
 
 ```shell
 kubectl get configmap game-config-env-file -o yaml
 ```
 
-where the output is similar to this:
+the output is similar to:
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2017-12-27T18:36:28Z
+  creationTimestamp: 2019-12-27T18:36:28Z
   name: game-config-env-file
   namespace: default
   resourceVersion: "809965"
@@ -296,7 +298,7 @@ where the output is similar to this:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2017-12-27T18:38:34Z
+  creationTimestamp: 2019-12-27T18:38:34Z
   name: config-multi-env-files
   namespace: default
   resourceVersion: "810136"
@@ -338,7 +340,7 @@ where the output is similar to this:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2016-02-18T18:54:22Z
+  creationTimestamp: 2022-02-18T18:54:22Z
   name: game-config-3
   namespace: default
   resourceVersion: "530"
@@ -375,7 +377,7 @@ The output is similar to this:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: 2016-02-18T19:14:38Z
+  creationTimestamp: 2022-02-18T19:14:38Z
   name: special-config
   namespace: default
   resourceVersion: "651"
@@ -385,14 +387,17 @@ data:
   special.type: charm
 ```
 
+
 ### Create a ConfigMap from generator
-`kubectl` supports `kustomization.yaml` since 1.14.
-You can also create a ConfigMap from generators and then apply it to create the object on
-the Apiserver. The generators
-should be specified in a `kustomization.yaml` inside a directory.
+
+You can also create a ConfigMap from generators and then apply it to create the object
+in the cluster's API server.
+You should specify the generators in a `kustomization.yaml` file within a directory.
 
 #### Generate ConfigMaps from files
+
 For example, to generate a ConfigMap from files `configure-pod-container/configmap/game.properties`
+
 ```shell
 # Create a kustomization.yaml file with ConfigMapGenerator
 cat <<EOF >./kustomization.yaml
@@ -403,9 +408,12 @@ configMapGenerator:
 EOF
 ```
 
-Apply the kustomization directory to create the ConfigMap object.
+Apply the kustomization directory to create the ConfigMap object:
+
 ```shell
 kubectl apply -k .
+```
+```
 configmap/game-config-4-m9dm2f92bt created
 ```
 
@@ -413,11 +421,18 @@ You can check that the ConfigMap was created like this:
 
 ```shell
 kubectl get configmap
+```
+```
 NAME                       DATA   AGE
 game-config-4-m9dm2f92bt   1      37s
+```
 
+and also:
 
+```shell
 kubectl describe configmaps/game-config-4-m9dm2f92bt
+```
+```
 Name:         game-config-4-m9dm2f92bt
 Namespace:    default
 Labels:       <none>
@@ -438,7 +453,7 @@ secret.code.lives=30
 Events:  <none>
 ```
 
-Note that the generated ConfigMap name has a suffix appended by hashing the contents. This
+Notice that the generated ConfigMap name has a suffix appended by hashing the contents. This
 ensures that a new ConfigMap is generated each time the content is modified.
 
 #### Define the key to use when generating a ConfigMap from a file
@@ -460,28 +475,41 @@ EOF
 Apply the kustomization directory to create the ConfigMap object.
 ```shell
 kubectl apply -k .
+```
+```
 configmap/game-config-5-m67dt67794 created
 ```
 
-#### Generate ConfigMaps from Literals
+#### Generate ConfigMaps from literals
 
-To generate a ConfigMap from literals `special.type=charm` and `special.how=very`,
-you can specify the ConfigMap generator in `kustomization.yaml` as
-```shell
-# Create a kustomization.yaml file with ConfigMapGenerator
-cat <<EOF >./kustomization.yaml
+This example shows you how to create a `ConfigMap` from two literal key/value pairs:
+`special.type=charm` and `special.how=very`, using Kustomize and kubectl. To achieve
+this, you can specify the `ConfigMap` generator. Create (or replace)
+`kustomization.yaml` so that it has the following contents:
+
+```yaml
+---
+# kustomization.yaml contents for creating a ConfigMap from literals
 configMapGenerator:
 - name: special-config-2
   literals:
   - special.how=very
   - special.type=charm
-EOF
 ```
-Apply the kustomization directory to create the ConfigMap object.
+
+Apply the kustomization directory to create the ConfigMap object:
 ```shell
 kubectl apply -k .
+```
+```
 configmap/special-config-2-c92b5mmcf2 created
 ```
+
+
+Now that you have learned to define ConfigMaps, you can move on to the next
+section, and learn how to use these objects with Pods.
+
+---
 
 ## Define container environment variables using ConfigMap data
 
@@ -507,11 +535,12 @@ configmap/special-config-2-c92b5mmcf2 created
 
 ### Define container environment variables with data from multiple ConfigMaps
 
-* As with the previous example, create the ConfigMaps first.
+As with the previous example, create the ConfigMaps first.
+Here is the manifest you will use:
 
-  {{< codenew file="configmap/configmaps.yaml" >}}
+{{< codenew file="configmap/configmaps.yaml" >}}
 
-  Create the ConfigMap:
+* Create the ConfigMap:
 
   ```shell
   kubectl create -f https://kubernetes.io/examples/configmap/configmaps.yaml
@@ -551,26 +580,26 @@ configmap/special-config-2-c92b5mmcf2 created
   ```shell
   kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-envFrom.yaml
   ```
-
-  Now, the Pod's output includes environment variables `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`.
-
+  Now, the Pod's output includes environment variables `SPECIAL_LEVEL=very` and
+  `SPECIAL_TYPE=charm`.
 
 ## Use ConfigMap-defined environment variables in Pod commands
 
 You can use ConfigMap-defined environment variables in the `command` and `args` of a container
 using the `$(VAR_NAME)` Kubernetes substitution syntax.
 
-For example, the following Pod specification
+For example, the following Pod manifest:
 
 {{< codenew file="pods/pod-configmap-env-var-valueFrom.yaml" >}}
 
-created by running
+Create that Pod, by running:
+
 
 ```shell
 kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-env-var-valueFrom.yaml
 ```
 
-produces the following output in the `test-container` container:
+That pod produces the following output from the `test-container` container:
 
 ```
 very charm
@@ -582,7 +611,7 @@ As explained in [Create ConfigMaps from files](#create-configmaps-from-files), w
 a ConfigMap using ``--from-file``, the filename becomes a key stored in the `data` section of
 the ConfigMap. The file contents become the key's value.
 
-The examples in this section refer to a ConfigMap named special-config, shown below.
+The examples in this section refer to a ConfigMap named `special-config`:
 
 {{< codenew file="configmap/configmap-multikeys.yaml" >}}
 
@@ -614,13 +643,12 @@ SPECIAL_LEVEL
 SPECIAL_TYPE
 ```
 
-{{< caution >}}
-If there are some files in the `/etc/config/` directory, they will be deleted.
-{{< /caution >}}
+Text data is exposed as files using the UTF-8 character encoding. To use some other
+character encoding, use `binaryData` (see [ConfigMap object](/docs/concepts/configuration/configmap/#configmap-object) for more details).
 
 {{< note >}}
-Text data is exposed as files using the UTF-8 character encoding. To use some other character
-encoding, use binaryData.
+If there are any files in the `/etc/config` directory of that container image, the volume
+mount will make those files from the image inaccessible.
 {{< /note >}}
 
 ### Add ConfigMap data to a specific path in the Volume
@@ -649,10 +677,33 @@ Like before, all previous files in the `/etc/config/` directory will be deleted.
 ### Project keys to specific paths and file permissions
 
 You can project keys to specific paths and specific permissions on a per-file
-basis. The [Secrets](/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod)
-user guide explains the syntax.
+basis. The
+[Secrets](/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod)
+guide explains the syntax.
 
+### Optional references
 
+A ConfigMap reference may be marked _optional_.  If the ConfigMap is non-existent, the mounted
+volume will be empty. If the ConfigMap exists, but the referenced key is non-existent the path
+will be absent beneath the mount point. See [Optional ConfigMaps](#optional-configmaps) for more
+details.
+
+### Mounted ConfigMaps are updated automatically
+
+When a mounted ConfigMap is updated, the projected content is eventually updated too.
+This applies in the case where an optionally referenced ConfigMap comes into
+existence after a pod has started.
+
+Kubelet checks whether the mounted ConfigMap is fresh on every periodic sync. However,
+it uses its local TTL-based cache for getting the current value of the ConfigMap. As a
+result, the total delay from the moment when the ConfigMap is updated to the moment
+when new keys are projected to the pod can be as long as kubelet sync period (1
+minute by default) + TTL of ConfigMaps cache (1 minute by default) in kubelet. You
+can trigger an immediate refresh by updating one of the pod's annotations.
+
+{{< note >}}
+A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath) volume will not receive ConfigMap updates.
+{{< /note >}}
 
 <!-- discussion -->
 
@@ -693,35 +744,16 @@ data:
     property.3=value-3
 ```
 
-### Restrictions
+When `kubectl` creates a ConfigMap from inputs that are not ASCII or UTF-8, the tool puts
+these into the `binaryData` field of the ConfigMap, and not in `data`. Both text and binary
+data sources can be combined in one ConfigMap.
 
-- You must create the `ConfigMap` object before you reference it in a Pod
-  specification. Alternatively, mark the ConfigMap reference as `optional` in the Pod spec (see
-  [Optional ConfigMaps](#optional-configmaps)). If you reference a ConfigMap that doesn't exist
-  and you don't mark the reference as `optional`, the Pod won't start. Similarly, references
-  to keys that don't exist in the ConfigMap will also prevent the Pod from starting, unless
-  you mark the key references as `optional`.
+If you want to view the `binaryData` keys (and their values) in a ConfigMap, you can run
+`kubectl get configmap -o jsonpath='{.binaryData}' <name>`.
 
-- If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered
-  invalid will be skipped. The pod will be allowed to start, but the invalid names will be
-  recorded in the event log (`InvalidVariableNames`). The log message lists each skipped
-  key. For example:
+Pods can load data from a ConfigMap that uses either `data` or `binaryData`.
 
-  ```shell
-  kubectl get events
-  ```
-
-  The output is similar to this:
-  ```
-  LASTSEEN FIRSTSEEN COUNT NAME          KIND  SUBOBJECT  TYPE      REASON                            SOURCE                MESSAGE
-  0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
-  ```
-
-- ConfigMaps reside in a specific {{< glossary_tooltip term_id="namespace" >}}. A ConfigMap can only be referenced by pods residing in the same namespace.
-
-- You can't use ConfigMaps for {{< glossary_tooltip text="static pods" term_id="static-pod" >}}, because the Kubelet does not support this.
-
-### Optional ConfigMaps
+## Optional ConfigMaps
 
 You can mark a reference to a ConfigMap as _optional_ in a Pod specification.
 If the ConfigMap doesn't exist, the configuration for which it provides data in the Pod
@@ -796,6 +828,38 @@ ConfigMaps cache (1 minute by default) in kubelet.
 {{< note >}}
 A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath) volume will not receive ConfigMap updates.
 {{< /note >}}
+
+## Restrictions
+
+- You must create the `ConfigMap` object before you reference it in a Pod
+  specification. Alternatively, mark the ConfigMap reference as `optional` in the Pod spec (see
+  [Optional ConfigMaps](#optional-configmaps)). If you reference a ConfigMap that doesn't exist
+  and you don't mark the reference as `optional`, the Pod won't start. Similarly, references
+  to keys that don't exist in the ConfigMap will also prevent the Pod from starting, unless
+  you mark the key references as `optional`.
+
+- If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered
+  invalid will be skipped. The pod will be allowed to start, but the invalid names will be
+  recorded in the event log (`InvalidVariableNames`). The log message lists each skipped
+  key. For example:
+
+  ```shell
+  kubectl get events
+  ```
+
+  The output is similar to this:
+  ```
+  LASTSEEN FIRSTSEEN COUNT NAME          KIND  SUBOBJECT  TYPE      REASON                            SOURCE                MESSAGE
+  0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
+  ```
+
+- ConfigMaps reside in a specific {{< glossary_tooltip term_id="namespace" >}}.
+  Pods can only refer to ConfigMaps that are in the same namespace as the Pod.
+
+- You can't use ConfigMaps for
+  {{< glossary_tooltip text="static pods" term_id="static-pod" >}}, because the
+  kubelet does not support this.
+
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -724,7 +724,7 @@ guide explains the syntax.
 ### Optional references
 
 A ConfigMap reference may be marked _optional_.  If the ConfigMap is non-existent, the mounted
-volume will be empty. If the ConfigMap exists, but the referenced key is non-existent the path
+volume will be empty. If the ConfigMap exists, but the referenced key is non-existent, the path
 will be absent beneath the mount point. See [Optional ConfigMaps](#optional-configmaps) for more
 details.
 
@@ -763,8 +763,8 @@ data item in the ConfigMap is represented by an individual file in the volume.
 {{< /note >}}
 
 The ConfigMap's `data` field contains the configuration data. As shown in the example below,
-this can be simple -- like individual properties defined using `--from-literal` -- or complex --
-like configuration files or JSON blobs defined using `--from-file`.
+this can be simple (like individual properties defined using `--from-literal`) or complex
+(like configuration files or JSON blobs defined using `--from-file`).
 
 ```yaml
 apiVersion: v1
@@ -797,7 +797,7 @@ Pods can load data from a ConfigMap that uses either `data` or `binaryData`.
 
 You can mark a reference to a ConfigMap as _optional_ in a Pod specification.
 If the ConfigMap doesn't exist, the configuration for which it provides data in the Pod
-(e.g. environment variable, mounted volume) will be empty.
+(for example: environment variable, mounted volume) will be empty.
 If the ConfigMap exists, but the referenced key is non-existent the data is also empty.
 
 For example, the following Pod specification marks an environment variable from a ConfigMap

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -403,6 +403,8 @@ For example, to generate a ConfigMap from files `configure-pod-container/configm
 cat <<EOF >./kustomization.yaml
 configMapGenerator:
 - name: game-config-4
+  labels:
+    game-config: config-4
   files:
   - configure-pod-container/configmap/game.properties
 EOF
@@ -435,7 +437,7 @@ kubectl describe configmaps/game-config-4-m9dm2f92bt
 ```
 Name:         game-config-4-m9dm2f92bt
 Namespace:    default
-Labels:       <none>
+Labels:       game-config=config-4
 Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                 {"apiVersion":"v1","data":{"game.properties":"enemies=aliens\nlives=3\nenemies.cheat=true\nenemies.cheat.level=noGoodRotten\nsecret.code.p...
 
@@ -467,6 +469,8 @@ with the key `game-special-key`
 cat <<EOF >./kustomization.yaml
 configMapGenerator:
 - name: game-config-5
+  labels:
+    game-config: config-5
   files:
   - game-special-key=configure-pod-container/configmap/game.properties
 EOF
@@ -505,6 +509,15 @@ kubectl apply -k .
 configmap/special-config-2-c92b5mmcf2 created
 ```
 
+## Interim cleanup
+
+Before proceeding, clean up some of the ConfigMaps you made:
+
+```bash
+kubectl delete configmap special-config
+kubectl delete configmap env-config
+kubectl delete configmap -l 'game-config in (config-4,config-5)’
+```
 
 Now that you have learned to define ConfigMaps, you can move on to the next
 section, and learn how to use these objects with Pods.
@@ -558,6 +571,11 @@ Here is the manifest you will use:
 
   Now, the Pod's output includes environment variables `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=INFO`.
 
+  Once you're happy to move on, delete that Pod:
+  ```shell
+  kubectl delete pod dapi-test-pod --now
+  ```
+
 ## Configure all key-value pairs in a ConfigMap as container environment variables
 
 * Create a ConfigMap containing multiple key-value pairs.
@@ -569,6 +587,7 @@ Here is the manifest you will use:
   ```shell
   kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
   ```
+
 
 * Use `envFrom` to define all of the ConfigMap's data as container environment variables. The
   key from the ConfigMap becomes the environment variable name in the Pod.
@@ -582,6 +601,11 @@ Here is the manifest you will use:
   ```
   Now, the Pod's output includes environment variables `SPECIAL_LEVEL=very` and
   `SPECIAL_TYPE=charm`.
+
+  Once you're happy to move on, delete that Pod:
+  ```shell
+  kubectl delete pod dapi-test-pod --now
+  ```
 
 ## Use ConfigMap-defined environment variables in Pod commands
 
@@ -603,6 +627,11 @@ That pod produces the following output from the `test-container` container:
 
 ```
 very charm
+```
+
+Once you're happy to move on, delete that Pod:
+```shell
+kubectl delete pod dapi-test-pod --now
 ```
 
 ## Add ConfigMap data to a Volume
@@ -651,6 +680,11 @@ If there are any files in the `/etc/config` directory of that container image, t
 mount will make those files from the image inaccessible.
 {{< /note >}}
 
+Once you're happy to move on, delete that Pod:
+```shell
+kubectl delete pod dapi-test-pod --now
+```
+
 ### Add ConfigMap data to a specific path in the Volume
 
 Use the `path` field to specify the desired file path for specific ConfigMap items.
@@ -673,6 +707,12 @@ very
 {{< caution >}}
 Like before, all previous files in the `/etc/config/` directory will be deleted.
 {{< /caution >}}
+
+Delete that Pod:
+```shell
+kubectl delete pod dapi-test-pod --now
+```
+
 
 ### Project keys to specific paths and file permissions
 
@@ -859,6 +899,23 @@ A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#usi
 - You can't use ConfigMaps for
   {{< glossary_tooltip text="static pods" term_id="static-pod" >}}, because the
   kubelet does not support this.
+
+## {{% heading "cleanup" %}}
+
+Delete the ConfigMaps and Pods that you made:
+
+```bash
+kubectl delete configmaps/game-config configmaps/game-config-2 configmaps/game-config-3 \
+               configmaps/game-config-env-file
+kubectl delete pod dapi-test-pod --now
+
+# You might already have removed the next set
+kubectl delete configmaps/special-config configmaps/env-config
+kubectl delete configmap -l 'game-config in (config-4,config-5)’
+```
+
+If you created a directory `configure-pod-container` and no longer need it, you should remove that too,
+or move it into the trash can / deleted files location.
 
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -62,9 +62,18 @@ about a ConfigMap.
 
 You can use `kubectl create configmap` to create a ConfigMap from multiple files in the same
 directory. When you are creating a ConfigMap based on a directory, kubectl identifies files
-whose basename is a valid key in the directory and packages each of those files into the new
+whose filename is a valid key in the directory and packages each of those files into the new
 ConfigMap. Any directory entries except regular files are ignored (for example: subdirectories,
 symlinks, devices, pipes, and more).
+
+
+{{< note >}}
+Each filename being used for ConfigMap creation must consist of only acceptable characters, which are: letters (`A` to `Z` and `a` to z`), digits (`0` to `9`), '-', '_', or '.'.
+If you use `kubectl create configmap` with a directory where any of the file names contains an unacceptable character, the `kubectl` command may fail.
+
+The `kubectl` command does not print an error when it encounters an invalid filename.
+{{< /note >}}
+
 
 Create the local directory:
 


### PR DESCRIPTION
- wrap text
- don't check whether Kubernetes supports this; it just does
- emphasize optional ConfigMap references
- other tidying (see 2nd commit)