### PR TITLE
[en]Removed duplicated sectioncontainer on runtimes.md

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -295,12 +295,6 @@ Docker Engine with Kubernetes.
 
 For `cri-dockerd`, the CRI socket is `/run/cri-dockerd.sock` by default.
 
-#### Overriding the sandbox (pause) image {#override-pause-image-cri-dockerd}
-
-The `cri-dockerd` adapter accepts a command line argument for
-specifying which container image to use as the Pod infrastructure container (“pause image”).
-The command line argument to use is `--pod-infra-container-image`.
-
 ### Mirantis Container Runtime {#mcr}
 
 [Mirantis Container Runtime](https://docs.mirantis.com/mcr/20.10/overview.html) (MCR) is a commercially


### PR DESCRIPTION
There are two parts that repeat,fllow #36558 
```yaml
content/en /docs/setup/production-environment/container-runtimes.md
```
en:
![image](https://user-images.githubusercontent.com/29862632/188268765-44418bda-67aa-4202-8818-bef84b4a928d.png)

