### PR TITLE
Add blog article about minReadySeconds for StatefulSets and maxSurge for DaemonSets

### DIFF
--- a/content/en/blog/_posts/2022-07-27-sig-apps-GA-1.25/index.md
+++ b/content/en/blog/_posts/2022-07-27-sig-apps-GA-1.25/index.md
@@ -1,0 +1,66 @@
+---
+layout: blog
+title: "sig-apps features graduating to stable in 1.25"
+date: 2022-07-27
+slug: "sig-apps features graduating to stable in 1.25"
+---
+
+**Authors:** Ravi Gudimetla (Apple), Filip Krepensky (Red Hat), Maciej Szulik (Red Hat)
+
+This blog describes the two features namely `minReadySeconds for StatefulSets` and `maxSurge for Daemonsets` that sig-apps is happy to graduate to stable in 1.25
+
+## What problems does these features solve?
+
+### MinReadySeconds for StatefulSets
+`minReadySeconds` ensures that the statefulset workload is `Ready` for the given number of seconds before calling the
+pod `Available`. The notion of being `Ready` and `Available` is quiet important for workloads. For example, some workloads like Prometheus with multiple instances of Alertmanager should be considered `Available` only when the Alertmanager's state transfer is complete. `minReadySeconds` also helps when using loadbalancers with cloud providers. Since the pod should be `Ready` for the given number of seconds, it provides buffer time to prevent killing pods in rotation before new pods show up.
+
+
+### MaxSurge for DaemonSets
+`MaxSurge` allows a daemonset workload to run multiple instances of the same pod on a node during rollout to minimize the downtime of the daemonset to other consumers. Kubernetes system-level components like CNI, CSI are typically run as daemonsets. These components can have impact on the availablity of the workloads if those daemonsets go down momentarily during the upgrades. The feature allows daemonset pods to surge, there by ensuring zero-downtime for the daemonsets.
+
+Please note that the usage of `HostPort` in conjunction with `MaxSurge` in daemonsets is not allowed as daemonset pods are tied to a single node and two active pods cannot share the same port on the same node.
+
+
+## How does it work?
+
+### MinReadySeconds for StatefulSets
+
+The statefulSet controller watches for the statefulset pods and counts how long a particular pod has been in the `Running` state, if this value is greater than or equal to the time specified in `.spec.minReadySeconds` field of the statefulset, the statefulset controller updates the `AvailableReplicas` field in the statefulset's status.
+
+
+### MaxSurge for DaemonSets
+
+The `DaemonSet` controller creates the additional pods based on the value given in `.spec.strategy.rollingUpdate.maxSurge`. The additional pods would run on the same node where the old daemonset pod is running till the old pod gets killed. This value cannot be `0` when `MaxUnavailable` is 0. The default value is 0.
+
+## How do I use it?
+
+### MinReadySeconds for StatefulSets
+
+You are required to download and install a kubectl greater than v1.22.0 version
+
+Specify a value for `minReadySeconds` for any StatefulSet and you check if pods are available or not by checking
+`AvailableReplicas` field using:
+
+`kubectl get statefulset/<name_of_the_statefulset> -o yaml
+
+Please note that the default value of `minReadySeconds` is 0
+
+### MaxSurge for DaemonSets
+
+Specify the update strategy to `RollingUpdate` and set `.spec.updateStrategy.rollingUpdate.maxSurge`
+
+
+## How can I learn more?
+
+### MinReadySeconds for StatefulSets
+KEP: https://github.com/kubernetes/enhancements/issues/2599
+API Changes: https://github.com/kubernetes/kubernetes/pull/100842
+
+### MaxSurge for DaemonSets
+KEP: https://github.com/kubernetes/enhancements/issues/1591
+API Changes: https://github.com/kubernetes/kubernetes/pull/96375
+
+## How do I get involved?
+
+Please reach out to us on [#sig-apps](https://kubernetes.slack.com/archives/C18NZM5K9) channel on slack, sig-apps mailing list-kubernetes-sig-apps@googlegroups.com

--- a/content/en/blog/_posts/2022-07-27-sig-apps-GA-1.25/index.md
+++ b/content/en/blog/_posts/2022-07-27-sig-apps-GA-1.25/index.md
@@ -5,61 +5,79 @@ date: 2022-07-27
 slug: "sig-apps features graduating to stable in 1.25"
 ---
 
-**Authors:** Ravi Gudimetla (Apple), Filip Krepensky (Red Hat), Maciej Szulik (Red Hat)
+**Authors:** Ravi Gudimetla (Apple), Filip Křepinský (Red Hat), Maciej Szulik (Red Hat)
 
-This blog describes the two features namely `minReadySeconds for StatefulSets` and `maxSurge for Daemonsets` that sig-apps is happy to graduate to stable in 1.25
+This blog describes the two features namely `minReadySeconds` for StatefulSets and `maxSurge` for DaemonSets that sig-apps is happy to graduate to stable in 1.25.
 
-## What problems does these features solve?
+Specifying `minReadySeconds` slows down a rollout of a StatefulSet, when using a `RollingUpdate` value in `.spec.updateStrategy` field, by waiting for each pod for a desired time.
+This time can be used for initializing the pod (e.g. warming up the cache) or as a delay before acknowledging the pod.
+
+`maxSurge` allows a DaemonSet workload to run multiple instances of the same pod on a node during a rollout when using a `RollingUpdate` value in `.spec.updateStrategy` field.
+This helps to minimize the downtime of the DaemonSet for consumers.
+
+These features are already available in a Deployment and other workloads. This graduation helps to align this functionality across the workloads.
+
+## What problems do these features solve?
 
 ### MinReadySeconds for StatefulSets
-`minReadySeconds` ensures that the statefulset workload is `Ready` for the given number of seconds before calling the
-pod `Available`. The notion of being `Ready` and `Available` is quiet important for workloads. For example, some workloads like Prometheus with multiple instances of Alertmanager should be considered `Available` only when the Alertmanager's state transfer is complete. `minReadySeconds` also helps when using loadbalancers with cloud providers. Since the pod should be `Ready` for the given number of seconds, it provides buffer time to prevent killing pods in rotation before new pods show up.
+`minReadySeconds` ensures that the StatefulSet workload is `Ready` for the given number of seconds before reporting the
+pod as `Available`. The notion of being `Ready` and `Available` is quite important for workloads. For example, some workloads, like Prometheus with multiple instances of Alertmanager, should be considered `Available` only when the Alertmanager's state transfer is complete. `minReadySeconds` also helps when using loadbalancers with cloud providers. Since the pod should be `Ready` for the given number of seconds, it provides buffer time to prevent killing pods in rotation before new pods show up.
 
 
 ### MaxSurge for DaemonSets
-`MaxSurge` allows a daemonset workload to run multiple instances of the same pod on a node during rollout to minimize the downtime of the daemonset to other consumers. Kubernetes system-level components like CNI, CSI are typically run as daemonsets. These components can have impact on the availablity of the workloads if those daemonsets go down momentarily during the upgrades. The feature allows daemonset pods to surge, there by ensuring zero-downtime for the daemonsets.
+Kubernetes system-level components like CNI, CSI are typically run as DaemonSets. These components can have impact on the availability of the workloads if those DaemonSets go down momentarily during the upgrades. The feature allows DaemonSet pods to temporarily increase their number, thereby ensuring zero-downtime for the DaemonSets.
 
-Please note that the usage of `HostPort` in conjunction with `MaxSurge` in daemonsets is not allowed as daemonset pods are tied to a single node and two active pods cannot share the same port on the same node.
+Please note that the usage of `HostPort` in conjunction with `MaxSurge` in DaemonSets is not allowed as DaemonSet pods are tied to a single node and two active pods cannot share the same port on the same node.
 
 
 ## How does it work?
 
 ### MinReadySeconds for StatefulSets
 
-The statefulSet controller watches for the statefulset pods and counts how long a particular pod has been in the `Running` state, if this value is greater than or equal to the time specified in `.spec.minReadySeconds` field of the statefulset, the statefulset controller updates the `AvailableReplicas` field in the statefulset's status.
+The StatefulSet controller watches for the StatefulSet pods and counts how long a particular pod has been in the `Running` state, if this value is greater than or equal to the time specified in `.spec.minReadySeconds` field of the StatefulSet, the StatefulSet controller updates the `AvailableReplicas` field in the StatefulSet's status.
 
 
 ### MaxSurge for DaemonSets
 
-The `DaemonSet` controller creates the additional pods based on the value given in `.spec.strategy.rollingUpdate.maxSurge`. The additional pods would run on the same node where the old daemonset pod is running till the old pod gets killed. This value cannot be `0` when `MaxUnavailable` is 0. The default value is 0.
+The DaemonSet controller creates the additional pods (above the desired number resulting from DaemonSet spec) based on the value given in `.spec.strategy.rollingUpdate.maxSurge`. The additional pods would run on the same node where the old DaemonSet pod is running till the old pod gets killed.
+
+- The default value is 0.
+- The value cannot be `0` when `MaxUnavailable` is 0.
+- The value can be specified either as an absolute number of pods, or a percentage (rounded up) of desired pods.
 
 ## How do I use it?
 
 ### MinReadySeconds for StatefulSets
 
-You are required to download and install a kubectl greater than v1.22.0 version
-
-Specify a value for `minReadySeconds` for any StatefulSet and you check if pods are available or not by checking
+Specify a value for `minReadySeconds` for any StatefulSet and check if pods are available or not by inspecting
 `AvailableReplicas` field using:
 
-`kubectl get statefulset/<name_of_the_statefulset> -o yaml
+`kubectl get statefulset/<name_of_the_statefulset> -o yaml`
 
