### PR TITLE
Link from Policies concept to NetworkPolicy page

### DIFF
--- a/content/en/docs/concepts/policy/_index.md
+++ b/content/en/docs/concepts/policy/_index.md
@@ -4,3 +4,8 @@ weight: 90
 description: >
   Policies you can configure that apply to groups of resources.
 ---
+
+{{< note >}}
+See [Network Policies](/docs/concepts/services-networking/network-policies/)
+for documentation about NetworkPolicy in Kubernetes.
+{{< /note >}}


### PR DESCRIPTION
Split out from https://github.com/kubernetes/website/pull/30817

Link from [Policies](https://kubernetes.io/docs/concepts/policy/) concept to [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) page. [[preview](https://deploy-preview-36670--kubernetes-io-main-staging.netlify.app/docs/concepts/policy/)]