### PR TITLE
zh-cn: update Pod Lifecycle doc section header

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/garbage-collection.md
+++ b/content/zh-cn/docs/concepts/architecture/garbage-collection.md
@@ -20,7 +20,7 @@ allows the clean up of resources like the following:
 垃圾收集允许系统清理如下资源：
 
 <!--
-* [Failed pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
+* [Terminated pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
 * [Completed Jobs](/docs/concepts/workloads/controllers/ttlafterfinished/)
 * [Objects without owner references](#owners-dependents)
 * [Unused containers and container images](#containers-images)
@@ -32,7 +32,7 @@ allows the clean up of resources like the following:
     manager
 * [Node Lease objects](/docs/concepts/architecture/nodes/#heartbeats)
 -->
-* [失败的 Pod](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
+* [终止的 Pod](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
 * [已完成的 Job](/zh-cn/docs/concepts/workloads/controllers/ttlafterfinished/)
 * [不再存在属主引用的对象](#owners-dependents)
 * [未使用的容器和容器镜像](#containers-images)
@@ -357,4 +357,3 @@ configure garbage collection:
 * 进一步了解 Kubernetes [finalizers](/zh-cn/docs/concepts/overview/working-with-objects/finalizers/)。
 * 进一步了解 [TTL 控制器](/zh-cn/docs/concepts/workloads/controllers/ttlafterfinished/) (beta)，
   该控制器负责清理已完成的 Job。
-

--- a/content/zh-cn/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -878,7 +878,7 @@ API 服务器直接删除 Pod 对象，这样新的与之同名的 Pod 即可以
 的任务文档。
 
 <!--
-### Garbage collection of failed Pods {#pod-garbage-collection}
+### Garbage collection of terminated Pods {#pod-garbage-collection}
 
 For failed Pods, the API objects remain in the cluster's API until a human or
 {{< glossary_tooltip term_id="controller" text="controller" >}} process
@@ -889,7 +889,7 @@ The control plane cleans up terminated Pods (with a phase of `Succeeded` or
 (determined by `terminated-pod-gc-threshold` in the kube-controller-manager).
 This avoids a resource leak as Pods are created and terminated over time.
 -->
-### 失效 Pod 的垃圾收集    {#pod-garbage-collection}
+### 已终止 Pod 的垃圾收集    {#pod-garbage-collection}
 
 对于已失败的 Pod 而言，对应的 API 对象仍然会保留在集群的 API 服务器上，直到
 用户或者{{< glossary_tooltip term_id="controller" text="控制器" >}}进程显式地
@@ -920,4 +920,3 @@ This avoids a resource leak as Pods are created and terminated over time.
 * 进一步了解[容器生命周期回调](/zh-cn/docs/concepts/containers/container-lifecycle-hooks/)。
 * 关于 API 中定义的有关 Pod 和容器状态的详细规范信息，
   可参阅 API 参考文档中 Pod 的 [`.status`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) 字段。
-


### PR DESCRIPTION
to be more accurate. It currently says failed,
but then following paragraph includes `Succeeded`.
It seems like replacing "failed" with "terminated" is more accurate.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
