### PR TITLE
Fix the link failure in the English custom-resource-definition-v1.md

### DIFF
--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -276,7 +276,7 @@ CustomResourceDefinitionSpec describes how a user wants their resource to appear
 
 - **preserveUnknownFields** (boolean)
 
-  preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
+  preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.
 
 
 


### PR DESCRIPTION
Signed-off-by: sky li (李少凯)-浪潮数据 <lishaokai1995@126.com>
English custom-resource-definition-v1.md has invalid link, I fixed it
