### PR TITLE
Revert wrong K8s minor version displays in v1.20 docs

### DIFF
--- a/content/en/docs/setup/release/version-skew-policy.md
+++ b/content/en/docs/setup/release/version-skew-policy.md
@@ -24,7 +24,7 @@ Kubernetes versions are expressed as **x.y.z**,
 where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
 For more information, see [Kubernetes Release Versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning).
 
-The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
+The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
 
 Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
 Patch releases are cut from those branches at a [regular cadence](https://git.k8s.io/sig-release/releases/patch-releases.md#cadence), plus additional urgent releases, when required.


### PR DESCRIPTION
This is a backport of [this suggestion](https://github.com/kubernetes/website/pull/34349#pullrequestreview-1010188253).

[[As-is](https://v1-20.docs.kubernetes.io/docs/setup/release/version-skew-policy/#:~:text=three%20minor%20releases%20(-,1.20%2C%201.19%2C%201.18,-).%20Kubernetes%201.19%20and)]
![image](https://user-images.githubusercontent.com/46767780/184441581-52c24e10-5a0c-42dd-bb0a-6e549d94cf48.png)

[To-be]
![image](https://user-images.githubusercontent.com/46767780/184441824-c487fd82-e9d9-400d-ae45-475445a0255d.png)

[Related issues/PRs]
- #31551
- #34349
- #34346
- ...

[CC]
- @sftim (from [#34349](https://github.com/kubernetes/website/pull/34349))
- @tengqm (from [#34346](https://github.com/kubernetes/website/pull/34346))