### PR TITLE
Adding localization alias, cleaning up approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,17 @@ aliases:
     - onlydole
     - sftim
     - nate-double-u
+  sig-docs-localization-owners: # Admins for localization content
+    - a-mccarthy
+    - bradtopol
+    - divya-mohan0209
+    - jimangel
+    - kbhawkey
+    - natalisucks
+    - onlydole
+    - reylejano
+    - sftim
+    - tengqm
   sig-docs-de-owners: # Admins for German content
     - bene2k1
     - mkorbi
@@ -27,9 +38,7 @@ aliases:
     - kcmartin
     - natalisucks
     - onlydole
-    - pi-victor
     - reylejano
-    - savitharaghunathan
     - sftim
     - tengqm
   sig-docs-en-reviews: # PR reviews for English content
@@ -42,6 +51,7 @@ aliases:
     - natalisucks
     - onlydole
     - rajeshdeshpande02
+    - reylejano
     - sftim
     - shannonxtreme
     - tengqm


### PR DESCRIPTION
As part of the assorted admin needed for the Localization subproject, I'm adding an alias that includes all SIG Docs chairs and tech leads, alongside subproject owners @bradtopol and @a-mccarthy.

This completes the final TODO in our [tracked issue](https://github.com/kubernetes/website/issues/31955).

Abbie has already created [the corresponding PR](https://github.com/kubernetes/community/pull/6769
) to update our community docs.

Alongside these changes, I've also cleaned up the website approvers list, as per [this Slack update](https://kubernetes.slack.com/archives/C1J0BPD2M/p1648568995444079?thread_ts=1648568436.074959&cid=C1J0BPD2M). @reylejano was missing from our English PR reviewers alias, so he has been added.