### PR TITLE
[zh-cn] Localize 1.25 issues-security/official-cve-feed.md

### DIFF
--- a/content/zh-cn/docs/reference/issues-security/official-cve-feed.md
+++ b/content/zh-cn/docs/reference/issues-security/official-cve-feed.md
@@ -1,0 +1,67 @@
+---
+title: 官方 CVE 订阅源
+weight: 25
+layout: cve-feed
+---
+<!--
+title: Official CVE Feed
+weight: 25
+outputs:
+  - json
+  - html 
+layout: cve-feed
+-->
+
+{{< feature-state for_k8s_version="v1.25" state="alpha" >}}
+
+<!--
+This is a community maintained list of official CVEs announced by
+the Kubernetes Security Response Committee. See
+[Kubernetes Security and Disclosure Information](/docs/reference/issues-security/security/)
+for more details.
+
+The Kubernetes project publishes a programmatically accessible
+[JSON Feed](/docs/reference/issues-security/official-cve-feed/index.json) of 
+published security issues. You can access it by executing the following command:
+-->
+这是由 Kubernetes 安全响应委员会（Security Response Committee, SRC）公布的经社区维护的官方 CVE 列表。
+更多细节请参阅 [Kubernetes 安全和信息披露](/zh-cn/docs/reference/issues-security/security/)。
+
+Kubernetes 项目就已发布的安全问题发布了一个可使用程序访问的
+[JSON Feed](/docs/reference/issues-security/official-cve-feed/index.json)。
+你可以通过执行以下命令来查阅这些安全问题：
+
+{{< comment >}}
+<!--
+`replace` is used to bypass known issue with rendering ">"
+: https://github.com/gohugoio/hugo/issues/7229 in JSON layouts template
+`layouts/_default/cve-feed.json`
+-->
+`replace` 用于绕过已知问题，在 JSON 布局模板 `layouts/_default/cve-feed.json` 中呈现为 “>”
+: https://github.com/gohugoio/hugo/issues/7229
+{{< /comment >}}
+
+```shell
+curl -v https://k8s.io/docs/reference/issues-security/official-cve-feed/index.json
+```
+
+{{< cve-feed >}}
+
+<!-- | CVE ID      | Issue Summary | CVE GitHub Issue URL |
+| ----------- | ----------- | --------- |
+| [CVE-2021-25741](https://www.cve.org/CVERecord?id=CVE-2021-25741)      | Symlink Exchange Can Allow Host Filesystem Access | [#104980](https://github.com/kubernetes/kubernetes/issues/104980) |
+| [CVE-2020-8565](https://www.cve.org/CVERecord?id=CVE-2020-8565)      | Incomplete fix for CVE-2019-11250 allows for token leak in logs when logLevel >= 9 | [#95623](https://github.com/kubernetes/kubernetes/issues/95623) | -->
+
+<!--
+This feed is auto-refreshing with a noticeable but small lag (minutes to hours)
+from the time a CVE is announced to the time it is accessible in this feed.
+
+The source of truth of this feed is a set of GitHub Issues, filtered by a controlled and
+restricted label `official-cve-feed`. The raw data is stored in a Google Cloud
+Bucket which is writable only by a small number of trusted members of the
+Community.
+-->
+此订阅源会自动刷新，但从宣布 CVE 到可在此订阅源中找到对应的 CVE 会有一个明显却很小的延迟（几分钟到几小时）。
+
+此订阅源的真实来源是一组 GitHub Issue，通过受控和受限的标签 `official-cve-feed` 进行过滤。
+原始数据存放在 Google Cloud Bucket 中，只有社区少数受信任的成员可以写入。


### PR DESCRIPTION
Added the zh-cn text to:
```
content/zh-cn/docs/reference/issues-security/official-cve-feed.md
```
Preview: https://deploy-preview-36259--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/issues-security/official-cve-feed/