-Please note that the default value of `minReadySeconds` is 0
+Please note that the default value of `minReadySeconds` is 0.
 
 ### MaxSurge for DaemonSets
 
-Specify the update strategy to `RollingUpdate` and set `.spec.updateStrategy.rollingUpdate.maxSurge`
+Specify a value for `.spec.updateStrategy.rollingUpdate.maxSurge` and set `.spec.updateStrategy.rollingUpdate.maxUnavailable` to `0`. 
 
+Then observe a faster rollout and higher number of pods running at the same time in the next rollout.
+
+```
+kubectl rollout restart daemonset <name_of_the_daemonset>
+kubectl get pods -w
+```
 
 ## How can I learn more?
 
 ### MinReadySeconds for StatefulSets
-KEP: https://github.com/kubernetes/enhancements/issues/2599
-API Changes: https://github.com/kubernetes/kubernetes/pull/100842
+
+- KEP: https://github.com/kubernetes/enhancements/issues/2599
+- API Changes: https://github.com/kubernetes/kubernetes/pull/100842
 
 ### MaxSurge for DaemonSets
-KEP: https://github.com/kubernetes/enhancements/issues/1591
-API Changes: https://github.com/kubernetes/kubernetes/pull/96375
+
+- KEP: https://github.com/kubernetes/enhancements/issues/1591
+- API Changes: https://github.com/kubernetes/kubernetes/pull/96375
 
 ## How do I get involved?
 

