### PR TITLE
[zh-cn] Sync use IPv6 Address Prefix Reserved for Documentation

### DIFF
--- a/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
@@ -540,7 +540,7 @@ The output is similar to this:
 -->
 输出类似于：
 ```
-nameserver fd00:79:30::a
+nameserver 2001:db8:30::a
 search default.svc.cluster-domain.example svc.cluster-domain.example cluster-domain.example
 options ndots:5
 ```

--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -222,7 +222,7 @@ on the provisioned node, specify the `--cri-socket` argument to `kubeadm`. See
 with the default gateway to set the advertise address for this particular control-plane node's API server.
 To use a different network interface, specify the `--apiserver-advertise-address=<ip-address>` argument
 to `kubeadm init`. To deploy an IPv6 Kubernetes cluster using IPv6 addressing, you
-must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::101`
+must specify an IPv6 address, for example `--apiserver-advertise-address=2001:db8::101`
 -->
 1. （可选）`kubeadm` 试图通过使用已知的端点列表来检测容器运行时。
    使用不同的容器运行时或在预配置的节点上安装了多个容器运行时，请为 `kubeadm init` 指定 `--cri-socket` 参数。
@@ -230,7 +230,7 @@ must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::1
 1. （可选）除非另有说明，否则 `kubeadm` 使用与默认网关关联的网络接口来设置此控制平面节点 API server 的广播地址。
    要使用其他网络接口，请为 `kubeadm init` 设置 `--apiserver-advertise-address=<ip-address>` 参数。
    要部署使用 IPv6 地址的 Kubernetes 集群，
-   必须指定一个 IPv6 地址，例如 `--apiserver-advertise-address=fd00::101`
+   必须指定一个 IPv6 地址，例如 `--apiserver-advertise-address=2001:db8::101`
 
 <!--
 To initialize the control-plane node run:
@@ -676,10 +676,10 @@ The output is similar to:
 ```
 
 <!--
-To specify an IPv6 tuple for `<control-plane-host>:<control-plane-port>`, IPv6 address must be enclosed in square brackets, for example: `[fd00::101]:2073`.
+To specify an IPv6 tuple for `<control-plane-host>:<control-plane-port>`, IPv6 address must be enclosed in square brackets, for example: `[2001:db8::101]:2073`.
 -->
 {{< note >}}
-要为 `<control-plane-host>:<control-plane-port>` 指定 IPv6 元组，必须将 IPv6 地址括在方括号中，例如：`[fd00::101]:2073`
+要为 `<control-plane-host>:<control-plane-port>` 指定 IPv6 元组，必须将 IPv6 地址括在方括号中，例如：`[2001:db8::101]:2073`
 {{< /note >}}
 
 <!--

--- a/content/zh-cn/docs/tasks/network/validate-dual-stack.md
+++ b/content/zh-cn/docs/tasks/network/validate-dual-stack.md
@@ -62,7 +62,7 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 
 ```
 10.244.1.0/24
-a00:100::/24
+2001:db8::/64
 ```
 
 <!--
@@ -82,8 +82,8 @@ kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .
 
 ```
 Hostname: k8s-linuxpool1-34450317-0
-InternalIP: 10.240.0.5
-InternalIP: 2001:1234:5678:9abc::5
+InternalIP: 10.0.0.5
+InternalIP: 2001:db8:10::5
 ```
 
 <!--
@@ -102,7 +102,7 @@ kubectl get pods pod01 -o go-template --template='{{range .status.podIPs}}{{prin
 
 ```
 10.244.1.4
-a00:100::4
+2001:db8::4
 ```
 
 <!--
@@ -130,7 +130,7 @@ kubectl exec -it pod01 -- set | grep MY_POD_IPS
 ```
 
 ```
-MY_POD_IPS=10.244.1.4,a00:100::4
+MY_POD_IPS=10.244.1.4,2001:db8::4
 ```
 
 <!--
@@ -153,7 +153,7 @@ fe00::0    ip6-mcastprefix
 fe00::1    ip6-allnodes
 fe00::2    ip6-allrouters
 10.244.1.4    pod01
-a00:100::4    pod01
+2001:db8::4    pod01
 ```
 
 <!--
@@ -243,9 +243,9 @@ metadata:
     app.kubernetes.io/name: MyApp
   name: my-service
 spec:
-  clusterIP: fd00::5118
+  clusterIP: 2001:db8:fd00::5118
   clusterIPs:
-  - fd00::5118
+  - 2001:db8:fd00::5118
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
@@ -305,7 +305,7 @@ Type:              ClusterIP
 IP Family Policy:  PreferDualStack
 IP Families:       IPv4,IPv6
 IP:                10.0.216.242
-IPs:               10.0.216.242,fd00::af55
+IPs:               10.0.216.242,2001:db8:fd00::af55
 Port:              <unset>  80/TCP
 TargetPort:        9376/TCP
 Endpoints:         <none>
@@ -342,7 +342,6 @@ Validate that the Service receives a `CLUSTER-IP` address from the IPv6 address 
 然后，你可以通过 IP 和端口验证对服务的访问。
 
 ```shell
-NAME         TYPE           CLUSTER-IP   EXTERNAL-IP        PORT(S)        AGE
-my-service   LoadBalancer   fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
+NAME         TYPE           CLUSTER-IP            EXTERNAL-IP        PORT(S)        AGE
+my-service   LoadBalancer   2001:db8:fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
 ```
-


### PR DESCRIPTION
Sync PR: https://github.com/kubernetes/website/pull/36683

```
content/zh-cn/docs/concepts/services-networking/dns-pod-service.md

content/zh-cn/docs/tasks/network/validate-dual-stack.md

content/zh-cn/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md

```