### PR TITLE
fix sts minReadySeconds desc

### DIFF
--- a/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
@@ -126,7 +126,7 @@ A StatefulSetSpec is the specification of a StatefulSet.
 
 - **minReadySeconds** (int32)
 
-  Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.
+  Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready). This is a beta field and enabled/disabled by StatefulSetMinReadySeconds feature gate.
 
 - **persistentVolumeClaimRetentionPolicy** (StatefulSetPersistentVolumeClaimRetentionPolicy)
 


### PR DESCRIPTION
fix sts description when StatefulSet minReadySeconds is promoted to beta.
link: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/
the minReadySeconds is enabled after 1.23, and StatefulSetMinReadySeconds is promoted to beta.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
