### PR TITLE
[ko] Update outdated files dev-1.24-ko.3 (M66-M76)

### DIFF
--- a/content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml
+++ b/content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml
@@ -8,11 +8,10 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: topology.kubernetes.io/zone
+          - key: kubernetes.io/os
             operator: In
             values:
-            - antarctica-east1
-            - antarctica-west1
+            - linux
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:
@@ -30,4 +29,4 @@ spec:
             - key-2
   containers:
   - name: with-node-affinity
-    image: k8s.gcr.io/pause:2.0 
+    image: k8s.gcr.io/pause:2.0

--- a/content/ko/examples/pods/pod-with-node-affinity.yaml
+++ b/content/ko/examples/pods/pod-with-node-affinity.yaml
@@ -8,10 +8,11 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: kubernetes.io/os
+          - key: topology.kubernetes.io/zone
             operator: In
             values:
-            - linux
+            - antarctica-east1
+            - antarctica-west1
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:

--- a/content/ko/examples/service/networking/dual-stack-default-svc.yaml
+++ b/content/ko/examples/service/networking/dual-stack-default-svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/ko/examples/service/networking/dual-stack-ipfamilies-ipv6.yaml
+++ b/content/ko/examples/service/networking/dual-stack-ipfamilies-ipv6.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-service
+  labels:
+    app.kubernetes.io/name: MyApp
 spec:
-  ipFamily: IPv4
+  ipFamilies:
+  - IPv6
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 9376

--- a/content/ko/examples/service/networking/dual-stack-ipv6-svc.yaml
+++ b/content/ko/examples/service/networking/dual-stack-ipv6-svc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ipFamily: IPv6
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/ko/examples/service/networking/dual-stack-prefer-ipv6-lb-svc.yaml
+++ b/content/ko/examples/service/networking/dual-stack-prefer-ipv6-lb-svc.yaml
@@ -3,13 +3,14 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
-  ipFamily: IPv6
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+  - IPv6
   type: LoadBalancer
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 9376

--- a/content/ko/examples/service/networking/dual-stack-preferred-ipfamilies-svc.yaml
+++ b/content/ko/examples/service/networking/dual-stack-preferred-ipfamilies-svc.yaml
@@ -3,14 +3,14 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   ipFamilyPolicy: PreferDualStack
   ipFamilies:
   - IPv6
   - IPv4
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/ko/examples/service/networking/dual-stack-preferred-svc.yaml
+++ b/content/ko/examples/service/networking/dual-stack-preferred-svc.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   ipFamilyPolicy: PreferDualStack
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/ko/releases/version-skew-policy.md
+++ b/content/ko/releases/version-skew-policy.md
@@ -21,7 +21,7 @@ description: >
 ## 지원되는 버전
 
 쿠버네티스 버전은 **x.y.z** 로 표현되는데, 여기서 **x** 는 메이저 버전, **y** 는 마이너 버전, **z** 는 패치 버전을 의미하며, 이는 [시맨틱 버전](https://semver.org/) 용어에 따른 것이다.
-자세한 내용은 [쿠버네티스 릴리스 버전](https://git.k8s.io/design-proposals-archive/release/versioning.md#kubernetes-release-versioning)을 참조한다.
+자세한 내용은 [쿠버네티스 릴리스 버전](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning)을 참조한다.
 
 쿠버네티스 프로젝트는 최근 세 개의 마이너 릴리스 ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}) 에 대한 릴리스 분기를 유지한다. 쿠버네티스 1.19 이상은 약 1년간의 패치 지원을 받는다. 쿠버네티스 1.18 이상은 약 9개월의 패치 지원을 받는다.
 
@@ -103,6 +103,19 @@ HA 클러스터의 `kube-apiserver` 인스턴스 간에 버전 차이가 있으�
 구성요소 간 지원되는 버전 차이는 구성요소를 업그레이드하는 순서에 영향을 준다.
 이 섹션에서는 기존 클러스터를 버전 **{{< skew prevMinorVersion >}}** 에서 버전 **{{< skew latestVersion >}}** 로 전환하기 위해 구성 요소를 업그레이드하는 순서를 설명한다.
 
