### PR TITLE
Reinstate legacy taint for control plane nodes

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -738,10 +738,20 @@ Used on: Node
 
 Label that kubeadm applies on the control plane nodes that it manages.
 
-### node-role.kubernetes.io/control-plane
+### node-role.kubernetes.io/control-plane {#node-role-kubernetes-io-control-plane-taint}
 
 Used on: Node
 
 Example: `node-role.kubernetes.io/control-plane:NoSchedule`
 
 Taint that kubeadm applies on control plane nodes to allow only critical workloads to schedule on them.
+
+### node-role.kubernetes.io/master (deprecated) {#node-role-kubernetes-io-master-taint}
+
+Used on: Node
+
+Example: `node-role.kubernetes.io/master:NoSchedule`
+
+Taint that kubeadm previously applied on control plane nodes to allow only critical workloads to schedule on them.
+Replaced by [`node-role.kubernetes.io/control-plane`](#node-role-kubernetes-io-control-plane-taint); kubeadm
+no longer sets or uses this deprecated taint.


### PR DESCRIPTION
Similar to APIs, we don't delete legacy taints and labels from the page, we leave them there and mark them as deprecated.

Reinstate taint `node-role.kubernetes.io/master` (was removed in PR https://github.com/kubernetes/website/pull/33834).
[Preview](https://deploy-preview-36173--kubernetes-io-vnext-staging.netlify.app/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint)
