### PR TITLE
Fix sidebar rendering for narrow viewports

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -88,6 +88,5 @@
 {{- end -}}
 <script defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 {{- end -}}
-<script src="{{ "/js/script.js" | relURL }}"></script>
 {{ with .Params.js }}{{ range (split . ",") }}<script src="{{ (trim . " ") | relURL }}"></script><!-- custom js added -->
 {{ end }}{{ else }}<!-- no custom js detected -->{{ end }}


### PR DESCRIPTION
Fix a [bug](https://github.com/kubernetes/website/issues/36589) that's noticeable when the viewport is narrow: you can toggle the menu, but that menu is actually blank.

The fix seems simple: only include `/js/script.js` once. It works well for me.