### PR TITLE
Update docs to reference new container image registry

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -566,7 +566,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       envFrom:
       - secretRef:
@@ -794,7 +794,7 @@ spec:
       secretName: dotfile-secret
   containers:
   - name: dotfile-test-container
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/busybox
     command:
     - ls
     - "-l"

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -68,7 +68,7 @@ metadata:
 spec:
   containers:
     - name: demo-container-1
-      image: k8s.gcr.io/pause:2.0
+      image: registry.k8s.io/pause:2.0
       resources:
         limits:
           hardware-vendor.example/foo: 2

--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -124,7 +124,7 @@ metadata:
 spec:
   containers:
     - name: cuda-test
-      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      image: "registry.k8s.io/cuda-vector-add:v0.1"
       resources:
         limits:
           nvidia.com/gpu: 1

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -166,7 +166,7 @@ spec:
       path: /any/path/it/will/be/replaced
   containers:
   - name: pv-recycler
-    image: "k8s.gcr.io/busybox"
+    image: "registry.k8s.io/busybox"
     command: ["/bin/sh", "-c", "test -e /scrub && rm -rf /scrub/..?* /scrub/.[!.]* /scrub/*  && test -z \"$(ls -A /scrub)\" || exit 1"]
     volumeMounts:
     - name: vol

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -104,7 +104,7 @@ metadata:
   name: test-ebs
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-ebs
@@ -225,7 +225,7 @@ metadata:
   name: test-cinder
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-cinder-container
     volumeMounts:
     - mountPath: /test-cinder
@@ -357,7 +357,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /cache
@@ -427,7 +427,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-pd
@@ -611,7 +611,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-pd
@@ -642,7 +642,7 @@ metadata:
 spec:
   containers:
   - name: test-webserver
-    image: k8s.gcr.io/test-webserver:latest
+    image: registry.k8s.io/test-webserver:latest
     volumeMounts:
     - mountPath: /var/local/aaa
       name: mydir
@@ -798,7 +798,7 @@ metadata:
   name: test-portworx-volume-pod
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /mnt

--- a/content/en/docs/concepts/windows/intro.md
+++ b/content/en/docs/concepts/windows/intro.md
@@ -283,7 +283,7 @@ network port spaces). Kubernetes uses pause containers to allow for worker conta
 crashing or restarting without losing any of the networking configuration.
 
 Kubernetes maintains a multi-architecture image that includes support for Windows.
