### PR TITLE
Remove redundant description in glossary/cni

### DIFF
--- a/content/en/docs/reference/glossary/cni.md
+++ b/content/en/docs/reference/glossary/cni.md
@@ -2,7 +2,7 @@
 title: Container network interface (CNI)
 id: cni
 date: 2018-05-25
-full_link: /docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni
+full_link: /docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 short_description: >
     Container network interface (CNI) plugins are a type of Network plugin that adheres to the appc/CNI specification.
 
@@ -12,7 +12,7 @@ tags:
 - networking 
 ---
  Container network interface (CNI) plugins are a type of Network plugin that adheres to the appc/CNI specification.
-<!--more--> 
 
-* For information on Kubernetes and CNI refer to [this](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni).
-* For information on Kubernetes and CNI, see ["Network plugins"](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni).
+<!--more-->
+
+* For information on Kubernetes and CNI, see [**Network Plugins**](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/).


### PR DESCRIPTION
The reason for the update is as follows:
1. Remove redundant description:
    The two links are the same, and the descriptions are similar, I think readers will be confused by this.
    ```
    * For information on Kubernetes and CNI refer to [this](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni).
    * For information on Kubernetes and CNI, see ["Network plugins"](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni).
    ```
2. Fix the title and the anchor:
    In the title and anchor of the link, it does not match the original
    * original title: Network Plugins
    * original anchor : There is no anchor for this XXX
    
    https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/


Signed-off-by: ydFu <ader.ydfu@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
