### PR TITLE
[zh-cn] fix k8s minor versions for `release-1.21` branch

### DIFF
--- a/content/zh/docs/concepts/services-networking/network-policies.md
+++ b/content/zh/docs/concepts/services-networking/network-policies.md
@@ -41,9 +41,8 @@ When defining a pod- or namespace- based NetworkPolicy, you use a {{< glossary_t
 
 Meanwhile, when IP based NetworkPolicies are created, we define policies based on IP blocks (CIDR ranges).
 -->
-在定义基于 Pod 或名字空间的 NetworkPolicy 时，你会使用 
-{{< glossary_tooltip text="选择算符" term_id="selector">}} 来设定哪些流量
-可以进入或离开与该算符匹配的 Pod。
+在定义基于 Pod 或名字空间的 NetworkPolicy 时，
+你会使用{{< glossary_tooltip text="选择算符" term_id="selector">}}来设定哪些流量可以进入或离开与该算符匹配的 Pod。
 
 同时，当基于 IP 的 NetworkPolicy 被创建时，我们基于 IP 组块（CIDR 范围）
 来定义策略。
@@ -531,11 +530,11 @@ standardized label to target a specific namespace.
 <!--
 ## What you can't do with network policies (at least, not yet)
 
-As of Kubernetes {{< skew latestVersion >}}, the following functionality does not exist in the NetworkPolicy API, but you might be able to implement workarounds using Operating System components (such as SELinux, OpenVSwitch, IPTables, and so on) or Layer 7 technologies (Ingress controllers, Service Mesh implementations) or admission controllers.  In case you are new to network security in Kubernetes, its worth noting that the following User Stories cannot (yet) be implemented using the NetworkPolicy API.
+As of Kubernetes {{< skew currentVersion >}}, the following functionality does not exist in the NetworkPolicy API, but you might be able to implement workarounds using Operating System components (such as SELinux, OpenVSwitch, IPTables, and so on) or Layer 7 technologies (Ingress controllers, Service Mesh implementations) or admission controllers.  In case you are new to network security in Kubernetes, its worth noting that the following User Stories cannot (yet) be implemented using the NetworkPolicy API.
 -->
 ## 通过网络策略（至少目前还）无法完成的工作
 
-到 Kubernetes {{< skew latestVersion >}} 为止，NetworkPolicy API 还不支持以下功能，不过
+到 Kubernetes {{< skew currentVersion >}} 为止，NetworkPolicy API 还不支持以下功能，不过
 你可能可以使用操作系统组件（如 SELinux、OpenVSwitch、IPTables 等等）
 或者第七层技术（Ingress 控制器、服务网格实现）或准入控制器来实现一些
 替代方案。

--- a/content/zh/docs/setup/release/version-skew-policy.md
+++ b/content/zh/docs/setup/release/version-skew-policy.md
@@ -31,10 +31,10 @@ Kubernetes 版本号格式为 **x.y.z**，其中 **x** 为大版本号，**y** �
 [Kubernetes 发布版本](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning)。
 
 <!--
-The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
+The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
 -->
-Kubernetes 项目会维护最近的三个小版本分支（{{< skew latestVersion >}}, 
-{{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}）。
+Kubernetes 项目会维护最近的三个小版本分支（{{< skew currentVersion >}}, 
+{{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}）。
 Kubernetes 1.19 及更高的版本将获得大约1年的补丁支持。
 Kubernetes 1.18 及更早的版本获得大约9个月的补丁支持。
 
@@ -74,12 +74,12 @@ Example:
 例如：
 
 <!--
-* newest `kube-apiserver` is at **{{< skew latestVersion >}}**
-* other `kube-apiserver` instances are supported at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
+* newest `kube-apiserver` is at **{{< skew currentVersion >}}**
+* other `kube-apiserver` instances are supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 -->
-* 最新的 `kube-apiserver` 版本号如果是 **{{< skew latestVersion >}}**
-* 其他受支持的 `kube-apiserver` 版本号包括 **{{< skew latestVersion >}}** 和
-  **{{< skew prevMinorVersion >}}**
+* 最新的 `kube-apiserver` 版本号如果是 **{{< skew currentVersion >}}**
+* 其他受支持的 `kube-apiserver` 版本号包括 **{{< skew currentVersion >}}** 和
+  **{{< skew currentVersionAddMinor >}}**
 
 ### kubelet
 
@@ -91,14 +91,14 @@ Example:
 <!--
 Example:
 
-* `kube-apiserver` is at **{{< skew latestVersion >}}**
-* `kubelet` is supported at **{{< skew latestVersion >}}**, **{{< skew prevMinorVersion >}}**, and **{{< skew oldestMinorVersion >}}**
+* `kube-apiserver` is at **{{< skew currentVersion >}}**
+* `kubelet` is supported at **{{< skew currentVersion >}}**, **{{< skew currentVersionAddMinor -1 >}}**, and **{{< skew currentVersionAddMinor -2 >}}**
 -->
 例如：
 
-* `kube-apiserver` 版本号如果是 **{{< skew latestVersion >}}**
-* 受支持的的 `kubelet` 版本将包括 **{{< skew latestVersion >}}**、
-  **{{< skew prevMinorVersion >}}** 和 **{{< skew oldestMinorVersion >}}**
+* `kube-apiserver` 版本号如果是 **{{< skew currentVersion >}}**
+* 受支持的的 `kubelet` 版本将包括 **{{< skew currentVersion >}}**、
+  **{{< skew currentVersionAddMinor -1 >}}** 和 **{{< skew currentVersionAddMinor -2 >}}**
 
 <!--
 If version skew exists between `kube-apiserver` instances in an HA cluster, this narrows the allowed `kubelet` versions.
@@ -110,17 +110,17 @@ If version skew exists between `kube-apiserver` instances in an HA cluster, this
 <!--
 Example:
 
-* `kube-apiserver` instances are at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
-* `kubelet` is supported at **{{< skew prevMinorVersion >}}**, and **{{< skew oldestMinorVersion >}}** (**{{< skew latestVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew prevMinorVersion >}}**)
+* `kube-apiserver` instances are at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
+* `kubelet` is supported at **{{< skew currentVersionAddMinor -1 >}}**, and **{{< skew currentVersionAddMinor -2 >}}** (**{{< skew currentVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew currentVersionAddMinor -1 >}}**)
 -->
 例如：
 
-* 如果 `kube-apiserver` 实例同时存在 **{{< skew latestVersion >}}** 和
-  **{{< skew prevMinorVersion >}}**
-* `kubelet` 的受支持版本将是 **{{< skew prevMinorVersion >}}** 和
-  **{{< skew oldestMinorVersion >}}**
-  （**{{< skew latestVersion >}}** 不再支持，因为它比
-  **{{< skew prevMinorVersion >}}** 版本的 `kube-apiserver` 更新）
+* 如果 `kube-apiserver` 实例同时存在 **{{< skew currentVersion >}}** 和
+  **{{< skew currentVersionAddMinor -1 >}}**
+* `kubelet` 的受支持版本将是 **{{< skew currentVersionAddMinor -1 >}}** 和
+  **{{< skew currentVersionAddMinor -2 >}}**
+  （**{{< skew currentVersion >}}** 不再支持，因为它比
+  **{{< skew currentVersionAddMinor -1 >}}** 版本的 `kube-apiserver` 更新）
 
 <!--
 ### kube-controller-manager, kube-scheduler, and cloud-controller-manager
@@ -138,14 +138,14 @@ Example:
 <!--
 Example:
 
-* `kube-apiserver` is at **{{< skew latestVersion >}}**
-* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
+* `kube-apiserver` is at **{{< skew currentVersion >}}**
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 -->
 例如：
 
-* 如果 `kube-apiserver` 版本号为 **{{< skew latestVersion >}}**
+* 如果 `kube-apiserver` 版本号为 **{{< skew currentVersion >}}**
 * `kube-controller-manager`、`kube-scheduler` 和 `cloud-controller-manager`
-  版本支持 **{{< skew latestVersion >}}** 和 **{{< skew prevMinorVersion >}}**
+  版本支持 **{{< skew currentVersion >}}** 和 **{{< skew currentVersionAddMinor -1 >}}**
 
 <!--
 If version skew exists between `kube-apiserver` instances in an HA cluster, and these components can communicate with any `kube-apiserver` instance in the cluster (for example, via a load balancer), this narrows the allowed versions of these components.
@@ -160,19 +160,19 @@ If version skew exists between `kube-apiserver` instances in an HA cluster, and 
 <!--
 Example:
 
-* `kube-apiserver` instances are at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
+* `kube-apiserver` instances are at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 * `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` communicate with a load balancer that can route to any `kube-apiserver` instance
-* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew prevMinorVersion >}}** (**{{< skew latestVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew prevMinorVersion >}}**)
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew currentVersionAddMinor -1 >}}** (**{{< skew currentVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew currentVersionAddMinor -1 >}}**)
 -->
 例如：
 
