### PR TITLE
[zh-cn] Improve network-plugins page

### DIFF
--- a/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -15,7 +15,7 @@ weight: 10
 Kubernetes {{< skew currentVersion >}} supports [Container Network Interface](https://github.com/containernetworking/cni)
 (CNI) plugins for cluster networking. You must use a CNI plugin that is compatible with your cluster and that suits your needs. Different plugins are available (both open- and closed- source) in the wider Kubernetes ecosystem. 
 -->
-Kubernetes {{< skew currentVersion >}} 支持[容器网络接口](https://github.com/containernetworking/cni) (CNI) 集群网络插件。
+Kubernetes {{< skew currentVersion >}} 支持用于集群联网的[容器网络接口](https://github.com/containernetworking/cni) (CNI) 插件。
 你必须使用和你的集群相兼容并且满足你的需求的 CNI 插件。
 在更广泛的 Kubernetes 生态系统中你可以使用不同的插件（开源和闭源）。
 


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
When I was reading the network plugin page, I found this translation difficult to understand, which was a little different from the original English meaning.

page: https://kubernetes.io/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/

The difference is not very obvious, but when I read it for the first time, I really couldn't understand it. I only knew the meaning after reading the original English text.


Preview page: https://deploy-preview-35869--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/


