### PR TITLE
Update page title of operator.md to APA style 'Title Case Capitalization'.

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -1,5 +1,5 @@
 ---
-title: Operator pattern
+title: Operator Pattern
 content_type: concept
 weight: 30
 ---


### PR DESCRIPTION
Capitalized the title as per the [APA Title Case Capitalization](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case) (as well as the rest of the documentation pages).