### PR TITLE
[zh] Sync1.25 /kubernetes-api/workload-resources/daemon-set-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
@@ -4,7 +4,7 @@ api_metadata:
   import: "k8s.io/api/apps/v1"
   kind: "DaemonSet"
 content_type: "api_reference"
-description: "DaemonSet 表示守护程序集的配置。"
+description: "DaemonSet 表示守护进程集的配置。"
 title: "DaemonSet"
 weight: 8
 ---
@@ -21,7 +21,6 @@ weight: 8
 auto_generated: true
 -->
 
-
 `apiVersion: apps/v1`
 
 `import "k8s.io/api/apps/v1"`
@@ -33,12 +32,11 @@ DaemonSet represents the configuration of a daemon set.
 -->
 ## DaemonSet {#DaemonSet}
 
-DaemonSet 表示守护程序集的配置。
+DaemonSet 表示守护进程集的配置。
 
 <hr>
 
 - **apiVersion**: apps/v1
-
 
 - **kind**: DaemonSet
 
@@ -49,7 +47,8 @@ DaemonSet 表示守护程序集的配置。
 -->
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
-  标准的对象元数据。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  标准的对象元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 <!--
 - **spec** (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetSpec" >}}">DaemonSetSpec</a>)
@@ -58,7 +57,8 @@ DaemonSet 表示守护程序集的配置。
 -->
 - **spec** (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetSpec" >}}">DaemonSetSpec</a>)
 
-  此守护程序集的预期行为。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  此守护进程集的预期行为。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 <!--
 - **status** (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetStatus" >}}">DaemonSetStatus</a>)
@@ -67,9 +67,9 @@ DaemonSet 表示守护程序集的配置。
 -->
 - **status** (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetStatus" >}}">DaemonSetStatus</a>)
 
-  此守护程序集的当前状态。此数据可能已经过时一段时间。由系统填充。
-  只读。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-
+  此守护进程集的当前状态。此数据可能已经过时一段时间。由系统填充。
+  只读。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 <!--
 ## DaemonSetSpec {#DaemonSetSpec}
@@ -78,7 +78,7 @@ DaemonSetSpec is the specification of a daemon set.
 -->
 ## DaemonSetSpec {#DaemonSetSpec}
 
-DaemonSetSpec 是守护程序集的规约。
+DaemonSetSpec 是守护进程集的规约。
 
 <hr>
 
@@ -89,7 +89,7 @@ DaemonSetSpec 是守护程序集的规约。
 -->
 - **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), 必需
 
-  对由守护程序集管理的 Pod 的标签查询。Pod 必须匹配此查询才能被此 DaemonSet 控制。
+  对由守护进程集管理的 Pod 的标签查询。Pod 必须匹配此查询才能被此 DaemonSet 控制。
   查询条件必须与 Pod 模板的标签匹配。
   更多信息： https://kubernetes.io/zh-cn/concepts/overview/working-with-objects/labels/#label-selectors
 
@@ -111,7 +111,8 @@ DaemonSetSpec 是守护程序集的规约。
 -->
 - **minReadySeconds** (int32)
 
-  新建的 DaemonSet Pod 应该在没有任何容器崩溃的情况下处于就绪状态的最小秒数，这样它才会被认为是可用的。默认为 0（Pod 准备就绪后将被视为可用）。
+  新建的 DaemonSet Pod 应该在没有任何容器崩溃的情况下处于就绪状态的最小秒数，这样它才会被认为是可用的。
+  默认为 0（Pod 准备就绪后将被视为可用）。
 
 <!--
 - **updateStrategy** (DaemonSetUpdateStrategy)
@@ -126,6 +127,7 @@ DaemonSetSpec 是守护程序集的规约。
   <a name="DaemonSetUpdateStrategy"></a>
   *DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.*
   -->
+
   <a name="DaemonSetUpdateStrategy"></a>
   **DaemonSetUpdateStrategy 是一个结构体，用于控制 DaemonSet 的更新策略。**
 
@@ -137,9 +139,9 @@ DaemonSetSpec 是守护程序集的规约。
   
   - **updateStrategy.type** (string)
 
-    守护程序集更新的类型。可以是 "RollingUpdate" 或 "OnDelete"。默认为 RollingUpdate。
+    守护进程集更新的类型。可以是 "RollingUpdate" 或 "OnDelete"。默认为 RollingUpdate。
 
-  <!-- 
+  <!--
   - **updateStrategy.rollingUpdate** (RollingUpdateDaemonSet)
 
     Rolling update config params. Present only if type = "RollingUpdate".
@@ -149,17 +151,17 @@ DaemonSetSpec 是守护程序集的规约。
 
     滚动更新配置参数。仅在 type 值为 "RollingUpdate" 时出现。
     
