### PR TITLE
Enable AutoCompletion in Current Session of Bash

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -51,3 +51,7 @@ bash-completion sources all completion scripts in `/etc/bash_completion.d`.
 {{< /note >}}
 
 Both approaches are equivalent. After reloading your shell, kubectl autocompletion should be working.
+To enable bash autocompletion in current session of shell, source the ~/.bashrc file:
+```bash
+source ~/.bashrc
+```


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Updates the doc for enabling bash autocompletion in current session.

### 2. Which issues (if any) are related?
Fixes https://github.com/kubernetes/website/issues/35931

### 3. Which documentation changes (if any) need to be made?
https://kubernetes.io/docs/tasks/tools/included/optional-kubectl-configs-bash-linux/#bash

### 4. Does this introduce a backward incompatible change or deprecation?
No