### PR TITLE
Fix the extra '{' or '}'  in different files

### DIFF
--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -194,12 +194,12 @@ The tab **name** in a `tabs` definition must be unique within a content page.
 
 ```go-text-template
 {{</* tabs name="tab_with_code" >}}
-{{{< tab name="Tab 1" codelang="bash" >}}
+{{< tab name="Tab 1" codelang="bash" >}}
 echo "This is tab 1."
 {{< /tab >}}
 {{< tab name="Tab 2" codelang="go" >}}
 println "This is tab 2."
-{{< /tab >}}}
+{{< /tab >}}
 {{< /tabs */>}}
 ```
 
@@ -306,7 +306,6 @@ Add the shortcode:
 
 before the item, or just below the heading for the specific item.
 
-
 ## Version strings
 
 To generate a version string for inclusion in the documentation, you can choose from
@@ -378,4 +377,3 @@ Renders to:
 * Learn about [page content types](/docs/contribute/style/page-content-types/).
 * Learn about [opening a pull request](/docs/contribute/new-content/open-a-pr/).
 * Learn about [advanced contributing](/docs/contribute/advanced/).
-

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -31,12 +31,12 @@ Reload your shell and verify that bash-completion is correctly installed by typi
 You now need to ensure that the kubectl completion script gets sourced in all your shell sessions. There are two ways in which you can do this:
 
 {{< tabs name="kubectl_bash_autocompletion" >}}
-{{{< tab name="User" codelang="bash" >}}
+{{< tab name="User" codelang="bash" >}}
 echo 'source <(kubectl completion bash)' >>~/.bashrc
 {{< /tab >}}
 {{< tab name="System" codelang="bash" >}}
 kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl > /dev/null
-{{< /tab >}}}
+{{< /tab >}}
 {{< /tabs >}}
 
 If you have an alias for kubectl, you can extend shell completion to work with that alias:

--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -68,10 +68,10 @@ into the cluster.
 {{< /tab >}}
 {{< tab name="violation.json" >}}
 {{< codenew file="pods/security/seccomp/profiles/violation.json" >}}
-{{< /tab >}}}
+{{< /tab >}}
 {{< tab name="fine-grained.json" >}}
 {{< codenew file="pods/security/seccomp/profiles/fine-grained.json" >}}
-{{< /tab >}}}
+{{< /tab >}}
 {{< /tabs >}}
 
 Run these commands:
@@ -89,9 +89,7 @@ You should see three profiles listed at the end of the final step:
 audit.json  fine-grained.json  violation.json
 ```
 
-
 ## Create a local Kubernetes cluster with kind
-
 
 For simplicity, [kind](https://kind.sigs.k8s.io/) can be used to create a single
 node cluster with the seccomp profiles loaded. Kind runs Kubernetes in Docker,


### PR DESCRIPTION
Delete the extra `{` and `}` according to [this PR](https://github.com/kubernetes/website/pull/35902), I found that other files also have issues, and propose to correct them together.

Listed below:
```
1. content/en/docs/contribute/style/hugo-shortcodes/index.md
2. content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
3. content/en/docs/tutorials/security/seccomp.md
```
Signed-off-by: ydFu <ader.ydfu@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
