### PR TITLE
Reinstate implementation details for CVE feed announcement

### DIFF
--- a/content/en/blog/_posts/2022-09-12-Announcing-the-Auto-Refreshing-Official-CVE-Feed/index.md
+++ b/content/en/blog/_posts/2022-09-12-Announcing-the-Auto-Refreshing-Official-CVE-Feed/index.md
@@ -48,6 +48,14 @@ official Kubernetes CVEs
   releases through their work in Kubernetes Community - via various Special
   Interest Groups and Committees.
 
+## Implementation Details
+
+A supporting
+[contributor blog](https://kubernetes.dev/blog/2022/09/12/k8s-cve-feed-alpha/)
+was published that describes in depth on how this CVE feed was implemented to
+ensure the feed was reasonably protected against tampering and was automatically
+updated after a new CVE was announced.
+
 ## What's Next?
 
 In order to graduate this feature, SIG Security


### PR DESCRIPTION
After https://github.com/kubernetes/website/pull/35608 merged, I made commit 3403ffa7b5545958ea745fde546c67fe0a3be41c to omit a link that wouldn't be live when @PushkarJ's blog article publishes.

The link won't work until we manually unhold https://github.com/kubernetes/contributor-site/pull/330 

Once the related implementation details article is published, we can reinstate the paragraph that hyperlinks to that article. This commit does that.

/area blog
/language en

/hold
until https://github.com/kubernetes/contributor-site/pull/330 is merged