### PR TITLE
Fix Typo in Deprecation Guide

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -215,7 +215,7 @@ The **extensions/v1beta1** and **networking.k8s.io/v1beta1** API versions of Ing
     * `spec.backend` is renamed to `spec.defaultBackend`
     * The backend `serviceName` field is renamed to `service.name`
     * Numeric backend `servicePort` fields are renamed to `service.port.number`
-    * String backend `servicePort` fields are renamed to `service.port.name`
+    * String backend `serviceName` fields are renamed to `service.port.name`
     * `pathType` is now required for each specified path. Options are `Prefix`, `Exact`, and `ImplementationSpecific`. To match the undefined `v1beta1` behavior, use `ImplementationSpecific`.
 
 #### IngressClass {#ingressclass-v122}


### PR DESCRIPTION
There is currently a typo in the deprecation guide where, when referring to the string backend fields renaming schema, `serviceName` is listed when it should instead be `serviceName`.