### PR TITLE
fix: Fix incorrect feature state in Topology Aware hints page

### DIFF
--- a/content/en/docs/concepts/services-networking/topology-aware-hints.md
+++ b/content/en/docs/concepts/services-networking/topology-aware-hints.md
@@ -19,12 +19,6 @@ those network endpoints can be routed closer to where it originated.
 For example, you can route traffic within a locality to reduce
 costs, or to improve network performance.
 
-{{< note >}}
-The "topology-aware hints" feature is at Beta stage and it is **NOT** enabled
-by default. To try out this feature, you have to enable the `TopologyAwareHints`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
-{{< /note >}}
-
 <!-- body -->
 
 ## Motivation


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Ref: https://github.com/kubernetes/website/issues/36825
Fixed Incorrect feature state in Topology Aware hints documentation.

I'm currently unsure, maybe it will be better to completely remove this note or make `enabled` word not bold. Which style will be preferable in this case?
