### PR TITLE
Update download.md

### DIFF
--- a/content/en/blog/_posts/2020-05-27-An-Introduction-to-the-K8s-Infrastructure-Working-Group.md
+++ b/content/en/blog/_posts/2020-05-27-An-Introduction-to-the-K8s-Infrastructure-Working-Group.md
@@ -55,7 +55,7 @@ The team has made progress in the last few months that is well worth celebrating
 
 - The K8s-Infrastructure Working Group released an automated billing report that they start every meeting off by reviewing as a group. 
 - DNS for k8s.io and kubernetes.io are also fully [community-owned](https://groups.google.com/g/kubernetes-dev/c/LZTYJorGh7c/m/u-ydk-yNEgAJ), with community members able to [file issues](https://github.com/kubernetes/k8s.io/issues/new?assignees=&labels=wg%2Fk8s-infra&template=dns-request.md&title=DNS+REQUEST%3A+%3Cyour-dns-record%3E) to manage records.
-- The container registry [k8s.gcr.io](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io) is also fully community-owned and available for all Kubernetes subprojects to use. 
+- The container registry [registry.k8s.io](https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-\(registry.k8s.io\)) is also fully community-owned and available for all Kubernetes subprojects to use. 
 - The Kubernetes [publishing-bot](https://github.com/kubernetes/publishing-bot) responsible for keeping k8s.io/kubernetes/staging repositories published to their own top-level repos (For example: [kubernetes/api](https://github.com/kubernetes/api)) runs on a community-owned cluster.
 - The gcsweb.k8s.io service used to provide anonymous access to GCS buckets for kubernetes artifacts runs on a community-owned cluster.
 - There is also an automated process of promoting all our container images. This includes a fully documented infrastructure, managed by the Kubernetes community, with automated processes for provisioning permissions. 

--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -13,10 +13,10 @@ for multiple operating systems as well as hardware architectures.
 ## Container Images
 
 All Kubernetes container images are deployed to the
-[k8s.gcr.io](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/GLOBAL)
+[registry.k8s.io](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/GLOBAL)
 container registry.
 
-{{< feature-state for_k8s_version="v1.24" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.25" state="alpha" >}}
 
 For Kubernetes {{< param "version" >}}, the following
 container images are signed using [cosign](https://github.com/sigstore/cosign)
@@ -24,11 +24,11 @@ signatures:
 
 | Container Image                                                     | Supported Architectures                                                                  |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [k8s.gcr.io/kube-apiserver:{{< param "fullversion" >}}][0]          | [amd64][0-amd64], [arm][0-arm], [arm64][0-arm64], [ppc64le][0-ppc64le], [s390x][0-s390x] |
-| [k8s.gcr.io/kube-controller-manager:{{< param "fullversion" >}}][1] | [amd64][1-amd64], [arm][1-arm], [arm64][1-arm64], [ppc64le][1-ppc64le], [s390x][1-s390x] |
-| [k8s.gcr.io/kube-proxy:{{< param "fullversion" >}}][2]              | [amd64][2-amd64], [arm][2-arm], [arm64][2-arm64], [ppc64le][2-ppc64le], [s390x][2-s390x] |
-| [k8s.gcr.io/kube-scheduler:{{< param "fullversion" >}}][3]          | [amd64][3-amd64], [arm][3-arm], [arm64][3-arm64], [ppc64le][3-ppc64le], [s390x][3-s390x] |
-| [k8s.gcr.io/conformance:{{< param "fullversion" >}}][4]             | [amd64][4-amd64], [arm][4-arm], [arm64][4-arm64], [ppc64le][4-ppc64le], [s390x][4-s390x] |
+| [registry.k8s.io/kube-apiserver:{{< param "fullversion" >}}][0]          | [amd64][0-amd64], [arm][0-arm], [arm64][0-arm64], [ppc64le][0-ppc64le], [s390x][0-s390x] |
+| [registry.k8s.io/kube-controller-manager:{{< param "fullversion" >}}][1] | [amd64][1-amd64], [arm][1-arm], [arm64][1-arm64], [ppc64le][1-ppc64le], [s390x][1-s390x] |
+| [registry.k8s.io/kube-proxy:{{< param "fullversion" >}}][2]              | [amd64][2-amd64], [arm][2-arm], [arm64][2-arm64], [ppc64le][2-ppc64le], [s390x][2-s390x] |
+| [registry.k8s.io/kube-scheduler:{{< param "fullversion" >}}][3]          | [amd64][3-amd64], [arm][3-arm], [arm64][3-arm64], [ppc64le][3-ppc64le], [s390x][3-s390x] |
+| [registry.k8s.io/conformance:{{< param "fullversion" >}}][4]             | [amd64][4-amd64], [arm][4-arm], [arm64][4-arm64], [ppc64le][4-ppc64le], [s390x][4-s390x] |
 
 [0]: https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-apiserver
 [0-amd64]: https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-apiserver-amd64
@@ -65,7 +65,7 @@ All container images are available for multiple architectures, whereas the
 container runtime should choose the correct one based on the underlying
 platform. It is also possible to pull a dedicated architecture by suffixing the
 container image name, for example
-[`k8s.gcr.io/kube-apiserver-arm64:{{< param "fullversion" >}}`][0-arm64]. All
+[`registry.k8s.io/kube-apiserver-arm64:{{< param "fullversion" >}}`][0-arm64]. All
 those derivations are signed in the same way as the multi-architecture manifest lists.
 
 The Kubernetes project publishes a list of signed Kubernetes container images

--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -13,8 +13,7 @@ for multiple operating systems as well as hardware architectures.
 ## Container Images
 
 All Kubernetes container images are deployed to the
-[registry.k8s.io](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/GLOBAL)
-container registry.
+`registry.k8s.io` container image registry.
 
 {{< feature-state for_k8s_version="v1.25" state="alpha" >}}
 

--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -15,7 +15,7 @@ for multiple operating systems as well as hardware architectures.
 All Kubernetes container images are deployed to the
 `registry.k8s.io` container image registry.
 
-{{< feature-state for_k8s_version="v1.25" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.24" state="alpha" >}}
 
 For Kubernetes {{< param "version" >}}, the following
 container images are signed using [cosign](https://github.com/sigstore/cosign)


### PR DESCRIPTION

Hello,

After the launch of [Kubernetes v1.25 release](https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/), I noticed there is a default change in the pull release of container images. Hence, This needs to be visible on the Kubernetes release website page. This works for all images, not just v1.25.
- this needs to fix as it will help automate further for new projects.
- screenshot attached.

<img width="945" alt="Screenshot 2022-08-25 at 2 01 21 PM" src="https://user-images.githubusercontent.com/48523873/186615962-dfb6f698-f9ce-4f64-a8dd-c99350979102.png">


