### PR TITLE
Updated Supported Linux Distributions in kubespray.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubespray.md
+++ b/content/en/docs/setup/production-environment/tools/kubespray.md
@@ -17,14 +17,15 @@ Kubespray provides:
   - Flatcar Container Linux by Kinvolk
   - Debian Bullseye, Buster, Jessie, Stretch
   - Ubuntu 16.04, 18.04, 20.04, 22.04
-  - CentOS/RHEL 7, 8
-  - Fedora 34, 35
+  - CentOS/RHEL 7, 8, 9
+  - Fedora 35, 36
   - Fedora CoreOS
   - openSUSE Leap 15.x/Tumbleweed
-  - Oracle Linux 7, 8
-  - Alma Linux 8
-  - Rocky Linux 8
-  - Amazon Linux 2 
+  - Oracle Linux 7, 8, 9
+  - Alma Linux 8, 9
+  - Rocky Linux 8, 9
+  - Kylin Linux Advanced Server V10
+  - Amazon Linux 2
 * Continuous integration tests.
 
 To choose a tool which best fits your use case, read [this comparison](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/comparisons.md) to


### PR DESCRIPTION
Update `production-environment/tools/kubespray.md` docs  based on the official documentation on kubespray.io

Sync Supported Linux Distributions with [Kubespray - Supported Linux Distributions](https://github.com/kubernetes-sigs/kubespray#supported-linux-distributions)

```
## Supported Linux Distributions
- **Flatcar Container Linux by Kinvolk**
- **Debian** Bullseye, Buster, Jessie, Stretch
- **Ubuntu** 16.04, 18.04, 20.04, 22.04
- **CentOS/RHEL** 7, 8, 9
- **Fedora** 35, 36
- **Fedora CoreOS**
- **openSUSE** Leap 15.x/Tumbleweed
- **Oracle Linux** 7, 8, 9
- **Alma Linux** 8, 9
- **Rocky Linux** 8, 9
- **Kylin Linux Advanced Server V10** 
- **Amazon Linux 2** 
```

Signed-off-by: ydFu <ader.ydfu@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
