### PR TITLE
fix note typo

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -345,14 +345,14 @@ When faced with an admission decision, the API Server POSTs a JSON serialized
 This object contains fields describing the containers being admitted, as well as
 any pod annotations that match `*.image-policy.k8s.io/*`.
 
-{{ note }}
+{{< note >}}
 The webhook API objects are subject to the same versioning compatibility rules
 as other Kubernetes API objects. Implementers should be aware of looser compatibility
 promises for alpha objects and check the `apiVersion` field of the request to
 ensure correct deserialization.
 Additionally, the API Server must enable the `imagepolicy.k8s.io/v1alpha1` API extensions
 group (`--runtime-config=imagepolicy.k8s.io/v1alpha1=true`).
-{{ /note }}
+{{< /note >}}
 
 An example request body:
 


### PR DESCRIPTION
Fix note typo from `{{ note }}` to `{{< note >}}`

Updated page: 
- https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#request-payloads