### PR TITLE
Update to etcdctl restore command syntax

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -345,7 +345,12 @@ ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshotdb
 ```
 Another example for restoring using etcdctl options:
 ```shell
-ETCDCTL_API=3 etcdctl --data-dir <data-dir-location> snapshot restore snapshotdb
+ETCDCTL_API=3 etcdctl snapshot restore --data-dir <data-dir-location> snapshotdb
+```
+Yet another example would be to first export the environment variable
+```shell
+export ETCDCTL_API=3
+etcdctl snapshot restore --data-dir <data-dir-location> snapshotdb
 ```
 
 For more information and examples on restoring a cluster from a snapshot file, see


### PR DESCRIPTION
The syntax of the restore command at line 348 is problematic (doesn't work) or might have issues with a certain versions of Kubernetes (tried on version 1.23.0), doesn't work.

Also included export of the ECTDCTL_API=3 variable `export ECTDCTL_API=3`