### PR TITLE
Make sub-items visible in localizations

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -47,6 +47,15 @@
   {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false -}}
   {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
   {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+  {{/* We get untranslated subpages below to make sure we build all levels of the sidenav in localizationed docs sets */}}
+  {{ with site.Params.language_alternatives -}}
+    {{ range . }}
+      {{ with (where $.section.Translations ".Lang" . ) -}}
+        {{ $p := index . 0 -}}
+        {{ $pages_tmp = where ( $pages_tmp | lang.Merge (union $p.Pages $p.Sections)) ".Params.toc_hide" "!=" true -}}
+      {{ end -}}
+    {{ end -}}
+  {{ end -}}
   {{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
   {{ $withChild := gt (len $pages) 0 -}}
   {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}


### PR DESCRIPTION
Fixes #28616 

In localization we noticed an issue displaying sub-items in the side nav when only the _index.md page was translated. Specifically, this was noticed when comparing the Kubeadm reference docs when all sub-items under kubeadm show in English, but are missing in the Korean docs. The sub items appear correctly in the French docs, where more sub pages have been translated.

* English: https://kubernetes.io/docs/reference/setup-tools/kubeadm/
* Korean: https://kubernetes.io/ko/docs/reference/setup-tools/kubeadm/
* French: https://kubernetes.io/fr/docs/reference/setup-tools/kubeadm/

The side nav should show any untranslated page as a link to the english docs. This is an attempt to correct this behavior and have all sub-items listed, even when pages aren't translated. 

More details in the original [issue](#28616 ), and the fix specifically in [this comment](https://github.com/kubernetes/website/issues/28616#issuecomment-1242147669) 
