### PR TITLE
Add learning environment page

### DIFF
--- a/content/en/docs/setup/learning-environment/_index.md
+++ b/content/en/docs/setup/learning-environment/_index.md
@@ -1,6 +1,9 @@
 ---
 title: Learning environment
+main_menu: true
 weight: 20
+content_type: concept
+no_list: true
 ---
 
 <!--
@@ -11,7 +14,9 @@ weight: 20
 {{/* If you're localizing this page, you only need to copy the front matter */}}
 {{/* and add a redirect into "/static/_redirects", for YOUR localization. */}}
 -->
-<!--
+
+<!-- overview -->
+
 ## kind
 
 [`kind`](https://kind.sigs.k8s.io/docs/) lets you run Kubernetes on
@@ -20,6 +25,8 @@ your local computer. This tool requires that you have
 
 The kind [Quick Start](https://kind.sigs.k8s.io/docs/user/quick-start/) page
 shows you what you need to do to get up and running with kind.
+
+<a class="btn btn-primary" href="https://kind.sigs.k8s.io/docs/user/quick-start/" role="button" aria-label="View kind Quick Start Guide">View kind Quick Start Guide</a>
 
 ## minikube
 
@@ -31,5 +38,18 @@ Kubernetes, or for daily development work.
 You can follow the official
 [Get Started!](https://minikube.sigs.k8s.io/docs/start/) guide if your focus is
 on getting the tool installed.
--->
+
+<a class="btn btn-primary" href="https://minikube.sigs.k8s.io/docs/start/" role="button" aria-label="View minikube Get Started! Guide">View minikube Get Started! Guide</a>
+
+Once you have `minikube` working, you can use it to
+[run a sample application](/docs/tutorials/hello-minikube/).
+
+
+## {{% heading "whatsnext" %}}
+
+- Make sure to install [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) as well.
+
+- If you still can't decide, pick `minicube` and start [here](https://kubernetes.io/docs/tutorials/hello-minikube/). `kubeadm` installs are a lot to cover for a beginner.
+
+- Continue your learning journey with a [production environment](https://k8s.io/docs/setup/production-environment/).
 

--- a/content/en/docs/setup/learning-environment/_index.md
+++ b/content/en/docs/setup/learning-environment/_index.md
@@ -4,15 +4,6 @@ main_menu: true
 weight: 20
 ---
 
-<!--
-{{/* There is a Netlify redirect from this page to /docs/tasks/tools/ */}}
-{{/* This page content only exists to provide a navigation stub */}}
-{{/* and to protect in case that redirect is one day removed. */}}
-
-{{/* If you're localizing this page, you only need to copy the front matter */}}
-{{/* and add a redirect into "/static/_redirects", for YOUR localization. */}}
--->
-
 <!-- overview -->
 
 ## kind

--- a/content/en/docs/setup/learning-environment/_index.md
+++ b/content/en/docs/setup/learning-environment/_index.md
@@ -2,8 +2,6 @@
 title: Learning environment
 main_menu: true
 weight: 20
-content_type: concept
-no_list: true
 ---
 
 <!--
@@ -47,9 +45,11 @@ Once you have `minikube` working, you can use it to
 
 ## {{% heading "whatsnext" %}}
 
-- Make sure to install [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) as well.
+- Make sure to [install `kubectl`](/docs/tasks/tools/#kubectl) as well.
 
-- If you still can't decide, pick `minicube` and start [here](https://kubernetes.io/docs/tutorials/hello-minikube/). `kubeadm` installs are a lot to cover for a beginner.
+- If you still can't decide, pick `minikube` and start with [Hello Minikube](/docs/tutorials/hello-minikube/). `kubeadm` installs are a lot to cover for a beginner.
 
-- Continue your learning journey with a [production environment](https://k8s.io/docs/setup/production-environment/).
+- Already familiar with Kubernetes? Learn how to deploy a cluster for a
+[production environment](https://k8s.io/docs/setup/production-environment/).
+That guidance is also useful if you want to deploy an environment that matches a production setup.
 

--- a/content/en/docs/setup/learning-environment/_index.md
+++ b/content/en/docs/setup/learning-environment/_index.md
@@ -6,6 +6,10 @@ weight: 20
 
 <!-- overview -->
 
+This page helps you set up Kubernetes to learn more about it. If you wanted to run real workloads on Kubernetes, read the [Production Environment](/docs/setup/production-environment/) setup guide.
+
+<!-- body -->
+
 ## kind
 
 [`kind`](https://kind.sigs.k8s.io/docs/) lets you run Kubernetes on
@@ -38,7 +42,7 @@ Once you have `minikube` working, you can use it to
 
 - Make sure to [install `kubectl`](/docs/tasks/tools/#kubectl) as well.
 
-- If you still can't decide, pick `minikube` and start with [Hello Minikube](/docs/tutorials/hello-minikube/). `kubeadm` installs are a lot to cover for a beginner.
+- If you still can't decide, pick `minikube` and start with [Hello Minikube](/docs/tutorials/hello-minikube/).
 
 - Already familiar with Kubernetes? Learn how to deploy a cluster for a
 [production environment](https://k8s.io/docs/setup/production-environment/).

--- a/static/_redirects
+++ b/static/_redirects
@@ -539,7 +539,6 @@
 
 /docs/setup/minikube/     /docs/tasks/tools/ 302
 /id/docs/setup/minikube/     /id/docs/tasks/tools/ 302
-/docs/setup/learning-environment/     /docs/tasks/tools/  302!
 /id/docs/setup/learning-environment/     /id/docs/tasks/tools/  302!
 /zh/docs/setup/learning-environment/     /zh-cn/docs/tasks/tools/  302!
 /hi/docs/setup/learning-environment/     /hi/docs/tasks/tools/ 302!


### PR DESCRIPTION
Working on issue #31186 . 
Added https://kubernetes.io/docs/setup/learning-environment/ (replacing the existing stub)
and removing redirect.
Details which, where to download and guides to follow.
Adds What's Next for further options / learning.