-* `kube-apiserver` 实例同时存在 **{{< skew latestVersion >}}** 和
-  **{{< skew prevMinorVersion >}}** 版本
+* `kube-apiserver` 实例同时存在 **{{< skew currentVersion >}}** 和
+  **{{< skew currentVersionAddMinor -1 >}}** 版本
 * `kube-controller-manager`、`kube-scheduler` 和 `cloud-controller-manager`
   可以通过 load balancer 与所有的 `kube-apiserver` 通信
 * `kube-controller-manager`、`kube-scheduler` 和 `cloud-controller-manager`
-  可选版本为 **{{< skew prevMinorVersion >}}**
-  （**{{< skew latestVersion >}}** 不再支持，因为它比 **{{< skew prevMinorVersion >}}**
+  可选版本为 **{{< skew currentVersionAddMinor -1 >}}**
+  （**{{< skew currentVersion >}}** 不再支持，因为它比 **{{< skew currentVersionAddMinor -1 >}}**
   版本的 `kube-apiserver` 更新）
 
 ### kubectl
@@ -185,14 +185,14 @@ Example:
 <!--
 Example:
 
-* `kube-apiserver` is at **{{< skew latestVersion >}}**
-* `kubectl` is supported at **{{< skew nextMinorVersion >}}**, **{{< skew latestVersion >}}**, and **{{< skew prevMinorVersion >}}**
+* `kube-apiserver` is at **{{< skew currentVersion >}}**
+* `kubectl` is supported at **{{< skew nextMinorVersion >}}**, **{{< skew currentVersion >}}**, and **{{< skew currentVersionAddMinor -1 >}}**
 -->
 例如：
 
