### PR TITLE
[zh] Fix EOL style for user guide content moved page

### DIFF
--- a/content/zh-cn/includes/user-guide-content-moved.md
+++ b/content/zh-cn/includes/user-guide-content-moved.md
@@ -3,6 +3,6 @@ The topics in the [User Guide](/docs/user-guide/) section of the Kubernetes docs
 are being moved to the [Tasks](/docs/tasks/), [Tutorials](/docs/tutorials/), and
 [Concepts](/docs/concepts) sections. The content in this topic has moved to:
 -->
-Kubernetes文档中[用户指南](/zh-cn/docs/user-guide/)部分中的主题被移动到
-[任务](/zh-cn/docs/tasks/)、[教程](/zh-cn/docs/tutorials/)和[概念](/zh-cn/docs/concepts)节。
+Kubernetes文档中[用户指南](/zh-cn/docs/user-guide/)部分中的主题被移动到[任务](/zh-cn/docs/tasks/)、
+[教程](/zh-cn/docs/tutorials/)和[概念](/zh-cn/docs/concepts)节。
 本主题内容已移至:


### PR DESCRIPTION
This PR converts the EOL style from DOS to UNIX.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
