### PR TITLE
`run=source-ip-app` is changed into `app=source-ip-app`

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -326,7 +326,7 @@ The `service.spec.healthCheckNodePort` field points to a port on every node
 serving the health check at `/healthz`. You can test this:
 
 ```shell
-kubectl get pod -o wide -l run=source-ip-app
+kubectl get pod -o wide -l app=source-ip-app
 ```
 The output is similar to this:
 ```


### PR DESCRIPTION
## Fixes #36087 

## Closes #36087 

## description

In this page https://kubernetes.io/docs/tutorials/services/source-ip/
for this command 
```bash
kubectl get pod -o wide -l run=source-ip-app
```
according to the pod labels it should be 

```bash
kubectl get pod -o wide -l app=source-ip-app
```