### PR TITLE
Clear some IsSet warnings for Hugo build

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -89,7 +89,7 @@ The tables below include the known endpoints for supported operating systems:
 {{< tabs name="container_runtime" >}}
 {{% tab name="Linux" %}}
 
-{{< table >}}
+{{< table caption="Linux container runtimes" >}}
 | Runtime                            | Path to Unix domain socket                   |
 |------------------------------------|----------------------------------------------|
 | containerd                         | `unix:///var/run/containerd/containerd.sock` |
@@ -101,7 +101,7 @@ The tables below include the known endpoints for supported operating systems:
 
 {{% tab name="Windows" %}}
 
-{{< table >}}
+{{< table caption="Windows container runtimes" >}}
 | Runtime                            | Path to Windows named pipe                   |
 |------------------------------------|----------------------------------------------|
 | containerd                         | `npipe:////./pipe/containerd-containerd`     |


### PR DESCRIPTION
## The problem
The Hugo warning message:
```
WARNING: calling IsSet with unsupported type "invalid" (<nil>) will always return false.`
```

During investigation, we found that it is caused by `{{< table >}}` without caption.

## How to verify the fix
This fix can only be verify locally since Netlify bot didn't have verbose output.

```bash
# Check which file caused the problem.
git switch main
hugo server --watch=false --debug | grep -B1 WARNING
# Expected output: Render page Installing kubeadm to "/docs/setup/.../index.html"
```

```bash
# Then checkout this PR
git fetch upstream pull/35813/head:sean-hugo-fix
git switch sean-hugo-fix
hugo server --watch=false --debug | grep -B1 WARNING
# Expected output: Render page 使用 kubeadm 创建一个高可用 etcd 集群 to "/zh-cn/docs/.../index.html"
```

## Notes
There are three occurrence in this repo:
```bash
$ grep -Rl '< table >' content
content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
```
This PR fixes only `en` one, I will open another PR for `zh-cn` and `ko` later.

<br>

And this fix does **not** solved #35780, just removed a annoying warning.
- #35780