+선택적으로, 업그레이드를 준비할 때, 쿠버네티스 프로젝트는 
+업그레이드 중 가능한 많은 회귀 분석 및 버그 수정의 이점을 얻기 위해 
+다음을 수행할 것을 권장한다.
+
+*  구성 요소가 현재 마이너 버전의 
+   최신 패치 버전에 있는지 확인한다.
+*  구성 요소를 대상 마이너 버전의 
+   최신 패치 버전으로 업그레이드 한다.
+
+예를 들어, 만약 {{<skew currentVersionAddMinor -1>}} 버전을 실행 중인 경우, 
+최신 패치 버전을 사용 중인지 확인한다. 그런 다음, 최신 패치 버전인 {{<skew currentVersion>}}로 
+업그레이드 한다.
+
 ### kube-apiserver
 
 사전 요구 사항:
@@ -127,9 +140,13 @@ HA 클러스터의 `kube-apiserver` 인스턴스 간에 버전 차이가 있으�
 
 사전 요구 사항:
 
-* `kube-apiserver` 인스턴스는 **{{< skew latestVersion >}}** 이여야 한다(HA 클러스터에서 `kube-apiserver` 인스턴스와 통신할 수 있는 구성 요소를 업그레이드 전에 모든 `kube-apiserver` 인스턴스는 업그레이드되어야 한다).
+* `kube-apiserver` 인스턴스는 **{{< skew currentVersion >}}** 이여야 한다(HA 클러스터에서 `kube-apiserver` 인스턴스와 통신할 수 있는 구성 요소를 업그레이드 전에 모든 `kube-apiserver` 인스턴스는 업그레이드되어야 한다).
 
-`kube-controller-manager`, `kube-scheduler` 및 `cloud-controller-manager` 를 **{{< skew latestVersion >}}** 으로 업그레이드한다.
+`kube-controller-manager`, `kube-scheduler` 및 `cloud-controller-manager` 를 
+**{{< skew currentVersion >}}** 으로 업그레이드한다. `kube-controller-manager`, `kube-scheduler` 및 `cloud-controller-manager` 사이에는 
+업그레이드에 우선순위가 없다. 이 구성 요소들을 
+임의의 순서 또는 심지어 동시에 
+업그레이드해도 된다.
 
 ### kubelet
 


### PR DESCRIPTION
M66-M76 변경사항을 반영하였습니다.
- From #35802 

M66, M67은 변경 필요사항이 이미 반영되어 있어 수정하지 않았습니다.

> M66. content/en/examples/admin/konnectivity/egress-selector-configuration.yaml | 1(+XS) 1(-)
> M67. content/en/examples/controllers/job.yaml | 1(+XS) 1(-)
> M68. content/en/examples/pods/pod-with-affinity-anti-affinity.yaml | 2(+XS) 3(-)
> M69. content/en/examples/pods/pod-with-node-affinity.yaml | 3(+XS) 2(-)
> M70. content/en/examples/service/networking/dual-stack-default-svc.yaml | 2(+XS) 2(-)
> M71. content/en/examples/service/networking/dual-stack-ipfamilies-ipv6.yaml | 2(+XS) 2(-)
> M72. content/en/examples/service/networking/dual-stack-ipv6-svc.yaml | 2(+XS) 2(-)
> M73. content/en/examples/service/networking/dual-stack-prefer-ipv6-lb-svc.yaml | 2(+XS) 2(-)
> M74. content/en/examples/service/networking/dual-stack-preferred-ipfamilies-svc.yaml | 2(+XS) 2(-)
> M75. content/en/examples/service/networking/dual-stack-preferred-svc.yaml | 2(+XS) 2(-)
> M76. content/en/releases/version-skew-policy.md | 19(+S) 2(-)