### PR TITLE
Fix note about ReplicaSet names

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -121,8 +121,8 @@ Follow the steps given below to create the above Deployment:
    * `READY` displays how many replicas of the application are available to your users.
    * `AGE` displays the amount of time that the application has been running.
      
-   Notice that the name of the ReplicaSet is always formatted as `[DEPLOYMENT-NAME]-[RANDOM-STRING]`.
-   The random string is randomly generated and uses the `pod-template-hash` as a seed.
+   Notice that the name of the ReplicaSet is always formatted as `[DEPLOYMENT-NAME]-[HASH]`.
+   The `HASH` string is the same as the `pod-template-hash` label on the ReplicaSet.
 
 6. To see the labels automatically generated for each Pod, run `kubectl get pods --show-labels`.
    The output is similar to:


### PR DESCRIPTION
The RS name is always derived from the hash of the pod template and
it's not random.
