### PR TITLE
[zh] Update reference\glossary (6)

### DIFF
--- a/content/zh-cn/docs/reference/glossary/code-contributor.md
+++ b/content/zh-cn/docs/reference/glossary/code-contributor.md
@@ -11,9 +11,7 @@ tags:
 - community
 - user-type
 ---
-
 <!--
----
 title: Code Contributor
 id: code-contributor
 date: 2018-04-12
@@ -25,13 +23,11 @@ aka:
 tags:
 - community
 - user-type
----
 -->
 
 <!--
  A person who develops and contributes code to the Kubernetes open source codebase.
 -->
-
  为 Kubernetes 开源代码库开发并贡献代码的人。
 
 <!--more--> 
@@ -39,5 +35,4 @@ tags:
 <!--
 They are also an active {{< glossary_tooltip text="community member" term_id="member" >}} who participates in one or more {{< glossary_tooltip text="Special Interest Groups (SIGs)" term_id="sig" >}}.
 -->
-
-代码贡献者也是加入一个或多个 {{< glossary_tooltip text="特别兴趣小组 (SIGs)" term_id="sig" >}} 的活跃的 {{< glossary_tooltip text="社区成员" term_id="member" >}}。
+他们也是加入一个或多个{{< glossary_tooltip text="特别兴趣小组 (Special Interest Groups；SIGs)" term_id="sig" >}}的活跃{{< glossary_tooltip text="成员" term_id="member" >}}。

--- a/content/zh-cn/docs/reference/glossary/configmap.md
+++ b/content/zh-cn/docs/reference/glossary/configmap.md
@@ -10,9 +10,7 @@ aka:
 tags:
 - core-object
 ---
-
 <!--
----
 title: ConfigMap
 id: configmap
 date: 2018-04-12
@@ -23,7 +21,6 @@ short_description: >
 aka: 
 tags:
 - core-object
----
 -->
 
 <!--
@@ -32,7 +29,6 @@ tags:
 environment variables, command-line arguments, or as configuration files in a
 {{< glossary_tooltip text="volume" term_id="volume" >}}.
 -->
-
  ConfigMap 是一种 API 对象，用来将非机密性的数据保存到键值对中。使用时， {{< glossary_tooltip text="Pods" term_id="pod" >}} 可以将其用作环境变量、命令行参数或者存储卷中的配置文件。
 
 <!--more--> 
@@ -40,5 +36,4 @@ environment variables, command-line arguments, or as configuration files in a
 <!--
 A ConfigMap allows you to decouple environment-specific configuration from your {{< glossary_tooltip text="container images" term_id="image" >}}, so that your applications are easily portable.
 -->
-
 ConfigMap 将你的环境配置信息和 {{< glossary_tooltip text="容器镜像" term_id="image" >}} 解耦，便于应用配置的修改。

--- a/content/zh-cn/docs/reference/glossary/container-env-variables.md
+++ b/content/zh-cn/docs/reference/glossary/container-env-variables.md
@@ -10,9 +10,7 @@ aka:
 tags:
 - fundamental
 ---
-
 <!--
----
 title: Container Environment Variables
 id: container-env-variables
 date: 2018-04-12
@@ -23,18 +21,16 @@ short_description: >
 aka: 
 tags:
 - fundamental
----
 -->
 
 <!--
  Container environment variables are name=value pairs that provide useful information into containers running in a {{< glossary_tooltip text="pod" term_id="pod" >}}
 -->
-
-  容器环境变量提供了 name=value 形式的、在 {{< glossary_tooltip text="pod" term_id="pod" >}} 中运行的容器所必须的一些重要信息。
+容器环境变量提供了 name=value 形式的、在 {{< glossary_tooltip text="Pod" term_id="pod" >}} 中运行的容器所必须的一些重要信息。
   
 <!--more-->
+
 <!--
 Container environment variables provide information that is required by the running containerized applications along with information about important resources to the {{< glossary_tooltip text="containers" term_id="container" >}}. For example, file system details, information about the container itself, and other cluster resources such as service endpoints.
 -->
-
-  容器环境变量为运行中的容器化应用提供必要的信息，同时还提供与 {{< glossary_tooltip text="容器" term_id="container" >}} 重要资源相关的其他信息，例如：文件系统信息、容器自身的信息以及其他像服务端点（Service endpoints）这样的集群资源信息。
+容器环境变量为运行中的容器化应用提供必要的信息，同时还提供与{{< glossary_tooltip text="容器" term_id="container" >}}重要资源相关的其他信息，例如：文件系统信息、容器自身的信息以及其他像服务端点（Service endpoints）这样的集群资源信息。

--- a/content/zh-cn/docs/reference/glossary/container-lifecycle-hooks.md
+++ b/content/zh-cn/docs/reference/glossary/container-lifecycle-hooks.md
@@ -11,7 +11,6 @@ tags:
 - extension
 ---
 <!--
----
 title: Container Lifecycle Hooks
 id: container-lifecycle-hooks
 date: 2018-10-08
@@ -22,17 +21,18 @@ short_description: >
 aka:
 tags:
 - extension
----
 -->
 
-  生命周期钩子暴露{{< glossary_tooltip text="容器" term_id="container" >}}管理生命周期中的事件，允许用户在事件发生时运行代码。
   <!--
-  The lifecycle hooks expose events in the {{< glossary_tooltip text="Container" term_id="container" >}}container management lifecycle and let the user run code when the events occur.
+  The lifecycle hooks expose events in the {{< glossary_tooltip text="Container" term_id="container" >}} management lifecycle and let the user run code when the events occur.
   -->
+  生命周期钩子（Lifecycle Hooks）暴露{{< glossary_tooltip text="容器" term_id="container" >}}管理生命周期中的事件，允许用户在事件发生时运行代码。
 
 <!--more--> 
 
-针对容器暴露了两个钩子：PostStart 在容器创建之后立即执行，PreStop 在容器停止之前立即阻塞并被调用。
 <!--
 Two hooks are exposed to Containers: PostStart which executes immediately after a container is created and PreStop which is blocking and is called immediately before a container is terminated.
 -->
+针对容器暴露了两个钩子：
+PostStart 在容器创建之后立即执行，
+PreStop 在容器停止之前立即阻塞并被调用。


### PR DESCRIPTION
Update about reference/glossary,this chapter is often used, so make adjustments,and ensure all these files were still in sync with English upstream now.

the following
```
content/zh-cn/docs/reference/glossary/code-contributor.md
content/zh-cn/docs/reference/glossary/configmap.md
content/zh-cn/docs/reference/glossary/container-env-variables.md
content/zh-cn/docs/reference/glossary/container-lifecycle-hooks.md
```

Signed-off-by: ydFu <ader.ydfu@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
