### PR TITLE
Added Documents for cluster-autoscaler.kubernetes.io/enable-ds-eviction annotation.

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -168,6 +168,21 @@ Used on: Pod
 This annotation is used to set [Pod Deletion Cost](/docs/concepts/workloads/controllers/replicaset/#pod-deletion-cost)
 which allows users to influence ReplicaSet downscaling order. The annotation parses into an `int32` type.
 
+### cluster-autoscaler.kubernetes.io/enable-ds-eviction
+
+Example: `cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"`
+
+Used on: Pod
+
+This annotation is controlling whether a DaemonSet pod should be evicted or not by  ClusterAutoscaler. This annotation needs to be specified on DaemonSet pods, not the DaemonSet object itself. In order to do that for all DaemonSet pods, it is sufficient to modify the pod spec in the DaemonSet object.
+
+When this annotation is set to `true`, the Cluster Autoscaler is allowed to evict a DaemonSet Pod even if other rules would normally prevent that. To disable the DaemonSet pods eviction so that the Cluster Autoscaler never evicts DaemonSet pods, Explicitly set this annotation to `false`; you could set that on an important pod that you want to keep running.
+If this annotation is not set then the Cluster Autoscaler follows its overall behaviour.
+
+{{< note >}}
+This annotation has no effect on pods that are not a part of any DaemonSet.
+{{< /note >}}
+
 ### kubernetes.io/ingress-bandwidth
 
 {{< note >}}

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -176,10 +176,10 @@ Used on: Pod
 
 This annotation controls whether a DaemonSet pod should be evicted by a ClusterAutoscaler.
 This annotation needs to be specified on DaemonSet pods in a DaemonSet manifest.
-When this annotation is set to `"true"`, the ClusterAutoscaler is allowed to evict a DaemonSet Pod
+When this annotation is set to `"true"`, the ClusterAutoscaler is allowed to evict a DaemonSet Pod,
 even if other rules would normally prevent that. To disallow the ClusterAutoscaler from evicting DaemonSet pods,
 you can set this annotation to `"false"` for important DaemonSet pods.
-If this annotation is not set then the Cluster Autoscaler follows its overall behaviour i.e evict the DaemonSets based on its configuration.
+If this annotation is not set, then the Cluster Autoscaler follows its overall behaviour (i.e evict the DaemonSets based on its configuration).
 
 {{< note >}}
 This annotation only impacts DaemonSet pods.

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -174,13 +174,15 @@ Example: `cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"`
 
 Used on: Pod
 
-This annotation is controlling whether a DaemonSet pod should be evicted or not by  ClusterAutoscaler. This annotation needs to be specified on DaemonSet pods, not the DaemonSet object itself. In order to do that for all DaemonSet pods, it is sufficient to modify the pod spec in the DaemonSet object.
-
-When this annotation is set to `true`, the Cluster Autoscaler is allowed to evict a DaemonSet Pod even if other rules would normally prevent that. To disable the DaemonSet pods eviction so that the Cluster Autoscaler never evicts DaemonSet pods, Explicitly set this annotation to `false`; you could set that on an important pod that you want to keep running.
-If this annotation is not set then the Cluster Autoscaler follows its overall behaviour.
+This annotation controls whether a DaemonSet pod should be evicted by a ClusterAutoscaler.
+This annotation needs to be specified on DaemonSet pods in a DaemonSet manifest.
+When this annotation is set to `"true"`, the ClusterAutoscaler is allowed to evict a DaemonSet Pod
+even if other rules would normally prevent that. To disallow the ClusterAutoscaler from evicting DaemonSet pods,
+you can set this annotation to `"false"` for important DaemonSet pods.
+If this annotation is not set then the Cluster Autoscaler follows its overall behaviour i.e evict the DaemonSets based on its configuration.
 
 {{< note >}}
-This annotation has no effect on pods that are not a part of any DaemonSet.
+This annotation only impacts DaemonSet pods.
 {{< /note >}}
 
 ### kubernetes.io/ingress-bandwidth


### PR DESCRIPTION
This PR Registered and documented the cluster-autoscaler.kubernetes.io/enable-ds-eviction annotation under [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/).

Fixes: #35851