### PR TITLE
[zh-cn]Fix layout of resource-metrics-pipeline.md

### DIFF
--- a/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -30,7 +30,7 @@ You can also view the resource metrics using the
 command.
 -->
 
-对于 Kubernetes，_Metrics API_ 提供了一组基本的指标，以支持自动伸缩和类似的用例。
+对于 Kubernetes，**Metrics API** 提供了一组基本的指标，以支持自动伸缩和类似的用例。
 该 API 提供有关节点和 Pod 的资源使用情况的信息，
 包括 CPU 和内存的指标。如果将 Metrics API 部署到集群中，
 那么 Kubernetes API 的客户端就可以查询这些信息，并且可以使用 Kubernetes 的访问控制机制来管理权限。
@@ -51,7 +51,7 @@ the simpler Metrics API by deploying a second
 that uses the _Custom Metrics API_.
 -->
 Metrics API 及其启用的指标管道仅提供最少的 CPU 和内存指标，以启用使用 HPA 和/或 VPA 的自动扩展。
-如果你想提供更完整的指标集，你可以通过部署使用 _Custom Metrics API_ 的第二个
+如果你想提供更完整的指标集，你可以通过部署使用 **Custom Metrics API** 的第二个
 [指标管道](/zh-cn/docs/tasks/debug/debug-cluster/resource-usage-monitoring/#full-metrics-pipeline)来作为简单的 Metrics API 的补充。
 {{< /note >}}
 
@@ -158,14 +158,18 @@ metrics-server 实现了 Metrics API。此 API 允许你访问集群中节点和
 kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes/minikube" | jq '.'
 ```
 
-<!-- Here is the same API call using `curl`: -->
+<!--
+Here is the same API call using `curl`:
+-->
 这是使用 `curl` 来执行的相同 API 调用：
 
 ```shell
 curl http://localhost:8080/apis/metrics.k8s.io/v1beta1/nodes/minikube
 ```
 
-<!-- Sample response: -->
+<!--
+Sample response:
+-->
 响应示例：
 
 ```json
@@ -198,14 +202,18 @@ Here is an example of the Metrics API request for a `kube-scheduler-minikube` po
 kubectl get --raw "/apis/metrics.k8s.io/v1beta1/namespaces/kube-system/pods/kube-scheduler-minikube" | jq '.'
 ```
 
-<!-- Here is the same API call using `curl`: -->
+<!--
+Here is the same API call using `curl`:
+-->
 这是使用 `curl` 来完成的相同 API 调用：
 
 ```shell
 curl http://localhost:8080/apis/metrics.k8s.io/v1beta1/namespaces/kube-system/pods/kube-scheduler-minikube
 ```
 
-<!-- Sample response: -->
+<!--
+Sample response:
+-->
 响应示例：
 
 ```json
@@ -238,7 +246,7 @@ repository. You must enable the [API aggregation layer](/docs/tasks/extend-kuber
 and register an [APIService](/docs/reference/kubernetes-api/cluster-resources/api-service-v1/)
 for the `metrics.k8s.io` API.
 
-To learn more about the Metrics API, see [resource metrics API design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/resource-metrics-api.md),
+To learn more about the Metrics API, see [resource metrics API design](https://git.k8s.io/design-proposals-archive/instrumentation/resource-metrics-api.md),
 the [metrics-server repository](https://github.com/kubernetes-sigs/metrics-server) and the
 [resource metrics API](https://github.com/kubernetes/metrics#resource-metrics-api).
 -->
@@ -248,7 +256,7 @@ Metrics API 在 [k8s.io/metrics](https://github.com/kubernetes/metrics) 代码�
 `metrics.k8s.io` API 注册一个 [APIService](/zh-cn/docs/reference/kubernetes-api/cluster-resources/api-service-v1/)。
 
 要了解有关 Metrics API 的更多信息，
-请参阅资源 [Resource Metrics API Design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/resource-metrics-api.md)、
+请参阅资源 [Resource Metrics API Design](https://git.k8s.io/design-proposals-archive/instrumentation/resource-metrics-api.md)、
 [metrics-server 代码库](https://github.com/kubernetes-sigs/metrics-server) 和
 [Resource Metrics API](https://github.com/kubernetes/metrics#resource-metrics-api)。
 
@@ -261,7 +269,7 @@ to access it.
 {{< /note >}}
 
 <!--
-## Measuring Resource Usage
+## Measuring resource usage
 
 ### CPU
 
@@ -362,7 +370,7 @@ To learn more about the metrics-server, see the
 
 You can also check out the following:
 
-* [metrics-server design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
+* [metrics-server design](https://git.k8s.io/design-proposals-archive/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)
@@ -373,23 +381,24 @@ You can also check out the following:
 
 你还可以查看以下内容：
 
-* [metrics-server 设计](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
+* [metrics-server 设计](https://git.k8s.io/design-proposals-archive/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)
 * [Horizontal Pod Autoscaling](/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale/)
 
 <!--
-### Summary API Source
+### Summary API source
 
-The [Kubelet](/docs/reference/command-line-tools-reference/kubelet/) gathers stats at node, volume, pod and container level, and emits
-them in the [Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go)
+The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) gathers stats at the node,
+volume, pod and container level, and emits this information in
+the [Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go)
 for consumers to read.
 -->
 
 ### Summary API 来源   {#summary-api-source}
 
-[Kubelet](/zh-cn/docs/reference/command-line-tools-reference/kubelet/) 在节点、卷、Pod 和容器级别收集统计信息，
+[kubelet](/zh-cn/docs/reference/command-line-tools-reference/kubelet/) 在节点、卷、Pod 和容器级别收集统计信息，
 并在 [Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go)
 中提供它们的统计信息供消费者阅读。
 
@@ -403,7 +412,9 @@ Here is an example of a Summary API request for a `minikube` node:
 kubectl get --raw "/api/v1/nodes/minikube/proxy/stats/summary"
 ```
 
-<!-- Here is the same API call using `curl`: -->
+<!--
+Here is the same API call using `curl`:
+-->
 这是使用 `curl` 来执行的相同 API 调用：
 
 ```shell


### PR DESCRIPTION
Chage `github.com/kubernetes` to `git.k8s.io`
Preview:


https://deploy-preview-36583--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline
```yaml
content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
```