### PR TITLE
[bugfix/fix-declare-network-policy-word] fix🐛:  Remove the extra char

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/declare-network-policy.md
@@ -105,7 +105,7 @@ You should be able to access the new `nginx` service from other Pods. To access 
 ## 通过从 Pod 访问服务对其进行测试
 
 你应该可以从其它的 Pod 访问这个新的 `nginx` 服务。
-要从 default 命名空间中的其它s Pod 来访问该服务。可以启动一个 busybox 容器：
+要从 default 命名空间中的其它 Pod 来访问该服务。可以启动一个 busybox 容器：
 
 ```shell
 kubectl run busybox --rm -ti --image=busybox:1.28 /bin/sh


### PR DESCRIPTION
# Remove the extra character s
In Chinese documents under [Declare Network Policy](https://kubernetes.io/zh-cn/docs/tasks/administer-cluster/declare-network-policy/) and [Test the service by its function from another Pod](https://kubernetes.io/zh-cn/docs/tasks/administer-cluster/declare-network-policy/#%E9%80%9A%E8%BF%87%E4%BB%8E-pod-%E8%AE%BF%E9%97%AE%E6%9C%8D%E5%8A%A1%E5%AF%B9%E5%85%B6%E8%BF%9B%E8%A1%8C%E6%B5%8B%E8%AF%95), there is an extra character 's'.
<img width="886" alt="image" src="https://user-images.githubusercontent.com/50101020/190626207-3cecc297-a6f4-41b6-880a-b51aa70adafb.png">


Signed-off-by: qi.han <qi.han@daocloud.io>

