### PR TITLE
Update hugo build timeout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,7 +15,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 ignoreFiles = [ "(?:^|/)OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
-timeout = 3000
+timeout = "180s"
 
 # Highlighting config.
 pygmentsCodeFences = true


### PR DESCRIPTION
According to https://gohugo.io/getting-started/configuration/#timeout, the timeout value should be a duration (e.g. `100s`) or number of milliseconds. Current value of 3000 translates to 3 seconds.

This PR updates the timeout in hope it resolves the netlify preview issues that show up frequently during past weeks.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
