### PR TITLE
[zh] Fix layout of contribute.md

### DIFF
--- a/content/zh-cn/docs/contribute/_index.md
+++ b/content/zh-cn/docs/contribute/_index.md
@@ -50,6 +50,7 @@ about contributing to Kubernetes.
 你还可以阅读
 {{< glossary_tooltip text="CNCF" term_id="cncf" >}}
 关于为 Kubernetes 做贡献的[页面](https://contribute.cncf.io/contributors/projects/#kubernetes)。
+{{< /note >}}
 
 <!--
 This website is maintained by [Kubernetes SIG Docs](/docs/contribute/#get-involved-with-sig-docs).


### PR DESCRIPTION
Hi, I found a problem in the document. There is navigation on the right side of the English document, but there is no navigation on the right side of the Chinese document. 

Chinese document : https://kubernetes.io/zh-cn/docs/contribute/
English document : https://kubernetes.io/docs/contribute/