### PR TITLE
Fix release-data i18n

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -262,6 +262,15 @@ other = "(released: "
 [release_date_format]
 other = "2006-01-02"
 
+[release_full_details_initial_text]
+other = "Complete"
+
+[release_schedule]
+other = "Schedule"
+
+[release_changelog]
+other = "Changelog"
+
 [seealso_heading]
 other = "See Also"
 

--- a/layouts/shortcodes/release-data.html
+++ b/layouts/shortcodes/release-data.html
@@ -33,10 +33,10 @@
 </div>
 
 {{- end -}}
-<!-- not yet localized, mark as English -->
-<p lang="en">
-Complete {{ $dataVersion }} <a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">Schedule</a>
-and <a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">Changelog</a>
+<p>
+{{ T "release_full_details_initial_text" }} {{ $dataVersion }}
+<a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">{{ T "release_schedule" }}</a>{{ T "inline_list_separator" }}
+<a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">{{ T "release_changelog" }}</a>
 </p>
 
 </div>


### PR DESCRIPTION
Not sure how to extract three single word.

Please give me some advice about better practices.

Current: https://kubernetes.io/releases/ (Hard-coded)
Preview: https://deploy-preview-35950--kubernetes-io-main-staging.netlify.app/releases/ (Not broken)
zh: https://deploy-preview-35950--kubernetes-io-main-staging.netlify.app/zh-cn/releases/ (Not translated yet)

Relates: #35932