### PR TITLE
Fix broken link to KEP doc in `data/user-personas/contributors/code-contributor.yaml`

### DIFF
--- a/data/user-personas/contributors/code-contributor.yaml
+++ b/data/user-personas/contributors/code-contributor.yaml
@@ -9,7 +9,7 @@ foundational:
 intermediate:
   - label: "Learn about the Kubernetes Enhancement Proposal (KEP) process"
     icon: fa-upload
-    url: "https://github.com/kubernetes/enhancements/blob/master/keps/0001-kubernetes-enhancement-proposal-process.md"
+    url: "https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/0000-kep-process/README.md"
   - label: "Understand the API conventions"
     icon: fa-map-o
     url: "https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md"


### PR DESCRIPTION
Signed-off-by: amolmote <amolmote201@gmail.com>

Fixex #36721 
Updated the link of KEP process from outdated to latest one.

