### PR TITLE
[zh]Sync labels-annotations-taints/_index.md

### DIFF
--- a/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
+++ b/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
@@ -14,11 +14,11 @@ no_list: true
 
 <!-- overview -->
 <!--
-Kubernetes reserves all labels and annotations in the kubernetes.io namespace.
+Kubernetes reserves all labels and annotations in the kubernetes.io and k8s.io namespaces.
 
 This document serves both as a reference to the values and as a coordination point for assigning values.
 -->
-Kubernetes 将所有标签和注解保留在 kubernetes.io Namespace中。
+Kubernetes 将所有标签和注解保留在 kubernetes.io 和 k8s.io 名字空间中。
 
 本文档既可作为值的参考，也可作为分配值的协调点。
 
@@ -36,7 +36,7 @@ The component within the architecture.
 
 One of the [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels).
 -->
-## API 对象上使用的标签、注解和污点
+## API 对象上使用的标签、注解和污点   {#labels-annotations-and-taints-used-on-api-objects}
 
 ### app.kubernetes.io/component {#app-kubernetes-io-component}
 
@@ -49,17 +49,15 @@ One of the [recommended labels](/docs/concepts/overview/working-with-objects/com
 [推荐标签](/zh-cn/docs/concepts/overview/working-with-objects/common-labels/#labels)之一。
 
 <!--
-### app.kubernetes.io/created-by
+### app.kubernetes.io/created-by (deprecated)
 
 Example: `app.kubernetes.io/created-by: "controller-manager"`
 
 Used on: All Objects
 
 The controller/user who created this resource.
-
-One of the [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels).
 -->
-### app.kubernetes.io/created-by {#app-kubernetes-io-created-by}
+### app.kubernetes.io/created-by（已弃用）  {#app-kubernetes-io-created-by}
 
 示例：`app.kubernetes.io/created-by: "controller-manager"`
 
@@ -67,7 +65,12 @@ One of the [recommended labels](/docs/concepts/overview/working-with-objects/com
 
 创建此资源的控制器/用户。
 
-[推荐标签](/zh-cn/docs/concepts/overview/working-with-objects/common-labels/#labels)之一。
+{{< note >}}
+<!--
+Starting from v1.9, this label is deprecated.
+-->
+从 v1.9 开始，这个标签被弃用。
+{{< /note >}}
 
 <!--
 ### app.kubernetes.io/instance
@@ -122,7 +125,6 @@ The name of the application.
 
 One of the [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels).
 -->
-
 ### app.kubernetes.io/name {#app-kubernetes-io-name}
 
 示例：`app.kubernetes.io/name: "mysql"`
@@ -174,6 +176,29 @@ One of the [recommended labels](/docs/concepts/overview/working-with-objects/com
 应用的当前版本（例如，语义版本、修订哈希等）。
 
 [推荐标签](/zh-cn/docs/concepts/overview/working-with-objects/common-labels/#labels)之一。
+
+<!--
+### cluster-autoscaler.kubernetes.io/safe-to-evict
+
+Example: `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`
+
+Used on: Pod
+
+When this annotation is set to `"true"`, the cluster autoscaler is allowed to evict a Pod
+even if other rules would normally prevent that.
+The cluster autoscaler never evicts Pods that have this annotation explicitly set to
+`"false"`; you could set that on an important Pod that you want to keep running.
+If this annotation is not set then the cluster autoscaler follows its Pod-level behavior.
+-->
+### cluster-autoscaler.kubernetes.io/safe-to-evict  {#cluster-autoscaler-safe-to-evict}
+
+例子：`cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`
+
+用于：Pod
+
+当这个注解设置为 `"true"` 时，即使其他规则通常会阻止驱逐操作，也会允许该集群自动扩缩器驱逐一个 Pod。
+集群自动扩缩器从不驱逐将此注解显式设置为 `"false"` 的 Pod；你可以针对要保持运行的重要 Pod 设置此注解。
+如果未设置此注解，则集群自动扩缩器将遵循其 Pod 级别的行为。
 
 <!-- 
 ### kubernetes.io/arch


### PR DESCRIPTION
Sync with #35846 and clear difference found by `./scripts/lsync.sh`

```
content/zh-cn/docs/reference/labels-annotations-taints/_index.md
```
Preview: https://deploy-preview-36792--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/labels-annotations-taints/