### PR TITLE
[zh-cn]Sync 1.25 k8s.gcr.io to registry.k8s.io

### DIFF
--- a/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -111,7 +111,7 @@ metadata:
 spec:
   containers:
     - name: demo-container-1
-      image: k8s.gcr.io/pause:2.0
+      image: registry.k8s.io/pause:2.0
       resources:
         limits:
           hardware-vendor.example/foo: 2

--- a/content/zh-cn/docs/tutorials/services/source-ip.md
+++ b/content/zh-cn/docs/tutorials/services/source-ip.md
@@ -85,7 +85,7 @@ IP of requests it receives through an HTTP header. You can create it as follows:
 你可以按如下方式创建它：
 
 ```shell
-kubectl create deployment source-ip-app --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.4
 ```
 <!-- 
 The output is:

--- a/content/zh-cn/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -942,9 +942,9 @@ Get the Pods to view their container images:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
-k8s.gcr.io/nginx-slim:0.8
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 <!--
@@ -994,7 +994,7 @@ Patch the StatefulSet again to change the container's image:
 再次 Patch StatefulSet 来改变容器镜像：
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"k8s.gcr.io/nginx-slim:0.7"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.7"}]'
 ```
 ```
 statefulset.apps/web patched
@@ -1037,7 +1037,7 @@ Get the Pod's container image:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 <!--
@@ -1098,7 +1098,8 @@ Get the Pod's container:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+
 ```
 
 <!--
@@ -1158,7 +1159,7 @@ Get the `web-1` Pod's container image:
 kubectl get pod web-1 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 <!--
@@ -1242,9 +1243,9 @@ Get the container image details for the Pods in the StatefulSet:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-k8s.gcr.io/nginx-slim:0.7
-k8s.gcr.io/nginx-slim:0.7
-k8s.gcr.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
 ```
 
 <!--


### PR DESCRIPTION
Sync 1.25 `k8s.gcr.io` to `registry.k8s.io`
```yaml
content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
```
```yaml
content/zh-cn/docs/tutorials/services/source-ip.md
```
```yaml
content/zh-cn/docs/tutorials/stateful-application/basic-stateful-set.md
```