### PR TITLE
add new note for ephemeral storage calculations

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -324,6 +324,10 @@ The kubelet tracks `tmpfs` emptyDir volumes as container memory use, rather
 than as local ephemeral storage.
 {{< /note >}}
 
+{{< note >}}
+The kubelet will only track the root filesystem for ephemeral storage. OS layouts that mount a separate disk to `/var/lib/kubelet` or `/var/lib/containers` will not report ephemeral storage correctly.
+{{< /note >}}
+
 ### Setting requests and limits for local ephemeral storage
 
 You can specify `ephemeral-storage` for managing local ephemeral storage. Each


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/111965 brings up a concern about ephemeral storage calculations. I took the concern to Sig-Node and the collective thought is that mounting disks to /var/lib/kubelet and /var/lib/containers is not necessarily supported, and definitely not supported with ephemeral storage calculations.

This PR adds a blurb that ephemeral storage is not reported correctly in this instance.