### PR TITLE
Removing created-by label deprecated since 1.9

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/common-labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/common-labels.md
@@ -40,7 +40,6 @@ on every resource object.
 | `app.kubernetes.io/component`       | The component within the architecture | `database` | string |
 | `app.kubernetes.io/part-of`         | The name of a higher level application this one is part of | `wordpress` | string |
 | `app.kubernetes.io/managed-by`      | The tool being used to manage the operation of an application | `helm` | string |
-| `app.kubernetes.io/created-by`      | The controller/user who created this resource | `controller-manager` | string |
 
 To illustrate these labels in action, consider the following {{< glossary_tooltip text="StatefulSet" term_id="statefulset" >}} object:
 
@@ -56,7 +55,6 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/part-of: wordpress
     app.kubernetes.io/managed-by: helm
-    app.kubernetes.io/created-by: controller-manager
 ```
 
 ## Applications And Instances Of Applications

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -33,10 +33,8 @@ Used on: All Objects
 
 The controller/user who created this resource.
 
-One of the [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels).
-
 {{< note >}}
-Starting from v1.9, this annotation is deprecated.
+Starting from v1.9, this label is deprecated.
 {{< /note >}}
 
 ### app.kubernetes.io/instance

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -25,7 +25,7 @@ The component within the architecture.
 
 One of the [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels).
 
-### app.kubernetes.io/created-by
+### app.kubernetes.io/created-by (deprecated)
 
 Example: `app.kubernetes.io/created-by: "controller-manager"`
 
@@ -34,6 +34,10 @@ Used on: All Objects
 The controller/user who created this resource.
 
 One of the [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels).
+
+{{< note >}}
+Starting from v1.9, this annotation is deprecated.
+{{< /note >}}
 
 ### app.kubernetes.io/instance
 


### PR DESCRIPTION
**Why this change?**
This changes removes the `created-by` annotation given that it has been deprecated since 1.9, see [Kubernetes PR# 54445](https://github.com/kubernetes/kubernetes/pull/54445).

This deprecation was announced in the following release notes:
- [Change log Kubernetes 1.8 - Deprecations](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.8.md#deprecations)
- [Change log Kubernetes 1.8 - Other notable changes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.9.md#other-notable-changes-14)