### PR TITLE
fix: mysql:5.7 is now based on Oracle

### DIFF
--- a/content/en/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/en/examples/application/mysql/mysql-statefulset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
       - name: init-mysql
-        image: mysql:5.7
+        image: mysql:5.7-debian
         command:
         - bash
         - "-c"


### PR DESCRIPTION
Does not include `hostname` binary anymore

See [application/mysql/mysql-statefulset.yaml](https://github.com/docker-library/mysql/issues/877)
