### PR TITLE
Fix release-1.22 config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -190,7 +190,7 @@ fullversion = "v1.24.4"
 version = "v1.24"
 githubbranch = "v1.24.4"
 docsbranch = "release-1.24"
-url = "https://kubernetes.io"
+url = "https://v1-24.docs.kubernetes.io"
 
 [[params.versions]]
 fullversion = "v1.23.10"


### PR DESCRIPTION
This PR fixes the config.toml for the release-1.22 branch
The 1.24 version pointed to the 1.25 (kubernetes.io) docs instead of v1-24.docs.kubernetes.io