### PR TITLE
Fix release-data i18n

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -1,5 +1,13 @@
 # i18n strings for the English (main) site.
 # NOTE: Please keep the entries in alphabetical order when editing
+
+# Avoid using conjunction_1.
+# Must match the context in layouts/shortcodes/release-data.html
+# Appears on https://kubernetes.io/releases/
+# For example the "and" in "Complete 1.25 Schedule and Changelog"
+[conjunction_1]
+other = "and"
+
 [caution]
 other = "Caution:"
 
@@ -261,6 +269,21 @@ other = "(released: "
 # Use a suitable format for your locale
 [release_date_format]
 other = "2006-01-02"
+
+# Deprecated. Planned for removal in a future release.
+# Use [release_full_details_initial_text] instead.
+[release_complete]
+other = "Complete"
+
+# Replace [release_complete] with [release_full_details_initial_text]
+[release_full_details_initial_text]
+other = "Complete"
+
+[release_schedule]
+other = "Schedule"
+
+[release_changelog]
+other = "Changelog"
 
 [seealso_heading]
 other = "See Also"

--- a/layouts/shortcodes/release-data.html
+++ b/layouts/shortcodes/release-data.html
@@ -33,10 +33,10 @@
 </div>
 
 {{- end -}}
-<!-- not yet localized, mark as English -->
-<p lang="en">
-Complete {{ $dataVersion }} <a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">Schedule</a>
-and <a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">Changelog</a>
+<p>
+{{ T "release_full_details_initial_text" }} {{ $dataVersion }}
+<a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">{{ T "release_schedule" }}</a> {{ T "conjunction_1" }}
+<a hreflang="en" href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">{{ T "release_changelog" }}</a>
 </p>
 
 </div>


### PR DESCRIPTION
Partially fixes https://github.com/kubernetes/website/issues/35932.

Notes:

- This PR,  #36375, relates to @Sea-n 's PR: https://github.com/kubernetes/website/pull/35950, but is not git based on it.
- This PR,  #36375, supersedes my previous PR, https://github.com/kubernetes/website/pull/36359, which I closed because it was based on `zh-cn` (via Sea-n's on https://github.com/kubernetes/website/pull/35950). 
- To merge with `main`, this branch/PR must be based on `main`.