### PR TITLE
Update Customizing DNS Service

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -30,8 +30,8 @@ DNS is a built-in Kubernetes service launched automatically
 using the _addon manager_
 [cluster add-on](http://releases.k8s.io/master/cluster/addons/README.md).
 
-As of Kubernetes v1.12, CoreDNS is the recommended DNS Server, replacing kube-dns. If your cluster
-originally used kube-dns, you may still have `kube-dns` deployed rather than CoreDNS.
+As of Kubernetes v1.12, CoreDNS is the recommended DNS server, replacing `kube-dns`.
+If your cluster originally used kube-dns, you may still have `kube-dns` deployed rather than CoreDNS.
 
 {{< note >}}
 The CoreDNS Service is named `kube-dns` in the `metadata.name` field.  
@@ -105,9 +105,9 @@ The Corefile configuration includes the following [plugins](https://coredns.io/p
 * [health](https://coredns.io/plugins/health/): Health of CoreDNS is reported to `http://localhost:8080/health`. In this extended syntax `lameduck` will make the process unhealthy then wait for 5 seconds before the process is shut down.
 * [ready](https://coredns.io/plugins/ready/): An HTTP endpoint on port 8181 will return 200 OK, when all plugins that are able to signal readiness have done so.
 * [kubernetes](https://coredns.io/plugins/kubernetes/): CoreDNS will reply to DNS queries based on IP of the services and pods of Kubernetes. You can find [more details](https://coredns.io/plugins/kubernetes/) about that plugin on the CoreDNS website. `ttl` allows you to set a custom TTL for responses. The default is 5 seconds. The minimum TTL allowed is 0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.  
-  The `pods insecure` option is provided for backward compatibility with _kube-dns_. You can use the `pods verified` option, which returns an A record only if there exists a pod in same namespace with matching IP. The `pods disabled` option can be used if you don't use pod records.
+  The `pods insecure` option is provided for backward compatibility with `kube-dns`. You can use the `pods verified` option, which returns an A record only if there exists a pod in same namespace with matching IP. The `pods disabled` option can be used if you don't use pod records.
 * [prometheus](https://coredns.io/plugins/metrics/): Metrics of CoreDNS are available at `http://localhost:9153/metrics` in [Prometheus](https://prometheus.io/) format (also known as OpenMetrics).
-* [forward](https://coredns.io/plugins/forward/): Any queries that are not within the cluster domain of Kubernetes will be forwarded to predefined resolvers (/etc/resolv.conf).
+* [forward](https://coredns.io/plugins/forward/): Any queries that are not within the cluster domain of Kubernetes will be forwarded to predefined resolvers (`/etc/resolv.conf`).
 * [cache](https://coredns.io/plugins/cache/): This enables a frontend cache.
 * [loop](https://coredns.io/plugins/loop/): Detects simple forwarding loops and halts the CoreDNS process if a loop is found.
 * [reload](https://coredns.io/plugins/reload): Allows automatic reload of a changed Corefile. After you edit the ConfigMap configuration, allow two minutes for your changes to take effect.
@@ -115,14 +115,15 @@ The Corefile configuration includes the following [plugins](https://coredns.io/p
 
 You can modify the default CoreDNS behavior by modifying the ConfigMap.
 
-### Configuration of Stub-domain and upstream nameserver using CoreDNS
+### Configuration of `stubDomains` and `upstreamNameservers` using CoreDNS
 
-CoreDNS has the ability to configure stubdomains and upstream nameservers using the [forward plugin](https://coredns.io/plugins/forward/).
+CoreDNS has the ability to configure `stubDomains` and `upstreamNameservers` using the [forward plugin](https://coredns.io/plugins/forward/).
 
 #### Example
-If a cluster operator has a [Consul](https://www.consul.io/) domain server located at 10.150.0.1, and all Consul names have the suffix .consul.local. To configure it in CoreDNS, the cluster administrator creates the following stanza in the CoreDNS ConfigMap.
+If a cluster operator has a [Consul](https://www.consul.io/) domain server located at `10.150.0.1`, and all Consul names have the suffix `.consul.local`. 
+To configure it in CoreDNS, the cluster administrator creates the following stanza in the CoreDNS ConfigMap.
 
-```
+```yaml
 consul.local:53 {
         errors
         cache 30
@@ -130,9 +131,9 @@ consul.local:53 {
     }
 ```
 
-To explicitly force all non-cluster DNS lookups to go through a specific nameserver at 172.16.0.1, point the `forward` to the nameserver instead of `/etc/resolv.conf`
+To explicitly force all non-cluster DNS lookups to go through a specific nameserver at `172.16.0.1`, point the `forward` to the nameserver instead of `/etc/resolv.conf`.
 
-```
+```shell
 forward .  172.16.0.1
 ```
 
@@ -167,22 +168,22 @@ data:
     }
 ```
 
-The `kubeadm` tool supports automatic translation from the kube-dns ConfigMap
+The `kubeadm` tool supports automatic translation from the `kube-dns` ConfigMap
 to the equivalent CoreDNS ConfigMap.
 
 {{< note >}}
-While kube-dns accepts an FQDN for stubdomain and nameserver (eg: ns.foo.com), CoreDNS does not support this feature.
+While `kube-dns` accepts an FQDN for stubdomain and nameserver (For example: `ns.foo.com`), CoreDNS does not support this feature.
 During translation, all FQDN nameservers will be omitted from the CoreDNS config.
 {{< /note >}}
 
-## CoreDNS configuration equivalent to kube-dns
+## CoreDNS configuration equivalent to `kube-dns`
 
-CoreDNS supports the features of kube-dns and more.
-A ConfigMap created for kube-dns to support `StubDomains`and `upstreamNameservers` translates to the `forward` plugin in CoreDNS.
+CoreDNS supports the features of `kube-dns` and more.
+A ConfigMap created for `kube-dns` to support `stubDomains` and `upstreamNameservers` translates to the `forward` plugin in CoreDNS.
 
 ### Example
 
-This example ConfigMap for kube-dns specifies stubdomains and upstreamnameservers:
+This example ConfigMap for `kube-dns` specifies `stubDomains` and `upstreamNameservers`:
 
 ```yaml
 apiVersion: v1
@@ -196,23 +197,23 @@ kind: ConfigMap
 
 The equivalent configuration in CoreDNS creates a Corefile:
 
-* For stubDomains:
-```yaml
-abc.com:53 {
-    errors
-    cache 30
-    forward . 1.2.3.4
-}
-my.cluster.local:53 {
-    errors
-    cache 30
-    forward . 2.3.4.5
-}
-```
+* For `stubDomains`:
+  ```yaml
+  abc.com:53 {
+      errors
+      cache 30
+      forward . 1.2.3.4
+  }
+  my.cluster.local:53 {
+      errors
+      cache 30
+      forward . 2.3.4.5
+  }
+  ```
 
 The complete Corefile with the default plugins:
 
-```
+```yaml
 .:53 {
     errors
     health
@@ -241,9 +242,9 @@ my.cluster.local:53 {
 
 ## Migration to CoreDNS
 
-To migrate from kube-dns to CoreDNS, a detailed
+To migrate from `kube-dns` to CoreDNS, a detailed
 [blog article](https://coredns.io/2018/05/21/migration-from-kube-dns-to-coredns/)
-is available to help users adapt CoreDNS in place of kube-dns.
+is available to help users adapt CoreDNS in place of `kube-dns`.
 
 You can also migrate using the official CoreDNS
 [deploy script](https://github.com/coredns/deployment/blob/master/kubernetes/deploy.sh).
@@ -251,4 +252,4 @@ You can also migrate using the official CoreDNS
 
 ## {{% heading "whatsnext" %}}
 
-- Read [Debugging DNS Resolution](/docs/tasks/administer-cluster/dns-debugging-resolution/)
+- Read [Debugging DNS Resolution](/docs/tasks/administer-cluster/dns-debugging-resolution/).


### PR DESCRIPTION
* Fix indentation error:
When [localizing Customizing DNS Service](https://github.com/kubernetes/website/pull/35910), found indentation error in the [CoreDNS configuration equivalent to kube-dns Example](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#example-1) .
![image](https://user-images.githubusercontent.com/64598482/184465714-9d800156-d381-4370-963d-0ad0498463c4.png)

* Adjust according to [Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/):
  - Avoid Latin phrases 
  - Use code style for filenames, directories, and paths 

* Unify the notation of `kube-dns`

* Fix typo in `stubDomains` and `upstreamNameservers` 




Signed-off-by: ydFu <ader.ydfu@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
