### PR TITLE
Fixing link on Contributing to Kubernetes Documentation in kubernetes / website github repository page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,6 @@ Note that code issues should be filed against the main kubernetes repository, wh
 
 ### Submitting Documentation Pull Requests
 
-If you're fixing an issue in the existing documentation, you should submit a PR against the main branch.  Follow [these instructions to create a documentation pull request against the kubernetes.io repository](http://kubernetes.io/docs/home/contribute/create-pull-request/).
+If you're fixing an issue in the existing documentation, you should submit a PR against the main branch.  Follow [these instructions to create a documentation pull request against the kubernetes.io repository](https://kubernetes.io/docs/contribute/new-content/open-a-pr/).
 
 For more information, see [contributing to Kubernetes docs](https://kubernetes.io/docs/contribute/).


### PR DESCRIPTION
Fixes #36288

Updated page [Contributing to Kubernetes Documentation](https://github.com/kubernetes/website/blob/main/CONTRIBUTING.md) of kubernetes / website github repository page