### PR TITLE
Update Cilium's Installation Output

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -41,43 +41,39 @@ minikube version: v1.5.2
 minikube start --network-plugin=cni
 ```
 
-For minikube you can install Cilium using its CLI tool. Cilium will
-automatically detect the cluster configuration and will install the appropriate
-components for a successful installation:
+For minikube you can install Cilium using its CLI tool. To do so, first download the latest
+version of the CLI with the following command:
 
 ```shell
 curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+```
+
+Then extract the downloaded file to your `/usr/local/bin` directory with the following command:
+
+```shell
 sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
 rm cilium-linux-amd64.tar.gz
+```
+
+After running the above commands, you can now install Cilium with the following command: 
+
+```shell
 cilium install
 ```
-```
-🔮 Auto-detected Kubernetes kind: minikube
-✨ Running "minikube" validation checks
-✅ Detected minikube version "1.20.0"
-ℹ️  Cilium version not set, using default version "v1.10.0"
-🔮 Auto-detected cluster name: minikube
-🔮 Auto-detected IPAM mode: cluster-pool
-🔮 Auto-detected datapath mode: tunnel
-🔑 Generating CA...
-2021/05/27 02:54:44 [INFO] generate received request
-2021/05/27 02:54:44 [INFO] received CSR
-2021/05/27 02:54:44 [INFO] generating key: ecdsa-256
-2021/05/27 02:54:44 [INFO] encoded CSR
-2021/05/27 02:54:44 [INFO] signed certificate with serial number 48713764918856674401136471229482703021230538642
-🔑 Generating certificates for Hubble...
-2021/05/27 02:54:44 [INFO] generate received request
-2021/05/27 02:54:44 [INFO] received CSR
-2021/05/27 02:54:44 [INFO] generating key: ecdsa-256
-2021/05/27 02:54:44 [INFO] encoded CSR
-2021/05/27 02:54:44 [INFO] signed certificate with serial number 3514109734025784310086389188421560613333279574
-🚀 Creating Service accounts...
-🚀 Creating Cluster roles...
-🚀 Creating ConfigMap...
-🚀 Creating Agent DaemonSet...
-🚀 Creating Operator Deployment...
-⌛ Waiting for Cilium to be installed...
-```
+
+Cilium will then automatically detect the cluster configuration and create and
+install the appropriate components for a successful installation.
+The components are:
+
+- Certificate Authority (CA) in Secret `cilium-ca` and certificates for Hubble (Cilium's observability layer).
+- Service accounts.
+- Cluster roles.
+- ConfigMap.
+- Agent DaemonSet and an Operator Deployment.
+
+After the installation, you can view the overall status of the Cilium deployment with the `cilium status` command.
+See the expected output of the `status` command
+[here](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#validate-the-installation). 
 
 The remainder of the Getting Started Guide explains how to enforce both L3/L4
 (i.e., IP address + port) security policies, as well as L7 (e.g., HTTP) security


### PR DESCRIPTION
The current Cilium installation output is a bit outdated as it is of version "v1.10.0" while Cilium is currently in "v1.12.1".
This change updates it to be consistent with what users will see when they run the "cilium install" command after installing the latest version of Cilium as in the previous steps.

Signed-off-by: Divine Odazie <dodazie@gmail.com>
