### PR TITLE
Update docs for NetworkPolicy port range to GA for 1.25

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -193,9 +193,9 @@ When the feature gate is enabled, you can set the `protocol` field of a NetworkP
 You must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin that supports SCTP protocol NetworkPolicies.
 {{< /note >}}
 
-## Targeting a range of Ports
+## Targeting a range of ports
 
-{{< feature-state for_k8s_version="v1.22" state="beta" >}}
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
 When writing a NetworkPolicy, you can target a range of ports instead of a single port.
 
@@ -228,10 +228,6 @@ with any IP within the range `10.0.0.0/24` over TCP, provided that the target
 port is between the range 32000 and 32768.
 
 The following restrictions apply when using this field:
-* As a beta feature, this is enabled by default. To disable the `endPort` field 
-at a cluster level, you (or your cluster administrator) need to disable the 
-`NetworkPolicyEndPort` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) 
-for the API server with `--feature-gates=NetworkPolicyEndPort=false,…`.
 * The `endPort` field must be equal to or greater than the `port` field.
 * `endPort` can only be defined if `port` is also defined.
 * Both ports must be numeric.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -152,8 +152,6 @@ different Kubernetes components.
 | `MinDomainsInPodTopologySpread` | `true` | Beta | 1.25 | |
 | `MixedProtocolLBService` | `false` | Alpha | 1.20 | 1.23 |
 | `MixedProtocolLBService` | `true` | Beta | 1.24 | |
-| `NetworkPolicyEndPort` | `false` | Alpha | 1.21 | 1.21 |
-| `NetworkPolicyEndPort` | `true` | Beta | 1.22 |  |
 | `NetworkPolicyStatus` | `false` | Alpha | 1.24 |  |
 | `NodeSwap` | `false` | Alpha | 1.22 | |
 | `NodeOutOfServiceVolumeDetach` | `false` | Alpha | 1.24 | |
@@ -395,6 +393,9 @@ different Kubernetes components.
 | `MountPropagation` | `true` | GA | 1.12 | - |
 | `NamespaceDefaultLabelName` | `true` | Beta | 1.21 | 1.21 |
 | `NamespaceDefaultLabelName` | `true` | GA | 1.22 | - |
+| `NetworkPolicyEndPort` | `false` | Alpha | 1.21 | 1.21 |
+| `NetworkPolicyEndPort` | `true` | Beta | 1.22 |  |
+| `NetworkPolicyEndPort` | `true` | GA | 1.25 | - |
 | `NodeDisruptionExclusion` | `false` | Alpha | 1.16 | 1.18 |
 | `NodeDisruptionExclusion` | `true` | Beta | 1.19 | 1.20 |
 | `NodeDisruptionExclusion` | `true` | GA | 1.21 | - |

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -394,7 +394,7 @@ different Kubernetes components.
 | `NamespaceDefaultLabelName` | `true` | Beta | 1.21 | 1.21 |
 | `NamespaceDefaultLabelName` | `true` | GA | 1.22 | - |
 | `NetworkPolicyEndPort` | `false` | Alpha | 1.21 | 1.21 |
-| `NetworkPolicyEndPort` | `true` | Beta | 1.22 |  |
+| `NetworkPolicyEndPort` | `true` | Beta | 1.22 | 1.24 |
 | `NetworkPolicyEndPort` | `true` | GA | 1.25 | - |
 | `NodeDisruptionExclusion` | `false` | Alpha | 1.16 | 1.18 |
 | `NodeDisruptionExclusion` | `true` | Beta | 1.19 | 1.20 |


### PR DESCRIPTION
This PR updates docs for the NetworkPolicy port range enhancement that is graduating to stable in 1.25 by the following:
- updates the feature state on the [Targeting a Range of Ports section on the Network Policies page](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-range-of-ports) to 1.25
- updates the Feature Gates page for _NetworkPolicyEndPort_ and moves entries from _Feature gates for Alpha or Beta features_ section to the _Feature gates for graduated or deprecated features_ section and adding an entry for 1.25 to GA 

Enhancement issue: https://github.com/kubernetes/enhancements/issues/2079
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2079-network-policy-port-range

/sig network
/milestone 1.25
/assign @kcmartin @rikatz 