### PR TITLE
Google analytics: use GA4 site tag for v1.24

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,13 +8,13 @@
 {{- end -}}
 {{- if in (slice "production" "nonprod") hugo.Environment -}}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-36037335-10"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JPP6RFM2BP"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-36037335-10');
+  gtag('config', 'G-JPP6RFM2BP');
 </script>
 {{- end -}}
 


### PR DESCRIPTION
- Contributes to #35299
- ~This PR assumes that release-doc subdomains are handled from the same Netlify account. @onlydole, might you be able to confirm that?~ Edit: I've "hard-coded" the GA4 ID.

/cc @nate-double-u 