### PR TITLE
[ko] Clear some IsSet warnings for Hugo build

### DIFF
--- a/content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -12,7 +12,7 @@ card:
 
 <img src="/images/kubeadm-stacked-color.png" align="right" width="150px"></img>
 이 페이지에서는 `kubeadm` 툴박스 설치 방법을 보여준다.
-이 설치 프로세스를 수행한 후 kubeadm으로 클러스터를 만드는 방법에 대한 자세한 내용은 [kubeadm을 사용하여 클러스터 생성하기](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) 페이지를 참고한다.
+이 설치 프로세스를 수행한 후 kubeadm으로 클러스터를 만드는 방법에 대한 자세한 내용은 [kubeadm 으로 클러스터 생성하기](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) 페이지를 참고한다.
 
 
 ## {{% heading "prerequisites" %}}
@@ -89,7 +89,7 @@ cri-dockerd는 쿠버네티스 버전 1.24부터 kubelet에서 [제거](/dockers
 {{< tabs name="container_runtime" >}}
 {{% tab name="리눅스" %}}
 
-{{< table >}}
+{{< table caption="리눅스 컨테이너 런타임" >}}
 | 런타임                            | 유닉스 도메인 소켓 경로                   |
 |------------------------------------|----------------------------------------------|
 | containerd                         | `unix:///var/run/containerd/containerd.sock` |
@@ -101,7 +101,7 @@ cri-dockerd는 쿠버네티스 버전 1.24부터 kubelet에서 [제거](/dockers
 
 {{% tab name="윈도우" %}}
 
-{{< table >}}
+{{< table caption="윈도우 컨테이너 런타임" >}}
 | 런타임                            | 윈도우 네임드 파이프(named pipe) 경로                   |
 |------------------------------------|----------------------------------------------|
 | containerd                         | `npipe:////./pipe/containerd-containerd`     |


### PR DESCRIPTION
Adapt small change from PR #35813.
- #35813

Checked with `lsync.sh` script.
```bash
./scripts/lsync.sh content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
```