### PR TITLE
[zh-cn]Fix redundant picture text display of components.md

### DIFF
--- a/content/zh-cn/docs/concepts/overview/components.md
+++ b/content/zh-cn/docs/concepts/overview/components.md
@@ -24,12 +24,12 @@ card:
 
 <!--
 When you deploy Kubernetes, you get a cluster.
-{{< glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
+-{{ < glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
 
 This document outlines the various components you need to have for
 a complete and working Kubernetes cluster.
 
-{{< figure src="/images/docs/components-of-kubernetes.svg" alt="Components of Kubernetes" caption="The components of a Kubernetes cluster" class="diagram-large" >}}
+{{ < figure src="/images/docs/components-of-kubernetes.svg" alt="Components of Kubernetes" caption="The components of a Kubernetes cluster" class="diagram-large" >}}
 -->
 <!-- overview -->
 当你部署完 Kubernetes，便拥有了一个完整的集群。


### PR DESCRIPTION
Signed-off-by: Xieql <xieqianglong@huawei.com>
redundant image and text display appear on

`content/zh-cn/docs/concepts/overview/components.md`

Preview: https://kubernetes.io/zh-cn/docs/concepts/overview/components/