### PR TITLE
correct CheckpointContainer to ContainerCheckpoint

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -64,7 +64,7 @@ different Kubernetes components.
 | `AnyVolumeDataSource` | `false` | Alpha | 1.18 | 1.23 |
 | `AnyVolumeDataSource` | `true` | Beta | 1.24 | |
 | `AppArmor` | `true` | Beta | 1.4 | |
-| `CheckpointContainer` | `false` | Alpha | 1.25 | |
+| `ContainerCheckpoint` | `false` | Alpha | 1.25 | |
 | `CPUManager` | `false` | Alpha | 1.8 | 1.9 |
 | `CPUManager` | `true` | Beta | 1.10 | |
 | `CPUManagerPolicyAlphaOptions` | `false` | Alpha | 1.23 | |
@@ -663,7 +663,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   flag `--service-account-extend-token-expiration=false`.
   Check [Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md)
   for more details.
-- `CheckpointContainer`: Enables the kubelet `checkpoint` API.
+- `ContainerCheckpoint`: Enables the kubelet `checkpoint` API.
   See [Kubelet Checkpoint API](/docs/reference/node/kubelet-checkpoint-api/) for more details.
 - `ControllerManagerLeaderMigration`: Enables Leader Migration for
   [kube-controller-manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/#initial-leader-migration-configuration) and

--- a/content/en/docs/reference/node/kubelet-checkpoint-api.md
+++ b/content/en/docs/reference/node/kubelet-checkpoint-api.md
@@ -80,7 +80,7 @@ POST /checkpoint/{namespace}/{pod}/{container}
 
 401: Unauthorized
 
-404: Not Found (if the `CheckpointContainer` feature gate is disabled)
+404: Not Found (if the `ContainerCheckpoint` feature gate is disabled)
 
 404: Not Found (if the specified `namespace`, `pod` or `container` cannot be found)
 
@@ -91,6 +91,6 @@ POST /checkpoint/{namespace}/{pod}/{container}
 {{< comment >}}
 TODO: Add more information about return codes once CRI implementation have checkpoint/restore.
       This TODO cannot be fixed before the release, because the CRI implementation need
-      the Kubernetes changes to be merged to implement the new CheckpointContainer CRI API
+      the Kubernetes changes to be merged to implement the new ContainerCheckpoint CRI API
       call. We need to wait after the 1.25 release to fix this.
 {{< /comment >}}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/36705

The feature gate name is `ContainerCheckpoint ` according to https://github.com/kubernetes/kubernetes/pull/104907

https://github.com/kubernetes/kubernetes/blob/d569886a234cb65cb1ec777b7ab2e5b9a35d7145/pkg/features/kube_features.go#L189-L194

**BTW**

[reorder feature gates for alphabet order](https://github.com/kubernetes/website/pull/36699/commits/f6cdf2fa48d9c29b186759dbbc21ca8950d8afc2)
The order is wrong for some feature gates and I find a dup and removed it.