### PR TITLE
use $HOSTNAME env variable instead of hostname command in new Oracle based mysql container

### DIFF
--- a/content/en/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/en/examples/application/mysql/mysql-statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         - |
           set -ex
           # Generate mysql server-id from pod ordinal index.
-          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+          [[ $HOSTNAME =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           echo [mysqld] > /mnt/conf.d/server-id.cnf
           # Add an offset to avoid reserved server-id=0 value.


### PR DESCRIPTION
As per the issue #35432, `hostname` command is no longer available as `mysql:5.7` is now based on Oracle. 
For the command on line 27 to work, it is sufficient to use the `$HOSTNAME` variable which is set in the container,
for it to work effectively.