-* 如果 `kube-apiserver` 当前是 **{{< skew latestVersion >}}** 版本
-* `kubectl` 则支持 **{{< skew nextMinorVersion >}}**、**{{< skew latestVersion >}}**
-  和 **{{< skew prevMinorVersion >}}**
+* 如果 `kube-apiserver` 当前是 **{{< skew currentVersion >}}** 版本
+* `kubectl` 则支持 **{{< skew nextMinorVersion >}}**、**{{< skew currentVersion >}}**
+  和 **{{< skew currentVersionAddMinor -1 >}}**
 
 <!--
 If version skew exists between `kube-apiserver` instances in an HA cluster, this narrows the supported `kubectl` versions.
@@ -204,15 +204,15 @@ If version skew exists between `kube-apiserver` instances in an HA cluster, this
 <!--
 Example:
 
-* `kube-apiserver` instances are at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
-* `kubectl` is supported at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}** (other versions would be more than one minor version skewed from one of the `kube-apiserver` components)
+* `kube-apiserver` instances are at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
+* `kubectl` is supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}** (other versions would be more than one minor version skewed from one of the `kube-apiserver` components)
 -->
 例如：
 
-* `kube-apiserver` 多个实例同时存在 **{{< skew latestVersion >}}** 和
-  **{{< skew prevMinorVersion >}}**
-* `kubectl` 可选的版本为 **{{< skew latestVersion >}}** 和
-  **{{< skew prevMinorVersion >}}**（其他版本不再支持，
+* `kube-apiserver` 多个实例同时存在 **{{< skew currentVersion >}}** 和
+  **{{< skew currentVersionAddMinor -1 >}}**
+* `kubectl` 可选的版本为 **{{< skew currentVersion >}}** 和
+  **{{< skew currentVersionAddMinor -1 >}}**（其他版本不再支持，
   因为它会比其中某个 `kube-apiserver` 实例高或低一个小版本）
 
 <!--
@@ -222,10 +222,10 @@ Example:
 
 <!--
 The supported version skew between components has implications on the order in which components must be upgraded.
-This section describes the order in which components must be upgraded to transition an existing cluster from version **{{< skew prevMinorVersion >}}** to version **{{< skew latestVersion >}}**.
+This section describes the order in which components must be upgraded to transition an existing cluster from version **{{< skew currentVersionAddMinor -1 >}}** to version **{{< skew currentVersion >}}**.
 -->
 组件之间支持的版本偏差会影响组件升级的顺序。
-本节描述组件从版本 **{{< skew prevMinorVersion >}}** 到 **{{< skew latestVersion >}}**
+本节描述组件从版本 **{{< skew currentVersionAddMinor -1 >}}** 到 **{{< skew currentVersion >}}**
 的升级次序。
 
 ### kube-apiserver
@@ -236,33 +236,33 @@ Pre-requisites:
 前提条件：
 
 <!--
-* In a single-instance cluster, the existing `kube-apiserver` instance is **{{< skew prevMinorVersion >}}**
-* In an HA cluster, all `kube-apiserver` instances are at **{{< skew prevMinorVersion >}}** or **{{< skew latestVersion >}}** (this ensures maximum skew of 1 minor version between the oldest and newest `kube-apiserver` instance)
-* The `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` instances that communicate with this server are at version **{{< skew prevMinorVersion >}}** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
-* `kubelet` instances on all nodes are at version **{{< skew prevMinorVersion >}}** or **{{< skew oldestMinorVersion >}}** (this ensures they are not newer than the existing API server version, and are within 2 minor versions of the new API server version)
+* In a single-instance cluster, the existing `kube-apiserver` instance is **{{< skew currentVersionAddMinor -1 >}}**
+* In an HA cluster, all `kube-apiserver` instances are at **{{< skew currentVersionAddMinor -1 >}}** or **{{< skew currentVersion >}}** (this ensures maximum skew of 1 minor version between the oldest and newest `kube-apiserver` instance)
+* The `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` instances that communicate with this server are at version **{{< skew currentVersionAddMinor -1 >}}** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
+* `kubelet` instances on all nodes are at version **{{< skew currentVersionAddMinor -1 >}}** or **{{< skew currentVersionAddMinor -2 >}}** (this ensures they are not newer than the existing API server version, and are within 2 minor versions of the new API server version)
 * Registered admission webhooks are able to handle the data the new `kube-apiserver` instance will send them:
