### PR TITLE
Fix Pod spec in debugging crictl

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/crictl.md
+++ b/content/en/docs/tasks/debug/debug-cluster/crictl.md
@@ -257,7 +257,7 @@ deleted by the Kubelet.
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
      },
-     "logDirectory": "/tmp",
+     "log_directory": "/tmp",
      "linux": {
      }
    }
@@ -293,10 +293,10 @@ deleted by the Kubelet.
    ```json
    {
      "metadata": {
-       "name": "nginx-sandbox",
+       "name": "busybox-sandbox",
        "namespace": "default",
        "attempt": 1,
-       "uid": "hdishd83djaidwnduwk28bcsb"
+       "uid": "aewi4aeThua7ooShohbo1phoj"
      },
      "log_directory": "/tmp",
      "linux": {


### PR DESCRIPTION
Fix JSON definition of pod sandbox in debugging cluster with crictl page.

It currently has one line from YAML that has camel case notation instead of snake case which makes crictl ignore unrecognized field and container subsequently created in the pod sandbox cannot produce logs because logs directory is not set for Pod sandbox.

Second definition of pod on the same page has log_directory correctly spelled in JSON notation, but with mismatching name of the sandbox.
