### PR TITLE
Updated the blog guidelines link

### DIFF
--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -91,7 +91,7 @@ To submit a blog post, follow these steps:
 - Blog posts should be relevant to Kubernetes users.
 
   - Topics related to participation in or results of Kubernetes SIGs activities are always on
-    topic (see the work in the [Upstream Marketing Team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/blog-guidelines.md#upstream-marketing-blog-guidelines)
+    topic (see the work in the [Upstream Marketing Team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/storytelling-resources/blog-guidelines.md#upstream-marketing-blog-guidelines)
     for support on these posts). 
   - The components of Kubernetes are purposely modular, so tools that use existing integration
     points like CNI and CSI are on topic. 


### PR DESCRIPTION
The file named `communication/marketing-team/blog-guidelines.md` is moved to `communication/marketing-team/storytelling-resources/blog-guidelines.md` in this [PR](https://github.com/kubernetes/community/pull/5989)

The link to blog-guidelines is updated in the page: https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/