### PR TITLE
Remove celestehorgan as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,12 +7,13 @@ approvers:
 - sig-docs-en-owners # Defined in OWNERS_ALIASES
 
 emeritus_approvers:
+# - celestehorgan, commented out to disable PR assignments
 # - chenopis, commented out to disable PR assignments
 # - irvifa, commented out to disable PR assignments
 # - jaredbhatti, commented out to disable PR assignments
 # - kbarnard10, commented out to disable PR assignments
 # - steveperry-53, commented out to disable PR assignments
-- stewart-yu 
+- stewart-yu
 # - zacharysarah, commented out to disable PR assignments
 
 labels:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,6 @@ aliases:
   sig-docs-en-owners: # Admins for English content
     - annajung
     - bradtopol
-    - celestehorgan
     - divya-mohan0209
     - jimangel
     - jlbutler
@@ -35,7 +34,6 @@ aliases:
     - tengqm
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol
-    - celestehorgan
     - daminisatya
     - divya-mohan0209
     - jimangel


### PR DESCRIPTION
I found it strange to see the bot add @celestehorgan as an approver for a previous PR since she has moved on. Maybe she's still contributing to the k8s docs, but I don't think so. I followed Zach's example in #27637.

/cc @nate-double-u @jimangel @sftim 

 