### PR TITLE
[zh] Sync1.25 /kubernetes-api/common-definitions/quantity.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity.md
@@ -7,9 +7,7 @@ content_type: "api_reference"
 description: "数量（Quantity）是数字的定点表示。"
 title: "Quantity"
 weight: 10
-auto_generated: true
 ---
-
 <!-- 
 api_metadata:
   apiVersion: ""
@@ -22,21 +20,7 @@ weight: 10
 auto_generated: true
 -->
 
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-
-
 `import "k8s.io/apimachinery/pkg/api/resource"`
-
 
 <!-- 
 Quantity is a fixed-point representation of a number. 
@@ -47,7 +31,7 @@ The serialization format is:
 -->
 数量（Quantity）是数字的定点表示。
 除了 String() 和 AsInt64() 的访问接口之外，
-它以 JSON 和 YAML形式提供方便的打包和解包方法。
+它以 JSON 和 YAML 形式提供方便的打包和解包方法。
 
 序列化格式如下：
 
@@ -82,40 +66,44 @@ The serialization format is:
 <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber> </br>
 ```
 
-
 <!-- 
 No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
 
 When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
 -->
 无论使用三种指数形式中哪一种，没有数量可以表示大于 2<sup>63</sup>-1 的数，也不可能超过 3 个小数位。
-更大或更精确的数字将被截断或向上取整。（例如：0.1m 将向上取整为 1m。）
+更大或更精确的数字将被截断或向上取整（例如：0.1m 将向上取整为 1m）。
 如果将来我们需要更大或更小的数量，可能会扩展。
 
 当从字符串解析数量时，它将记住它具有的后缀类型，并且在序列化时将再次使用相同类型。
 
 <!-- 
-Before serializing, Quantity will be put in "canonical form". 
-This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
-  a. No precision is lost
-  b. No fractional digits will be emitted
-  c. The exponent (or suffix) is as large as possible.
+Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+
+- No precision is lost
+- No fractional digits will be emitted
+- The exponent (or suffix) is as large as possible.
+
 The sign will be omitted unless the number is negative.
 -->
 在序列化之前，数量将以“规范形式”放置。这意味着指数或者后缀将被向上或向下调整（尾数相应增加或减少），并确保：
-  1. 没有精度丢失
-  2. 不会输出小数数字
-  3. 指数（或后缀）尽可能大。
+
+- 没有精度丢失
+- 不会输出小数数字
+- 指数（或后缀）尽可能大。
+
 除非数量是负数，否则将省略正负号。
 
 <!-- 
 Examples:
-  1.5 will be serialized as "1500m"
-  1.5Gi will be serialized as "1536Mi"
+
+- 1.5 will be serialized as "1500m"
+- 1.5Gi will be serialized as "1536Mi"
 -->
 例如：
-  - 1.5 将会被序列化成 “1500m”
-  - 1.5Gi 将会被序列化成 “1536Mi”
+
+- 1.5 将会被序列化成 “1500m”
+- 1.5Gi 将会被序列化成 “1536Mi”
 
 <!-- 
 Note that the quantity will NEVER be internally represented by a floating point number. 
@@ -128,7 +116,7 @@ This format is intended to make it difficult to use these numbers without writin
 -->
 请注意，数量永远**不会**在内部以浮点数表示。这是本设计的重中之重。
 
-只要它们格式正确，非规范值仍将解析，但将以其规范形式重新输出。（所以应该总是使用规范形式，否则不要执行 diff 比较。）
+只要它们格式正确，非规范值仍将解析，但将以其规范形式重新输出（所以应该总是使用规范形式，否则不要执行 diff 比较）。
 
 这种格式旨在使得很难在不撰写某种特殊处理代码的情况下使用这些数字，进而希望实现者也使用定点实现。
 


### PR DESCRIPTION
- Remove redundant info
- Add changes from 1.25
- Localize punctuations `中文句点落在（括号）后。`
```
content/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity.md
```
Preview: https://deploy-preview-36331--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity/