### PR TITLE
Typo fixed in documentation for Use strategic merge

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -335,7 +335,7 @@ With this patch, we indicate that we want to retain only the `type` key of the `
 Patch your Deployment again with this new patch:
 
 ```shell
-kubectl patch deployment retainkeys-demo --type merge --patch-file patch-file-retainkeys.yaml
+kubectl patch deployment retainkeys-demo --type strategic --patch-file patch-file-retainkeys.yaml
 ```
 
 Examine the content of the Deployment:


### PR DESCRIPTION
## Fixes #36074 

## Closes #36074 

## description

Typo in this [`documentation`](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-strategic-merge-patch-to-update-a-deployment-using-the-retainkeys-strategy)

the command 
```go
kubectl patch deployment retainkeys-demo --type merge --patch-file patch-file-retainkeys.yaml
```
should be 

```go
kubectl patch deployment retainkeys-demo --type strategic --patch-file patch-file-retainkeys.yaml
```