### PR TITLE
Update Resource Types table for 1.25

### DIFF
--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -159,66 +159,66 @@ To learn more about command operations, see the [kubectl](/docs/reference/kubect
 
 The following table includes a list of all the supported resource types and their abbreviated aliases.
 
-(This output can be retrieved from `kubectl api-resources`, and was accurate as of Kubernetes 1.19.1.)
+(This output can be retrieved from `kubectl api-resources`, and was accurate as of Kubernetes 1.24.3)
 
-| NAME | SHORTNAMES | APIGROUP | NAMESPACED | KIND |
-|---|---|---|---|---|
-| `bindings` | | | true | Binding |
-| `componentstatuses` | `cs` | | false | ComponentStatus |
-| `configmaps` | `cm` | | true | ConfigMap |
-| `endpoints` | `ep` | | true | Endpoints |
-| `events` | `ev` | | true | Event |
-| `limitranges` | `limits` | | true | LimitRange |
-| `namespaces` | `ns` | | false | Namespace |
-| `nodes` | `no` | | false | Node |
-| `persistentvolumeclaims` | `pvc` | | true | PersistentVolumeClaim |
-| `persistentvolumes` | `pv` | | false | PersistentVolume |
-| `pods` | `po` | | true | Pod |
-| `podtemplates` | | | true | PodTemplate |
-| `replicationcontrollers` | `rc` | | true | ReplicationController |
-| `resourcequotas` | `quota` | | true | ResourceQuota |
-| `secrets` | | | true | Secret |
-| `serviceaccounts` | `sa` | | true | ServiceAccount |
-| `services` | `svc` | | true | Service |
-| `mutatingwebhookconfigurations` | | admissionregistration.k8s.io | false | MutatingWebhookConfiguration |
-| `validatingwebhookconfigurations` | | admissionregistration.k8s.io | false | ValidatingWebhookConfiguration |
-| `customresourcedefinitions` | `crd,crds` | apiextensions.k8s.io | false | CustomResourceDefinition |
-| `apiservices` | | apiregistration.k8s.io | false | APIService |
-| `controllerrevisions` | | apps | true | ControllerRevision |
-| `daemonsets` | `ds` | apps | true | DaemonSet |
-| `deployments` | `deploy` | apps | true | Deployment |
-| `replicasets` | `rs` | apps | true | ReplicaSet |
-| `statefulsets` | `sts` | apps | true | StatefulSet |
-| `tokenreviews` | | authentication.k8s.io | false | TokenReview |
-| `localsubjectaccessreviews` | | authorization.k8s.io | true | LocalSubjectAccessReview |
-| `selfsubjectaccessreviews` | | authorization.k8s.io | false | SelfSubjectAccessReview |
-| `selfsubjectrulesreviews` | | authorization.k8s.io | false | SelfSubjectRulesReview |
-| `subjectaccessreviews` | | authorization.k8s.io | false | SubjectAccessReview |
-| `horizontalpodautoscalers` | `hpa` | autoscaling | true | HorizontalPodAutoscaler |
-| `cronjobs` | `cj` | batch | true | CronJob |
-| `jobs` | | batch | true | Job |
-| `certificatesigningrequests` | `csr` | certificates.k8s.io | false | CertificateSigningRequest |
-| `leases` | | coordination.k8s.io | true | Lease |
-| `endpointslices` |  | discovery.k8s.io | true | EndpointSlice |
-| `events` | `ev` | events.k8s.io | true | Event |
-| `ingresses` | `ing` | extensions | true | Ingress |
-| `flowschemas` |  | flowcontrol.apiserver.k8s.io | false | FlowSchema |
-| `prioritylevelconfigurations` |  | flowcontrol.apiserver.k8s.io | false | PriorityLevelConfiguration |
-| `ingressclasses` |  | networking.k8s.io | false | IngressClass |
-| `ingresses` | `ing` | networking.k8s.io | true | Ingress |
-| `networkpolicies` | `netpol` | networking.k8s.io | true | NetworkPolicy |
-| `runtimeclasses` |  | node.k8s.io | false | RuntimeClass |
-| `poddisruptionbudgets` | `pdb` | policy | true | PodDisruptionBudget |
-| `podsecuritypolicies` | `psp` | policy | false | PodSecurityPolicy |
-| `clusterrolebindings` | | rbac.authorization.k8s.io | false | ClusterRoleBinding |
-| `clusterroles` | | rbac.authorization.k8s.io | false | ClusterRole |
-| `rolebindings` | | rbac.authorization.k8s.io | true | RoleBinding |
-| `roles` | | rbac.authorization.k8s.io | true | Role |
-| `priorityclasses` | `pc` | scheduling.k8s.io | false | PriorityClass |
-| `csidrivers` | | storage.k8s.io | false | CSIDriver |
-| `csinodes` | | storage.k8s.io | false | CSINode |
-| `storageclasses` | `sc` | storage.k8s.io | false | StorageClass |
-| `volumeattachments` | | storage.k8s.io | false | VolumeAttachment |
+| NAME                              | SHORTNAMES | APIVERSION                             | NAMESPACED | KIND |
+|-----------------------------------|------------|----------------------------------------|------------|------|
+| `bindings`                        |            |   v1                                   | true  | Binding |
+| `componentstatuses`               |   `cs`       |   v1                                   | false | ComponentStatus |
+| `configmaps`                      |   `cm`       |   v1                                   | true  | ConfigMap |
+| `endpoints`                       |   `ep`       |   v1                                   | true  | Endpoints |
+| `events`                          |   `ev`       |   v1                                   | true  | Event |
+| `limitranges`                     |   `limits`   |   v1                                   | true  | LimitRange |
+| `namespaces`                      |   `ns`       |   v1                                   | false | Namespace |
+| `nodes`                           |   `no`       |   v1                                   | false | Node |
+| `persistentvolumeclaims`          |   `pvc`      |   v1                                   | true  | PersistentVolumeClaim |
+| `persistentvolumes`               |   `pv`       |   v1                                   | false | PersistentVolume |
+| `pods`                            |   `po`       |   v1                                   | true  | Pod |
+| `podtemplates`                    |            |   v1                                   | true  | PodTemplate |
+| `replicationcontrollers`          |   `rc`       |   v1                                   | true  | ReplicationController |
+| `resourcequotas`                  |   `quota`    |   v1                                   | true  | ResourceQuota |
+| `secrets`                         |            |   v1                                   | true  | Secret |
+| `serviceaccounts`                 |   `sa`       |   v1                                   | true  | ServiceAccount |
+| `services`                        |   `svc`      |   v1                                   | true  | Service |
+| `mutatingwebhookconfigurations`   |            |   admissionregistration.k8s.io/v1      | false | MutatingWebhookConfiguration |
+| `validatingwebhookconfigurations` |            |   admissionregistration.k8s.io/v1      | false | ValidatingWebhookConfiguration |
+| `customresourcedefinitions`       |   `crd,crds` |   apiextensions.k8s.io/v1              | false | CustomResourceDefinition |
+| `apiservices`                     |            |   apiregistration.k8s.io/v1            | false | APIService |
+| `controllerrevisions`             |            |   apps/v1                              | true  | ControllerRevision |
+| `daemonsets`                      |   `ds`       |   apps/v1                              | true  | DaemonSet |
+| `deployments`                     |   `deploy`   |   apps/v1                              | true  | Deployment |
+| `replicasets`                     |   `rs`       |   apps/v1                              | true  | ReplicaSet |
+| `statefulsets`                    |   `sts`      |   apps/v1                              | true  | StatefulSet |
+| `tokenreviews`                    |            |   authentication.k8s.io/v1             | false | TokenReview |
+| `localsubjectaccessreviews`       |            |   authorization.k8s.io/v1              | true  | LocalSubjectAccessReview |
+| `selfsubjectaccessreviews`        |            |   authorization.k8s.io/v1              | false | SelfSubjectAccessReview |
+| `selfsubjectrulesreviews`         |            |   authorization.k8s.io/v1              | false | SelfSubjectRulesReview |
+| `subjectaccessreviews`            |            |   authorization.k8s.io/v1              | false | SubjectAccessReview |
+| `horizontalpodautoscalers`        |   `hpa`      |   autoscaling/v2                       | true  | HorizontalPodAutoscaler |
+| `cronjobs`                        |   `cj`       |   batch/v1                             | true  | CronJob |
+| `jobs`                            |            |   batch/v1                             | true  | Job |
+| `certificatesigningrequests`      |   `csr`      |   certificates.k8s.io/v1               | false | CertificateSigningRequest |
+| `leases                           |            |  coordination.k8s.io/v1                | rue   |Lease |
+| `endpointslices`                  |            |   discovery.k8s.io/v1                  | true  | EndpointSlice |
+| `events`                          |   `ev`       |   events.k8s.io/v1                     | true  | Event |
+| `flowschemas`                     |            |   flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |
+| `prioritylevelconfigurations`     |            |   flowcontrol.apiserver.k8s.io/v1beta2 | false | PriorityLevelConfiguration |
+| `ingressclasses`                  |            |   networking.k8s.io/v1                 | false | IngressClass |
+| `ingresses`                       |   `ing`      |   networking.k8s.io/v1                 | true  | Ingress |
+| `networkpolicies`                 |   `netpol`   |   networking.k8s.io/v1                 | true  | NetworkPolicy |
+| `runtimeclasses`                  |            |   node.k8s.io/v1                       | false | RuntimeClass |
+| `poddisruptionbudgets`            |   `pdb`      |   policy/v1                            | true  | PodDisruptionBudget |
+| `podsecuritypolicies`             |   `psp`      |   policy/v1beta1                       | false | PodSecurityPolicy |
+| `clusterrolebindings`             |            |   rbac.authorization.k8s.io/v1         | false | ClusterRoleBinding |
+| `clusterroles`                    |            |   rbac.authorization.k8s.io/v1         | false | ClusterRole |
+| `rolebindings`                    |            |   rbac.authorization.k8s.io/v1         | true  | RoleBinding |
+| `roles`                           |            |   rbac.authorization.k8s.io/v1         | true  | Role |
+| `priorityclasses`                 |   `pc`       |   scheduling.k8s.io/v1                 | false | PriorityClass |
+| `csidrivers`                      |            |   storage.k8s.io/v1                    | false | CSIDriver |
+| `csinodes`                        |            |   storage.k8s.io/v1                    | false | CSINode |
+| `csistoragecapacities`            |            |   storage.k8s.io/v1                    | true  | CSIStorageCapacity |
+| `storageclasses`                  |   `sc`       |   storage.k8s.io/v1                    | false | StorageClass |
+| `volumeattachments`               |            |   storage.k8s.io/v1                    | false | VolumeAttachment |
 
 ## Output options
 

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -161,64 +161,64 @@ The following table includes a list of all the supported resource types and thei
 
 (This output can be retrieved from `kubectl api-resources`, and was accurate as of Kubernetes 1.24.3)
 
-| NAME                              | SHORTNAMES | APIVERSION                             | NAMESPACED | KIND |
-|-----------------------------------|------------|----------------------------------------|------------|------|
-| `bindings`                        |            |   v1                                   | true  | Binding |
-| `componentstatuses`               |   `cs`       |   v1                                   | false | ComponentStatus |
-| `configmaps`                      |   `cm`       |   v1                                   | true  | ConfigMap |
-| `endpoints`                       |   `ep`       |   v1                                   | true  | Endpoints |
-| `events`                          |   `ev`       |   v1                                   | true  | Event |
-| `limitranges`                     |   `limits`   |   v1                                   | true  | LimitRange |
-| `namespaces`                      |   `ns`       |   v1                                   | false | Namespace |
-| `nodes`                           |   `no`       |   v1                                   | false | Node |
-| `persistentvolumeclaims`          |   `pvc`      |   v1                                   | true  | PersistentVolumeClaim |
-| `persistentvolumes`               |   `pv`       |   v1                                   | false | PersistentVolume |
-| `pods`                            |   `po`       |   v1                                   | true  | Pod |
-| `podtemplates`                    |            |   v1                                   | true  | PodTemplate |
-| `replicationcontrollers`          |   `rc`       |   v1                                   | true  | ReplicationController |
-| `resourcequotas`                  |   `quota`    |   v1                                   | true  | ResourceQuota |
-| `secrets`                         |            |   v1                                   | true  | Secret |
-| `serviceaccounts`                 |   `sa`       |   v1                                   | true  | ServiceAccount |
-| `services`                        |   `svc`      |   v1                                   | true  | Service |
-| `mutatingwebhookconfigurations`   |            |   admissionregistration.k8s.io/v1      | false | MutatingWebhookConfiguration |
-| `validatingwebhookconfigurations` |            |   admissionregistration.k8s.io/v1      | false | ValidatingWebhookConfiguration |
-| `customresourcedefinitions`       |   `crd,crds` |   apiextensions.k8s.io/v1              | false | CustomResourceDefinition |
-| `apiservices`                     |            |   apiregistration.k8s.io/v1            | false | APIService |
-| `controllerrevisions`             |            |   apps/v1                              | true  | ControllerRevision |
-| `daemonsets`                      |   `ds`       |   apps/v1                              | true  | DaemonSet |
-| `deployments`                     |   `deploy`   |   apps/v1                              | true  | Deployment |
-| `replicasets`                     |   `rs`       |   apps/v1                              | true  | ReplicaSet |
-| `statefulsets`                    |   `sts`      |   apps/v1                              | true  | StatefulSet |
-| `tokenreviews`                    |            |   authentication.k8s.io/v1             | false | TokenReview |
-| `localsubjectaccessreviews`       |            |   authorization.k8s.io/v1              | true  | LocalSubjectAccessReview |
-| `selfsubjectaccessreviews`        |            |   authorization.k8s.io/v1              | false | SelfSubjectAccessReview |
-| `selfsubjectrulesreviews`         |            |   authorization.k8s.io/v1              | false | SelfSubjectRulesReview |
-| `subjectaccessreviews`            |            |   authorization.k8s.io/v1              | false | SubjectAccessReview |
-| `horizontalpodautoscalers`        |   `hpa`      |   autoscaling/v2                       | true  | HorizontalPodAutoscaler |
-| `cronjobs`                        |   `cj`       |   batch/v1                             | true  | CronJob |
-| `jobs`                            |            |   batch/v1                             | true  | Job |
-| `certificatesigningrequests`      |   `csr`      |   certificates.k8s.io/v1               | false | CertificateSigningRequest |
-| `leases                           |            |  coordination.k8s.io/v1                | rue   |Lease |
-| `endpointslices`                  |            |   discovery.k8s.io/v1                  | true  | EndpointSlice |
-| `events`                          |   `ev`       |   events.k8s.io/v1                     | true  | Event |
-| `flowschemas`                     |            |   flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |
-| `prioritylevelconfigurations`     |            |   flowcontrol.apiserver.k8s.io/v1beta2 | false | PriorityLevelConfiguration |
-| `ingressclasses`                  |            |   networking.k8s.io/v1                 | false | IngressClass |
-| `ingresses`                       |   `ing`      |   networking.k8s.io/v1                 | true  | Ingress |
-| `networkpolicies`                 |   `netpol`   |   networking.k8s.io/v1                 | true  | NetworkPolicy |
-| `runtimeclasses`                  |            |   node.k8s.io/v1                       | false | RuntimeClass |
-| `poddisruptionbudgets`            |   `pdb`      |   policy/v1                            | true  | PodDisruptionBudget |
-| `podsecuritypolicies`             |   `psp`      |   policy/v1beta1                       | false | PodSecurityPolicy |
-| `clusterrolebindings`             |            |   rbac.authorization.k8s.io/v1         | false | ClusterRoleBinding |
-| `clusterroles`                    |            |   rbac.authorization.k8s.io/v1         | false | ClusterRole |
-| `rolebindings`                    |            |   rbac.authorization.k8s.io/v1         | true  | RoleBinding |
-| `roles`                           |            |   rbac.authorization.k8s.io/v1         | true  | Role |
-| `priorityclasses`                 |   `pc`       |   scheduling.k8s.io/v1                 | false | PriorityClass |
-| `csidrivers`                      |            |   storage.k8s.io/v1                    | false | CSIDriver |
-| `csinodes`                        |            |   storage.k8s.io/v1                    | false | CSINode |
-| `csistoragecapacities`            |            |   storage.k8s.io/v1                    | true  | CSIStorageCapacity |
-| `storageclasses`                  |   `sc`       |   storage.k8s.io/v1                    | false | StorageClass |
-| `volumeattachments`               |            |   storage.k8s.io/v1                    | false | VolumeAttachment |
+| NAME | SHORTNAMES | APIVERSION | NAMESPACED | KIND |
+|---|---|---|---|---|
+| `bindings` |  | v1 | true | Binding |
+| `componentstatuses` | `cs` | v1 | false | ComponentStatus |
+| `configmaps` | `cm` | v1 | true | ConfigMap |
+| `endpoints` | `ep` | v1 | true | Endpoints |
+| `events` | `ev` | v1 | true | Event |
+| `limitranges` | `limits` | v1 | true | LimitRange |
+| `namespaces` | `ns` | v1 | false | Namespace |
+| `nodes` | `no` | v1 | false | Node |
+| `persistentvolumeclaims` | `pvc` | v1 | true | PersistentVolumeClaim |
+| `persistentvolumes` | `pv` | v1 | false | PersistentVolume |
+| `pods` | `po` | v1 | true | Pod |
+| `podtemplates` |  | v1 | true | PodTemplate |
+| `replicationcontrollers` | `rc` | v1 | true | ReplicationController |
+| `resourcequotas` | `quota` | v1 | true | ResourceQuota |
+| `secrets` |  | v1 | true | Secret |
+| `serviceaccounts` | `sa` | v1 | true | ServiceAccount |
+| `services` | `svc` | v1 | true | Service |
+| `mutatingwebhookconfigurations` |  | admissionregistration.k8s.io/v1 | false | MutatingWebhookConfiguration |
+| `validatingwebhookconfigurations` |  | admissionregistration.k8s.io/v1 | false | ValidatingWebhookConfiguration |
+| `customresourcedefinitions` | `crd,crds` | apiextensions.k8s.io/v1 | false | CustomResourceDefinition |
+| `apiservices` |  | apiregistration.k8s.io/v1 | false | APIService |
+| `controllerrevisions` |  | apps/v1 | true | ControllerRevision |
+| `daemonsets` | `ds` | apps/v1 | true | DaemonSet |
+| `deployments` | `deploy` | apps/v1 | true | Deployment |
+| `replicasets` | `rs` | apps/v1 | true | ReplicaSet |
+| `statefulsets` | `sts` | apps/v1 | true | StatefulSet |
+| `tokenreviews` |  | authentication.k8s.io/v1 | false | TokenReview |
+| `localsubjectaccessreviews` |  | authorization.k8s.io/v1 | true | LocalSubjectAccessReview |
+| `selfsubjectaccessreviews` |  | authorization.k8s.io/v1 | false | SelfSubjectAccessReview |
+| `selfsubjectrulesreviews` |  | authorization.k8s.io/v1 | false | SelfSubjectRulesReview |
+| `subjectaccessreviews` |  | authorization.k8s.io/v1 | false | SubjectAccessReview |
+| `horizontalpodautoscalers` | `hpa` | autoscaling/v2 | true | HorizontalPodAutoscaler |
+| `cronjobs` | `cj` | batch/v1 | true | CronJob |
+| `jobs` |  | batch/v1 | true | Job |
+| `certificatesigningrequests` | `csr` | certificates.k8s.io/v1 | false | CertificateSigningRequest |
+| `leases |  | coordination.k8s.io/v1 | rue | Lease |
+| `endpointslices` |  | discovery.k8s.io/v1 | true | EndpointSlice |
+| `events` | `ev` | events.k8s.io/v1 | true | Event |
+| `flowschemas` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |
+| `prioritylevelconfigurations` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | PriorityLevelConfiguration |
+| `ingressclasses` |  | networking.k8s.io/v1 | false | IngressClass |
+| `ingresses` | `ing` | networking.k8s.io/v1 | true | Ingress |
+| `networkpolicies` | `netpol` | networking.k8s.io/v1 | true | NetworkPolicy |
+| `runtimeclasses` |  | node.k8s.io/v1 | false | RuntimeClass |
+| `poddisruptionbudgets` | `pdb` | policy/v1 | true | PodDisruptionBudget |
+| `podsecuritypolicies` | `psp` | policy/v1beta1 | false | PodSecurityPolicy |
+| `clusterrolebindings` |  | rbac.authorization.k8s.io/v1 | false | ClusterRoleBinding |
+| `clusterroles` |  | rbac.authorization.k8s.io/v1 | false | ClusterRole |
+| `rolebindings` |  | rbac.authorization.k8s.io/v1 | true | RoleBinding |
+| `roles` |  | rbac.authorization.k8s.io/v1 | true | Role |
+| `priorityclasses` | `pc` | scheduling.k8s.io/v1 | false | PriorityClass |
+| `csidrivers` |  | storage.k8s.io/v1 | false | CSIDriver |
+| `csinodes` |  | storage.k8s.io/v1 | false | CSINode |
+| `csistoragecapacities` |  | storage.k8s.io/v1 | true | CSIStorageCapacity |
+| `storageclasses` | `sc` | storage.k8s.io/v1 | false | StorageClass |
+| `volumeattachments` |  | storage.k8s.io/v1 | false | VolumeAttachment |
 
 ## Output options
 

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -203,6 +203,8 @@ The following table includes a list of all the supported resource types and thei
 | `events` | `ev` | events.k8s.io/v1 | true | Event |
 | `flowschemas` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |
 | `prioritylevelconfigurations` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | PriorityLevelConfiguration |
+| `nodes` |  | metrics.k8s.io/v1beta1 | false | NodeMetrics |
+| `pods` |  | metrics.k8s.io/v1beta1 | true | PodMetrics |
 | `ingressclasses` |  | networking.k8s.io/v1 | false | IngressClass |
 | `ingresses` | `ing` | networking.k8s.io/v1 | true | Ingress |
 | `networkpolicies` | `netpol` | networking.k8s.io/v1 | true | NetworkPolicy |

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -198,7 +198,7 @@ The following table includes a list of all the supported resource types and thei
 | `cronjobs` | `cj` | batch/v1 | true | CronJob |
 | `jobs` |  | batch/v1 | true | Job |
 | `certificatesigningrequests` | `csr` | certificates.k8s.io/v1 | false | CertificateSigningRequest |
-| `leases |  | coordination.k8s.io/v1 | true | Lease |
+| `leases` |  | coordination.k8s.io/v1 | true | Lease |
 | `endpointslices` |  | discovery.k8s.io/v1 | true | EndpointSlice |
 | `events` | `ev` | events.k8s.io/v1 | true | Event |
 | `flowschemas` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -198,7 +198,7 @@ The following table includes a list of all the supported resource types and thei
 | `cronjobs` | `cj` | batch/v1 | true | CronJob |
 | `jobs` |  | batch/v1 | true | Job |
 | `certificatesigningrequests` | `csr` | certificates.k8s.io/v1 | false | CertificateSigningRequest |
-| `leases |  | coordination.k8s.io/v1 | rue | Lease |
+| `leases |  | coordination.k8s.io/v1 | true | Lease |
 | `endpointslices` |  | discovery.k8s.io/v1 | true | EndpointSlice |
 | `events` | `ev` | events.k8s.io/v1 | true | Event |
 | `flowschemas` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -159,7 +159,7 @@ To learn more about command operations, see the [kubectl](/docs/reference/kubect
 
 The following table includes a list of all the supported resource types and their abbreviated aliases.
 
-(This output can be retrieved from `kubectl api-resources`, and was accurate as of Kubernetes 1.24.3)
+(This output can be retrieved from `kubectl api-resources`, and was accurate as of Kubernetes 1.25.0)
 
 | NAME | SHORTNAMES | APIVERSION | NAMESPACED | KIND |
 |---|---|---|---|---|
@@ -203,8 +203,6 @@ The following table includes a list of all the supported resource types and thei
 | `events` | `ev` | events.k8s.io/v1 | true | Event |
 | `flowschemas` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | FlowSchema |
 | `prioritylevelconfigurations` |  | flowcontrol.apiserver.k8s.io/v1beta2 | false | PriorityLevelConfiguration |
-| `nodes` |  | metrics.k8s.io/v1beta1 | false | NodeMetrics |
-| `pods` |  | metrics.k8s.io/v1beta1 | true | PodMetrics |
 | `ingressclasses` |  | networking.k8s.io/v1 | false | IngressClass |
 | `ingresses` | `ing` | networking.k8s.io/v1 | true | Ingress |
 | `networkpolicies` | `netpol` | networking.k8s.io/v1 | true | NetworkPolicy |


### PR DESCRIPTION
This PR updates the resource types table for the Kubernetes v1.24.3 release.

Closes: #35206 