### PR TITLE
[zh] Resync manage-resources-containers.md and feature-gates.md

### DIFF
--- a/content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
@@ -5,7 +5,7 @@ weight: 40
 feature:
   title: 自动装箱
   description: >
-    根据资源需求和其他约束自动放置容器，同时避免影响可用性。
+    根据资源需求和其他限制自动放置容器，同时避免影响可用性。
     将关键性的和尽力而为性质的工作负载进行混合放置，以提高资源利用率并节省更多资源。
 ---
 <!--
@@ -41,7 +41,7 @@ to use.
 当你为 Pod 中的 Container 指定了资源 __请求__ 时，
 {{< glossary_tooltip text="kube-scheduler" term_id="kube-scheduler" >}}
 就利用该信息决定将 Pod 调度到哪个节点上。
-当你还为 Container 指定了资源 __约束__ 时，kubelet 就可以确保运行的容器不会使用超出所设约束的资源。
+当你还为 Container 指定了资源 __限制__ 时，kubelet 就可以确保运行的容器不会使用超出所设限制的资源。
 kubelet 还会为容器预留所 __请求__ 数量的系统资源，供其使用。
 
 <!-- body -->
@@ -57,14 +57,14 @@ For example, if you set a `memory` request of 256 MiB for a container, and that 
 a Pod scheduled to a Node with 8GiB of memory and no other Pods, then the container can try to use
 more RAM.
 -->
-## 请求和约束  {#requests-and-limits}
+## 请求和限制  {#requests-and-limits}
 
 如果 Pod 运行所在的节点具有足够的可用资源，容器可能（且可以）使用超出对应资源
 `request` 属性所设置的资源量。不过，容器不可以使用超出其资源 `limit`
 属性所设置的资源量。
 
 例如，如果你将容器的 `memory` 的请求量设置为 256 MiB，而该容器所处的 Pod
-被调度到一个具有 8 GiB 内存的节点上，并且该节点上没有其他 Pods
+被调度到一个具有 8 GiB 内存的节点上，并且该节点上没有其他 Pod
 运行，那么该容器就可以尝试使用更多的内存。
 
 <!--
@@ -79,15 +79,14 @@ Limits can be implemented either reactively (the system intervenes once it sees 
 or by enforcement (the system prevents the container from ever exceeding the limit). Different
 runtimes can have different ways to implement the same restrictions.
 -->
-如果你将某容器的 `memory` 约束设置为 4 GiB，kubelet （和
-{{< glossary_tooltip text="容器运行时" term_id="container-runtime" >}}）
-就会确保该约束生效。
-容器运行时会禁止容器使用超出所设置资源约束的资源。
+如果你将某容器的 `memory` 限制设置为 4 GiB，kubelet
+（和{{< glossary_tooltip text="容器运行时" term_id="container-runtime" >}}）就会确保该限制生效。
+容器运行时会禁止容器使用超出所设置资源限制的资源。
 例如：当容器中进程尝试使用超出所允许内存量的资源时，系统内核会将尝试申请内存的进程终止，
 并引发内存不足（OOM）错误。
 
-约束值可以以被动方式来实现（系统会在发现违例时进行干预），或者通过强制生效的方式实现
-（系统会避免容器用量超出约束值）。不同的容器运行时采用不同方式来实现相同的限制。
+限制可以以被动方式来实现（系统会在发现违例时进行干预），或者通过强制生效的方式实现
+（系统会避免容器用量超出限制）。不同的容器运行时采用不同方式来实现相同的限制。
 
 {{< note >}}
 <!--
@@ -116,13 +115,13 @@ total of 80 MiB), that allocation fails.
 -->
 ## 资源类型  {#resource-types}
 