--- a/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
+++ b/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
@@ -1,13 +1,13 @@
 ---
 layout: blog
-title: "sig-apps features graduating to stable in 1.25"
+title: "SIG Apps Features Graduating to Stable in Kubernetes 1.25"
 date: 2022-09-15
-slug: "sig-apps features graduating to stable in 1.25"
+slug: "sig-apps-features-stable-1-25"
 ---
 
 **Authors:** Ravi Gudimetla (Apple), Filip Křepinský (Red Hat), Maciej Szulik (Red Hat)
 
-This blog describes the two features namely `minReadySeconds` for StatefulSets and `maxSurge` for DaemonSets that sig-apps is happy to graduate to stable in 1.25.
+This blog describes the two features namely `minReadySeconds` for StatefulSets and `maxSurge` for DaemonSets that SIG Apps is happy to graduate to stable in Kubernetes 1.25.
 
 Specifying `minReadySeconds` slows down a rollout of a StatefulSet, when using a `RollingUpdate` value in `.spec.updateStrategy` field, by waiting for each pod for a desired time.
 This time can be used for initializing the pod (e.g. warming up the cache) or as a delay before acknowledging the pod.
@@ -15,29 +15,29 @@ This time can be used for initializing the pod (e.g. warming up the cache) or as
 `maxSurge` allows a DaemonSet workload to run multiple instances of the same pod on a node during a rollout when using a `RollingUpdate` value in `.spec.updateStrategy` field.
 This helps to minimize the downtime of the DaemonSet for consumers.
 
-These features are already available in a Deployment and other workloads. This graduation helps to align this functionality across the workloads.
+These features were already available in a Deployment and other workloads. This graduation helps to align this functionality across the workloads.
 
 ## What problems do these features solve?
 
-### MinReadySeconds for StatefulSets
+### minReadySeconds for StatefulSets {#solved-problem-statefulset-minreadyseconds}
 `minReadySeconds` ensures that the StatefulSet workload is `Ready` for the given number of seconds before reporting the
 pod as `Available`. The notion of being `Ready` and `Available` is quite important for workloads. For example, some workloads, like Prometheus with multiple instances of Alertmanager, should be considered `Available` only when the Alertmanager's state transfer is complete. `minReadySeconds` also helps when using loadbalancers with cloud providers. Since the pod should be `Ready` for the given number of seconds, it provides buffer time to prevent killing pods in rotation before new pods show up.
 
 
-### MaxSurge for DaemonSets
+### maxSurge for DaemonSets {#how-use-daemonset-maxsurge}
 Kubernetes system-level components like CNI, CSI are typically run as DaemonSets. These components can have impact on the availability of the workloads if those DaemonSets go down momentarily during the upgrades. The feature allows DaemonSet pods to temporarily increase their number, thereby ensuring zero-downtime for the DaemonSets.
 
