### PR TITLE
[uk] Cleanup some UK pages

### DIFF
--- a/content/uk/docs/setup/production-environment/_index.md
+++ b/content/uk/docs/setup/production-environment/_index.md
@@ -1,5 +1,7 @@
 ---
-#title: Production environment
+# title: Production environment
+# description: Create a production-quality Kubernetes cluster
 title: Прод оточення
 weight: 30
+no_list: true
 ---

--- a/content/uk/docs/setup/production-environment/on-premises-vm/_index.md
+++ b/content/uk/docs/setup/production-environment/on-premises-vm/_index.md
@@ -1,5 +1,0 @@
----
-# title: On-Premises VMs
-title: Менеджери віртуалізації
-weight: 40
----

--- a/content/uk/docs/setup/production-environment/turnkey/_index.md
+++ b/content/uk/docs/setup/production-environment/turnkey/_index.md
@@ -1,5 +1,0 @@
----
-# title: Turnkey Cloud Solutions
-title: Хмарні рішення під ключ
-weight: 30
----

--- a/content/uk/docs/setup/production-environment/windows/_index.md
+++ b/content/uk/docs/setup/production-environment/windows/_index.md
@@ -1,5 +1,0 @@
----
-# title: "Windows in Kubernetes"
-title: "Windows в Kubernetes"
-weight: 50
----

--- a/content/uk/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/uk/docs/tutorials/kubernetes-basics/_index.html
@@ -1,6 +1,7 @@
 ---
 title: Дізнатися про основи Kubernetes
 linkTitle: Основи Kubernetes
+no_list: true
 weight: 10
 card:
   name: навчальні матеріали
@@ -10,7 +11,7 @@ card:
 
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="uk">
 
 <body>
 


### PR DESCRIPTION
This PR is about the netlify preview issues. Based on some initial experiments (e.g. #36103), the netlify preview build often stuck at generating `/uk/docs/setup/production-environment/index.html` or `/uk/docs/tutorials/kubernetes-basics/update/index.html`.
This PR attempts to change these pages without disrupting any existing efforts in UK localizations.
Some outdated placeholders are removed to make sure the docs build.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