-  * `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects are updated to include any new versions of REST resources added in **{{< skew latestVersion >}}** (or use the [`matchPolicy: Equivalent` option](/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy) available in v1.15+)
-  * The webhooks are able to handle any new versions of REST resources that will be sent to them, and any new fields added to existing versions in **{{< skew latestVersion >}}**
+  * `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects are updated to include any new versions of REST resources added in **{{< skew currentVersion >}}** (or use the [`matchPolicy: Equivalent` option](/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy) available in v1.15+)
+  * The webhooks are able to handle any new versions of REST resources that will be sent to them, and any new fields added to existing versions in **{{< skew currentVersion >}}**
 -->
-* 单实例集群中，`kube-apiserver` 实例版本号须是 **{{< skew prevMinorVersion >}}**
+* 单实例集群中，`kube-apiserver` 实例版本号须是 **{{< skew currentVersionAddMinor -1 >}}**
 * 高可用（HA）集群中，所有的 `kube-apiserver` 实例版本号必须是
-  **{{< skew prevMinorVersion >}}** 或 **{{< skew latestVersion >}}**
+  **{{< skew currentVersionAddMinor -1 >}}** 或 **{{< skew currentVersion >}}**
   （确保满足最新和最旧的实例小版本号相差不大于1）
 * `kube-controller-manager`、`kube-scheduler` 和 `cloud-controller-manager`
-  版本号必须为 **{{< skew prevMinorVersion >}}**
+  版本号必须为 **{{< skew currentVersionAddMinor -1 >}}**
   （确保不高于 API server 的版本，且版本号相差不大于1）
-* `kubelet` 实例版本号必须是 **{{< skew prevMinorVersion >}}** 或
-  **{{< skew oldestMinorVersion >}}**（确保版本号不高于 API server，且版本号相差不大于2）
+* `kubelet` 实例版本号必须是 **{{< skew currentVersionAddMinor -1 >}}** 或
+  **{{< skew currentVersionAddMinor -2 >}}**（确保版本号不高于 API server，且版本号相差不大于2）
 * 注册的 admission 插件必须能够处理新的 `kube-apiserver` 实例发送过来的数据：
   * `ValidatingWebhookConfiguration` 和 `MutatingWebhookConfiguration` 对象必须升级到可以处理
-    **{{< skew latestVersion >}}** 版本新加的 REST 资源（或使用 1.15 版本提供的
+    **{{< skew currentVersion >}}** 版本新加的 REST 资源（或使用 1.15 版本提供的
     [`matchPolicy: Equivalent` 选项](/zh/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy)）
-  * 插件可以处理任何 **{{< skew latestVersion >}}** 版本新的 REST 资源数据和新加的字段
+  * 插件可以处理任何 **{{< skew currentVersion >}}** 版本新的 REST 资源数据和新加的字段
 
 <!--
-Upgrade `kube-apiserver` to **{{< skew latestVersion >}}**
+Upgrade `kube-apiserver` to **{{< skew currentVersion >}}**
 -->
-升级 `kube-apiserver` 到 **{{< skew latestVersion >}}**
+升级 `kube-apiserver` 到 **{{< skew currentVersion >}}**
 
 {{< note >}}
 <!--
@@ -284,34 +284,34 @@ require `kube-apiserver` to not skip minor versions when upgrading, even in sing
 <!--
 Pre-requisites:
 
