### PR TITLE
code-contributor.md updated with full path

### DIFF
--- a/content/en/docs/reference/glossary/code-contributor.md
+++ b/content/en/docs/reference/glossary/code-contributor.md
@@ -2,7 +2,7 @@
 title: Code Contributor
 id: code-contributor
 date: 2018-04-12
-full_link: /docs/community/devel/
+full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
 short_description: >
   A person who develops and contributes code to the Kubernetes open source codebase.
 


### PR DESCRIPTION
Signed-off-by: amolmote <amolmote201@gmail.com>
Fixes #35642 

*What I did?*

Me and @mtardy did discussion on this issue. So I gone through all the possible aspects of this issue.
- basically this page  [developer.md](https://github.com/kubernetes/website/blob/3ca34b9a3be454055ba234f1d2ff7d55809b5040/content/en/docs/reference/glossary/developer.md) has issue but I have updated the [code-contributor.md](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/code-contributor.md).

*why I did this?* 

- Because when user click on `Code Contributor` then this page redirected to the [code-contributor.md](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/code-contributor.md) because it used term-id as `code-contributor`.

![devloper](https://user-images.githubusercontent.com/98871024/190885687-cd896353-e09d-4b40-891b-f0fffb94193b.PNG)

- But code-contributor.md has not its full path because  of which we facing the `page not found` issue
- So I thought that this way may resolve this issue.

Will Look for the similar kind of issues in other localization, I will try to resolve this as soon as I can.


