### PR TITLE
[zh-cn] updated style-guide & page-content-types

### DIFF
--- a/content/zh-cn/docs/contribute/style/page-content-types.md
+++ b/content/zh-cn/docs/contribute/style/page-content-types.md
@@ -88,7 +88,7 @@ For example, to create a `whatsnext` heading, add the heading shortcode with the
 - seealso
 - options
 
-例如，要创建一个 `whatsnext` 标题，添加 heading 短代码并指定 "whatsnext" 字符串：
+例如，要创建一个 `whatsnext` 标题，添加 `heading` 短代码并指定 "whatsnext" 字符串：
 
 ```none
 ## {{%/* heading "whatsnext" */%}}
@@ -163,16 +163,16 @@ Concept pages are divided into three sections:
 中的 Deployment 对象，解释其作为应用的角色如何部署、扩缩和更新。
 通常，概念页面不需要包含步骤序列，但包含指向任务或教程的链接。
 
-要编写一个新的概念页面，在 `/content/en/docs/concepts` 目录下面的子目录中新建
-一个 Markdown 文件。该文件具有以下特点。
+要编写一个新的概念页面，在 `/content/en/docs/concepts` 目录下面的子目录中新建一个 Markdown 文件。
+该文件具有以下特点。
 
 概念页面分为三个章节：
 
 | 页面章节           |
 |--------------------|
-| overview （概述）  |
-| body (主体）       |
-| whatsnext (接下来）|
+| overview（概述）  |
+| body（正文）      |
+| whatsnext（接下来）|
 
 <!--
 The `overview` and `body` sections appear as comments in the concept page.
@@ -193,13 +193,12 @@ published example of a concept page.
 
 在为每个章节撰写内容时，遵从一些规定：
 
-- 使用二级和三级标题（H2、H3）来组织内容
-- 在 `overview` 节中，使用一段文字来为主体部分铺陈上下文；
+- 使用二级和三级标题（H2、H3）来组织内容；
+- 在 `overview` 节中，使用一段文字概括当前主题的上下文；
 - 在 `body` 节中，详细解释对应概念；
-- 对于 `whatsnext` 节，提供一个项目符号列表（最多 5 个），帮助读者进一步学习掌握概念
+- 对于 `whatsnext` 节，提供一个项目符号列表（最多 5 个），帮助读者进一步学习掌握概念。
 
-[注解](/zh-cn/docs/concepts/overview/working-with-objects/annotations/)页面是一个已经
-上线的概念页面的例子。
+[注解](/zh-cn/docs/concepts/overview/working-with-objects/annotations/)页面是一个已经上线的概念页面的例子。
 
 <!--
 ### Task
@@ -222,19 +221,18 @@ To write a new task page, create a Markdown file in a subdirectory of the
 ### 任务（Task）  {#task}
 
 任务页面讲解如何完成某项工作，通常包含由为数不多的几个步骤组成的序列。
-任务页面的讲解文字很少，不过通常会包含指向概念主题的链接，以便读者
-能够了解相关的背景和知识。
+任务页面的讲解文字很少，不过通常会包含指向概念主题的链接，以便读者能够了解相关的背景和知识。
 
-编写新的任务页面时，在 `/content/en/docs/tasks` 目录下的子目录中创建一个
-新的 Markdown 文件。该文件特点如下。
+编写新的任务页面时，在 `/content/en/docs/tasks` 目录下的子目录中创建一个新的 Markdown 文件。
+该文件特点如下。
 
 | 页面章节                  |
 |---------------------------|
-| overview （概述）         |
-| prerequisites （准备工作）|
-| steps （步骤）            |
-| discussion （讨论）       |
-| whatsnext （接下来）      |
+| overview（概述）         |
+| prerequisites（准备工作）|
+| steps（步骤）            |
+| discussion（讨论）       |
+| whatsnext（接下来）      |
 
 <!--
 The `overview`, `steps`, and `discussion` sections appear as comments in the task page.
@@ -261,17 +259,16 @@ An example of a published task topic is [Using an HTTP proxy to access the Kuber
 
 在每个小节内撰写内容时注意以下规定：
 
-- 最低使用二级标题（H2，标题行前带两个 `#` 字符）。每个小节都会由模版自动给出标题。
-- 在 `overview` 节中，用一个段落为整个任务主体设定语境；
+- 最低使用二级标题（H2，标题行前带两个 `#` 字符）。每个小节都会由模板自动给出标题。
+- 在 `overview` 节中，用一个段落为整个任务主题设定语境；
 - 在 `prerequisites` 节中，尽可能使用项目符号列表。
   额外的环境准备条件要加在 `include` 短代码之后。
   默认的环境准备条件是拥有一个在运行的 Kubernetes 集群。
 - 在 `steps` 节中，使用编号符号列表。
 - 在 `discussion` 节中，使用正常文字内容来对 `steps` 节中内容展开叙述。
