### PR TITLE
limit rss to 10 & use standard hugo limit var

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,7 +33,9 @@ enableGitInfo = true
 # Hindi is disabled because it's currently in development.
 disableLanguages = ["hi", "no"]
 
-rssLimit = 10
+# Limit number of blog articles included in the syndication feed
+[services.rss]
+limit = 10
 
 [caches]
  [caches.assets]

--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,8 @@ enableGitInfo = true
 # Hindi is disabled because it's currently in development.
 disableLanguages = ["hi", "no"]
 
+rssLimit = 10
+
 [caches]
  [caches.assets]
   dir = ":cacheDir/_gen"

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -17,7 +17,8 @@
     {{ with .OutputFormats.Get "RSS" }}
 	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range first 50 (where site.RegularPages "Type" "in" (slice "blog")) }}
+    {{ $pages := (where site.RegularPages "Type" "in" (slice "blog")) }}
+    {{ range first $.Site.Config.Services.RSS.Limit $pages }}
     <item>
       <title>{{ .Section | title }}: {{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
First, the k8s rss feed is too big. It's ~800kb every time I run a feed check, which can be problematic in certain circumstances, like if I haven't (or can't) configure my reader to check feeds in parallel, or I just have slow internet. And it extends back to midway through last year. A user almost always wants to catch up the last few articles she might have missed, not populate a local copy of the last 1-2 years worth of k8s blog posts. So we reduce the number of items emitted from 50 to 10.

Second, let's say in the future somebody said "We should actually bump it back up to 20 items" (not an unreasonable compromise). He would probably go looking in the Hugo docs and see the `rssLimit` variable documented and attempt to set it, and be confused as to why it wasn't changing (or wasn't already set). So we change the template to use this variable in order to be Hugo-idiomatic.