### PR TITLE
Move "Connecting Applications with Services" to tutorials section

### DIFF
--- a/content/en/docs/concepts/services-networking/_index.md
+++ b/content/en/docs/concepts/services-networking/_index.md
@@ -49,8 +49,8 @@ blind to the existence or non-existence of host ports.
 Kubernetes networking addresses four concerns:
 - Containers within a Pod [use networking to communicate](/docs/concepts/services-networking/dns-pod-service/) via loopback.
 - Cluster networking provides communication between different Pods.
-- The [Service](/docs/concepts/services-networking/service/) resource lets you
-  [expose an application running in Pods](/docs/concepts/services-networking/connect-applications-service/)
+- The [Service](/docs/concepts/services-networking/service/) API lets you
+  [expose an application running in Pods](/docs/tutorials/services/connect-applications-service/)
   to be reachable from outside your cluster.
   - [Ingress](/docs/concepts/services-networking/ingress/) provides extra functionality
     specifically for exposing HTTP applications, websites and APIs.

--- a/content/en/docs/concepts/services-networking/_index.md
+++ b/content/en/docs/concepts/services-networking/_index.md
@@ -57,5 +57,7 @@ Kubernetes networking addresses four concerns:
 - You can also use Services to
   [publish services only for consumption inside your cluster](/docs/concepts/services-networking/service-traffic-policy/).
 
+The [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/) tutorial lets you learn about Services and Kubernetes networking with a hands-on example.
+
 [Cluster Networking](/docs/concepts/cluster-administration/networking/) explains how to set
 up networking for your cluster, and also provides an overview of the technologies involved.

--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -273,4 +273,4 @@ networking and topology-aware routing.
 
 ## {{% heading "whatsnext" %}}
 
-* Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
+* Follow the [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/) tutorial

--- a/content/en/docs/concepts/services-networking/service-traffic-policy.md
+++ b/content/en/docs/concepts/services-networking/service-traffic-policy.md
@@ -69,4 +69,4 @@ When the [feature gate](/docs/reference/command-line-tools-reference/feature-gat
 
 * Read about [Topology Aware Hints](/docs/concepts/services-networking/topology-aware-hints)
 * Read about [Service External Traffic Policy](/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)
-* Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
+* Follow the [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/) tutorial

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -1557,6 +1557,6 @@ followed by the data from the client.
 
 ## {{% heading "whatsnext" %}}
 
-* Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
+* Follow the [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/) tutorial
 * Read about [Ingress](/docs/concepts/services-networking/ingress/)
 * Read about [EndpointSlices](/docs/concepts/services-networking/endpoint-slices/)

--- a/content/en/docs/concepts/services-networking/topology-aware-hints.md
+++ b/content/en/docs/concepts/services-networking/topology-aware-hints.md
@@ -159,4 +159,4 @@ zone.
 
 ## {{% heading "whatsnext" %}}
 
-* Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
+* Follow the [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/) tutorial

--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -198,6 +198,6 @@ balancer, the control plane looks up that external IP address and populates it i
 
 ## {{% heading "whatsnext" %}}
 
+* Follow the [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/) tutorial
 * Read about [Service](/docs/concepts/services-networking/service/)
 * Read about [Ingress](/docs/concepts/services-networking/ingress/)
-* Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)

--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -153,7 +153,6 @@ the Hello World application, enter this command:
 
 ## {{% heading "whatsnext" %}}
 
-
-Learn more about
-[connecting applications with services](/docs/concepts/services-networking/connect-applications-service/).
-
+Follow the
+[Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/)
+tutorial.

--- a/content/en/docs/tasks/administer-cluster/enabling-service-topology.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-service-topology.md
@@ -50,6 +50,5 @@ To enable service topology, enable the `ServiceTopology`
 * Read about [Topology Aware Hints](/docs/concepts/services-networking/topology-aware-hints/), the replacement for the `topologyKeys` field.
 * Read about [EndpointSlices](/docs/concepts/services-networking/endpoint-slices/)
 * Read about the [Service Topology](/docs/concepts/services-networking/service-topology/) concept
-* Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
-
+* Read [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/)
 

--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -49,6 +49,7 @@ Before walking through each tutorial, you may want to bookmark the
 
 ## Services
 
+* [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/)
 * [Using Source IP](/docs/tutorials/services/source-ip/)
 
 ## Security

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -37,7 +37,7 @@ weight: 10
 				<li><i>LoadBalancer</i> - Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP to the Service. Superset of NodePort.</li>
 				<li><i>ExternalName</i> - Maps the Service to the contents of the <code>externalName</code> field (e.g. <code>foo.bar.example.com</code>), by returning a <code>CNAME</code> record with its value. No proxying of any kind is set up. This type requires v1.7 or higher of <code>kube-dns</code>, or CoreDNS version 0.0.8 or higher.</li>
 			</ul>
