### PR TITLE
Ensure release-branch deploys are production quality with noindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,9 @@ functions-build:
 check-headers-file:
 	scripts/check-headers-file.sh
 
-production-build: module-check ## Build the production site and ensure that noindex headers aren't added
+production-build: module-check ## Build the production or a release-branch site and ensure that noindex headers aren't added
 	hugo --cleanDestinationDir --minify --environment production
-	HUGO_ENV=production $(MAKE) check-headers-file
-
-non-production-build: module-check ## Build the non-production site, which adds noindex headers to prevent indexing
-	hugo --cleanDestinationDir --enableGitInfo --environment nonprod
+	$(MAKE) check-headers-file
 
 serve: module-check ## Boot the development server.
 	hugo server --buildFuture --environment development

--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -1,4 +1,4 @@
-{{- if eq hugo.Environment "production" }}
+{{- if and hugo.IsProduction (not .Site.Params.deprecated) }}
 {{- $cssFilesFromConfig := site.Params.pushAssets.css -}}
 {{- $jsFilesFromConfig := site.Params.pushAssets.js -}}
 {{- $pages := site.RegularPages -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 {{- $isBlogPost := eq .Section "blog" }}
 {{- $ogType := cond (.IsHome) "website" "article" }}
 <!-- per-page robot indexing controls -->
-{{- if hugo.IsProduction -}}
+{{- if and hugo.IsProduction (not .Site.Params.deprecated) -}}
 <meta name="ROBOTS" content="INDEX, FOLLOW">
 {{- else -}}
 <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,10 @@
 [build]
 # This default build command adds the robots noindex directive to the site headers.
-# It is turned off for only for the production site by using [context.master] below
+# It is turned off for only for the production site by using [context.main] below
 # DO NOT REMOVE THIS (contact @kubernetes/sig-docs-leads)
 publish = "public"
 functions = "functions"
-command = "git submodule update --init --recursive --depth 1 && make non-production-build"
+command = "git submodule update --init --recursive --depth 1 && make build"
 
 [build.environment]
 NODE_VERSION = "10.20.0"
@@ -20,7 +20,7 @@ HUGO_ENABLEGITINFO = "true"
 command = "git submodule update --init --recursive --depth 1 && make deploy-preview"
 
 [context.branch-deploy]
-command = "git submodule update --init --recursive --depth 1 && make non-production-build"
+command = "git submodule update --init --recursive --depth 1 && make production-build"
 
 [context.main]
 # This context is triggered by the `main` branch and allows search indexing

--- a/scripts/check-headers-file.sh
+++ b/scripts/check-headers-file.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ "$HUGO_ENV" == "production" ]; then
-  echo "INFO: Production environment. Checking the _headers file for noindex headers."
+if [[ -n "$NETLIFY" && "$CONTEXT" = "production" ]]; then
+  echo "INFO: Netlify production context. Checking the _headers file for noindex headers."
 
   if grep -q "noindex" public/_headers; then
     echo "PANIC: noindex headers were found in the _headers file. This build has failed."
@@ -11,6 +11,6 @@ if [ "$HUGO_ENV" == "production" ]; then
     exit 0
   fi
 else
-  echo "Non-production environment. Skipping the _headers file check."
+  echo "Not a Netlify-production context. Skipping the _headers file check."
   exit 0
 fi


### PR DESCRIPTION
- Closes #36333
- Changes in this PR **improve site performance and UX** for **release-branch subdomain sites** by doing the following: it ensures that release-branch deploys are built in a _production_ environment just like the main site deploy, which ensures that, e.g.:
  - Asset files are fingerprinted -- avoiding caching issues for site users when assets change (improving UX)
  - Site files are minified -- improving site access performance
- Simplifies Makefile targets: there is now a `production-build`, every other build target is a (true) non-production build.
- This PR preserves the behavior that only the main site deploy is indexable. Release-branch deploys remain non-indexable (noindex, nofollow). The criteria used here for choosing to allow indexing of a production site or not is based on the site config value of `params.deprecated`, which is true for the main site and false otherwise. Non-production sites remain non-indexable.

/cc @nate-double-u 
/cc @sftim 