### PR TITLE
Document “Panic: no auth provider found” error message and advice for kubectl

### DIFF
--- a/content/en/docs/tasks/tools/included/verify-kubectl.md
+++ b/content/en/docs/tasks/tools/included/verify-kubectl.md
@@ -32,3 +32,16 @@ If kubectl cluster-info returns the url response but you can't access your clust
 ```shell
 kubectl cluster-info dump
 ```
+
+```
+### Panic: no auth provider found error message
+
+{{% thirdparty-content %}}
+
+In Kubernetes v1.25, kubectl removed the built-in authentication for the following cloud
+providers' managed Kubernetes offerings. These providers have released kubectl plugins
+to fix the authentication. For instructions, refer to the following provider documentation:
+
+*  AKS (Azure): [kubelogin plugin](https://github.com/Azure/kubelogin)
+*  GKE (Google Cloud): [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin)
+```


### PR DESCRIPTION
Fixes #35896

Updated pages
Install and Set Up kubectl on [Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux), [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/), [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows).
