### PR TITLE
Fix bug in curl command to fetch official CVE feed

### DIFF
--- a/content/en/docs/reference/issues-security/official-cve-feed.md
+++ b/content/en/docs/reference/issues-security/official-cve-feed.md
@@ -25,7 +25,7 @@ published security issues. You can access it by executing the following command:
 {{< /comment >}}
 
 ```shell
-curl -v https://k8s.io/docs/reference/issues-security/official-cve-feed/index.json
+curl -Lv https://k8s.io/docs/reference/issues-security/official-cve-feed/index.json
 ```
 
 {{< cve-feed >}}


### PR DESCRIPTION
Without the `-L` flag `curl` will only report there's a redirect. `L` will follow redirects all the way to the destination.
