### PR TITLE
Added make module-init command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,16 @@ cd website
 
 The Kubernetes website uses the [Docsy Hugo theme](https://github.com/google/docsy#readme). Even if you plan to run the website in a container, we strongly recommend pulling in the submodule and other development dependencies by running the following:
 
-```bash
+### Windows
+```powershell
 # pull in the Docsy submodule
 git submodule update --init --recursive --depth 1
+```
+
+### Linux
+```bash
+# fetch all the dependencies
+make module-init
 ```
 
 ## Running the website using a container

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The Kubernetes website uses the [Docsy Hugo theme](https://github.com/google/doc
 
 ### Windows
 ```powershell
-# pull in the Docsy submodule
+# fetch submodule dependencies
 git submodule update --init --recursive --depth 1
 ```
 
-### Linux
+### Linux / other Unix
 ```bash
-# fetch all the dependencies
+# fetch submodule dependencies
 make module-init
 ```
 


### PR DESCRIPTION
A command inside Readme.md was missing for starting of local docker container

Signed-off-by: Dipankar Das <dipankardas0115@gmail.com>
