### PR TITLE
[zh-cn] sync1.25 kubeadm-config.v1beta2.md and kubeadm-config.v1beta2.md

### DIFF
--- a/content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta2.md
+++ b/content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta2.md
@@ -308,7 +308,7 @@ https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration。</p>
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># one of local or external</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">local</span>:<span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageTag</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;3.2.24&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">dataDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/lib/etcd&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
@@ -362,7 +362,7 @@ https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration。</p>
 </span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
 </span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificatesDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/kubernetes/pki&#34;</span><span style="color:#bbb">
-</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">useHyperKubeImage</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">clusterName</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;example-cluster&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span>---<span style="color:#bbb">
@@ -563,16 +563,16 @@ be used for assigning a stable DNS to the control plane.</li>
 <td>
    <!--
    <p><code>imageRepository</code> sets the container registry to pull images from.
-If empty, <code>k8s.gcr.io</code> will be used by default; in case of kubernetes version is
+If empty, <code>registry.k8s.io</code> will be used by default; in case of kubernetes version is
 a CI build (kubernetes version starts with <code>ci/</code>) <code>gcr.io/k8s-staging-ci-images</code>
 is used as a default for control plane components and for kube-proxy, while
-<code>k8s.gcr.io</code> will be used for all the other images.</p>
+<code>registry.k8s.io</code> will be used for all the other images.</p>
    -->
    <p><code>imageRepository</code> 设置用来拉取镜像的容器仓库。
-如果此字段为空，默认使用 <code>k8s.gcr.io</code>；
+如果此字段为空，默认使用 <code>registry.k8s.io</code>；
 当 Kubernetes 用来执行 CI 构造时（Kubernetes 版本以 <code>ci/</code> 开头），
 将默认使用 <code>gcr.io/k8s-staging-ci-images</code> 来拉取控制面组件镜像，
-而使用 <code>k8s.gcr.io</code> 来拉取所有其他镜像。</p>
+而使用 <code>registry.k8s.io</code> 来拉取所有其他镜像。</p>
 </td>
 </tr>
 <tr><td><code>useHyperKubeImage</code> <B><!--[Required]-->[必需]</B><br/>

--- a/content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -332,7 +332,7 @@ https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration。</p>
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># one of local or external</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">local</span>:<span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageTag</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;3.2.24&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">dataDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/lib/etcd&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
@@ -386,7 +386,7 @@ https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration。</p>
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificatesDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/kubernetes/pki&#34;</span><span style="color:#bbb">
-</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;registry.k8s.io&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">clusterName</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;example-cluster&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb"></span>---<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
@@ -584,16 +584,16 @@ be used for assigning a stable DNS to the control plane.</li>
 <td>
    <!--
    <p><code>imageRepository</code> sets the container registry to pull images from.
-If empty, <code>k8s.gcr.io</code> will be used by default.
+If empty, <code>registry.k8s.io</code> will be used by default.
 In case of kubernetes version is a CI build (kubernetes version starts with <code>ci/</code>)
 <code>gcr.io/k8s-staging-ci-images</code> will be used as a default for control plane components
-and for kube-proxy, while <code>k8s.gcr.io</code> will be used for all the other images.</p>
+and for kube-proxy, while <code>registry.k8s.io</code> will be used for all the other images.</p>
    -->
    <p><code>imageRepository</code> 设置用来拉取镜像的容器仓库。
-如果此字段为空，默认使用 <code>k8s.gcr.io</code>。
+如果此字段为空，默认使用 <code>registry.k8s.io</code>。
 当 Kubernetes 用来执行 CI 构造时（Kubernetes 版本以 <code>ci/</code> 开头），
 将默认使用 <code>gcr.io/k8s-staging-ci-images</code> 来拉取控制面组件镜像，
-而使用 <code>k8s.gcr.io</code> 来拉取所有其他镜像。</p>
+而使用 <code>registry.k8s.io</code> 来拉取所有其他镜像。</p>
 </td>
 </tr>
 <tr><td><code>featureGates</code><br/>


### PR DESCRIPTION
updated `k8s.gcr` to `registry.k8s`

```
content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta2.md
```
```
content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta3.md
```