### PR TITLE
Fix Kubelet authentication/authorization reference link in kubelet-checkpoint-api page

### DIFF
--- a/content/en/docs/reference/node/kubelet-checkpoint-api.md
+++ b/content/en/docs/reference/node/kubelet-checkpoint-api.md
@@ -31,7 +31,7 @@ system all memory pages will be readable by the owner of the checkpoint archive.
 
 Tell the kubelet to checkpoint a specific container from the specified Pod.
 
-Consult the [Kubelet authentication/authorization reference](/docs/reference/command-line-tools-reference/kubelet-authentication-authorization)
+Consult the [Kubelet authentication/authorization reference](/docs/reference/access-authn-authz/kubelet-authn-authz)
 for more information about how access to the kubelet checkpoint interface is
 controlled.
 


### PR DESCRIPTION

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fixes https://github.com/kubernetes/website/issues/36296

Preview page: https://deploy-preview-36303--kubernetes-io-main-staging.netlify.app/docs/reference/node/kubelet-checkpoint-api/