### PR TITLE
Sync use IPv6 Address Prefix Reserved for Documentation

### DIFF
--- a/content/fr/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/fr/docs/concepts/services-networking/dns-pod-service.md
@@ -216,7 +216,7 @@ Pour la configuration IPv6, le chemin de recherche et le serveur de noms doivent
 
 ```
 $ kubectl exec -it exemple-dns -- cat /etc/resolv.conf
-nameserver fd00:79:30::a
+nameserver 2001:db8:30::a
 search default.svc.cluster.local svc.cluster.local cluster.local
 options ndots:5
 ```

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -127,7 +127,7 @@ une valeur spécifique au fournisseur. Voir [Installation d'un add-on réseau de
 avec la passerelle par défaut pour annoncer l’IP du master. Pour utiliser une autre
 interface réseau, spécifiez l'option `--apiserver-advertise-address=<ip-address>`
 à `kubeadm init`. Pour déployer un cluster Kubernetes en utilisant l’adressage IPv6, vous devez
- spécifier une adresse IPv6, par exemple `--apiserver-advertise-address=fd00::101`
+ spécifier une adresse IPv6, par exemple `--apiserver-advertise-address=2001:db8::101`
 1. (Optional) Lancez `kubeadm config images pull` avant de faire `kubeadm init` pour vérifier la
 connectivité aux registres gcr.io.
 
@@ -513,7 +513,7 @@ L'output est similaire à ceci:
 
 {{< note >}}
 Pour spécifier un tuple IPv6 pour `<maître-ip>: <maître-port>`, l'adresse IPv6 doit être placée
-entre crochets, par exemple: `[fd00 :: 101]: 2073`.{{< /note >}}
+entre crochets, par exemple: `[2001:db8 :: 101]: 2073`.{{< /note >}}
 
 Le resultat devrait ressembler à quelque chose comme:
 ```

--- a/content/id/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/id/docs/concepts/services-networking/dns-pod-service.md
@@ -243,7 +243,7 @@ kubectl exec -it dns-example -- cat /etc/resolv.conf
 ```
 Keluaran yang dihasilkan akan menyerupai:
 ```shell
-nameserver fd00:79:30::a
+nameserver 2001:db8:30::a
 search default.svc.cluster-domain.example svc.cluster-domain.example cluster-domain.example
 options ndots:5
 ```

--- a/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -99,7 +99,7 @@ pada `kubeadm init`. Lihat [Menginstal _runtime_](/id/docs/setup/production-envi
 dengan _default gateway_ untuk mengatur alamat _advertise_ untuk API Server pada Node _control-plane_ ini.
 Untuk menggunakan antarmuka jaringan yang berbeda, tentukan argumen `--apiserver-advertise-address=<ip-address>` 
 pada `kubeadm init`. Untuk men-_deploy_ klaster Kubernetes IPv6 menggunakan pengalamatan IPv6, kamu
-harus menentukan alamat IPv6, sebagai contoh `--apiserver-advertise-address=fd00::101`
+harus menentukan alamat IPv6, sebagai contoh `--apiserver-advertise-address=2001:db8::101`
 5. (Opsional) Jalankan `kubeadm config images pull` sebelum `kubeadm init` untuk memastikan
 konektivitas ke _container image registry_ gcr.io.
 
@@ -453,7 +453,7 @@ Keluaran yang diberikan kurang lebih akan ditampilkan sebagai berikut:
 ```
 
 {{< note >}}
-Untuk menentukan _tuple_ IPv6 untuk `<control-plane-host>:<control-plane-port>`, alamat IPv6 harus be ditutup dengan kurung siku, sebagai contoh: `[fd00::101]:2073`.
+Untuk menentukan _tuple_ IPv6 untuk `<control-plane-host>:<control-plane-port>`, alamat IPv6 harus be ditutup dengan kurung siku, sebagai contoh: `[2001:db8::101]:2073`.
 {{< /note >}}
 
 Keluaran yang diberikan kurang lebih akan ditampilkan sebagai berikut:

--- a/content/ja/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/ja/docs/concepts/services-networking/dns-pod-service.md
@@ -207,7 +207,7 @@ IPv6用のセットアップのためには、サーチパスとname serverは�
 
 ```
 $ kubectl exec -it dns-example -- cat /etc/resolv.conf
-nameserver fd00:79:30::a
+nameserver 2001:db8:30::a
 search default.svc.cluster.local svc.cluster.local cluster.local
 options ndots:5
 ```

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -63,7 +63,7 @@ kubeadmツールの全体の機能の状態は、一般利用可能(GA)です。
 1. (推奨)シングルコントロールプレーンの`kubeadm`クラスターを高可用性クラスターにアップグレードする予定がある場合、`--control-plane-endpoint`を指定して、すべてのコントロールプレーンノードとエンドポイントを共有する必要があります。エンドポイントにはDNSネームやロードバランサーのIPアドレスが使用できます。
 1. Podネットワークアドオンを選んで、`kubeadm init`に引数を渡す必要があるかどうか確認してください。選んだサードパーティーのプロバイダーによっては、`--pod-network-cidr`をプロバイダー固有の値に設定する必要がある場合があります。詳しくは、[Podネットワークアドオンのインストール](#pod-network)を参照してください。
 1. (オプション)バージョン1.14から、`kubeadm`はよく知られたドメインソケットのパスリストを用いて、Linux上のコンテナランタイムの検出を試みます。異なるコンテナランタイムを使用する場合やプロビジョニングするノードに2つ以上のランタイムがインストールされている場合、`kubeadm init`に`--cri-socket`引数を指定してください。詳しくは、[ランタイムのインストール](/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-runtime)を読んでください。
-1. (オプション)明示的に指定しない限り、`kubeadm`はデフォルトゲートウェイに関連付けられたネットワークインターフェイスを使用して、この特定のコントロールプレーンノードのAPIサーバーのadvertise addressを設定します。異なるネットワークインターフェイスを使用するには、`kubeadm init`に`--apiserver-advertise-address=<ip-address>`引数を指定してください。IPv6アドレスを使用するIPv6 Kubernetesクラスターをデプロイするには、たとえば`--apiserver-advertise-address=fd00::101`のように、IPv6アドレスを指定する必要があります。
+1. (オプション)明示的に指定しない限り、`kubeadm`はデフォルトゲートウェイに関連付けられたネットワークインターフェイスを使用して、この特定のコントロールプレーンノードのAPIサーバーのadvertise addressを設定します。異なるネットワークインターフェイスを使用するには、`kubeadm init`に`--apiserver-advertise-address=<ip-address>`引数を指定してください。IPv6アドレスを使用するIPv6 Kubernetesクラスターをデプロイするには、たとえば`--apiserver-advertise-address=2001:db8::101`のように、IPv6アドレスを指定する必要があります。
 1. (オプション)`kubeadm init`を実行する前に`kubeadm config images pull`を実行して、gcr.ioコンテナイメージレジストリに接続できるかどうかを確認します。
 
 コントロールプレーンノードを初期化するには、次のコマンドを実行します。
@@ -296,7 +296,7 @@ openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outfor
 ```
 
 {{< note >}}
-IPv6タプルを`<control-plane-host>:<control-plane-port>`と指定するためには、IPv6アドレスを角括弧で囲みます。たとえば、`[fd00::101]:2073`のように書きます。
+IPv6タプルを`<control-plane-host>:<control-plane-port>`と指定するためには、IPv6アドレスを角括弧で囲みます。たとえば、`[2001:db8::101]:2073`のように書きます。
 {{< /note >}}
 
 出力は次のようになります。

--- a/content/ja/docs/tasks/network/validate-dual-stack.md
+++ b/content/ja/docs/tasks/network/validate-dual-stack.md
@@ -32,7 +32,7 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 ```
 ```
 10.244.1.0/24
-a00:100::/24
+2001:db8::/64
 ```
 
 IPv4ブロックとIPv6ブロックがそれぞれ1つずつ割り当てられているはずです。
@@ -44,8 +44,8 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 ```
 ```
 Hostname: k8s-linuxpool1-34450317-0
-InternalIP: 10.240.0.5
-InternalIP: 2001:1234:5678:9abc::5
+InternalIP: 10.0.0.5
+InternalIP: 2001:db8:10::5
 ```
 
 ### Podアドレスの検証
@@ -57,7 +57,7 @@ kubectl get pods pod01 -o go-template --template='{{range .status.podIPs}}{{prin
 ```
 ```
 10.244.1.4
-a00:100::4
+2001:db8::4
 ```
 
 Downward APIを使用して、`status.podIPs`のfieldPath経由でPod IPを検証することもできます。次のスニペットは、Pod IPを`MY_POD_IPS`という名前の環境変数経由でコンテナ内に公開する方法を示しています。
@@ -76,7 +76,7 @@ Downward APIを使用して、`status.podIPs`のfieldPath経由でPod IPを検�
 kubectl exec -it pod01 -- set | grep MY_POD_IPS
 ```
 ```
-MY_POD_IPS=10.244.1.4,a00:100::4
+MY_POD_IPS=10.244.1.4,2001:db8::4
 ```
 
 PodのIPアドレスは、コンテナ内の`/etc/hosts`にも書き込まれます。次のコマンドは、デュアルスタックのPod上で`/etc/hosts`に対してcatコマンドを実行します。出力を見ると、Pod用のIPv4およびIPv6のIPアドレスの両方が確認できます。
@@ -93,7 +93,7 @@ fe00::0    ip6-mcastprefix
 fe00::1    ip6-allnodes
 fe00::2    ip6-allrouters
 10.244.1.4    pod01
-a00:100::4    pod01
+2001:db8::4    pod01
 ```
 
 ## Serviceの検証
@@ -155,9 +155,9 @@ metadata:
     app: MyApp
   name: my-service
 spec:
-  clusterIP: fd00::5118
+  clusterIP: 2001:db8:fd00::5118
   clusterIPs:
-  - fd00::5118
+  - 2001:db8:fd00::5118
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
@@ -204,7 +204,7 @@ Type:              ClusterIP
 IP Family Policy:  PreferDualStack
 IP Families:       IPv4,IPv6
 IP:                10.0.216.242
-IPs:               10.0.216.242,fd00::af55
+IPs:               10.0.216.242,2001:db8:fd00::af55
 Port:              <unset>  80/TCP
 TargetPort:        9376/TCP
 Endpoints:         <none>
@@ -227,6 +227,6 @@ kubectl get svc -l app=MyApp
 ServiceがIPv6アドレスブロックから`CLUSTER-IP`のアドレスと`EXTERNAL-IP`を割り当てられていることを検証します。その後、IPとポートを用いたServiceへのアクセスを検証することもできます。
 
 ```shell
-NAME         TYPE           CLUSTER-IP   EXTERNAL-IP        PORT(S)        AGE
-my-service   LoadBalancer   fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
+NAME         TYPE           CLUSTER-IP            EXTERNAL-IP        PORT(S)        AGE
+my-service   LoadBalancer   2001:db8:fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
 ```

--- a/content/ko/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/ko/docs/concepts/services-networking/dns-pod-service.md
@@ -308,7 +308,7 @@ kubectl exec -it dns-example -- cat /etc/resolv.conf
 ```
 출력은 다음과 같은 형식일 것이다.
 ```
-nameserver fd00:79:30::a
+nameserver 2001:db8:30::a
 search default.svc.cluster-domain.example svc.cluster-domain.example cluster-domain.example
 options ndots:5
 ```

--- a/content/ko/docs/tasks/network/validate-dual-stack.md
+++ b/content/ko/docs/tasks/network/validate-dual-stack.md
@@ -39,7 +39,7 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 ```
 ```
 10.244.1.0/24
-a00:100::/24
+2001:db8::/64
 ```
 단일 IPv4 블록과 단일 IPv6 블록이 할당되어야 한다.
 
@@ -50,8 +50,8 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 ```
 ```
 Hostname: k8s-linuxpool1-34450317-0
-InternalIP: 10.240.0.5
-InternalIP: 2001:1234:5678:9abc::5
+InternalIP: 10.0.0.5
+InternalIP: 2001:db8:10::5
 ```
 
 ### 파드 어드레싱 검증
@@ -63,7 +63,7 @@ kubectl get pods pod01 -o go-template --template='{{range .status.podIPs}}{{prin
 ```
 ```
 10.244.1.4
-a00:100::4
+2001:db8::4
 ```
 
 `status.podIPs` fieldPath를 통한 다운워드(downward) API로 파드 IP들을 검증할 수도 있다. 다음 스니펫은 컨테이너 내 `MY_POD_IPS` 라는 환경 변수를 통해 파드 IP들을 어떻게 노출시킬 수 있는지 보여준다.
@@ -82,7 +82,7 @@ a00:100::4
 kubectl exec -it pod01 -- set | grep MY_POD_IPS
 ```
 ```
-MY_POD_IPS=10.244.1.4,a00:100::4
+MY_POD_IPS=10.244.1.4,2001:db8::4
 ```
 
 파드의 IP 주소는 또한 컨테이너 내 `/etc/hosts` 에 적힐 것이다. 다음 커맨드는 이중 스택 파드의 `/etc/hosts` 에 cat을 실행시킨다. 출력 값을 통해 파드의 IPv4 및 IPv6 주소 모두 검증할 수 있다.
@@ -99,7 +99,7 @@ fe00::0    ip6-mcastprefix
 fe00::1    ip6-allnodes
 fe00::2    ip6-allrouters
 10.244.1.4    pod01
-a00:100::4    pod01
+2001:db8::4    pod01
 ```
 
 ## 서비스 검증
@@ -161,7 +161,7 @@ metadata:
     app: MyApp
   name: my-service
 spec:
-  clusterIP: fd00::5118
+  clusterIP: 2001:db8:fd00::5118
   clusterIPs:
   - fd00::5118
   ipFamilies:
@@ -210,7 +210,7 @@ Type:              ClusterIP
 IP Family Policy:  PreferDualStack
 IP Families:       IPv4,IPv6
 IP:                10.0.216.242
-IPs:               10.0.216.242,fd00::af55
+IPs:               10.0.216.242,2001:db8:fd00::af55
 Port:              <unset>  80/TCP
 TargetPort:        9376/TCP
 Endpoints:         <none>
@@ -233,6 +233,6 @@ kubectl get svc -l app=MyApp
 서비스가 IPv6 주소 블록에서 `CLUSTER-IP` 주소 및 `EXTERNAL-IP` 주소를 할당받는지 검증한다. 그리고 나서 IP 및 포트로 서비스 접근이 가능한지 검증할 수 있다.
 
 ```shell
-NAME         TYPE           CLUSTER-IP   EXTERNAL-IP        PORT(S)        AGE
-my-service   LoadBalancer   fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
+NAME         TYPE           CLUSTER-IP            EXTERNAL-IP        PORT(S)        AGE
+my-service   LoadBalancer   2001:db8:fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
 ```

--- a/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
@@ -540,7 +540,7 @@ The output is similar to this:
 -->
 输出类似于：
 ```
-nameserver fd00:79:30::a
+nameserver 2001:db8:30::a
 search default.svc.cluster-domain.example svc.cluster-domain.example cluster-domain.example
 options ndots:5
 ```

--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -222,7 +222,7 @@ on the provisioned node, specify the `--cri-socket` argument to `kubeadm`. See
 with the default gateway to set the advertise address for this particular control-plane node's API server.
 To use a different network interface, specify the `--apiserver-advertise-address=<ip-address>` argument
 to `kubeadm init`. To deploy an IPv6 Kubernetes cluster using IPv6 addressing, you
-must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::101`
+must specify an IPv6 address, for example `--apiserver-advertise-address=2001:db8::101`
 -->
 1. （可选）`kubeadm` 试图通过使用已知的端点列表来检测容器运行时。
    使用不同的容器运行时或在预配置的节点上安装了多个容器运行时，请为 `kubeadm init` 指定 `--cri-socket` 参数。
@@ -230,7 +230,7 @@ must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::1
 1. （可选）除非另有说明，否则 `kubeadm` 使用与默认网关关联的网络接口来设置此控制平面节点 API server 的广播地址。
    要使用其他网络接口，请为 `kubeadm init` 设置 `--apiserver-advertise-address=<ip-address>` 参数。
    要部署使用 IPv6 地址的 Kubernetes 集群，
-   必须指定一个 IPv6 地址，例如 `--apiserver-advertise-address=fd00::101`
+   必须指定一个 IPv6 地址，例如 `--apiserver-advertise-address=2001:db8::101`
 
 <!--
 To initialize the control-plane node run:
@@ -676,10 +676,10 @@ The output is similar to:
 ```
 
 <!--
-To specify an IPv6 tuple for `<control-plane-host>:<control-plane-port>`, IPv6 address must be enclosed in square brackets, for example: `[fd00::101]:2073`.
+To specify an IPv6 tuple for `<control-plane-host>:<control-plane-port>`, IPv6 address must be enclosed in square brackets, for example: `[2001:db8::101]:2073`.
 -->
 {{< note >}}
-要为 `<control-plane-host>:<control-plane-port>` 指定 IPv6 元组，必须将 IPv6 地址括在方括号中，例如：`[fd00::101]:2073`
+要为 `<control-plane-host>:<control-plane-port>` 指定 IPv6 元组，必须将 IPv6 地址括在方括号中，例如：`[2001:db8::101]:2073`
 {{< /note >}}
 
 <!--

--- a/content/zh-cn/docs/tasks/network/validate-dual-stack.md
+++ b/content/zh-cn/docs/tasks/network/validate-dual-stack.md
@@ -62,7 +62,7 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 
 ```
 10.244.1.0/24
-a00:100::/24
+2001:db8::/64
 ```
 
 <!--
@@ -82,8 +82,8 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 
 ```
 Hostname: k8s-linuxpool1-34450317-0
-InternalIP: 10.240.0.5
-InternalIP: 2001:1234:5678:9abc::5
+InternalIP: 10.0.0.5
+InternalIP: 2001:db8:10::5
 ```
 
 <!--
@@ -102,7 +102,7 @@ kubectl get pods pod01 -o go-template --template='{{range .status.podIPs}}{{prin
 
 ```
 10.244.1.4
-a00:100::4
+2001:db8::4
 ```
 
 <!--
@@ -130,7 +130,7 @@ kubectl exec -it pod01 -- set | grep MY_POD_IPS
 ```
 
 ```
-MY_POD_IPS=10.244.1.4,a00:100::4
+MY_POD_IPS=10.244.1.4,2001:db8::4
 ```
 
 <!--
@@ -153,7 +153,7 @@ fe00::0    ip6-mcastprefix
 fe00::1    ip6-allnodes
 fe00::2    ip6-allrouters
 10.244.1.4    pod01
-a00:100::4    pod01
+2001:db8::4    pod01
 ```
 
 <!--
@@ -243,9 +243,9 @@ metadata:
     app.kubernetes.io/name: MyApp
   name: my-service
 spec:
-  clusterIP: fd00::5118
+  clusterIP: 2001:db8:fd00::5118
   clusterIPs:
-  - fd00::5118
+  - 2001:db8:fd00::5118
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
@@ -305,7 +305,7 @@ Type:              ClusterIP
 IP Family Policy:  PreferDualStack
 IP Families:       IPv4,IPv6
 IP:                10.0.216.242
-IPs:               10.0.216.242,fd00::af55
+IPs:               10.0.216.242,2001:db8:fd00::af55
 Port:              <unset>  80/TCP
 TargetPort:        9376/TCP
 Endpoints:         <none>
@@ -342,7 +342,6 @@ Validate that the Service receives a `CLUSTER-IP` address from the IPv6 address 
 然后，你可以通过 IP 和端口验证对服务的访问。
 
 ```shell
-NAME         TYPE           CLUSTER-IP   EXTERNAL-IP        PORT(S)        AGE
-my-service   LoadBalancer   fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
+NAME         TYPE           CLUSTER-IP            EXTERNAL-IP        PORT(S)        AGE
+my-service   LoadBalancer   2001:db8:fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
 ```
-


### PR DESCRIPTION
Sync  PR: https://github.com/kubernetes/website/pull/36683

```
content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
content/fr/docs/concepts/services-networking/dns-pod-service.md
content/id/docs/concepts/services-networking/dns-pod-service.md
content/ja/docs/concepts/services-networking/dns-pod-service.md
content/ko/docs/concepts/services-networking/dns-pod-service.md
content/zh-cn/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
content/ja/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
content/ja/docs/tasks/network/validate-dual-stack.md
content/ko/docs/tasks/network/validate-dual-stack.md
content/zh-cn/docs/tasks/network/validate-dual-stack.md
content/en/docs/tasks/network/validate-dual-stack.md
```