-For Kubernetes v{{< skew currentVersion >}} the recommended pause image is `k8s.gcr.io/pause:3.6`.
+For Kubernetes v{{< skew currentVersion >}} the recommended pause image is `registry.k8s.io/pause:3.6`.
 The [source code](https://github.com/kubernetes/kubernetes/tree/master/build/pause)
 is available on GitHub.
 

--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -94,7 +94,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -849,7 +849,7 @@ WindowsHostProcessContainers=true|false (BETA - default=true)<br/>
 </tr>
 
 <tr>
-<td colspan="2">--pod-infra-container-image string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: <code>k8s.gcr.io/pause:3.6</code></td>
+<td colspan="2">--pod-infra-container-image string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: <code>registry.k8s.io/pause:3.6</code></td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">Specified image will not be pruned by the image garbage collector. When container-runtime is set to <code>docker</code>, all containers in each pod will use the network/IPC namespaces from this image. Other CRI implementations have their own configuration to set this image.</td>

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta2.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta2.md
@@ -159,7 +159,7 @@ configuration types to be used during a <code>kubeadm init</code> run.</p>
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># one of local or external</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">local</span>:<span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageTag</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;3.2.24&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">dataDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/lib/etcd&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
@@ -213,7 +213,7 @@ configuration types to be used during a <code>kubeadm init</code> run.</p>
 </span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
 </span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificatesDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/kubernetes/pki&#34;</span><span style="color:#bbb">
-</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">useHyperKubeImage</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">clusterName</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;example-cluster&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span>---<span style="color:#bbb">
@@ -349,10 +349,10 @@ could be used for assigning a stable DNS to the control plane.</li>
 </td>
 <td>
    <p><code>imageRepository</code> sets the container registry to pull images from.
-If empty, <code>k8s.gcr.io</code> will be used by default; in case of kubernetes version is
+If empty, <code>registry.k8s.io</code> will be used by default; in case of kubernetes version is
 a CI build (kubernetes version starts with <code>ci/</code>) <code>gcr.io/k8s-staging-ci-images</code>
 is used as a default for control plane components and for kube-proxy, while
-<code>k8s.gcr.io</code> will be used for all the other images.</p>
+<code>registry.k8s.io</code> will be used for all the other images.</p>
 </td>
 </tr>
 <tr><td><code>useHyperKubeImage</code> <B>[Required]</B><br/>

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -171,7 +171,7 @@ configuration types to be used during a <code>kubeadm init</code> run.</p>
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># one of local or external</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">local</span>:<span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageTag</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;3.2.24&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">dataDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/lib/etcd&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
@@ -225,7 +225,7 @@ configuration types to be used during a <code>kubeadm init</code> run.</p>
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificatesDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/kubernetes/pki&#34;</span><span style="color:#bbb">
-</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">clusterName</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;example-cluster&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span>---<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
@@ -359,10 +359,10 @@ be used for assigning a stable DNS to the control plane.</li>
 </td>
 <td>
    <p><code>imageRepository</code> sets the container registry to pull images from.
-If empty, <code>k8s.gcr.io</code> will be used by default.
+If empty, <code>registry.k8s.io</code> will be used by default.
 In case of kubernetes version is a CI build (kubernetes version starts with <code>ci/</code>)
 <code>gcr.io/k8s-staging-ci-images</code> will be used as a default for control plane components
-and for kube-proxy, while <code>k8s.gcr.io</code> will be used for all the other images.</p>
+and for kube-proxy, while <code>registry.k8s.io</code> will be used for all the other images.</p>
 </td>
 </tr>
 <tr><td><code>featureGates</code><br/>

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -439,8 +439,8 @@ kubectl get pods -A -o=custom-columns='DATA:spec.containers[*].image'
 # All images running in namespace: default, grouped by Pod
 kubectl get pods --namespace default --output=custom-columns="NAME:.metadata.name,IMAGE:.spec.containers[*].image"
 
- # All images excluding "k8s.gcr.io/coredns:1.6.2"
-kubectl get pods -A -o=custom-columns='DATA:spec.containers[?(@.image!="k8s.gcr.io/coredns:1.6.2")].image'
+ # All images excluding "registry.k8s.io/coredns:1.6.2"
+kubectl get pods -A -o=custom-columns='DATA:spec.containers[?(@.image!="registry.k8s.io/coredns:1.6.2")].image'
 
 # All fields under metadata regardless of name
 kubectl get pods -A -o=custom-columns='DATA:metadata.*'

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
@@ -356,7 +356,7 @@ NodeStatus is information about the current status of a node.
 
   - **images.names** ([]string)
 
-    Names by which this image is known. e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+    Names by which this image is known. e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 
   - **images.sizeBytes** (int64)
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
@@ -66,7 +66,7 @@ kubeadm config images list [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
@@ -59,7 +59,7 @@ kubeadm config images pull [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init.md
@@ -156,7 +156,7 @@ kubeadm init [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_addon_all.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_addon_all.md
@@ -73,7 +73,7 @@ kubeadm init phase addon all [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_addon_coredns.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_addon_coredns.md
@@ -52,7 +52,7 @@ kubeadm init phase addon coredns [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_addon_kube-proxy.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_addon_kube-proxy.md
@@ -66,7 +66,7 @@ kubeadm init phase addon kube-proxy [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
@@ -112,7 +112,7 @@ kubeadm init phase control-plane all [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
@@ -94,7 +94,7 @@ kubeadm init phase control-plane apiserver [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
@@ -66,7 +66,7 @@ kubeadm init phase control-plane controller-manager [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
@@ -59,7 +59,7 @@ kubeadm init phase control-plane scheduler [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_etcd_local.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_etcd_local.md
@@ -64,7 +64,7 @@ kubeadm init phase etcd local [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Choose a container registry to pull control plane images from</p></td>

--- a/content/en/docs/setup/best-practices/node-conformance.md
+++ b/content/en/docs/setup/best-practices/node-conformance.md
@@ -40,7 +40,7 @@ To run the node conformance test, perform the following steps:
 # $LOG_DIR is the test output path.
 sudo docker run -it --rm --privileged --net=host \
   -v /:/rootfs -v $CONFIG_DIR:$CONFIG_DIR -v $LOG_DIR:/var/result \
-  k8s.gcr.io/node-test:0.2
+  registry.k8s.io/node-test:0.2
 ```
 
 ## Running Node Conformance Test for Other Architectures
@@ -63,7 +63,7 @@ regular expression of tests you want to run.
 sudo docker run -it --rm --privileged --net=host \
   -v /:/rootfs:ro -v $CONFIG_DIR:$CONFIG_DIR -v $LOG_DIR:/var/result \
   -e FOCUS=MirrorPod \ # Only run MirrorPod test
-  k8s.gcr.io/node-test:0.2
+  registry.k8s.io/node-test:0.2
 ```
 
 To skip specific tests, overwrite the environment variable `SKIP` with the
@@ -73,7 +73,7 @@ regular expression of tests you want to skip.
 sudo docker run -it --rm --privileged --net=host \
   -v /:/rootfs:ro -v $CONFIG_DIR:$CONFIG_DIR -v $LOG_DIR:/var/result \
   -e SKIP=MirrorPod \ # Run all conformance tests but skip MirrorPod test
-  k8s.gcr.io/node-test:0.2
+  registry.k8s.io/node-test:0.2
 ```
 
 Node conformance test is a containerized version of [node e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/e2e-node-tests.md).

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -235,7 +235,7 @@ sandbox image by setting the following config:
 
 ```toml
 [plugins."io.containerd.grpc.v1.cri"]
-  sandbox_image = "k8s.gcr.io/pause:3.2"
+  sandbox_image = "registry.k8s.io/pause:3.2"
 ```
 
 You might need to restart `containerd` as well once you've updated the config file: `systemctl restart containerd`.

--- a/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -269,7 +269,7 @@ kubectl get pods
 Production likes to run cattle, so let's create some cattle pods.
 
 ```shell
-kubectl create deployment cattle --image=k8s.gcr.io/serve_hostname --replicas=5
+kubectl create deployment cattle --image=registry.k8s.io/serve_hostname --replicas=5
 
 kubectl get deployment
 ```

--- a/content/en/docs/tasks/administer-cluster/namespaces.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces.md
@@ -195,7 +195,7 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
     To demonstrate this, let's spin up a simple Deployment and Pods in the `development` namespace.
 
     ```shell
-    kubectl create deployment snowflake --image=k8s.gcr.io/serve_hostname  -n=development --replicas=2
+    kubectl create deployment snowflake --image=registry.k8s.io/serve_hostname  -n=development --replicas=2
     ```
     We have created a deployment whose replica size is 2 that is running the pod called `snowflake` with a basic container that serves the hostname.
 
@@ -229,7 +229,7 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
     Production likes to run cattle, so let's create some cattle pods.
 
     ```shell
-    kubectl create deployment cattle --image=k8s.gcr.io/serve_hostname -n=production
+    kubectl create deployment cattle --image=registry.k8s.io/serve_hostname -n=production
     kubectl scale deployment cattle --replicas=5 -n=production
 
     kubectl get deployment -n=production

--- a/content/en/docs/tasks/administer-cluster/verify-signed-images.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-images.md
@@ -28,7 +28,7 @@ Let's pick one image from this list and verify its signature using
 the `cosign verify` command:
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify k8s.gcr.io/kube-apiserver-amd64:v1.24.0
+COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/kube-apiserver-amd64:v1.24.0
 ```
 
 {{< note >}}
@@ -42,7 +42,7 @@ in `KEYLESS` mode. To learn more about keyless signing, please refer to
 To verify all signed control plane images, please run this command:
 
 ```shell
-curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release | grep 'PackageName: k8s.gcr.io/' | awk '{print $2}' > images.txt
+curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release | grep 'PackageName: registry.k8s.io/' | awk '{print $2}' > images.txt
 input=images.txt
 while IFS= read -r image
 do

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -43,7 +43,7 @@ broken states, and cannot recover except by being restarted. Kubernetes provides
 liveness probes to detect and remedy such situations.
 
 In this exercise, you create a Pod that runs a container based on the
-`k8s.gcr.io/busybox` image. Here is the configuration file for the Pod:
+`registry.k8s.io/busybox` image. Here is the configuration file for the Pod:
 
 {{< codenew file="pods/probe/exec-liveness.yaml" >}}
 
@@ -84,8 +84,8 @@ The output indicates that no liveness probes have failed yet:
 Type    Reason     Age   From               Message
   ----    ------     ----  ----               -------
   Normal  Scheduled  11s   default-scheduler  Successfully assigned default/liveness-exec to node01
-  Normal  Pulling    9s    kubelet, node01    Pulling image "k8s.gcr.io/busybox"
-  Normal  Pulled     7s    kubelet, node01    Successfully pulled image "k8s.gcr.io/busybox"
+  Normal  Pulling    9s    kubelet, node01    Pulling image "registry.k8s.io/busybox"
+  Normal  Pulled     7s    kubelet, node01    Successfully pulled image "registry.k8s.io/busybox"
   Normal  Created    7s    kubelet, node01    Created container liveness
   Normal  Started    7s    kubelet, node01    Started container liveness
 ```
@@ -103,8 +103,8 @@ probes have failed, and the failed containers have been killed and recreated.
   Type     Reason     Age                From               Message
   ----     ------     ----               ----               -------
   Normal   Scheduled  57s                default-scheduler  Successfully assigned default/liveness-exec to node01
-  Normal   Pulling    55s                kubelet, node01    Pulling image "k8s.gcr.io/busybox"
-  Normal   Pulled     53s                kubelet, node01    Successfully pulled image "k8s.gcr.io/busybox"
+  Normal   Pulling    55s                kubelet, node01    Pulling image "registry.k8s.io/busybox"
+  Normal   Pulled     53s                kubelet, node01    Successfully pulled image "registry.k8s.io/busybox"
   Normal   Created    53s                kubelet, node01    Created container liveness
   Normal   Started    53s                kubelet, node01    Started container liveness
   Warning  Unhealthy  10s (x3 over 20s)  kubelet, node01    Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory
@@ -127,7 +127,7 @@ liveness-exec   1/1       Running   1          1m
 ## Define a liveness HTTP request
 
 Another kind of liveness probe uses an HTTP GET request. Here is the configuration
-file for a Pod that runs a container based on the `k8s.gcr.io/liveness`
+file for a Pod that runs a container based on the `registry.k8s.io/liveness`
 image.
 
 {{< codenew file="pods/probe/http-liveness.yaml" >}}

--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -98,7 +98,7 @@ you need is an existing `docker-compose.yml` file.
    services:
 
      redis-master:
-       image: k8s.gcr.io/redis:e2e
+       image: registry.k8s.io/redis:e2e
        ports:
          - "6379"
 

--- a/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -392,7 +392,7 @@ You can use the `kubectl debug` command to add ephemeral containers to a
 running Pod. First, create a pod for the example:
 
 ```shell
-kubectl run ephemeral-demo --image=k8s.gcr.io/pause:3.1 --restart=Never
+kubectl run ephemeral-demo --image=registry.k8s.io/pause:3.1 --restart=Never
 ```
 
 The examples in this section use the `pause` container image because it does not

--- a/content/en/docs/tasks/debug/debug-application/debug-service.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-service.md
@@ -43,7 +43,7 @@ probably debugging your own Service you can substitute your own details, or you
 can follow along and get a second data point.
 
 ```shell
-kubectl create deployment hostnames --image=k8s.gcr.io/serve_hostname
+kubectl create deployment hostnames --image=registry.k8s.io/serve_hostname
 ```
 ```none
 deployment.apps/hostnames created
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: hostnames
-        image: k8s.gcr.io/serve_hostname
+        image: registry.k8s.io/serve_hostname
 ```
 
 The label "app" is automatically set by `kubectl create deployment` to the name of the

--- a/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -63,7 +63,7 @@ spec:
   containers:
     - name: cuda-vector-add
       # https://github.com/kubernetes/kubernetes/blob/v1.7.11/test/images/nvidia-cuda/Dockerfile
-      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      image: "registry.k8s.io/cuda-vector-add:v0.1"
       resources:
         limits:
           nvidia.com/gpu: 1 # requesting 1 GPU
@@ -206,7 +206,7 @@ spec:
   containers:
     - name: cuda-vector-add
       # https://github.com/kubernetes/kubernetes/blob/v1.7.11/test/images/nvidia-cuda/Dockerfile
-      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      image: "registry.k8s.io/cuda-vector-add:v0.1"
       resources:
         limits:
           nvidia.com/gpu: 1

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -94,7 +94,7 @@ recommended way to manage the creation and scaling of Pods.
 Pod runs a Container based on the provided Docker image.
 
     ```shell
-    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
+    kubectl create deployment hello-node --image=registry.k8s.io/echoserver:1.4
     ```
 
 2. View the Deployment:
@@ -155,7 +155,7 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
     The `--type=LoadBalancer` flag indicates that you want to expose your Service
     outside of the cluster.
     
-    The application code inside the image `k8s.gcr.io/echoserver` only listens on TCP port 8080. If you used
+    The application code inside the image `registry.k8s.io/echoserver` only listens on TCP port 8080. If you used
     `kubectl expose` to expose a different port, clients could not connect to that other port.
 
 2. View the Service you created:

--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -48,7 +48,7 @@ The examples use a small nginx webserver that echoes back the source
 IP of requests it receives through an HTTP header. You can create it as follows:
 
 ```shell
-kubectl create deployment source-ip-app --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.4
 ```
 The output is:
 ```

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -606,9 +606,9 @@ Get the Pods to view their container images:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
-k8s.gcr.io/nginx-slim:0.8
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 
 ```
 
@@ -638,7 +638,7 @@ statefulset.apps/web patched
 Patch the StatefulSet again to change the container's image:
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"k8s.gcr.io/nginx-slim:0.7"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.7"}]'
 ```
 ```
 statefulset.apps/web patched
@@ -672,7 +672,7 @@ Get the Pod's container image:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 Notice that, even though the update strategy is `RollingUpdate` the StatefulSet
@@ -713,7 +713,7 @@ Get the Pod's container:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
 
 ```
 
@@ -756,7 +756,7 @@ Get the `web-1` Pod's container image:
 kubectl get pod web-1 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 `web-1` was restored to its original configuration because the Pod's ordinal
@@ -813,9 +813,9 @@ Get the container image details for the Pods in the StatefulSet:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-k8s.gcr.io/nginx-slim:0.7
-k8s.gcr.io/nginx-slim:0.7
-k8s.gcr.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
 ```
 
 By moving the `partition` to `0`, you allowed the StatefulSet to

--- a/content/en/examples/admin/cloud/ccm-example.yaml
+++ b/content/en/examples/admin/cloud/ccm-example.yaml
@@ -42,9 +42,9 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
       - name: cloud-controller-manager
-        # for in-tree providers we use k8s.gcr.io/cloud-controller-manager
+        # for in-tree providers we use registry.k8s.io/cloud-controller-manager
         # this can be replaced with any other image for out-of-tree providers
-        image: k8s.gcr.io/cloud-controller-manager:v1.8.0
+        image: registry.k8s.io/cloud-controller-manager:v1.8.0
         command:
         - /usr/local/bin/cloud-controller-manager
         - --cloud-provider=[YOUR_CLOUD_PROVIDER]  # Add your own cloud provider here!

--- a/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
+++ b/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
@@ -65,7 +65,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.4
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.4
         resources:
             requests:
                 cpu: "20m"

--- a/content/en/examples/admin/dns/dnsutils.yaml
+++ b/content/en/examples/admin/dns/dnsutils.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
+    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
     command:
       - sleep
       - "3600"

--- a/content/en/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
+++ b/content/en/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
@@ -22,7 +22,7 @@ spec:
     - name: varlog
       mountPath: /var/log
   - name: count-agent
-    image: k8s.gcr.io/fluentd-gcp:1.30
+    image: registry.k8s.io/fluentd-gcp:1.30
     env:
     - name: FLUENTD_ARGS
       value: -c /etc/fluentd-config/fluentd.conf

--- a/content/en/examples/admin/sched/pod1.yaml
+++ b/content/en/examples/admin/sched/pod1.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: pod-with-no-annotation-container
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/en/examples/admin/sched/pod2.yaml
+++ b/content/en/examples/admin/sched/pod2.yaml
@@ -8,4 +8,4 @@ spec:
   schedulerName: default-scheduler
   containers:
   - name: pod-with-default-annotation-container
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/en/examples/admin/sched/pod3.yaml
+++ b/content/en/examples/admin/sched/pod3.yaml
@@ -8,4 +8,4 @@ spec:
   schedulerName: my-scheduler
   containers:
   - name: pod-with-second-annotation-container
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/en/examples/admin/snowflake-deployment.yaml
+++ b/content/en/examples/admin/snowflake-deployment.yaml
@@ -15,6 +15,6 @@ spec:
         app: snowflake
     spec:
       containers:
-      - image: k8s.gcr.io/serve_hostname
+      - image: registry.k8s.io/serve_hostname
         imagePullPolicy: Always
         name: snowflake

--- a/content/en/examples/application/php-apache.yaml
+++ b/content/en/examples/application/php-apache.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: php-apache
-        image: k8s.gcr.io/hpa-example
+        image: registry.k8s.io/hpa-example
         ports:
         - containerPort: 80
         resources:

--- a/content/en/examples/application/web/web-parallel.yaml
+++ b/content/en/examples/application/web/web-parallel.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/content/en/examples/application/web/web.yaml
+++ b/content/en/examples/application/web/web.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/content/en/examples/application/zookeeper/zookeeper.yaml
+++ b/content/en/examples/application/zookeeper/zookeeper.yaml
@@ -68,7 +68,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+        image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
         resources:
           requests:
             memory: "1Gi"

--- a/content/en/examples/debug/event-exporter.yaml
+++ b/content/en/examples/debug/event-exporter.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: k8s.gcr.io/event-exporter:v0.2.3
+        image: registry.k8s.io/event-exporter:v0.2.3
         command:
         - '/event-exporter'
       terminationGracePeriodSeconds: 30

--- a/content/en/examples/debug/fluentd-gcp-ds.yaml
+++ b/content/en/examples/debug/fluentd-gcp-ds.yaml
@@ -30,7 +30,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: k8s.gcr.io/fluentd-gcp:2.0.2
+        image: registry.k8s.io/fluentd-gcp:2.0.2
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.

--- a/content/en/examples/debug/node-problem-detector-configmap.yaml
+++ b/content/en/examples/debug/node-problem-detector-configmap.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-problem-detector
-        image: k8s.gcr.io/node-problem-detector:v0.1
+        image: registry.k8s.io/node-problem-detector:v0.1
         securityContext:
           privileged: true
         resources:

--- a/content/en/examples/debug/node-problem-detector.yaml
+++ b/content/en/examples/debug/node-problem-detector.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-problem-detector
-        image: k8s.gcr.io/node-problem-detector:v0.1
+        image: registry.k8s.io/node-problem-detector:v0.1
         securityContext:
           privileged: true
         resources:

--- a/content/en/examples/pods/inject/dapi-envars-container.yaml
+++ b/content/en/examples/pods/inject/dapi-envars-container.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox:1.24
+      image: registry.k8s.io/busybox:1.24
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/inject/dapi-envars-pod.yaml
+++ b/content/en/examples/pods/inject/dapi-envars-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/inject/dapi-volume-resources.yaml
+++ b/content/en/examples/pods/inject/dapi-volume-resources.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: k8s.gcr.io/busybox:1.24
+      image: registry.k8s.io/busybox:1.24
       command: ["sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/inject/dapi-volume.yaml
+++ b/content/en/examples/pods/inject/dapi-volume.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: ["sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/pod-configmap-env-var-valueFrom.yaml
+++ b/content/en/examples/pods/pod-configmap-env-var-valueFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/echo", "$(SPECIAL_LEVEL_KEY) $(SPECIAL_TYPE_KEY)" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/en/examples/pods/pod-configmap-envFrom.yaml
+++ b/content/en/examples/pods/pod-configmap-envFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       envFrom:
       - configMapRef:

--- a/content/en/examples/pods/pod-configmap-volume-specific-key.yaml
+++ b/content/en/examples/pods/pod-configmap-volume-specific-key.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh","-c","cat /etc/config/keys" ]
       volumeMounts:
       - name: config-volume

--- a/content/en/examples/pods/pod-configmap-volume.yaml
+++ b/content/en/examples/pods/pod-configmap-volume.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "ls /etc/config/" ]
       volumeMounts:
       - name: config-volume

--- a/content/en/examples/pods/pod-multiple-configmap-env-variable.yaml
+++ b/content/en/examples/pods/pod-multiple-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/en/examples/pods/pod-single-configmap-env-variable.yaml
+++ b/content/en/examples/pods/pod-single-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         # Define the environment variable

--- a/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml
+++ b/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml
@@ -29,4 +29,4 @@ spec:
             - key-2
   containers:
   - name: with-node-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/en/examples/pods/pod-with-node-affinity.yaml
+++ b/content/en/examples/pods/pod-with-node-affinity.yaml
@@ -23,4 +23,4 @@ spec:
             - another-node-label-value
   containers:
   - name: with-node-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/en/examples/pods/pod-with-pod-affinity.yaml
+++ b/content/en/examples/pods/pod-with-pod-affinity.yaml
@@ -26,4 +26,4 @@ spec:
           topologyKey: topology.kubernetes.io/zone
   containers:
   - name: with-pod-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/en/examples/pods/probe/exec-liveness.yaml
+++ b/content/en/examples/pods/probe/exec-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/busybox
     args:
     - /bin/sh
     - -c

--- a/content/en/examples/pods/probe/grpc-liveness.yaml
+++ b/content/en/examples/pods/probe/grpc-liveness.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: etcd
-    image: k8s.gcr.io/etcd:3.5.1-0
+    image: registry.k8s.io/etcd:3.5.1-0
     command: [ "/usr/local/bin/etcd", "--data-dir",  "/var/lib/etcd", "--listen-client-urls", "http://0.0.0.0:2379", "--advertise-client-urls", "http://127.0.0.1:2379", "--log-level", "debug"]
     ports:
     - containerPort: 2379

--- a/content/en/examples/pods/probe/http-liveness.yaml
+++ b/content/en/examples/pods/probe/http-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/liveness
+    image: registry.k8s.io/liveness
     args:
     - /server
     livenessProbe:

--- a/content/en/examples/pods/probe/tcp-liveness-readiness.yaml
+++ b/content/en/examples/pods/probe/tcp-liveness-readiness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: goproxy
-    image: k8s.gcr.io/goproxy:0.1
+    image: registry.k8s.io/goproxy:0.1
     ports:
     - containerPort: 8080
     readinessProbe:

--- a/content/en/examples/pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml
+++ b/content/en/examples/pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml
@@ -23,4 +23,4 @@ spec:
             - zoneC
   containers:
   - name: pause
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.1

--- a/content/en/examples/pods/topology-spread-constraints/one-constraint.yaml
+++ b/content/en/examples/pods/topology-spread-constraints/one-constraint.yaml
@@ -14,4 +14,4 @@ spec:
         foo: bar
   containers:
   - name: pause
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.1

--- a/content/en/examples/pods/topology-spread-constraints/two-constraints.yaml
+++ b/content/en/examples/pods/topology-spread-constraints/two-constraints.yaml
@@ -20,4 +20,4 @@ spec:
         foo: bar
   containers:
   - name: pause
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.1

--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -13,7 +13,7 @@ for multiple operating systems as well as hardware architectures.
 ## Container Images
 
 All Kubernetes container images are deployed to the
-[k8s.gcr.io](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/GLOBAL)
+[registry.k8s.io](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/)
 container registry.
 
 {{< feature-state for_k8s_version="v1.24" state="alpha" >}}
@@ -24,11 +24,11 @@ signatures:
 
 | Container Image                                                     | Supported Architectures                                                                  |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [k8s.gcr.io/kube-apiserver:{{< param "fullversion" >}}][0]          | [amd64][0-amd64], [arm][0-arm], [arm64][0-arm64], [ppc64le][0-ppc64le], [s390x][0-s390x] |
-| [k8s.gcr.io/kube-controller-manager:{{< param "fullversion" >}}][1] | [amd64][1-amd64], [arm][1-arm], [arm64][1-arm64], [ppc64le][1-ppc64le], [s390x][1-s390x] |
-| [k8s.gcr.io/kube-proxy:{{< param "fullversion" >}}][2]              | [amd64][2-amd64], [arm][2-arm], [arm64][2-arm64], [ppc64le][2-ppc64le], [s390x][2-s390x] |
-| [k8s.gcr.io/kube-scheduler:{{< param "fullversion" >}}][3]          | [amd64][3-amd64], [arm][3-arm], [arm64][3-arm64], [ppc64le][3-ppc64le], [s390x][3-s390x] |
-| [k8s.gcr.io/conformance:{{< param "fullversion" >}}][4]             | [amd64][4-amd64], [arm][4-arm], [arm64][4-arm64], [ppc64le][4-ppc64le], [s390x][4-s390x] |
+| [registry.k8s.io/kube-apiserver:{{< param "fullversion" >}}][0]          | [amd64][0-amd64], [arm][0-arm], [arm64][0-arm64], [ppc64le][0-ppc64le], [s390x][0-s390x] |
+| [registry.k8s.io/kube-controller-manager:{{< param "fullversion" >}}][1] | [amd64][1-amd64], [arm][1-arm], [arm64][1-arm64], [ppc64le][1-ppc64le], [s390x][1-s390x] |
+| [registry.k8s.io/kube-proxy:{{< param "fullversion" >}}][2]              | [amd64][2-amd64], [arm][2-arm], [arm64][2-arm64], [ppc64le][2-ppc64le], [s390x][2-s390x] |
+| [registry.k8s.io/kube-scheduler:{{< param "fullversion" >}}][3]          | [amd64][3-amd64], [arm][3-arm], [arm64][3-arm64], [ppc64le][3-ppc64le], [s390x][3-s390x] |
+| [registry.k8s.io/conformance:{{< param "fullversion" >}}][4]             | [amd64][4-amd64], [arm][4-arm], [arm64][4-arm64], [ppc64le][4-ppc64le], [s390x][4-s390x] |
 
 [0]: https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-apiserver
 [0-amd64]: https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-apiserver-amd64
@@ -65,7 +65,7 @@ All container images are available for multiple architectures, whereas the
 container runtime should choose the correct one based on the underlying
 platform. It is also possible to pull a dedicated architecture by suffixing the
 container image name, for example
-[`k8s.gcr.io/kube-apiserver-arm64:{{< param "fullversion" >}}`][0-arm64]. All
+[`registry.k8s.io/kube-apiserver-arm64:{{< param "fullversion" >}}`][0-arm64]. All
 those derivations are signed in the same way as the multi-architecture manifest lists.
 
 The Kubernetes project publishes a list of signed Kubernetes container images
@@ -73,7 +73,7 @@ in SBoM (Software Bill of Materials) format.
 You can fetch that list using:
 
 ```shell
-curl -Ls "https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release"  | awk '/PackageName: k8s.gcr.io\// {print $2}'
+curl -Ls "https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release"  | awk '/PackageName: registry.k8s.io\// {print $2}'
 ```
 For Kubernetes v{{< skew currentVersion >}}, the only kind of code artifact that
 you can verify integrity for is a container image, using the experimental


### PR DESCRIPTION
k8s.gcr.io is deprecated in favor of registry.k8s.io. The kubernetes
codebase have been updated with the new endpoint.

Ref: https://github.com/kubernetes/k8s.io/issues/3411

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>