-    <!-- 
+    <!--
     <a name="RollingUpdateDaemonSet"></a>
     *Spec to control the desired behavior of daemon set rolling update.*
     -->
   
-    **用于控制守护程序集滚动更新的预期行为的规约。** 
+    **用于控制守护进程集滚动更新的预期行为的规约。**
     
-    <!-- 
+    <!--
     - **updateStrategy.rollingUpdate.maxSurge** (IntOrString)
 
-      The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption. This is beta field and enabled/disabled by DaemonSetUpdateSurge feature gate.
+      The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.
     -->
     
     - **updateStrategy.rollingUpdate.maxSurge** (IntOrString)
@@ -167,16 +169,16 @@ DaemonSetSpec 是守护程序集的规约。
       对于拥有可用 DaemonSet Pod 的节点而言，在更新期间可以拥有更新后的 DaemonSet Pod 的最大节点数。
       属性值可以是绝对数量（例如：5）或所需 Pod 的百分比（例如：10%）。
       如果 maxUnavailable 为 0，则该值不能为 0。绝对数是通过四舍五入从百分比计算得出的，最小值为 1。
-      默认值为 0。示例：当设置为 30% 时，最多为节点总数的 30% 节点上应该运行守护程序 Pod（即 status.desiredNumberScheduled）
+      默认值为 0。示例：当设置为 30% 时，最多为节点总数的 30% 节点上应该运行守护进程 Pod
+      （即 status.desiredNumberScheduled）
       可以在旧 Pod 标记为已删除之前创建一个新 Pod。更新首先在 30% 的节点上启动新的 Pod。
       一旦更新的 Pod 可用（就绪时长至少 minReadySeconds 秒），该节点上的旧 DaemonSet pod 就会被标记为已删除。
       如果旧 Pod 因任何原因变得不可用（Ready 转换为 false、被驱逐或节点被腾空），
       则会立即在该节点上创建更新的 Pod，而不考虑激增限制。
-      允许激增意味着如果就绪检查失败，任何给定节点上的守护程序集消耗的资源可能会翻倍，
-      因此资源密集型守护程序集应该考虑到它们可能会在中断期间导致驱逐。
-      此字段是 Beta 字段，由 DaemonSetUpdateSurge 特性门启用/禁用。
+      允许激增意味着如果就绪检查失败，任何给定节点上的守护进程集消耗的资源可能会翻倍，
+      因此资源密集型守护进程集应该考虑到它们可能会在中断期间导致驱逐。
   
-      <!-- 
+      <!--
       <a name="IntOrString"></a>
       *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
       -->
@@ -184,7 +186,7 @@ DaemonSetSpec 是守护程序集的规约。
       **IntOrString 是一种可以容纳 int32 或字符串的类型。在 JSON 或 YAML 编组和解组中使用时，它会生成或使用内部类型。
       例如，这允许你拥有一个可以接受名称或数字的 JSON 字段。**
 
-    <!-- 
+    <!--
     - **updateStrategy.rollingUpdate.maxUnavailable** (IntOrString)
 
       The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
@@ -194,19 +196,19 @@ DaemonSetSpec 是守护程序集的规约。
 
       更新期间不可用的 DaemonSet Pod 的最大数量。值可以是绝对数（例如：5）或更新开始时 DaemonSet Pod 总数的百分比（例如：10%）。
       绝对数是通过四舍五入的百分比计算得出的。如果 maxSurge 为 0，则此值不能为 0 默认值为 1。
-      例如：当设置为 30% 时，最多节点总数 30% 的、应该运行守护程序的节点总数（即 status.desiredNumberScheduled）
+      例如：当设置为 30% 时，最多节点总数 30% 的、应该运行守护进程的节点总数（即 status.desiredNumberScheduled）
       可以在任何给定时间停止更新。更新首先停止最多 30% 的 DaemonSet Pod，
       然后在它们的位置启动新的 DaemonSet Pod。
       一旦新的 Pod 可用，它就会继续处理其他 DaemonSet Pod，从而确保在更新期间至少 70% 的原始 DaemonSet Pod 数量始终可用。
       
-      <!-- 
+      <!--
       <a name="IntOrString"></a>
       *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
       -->
      
       **IntOrString 是一种可以保存 int32 或字符串的类型。在 JSON 或 YAML 编组和解组中使用时，它会生成或使用内部类型。例如，这允许你拥有一个可以接受名称或数字的 JSON 字段。**
 
-<!-- 
+<!--
 - **revisionHistoryLimit** (int32)
 
   The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
@@ -215,7 +217,6 @@ DaemonSetSpec 是守护程序集的规约。
 
   用来允许回滚而保留的旧历史记录的数量。此字段是个指针，用来区分明确的零值和未指定的指针。默认值是 10。
 
-
 <!--
 ## DaemonSetStatus {#DaemonSetStatus}
 
