### PR TITLE
[fr] Add the localized French release version page

### DIFF
--- a/content/fr/releases/_index.md
+++ b/content/fr/releases/_index.md
@@ -1,0 +1,32 @@
+---
+linktitle: Historique des versions
+title: Versions
+type: docs
+---
+
+<!-- overview -->
+
+Le projet Kubernetes maintient des branches de versions pour les trois versions
+mineures les plus récentes ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}},
+{{< skew oldestMinorVersion >}}). Kubernetes 1.19 et plus récent reçoivent
+[environ 1 an de support de correctifs](/releases/patch-releases/#support-period).
+Kubernetes 1.18 et plus ancien ont reçu environ 9 mois de support de correctifs.
+
+Les versions de Kubernetes sont exprimées sous la forme **x.y.z**, où **x** est
+la version majeure, **y** est la version mineure et **z** est la version du
+correctif, selon la terminologie de [Gestion sémantique de version](https://semver.org/lang/fr/).
+
+Plus d'informations dans le document sur la [politique en matière de version](/releases/version-skew-policy/).
+
+<!-- body -->
+
+## Historique des versions
+
+{{< release-data >}}
+
+## Publication à venir
+
+Consultez la [planification](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew nextMinorVersion >}})
+pour la prochaine version **{{< skew nextMinorVersion >}}** de Kubernetes !
+
+## Ressources utiles

--- a/data/i18n/fr/fr.toml
+++ b/data/i18n/fr/fr.toml
@@ -141,3 +141,15 @@ other = "Recherche"
 
 [input_placeholder_email_address]
 other = "adresse email"
+
+[latest_release]
+other = "Dernière version:"
+
+[end_of_life]
+other = "Fin du support:"
+
+[previous_patches]
+other = "Correctifs publiés:"
+
+[release_date_before]
+other = "(publiée: "


### PR DESCRIPTION
Fixes [[fr] Releases page in French is blank #35207](https://github.com/kubernetes/website/issues/35207).

I'm not really into localization but an actual [addition to the releases subfolder](https://github.com/kubernetes/website/pull/30233) introduced an issue and it was a shame to remove it so I just translated the release page for the French localization. I had to also add some localized data for the release structure to be localized as well.