### PR TITLE
update release-1.21 config.toml for release 1.25

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -138,11 +138,11 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.24"
+latest = "v1.25"
 
-fullversion = "v1.21.12"
+fullversion = "v1.21.14"
 version = "v1.21"
-githubbranch = "release-1.21"
+githubbranch = "v1.21.14"
 docsbranch = "release-1.21"
 deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
@@ -178,39 +178,39 @@ js = [
 ]
 
 [[params.versions]]
-fullversion = "v1.24.0"
-version = "v1.24"
-githubbranch = "v1.24.0"
+fullversion = "v1.25.0"
+version = "v1.25"
+githubbranch = "v1.25.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.23.6"
+fullversion = "v1.24.4"
+version = "v1.24"
+githubbranch = "v1.24.4"
+docsbranch = "main"
+url = "https://kubernetes.io"
+
+[[params.versions]]
+fullversion = "v1.23.10"
 version = "v1.23"
-githubbranch = "v1.23.6"
+githubbranch = "v1.23.10"
 docsbranch = "release-1.23"
 url = "https://v1-23.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.22.9"
+fullversion = "v1.22.13"
 version = "v1.22"
-githubbranch = "v1.22.9"
+githubbranch = "v1.22.13"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.21.12"
+fullversion = "v1.21.14"
 version = "v1.21"
-githubbranch = "v1.21.12"
+githubbranch = "v1.21.14"
 docsbranch = "release-1.21"
 url = "https://v1-21.docs.kubernetes.io"
-
-[[params.versions]]
-fullversion = "v1.20.15"
-version = "v1.20"
-githubbranch = "v1.20.15"
-docsbranch = "release-1.20"
-url = "https://v1-20.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -188,7 +188,7 @@ url = "https://kubernetes.io"
 fullversion = "v1.24.4"
 version = "v1.24"
 githubbranch = "v1.24.4"
-docsbranch = "main"
+docsbranch = "release-1.24"
 url = "https://kubernetes.io"
 
 [[params.versions]]


### PR DESCRIPTION
update release-1.21 config.toml for new release 1.25

Version were updated according to [latest patch releases](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md)

/cc @kcmartin @didicodes @sethmccombs @krol3 @reylejano 