-*CPU* 和 *内存* 都是 *资源类型*。每种资源类型具有其基本单位。
-CPU 表达的是计算处理能力，其单位是 [Kubernetes CPUs](#meaning-of-cpu)。
+**CPU** 和 **内存** 都是 **资源类型**。每种资源类型具有其基本单位。
+CPU 表达的是计算处理能力，其单位是 [Kubernetes CPU](#meaning-of-cpu)。
 内存的单位是字节。
 对于 Linux 负载，则可以指定巨页（Huge Page）资源。
 巨页是 Linux 特有的功能，节点内核在其中分配的内存块比默认页大小大得多。
 
-例如，在默认页面大小为 4KiB 的系统上，你可以指定约束 `hugepages-2Mi: 80Mi`。
+例如，在默认页面大小为 4KiB 的系统上，你可以指定限制 `hugepages-2Mi: 80Mi`。
 如果容器尝试分配 40 个 2MiB 大小的巨页（总共 80 MiB ），则分配请求会失败。
 
 {{< note >}}
@@ -130,7 +129,7 @@ CPU 表达的是计算处理能力，其单位是 [Kubernetes CPUs](#meaning-of-
 You cannot overcommit `hugepages-*` resources.
 This is different from the `memory` and `cpu` resources.
 -->
-你不能过量使用 `hugepages- * `资源。
+你不能过量使用 `hugepages- *` 资源。
 这与 `memory` 和 `cpu` 资源不同。
 {{< /note >}}
 
@@ -142,9 +141,9 @@ consumed. They are distinct from
 [Services](/docs/concepts/services-networking/service/) are objects that can be read and modified
 through the Kubernetes API server.
 -->
-CPU 和内存统称为“计算资源”，或简称为“资源”。
+CPU 和内存统称为 **计算资源**，或简称为 **资源**。
 计算资源的数量是可测量的，可以被请求、被分配、被消耗。
-它们与 [API 资源](/zh-cn/docs/concepts/overview/kubernetes-api/) 不同。
+它们与 [API 资源](/zh-cn/docs/concepts/overview/kubernetes-api/)不同。
 API 资源（如 Pod 和 [Service](/zh-cn/docs/concepts/services-networking/service/)）是可通过
 Kubernetes API 服务器读取和修改的对象。
 
@@ -154,9 +153,9 @@ Kubernetes API 服务器读取和修改的对象。
 For each container, you can specify resource limits and requests,
 including the following:
 -->
-## Pod 和 容器的资源请求和约束  {#resource-requests-and-limits-of-pod-and-container}
+## Pod 和 容器的资源请求和限制  {#resource-requests-and-limits-of-pod-and-container}
 
-针对每个容器，你都可以指定其资源约束和请求，包括如下选项：
+针对每个容器，你都可以指定其资源限制和请求，包括如下选项：
 
 * `spec.containers[].resources.limits.cpu`
 * `spec.containers[].resources.limits.memory`
@@ -172,8 +171,8 @@ a Pod.
 For a particular resource, a *Pod resource request/limit* is the sum of the
 resource requests/limits of that type for each container in the Pod.
 -->
-尽管你只能逐个容器地指定请求和限制值，考虑 Pod 的总体资源请求和约束也是有用的。
-对特定资源而言，Pod 的资源请求/约束值是 Pod 中各容器对该类型资源的请求/约束值的总和。
+尽管你只能逐个容器地指定请求和限制值，考虑 Pod 的总体资源请求和限制也是有用的。
+对特定资源而言，**Pod 的资源请求/限制** 是 Pod 中各容器对该类型资源的请求/限制的总和。
 
 <!--
 ## Resource units in Kubernetes
@@ -189,8 +188,8 @@ or a virtual machine running inside a physical machine.
 
 ### CPU 资源单位    {#meaning-of-cpu}
 
-CPU 资源的约束和请求以 “cpu” 为单位。
-在 Kubernetes 中，一个 CPU 等于**1 个物理 CPU 核** 或者 **一个虚拟核**，
+CPU 资源的限制和请求以 “cpu” 为单位。
+在 Kubernetes 中，一个 CPU 等于 **1 个物理 CPU 核** 或者 **1 个虚拟核**，
 取决于节点是一台物理主机还是运行在某物理主机上的虚拟机。
 
 <!--
@@ -238,7 +237,7 @@ Mi, Ki. For example, the following represent roughly the same value:
 -->
 ## 内存资源单位      {#meaning-of-memory}
 
-`memory` 的约束和请求以字节为单位。
+`memory` 的限制和请求以字节为单位。
 你可以使用普通的整数，或者带有以下
 [数量](/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity/)后缀
 的定点数字来表示内存：E、P、T、G、M、k。
@@ -270,7 +269,7 @@ MiB of memory, and a limit of 1 CPU and 256MiB of memory.
 ## 容器资源示例     {#example-1}
 
 以下 Pod 有两个容器。每个容器的请求为 0.25 CPU 和 64MiB（2<sup>26</sup> 字节）内存，
-每个容器的资源约束为 0.5 CPU 和 128MiB 内存。
+每个容器的资源限制为 0.5 CPU 和 128MiB 内存。
 你可以认为该 Pod 的资源请求为 0.5 CPU 和 128 MiB 内存，资源限制为 1 CPU 和 256MiB 内存。
 
 ```yaml
@@ -333,9 +332,9 @@ On Linux, the container runtime typically configures
 kernel {{< glossary_tooltip text="cgroups" term_id="cgroup" >}} that apply and enforce the
 limits you defined.
 -->
-## Kubernetes 应用资源请求与约束的方式 {#how-pods-with-resource-limits-are-run}
+## Kubernetes 应用资源请求与限制的方式 {#how-pods-with-resource-limits-are-run}
 
-当 kubelet 将容器作为 Pod 的一部分启动时，它会将容器的 CPU 和内存请求与约束信息传递给容器运行时。
+当 kubelet 将容器作为 Pod 的一部分启动时，它会将容器的 CPU 和内存请求与限制信息传递给容器运行时。
 
 在 Linux 系统上，容器运行时通常会配置内核
 {{< glossary_tooltip text="CGroups" term_id="cgroup" >}}，负责应用并实施所定义的请求。
@@ -345,8 +344,8 @@ limits you defined.
   During each scheduling interval (time slice), the Linux kernel checks to see if this
   limit is exceeded; if so, the kernel waits before allowing that cgroup to resume execution.
 -->
-- CPU 约束值定义的是容器可使用的 CPU 时间的硬性上限。
-  在每个调度周期（时间片）期间，Linux 内核检查是否已经超出该约束值；
+- CPU 限制定义的是容器可使用的 CPU 时间的硬性上限。
+  在每个调度周期（时间片）期间，Linux 内核检查是否已经超出该限制；
   内核会在允许该 cgroup 恢复执行之前会等待。
 <!--
 - The CPU request typically defines a weighting. If several different containers (cgroups)
@@ -369,7 +368,7 @@ limits you defined.
   to allocate memory. If that process is the container's PID 1, and the container is marked
   as restartable, Kubernetes restarts the container.
 -->
-- 内存约束值定义的是 CGroup 的内存约束。如果容器尝试分配的内存量超出约束值，
+- 内存限制定义的是 cgroup 的内存限制。如果容器尝试分配的内存量超出限制，
   则 Linux 内核的内存不足处理子系统会被激活，并停止尝试分配内存的容器中的某个进程。
   如果该进程在容器中 PID 为 1，而容器被标记为可重新启动，则 Kubernetes
   会重新启动该容器。
@@ -378,7 +377,7 @@ limits you defined.
   volumes, such as an `emptyDir`. The kubelet tracks `tmpfs` emptyDir volumes as container
   memory use, rather than as local ephemeral storage.
 -->
-- Pod 或容器的内存约束值也适用于通过内存供应的卷，例如 `emptyDir` 卷。
+- Pod 或容器的内存限制也适用于通过内存供应的卷，例如 `emptyDir` 卷。
   kubelet 会跟踪 `tmpfs` 形式的 emptyDir 卷用量，将其作为容器的内存用量，
   而不是临时存储用量。
 
@@ -394,12 +393,12 @@ To determine whether a container cannot be scheduled or is being killed due to r
 see the [Troubleshooting](#troubleshooting) section.
 -->
 如果某容器内存用量超过其内存请求值并且所在节点内存不足时，容器所处的 Pod
-可能被{{< glossary_tooltip text="逐出" term_id="eviction" >}}.
+可能被{{< glossary_tooltip text="逐出" term_id="eviction" >}}。
 
-每个容器可能被允许也可能不被允许使用超过其 CPU 约束的处理时间。
+每个容器可能被允许也可能不被允许使用超过其 CPU 限制的处理时间。
 但是，容器运行时不会由于 CPU 使用率过高而杀死 Pod 或容器。
 
-要确定某容器是否会由于资源约束而无法调度或被杀死，请参阅[疑难解答](#troubleshooting)节。
+要确定某容器是否会由于资源限制而无法调度或被杀死，请参阅[疑难解答](#troubleshooting)节。
 
 <!--
 ## Monitoring compute & memory resource usage
@@ -419,7 +418,7 @@ kubelet 会将 Pod 的资源使用情况作为 Pod
 的一部分来报告的。
 
 如果为集群配置了可选的[监控工具](/zh-cn/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)，
-则可以直接从[指标 API](/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-api) 
+则可以直接从[指标 API](/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-api)
 或者监控工具获得 Pod 的资源使用情况。
 
 <!--
@@ -462,9 +461,8 @@ As a beta feature, Kubernetes lets you track, reserve and limit the amount
 of ephemeral local storage a Pod can consume.
 -->
 
-kubelet 也使用此类存储来保存
-[节点层面的容器日志](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)，
-容器镜像文件、以及运行中容器的可写入层。
+kubelet 也使用此类存储来保存[节点层面的容器日志](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)、
+容器镜像文件以及运行中容器的可写入层。
 
 {{< caution >}}
 如果节点失效，存储在临时性存储中的数据会丢失。
@@ -499,8 +497,7 @@ Kubernetes 有两种方式支持节点上配置本地临时性存储：
 作为最有效的 kubelet 配置方式，这意味着该文件系统是专门提供给 Kubernetes
 （kubelet）来保存数据的。
 
-kubelet 也会生成
-[节点层面的容器日志](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)，
+kubelet 也会生成[节点层面的容器日志](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)，
 并按临时性本地存储的方式对待之。
 
 <!--
@@ -549,8 +546,7 @@ as you like.
 `emptyDir` 卷等。你可以使用这个文件系统来保存其他数据（例如：与 Kubernetes
 无关的其他系统日志）；这个文件系统还可以是根文件系统。
 
-kubelet 也将
-[节点层面的容器日志](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)
+kubelet 也将[节点层面的容器日志](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)
 写入到第一个文件系统中，并按临时性本地存储的方式对待之。
 
 同时你使用另一个由不同逻辑存储设备支持的文件系统。在这种配置下，你会告诉
@@ -567,13 +563,6 @@ The kubelet can measure how much local storage it is using. It does this provide
 that you have set up the node using one of the supported configurations for local
 ephemeral storage.
 
-- the `LocalStorageCapacityIsolation`
-  [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-  is enabled (the feature is on by default), and you have set up the node using one
-  of the supported configurations for local ephemeral storage.
-- Quotas are faster and more accurate than directory scanning. The
-  `LocalStorageCapacityIsolationFSQuotaMonitoring` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled (the feature is on by default), 
-
 If you have a different configuration, then the kubelet does not apply resource
 limits for ephemeral local storage.
 -->
@@ -581,13 +570,7 @@ limits for ephemeral local storage.
 kubelet 能够度量其本地存储的用量。
 实现度量机制的前提是你已使用本地临时存储所支持的配置之一对节点进行配置。
 
-- `LocalStorageCapacityIsolation`
-  [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)被启用（默认状态），
-  并且你已使用本地临时存储所支持的配置之一对节点进行了配置。
-- 配额机制比目录扫描更快、更准确。`LocalStorageCapacityIsolationFSQuotaMonitoring`
-  [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)被启用（默认状态）。
-
-如果你的节点配置不同于以上预期，kubelet 就无法对临时性本地存储的资源约束实施限制。
+如果你的节点配置不同于以上预期，kubelet 就无法对临时性本地存储实施资源限制。
 
 {{< note >}}
 <!--
@@ -595,6 +578,14 @@ The kubelet tracks `tmpfs` emptyDir volumes as container memory use, rather
 than as local ephemeral storage.
 -->
 kubelet 会将 `tmpfs` emptyDir 卷的用量当作容器内存用量，而不是本地临时性存储来统计。
+{{< /note >}}
+
+{{< note >}}
+<!--
+The kubelet will only track the root filesystem for ephemeral storage. OS layouts that mount a separate disk to `/var/lib/kubelet` or `/var/lib/containers` will not report ephemeral storage correctly.
+-->
+kubelet 将仅跟踪临时存储的根文件系统。
+挂载一个单独磁盘到 `/var/lib/kubelet` 或 `/var/lib/containers` 的操作系统布局将不会正确地报告临时存储。
 {{< /note >}}
 
 <!--
@@ -611,7 +602,7 @@ You can express storage as a plain integer or as a fixed-point number using one 
 E, P, T, G, M, k. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi,
 Mi, Ki. For example, the following quantities all represent roughly the same value:
 -->
-### 为本地临时性存储设置请求和约束值  {#setting-requests-and-limits-for-local-ephemeral-storage}
+### 为本地临时性存储设置请求和限制  {#setting-requests-and-limits-for-local-ephemeral-storage}
 
 你可以指定 `ephemeral-storage` 来管理本地临时性存储。
 Pod 中的每个容器可以设置以下属性：
@@ -619,8 +610,8 @@ Pod 中的每个容器可以设置以下属性：
 * `spec.containers[].resources.limits.ephemeral-storage`
 * `spec.containers[].resources.requests.ephemeral-storage`
 
-`ephemeral-storage` 的请求和约束值是按量纲计量的。你可以使用一般整数或者定点数字
-加上下面的后缀来表达存储量：E、P、T、G、M、k。
+`ephemeral-storage` 的请求和限制是按量纲计量的。
+你可以使用一般整数或者定点数字加上下面的后缀来表达存储量：E、P、T、G、M、k。
 你也可以使用对应的 2 的幂级数来表达：Ei、Pi、Ti、Gi、Mi、Ki。
 例如，下面的表达式所表达的大致是同一个值：
 
@@ -646,8 +637,8 @@ a limit of 8GiB of local ephemeral storage.
 -->
 
 在下面的例子中，Pod 包含两个容器。每个容器请求 2 GiB 大小的本地临时性存储。
-每个容器都设置了 4 GiB 作为其本地临时性存储的约束值。
-因此，整个 Pod 的本地临时性存储请求是 4 GiB，且其本地临时性存储的约束为 8 GiB。
+每个容器都设置了 4 GiB 作为其本地临时性存储的限制。
+因此，整个 Pod 的本地临时性存储请求是 4 GiB，且其本地临时性存储的限制为 8 GiB。
 
 ```yaml
 apiVersion: v1
@@ -697,8 +688,7 @@ The scheduler ensures that the sum of the resource requests of the scheduled con
 当你创建一个 Pod 时，Kubernetes 调度器会为 Pod 选择一个节点来运行之。
 每个节点都有一个本地临时性存储的上限，是其可提供给 Pod 使用的总量。
 欲了解更多信息，
-可参考[节点可分配资源](/zh-cn/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)
-节。
+可参考[节点可分配资源](/zh-cn/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)节。
 
 调度器会确保所调度的容器的资源请求总和不会超出节点的资源容量。
 
@@ -735,12 +725,12 @@ for eviction.
 如果某 Pod 的临时存储用量超出了你所允许的范围，kubelet
 会向其发出逐出（eviction）信号，触发该 Pod 被逐出所在节点。
 
-就容器层面的隔离而言，如果某容器的可写入镜像层和日志用量超出其存储约束，
+就容器层面的隔离而言，如果某容器的可写入镜像层和日志用量超出其存储限制，
 kubelet 也会将所在的 Pod 标记为逐出候选。
 
-就 Pod 层面的隔离而言，kubelet 会将 Pod 中所有容器的约束值相加，得到 Pod
-存储约束的总值。如果所有容器的本地临时性存储用量总和加上 Pod 的 `emptyDir`
-卷的用量超出 Pod 存储约束值，kubelet 也会将该 Pod 标记为逐出候选。
+就 Pod 层面的隔离而言，kubelet 会将 Pod 中所有容器的限制相加，得到 Pod
+存储限制的总值。如果所有容器的本地临时性存储用量总和加上 Pod 的 `emptyDir`
+卷的用量超出 Pod 存储限制，kubelet 也会将该 Pod 标记为逐出候选。
 
 {{< caution >}}
 <!--
@@ -757,7 +747,7 @@ See the supported [configurations](#configurations-for-local-ephemeral-storage)
 for ephemeral local storage.
 -->
 如果 kubelet 没有度量本地临时性存储的用量，即使 Pod
-的本地存储用量超出其约束值也不会被逐出。
+的本地存储用量超出其限制也不会被逐出。
 
 不过，如果用于可写入容器镜像层、节点层面日志或者 `emptyDir` 卷的文件系统中可用空间太少，
 节点会为自身设置本地存储不足的{{< glossary_tooltip text="污点" term_id="taint" >}}标签。
@@ -805,7 +795,7 @@ that file but the kubelet does not categorize the space as in use.
 
 {{% tab name="文件系统项目配额" %}}
 
-{{< feature-state for_k8s_version="v1.25" state="beta" >}}
+{{< feature-state for_k8s_version="v1.15" state="alpha" >}}
 
 <!--
 Project quotas are an operating-system level feature for managing
@@ -823,7 +813,7 @@ For example, XFS and ext4fs offer project quotas.
 <!--
 Project quotas let you monitor storage use; they do not enforce limits.
 -->
-项目配额可以帮你监视存储用量，但无法对存储约束执行限制。
+项目配额可以帮你监视存储用量，但无法强制执行限制。
 {{< /note >}}
 
 <!--
@@ -1085,14 +1075,14 @@ Extended resources replace Opaque Integer Resources.
 Users can use any domain name prefix other than `kubernetes.io` which is reserved.
 -->
 扩展资源取代了非透明整数资源（Opaque Integer Resources，OIR）。
-用户可以使用 `kubernetes.io` （保留）以外的任何域名前缀。
+用户可以使用 `kubernetes.io`（保留）以外的任何域名前缀。
 {{< /note >}}
 
 <!--
 To consume an extended resource in a Pod, include the resource name as a key
 in the `spec.containers[].resources.limits` map in the container spec.
 -->
-要在 Pod 中使用扩展资源，请在容器规范的 `spec.containers[].resources.limits`
+要在 Pod 中使用扩展资源，请在容器规约的 `spec.containers[].resources.limits`
 映射中包含资源名称作为键。
 
 {{< note >}}
@@ -1100,7 +1090,7 @@ in the `spec.containers[].resources.limits` map in the container spec.
 Extended resources cannot be overcommitted, so request and limit
 must be equal if both are present in a container spec.
 -->
-扩展资源不能过量使用，因此如果容器规范中同时存在请求和约束，则它们的取值必须相同。
+扩展资源不能过量使用，因此如果容器规约中同时存在请求和限制，则它们的取值必须相同。
 {{< /note >}}
 
 <!--
@@ -1370,7 +1360,7 @@ find that the application is behaving how you expect, consider setting a higher
 memory limit (and possibly request) for that container.
 -->
 你接下来要做的或许是检查应用代码，看看是否存在内存泄露。
-如果你发现应用的行为与你所预期的相同，则可以考虑为该容器设置一个更高的内存约束
+如果你发现应用的行为与你所预期的相同，则可以考虑为该容器设置一个更高的内存限制
 （也可能需要设置请求值）。
 
 ## {{% heading "whatsnext" %}}
@@ -1383,10 +1373,10 @@ memory limit (and possibly request) for that container.
 * Read about [project quotas](https://xfs.org/index.php/XFS_FAQ#Q:_Quota:_Do_quotas_work_on_XFS.3F) in XFS
 * Read more about the [kube-scheduler configuration reference (v1beta3)](/docs/reference/config-api/kube-scheduler-config.v1beta3/)
 -->
-* 获取[分配内存资源给容器和 Pod ](/zh-cn/docs/tasks/configure-pod-container/assign-memory-resource/) 的实践经验
-* 获取[分配 CPU 资源给容器和 Pod ](/zh-cn/docs/tasks/configure-pod-container/assign-cpu-resource/) 的实践经验
-* 阅读 API 参考中 [Container](/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
-  和其[资源请求](/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)定义。
+* 获取[分配内存资源给容器和 Pod](/zh-cn/docs/tasks/configure-pod-container/assign-memory-resource/) 的实践经验
+* 获取[分配 CPU 资源给容器和 Pod](/zh-cn/docs/tasks/configure-pod-container/assign-cpu-resource/) 的实践经验
+* 阅读 API 参考如何定义[容器](/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
+  及其[资源请求](/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)。
 * 阅读 XFS 中[配额](https://xfs.org/index.php/XFS_FAQ#Q:_Quota:_Do_quotas_work_on_XFS.3F)的文档
 * 进一步阅读 [kube-scheduler 配置参考 (v1beta3)](/zh-cn/docs/reference/config-api/kube-scheduler-config.v1beta3/)
 

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates.md
@@ -174,8 +174,7 @@ different Kubernetes components.
 | `KubeletPodResourcesGetAllocatable` | `false` | Alpha | 1.21 | 1.22 |
 | `KubeletPodResourcesGetAllocatable` | `true` | Beta | 1.23 | |
 | `KubeletTracing` | `false` | Alpha | 1.25 | |
-| `LocalStorageCapacityIsolationFSQuotaMonitoring` | `false` | Alpha | 1.15 | 1.24 |
-| `LocalStorageCapacityIsolationFSQuotaMonitoring` | `true` | Beta | 1.25 | |
+| `LocalStorageCapacityIsolationFSQuotaMonitoring` | `false` | Alpha | 1.15 | |
 | `LogarithmicScaleDown` | `false` | Alpha | 1.21 | 1.21 |
 | `LogarithmicScaleDown` | `true` | Beta | 1.22 | |
 | `MatchLabelKeysInPodTopologySpread` | `false` | Alpha | 1.25 | |
@@ -731,10 +730,10 @@ Each feature gate is designed for enabling/disabling a specific feature:
   See [Traces for Kubernetes System Components](/docs/concepts/cluster-administration/traces-for-kubernetes-system-components) for more details.
 -->
 - `APIListChunking`：启用 API 客户端以块的形式从 API 服务器检索（“LIST” 或 “GET”）资源。
-- `APIPriorityAndFairness`: 在每个服务器上启用优先级和公平性来管理请求并发（由 `RequestManagement` 重命名而来）。
+- `APIPriorityAndFairness`：在每个服务器上启用优先级和公平性来管理请求并发（由 `RequestManagement` 重命名而来）。
 - `APIResponseCompression`：压缩 “LIST” 或 “GET” 请求的 API 响应。
 - `APIServerIdentity`：为集群中的每个 API 服务器赋予一个 ID。
-- `APIServerTracing`: 为集群中的每个 API 服务器添加对分布式跟踪的支持。
+- `APIServerTracing`：为集群中的每个 API 服务器添加对分布式跟踪的支持。
   参阅[针对 Kubernetes 系统组件的追踪](/zh-cn/docs/concepts/cluster-administration/system-traces/)获取更多详细信息。
 <!--
 - `Accelerators`: Provided an early form of plugin to enable Nvidia GPU support when using
@@ -758,7 +757,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `AffinityInAnnotations`：启用 [Pod 亲和或反亲和](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)。
 - `AllowExtTrafficLocalEndpoints`：启用服务用于将外部请求路由到节点本地终端。
 - `AllowInsecureBackendProxy`：允许用户在执行 Pod 日志访问请求时跳过 TLS 验证。
-- `AnyVolumeDataSource`: 允许使用任何自定义的资源来做作为
+- `AnyVolumeDataSource`：允许使用任何自定义的资源来做作为
   {{< glossary_tooltip text="PVC" term_id="persistent-volume-claim" >}} 中的 `DataSource`。
 - `AppArmor`：在 Linux 节点上为 Pod 启用 AppArmor 机制的强制访问控制。
   请参见 [AppArmor 教程](/zh-cn/docs/tutorials/security/apparmor/)获取详细信息。
@@ -803,7 +802,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   查看[绑定服务账号令牌](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md)获取更多详细信息。
 - `CheckpointContainer`：启用 kubelet `checkpoint` API。
   参阅 [Kubelet Checkpoint API](/zh-cn/docs/reference/node/kubelet-checkpoint-api/) 获取更多详细信息。
-- `ControllerManagerLeaderMigration`: 为
+- `ControllerManagerLeaderMigration`：为
   [kube-controller-manager](/zh-cn/docs/tasks/administer-cluster/controller-manager-leader-migration/#initial-leader-migration-configuration) 和
   [cloud-controller-manager](/zh-cn/docs/tasks/administer-cluster/controller-manager-leader-migration/#deploy-cloud-controller-manager)
   启用 Leader 迁移，它允许集群管理者在没有停机的高可用集群环境下，实时把 kube-controller-manager
@@ -829,7 +828,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `CPUManagerPolicyBetaOptions`：允许对 CPUManager 策略进行微调，针对试验性的、Beta 质量级别的选项。
   此特性门控用来保护一组质量级别为 Beta 的 CPUManager 选项。
   此特性门控永远不会被升级为稳定版本。
-- `CPUManagerPolicyOptions`: 允许微调 CPU 管理策略。
+- `CPUManagerPolicyOptions`：允许微调 CPU 管理策略。
 <!--
 - `CRIContainerLogRotation`: Enable container log rotation for CRI container runtime.
   The default max size of a log file is 10MB and the default max number of
@@ -1011,15 +1010,15 @@ Each feature gate is designed for enabling/disabling a specific feature:
   of the `InTreePluginvSphereUnregister` feature flag which prevents the
   registration of in-tree vsphere plugin.
 -->
-- `CSIMigrationvSphere`: 允许封装和转换逻辑将卷操作从 vSphere 内嵌插件路由到
+- `CSIMigrationvSphere`：允许封装和转换逻辑将卷操作从 vSphere 内嵌插件路由到
   vSphere CSI 插件。如果节点禁用了此特性门控或者未安装和配置 vSphere CSI 插件，
   则支持回退到 vSphere 内嵌插件来执行挂载操作。
   不支持回退到内嵌插件来执行制备操作，因为对应的 CSI 插件必须已安装且正确配置。
   这需要启用 CSIMigration 特性标志。
-- `CSIMigrationvSphereComplete`: 停止在 kubelet 和卷控制器中注册 vSphere 内嵌插件，
+- `CSIMigrationvSphereComplete`：停止在 kubelet 和卷控制器中注册 vSphere 内嵌插件，
   并启用填充和转换逻辑以将卷操作从 vSphere 内嵌插件路由到 vSphere CSI 插件。
   这需要启用 CSIMigration 和 CSIMigrationvSphere 特性标志，并在集群中的所有节点上安装和配置
-  vSphere CSI 插件。该特性标志已被废弃，取而代之的是能防止注册内嵌 vsphere 插件的
+  vSphere CSI 插件。该特性标志已被废弃，取而代之的是能防止注册内嵌 vSphere 插件的
   `InTreePluginvSphereUnregister` 特性标志。
 <!--
 - `CSIMigrationPortworx`: Enables shims and translation logic to route volume operations
@@ -1049,11 +1048,10 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `CSIPersistentVolume`：启用发现和挂载通过
   [CSI（容器存储接口）](https://git.k8s.io/design-proposals-archive/storage/container-storage-interface.md)
   兼容卷插件配置的卷。
-- `CSIServiceAccountToken`: 允许 CSI 驱动接收挂载卷目标 Pods 的服务账户令牌。
+- `CSIServiceAccountToken`：允许 CSI 驱动接收挂载卷目标 Pods 的服务账户令牌。
   参阅[令牌请求（Token Requests）](https://kubernetes-csi.github.io/docs/token-requests.html)。
-- `CSIStorageCapacity`: 使 CSI 驱动程序可以发布存储容量信息，并使 Kubernetes
-  调度程序在调度 Pod 时使用该信息。参见
-  [存储容量](/zh-cn/docs/concepts/storage/storage-capacity/)。
+- `CSIStorageCapacity`：使 CSI 驱动程序可以发布存储容量信息，并使 Kubernetes
+  调度程序在调度 Pod 时使用该信息。参见[存储容量](/zh-cn/docs/concepts/storage/storage-capacity/)。
   详情请参见 [`csi` 卷类型](/zh-cn/docs/concepts/storage/volumes/#csi)。
 <!--
 - `CSIVolumeFSGroupPolicy`: Allows CSIDrivers to use the `fsGroupPolicy` field.
@@ -1131,7 +1129,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `CustomResourceWebhookConversion`：对于用
   [CustomResourceDefinition](/zh-cn/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
   创建的资源启用基于 Webhook 的转换。
-- `DaemonSetUpdateSurge`: 使 DaemonSet 工作负载在每个节点的更新期间保持可用性。
+- `DaemonSetUpdateSurge`：使 DaemonSet 工作负载在每个节点的更新期间保持可用性。
   参阅[对 DaemonSet 执行滚动更新](/zh-cn/docs/tasks/manage-daemon/update-daemon-set/)。
 <!--
 - `DefaultPodTopologySpread`: Enables the use of `PodTopologySpread` scheduling plugin to do
@@ -1144,16 +1142,14 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `DisableAcceleratorUsageMetrics`:
   [Disable accelerator metrics collected by the kubelet](/docs/concepts/cluster-administration/system-metrics/#disable-accelerator-metrics).
 -->
-- `DefaultPodTopologySpread`: 启用 `PodTopologySpread` 调度插件来完成
-  [默认的调度传播](/zh-cn/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints).
-- `DelegateFSGroupToCSIDriver`: 如果 CSI 驱动程序支持，则通过 NodeStageVolume 和
-  NodePublishVolume CSI 调用传递 `fsGroup` ，将应用 `fsGroup` 从 Pod 的
+- `DefaultPodTopologySpread`：启用 `PodTopologySpread` 调度插件来完成
+  [默认的调度传播](/zh-cn/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints)。
+- `DelegateFSGroupToCSIDriver`：如果 CSI 驱动程序支持，则通过 NodeStageVolume 和
+  NodePublishVolume CSI 调用传递 `fsGroup`，将应用 `fsGroup` 从 Pod 的
   `securityContext` 的角色委托给驱动。
-- `DevicePlugins`：在节点上启用基于
-  [设备插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-  的资源制备。
-- `DisableAcceleratorUsageMetrics`： 
-  [禁用 kubelet 收集加速器指标](/zh-cn/docs/concepts/cluster-administration/system-metrics/#disable-accelerator-metrics).
+- `DevicePlugins`：在节点上启用基于[设备插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)的资源制备。
+- `DisableAcceleratorUsageMetrics`：
+  [禁用 kubelet 收集加速器指标](/zh-cn/docs/concepts/cluster-administration/system-metrics/#disable-accelerator-metrics)。
 <!--
 - `DisableCloudProviders`: Disables any functionality in `kube-apiserver`,
   `kube-controller-manager` and `kubelet` related to the `--cloud-provider`
@@ -1166,15 +1162,14 @@ Each feature gate is designed for enabling/disabling a specific feature:
   so that validation, merging, and mutation can be tested without committing.
 - `DynamicAuditing`: Used to enable dynamic auditing before v1.19.
 -->
-- `DisableCloudProviders`: 禁用 `kube-apiserver`，`kube-controller-manager` 和
+- `DisableCloudProviders`：禁用 `kube-apiserver`，`kube-controller-manager` 和
   `kubelet` 组件的 `--cloud-provider` 标志相关的所有功能。
 - `DisableKubeletCloudCredentialProviders`：禁用 kubelet 中为拉取镜像内置的凭据机制，
   该凭据用于向某云提供商的容器镜像仓库执行身份认证。
-- `DownwardAPIHugePages`：允许在
-  [下行（Downward）API](/zh-cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information)
+- `DownwardAPIHugePages`：
+  允许在[下行（Downward）API](/zh-cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information)
   中使用巨页信息。
-- `DryRun`：启用在服务器端对请求进行
-  [试运行（Dry Run）](/zh-cn/docs/reference/using-api/api-concepts/#dry-run)，
+- `DryRun`：启用在服务器端对请求进行[试运行（Dry Run）](/zh-cn/docs/reference/using-api/api-concepts/#dry-run)，
   以便测试验证、合并和修改，同时避免提交更改。
 - `DynamicAuditing`：在 v1.19 版本前用于启用动态审计。
 <!--
@@ -1258,17 +1253,17 @@ Each feature gate is designed for enabling/disabling a specific feature:
   so that their [scheduling is guaranteed](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
   This feature is deprecated by Pod Priority and Preemption as of v1.13.
 -->
-- `ExpandCSIVolumes`: 启用扩展 CSI 卷。
-- `ExpandedDNSConfig`: 在 kubelet 和 kube-apiserver 上启用后，
+- `ExpandCSIVolumes`：启用扩展 CSI 卷。
+- `ExpandedDNSConfig`：在 kubelet 和 kube-apiserver 上启用后，
   允许使用更多的 DNS 搜索域和搜索域列表。此功能特性需要容器运行时
-  （Containerd：v1.5.6 或更高，CRI-O：v1.22 或更高）的支持。参阅
-  [扩展 DNS 配置](/zh-cn/docs/concepts/services-networking/dns-pod-service/#expanded-dns-configuration).
-- `ExpandInUsePersistentVolumes`：启用扩充使用中的 PVC 的尺寸。请查阅
-  [调整使用中的 PersistentVolumeClaim 的大小](/zh-cn/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim)。
-- `ExpandPersistentVolumes`：允许扩充持久卷。请查阅
-  [扩展持久卷申领](/zh-cn/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims)。
-- `ExperimentalCriticalPodAnnotation`：启用将特定 Pod 注解为 **critical** 的方式，用于
-  [确保其被调度](/zh-cn/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)。
+  （Containerd：v1.5.6 或更高，CRI-O：v1.22 或更高）的支持。
+  参阅[扩展 DNS 配置](/zh-cn/docs/concepts/services-networking/dns-pod-service/#expanded-dns-configuration).
+- `ExpandInUsePersistentVolumes`：启用扩充使用中的 PVC 的尺寸。
+  请查阅[调整使用中的 PersistentVolumeClaim 的大小](/zh-cn/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim)。
+- `ExpandPersistentVolumes`：允许扩充持久卷。
+  请查阅[扩展持久卷申领](/zh-cn/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims)。
+- `ExperimentalCriticalPodAnnotation`：启用将特定 Pod 注解为 **critical** 的方式，
+  用于[确保其被调度](/zh-cn/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)。
   从 v1.13 开始已弃用此特性，转而使用 Pod 优先级和抢占功能。
 <!--
 - `ExperimentalHostUserNamespaceDefaulting`: Enabling the defaulting user
@@ -1318,7 +1313,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   参阅[配置活跃态、就绪态和启动探针](/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe)。
 - `HonorPVReclaimPolicy`：无论 PV 和 PVC 的删除顺序如何，当持久卷申领的策略为 `Delete`
   时，确保这种策略得到处理。
-  更多详细信息，请参阅 [PersistentVolume 删除保护 finalizer](/zh-cn/docs/concepts/storage/persistent-volumes/#persistentvolume-deletion-protection-finalizer)文档。
+  更多详细信息，请参阅 [PersistentVolume 删除保护 finalizer](/zh-cn/docs/concepts/storage/persistent-volumes/#persistentvolume-deletion-protection-finalizer) 文档。
 <!--
 - `HPAContainerMetrics`: Enable the `HorizontalPodAutoscaler` to scale based on
   metrics from individual containers in target pods.
@@ -1332,14 +1327,13 @@ Each feature gate is designed for enabling/disabling a specific feature:
   [Hyper-V isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container)
   for Windows containers.
 -->
-- `HPAContainerMetrics`：允许 `HorizontalPodAutoscaler` 基于目标 Pods 中各容器
-  的度量值来执行扩缩操作。
+- `HPAContainerMetrics`：允许 `HorizontalPodAutoscaler` 基于目标 Pods 中各容器的度量值来执行扩缩操作。
 - `HPAScaleToZero`：使用自定义指标或外部指标时，可将 `HorizontalPodAutoscaler`
   资源的 `minReplicas` 设置为 0。
-- `HugePages`：启用分配和使用预分配的
-  [巨页资源](/zh-cn/docs/tasks/manage-hugepages/scheduling-hugepages/)。
-- `HugePageStorageMediumSize`：启用支持多种大小的预分配
-  [巨页资源](/zh-cn/docs/tasks/manage-hugepages/scheduling-hugepages/)。
+- `HugePages`：
+  启用分配和使用预分配的[巨页资源](/zh-cn/docs/tasks/manage-hugepages/scheduling-hugepages/)。
+- `HugePageStorageMediumSize`：
+  启用支持多种大小的预分配[巨页资源](/zh-cn/docs/tasks/manage-hugepages/scheduling-hugepages/)。
 - `HyperVContainer`：为 Windows 容器启用
   [Hyper-V 隔离](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container)。
 <!--
@@ -1373,9 +1367,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `IngressClassNamespacedParams`：允许在 `IngressClass` 资源中使用命名空间范围的参数引用。
   此功能为 `IngressClass.spec.parameters` 添加了两个字段 - `scope` 和 `namespace`。
 - `Initializers`：允许使用 Intializers 准入插件来异步协调对象创建操作。
-- `InTreePluginAWSUnregister`: 在 kubelet 和卷控制器上关闭注册 aws-ebs 内嵌插件。
-- `InTreePluginAzureDiskUnregister`: 在 kubelet 和卷控制器上关闭注册 azuredisk 内嵌插件。
-- `InTreePluginAzureFileUnregister`: 在 kubelet 和卷控制器上关闭注册 azurefile 内嵌插件。
+- `InTreePluginAWSUnregister`：在 kubelet 和卷控制器上关闭注册 aws-ebs 内嵌插件。
+- `InTreePluginAzureDiskUnregister`：在 kubelet 和卷控制器上关闭注册 azuredisk 内嵌插件。
+- `InTreePluginAzureFileUnregister`：在 kubelet 和卷控制器上关闭注册 azurefile 内嵌插件。
 <!--
 - `InTreePluginGCEUnregister`: Stops registering the gce-pd in-tree plugin in kubelet
   and volume controllers.
@@ -1386,10 +1380,10 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `InTreePluginRBDUnregister`: Stops registering the RBD in-tree plugin in kubelet
   and volume controllers.
 -->
-- `InTreePluginGCEUnregister`: 在 kubelet 和卷控制器上关闭注册 gce-pd 内嵌插件。
-- `InTreePluginOpenStackUnregister`: 在 kubelet 和卷控制器上关闭注册 OpenStack cinder 内嵌插件。
-- `InTreePluginPortworxUnregister`: 在 kubelet 和卷控制器上关闭注册 Portworx 内嵌插件。
-- `InTreePluginRBDUnregister`: 在 kubelet 和卷控制器上关闭注册 RBD 内嵌插件。
+- `InTreePluginGCEUnregister`：在 kubelet 和卷控制器上关闭注册 gce-pd 内嵌插件。
+- `InTreePluginOpenStackUnregister`：在 kubelet 和卷控制器上关闭注册 OpenStack cinder 内嵌插件。
+- `InTreePluginPortworxUnregister`：在 kubelet 和卷控制器上关闭注册 Portworx 内嵌插件。
+- `InTreePluginRBDUnregister`：在 kubelet 和卷控制器上关闭注册 RBD 内嵌插件。
 <!--
 - `InTreePluginvSphereUnregister`: Stops registering the vSphere in-tree plugin in kubelet
   and volume controllers.
@@ -1401,7 +1395,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `Initializers`: Allow asynchronous coordination of object creation using the
   Initializers admission plugin.
 -->
-- `InTreePluginvSphereUnregister`: 在 kubelet 和卷控制器上关闭注册 vSphere 内嵌插件。
+- `InTreePluginvSphereUnregister`：在 kubelet 和卷控制器上关闭注册 vSphere 内嵌插件。
 - `IndexedJob`：允许 [Job](/zh-cn/docs/concepts/workloads/controllers/job/)
   控制器根据完成索引来管理 Pod 完成。
 - `IngressClassNamespacedParams`：允许在 `IngressClass` 资源中引用命名空间范围的参数。
@@ -1438,12 +1432,12 @@ Each feature gate is designed for enabling/disabling a specific feature:
   See [setting kubelet parameters via a config file](/docs/tasks/administer-cluster/kubelet-config-file/)
   for more details.
 -->
-- `JobTrackingWithFinalizers`: 启用跟踪 [Job](/zh-cn/docs/concepts/workloads/controllers/job)
+- `JobTrackingWithFinalizers`：启用跟踪 [Job](/zh-cn/docs/concepts/workloads/controllers/job)
   完成情况，而不是永远从集群剩余 Pod 来获取信息判断完成情况。Job 控制器使用
   Pod finalizers 和 Job 状态中的一个字段来跟踪已完成的 Pod 以计算完成。
 - `KubeletConfigFile`：启用从使用配置文件指定的文件中加载 kubelet 配置。
-  有关更多详细信息，请参见
-  [通过配置文件设置 kubelet 参数](/zh-cn/docs/tasks/administer-cluster/kubelet-config-file/)。
+  有关更多详细信息，
+  请参见[通过配置文件设置 kubelet 参数](/zh-cn/docs/tasks/administer-cluster/kubelet-config-file/)。
 <!--
 - `KubeletCredentialProviders`: Enable kubelet exec credential providers for
   image pull credentials.
@@ -1454,8 +1448,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   to discover plugins such as [CSI volume drivers](/docs/concepts/storage/volumes/#csi).
 -->
 - `KubeletCredentialProviders`：允许使用 kubelet exec 凭据提供程序来设置镜像拉取凭据。
-- `KubeletInUserNamespace`: 支持在{{<glossary_tooltip text="用户名字空间" term_id="userns">}}
-  里运行 kubelet 。
+- `KubeletInUserNamespace`：支持在{{<glossary_tooltip text="用户名字空间" term_id="userns">}}里运行 kubelet。
   请参见[使用非 Root 用户来运行 Kubernetes 节点组件](/zh-cn/docs/tasks/administer-cluster/kubelet-in-userns/)。
 - `KubeletPluginsWatcher`：启用基于探针的插件监视应用程序，使 kubelet 能够发现类似
   [CSI 卷驱动程序](/zh-cn/docs/concepts/storage/volumes/#csi)这类插件。
@@ -1591,7 +1584,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `NodeOutOfServiceVolumeDetach`：当使用 `node.kubernetes.io/out-of-service`
   污点将节点标记为停止服务时，节点上不能容忍这个污点的 Pod 将被强制删除，
   并且该在节点上被终止的 Pod 将立即进行卷分离操作。
-- `NodeSwap`: 启用 kubelet 为节点上的 Kubernetes 工作负载分配交换内存的能力。
+- `NodeSwap`：启用 kubelet 为节点上的 Kubernetes 工作负载分配交换内存的能力。
   必须将 `KubeletConfiguration.failSwapOn` 设置为 false 的情况下才能使用。
   更多详细信息，请参见[交换内存](/zh-cn/docs/concepts/architecture/nodes/#swap-memory)。
 - `NonPreemptingPriority`：为 PriorityClass 和 Pod 启用 `preemptionPolicy` 选项。
@@ -1675,7 +1668,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   有关更多信息，请参见[改进提案](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2238-liveness-probe-grace-period)。
 - `ProcMountType`：允许容器通过设置 SecurityContext 的 `procMount` 字段来控制对
   proc 文件系统的挂载方式。
-- `ProxyTerminatingEndpoints`: 当 `ExternalTrafficPolicy=Local` 时，
+- `ProxyTerminatingEndpoints`：当 `ExternalTrafficPolicy=Local` 时，
   允许 kube-proxy 来处理终止过程中的端点。
 - `PVCProtection`：当 PersistentVolumeClaim (PVC) 仍然在 Pod 使用时被删除，启用保护。
 - `QOSReserved`：允许在 QoS 级别进行资源预留，以防止处于较低 QoS 级别的 Pod
@@ -1856,8 +1849,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
 -->
 - `StorageObjectInUseProtection`：如果仍在使用 PersistentVolume 或
   PersistentVolumeClaim 对象，则将其删除操作推迟。
-- `StorageVersionAPI`: 启用
-  [存储版本 API](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageversion-v1alpha1-internal-apiserver-k8s-io)。
+- `StorageVersionAPI`：
+  启用[存储版本 API](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageversion-v1alpha1-internal-apiserver-k8s-io)。
 - `StorageVersionHash`：允许 API 服务器在版本发现中公开存储版本的哈希值。
 - `StreamingProxyRedirects`：指示 API 服务器拦截（并跟踪）后端（kubelet）的重定向以处理流请求。
   流请求的例子包括 `exec`、`attach` 和 `port-forward` 请求。
@@ -1960,7 +1953,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `WarningHeaders`：允许在 API 响应中发送警告头部。
 - `WatchBookmark`：启用对 watch 操作中 bookmark 事件的支持。
 - `WinDSR`：允许 kube-proxy 为 Windows 创建 DSR 负载均衡。
-- `WinOverlay`：允许在 Windows 的覆盖网络模式下运行 kube-proxy 。
+- `WinOverlay`：允许在 Windows 的覆盖网络模式下运行 kube-proxy。
 <!--
 - `WindowsEndpointSliceProxying`: When enabled, kube-proxy running on Windows
   will use EndpointSlices as the primary data source instead of Endpoints,
@@ -1973,11 +1966,11 @@ Each feature gate is designed for enabling/disabling a specific feature:
   [Configuring RunAsUserName](/docs/tasks/configure-pod-container/configure-runasusername)
   for more details.
 -->
-- `WindowsEndpointSliceProxying`: 当启用时，运行在 Windows 上的 kube-proxy
+- `WindowsEndpointSliceProxying`：当启用时，运行在 Windows 上的 kube-proxy
   将使用 EndpointSlices 而不是 Endpoints 作为主要数据源，从而实现可伸缩性和并改进性能。
   详情请参见[启用端点切片](/zh-cn/docs/concepts/services-networking/endpoint-slices/)。
 - `WindowsGMSA`：允许将 GMSA 凭据规范从 Pod 传递到容器运行时。
-- `WindowsHostProcessContainers`: 启用对 Windows HostProcess 容器的支持。
+- `WindowsHostProcessContainers`：启用对 Windows HostProcess 容器的支持。
 - `WindowsRunAsUserName`：提供使用非默认用户在 Windows 容器中运行应用程序的支持。
   详情请参见[配置 RunAsUserName](/zh-cn/docs/tasks/configure-pod-container/configure-runasusername)。
 


### PR DESCRIPTION
- sync with en upstream #36401 
- change `约束值` and `约束` to `限制` by following [glossary](https://kubernetes.io/zh-cn/docs/contribute/localization_zh/#%E6%9C%AF%E8%AF%AD%E5%AF%B9%E7%85%A7)
```
content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates.md
```
Preview: https://deploy-preview-36679--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/configuration/manage-resources-containers/