-- 在 `whatsnext` 节中，使用项目符号列表（不超过 5 项），列举读者可能接下来有兴趣
-  阅读的主题。
+- 在 `whatsnext` 节中，使用项目符号列表（不超过 5 项），列举读者可能接下来有兴趣阅读的主题。
 
-已上线的任务主题示例之一是[使用 HTTP 代理来访问 Kubernetes API](/zh-cn/docs/tasks/extend-kubernetes/http-proxy-access-api/)。
+已上线的任务主题示例之一是[使用 HTTP 代理访问 Kubernetes API](/zh-cn/docs/tasks/extend-kubernetes/http-proxy-access-api/)。
 
 <!--
 ### Tutorial
@@ -298,21 +295,21 @@ To write a new tutorial page, create a Markdown file in a subdirectory of the
 ### 教程（Tutorial）  {#tutorial}
 
 教程页面描述如果完成一个比单一任务规模更大的目标。通常教程页面会有多个小节，
-每个小节由一系列步骤组成。例如，每个教程可能提供对代码示例的讲解，便于用户
-了解 Kubernetes 的某个功能特性。教程可以包含表面层面的概念解释，对于更深层面
-的概念主题应该使用链接。
+每个小节由一系列步骤组成。例如，每个教程可能提供对代码示例的讲解，
+便于用户了解 Kubernetes 的某个功能特性。教程可以包含表面层面的概念解释，
+对于更深层面的概念主题应该使用链接。
 
 撰写新的教程页面时，在 `/content/en/docs/tutorials` 目录下面的子目录中创建新的
 Markdown 文件。该文件有以下特点。
 
 | 页面节区                  |
 |---------------------------|
-| overview （概述）         |
-| prerequisites （环境准备）|
-| objectives （目标）       |
-| lessoncontent （教程内容）|
-| cleanup （清理工作）      |
-| whatsnext （接下来）      |
+| overview（概述）         |
+| prerequisites（环境准备）|
+| objectives（目标）       |
+| lessoncontent（教程内容）|
+| cleanup（清理工作）      |
+| whatsnext（接下来）      |
 
 <!--
 The `overview`, `objectives`, and `lessoncontent` sections appear as comments in the tutorial page.
@@ -335,7 +332,7 @@ Within each section, write your content. Use the following guidelines:
   interested in reading next.
 
 An example of a published tutorial topic is
-[Running a Stateless Application Using a Deployment](/docs/tutorials/stateless-application/run-stateless-application-deployment/).
+[Running a Stateless Application Using a Deployment](/docs/tasks/run-application/run-stateless-application-deployment/).
 -->
 教程页面的 `overview`、`objectives` 和 `lessoncontent` 小节显示为注释形式。
 你可以使用 `heading` 短代码根据需要添加 `prerequisites`、`cleanup` 和
@@ -343,15 +340,14 @@ An example of a published tutorial topic is
 
 在每个小节中编写内容时，请注意以下规定：
 
-- 最低使用二级标题（H2，标题前面有两个 `#` 字符）。模版会自动为每个小节设置标题。
+- 最低使用二级标题（H2，标题前面有两个 `#` 字符）。模板会自动为每个小节设置标题。
 - 在 `overview` 节中，用一个段落为整个主题设定语境；
 - 在 `prerequisites` 节中，尽可能使用项目符号列表。
   额外的环境准备条件要加在已包含的条件之后。
 - 在 `objectives` 节中，使用项目符号列表。
 - 在 `lessoncontent` 节中，结合使用编号符号列表和叙述性文字。
 - 在 `cleanup` 节中，使用编号符号列表来描述任务结束后清理集群状态所需要的步骤。