-			<p>More information about the different types of Services can be found in the <a href="/docs/tutorials/services/source-ip/">Using Source IP</a> tutorial. Also see <a href="/docs/concepts/services-networking/connect-applications-service">Connecting Applications with Services</a>.</p>
+			<p>More information about the different types of Services can be found in the <a href="/docs/tutorials/services/source-ip/">Using Source IP</a> tutorial. Also see <a href="/docs/tutorials/services/connect-applications-service/">Connecting Applications with Services</a>.</p>
 			<p>Additionally, note that there are some use cases with Services that involve not defining a <code>selector</code> in the spec. A Service created without <code>selector</code> will also not create the corresponding Endpoints object. This allows users to manually map a Service to specific endpoints. Another possibility why there may be no selector is you are strictly using <code>type: ExternalName</code>.</p>
 			</div>
 			<div class="col-md-4">

--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -4,8 +4,8 @@ reviewers:
 - lavalamp
 - thockin
 title: Connecting Applications with Services
-content_type: concept
-weight: 40
+content_type: tutorial
+weight: 20
 ---
 
 
@@ -17,7 +17,7 @@ Now that you have a continuously running, replicated application you can expose 
 
 Kubernetes assumes that pods can communicate with other pods, regardless of which host they land on. Kubernetes gives every pod its own cluster-private IP address, so you do not need to explicitly create links between pods or map container ports to host ports. This means that containers within a Pod can all reach each other's ports on localhost, and all pods in a cluster can see each other without NAT. The rest of this document elaborates on how you can run reliable services on such a networking model.
 
-This guide uses a simple nginx server to demonstrate proof of concept.
+This tutorial uses a simple nginx web server to demonstrate the concept.
 
 <!-- body -->
 

--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -2,7 +2,7 @@
 title: Using Source IP
 content_type: tutorial
 min-kubernetes-server-version: v1.5
-weight: 10
+weight: 40
 ---
 
 <!-- overview -->
@@ -416,5 +416,5 @@ kubectl delete deployment source-ip-app
 
 ## {{% heading "whatsnext" %}}
 
-* Learn more about [connecting applications via services](/docs/concepts/services-networking/connect-applications-service/)
+* Learn more about [connecting applications via services](/docs/tutorials/services/connect-applications-service/)
 * Read how to [Create an External Load Balancer](/docs/tasks/access-application-cluster/create-external-load-balancer/)

--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -175,4 +175,4 @@ kubectl delete deployment hello-world
 ## {{% heading "whatsnext" %}}
 
 Learn more about
-[connecting applications with services](/docs/concepts/services-networking/connect-applications-service/).
+[connecting applications with services](/docs/tutorials/services/connect-applications-service/).

--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -418,5 +418,5 @@ labels to delete multiple resources with one command.
 
 * Complete the [Kubernetes Basics](/docs/tutorials/kubernetes-basics/) Interactive Tutorials
 * Use Kubernetes to create a blog using [Persistent Volumes for MySQL and Wordpress](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/#visit-your-new-wordpress-blog)
-* Read more about [connecting applications](/docs/concepts/services-networking/connect-applications-service/)
+* Read more about [connecting applications with services](/docs/tutorials/services/connect-applications-service/)
 * Read more about [Managing Resources](/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively)

--- a/static/_redirects
+++ b/static/_redirects
@@ -120,6 +120,7 @@
 /docs/concepts/jobs/run-to-completion-finite-workloads/      /docs/concepts/workloads/controllers/job/ 301
 /id/docs/concepts/jobs/run-to-completion-finite-workloads/      /id/docs/concepts/workloads/controllers/job/ 301
 /docs/concepts/nodes/node/     /docs/concepts/architecture/nodes/ 301
+/docs/concepts/services-networking/connect-applications-service/    /docs/tutorials/services/connect-applications-service/   301
 /docs/concepts/object-metadata/annotations/     /docs/concepts/overview/working-with-objects/annotations/ 301
 /docs/concepts/overview/     /docs/concepts/overview/what-is-kubernetes/ 301
 /docs/concepts/overview/extending/     /docs/concepts/extend-kubernetes/ 301
@@ -393,7 +394,7 @@
 /docs/user-guide/configmap/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
 /docs/user-guide/configmap/README/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
 /docs/user-guide/configuring-containers/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
-/docs/user-guide/connecting-applications/     /docs/concepts/services-networking/connect-applications-service/ 301
+/docs/user-guide/connecting-applications/     /docs/tutorials/services/connect-applications-service/ 301
 /docs/user-guide/connecting-to-applications-port-forward/     /docs/tasks/access-application-cluster/port-forward-access-application-cluster/ 301
 /docs/user-guide/connecting-to-applications-proxy/     /docs/tasks/access-kubernetes-api/http-proxy-access-api/ 301
 /docs/user-guide/container-environment/     /docs/concepts/containers/container-lifecycle-hooks/ 301


### PR DESCRIPTION
Split out from https://github.com/kubernetes/website/pull/30817

Move [Connecting Applications with Services](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/) to tutorials section: it's a tutorial.
[[preview](https://deploy-preview-36669--kubernetes-io-main-staging.netlify.app/docs/tutorials/services/connect-applications-service/)]

_This_ PR is the move. After this merges, I hope to file an issue about further cleanup to the page in its new home.

/label refactor