### PR TITLE
Setting Kubecon 2022 NA banner to show on 2022-09-23

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -118,7 +118,7 @@ announcements:
     May 16 - 20, 2022.
 
 - name: Kubecon 2022 NA
-  startTime: 2022-10-17T00:00:00 # Added in https://github.com/kubernetes/website/pull/36107 
+  startTime: 2022-09-23T00:00:00 # Added in https://github.com/kubernetes/website/pull/36107 
   endTime: 2022-10-29T00:00:00
   style: >-
     background: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(114,114,255) 100%);

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -118,7 +118,8 @@ announcements:
     May 16 - 20, 2022.
 
 - name: Kubecon 2022 NA
-  startTime: 2022-09-23T00:00:00 # Added in https://github.com/kubernetes/website/pull/36107 
+  startTime: 2022-09-23T00:00:00 # Added in https://github.com/kubernetes/website/pull/36107
+                                 # Date amended in https://github.com/kubernetes/website/pull/36927
   endTime: 2022-10-29T00:00:00
   style: >-
     background: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(114,114,255) 100%);


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/website/pull/36107

The CNCF has asked if we can show the KubeCon 2022 NA banner sooner than was initially set. Showing the banner for a few weeks ahead of KubeCon would help a lot with awareness and attendance.

/committee steering
/cc @reylejano @natalisucks @sftim @mrbobbytables @dims @liggitt @cblecker 