### PR TITLE
Fix bad merge for kubeadm etcd static pod 

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -362,7 +362,7 @@ The static Pod manifest for the scheduler is not affected by parameters provided
 
 ### Generate static Pod manifest for local etcd
 
-If the user specified an external etcd this step will be skipped, otherwise kubeadm generates a
+If you specified an external etcd this step will be skipped, otherwise kubeadm generates a
 static Pod manifest file for creating a local etcd instance running in a Pod with following attributes:
 
 - listen on `localhost:2379` and use `HostNetwork=true`
@@ -373,10 +373,10 @@ Please note that:
 
 1. The etcd container image will be pulled from `registry.gcr.io` by default. See
    [using custom images](/docs/reference/setup-tools/kubeadm/kubeadm-init/#custom-images)
-   for customizing the image repository
-2. In case of kubeadm is executed in the `--dry-run` mode, the etcd static Pod manifest is written
-   in a temporary folder.
-3. Static Pod manifest generation for local etcd can be invoked individually with the
+   for customizing the image repository.
+2. If you run kubeadm in `--dry-run` mode, the etcd static Pod manifest is written
+   into a temporary folder.
+3. You can directly invoke static Pod manifest generation for local etcd, using the
    [`kubeadm init phase etcd local`](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-etcd)
    command.
 

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -371,12 +371,7 @@ static Pod manifest file for creating a local etcd instance running in a Pod wit
 
 Please note that:
 
-<<<<<<< HEAD
-1. The etcd image will be pulled from `registry.k8s.io` by default. See [using custom images](/docs/reference/setup-tools/kubeadm/kubeadm-init/#custom-images) for customizing the image repository
-2. in case of kubeadm is executed in the `--dry-run` mode, the etcd static Pod manifest is written in a temporary folder
-3. Static Pod manifest generation for local etcd can be invoked individually with the [`kubeadm init phase etcd local`](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-etcd) command
-=======
-1. The etcd image will be pulled from `k8s.gcr.io` by default. See
+1. The etcd container image will be pulled from `registry.gcr.io` by default. See
    [using custom images](/docs/reference/setup-tools/kubeadm/kubeadm-init/#custom-images)
    for customizing the image repository
 2. In case of kubeadm is executed in the `--dry-run` mode, the etcd static Pod manifest is written
@@ -384,7 +379,6 @@ Please note that:
 3. Static Pod manifest generation for local etcd can be invoked individually with the
    [`kubeadm init phase etcd local`](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-etcd)
    command.
->>>>>>> upstream/main
 
 ### Wait for the control plane to come up
 


### PR DESCRIPTION
Fix up https://github.com/kubernetes/website/pull/35758

plus, some further tweaks to https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#generate-static-pod-manifest-for-local-etcd that seemed reasonable to make.
/sig cluster-lifecycle
/milestone 1.25

This is probably easiest to review commit-by-commit.