-- 在 `whatsnext` 节中，使用项目符号列表（不超过 5 项），列举读者可能接下来有兴趣
-  阅读的主题。
+- 在 `whatsnext` 节中，使用项目符号列表（不超过 5 项），列举读者可能接下来有兴趣阅读的主题。
 
 已发布的教程主题的一个例子是
 [使用 Deployment 运行无状态应用](/zh-cn/docs/tasks/run-application/run-stateless-application-deployment/).
@@ -365,7 +361,7 @@ a Kubernetes component tool. Each page generates from scripts using the componen
 A tool reference page has several possible sections:
 
 | Page section                 |
-|--------------------------------|
+|------------------------------|
 | synopsis                     |
 | options                      |
 | options from parent commands |
@@ -387,11 +383,11 @@ Examples of published tool reference pages are:
 
 | 页面小节        |
 |-----------------|
-| synopsis (用法）|
+| synopsis（用法）|
 | options（选项） |
-| options from parent commands (从父命令集成的选项） |
-| examples （示例）|
-| seealso （参考）|
+| options from parent commands（从父命令集成的选项） |
+| examples（示例）|
+| seealso（参考）|
 
 已发布的工具参考页面示例包括：
 

--- a/content/zh-cn/docs/contribute/style/style-guide.md
+++ b/content/zh-cn/docs/contribute/style/style-guide.md
@@ -29,13 +29,12 @@ discussion.
 这些仅仅是指南而不是规则。
 你可以自行决定，且欢迎使用 PR 来为此文档提供修改意见。
 
-关于为 Kubernetes 文档贡献新内容的更多信息，可以参考
-[文档内容指南](/zh-cn/docs/contribute/style/content-guide/)。
+关于为 Kubernetes 文档贡献新内容的更多信息，
+可以参考[文档内容指南](/zh-cn/docs/contribute/style/content-guide/)。
 
 样式指南的变更是 SIG Docs 团队集体决定。
-如要提议更改或新增条目，请先将其添加到下一次 SIG Docs 例会的
-[议程表](https://bit.ly/sig-docs-agenda)
-上，并按时参加会议讨论。
+如要提议更改或新增条目，请先将其添加到下一次 SIG Docs
+例会的[议程表](https://bit.ly/sig-docs-agenda)上，并按时参加会议讨论。
 
 <!-- body -->
 <!--
@@ -46,7 +45,7 @@ and representing feature state.
 -->
 {{< note >}}
 Kubernetes 文档使用带调整的 [Goldmark Markdown 解释器](https://github.com/yuin/goldmark/)
-和一些 [Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/) 来支持词汇表项、Tab
+和一些 [Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/)来支持词汇表项、Tab
 页以及特性门控标注。
 {{< /note >}}
 
@@ -67,8 +66,7 @@ The English-language documentation uses U.S. English spelling and grammar.
 Kubernetes 文档已经被翻译为多个语种
 （参见 [本地化 READMEs](https://github.com/kubernetes/website/blob/main/README.md#localization-readmemds)）。
 
-为文档提供一种新的语言翻译的途径可以在
-[本地化 Kubernetes 文档](/zh-cn/docs/contribute/localization/)中找到。
+[本地化 Kubernetes 文档](/zh-cn/docs/contribute/localization/)描述了如何为一种新的语言提供本地化文档。
 
 英语文档使用美国英语的拼写和语法。
 
@@ -79,7 +77,7 @@ Kubernetes 文档已经被翻译为多个语种
 
 ### Use upper camel case for API objects
 
-When you refer specifically to interacting with an API object, use [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case), also known as Pascal Case. You may see different capitalization, such as "configMap", in the [API reference](/docs/reference/kubernetes-api/). When writing general documentation, it's better to use upper camel case, calling it "ConfigMap" instead.
+When you refer specifically to interacting with an API object, use [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case), also known as Pascal case. You may see different capitalization, such as "configMap", in the [API Reference](/docs/reference/kubernetes-api/). When writing general documentation, it's better to use upper camel case, calling it "ConfigMap" instead.
 
 When you are generally discussing an API object, use [sentence-style capitalization](https://docs.microsoft.com/en-us/style-guide/text-formatting/using-type/use-sentence-style-capitalization).
 
@@ -89,15 +87,17 @@ The following examples focus on capitalization. For more information about forma
 
 ### 对 API 对象使用大写驼峰式命名法  {#use-upper-camel-case-for-api-objects}
 
-当你与指定的 API 对象进行交互时，使用[大写驼峰式命名法](https://en.wikipedia.org/wiki/Camel_case)，也被称为帕斯卡拼写法（PascalCase）。
-你可能在 [API 参考](/zh-cn/docs/reference/kubernetes-api/)中看到不同的大小写形式，
-例如 "configMap"。在一般性的文档中，最好使用大写驼峰形式，将之称作 "ConfigMap"。
+当你与指定的 API 对象进行交互时，
+使用[大写驼峰式命名法](https://zh.wikipedia.org/wiki/%E9%A7%9D%E5%B3%B0%E5%BC%8F%E5%A4%A7%E5%B0%8F%E5%AF%AB)，
+也被称为帕斯卡拼写法（PascalCase）。
+你可以在 [API 参考](/zh-cn/docs/reference/kubernetes-api/)中看到不同的大小写形式，例如 "configMap"。
+在编写通用文档时，最好使用大写驼峰形式，将之称作 "ConfigMap"。
 
-在一般性地讨论 API 对象时，使用
+通常在讨论 API 对象时，使用
 [句子式大写](https://docs.microsoft.com/en-us/style-guide/text-formatting/using-type/use-sentence-style-capitalization)。
 
-下面的例子关注的是大小写问题。关于如何格式化 API 对象的名称，
-有关详细细节可参考相关的[代码风格](#code-style-inline-code)指南。
+下面的例子关注的是大小写问题。关于如何格式化 API 对象名称的更多信息，
+可参考相关的[代码风格](#code-style-inline-code)指南。
 
 <!--
 {{< table caption = "Do and Don't - Use Pascal case for API objects" >}}
@@ -114,7 +114,7 @@ For managing confidential data, consider using the Secret API. | For managing co
 可以 | 不可以
 :--| :-----
 该 HorizontalPodAutoscaler 负责... | 该 Horizontal pod autoscaler 负责...
-每个 PodList 是一个 Pod 组成的列表。 | 每个 Pod List 是一个由 pods 组成的列表。
+每个 PodList 是一个 Pod 组成的列表。 | 每个 Pod List 是一个由 Pod 组成的列表。
 该 Volume 对象包含一个 `hostPath` 字段。 | 此卷对象包含一个 hostPath 字段。
 每个 ConfigMap 对象都是某个名字空间的一部分。| 每个 configMap 对象是某个名字空间的一部分。
 要管理机密数据，可以考虑使用 Secret API。 | 要管理机密数据，可以考虑使用秘密 API。
@@ -136,15 +136,15 @@ If the namespace of the pod is `default`, you can omit the '-n' parameter.
 -->
 ### 在占位符中使用尖括号
 
-在占位符中使用尖括号，并让读者知道其中代表的事物。例如：
+用尖括号表示占位符，让读者知道占位符表示的是什么。例如：
 
-显示 Pod 信息：
+显示有关 Pod 的信息：
 
 ```shell
-kubectl describe pod <pod-名称> -n <名字空间>
+kubectl describe pod <Pod 名称> -n <名字空间>
 ```
 
-如果名字空间被忽略，默认为 `default`，你可以忽略 '-n' 参数。
+如果名字空间被忽略，默认为 `default`，你可以省略 '-n' 参数。
 
 <!--
 ### Use bold for user interface elements
@@ -158,11 +158,11 @@ Select **Other**. | Select "Other".
 -->
 ### 用粗体字表现用户界面元素
 
-{{< table caption = "粗体界面元素约定" >}}
+{{< table caption = "以粗体表示用户界面元素" >}}
 可以 | 不可以
 :--| :-----
-点击 **Fork**. | 点击 "Fork".
-选择 **Other**. | 选择 "Other".
+点击 **Fork**。 | 点击 "Fork"。
+选择 **Other**。 | 选择 "Other"。
 {{< /table >}}
 
 <!--
@@ -181,8 +181,12 @@ These components form the _control plane_. | These components form the **control
 可以 | 不可以
 :--| :-----
 每个 _集群_  是一组节点 ... | 每个“集群”是一组节点 ...
-这些组件构成了 _控制面_. | 这些组件构成了 **控制面**.
+这些组件构成了 _控制面_。 | 这些组件构成了 **控制面**。
 {{< /table >}}
+
+{{< note >}}
+注意：这一条不适用于中文本地化，中文本地化过程中通常将英文斜体改为粗体。
+{{< /note >}}
 
 <!--
 ### Use code style for filenames, directories, and paths
@@ -257,7 +261,7 @@ Remove trailing spaces in the code. | Add trailing spaces in the code, where the
 {{< table caption = "行间代码、命令和 API 对象约定" >}}
 可以 | 不可以
 :--| :-----
-`kubectl run` 命令会创建一个 `Pod` | "kubectl run" 命令会创建一个 pod。
+`kubectl run` 命令会创建一个 `Pod` | "kubectl run" 命令会创建一个 Pod。
 每个节点上的 kubelet 都会获得一个 `Lease` | 每个节点上的 kubelet 都会获得一个 lease…
 一个 `PersistentVolume` 代表持久存储 | 一个 Persistent Volume 代表持久存储…
 在声明式管理中，使用 `kubectl apply`。 | 在声明式管理中，使用 "kubectl apply"。
@@ -315,7 +319,7 @@ Run the process with the certificate, `kube-apiserver --client-ca-file=FILENAME`
 :--| :-----
 `kubelet` 维持节点稳定性。 | kubelet 负责维护节点稳定性。
 `kubectl` 处理 API 服务器的定位和身份认证。| kubectl 处理 API 服务器的定位和身份认证。
-使用该证书运行进程 `kube-apiserver --client-ca-file=FILENAME`. | 使用证书运行进程 kube-apiserver --client-ca-file=FILENAME. |
+使用该证书运行进程 `kube-apiserver --client-ca-file=FILENAME`。| 使用证书运行进程 kube-apiserver --client-ca-file=FILENAME。|
 {{< /table >}}
 
 <!--
@@ -352,8 +356,8 @@ Aggregated APIs are subordinate API servers. | Aggregated APIs are subordinate A
 {{< table caption = "组件名称与通用描述" >}}
 可以 | 不可以
 :--| :-----
-Kubernetes API 服务器提供 OpenAPI 规范。| apiserver 提供 OpenAPI 规范 
-聚合 APIs 是下级 API 服务器。 | 聚合 APIs 是下级 APIServers。
+Kubernetes API 服务器提供 OpenAPI 规范。| apiserver 提供 OpenAPI 规范。
+聚合 API 是下级 API 服务器。 | 聚合 API 是下级 APIServer。
 {{< /table >}}
 
 <!--
@@ -377,8 +381,8 @@ Set the value of the `replicas` field to 2. | Set the value of the `replicas` fi
 可以 | 不可以
 :--| :-----
 将 `imagePullPolicy` 设置为 Always。 | 将 `imagePullPolicy` 设置为 "Always"。
-将 `image` 设置为 nginx:1.16. | 将 `image` 设置为 `nginx:1.16`。
-将 `replicas` 字段值设置为 2. | 将 `replicas` 字段值设置为 `2`.
+将 `image` 设置为 nginx:1.16。 | 将 `image` 设置为 `nginx:1.16`。
+将 `replicas` 字段值设置为 2。 | 将 `replicas` 字段值设置为 `2`。
 {{< /table >}}
 
 <!--
@@ -522,8 +526,8 @@ To specify the Kubernetes version for a task or tutorial page, include `min-kube
 代码示例或者配置示例如果包含版本信息，应该与对应的文字描述一致。
 
 如果所给的信息是特定于具体版本的，需要在
-[任务模版](/zh-cn/docs/contribute/style/page-content-types/#task)
-或[教程模版](/zh-cn/docs/contribute/style/page-content-types/#tutorial)
+[任务模板](/zh-cn/docs/contribute/style/page-content-types/#task)
+或[教程模板](/zh-cn/docs/contribute/style/page-content-types/#tutorial)
 的 `prerequisites` 小节定义 Kubernetes 版本。
 页面保存之后，`prerequisites` 小节会显示为 **开始之前**。
 
@@ -622,7 +626,6 @@ Hugo [Shortcodes](https://gohugo.io/content-management/shortcodes) help create d
    The prefix you choose is the same text for the tag.
    {{< /note >}}
 -->
-
 ## 短代码（Shortcodes） {#shortcodes}
 
 Hugo [短代码（Shortcodes）](https://gohugo.io/content-management/shortcodes)
@@ -975,7 +978,7 @@ Use sentence case for headings. For example, **Extend kubectl with plugins** | U
 {{< table caption = "标题约定" >}}
 可以 | 不可以
 :--| :-----
-更新页面或博客在前言部分中的标题 | 使用一级标题。因为 Hugo 会自动将页面前言部分的标题转化为一级标题。
+更新页面或博客在前言部分中的标题。 | 使用一级标题。因为 Hugo 会自动将页面前言部分的标题转化为一级标题。
 使用编号的标题以便内容组织有一个更有意义的结构。| 使用四级到六级标题，除非非常有必要这样。如果你要编写的内容有非常多细节，可以尝试拆分成多个不同页面。
 在非博客内容页面中使用井号（`#`）| 使用下划线 `---` 或 `===` 来标记一级标题。
 使用正常大小写来标示标题。例如：**Extend kubectl with plugins** | 使用首字母大写来标示标题。例如：**Extend Kubectl With Plugins**
@@ -994,9 +997,9 @@ Use three hyphens (`---`) to create a horizontal rule. Use horizontal rules for 
 ### 段落    {#paragraphs}
 
 {{< table caption = "段落约定" >}}
-可以 | 不可以 
+可以 | 不可以
 :--| :-----
-尝试不要让段落超出 6 句话。 | 用空格来缩进第一段。例如，⋅⋅⋅段落前面的三个空格会将其缩进。
+尝试不要让段落超出 6 句话。 | 用空格来缩进第一段。例如，段落前面的三个空格⋅⋅⋅会将段落缩进。
 使用三个连字符（`---`）来创建水平线。使用水平线来分隔段落内容。例如，在故事中切换场景或者在上下文中切换主题。 | 使用水平线来装饰页面。
 {{< /table >}}
 
@@ -1014,8 +1017,8 @@ Write Markdown-style links: `[link text](URL)`. For example: `[Hugo shortcodes](
 {{< table caption = "链接约定" >}}
 可以 | 不可以
 :--| :-----
-插入超级链接时给出它们所链接到的目标内容的上下文。例如：你的机器上某些端口处于开放状态。参见<a href="#check-required-ports">检查所需端口</a>了解更详细信息。| 使用有二义性的术语，如“点击这里”。例如：你的机器上某些端口处于打开状态。参见<a href="#check-required-ports">这里</a>了解详细信息。
-编写 Markdown 风格的链接：`[链接文本](URL)`。例如：`[Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/#table-captions)`，输出是[Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/#table-captions). | 编写 HTML 风格的超级链接：`<a href="/media/examples/link-element-example.css" target="_blank">访问我们的教程！</a>`，或者创建会打开新 Tab 页或新窗口的链接。例如：`[网站示例](https://example.com){target="_blank"}`。
+插入超级链接时给出它们所链接到的目标内容的上下文。例如：你的机器上某些端口处于开放状态。参见<a href="#check-required-ports">检查所需端口</a>了解更详细信息。| 使用“点击这里”等模糊的词语。例如：你的机器上某些端口处于打开状态。参见<a href="#check-required-ports">这里</a>了解详细信息。
+编写 Markdown 风格的链接：`[链接文本](URL)`。例如：`[Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/#table-captions)`，输出是 [Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/#table-captions)。 | 编写 HTML 风格的超级链接：`<a href="/media/examples/link-element-example.css" target="_blank">访问我们的教程！</a>`，或者创建会打开新 Tab 页签或新窗口的链接。例如：`[网站示例](https://example.com){target="_blank"}`。
 {{< /table >}}
 
 <!--
@@ -1054,11 +1057,11 @@ Website navigation links can also be marked up as list items; after all they are
 
 - List items may consist of multiple paragraphs. Each subsequent paragraph in a list item must be indented by either four spaces or one tab.
 -->
-- 在编号列表中，使用数字 1（`1.`）
+- 在编号列表中，使用数字 1（`1.`）。
 
-- 对非排序列表，使用加号（`+`）、星号（`*`）、或者减号（`-`）
+- 对非排序列表，使用加号（`+`）、星号（`*`）、或者减号（`-`）。
 
-- 在每个列表之后留一个空行
+- 在每个列表之后留一个空行。
 
 - 对于嵌套的列表，相对缩进四个空格（例如，⋅⋅⋅⋅）。
 
@@ -1078,8 +1081,7 @@ The semantic purpose of a data table is to present tabular data. Sighted users c
 表格标题可以用来给数据表提供一个描述性的标题。
 辅助技术使用 HTML 表格标题元素来在页面结构中辨识表格内容。
 
-- 请 [Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/#table-captions)
-  为表格添加标题。
+- 使用 [Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/#table-captions)为表格添加标题。
 
 <!--
 ## Content best practices
@@ -1153,7 +1155,7 @@ View the pods. | With this next command, we'll view the Pods.
 :--| :-----
 要创建 ReplicaSet，... | 如果你想要创建 ReplicaSet，...
 参看配置文件。 | 请自行查看配置文件。
-查看 Pods。| 使用下面的命令，我们将会看到 Pods。
+查看 Pod。| 使用下面的命令，我们将会看到 Pod。
 {{< /table >}}  
 
 <!--
@@ -1193,11 +1195,11 @@ Exception: Use "etc." for et cetera.
 尽可能使用英语而不是拉丁语缩写。
 
 {{< table caption = "避免拉丁语短语" >}}
-可以 | 不可以 
+可以 | 不可以
 :--| :-----
 例如，... | e.g., ...
 也就是说，...| i.e., ...
-{{< /table >}}   
+{{< /table >}}
 
 例外：使用 etc. 表示等等。
 
@@ -1228,8 +1230,8 @@ This page teaches you how to use pods. | In this page, we are going to learn abo
 :--| :-----
 版本 1.4 包含了 ... | 在 1.4 版本中，我们添加了 ...
 Kubernetes 为 ... 提供了一项新功能。 | 我们提供了一项新功能...
-本页面教你如何使用 Pods。| 在本页中，我们将会学到如何使用 Pods。
-{{< /table >}}   
+本页面教你如何使用 Pod。| 在本页中，我们将会学到如何使用 Pod。
+{{< /table >}}
 
 <!--
 ### Avoid jargon and idioms
@@ -1253,7 +1255,7 @@ Create a new cluster. | Turn up a new cluster.
 :--| :-----
 Internally, ... | Under the hood, ...
 Create a new cluster. | Turn up a new cluster.
-{{< /table >}}   
+{{< /table >}}
 
 <!--
 ### Avoid statements about the future
@@ -1268,12 +1270,11 @@ is the [Deprecated API migration guide](/docs/reference/using-api/deprecation-gu
 -->
 ### 避免关于将来的陈述
 
-要避免对将来作出承诺或暗示。如果你需要讨论的是 Alpha 功能特性，可以将相关文字
-放在一个单独的标题下，标示为 alpha 版本信息。
+要避免对将来作出承诺或暗示。如果你需要讨论的是 Alpha 功能特性，
+可以将相关文字放在一个单独的标题下，标示为 Alpha 版本信息。
 
 此规则的一个例外是对未来版本中计划移除的已废弃功能选项的文档。
-此类文档的例子之一是
-[已弃用 API 迁移指南](/docs/reference/using-api/deprecation-guide/)。
+此类文档的例子之一是[已弃用 API 迁移指南](/zh-cn/docs/reference/using-api/deprecation-guide/)。
 
 <!--
 ### Avoid statements that will soon be out of date
@@ -1294,7 +1295,7 @@ The Federation feature provides ... | The new Federation feature provides ...
 今天而言是新的功能，过了几个月之后就不再是新的了。
 
 {{< table caption = "避免使用很快过时的表达" >}}
-可以 | 不可以 
+可以 | 不可以
 :--| :-----
 在版本 1.4 中，... | 在当前版本中，...
 联邦功能特性提供 ... | 新的联邦功能特性提供 ...
@@ -1330,6 +1331,11 @@ These steps ... | These simple steps ...
 
 ## {{% heading "whatsnext" %}}
 
+<!--
+* Learn about [writing a new topic](/docs/contribute/style/write-new-topic/).
+* Learn about [using page templates](/docs/contribute/style/page-content-types/).
+* Learn about [creating a pull request](/docs/contribute/new-content/open-a-pr/).
+-->
 * 了解[编写新主题](/zh-cn/docs/contribute/style/write-new-topic/)。
 * 了解[页面内容类型](/zh-cn/docs/contribute/style/page-content-types/)。
 * 了解[发起 PR](/zh-cn/docs/contribute/new-content/open-a-pr/)。


### PR DESCRIPTION
Updated two files:
```
content/zh-cn/docs/contribute/style/page-content-types.md
content/zh-cn/docs/contribute/style/style-guide.md
```
Preview: https://deploy-preview-35782--kubernetes-io-main-staging.netlify.app/zh-cn/docs/contribute/style/page-content-types/