### PR TITLE
 kube-proxy is part of the Kubernetes node components

### DIFF
--- a/content/en/docs/reference/access-authn-authz/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-tls-bootstrapping.md
@@ -448,7 +448,7 @@ A deployment-specific approval process for kubelet serving certificates should t
 
 All of TLS bootstrapping described in this document relates to the kubelet. However,
 other components may need to communicate directly with kube-apiserver. Notable is kube-proxy, which
-is part of the Kubernetes control plane and runs on every node, but may also include other components such as monitoring or networking.
+is part of the Kubernetes node components and runs on every node, but may also include other components such as monitoring or networking.
 
 Like the kubelet, these other components also require a method of authenticating to kube-apiserver.
 You have several options for generating these credentials:


### PR DESCRIPTION
kube-proxy is part of the Kubernetes node components not control plane. I think it's a typo.
ref: https://kubernetes.io/docs/concepts/overview/components/#node-components

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
