### PR TITLE
Fix broken link on Enforcing Pod Security Standards page

### DIFF
--- a/content/en/docs/setup/best-practices/enforcing-pod-security-standards.md
+++ b/content/en/docs/setup/best-practices/enforcing-pod-security-standards.md
@@ -28,7 +28,7 @@ namespace, and by referencing the Pod Security Standards, decide on an appropria
 each of them. Unlabeled namespaces should only indicate that they've yet to be evaluated.
 
 In the scenario that all workloads in all namespaces have the same security requirements,
-we provide an [example](/docs/concepts/security/pod-security-admission/#applying-to-all-namespaces)
+we provide an [example](/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/#applying-to-all-namespaces)
 that illustrates how the PodSecurity labels can be applied in bulk.
 
 ### Embrace the principle of least privilege


### PR DESCRIPTION
Fixes #36929 

Updated page [Enforcing Pod Security Standards](https://kubernetes.io/docs/setup/best-practices/enforcing-pod-security-standards/)