### PR TITLE
Gitignore /public even if it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ kubernetes.github.io.iml
 nohup.out
 
 # Hugo output
-/public/
+/public
 /resources/
 .hugo_build.lock
 


### PR DESCRIPTION
It can be useful, for debugging purposes for `/public` to be a symlink to a Git repo, which is used to diff generated site files. This rule pattern change in this PR supports this use case.

/cc @nate-double-u @sftim 