### PR TITLE
[zh] updated 5 YAML examples

### DIFF
--- a/content/zh-cn/examples/admin/cloud/ccm-example.yaml
+++ b/content/zh-cn/examples/admin/cloud/ccm-example.yaml
@@ -41,9 +41,9 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
       - name: cloud-controller-manager
-        # 对于树内驱动，我们使用 k8s.gcr.io/cloud-controller-manager，
+        # 对于树内驱动，我们使用 registry.k8s.io/cloud-controller-manager，
         # 镜像可以替换为其他树外驱动的镜像
-        image: k8s.gcr.io/cloud-controller-manager:v1.8.0
+        image: registry.k8s.io/cloud-controller-manager:v1.8.0
         command:
         - /usr/local/bin/cloud-controller-manager
         - --cloud-provider=[YOUR_CLOUD_PROVIDER]  # 在此处添加你自己的云驱动！

--- a/content/zh-cn/examples/admin/dns/dns-horizontal-autoscaler.yaml
+++ b/content/zh-cn/examples/admin/dns/dns-horizontal-autoscaler.yaml
@@ -65,7 +65,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.4
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.4
         resources:
             requests:
                 cpu: "20m"
@@ -74,10 +74,10 @@ spec:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system
           - --configmap=kube-dns-autoscaler
-          # 应该保持目标与 cluster/addons/dns/kube-dns.yaml.base 同步
+          # 应该保持目标与 cluster/addons/dns/kube-dns.yaml.base 同步。
           - --target=<SCALE_TARGET>
-          #当集群使用大节点（有更多核）时，“coresPerReplica”应该占主导地位。
-          #如果使用小节点，“nodesPerReplica“ 应该占主导地位。
+          # 当集群使用大节点（有更多核）时，“coresPerReplica”应该占主导地位。
+          # 如果使用小节点，“nodesPerReplica“ 应该占主导地位。
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true,"includeUnschedulableNodes":true}}
           - --logtostderr=true
           - --v=2

--- a/content/zh-cn/examples/admin/dns/dnsutils.yaml
+++ b/content/zh-cn/examples/admin/dns/dnsutils.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
+    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
     command:
       - sleep
       - "3600"

--- a/content/zh-cn/examples/admin/konnectivity/konnectivity-server.yaml
+++ b/content/zh-cn/examples/admin/konnectivity/konnectivity-server.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: konnectivity-server-container
-    image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-server:v0.0.16
+    image: registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32
     command: ["/proxy-server"]
     args: [
             "--logtostderr=true",

--- a/content/zh-cn/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
+++ b/content/zh-cn/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
@@ -22,7 +22,7 @@ spec:
     - name: varlog
       mountPath: /var/log
   - name: count-agent
-    image: k8s.gcr.io/fluentd-gcp:1.30
+    image: registry.k8s.io/fluentd-gcp:1.30
     env:
     - name: FLUENTD_ARGS
       value: -c /etc/fluentd-config/fluentd.conf


### PR DESCRIPTION
Mainly replace `k8s.gcr.io` with `registry.k8s.io` in the /admin folder:
```
content/zh-cn/examples/admin/cloud/ccm-example.yaml
content/zh-cn/examples/admin/dns/dns-horizontal-autoscaler.yaml
content/zh-cn/examples/admin/dns/dnsutils.yaml
content/zh-cn/examples/admin/konnectivity/konnectivity-server.yaml
content/zh-cn/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
```