### PR TITLE
update APISERVER in access to pods docs

### DIFF
--- a/content/en/docs/tasks/run-application/access-api-from-pod.md
+++ b/content/en/docs/tasks/run-application/access-api-from-pod.md
@@ -76,7 +76,7 @@ directly to the API server.  The internal certificate secures the connection.
 
 ```shell
 # Point to the internal API server hostname
-APISERVER=https://kubernetes.default.svc
+APISERVER=https://kubernetes.default.svc.cluster.local
 
 # Path to ServiceAccount token
 SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount


### PR DESCRIPTION
kubernetes.default.svc is not on the kube-dns search path in
/etc/resolv.conf. This results in NXDOMAIN. And the example as in the
docs do not work if directly copied.

kubernetes.default.svc.cluster.local resolves to the API endpoint.

The observed /etc/resolve.conf in both Kind and EKS clusters:

```bash
$ cat /etc/resolv.conf 
nameserver 172.20.0.10
search default.svc.cluster.local svc.cluster.local cluster.local ec2.internal
options ndots:5
```

lookup of kubernetes.default.svc returning NXDOMAIN

```bash
dig kubernetes.default.svc

; <<>> DiG 9.18.1-1ubuntu1.1-Ubuntu <<>> kubernetes.default.svc
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 34585
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
```

lookup of kubernetes.default.svc.cluster.local returning A record

```bash
dig kubernetes.default.svc.cluster.local

; <<>> DiG 9.18.1-1ubuntu1.1-Ubuntu <<>> kubernetes.default.svc.cluster.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 22171
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 0bcc905d28a2ae67 (echoed)
;; QUESTION SECTION:
;kubernetes.default.svc.cluster.local. IN A

;; ANSWER SECTION:
kubernetes.default.svc.cluster.local. 5 IN A    172.20.0.1
```


