### PR TITLE
Update link to etcd faq to etcd 3.5 on setting up prod env page

### DIFF
--- a/content/en/docs/setup/production-environment/_index.md
+++ b/content/en/docs/setup/production-environment/_index.md
@@ -117,7 +117,7 @@ consider these steps:
   extra security and availability. Because etcd stores cluster configuration data,
   backing up the etcd database should be done regularly to ensure that you can
   repair that database if needed.
-  See the [etcd FAQ](https://etcd.io/docs/v3.4/faq/) for details on configuring and using etcd.
+  See the [etcd FAQ](https://etcd.io/docs/v3.5/faq/) for details on configuring and using etcd.
   See [Operating etcd clusters for Kubernetes](/docs/tasks/administer-cluster/configure-upgrade-etcd/)
   and [Set up a High Availability etcd cluster with kubeadm](/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)
   for details.


### PR DESCRIPTION
This PR updates the link to the etcd faq from 3.4 to 3.5 on the [Production Environment page](https://kubernetes.io/docs/setup/production-environment/)
Kubernetes 1.25 uses etcd 3.5.4
From https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md
> Etcd: Update to v3.5.4 (https://github.com/kubernetes/kubernetes/pull/110033, [@mk46](https://github.com/mk46)) [SIG API Machinery, Cloud Provider, Cluster Lifecycle and Testing]