### PR TITLE
Fix Node affinity example pod

### DIFF
--- a/content/en/examples/pods/pod-with-node-affinity.yaml
+++ b/content/en/examples/pods/pod-with-node-affinity.yaml
@@ -6,13 +6,14 @@ spec:
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
+      - preference:
+          matchExpressions:
           - key: topology.kubernetes.io/zone
             operator: In
             values:
             - antarctica-east1
             - antarctica-west1
+        weight: 5
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
The provided example does not match API.

- `nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` is expected to be an array of `PreferredSchedulingTerm`.
- `nodeSelectorTerms` is the type for the key `preference`.

Reference:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#nodeaffinity-v1-core

Not sure if it needs to be updated for other languages.