-Please note that the usage of `HostPort` in conjunction with `MaxSurge` in DaemonSets is not allowed as DaemonSet pods are tied to a single node and two active pods cannot share the same port on the same node.
+Please note that the usage of `hostPort` in conjunction with `maxSurge` in DaemonSets is not allowed as DaemonSet pods are tied to a single node and two active pods cannot share the same port on the same node.
 
 
 ## How does it work?
 
-### MinReadySeconds for StatefulSets
+### minReadySeconds for StatefulSets {#how-does-statefulset-minreadyseconds-work}
 
 The StatefulSet controller watches for the StatefulSet pods and counts how long a particular pod has been in the `Running` state, if this value is greater than or equal to the time specified in `.spec.minReadySeconds` field of the StatefulSet, the StatefulSet controller updates the `AvailableReplicas` field in the StatefulSet's status.
 
 
-### MaxSurge for DaemonSets
+### maxSurge for DaemonSets {#how-does-daemonset-maxsurge-work}
 
 The DaemonSet controller creates the additional pods (above the desired number resulting from DaemonSet spec) based on the value given in `.spec.strategy.rollingUpdate.maxSurge`. The additional pods would run on the same node where the old DaemonSet pod is running till the old pod gets killed.
 
@@ -47,7 +47,7 @@ The DaemonSet controller creates the additional pods (above the desired number r
 
 ## How do I use it?
 
-### MinReadySeconds for StatefulSets
+### minReadySeconds for StatefulSets {#how-use-statefulset-minreadyseconds}
 
 Specify a value for `minReadySeconds` for any StatefulSet and check if pods are available or not by inspecting
 `AvailableReplicas` field using:
@@ -56,7 +56,7 @@ Specify a value for `minReadySeconds` for any StatefulSet and check if pods are 
 
 Please note that the default value of `minReadySeconds` is 0.
 
-### MaxSurge for DaemonSets
+### maxSurge for DaemonSets {#how-use-daemonset-maxsurge}
 
 Specify a value for `.spec.updateStrategy.rollingUpdate.maxSurge` and set `.spec.updateStrategy.rollingUpdate.maxUnavailable` to `0`. 
 
@@ -69,16 +69,18 @@ kubectl get pods -w
 
 ## How can I learn more?
 
-### MinReadySeconds for StatefulSets
+### minReadySeconds for StatefulSets {#learn-more-statefulset-minreadyseconds}
 
+- Documentation: https://k8s.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds
 - KEP: https://github.com/kubernetes/enhancements/issues/2599
 - API Changes: https://github.com/kubernetes/kubernetes/pull/100842
 
-### MaxSurge for DaemonSets
+### maxSurge for DaemonSets {#learn-more-daemonset-maxsurge}
 
+- Documentation: https://k8s.io/docs/tasks/manage-daemon/update-daemon-set/
 - KEP: https://github.com/kubernetes/enhancements/issues/1591
 - API Changes: https://github.com/kubernetes/kubernetes/pull/96375
 
 ## How do I get involved?
 
-Please reach out to us on [#sig-apps](https://kubernetes.slack.com/archives/C18NZM5K9) channel on slack, sig-apps mailing list-kubernetes-sig-apps@googlegroups.com
+Please reach out to us on [#sig-apps](https://kubernetes.slack.com/archives/C18NZM5K9) channel on Slack, or through the SIG Apps mailing list [kubernetes-sig-apps@googlegroups.com](https://groups.google.com/g/kubernetes-sig-apps).

--- a/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
+++ b/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "sig-apps features graduating to stable in 1.25"
-date: 2022-07-27
+date: 2022-09-15
 slug: "sig-apps features graduating to stable in 1.25"
 ---
 

--- a/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
+++ b/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
@@ -1,8 +1,8 @@
 ---
 layout: blog
-title: "SIG Apps Features Graduating to Stable in Kubernetes 1.25"
+title: "Kubernetes 1.25: Two Features for Apps Rollouts Graduate to Stable"
 date: 2022-09-15
-slug: "sig-apps-features-stable-1-25"
+slug: "app-rollout-features-reach-stable"
 ---
 
 **Authors:** Ravi Gudimetla (Apple), Filip Křepinský (Red Hat), Maciej Szulik (Red Hat)


### PR DESCRIPTION
sig-apps is excited to promote 2 features to GA this release:

- minReadySeconds for StatefulSets
- maxSurge for DS pods

This is a continuation of https://github.com/kubernetes/website/pull/35440 as I have agreed with @ravisantoshgudimetla that we should finish this soon.