### PR TITLE
Revert "Updated kubectl completion configuration"

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -51,7 +51,7 @@ bash-completion sources all completion scripts in `/etc/bash_completion.d`.
 {{< /note >}}
 
 Both approaches are equivalent. After reloading your shell, kubectl autocompletion should be working.
-To enable bash autocompletion in current session of shell, run `exec bash`:
+To enable bash autocompletion in current session of shell, source the ~/.bashrc file:
 ```bash
-exec bash
+source ~/.bashrc
 ```


### PR DESCRIPTION
Reverts kubernetes/website#36114

`source` executes a command in the **current** shell, and returns the status to the current shell.
`exec` closes the current shell and for a new shell with the same PID. The system call behind the `exec` command replaces the current process using a `exec*()`. The code, data and stack of the process are all replaced. The `exec` approach is much heavier than the `source` command.

If we google how to make some user land environment changes, we always prefer `source`.
