### PR TITLE
Revert wrong K8s minor version displays in v1.23 docs

### DIFF
--- a/content/en/releases/_index.md
+++ b/content/en/releases/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 <!-- overview -->
 
-The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive [approximately 1 year of patch support](/releases/patch-releases/#support-period). Kubernetes 1.18 and older received approximately 9 months of patch support.
+The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}). Kubernetes 1.19 and newer receive [approximately 1 year of patch support](/releases/patch-releases/#support-period). Kubernetes 1.18 and older received approximately 9 months of patch support.
 
 Kubernetes versions are expressed as **x.y.z**,
 where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
@@ -22,6 +22,6 @@ More information in the [version skew policy](/releases/version-skew-policy/) do
 
 ## Upcoming Release
 
-Check out the [schedule](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew currentVersionAddMinor 1 >}}) for the upcoming **{{< skew currentVersionAddMinor 1 >}}** Kubernetes release!
+Check out the [schedule](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew nextMinorVersion >}}) for the upcoming **{{< skew nextMinorVersion >}}** Kubernetes release!
 
 ## Helpful Resources

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -23,7 +23,7 @@ Specific cluster deployment tools may place additional restrictions on version s
 Kubernetes versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
 For more information, see [Kubernetes Release Versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning).
 
-The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
+The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}). Kubernetes 1.19 and newer receive [approximately 1 year of patch support](/releases/patch-releases/#support-period). Kubernetes 1.18 and older received approximately 9 months of patch support.
 
 Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
 Patch releases are cut from those branches at a [regular cadence](https://git.k8s.io/sig-release/releases/patch-releases.md#cadence), plus additional urgent releases, when required.


### PR DESCRIPTION
This is a backport of these suggestions: [1](https://github.com/kubernetes/website/pull/34349#pullrequestreview-1010185820), [2](https://github.com/kubernetes/website/pull/34349#pullrequestreview-1010187903), and [3](https://github.com/kubernetes/website/pull/34349#pullrequestreview-1010188253).

[[As-is](https://v1-23.docs.kubernetes.io/releases/version-skew-policy/#:~:text=three%20minor%20releases%20(-,1.23%2C%201.22%2C%201.21,-).%20Kubernetes%201.19%20and)]
![image](https://user-images.githubusercontent.com/46767780/184444772-0764a8eb-d36e-4979-9329-3b097a37af34.png)

[To-be]
![image](https://user-images.githubusercontent.com/46767780/184441824-c487fd82-e9d9-400d-ae45-475445a0255d.png)

[Related issues/PRs]
- #31551
- #34349
- #34346
- #35913
- #35914 (`main` branch)
- ...

[CC]
- @sftim (from [#34349](https://github.com/kubernetes/website/pull/34349))
- @tengqm (from [#34346](https://github.com/kubernetes/website/pull/34346))