### PR TITLE
clarify topologyinfo registration logic in device plugins

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -329,7 +329,9 @@ message NUMANode {
 ```
 Device Plugins that wish to leverage the Topology Manager can send back a populated TopologyInfo struct as part of the device registration, along with the device IDs and the health of the device. The device manager will then use this information to consult with the Topology Manager and make resource assignment decisions.
 
-`TopologyInfo` supports a `nodes` field that is either `nil` (the default) or a list of NUMA nodes. This lets the Device Plugin publish that can span NUMA nodes.
+`TopologyInfo` supports setting a `nodes` field to either `nil` or a list of NUMA nodes. This allows the Device Plugin to advertise a device that spans multiple NUMA nodes.
+
+Setting `TopologyInfo` to `nil`  or providing an empty list of NUMA nodes for a given device indicates that the Device Plugin does not have a NUMA affinity preference for that device.
 
 An example `TopologyInfo` struct populated for a device by a Device Plugin:
 


### PR DESCRIPTION
clarify topologyinfo registration logic in device plugins. The behavior how TopologyInfo
is interpreted was not well defined and lead to https://github.com/kubernetes/kubernetes/issues/112234.

https://github.com/kubernetes/kubernetes/pull/112387 proposes a fix and this PR is the 
corresponding documentation update.

Depends: https://github.com/kubernetes/kubernetes/pull/112387