### PR TITLE
[zh] Update releases page and fix the 404 link

### DIFF
--- a/content/zh-cn/releases/_index.md
+++ b/content/zh-cn/releases/_index.md
@@ -32,13 +32,17 @@ Kubernetes 版本表示为 **x.y.z**，
 
 <!-- body -->
 
-<!-- ## Release History -->
-## 发行版本历史
+<!--
+## Release History
+-->
+## 发行版本历史 {#release-history}
 
 {{< release-data >}}
 
-<!-- ## Upcoming Release -->
-## 未来的发行版本
+<!--
+## Upcoming Release
+-->
+## 未来的发行版本 {#upcoming-release}
 
 <!-- 
 Check out the [schedule](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew nextMinorVersion >}}) for the upcoming **{{< skew nextMinorVersion >}}** Kubernetes release!
@@ -46,5 +50,7 @@ Check out the [schedule](https://github.com/kubernetes/sig-release/tree/master/r
 查看[时间表](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew nextMinorVersion >}})，
 Kubernetes **{{< skew nextMinorVersion >}}** 版本即将发行！
 
-<!-- ## Helpful Resources -->
-## 有用的资源
+<!--
+## Helpful Resources
+-->
+## 有用的资源 {#helpful-resources}

--- a/content/zh-cn/releases/release-managers.md
+++ b/content/zh-cn/releases/release-managers.md
@@ -74,7 +74,7 @@ Some information about releases is subject to embargo and we have defined policy
 <!-- 
 ## Handbooks
 
-**NOTE:** The Patch Release Team and Branch Manager handbooks will be de-duplicated at a later date.
+**NOTE: The Patch Release Team and Branch Manager handbooks will be de-duplicated at a later date.**
 
 - [Patch Release Team][handbook-patch-release]
 - [Branch Managers][handbook-branch-mgmt]
@@ -82,7 +82,7 @@ Some information about releases is subject to embargo and we have defined policy
 -->
 ## 手册  {#handbooks}
 
-**注意：**补丁发布团队和分支管理员手册以后将会删除重复数据。
+**注意：补丁发布团队和分支管理员手册以后将会删除重复数据。**
 
 - [补丁发布团队][handbook-patch-release]
 - [分支管理员][handbook-branch-mgmt]
@@ -374,6 +374,9 @@ Example: [1.15 Release Team](https://git.k8s.io/sig-release/releases/release-1.1
 [handbook-packaging]: https://git.k8s.io/release/hack/rapture/README.md
 [handbook-patch-release]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/patch-release-team.md
 [k-sig-release-releases]: https://git.k8s.io/sig-release/releases
+<!--
+[patches]: /releases/patch-releases/
+-->
 [patches]: /zh-cn/releases/patch-releases/
 [src]: https://git.k8s.io/community/committee-security-response/README.md
 [release-team]: https://git.k8s.io/sig-release/release-team/README.md

--- a/content/zh-cn/releases/release.md
+++ b/content/zh-cn/releases/release.md
@@ -94,7 +94,7 @@ requirements exist when the target milestone is a prior release (see
 如果需要更新，自动化和发布团队将与你联系，但无响应可能会导致你的工作从里程碑中删除。
 当目标里程碑是先前版本时，还存在其他要求（请参阅 [Cherry Pick 流程][cherry-picks]了解更多信息）。
 
-## TL;DR
+## TL;DR {#tldr}
 
 <!-- 
 If you want your PR to get merged, it needs the following required labels and
@@ -103,7 +103,7 @@ milestones, represented here by the Prow /commands it would take to add them:
 如果你希望你的 PR 被合并，它需要以下必备的标签和里程碑，它们由 Prow /commands 所添加表示：
 
 <!-- 
-### Normal Dev (Weeks 1-8)
+### Normal Dev (Weeks 1-11)
 -->
 ### 正常开发（第 1-11 周）  {#normal-dev-weeks-1-11}
 
@@ -197,7 +197,7 @@ The general labeling process should be consistent across artifact types.
   The period of ~4 weeks before the final release date, during which only
   critical bug fixes are merged into the release.
 
-- *[Pruning](https://git.k8s.io/sig-release/releases/release*phases.md#pruning)*:
+- *[Pruning](https://git.k8s.io/sig-release/releases/release_phases.md#pruning)*:
   The process of removing an Enhancement from a release milestone if it is not
   fully implemented or is otherwise considered not stable.
 -->
@@ -210,7 +210,7 @@ The general labeling process should be consistent across artifact types.
 - **[代码冻结][code-freeze]**：
   最终发布日期前约 4 周的时间，在此期间，仅将关键错误修复合并到发布中。
 
-- **[修剪](https://git.k8s.io/sig-release/releases/release*phases.md#pruning)**：
+- **[修剪](https://git.k8s.io/sig-release/releases/release_phases.md#pruning)**：
   如果特性增强未完全实现或被认为不稳定，则在此过程中从发布里程碑中删除它。
 
 <!-- 

--- a/content/zh-cn/search.md
+++ b/content/zh-cn/search.md
@@ -4,8 +4,6 @@ title: 搜索结果
 ---
 
 <!--
----
 layout: search
 title: Search Results
----
 -->


### PR DESCRIPTION
Update this page to upstream and fix 404 link

list below:
```
1. content/zh-cn/releases/_index.md
2. content/zh-cn/releases/release-managers.md
3. content/zh-cn/releases/release.md
4. content/zh-cn/search.md
```

### update description
1. Update out-of-sync content in English
2. Improve the description.
3. Add the anchor for link.
4. Fix 404 links for `Pruning`
5. Fix fail render in `handbooks page`
    ![image](https://user-images.githubusercontent.com/64598482/186055577-0d5d7df6-b9e8-4a99-b916-a957bb8b2aee.png)


Signed-off-by: ydFu <ader.ydfu@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