@@ -223,7 +224,7 @@ DaemonSetStatus represents the current status of a daemon set.
 -->
 ## DaemonSetStatus {#DaemonSetStatus}
 
-DaemonSetStatus 表示守护程进程的当前状态。
+DaemonSetStatus 表示守护进程集的当前状态。
 
 <hr>
 
@@ -232,7 +233,7 @@ DaemonSetStatus 表示守护程进程的当前状态。
 
   numberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running with a Ready Condition.
 -->
-- **numberReady** (int32),必需
+- **numberReady** (int32)，必需
 
   numberReady 是应该运行守护进程 Pod 并且有一个或多个 DaemonSet Pod 以就绪条件运行的节点数。
 
@@ -259,27 +260,30 @@ DaemonSetStatus 表示守护程进程的当前状态。
 
   The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 -->
-- **numberMisscheduled** (int32),必需
+- **numberMisscheduled** (int32)，必需
 
-  正在运行守护进程 Pod，但不应该运行守护进程 Pod 的节点数量。更多信息： https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+  正在运行守护进程 Pod，但不应该运行守护进程 Pod 的节点数量。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/workloads/controllers/daemonset/
 
 <!--
 - **desiredNumberScheduled** (int32), required
 
   The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 -->
-- **desiredNumberScheduled** (int32),必需
+- **desiredNumberScheduled** (int32)，必需
 
-  应该运行守护进程 Pod 的节点总数（包括正确运行守护进程 Pod 的节点）。更多信息： https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+  应该运行守护进程 Pod 的节点总数（包括正确运行守护进程 Pod 的节点）。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/workloads/controllers/daemonset/
 
 <!--
 - **currentNumberScheduled** (int32), required
 
   The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 -->
-- **currentNumberScheduled** (int32),必需
+- **currentNumberScheduled** (int32)，必需
 
-  运行至少 1 个守护进程 Pod 并且应该运行守护进程 Pod 的节点数。多信息： https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+  运行至少 1 个守护进程 Pod 并且应该运行守护进程 Pod 的节点数。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/workloads/controllers/daemonset/
 
 <!--
 - **updatedNumberScheduled** (int32)
@@ -308,7 +312,7 @@ DaemonSetStatus 表示守护程进程的当前状态。
 
   **补丁策略：根据 `type` 键合并**
 
-  <!--  
+  <!-- 
   Represents the latest available observations of a DaemonSet's current state.
 
   <a name="DaemonSetCondition"></a>
@@ -329,11 +333,11 @@ DaemonSetStatus 表示守护程进程的当前状态。
     Type of DaemonSet condition.
   -->
   
-  - **conditions.status** (string),必需
+  - **conditions.status** (string)，必需
 
     状况的状态，True、False、Unknown 之一。
 
-  - **conditions.type** (string),必需
+  - **conditions.type** (string)，必需
 
     DaemonSet 状况的类型。
 
@@ -346,6 +350,7 @@ DaemonSetStatus 表示守护程进程的当前状态。
   - **conditions.lastTransitionTime** (Time)
 
     状况上次从一种状态转换到另一种状态的时间。
+
     <!--
     <a name="Time"></a>
     *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
@@ -383,7 +388,6 @@ DaemonSetStatus 表示守护程进程的当前状态。
 
   守护进程集控制器观察到的最新一代。
 
-
 <!--
 ## DaemonSetList {#DaemonSetList}
 
@@ -398,9 +402,7 @@ DaemonSetList 是守护进程集的集合。
 
 - **apiVersion**: apps/v1
 
-
 - **kind**: DaemonSetList
-
 
 <!--
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
@@ -419,7 +421,6 @@ DaemonSetList 是守护进程集的集合。
 - **items** ([]<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>), 必需
 
   DaemonSet 的列表。
-
 
 ## Operations {#Operations}
 
@@ -456,7 +457,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -466,7 +466,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -474,13 +473,11 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -533,13 +530,11 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -567,7 +562,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **allowWatchBookmarks** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
@@ -582,7 +576,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
@@ -591,7 +584,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **allowWatchBookmarks** (**路径参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
-
 
 - **continue** (**查询参数**): string
 
@@ -602,7 +594,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
@@ -611,7 +602,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **labelSelector** (**查询参数**): string
 
@@ -622,7 +612,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -631,7 +620,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -642,7 +630,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
@@ -651,7 +638,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (**查询参数**): string
 
@@ -662,7 +648,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -672,7 +657,6 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -680,13 +664,11 @@ GET /apis/apps/v1/namespaces/{namespace}/daemonsets
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetList" >}}">DaemonSetList</a>): OK
 
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetList" >}}">DaemonSetList</a>): OK
 
