### PR TITLE
Updating konnectivity container image registry and tag

### DIFF
--- a/content/en/examples/admin/konnectivity/konnectivity-server.yaml
+++ b/content/en/examples/admin/konnectivity/konnectivity-server.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: konnectivity-server-container
-    image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-server:v0.0.16
+    image: registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32
     command: ["/proxy-server"]
     args: [
             "--logtostderr=true",


### PR DESCRIPTION
Closes #36420.

Starting from Kubernetes 1.25, the new repository `registry.k8s.io` has been introduced, and new versions of the Konnectivity addon have been released.

I just double-checked the parameters for Konnectivity and they are correct, as well as the existence of the container image.