### PR TITLE
Fix cluster cleanup command

### DIFF
--- a/content/en/docs/tutorials/security/ns-level-pss.md
+++ b/content/en/docs/tutorials/security/ns-level-pss.md
@@ -155,7 +155,7 @@ with no warnings.
 
 ## Clean up
 
-Run `kind delete cluster -name psa-ns-level` to delete the cluster created.
+Run `kind delete cluster --name psa-ns-level` to delete the cluster created.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Was running through Namespace-level Pod Security Standards tutorial and noticed the error in the cluster clean up command: https://kubernetes.io/docs/tutorials/security/ns-level-pss/