@@ -714,7 +696,6 @@ GET /apis/apps/v1/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
@@ -723,7 +704,6 @@ GET /apis/apps/v1/daemonsets
 - **allowWatchBookmarks** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
-
 
 - **continue** (**查询参数**): string
 
@@ -734,7 +714,6 @@ GET /apis/apps/v1/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
@@ -743,7 +722,6 @@ GET /apis/apps/v1/daemonsets
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **labelSelector** (**查询参数**): string
 
@@ -754,7 +732,6 @@ GET /apis/apps/v1/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -763,7 +740,6 @@ GET /apis/apps/v1/daemonsets
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -774,7 +750,6 @@ GET /apis/apps/v1/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
@@ -783,7 +758,6 @@ GET /apis/apps/v1/daemonsets
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (**查询参数**): string
 
@@ -794,7 +768,6 @@ GET /apis/apps/v1/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -804,7 +777,6 @@ GET /apis/apps/v1/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -812,14 +784,12 @@ GET /apis/apps/v1/daemonsets
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetList" >}}">DaemonSetList</a>): OK
 
 401: Unauthorized
 -->
 
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSetList" >}}">DaemonSetList</a>): OK
 
@@ -847,13 +817,11 @@ POST /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, required
 -->
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, 必需
 
@@ -861,7 +829,6 @@ POST /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -872,7 +839,6 @@ POST /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -881,7 +847,6 @@ POST /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -892,14 +857,12 @@ POST /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -910,7 +873,6 @@ POST /apis/apps/v1/namespaces/{namespace}/daemonsets
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -942,11 +904,9 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   name of the DaemonSet
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, required
 -->
@@ -954,11 +914,9 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   DaemonSet 的名称
 
-
 - **namespace** (**路径参数**): string,必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>,必需  
 
@@ -966,7 +924,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -977,7 +934,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -986,7 +942,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -997,14 +952,12 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -1013,7 +966,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -1043,11 +995,9 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   name of the DaemonSet
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, required
 -->
@@ -1055,11 +1005,9 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   DaemonSet 的名称
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, 必需
 
@@ -1067,7 +1015,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1078,7 +1025,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1087,7 +1033,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -1098,14 +1043,12 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -1114,7 +1057,6 @@ PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -1144,11 +1086,9 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   name of the DaemonSet
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 -->
@@ -1157,11 +1097,9 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   DaemonSet 的名称
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, 必需
   
@@ -1169,7 +1107,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1180,7 +1117,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1190,7 +1126,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **force** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
@@ -1199,7 +1134,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 - **fieldValidation** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **force** **查询参数**): boolean
 
@@ -1218,7 +1152,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): Created
@@ -1226,7 +1159,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -1256,11 +1188,9 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   name of the DaemonSet
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 -->
@@ -1268,11 +1198,9 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   DaemonSet 的名称
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, 必需 
 
@@ -1280,7 +1208,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1291,7 +1218,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1301,7 +1227,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **force** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
@@ -1310,7 +1235,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 - **fieldValidation** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **force** (**查询参数**): boolean
 
@@ -1329,7 +1253,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): Created
@@ -1337,7 +1260,6 @@ PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
 
@@ -1367,7 +1289,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   name of the DaemonSet
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
@@ -1376,11 +1297,9 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   DaemonSet 的名称
 
-
 - **namespace** (**路径参数**): string,必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 
@@ -1388,7 +1307,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **gracePeriodSeconds** (*in query*): integer
 
@@ -1399,7 +1317,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
@@ -1408,7 +1325,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **propagationPolicy** (*in query*): string
 
@@ -1419,14 +1335,12 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **propagationPolicy** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
 
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
@@ -1436,7 +1350,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
 -->
 
 #### 响应
-
 
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
@@ -1471,14 +1384,12 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 
 <!--
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
-
 
 - **dryRun** (*in query*): string
 
@@ -1489,7 +1400,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
 
-
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
@@ -1498,7 +1408,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **fieldSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **gracePeriodSeconds** (*in query*): integer
 
@@ -1509,7 +1418,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
@@ -1518,7 +1426,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
-
 
 - **limit** (*in query*): integer
 
@@ -1529,7 +1436,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
 
-
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
@@ -1538,7 +1444,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **propagationPolicy** (*in query*): string
 
@@ -1549,7 +1454,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **propagationPolicy** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
@@ -1559,7 +1463,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
@@ -1568,7 +1471,6 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (**查询参数**): string
 
@@ -1587,13 +1489,11 @@ DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
 401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 


### PR DESCRIPTION
- remove extra line when two consecutive blank lines exist
- change some links to `/zh-cn`
- a para about 1.25
- update `daemon set` based on [/concepts/workloads/controllers/daemonset/](https://kubernetes.io/zh-cn/docs/concepts/workloads/controllers/daemonset/)
```
content/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
```
Preview: https://deploy-preview-36496--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/