### PR TITLE
Google analytics: use GA4 site tag

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -117,7 +117,8 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-id = "G-JPP6RFM2BP"
+# Bogus value in support of params.ui.feedback.
+id = "G-0000000000"
 
 [params]
 copyright_k8s = "The Kubernetes Authors"

--- a/config.toml
+++ b/config.toml
@@ -117,8 +117,8 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-# Bogus value in support of params.ui.feedback.
-id = "G-0000000000"
+# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
+id = "UA-00000000-0"
 
 [params]
 copyright_k8s = "The Kubernetes Authors"

--- a/config.toml
+++ b/config.toml
@@ -117,8 +117,7 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "G-JPP6RFM2BP"
 
 [params]
 copyright_k8s = "The Kubernetes Authors"

--- a/config.toml
+++ b/config.toml
@@ -117,7 +117,7 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
+# Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
 id = "UA-00000000-0"
 
 [params]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,17 +6,6 @@
 {{- else -}}
 <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
 {{- end -}}
-{{- if in (slice "production" "nonprod") hugo.Environment -}}
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-36037335-10"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-36037335-10');
-</script>
-{{- end -}}
 
 <!-- alternative translations -->
 {{ range .Translations -}}
@@ -36,7 +25,7 @@
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{- if hugo.IsProduction -}}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ end }}
 {{ partialCached "head-css.html" . "asdf" }}
 <script


### PR DESCRIPTION
- Contributes to #35299

Preparatory step:

- [x] Add the GA4 ID via Netlify config. [Done by @onlydole, thanks!]