### PR TITLE
[zh-cn] sync1.25 /configuration/secret.md

### DIFF
--- a/content/zh-cn/docs/concepts/configuration/secret.md
+++ b/content/zh-cn/docs/concepts/configuration/secret.md
@@ -964,7 +964,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       envFrom:
       - secretRef:
@@ -1204,7 +1204,7 @@ kubectl apply -k .
 Both containers will have the following files present on their filesystems with the values
 for each container's environment:
 -->
-两个文件都会在其文件系统中出现下面面的文件，文件中内容是各个容器的环境值：
+两个文件都会在其文件系统中出现下面的文件，文件中内容是各个容器的环境值：
 
 ```
 /etc/secret-volume/username
@@ -1279,7 +1279,7 @@ spec:
       secretName: dotfile-secret
   containers:
   - name: dotfile-test-container
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/busybox
     command:
     - ls
     - "-l"
@@ -2206,7 +2206,7 @@ Pod 来访问 Secret 的内容。
 <!--
 - In the API server, objects (including Secrets) are persisted into
   {{< glossary_tooltip term_id="etcd" >}}; therefore:
-  - only allow cluster admistrators to access etcd (this includes read-only access);
+  - only allow cluster administrators to access etcd (this includes read-only access);
   - enable [encryption at rest](/docs/tasks/administer-cluster/encrypt-data/)
     for Secret objects, so that the data of these Secrets are not stored in the clear
     into {{< glossary_tooltip term_id="etcd" >}};


### PR DESCRIPTION
Main change is from `k8s.gcr.io` to `registry.k8s.io`.
```
content/zh-cn/docs/concepts/configuration/secret.md
```
Preview: https://deploy-preview-36219--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/configuration/secret/