### PR TITLE
Remove docs-ja owners from reviews and remove commented reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -112,18 +112,12 @@ aliases:
     - mattiaperi
     - micheleberardi
   sig-docs-ja-owners: # Admins for Japanese content
-    # cstoku
     - inductor
     - nasa9084
   sig-docs-ja-reviews: # PR reviews for Japanese content
     - bells17
-    # cstoku
-    - inductor
     - kakts
     - makocchi-git
-    # MasayaAoyama
-    - nasa9084
-    # oke-py
     - ptux
     - t-inu
   sig-docs-ko-owners: # Admins for Korean content


### PR DESCRIPTION
* I commented out instead of remove because they are 'pausing' but a long time has passed
* @inductor and I were in both owner and reviewer because there were a few members but we have enough members for now (actually I recently haven't made `/lgtm` comments)