### PR TITLE
Fix URL in navbar-version-selector.html to point to correct localization

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -291,6 +291,9 @@ other = "End Of Life Date"
 [release_full_details_initial_text]
 other = "Complete"
 
+[release_information_navbar]
+other = "Release Information"
+
 [release_minor_version]
 other = "Minor Version"
 

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -3,7 +3,7 @@
 </a>
 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
 	{{ $p := . }}
-	<a class="dropdown-item" href="/releases">Release Information</a>
+	<a class="dropdown-item" href="{{ "releases" | relLangURL }}">{{ i18n "release_information_navbar" . }}</a>
 	{{ range .Site.Params.versions }}
 	<a class="dropdown-item" href="{{ .url }}{{ $p.RelPermalink }}">{{ .version }}</a>
 	{{ end }}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/website/issues/36903

Updates Release Information link in navbar-version-selector.html to point to the correct localization, instead of always redirecting to the English docs. 

This also updates the link text to make it so localization teams can translate Release Information. 