### PR TITLE
Fix the link failure on custom-resource-definition-v1.md

### DIFF
--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -276,7 +276,7 @@ CustomResourceDefinitionSpec describes how a user wants their resource to appear
 
 - **preserveUnknownFields** (boolean)
 
-  preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
+  preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.
 
 
 

--- a/content/zh-cn/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -581,7 +581,7 @@ CustomResourceDefinitionSpec 描述了用户希望资源的呈现方式
   preserveUnknownFields 表示将对象写入持久性存储时应保留 OpenAPI 模式中未规定的对象字段。
   apiVersion、kind、元数据（metadata）和元数据中的已知字段始终保留。不推荐使用此字段，而建议在
   `spec.versions[*].schema.openAPIV3Schema` 中设置 `x-preserve-unknown-fields` 为 true。
-  更多详细信息参见： https://kubernetes.io/zh-cn/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields
+  更多详细信息参见： https://kubernetes.io/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning
 
 ## JSONSchemaProps {#JSONSchemaProps}
 


### PR DESCRIPTION
Signed-off-by: sky li (李少凯)-浪潮数据 <lishaokai1995@126.com>
There is a link failure problem in the Chines custom-resource-definition-v1.md page, I found and fixed it