-* The `kube-apiserver` instances these components communicate with are at **{{< skew latestVersion >}}** (in HA clusters in which these control plane components can communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
+* The `kube-apiserver` instances these components communicate with are at **{{< skew currentVersion >}}** (in HA clusters in which these control plane components can communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
 -->
 前提条件：
 
-* `kube-apiserver` 实例必须为 **{{< skew latestVersion >}}** 
+* `kube-apiserver` 实例必须为 **{{< skew currentVersion >}}** 
   （HA 集群中，所有的`kube-apiserver` 实例必须在组件升级前完成升级）
 
 <!--
-Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **{{< skew latestVersion >}}**
+Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **{{< skew currentVersion >}}**
 -->
 升级 `kube-controller-manager`、`kube-scheduler` 和 `cloud-controller-manager`
-到 **{{< skew latestVersion >}}**
+到 **{{< skew currentVersion >}}**
 
 ### kubelet
 
 <!--
 Pre-requisites:
 
-* The `kube-apiserver` instances the `kubelet` communicates with are at **{{< skew latestVersion >}}**
+* The `kube-apiserver` instances the `kubelet` communicates with are at **{{< skew currentVersion >}}**
 
-Optionally upgrade `kubelet` instances to **{{< skew latestVersion >}}** (or they can be left at **{{< skew prevMinorVersion >}}** or **{{< skew oldestMinorVersion >}}**)
+Optionally upgrade `kubelet` instances to **{{< skew currentVersion >}}** (or they can be left at **{{< skew currentVersionAddMinor -1 >}}** or **{{< skew currentVersionAddMinor -2 >}}**)
 -->
 前提条件：
 
-* `kube-apiserver` 实例必须为 **{{< skew latestVersion >}}** 版本
+* `kube-apiserver` 实例必须为 **{{< skew currentVersion >}}** 版本
 
-`kubelet` 可以升级到 **{{< skew latestVersion >}}**（或者停留在
-**{{< skew prevMinorVersion >}}** 或 **{{< skew oldestMinorVersion >}}**）
+`kubelet` 可以升级到 **{{< skew currentVersion >}}**（或者停留在
+**{{< skew currentVersionAddMinor -1 >}}** 或 **{{< skew currentVersionAddMinor -2 >}}**）
 
 {{< note >}}
 <!--
@@ -351,15 +351,15 @@ Running a cluster with `kubelet` instances that are persistently two minor versi
 <!--  
 Example:
 
-If `kube-proxy` version is **{{< skew oldestMinorVersion >}}**:
+If `kube-proxy` version is **{{< skew currentVersionAddMinor -2 >}}**:
 
-* `kubelet` version must be at the same minor version as **{{< skew oldestMinorVersion >}}**.
-* `kube-apiserver` version must be between **{{< skew oldestMinorVersion >}}** and **{{< skew latestVersion >}}**, inclusive.
+* `kubelet` version must be at the same minor version as **{{< skew currentVersionAddMinor -2 >}}**.
+* `kube-apiserver` version must be between **{{< skew currentVersionAddMinor -2 >}}** and **{{< skew currentVersion >}}**, inclusive.
 -->
 例如：
 
-如果 `kube-proxy` 的版本是 **{{< skew oldestMinorVersion >}}**：
+如果 `kube-proxy` 的版本是 **{{< skew currentVersionAddMinor -2 >}}**：
 
-* `kubelet` 版本必须相同，也是 **{{< skew oldestMinorVersion >}}**
-* `kube-apiserver` 版本必须在 **{{< skew oldestMinorVersion >}}** 到
-  **{{< skew latestVersion >}}** 之间（闭区间）
+* `kubelet` 版本必须相同，也是 **{{< skew currentVersionAddMinor -2 >}}**
+* `kube-apiserver` 版本必须在 **{{< skew currentVersionAddMinor -2 >}}** 到
+  **{{< skew currentVersion >}}** 之间（闭区间）

--- a/content/zh/docs/tasks/administer-cluster/cluster-upgrade.md
+++ b/content/zh/docs/tasks/administer-cluster/cluster-upgrade.md
@@ -41,14 +41,14 @@ At a high level, the steps you perform are:
 
 <!-- 
 You must have an existing cluster. This page is about upgrading from Kubernetes
-{{< skew prevMinorVersion >}} to Kubernetes {{< skew latestVersion >}}. If your cluster
-is not currently running Kubernetes {{< skew prevMinorVersion >}} then please check
+{{< skew currentVersionAddMinor -1 >}} to Kubernetes {{< skew currentVersion >}}. If your cluster
+is not currently running Kubernetes {{< skew currentVersionAddMinor -1 >}} then please check
 the documentation for the version of Kubernetes that you plan to upgrade to.
 -->
 你必须有一个集群。
-本页内容涉及从 Kubernetes {{< skew prevMinorVersion >}} 
-升级到 Kubernetes {{< skew latestVersion >}}。
-如果你的集群未运行 Kubernetes {{< skew prevMinorVersion >}}，
+本页内容涉及从 Kubernetes {{< skew currentVersionAddMinor -1 >}} 
+升级到 Kubernetes {{< skew currentVersion >}}。
+如果你的集群未运行 Kubernetes {{< skew currentVersionAddMinor -1 >}}，
 那请参考目标 Kubernetes 版本的文档。
 
 <!-- ## Upgrade approaches -->
@@ -104,8 +104,8 @@ At this point you should
 [install the latest version of `kubectl`](/docs/tasks/tools/).
 
 For each node in your cluster, [drain](/docs/tasks/administer-cluster/safely-drain-node/)
-that node and then either replace it with a new node that uses the {{< skew latestVersion >}}
-kubelet, or upgrade the {{< skew latestVersion >}}
+that node and then either replace it with a new node that uses the {{< skew currentVersion >}}
+kubelet, or upgrade the {{< skew currentVersion >}}
 kubelet on that node and bring the node back into service.
 -->
 现在，你应该
@@ -113,7 +113,7 @@ kubelet on that node and bring the node back into service.
 
 对于群集中的每个节点，
 [排空](/zh/docs/tasks/administer-cluster/safely-drain-node/)
-节点，然后，或者用一个运行了 {{< skew latestVersion >}} kubelet 的新节点替换它；
+节点，然后，或者用一个运行了 {{< skew currentVersion >}} kubelet 的新节点替换它；
 或者升级此节点的 kubelet，并使节点恢复服务。
 
 <!-- 

--- a/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -451,7 +451,7 @@ serverTLSBootstrap: true
 
 <!--
 If you have already created the cluster you must adapt it by doing the following:
- - Find and edit the `kubelet-config-{{< skew latestVersion >}}` ConfigMap in the `kube-system` namespace.
+ - Find and edit the `kubelet-config-{{< skew currentVersion >}}` ConfigMap in the `kube-system` namespace.
 In that ConfigMap, the `kubelet` key has a
 [KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 document as its value. Edit the KubeletConfiguration document to set `serverTLSBootstrap: true`.
@@ -460,7 +460,7 @@ and restart the kubelet with `systemctl restart kubelet`
 -->
 如果你已经创建了集群，你必须通过执行下面的操作来完成适配：
 
-- 找到 `kube-system` 名字空间中名为 `kubelet-config-{{< skew latestVersion >}}`
+- 找到 `kube-system` 名字空间中名为 `kubelet-config-{{< skew currentVersion >}}`
   的 ConfigMap 并编辑之。
   在该 ConfigMap 中，`kubelet` 键下面有一个
   [KubeletConfiguration](/zh/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)

--- a/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -16,13 +16,13 @@ min-kubernetes-server-version: 1.18
 
 <!--
 This page explains how to upgrade a Kubernetes cluster created with kubeadm from version
-{{< skew latestVersionAddMinor -1 >}}.x to version {{< skew latestVersion >}}.x, and from version
-{{< skew latestVersion >}}.x to {{< skew latestVersion >}}.y (where `y > x`). Skipping MINOR versions
+{{< skew currentVersionAddMinor -1 >}}.x to version {{< skew currentVersion >}}.x, and from version
+{{< skew currentVersion >}}.x to {{< skew currentVersion >}}.y (where `y > x`). Skipping MINOR versions
 when upgrading is unsupported.
 -->
-本页介绍如何将 `kubeadm` 创建的 Kubernetes 集群从 {{< skew latestVersionAddMinor -1 >}}.x 版本
-升级到 {{< skew latestVersion >}}.x 版本以及从 {{< skew latestVersion >}}.x
-升级到 {{< skew latestVersion >}}.y（其中 `y > x`）。略过次版本号的升级是
+本页介绍如何将 `kubeadm` 创建的 Kubernetes 集群从 {{< skew currentVersionAddMinor -1 >}}.x 版本
+升级到 {{< skew currentVersion >}}.x 版本以及从 {{< skew currentVersion >}}.x
+升级到 {{< skew currentVersion >}}.y（其中 `y > x`）。略过次版本号的升级是
 不被支持的。
 
 <!--
@@ -89,26 +89,26 @@ The upgrade workflow at high level is the following:
 <!--
 ## Determine which version to upgrade to
 
-Find the latest stable {{< skew latestVersion >}} version using the OS package manager:
+Find the latest stable {{< skew currentVersion >}} version using the OS package manager:
 -->
 ## 确定要升级到哪个版本
 
-使用操作系统的包管理器找到最新的稳定 {{< skew latestVersion >}}：
+使用操作系统的包管理器找到最新的稳定 {{< skew currentVersion >}}：
 
 {{< tabs name="k8s_install_versions" >}}
 {{% tab name="Ubuntu、Debian 或 HypriotOS" %}}
 ```
 apt update
 apt-cache policy kubeadm
-# 在列表中查找最新的 {{< skew latestVersion >}} 版本
-# 它看起来应该是 {{< skew latestVersion >}}.x-00，其中 x 是最新的补丁版本
+# 在列表中查找最新的 {{< skew currentVersion >}} 版本
+# 它看起来应该是 {{< skew currentVersion >}}.x-00，其中 x 是最新的补丁版本
 ```
 {{% /tab %}}
 {{% tab name="CentOS、RHEL 或 Fedora" %}}
 ```
 yum list --showduplicates kubeadm --disableexcludes=kubernetes
-# 在列表中查找最新的 {{< skew latestVersion >}} 版本
-# 它看起来应该是 {{< skew latestVersion >}}.x-0，其中 x 是最新的补丁版本
+# 在列表中查找最新的 {{< skew currentVersion >}} 版本
+# 它看起来应该是 {{< skew currentVersion >}}.x-0，其中 x 是最新的补丁版本
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -143,20 +143,20 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
 {{< tabs name="k8s_install_kubeadm_first_cp" >}}
 {{% tab name="Ubuntu、Debian 或 HypriotOS" %}}
 ```shell
-# 用最新的补丁版本号替换 {{< skew latestVersion >}}.x-00 中的 x
+# 用最新的补丁版本号替换 {{< skew currentVersion >}}.x-00 中的 x
 apt-mark unhold kubeadm && \
-apt-get update && apt-get install -y kubeadm={{< skew latestVersion >}}.x-00 && \
+apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
 apt-mark hold kubeadm
 -
 # 从 apt-get 1.1 版本起，你也可以使用下面的方法
 apt-get update && \
-apt-get install -y --allow-change-held-packages kubeadm={{< skew latestVersion >}}.x-00
+apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00
 ```
 {{% /tab %}}
 {{% tab name="CentOS、RHEL 或 Fedora" %}}
 ```shell
-# 用最新的补丁版本号替换 {{< skew latestVersion >}}.x-0 中的 x
-yum install -y kubeadm-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+# 用最新的补丁版本号替换 {{< skew currentVersion >}}.x-0 中的 x
+yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -213,14 +213,14 @@ yum install -y kubeadm-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernet
 
   ```shell
   # replace x with the patch version you picked for this upgrade
-  sudo kubeadm upgrade apply v{{< skew latestVersion >}}.x
+  sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
   ```
 -->
 选择要升级到的目标版本，运行合适的命令。例如：
 
   ```shell
   # 将 x 替换为你为此次升级所选择的补丁版本号
-  sudo kubeadm upgrade apply v{{< skew latestVersion >}}.x
+  sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
   ```
 
   <!--
@@ -229,7 +229,7 @@ yum install -y kubeadm-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernet
   一旦该命令结束，你应该会看到：
 
   ```
-  [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew latestVersion >}}.x". Enjoy!
+  [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew currentVersion >}}.x". Enjoy!
 
   [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
   ```
@@ -311,21 +311,21 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
   {{% tab name="Ubuntu、Debian 或 HypriotOS" %}}
 
   <pre>
-  # 用最新的补丁版本替换 {{< skew latestVersion >}}.x-00 中的 x
+  # 用最新的补丁版本替换 {{< skew currentVersion >}}.x-00 中的 x
   apt-mark unhold kubelet kubectl && \
-  apt-get update && apt-get install -y kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00 && \
+  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
   apt-mark hold kubelet kubectl
   - 
   # 从 apt-get 的 1.1 版本开始，你也可以使用下面的方法：
   apt-get update && \
-  apt-get install -y --allow-change-held-packages kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00
+  apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00
   </pre>
   {{% /tab %}}
   {{% tab name="CentOS、RHEL 或 Fedora" %}}
  
   <pre> 
-  # 用最新的补丁版本号替换 {{< skew latestVersion >}}.x-00 中的 x
-  yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+  # 用最新的补丁版本号替换 {{< skew currentVersion >}}.x-00 中的 x
+  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
   </pre>
   {{% /tab %}}
   {{< /tabs >}}
@@ -384,21 +384,21 @@ without compromising the minimum required capacity for running your workloads.
   {{% tab name="Ubuntu、Debian 或 HypriotOS" %}}
   
   ```shell
-  # 将 {{< skew latestVersion >}}.x-00 中的 x 替换为最新的补丁版本号
+  # 将 {{< skew currentVersion >}}.x-00 中的 x 替换为最新的补丁版本号
   apt-mark unhold kubeadm && \
-  apt-get update && apt-get install -y kubeadm={{< skew latestVersion >}}.x-00 && \
+  apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
   apt-mark hold kubeadm
   - 
   # 从 apt-get 的 1.1 版本开始，你也可以使用下面的方法：
   apt-get update && \
-  apt-get install -y --allow-change-held-packages kubeadm={{< skew latestVersion >}}.x-00
+  apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00
   ```
   {{% /tab %}}
   {{% tab name="CentOS、RHEL 或 Fedora" %}}
   
   ```shell
-  # 用最新的补丁版本替换 {{< skew latestVersion >}}.x-00 中的 x
-  yum install -y kubeadm-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+  # 用最新的补丁版本替换 {{< skew currentVersion >}}.x-00 中的 x
+  yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
   ```
   {{% /tab %}}
   {{< /tabs >}}
@@ -449,23 +449,23 @@ without compromising the minimum required capacity for running your workloads.
   {{% tab name="Ubuntu、Debian 或 HypriotOS" %}}
   
   ```shell
-  # 将 {{< skew latestVersion >}}.x-00 中的 x 替换为最新的补丁版本
+  # 将 {{< skew currentVersion >}}.x-00 中的 x 替换为最新的补丁版本
   apt-mark unhold kubelet kubectl && \
-  apt-get update && apt-get install -y kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00 && \
+  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
   apt-mark hold kubelet kubectl
   
   # 从 apt-get 的 1.1 版本开始，你也可以使用下面的方法：
   
   apt-get update && \
-  apt-get install -y --allow-change-held-packages kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00
+  apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00
   ```
   
   {{% /tab %}}
   {{% tab name="CentOS, RHEL or Fedora" %}}
   
   ```shell
-  # 将 {{< skew latestVersion >}}.x-0 x 替换为最新的补丁版本
-  yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+  # 将 {{< skew currentVersion >}}.x-0 x 替换为最新的补丁版本
+  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
   ```
   {{% /tab %}}
   {{< /tabs >}}

--- a/content/zh/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/zh/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -611,14 +611,14 @@ case, you should not use `host`, but rather set the `Host` header in `httpHeader
 
 <!--
 For an HTTP probe, the kubelet sends two request headers in addition to the mandatory `Host` header:
-`User-Agent`, and `Accept`. The default values for these headers are `kube-probe/{{< skew latestVersion >}}`
-(where `{{< skew latestVersion >}}` is the version of the kubelet ), and `*/*` respectively.
+`User-Agent`, and `Accept`. The default values for these headers are `kube-probe/{{< skew currentVersion >}}`
+(where `{{< skew currentVersion >}}` is the version of the kubelet ), and `*/*` respectively.
 
 You can override the default headers by defining `.httpHeaders` for the probe; for example
 -->
 针对 HTTP 探针，kubelet 除了必需的 `Host` 头部之外还发送两个请求头部字段：
-`User-Agent` 和 `Accept`。这些头部的默认值分别是 `kube-probe/{{ skew latestVersion >}}`
-（其中 `{{< skew latestVersion >}}` 是 kubelet 的版本号）和 `*/*`。
+`User-Agent` 和 `Accept`。这些头部的默认值分别是 `kube-probe/{{ skew currentVersion >}}`
+（其中 `{{< skew currentVersion >}}` 是 kubelet 的版本号）和 `*/*`。
 
 你可以通过为探测设置 `.httpHeaders` 来重载默认的头部字段值；例如：
 

--- a/content/zh/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-linux.md
@@ -22,12 +22,12 @@ card:
 ## {{% heading "prerequisites" %}}
 
 <!-- 
-You must use a kubectl version that is within one minor version difference of your cluster. For example, a v{{< skew latestVersion >}} client can communicate with v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, and v{{< skew nextMinorVersion >}} control planes.
+You must use a kubectl version that is within one minor version difference of your cluster. For example, a v{{< skew currentVersion >}} client can communicate with v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, and v{{< skew nextMinorVersion >}} control planes.
 Using the latest version of kubectl helps avoid unforeseen issues.
 -->
 kubectl 版本和集群版本之间的差异必须在一个小版本号内。
-例如：v{{< skew latestVersion >}} 版本的客户端能与 v{{< skew prevMinorVersion >}}、
-v{{< skew latestVersion >}} 和 v{{< skew nextMinorVersion >}} 版本的控制面通信。
+例如：v{{< skew currentVersion >}} 版本的客户端能与 v{{< skew currentVersionAddMinor -1 >}}、
+v{{< skew currentVersion >}} 和 v{{< skew nextMinorVersion >}} 版本的控制面通信。
 用最新版的 kubectl 有助于避免不可预见的问题。
 
 <!-- 

--- a/content/zh/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-macos.md
@@ -22,12 +22,12 @@ card:
 ## {{% heading "prerequisites" %}}
 
 <!-- 
-You must use a kubectl version that is within one minor version difference of your cluster. For example, a v{{< skew latestVersion >}} client can communicate with v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, and v{{< skew nextMinorVersion >}} control planes.
+You must use a kubectl version that is within one minor version difference of your cluster. For example, a v{{< skew currentVersion >}} client can communicate with v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, and v{{< skew nextMinorVersion >}} control planes.
 Using the latest version of kubectl helps avoid unforeseen issues.
 -->
 kubectl 版本和集群之间的差异必须在一个小版本号之内。
-例如：v{{< skew latestVersion >}} 版本的客户端能与 v{{< skew prevMinorVersion >}}、
-v{{< skew latestVersion >}} 和 v{{< skew nextMinorVersion >}} 版本的控制面通信。
+例如：v{{< skew currentVersion >}} 版本的客户端能与 v{{< skew currentVersionAddMinor -1 >}}、
+v{{< skew currentVersion >}} 和 v{{< skew nextMinorVersion >}} 版本的控制面通信。
 用最新版本的 kubectl 有助于避免不可预见的问题。
 
 <!-- 

--- a/content/zh/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-windows.md
@@ -22,12 +22,12 @@ card:
 ## {{% heading "prerequisites" %}}
 
 <!-- 
-You must use a kubectl version that is within one minor version difference of your cluster. For example, a v{{< skew latestVersion >}} client can communicate with v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, and v{{< skew nextMinorVersion >}} control planes.
+You must use a kubectl version that is within one minor version difference of your cluster. For example, a v{{< skew currentVersion >}} client can communicate with v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, and v{{< skew nextMinorVersion >}} control planes.
 Using the latest version of kubectl helps avoid unforeseen issues.
 -->
 kubectl 版本和集群版本之间的差异必须在一个小版本号内。
-例如：v{{< skew latestVersion >}} 版本的客户端能与 v{{< skew prevMinorVersion >}}、
-v{{< skew latestVersion >}} 和 v{{< skew nextMinorVersion >}} 版本的控制面通信。
+例如：v{{< skew currentVersion >}} 版本的客户端能与 v{{< skew currentVersionAddMinor -1 >}}、
+v{{< skew currentVersion >}} 和 v{{< skew nextMinorVersion >}} 版本的控制面通信。
 用最新版的 kubectl 有助于避免不可预见的问题。
 
 <!-- 


### PR DESCRIPTION
Fix those k8s minor versions by following the en upstream #34346.

```
content/zh/docs/setup/release/version-skew-policy.md
content/zh/docs/tasks/administer-cluster/cluster-upgrade.md
content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
content/zh/docs/tasks/tools/install-kubectl-linux.md
content/zh/docs/tasks/tools/install-kubectl-macos.md
content/zh/docs/tasks/tools/install-kubectl-windows.md
```