### PR TITLE
Update service.md to include a missing word

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -287,7 +287,7 @@ There are a few reasons for using proxying for Services:
   on the DNS records could impose a high load on DNS that then becomes
   difficult to manage.
 
-Later in this page you can read about various kube-proxy implementations work. Overall,
+Later in this page you can read about how various kube-proxy implementations work. Overall,
 you should note that, when running `kube-proxy`, kernel level rules may be
 modified (for example, iptables rules might get created), which won't get cleaned up,
 in some cases until you reboot.  Thus, running kube-proxy is something that should


### PR DESCRIPTION
The service documentation was missing a 'how' in one of its sentences. Added.