### PR TITLE
Fix typo on cgroups page

### DIFF
--- a/content/en/docs/concepts/architecture/cgroups.md
+++ b/content/en/docs/concepts/architecture/cgroups.md
@@ -11,7 +11,7 @@ constrain resources that are allocated to processes.
 
 The {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} and the
 underlying container runtime need to interface with cgroups to enforce
-[resource mangement for pods and containers](/docs/concepts/configuration/manage-resources-containers/) which
+[resource management for pods and containers](/docs/concepts/configuration/manage-resources-containers/) which
 includes cpu/memory requests and limits for containerized workloads.
 
 There are two versions of cgroups in Linux: cgroup v1 and cgroup v2. cgroup v2 is


### PR DESCRIPTION
The spelling of the management i.e mangement is wrong, now it has been corrected.
Fixes: #36528 
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
