### PR TITLE
[en]fix some layout of /docs/tasks/inject-data-application

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -46,33 +46,33 @@ file for the Pod defines a command and two arguments:
 
 1. Create a Pod based on the YAML configuration file:
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/pods/commands.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/commands.yaml
+   ```
 
 1. List the running Pods:
 
-    ```shell
-    kubectl get pods
-    ```
+   ```shell
+   kubectl get pods
+   ```
 
-    The output shows that the container that ran in the command-demo Pod has
-    completed.
+   The output shows that the container that ran in the command-demo Pod has
+   completed.
 
 1. To see the output of the command that ran in the container, view the logs
 from the Pod:
 
-    ```shell
-    kubectl logs command-demo
-    ```
+   ```shell
+   kubectl logs command-demo
+   ```
 
-    The output shows the values of the HOSTNAME and KUBERNETES_PORT environment
-    variables:
+   The output shows the values of the HOSTNAME and KUBERNETES_PORT environment
+   variables:
 
-    ```
-    command-demo
-    tcp://10.3.240.1:443
-    ```
+   ```
+   command-demo
+   tcp://10.3.240.1:443
+   ```
 
 ## Use environment variables to define arguments
 

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -30,39 +30,39 @@ Pod:
 
 1. Create a Pod based on that manifest:
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/pods/inject/envars.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/inject/envars.yaml
+   ```
 
 1. List the running Pods:
 
-    ```shell
-    kubectl get pods -l purpose=demonstrate-envars
-    ```
+   ```shell
+   kubectl get pods -l purpose=demonstrate-envars
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    NAME            READY     STATUS    RESTARTS   AGE
-    envar-demo      1/1       Running   0          9s
-    ```
+   ```
+   NAME            READY     STATUS    RESTARTS   AGE
+   envar-demo      1/1       Running   0          9s
+   ```
 
 1. List the Pod's container environment variables:
 
-    ```shell
-    kubectl exec envar-demo -- printenv
-    ```
+   ```shell
+   kubectl exec envar-demo -- printenv
+   ```
 
-    The output is similar to this:
+   The output is similar to this:
 
-    ```
-    NODE_VERSION=4.4.2
-    EXAMPLE_SERVICE_PORT_8080_TCP_ADDR=10.3.245.237
-    HOSTNAME=envar-demo
-    ...
-    DEMO_GREETING=Hello from the environment
-    DEMO_FAREWELL=Such a sweet sorrow
-    ```
+   ```
+   NODE_VERSION=4.4.2
+   EXAMPLE_SERVICE_PORT_8080_TCP_ADDR=10.3.245.237
+   HOSTNAME=envar-demo
+   ...
+   DEMO_GREETING=Hello from the environment
+   DEMO_FAREWELL=Such a sweet sorrow
+   ```
 
 {{< note >}}
 The environment variables set using the `env` or `envFrom` field

--- a/content/en/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
+++ b/content/en/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
@@ -30,34 +30,34 @@ Pod:
 
 1. Create a Pod based on that manifest:
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/pods/inject/dependent-envars.yaml
-    ```
-    ```
-    pod/dependent-envars-demo created
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/inject/dependent-envars.yaml
+   ```
+   ```
+   pod/dependent-envars-demo created
+   ```
 
 2. List the running Pods:
 
-    ```shell
-    kubectl get pods dependent-envars-demo
-    ```
-    ```
-    NAME                      READY     STATUS    RESTARTS   AGE
-    dependent-envars-demo     1/1       Running   0          9s
-    ```
+   ```shell
+   kubectl get pods dependent-envars-demo
+   ```
+   ```
+   NAME                      READY     STATUS    RESTARTS   AGE
+   dependent-envars-demo     1/1       Running   0          9s
+   ```
 
 3. Check the logs for the container running in your Pod:
 
-    ```shell
-    kubectl logs pod/dependent-envars-demo
-    ```
-    ```
+   ```shell
+   kubectl logs pod/dependent-envars-demo
+   ```
+   ```
 
-    UNCHANGED_REFERENCE=$(PROTOCOL)://172.17.0.1:80
-    SERVICE_ADDRESS=https://172.17.0.1:80
-    ESCAPED_REFERENCE=$(PROTOCOL)://172.17.0.1:80
-    ```
+   UNCHANGED_REFERENCE=$(PROTOCOL)://172.17.0.1:80
+   SERVICE_ADDRESS=https://172.17.0.1:80
+   ESCAPED_REFERENCE=$(PROTOCOL)://172.17.0.1:80
+   ```
 
 As shown above, you have defined the correct dependency reference of `SERVICE_ADDRESS`, bad dependency reference of `UNCHANGED_REFERENCE` and skip dependent references of `ESCAPED_REFERENCE`.
 

--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -43,44 +43,44 @@ username and password:
 
 1. Create the Secret
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/pods/inject/secret.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/inject/secret.yaml
+   ```
 
 1. View information about the Secret:
 
-    ```shell
-    kubectl get secret test-secret
-    ```
+   ```shell
+   kubectl get secret test-secret
+   ```
 
-    Output:
+   Output:
 
-    ```
-    NAME          TYPE      DATA      AGE
-    test-secret   Opaque    2         1m
-    ```
+   ```
+   NAME          TYPE      DATA      AGE
+   test-secret   Opaque    2         1m
+   ```
 
 1. View more detailed information about the Secret:
 
-    ```shell
-    kubectl describe secret test-secret
-    ```
+   ```shell
+   kubectl describe secret test-secret
+   ```
 
-    Output:
+   Output:
 
-    ```
-    Name:       test-secret
-    Namespace:  default
-    Labels:     <none>
-    Annotations:    <none>
+   ```
+   Name:       test-secret
+   Namespace:  default
+   Labels:     <none>
+   Annotations:    <none>
 
-    Type:   Opaque
+   Type:   Opaque
 
-    Data
-    ====
-    password:   13 bytes
-    username:   7 bytes
-    ```
+   Data
+   ====
+   password:   13 bytes
+   username:   7 bytes
+   ```
 
 ### Create a Secret directly with kubectl
 


### PR DESCRIPTION
Excess space was removed:
```yaml
content/en/docs/tasks/inject-data-application/define-command-argument-container.md
```
```yaml
content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
```
```yaml
content/en/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
```
```yaml
content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
```