### PR TITLE
[zh]Sync enforce-standards-admission-controller.md

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -36,16 +36,13 @@ You can configure this admission controller to set cluster-wide defaults and [ex
 -->
 ## 配置准入控制器    {#configure-the-admission-controller}
 
-{{< tabs name="PodSecurityConfiguration_example_1" >}}
-{{% tab name="pod-security.admission.config.k8s.io/v1beta1" %}}
-
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - name: PodSecurity
   configuration:
-    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    apiVersion: pod-security.admission.config.k8s.io/v1
     kind: PodSecurityConfiguration
     # 当未设置 mode 标签时会应用的默认设置
     #
@@ -75,46 +72,12 @@ plugins:
 
 {{< note >}}
 <!--
-v1beta1 configuration requires v1.23+. For v1.22, use v1alpha1.
+`pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
+For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
 -->
+`pod-security.admission.config.k8s.io/v1` 配置需要 v1.25+。
+对于 v1.23 和 v1.24，使用 [v1beta1](https://v1-24.docs.kubernetes.io/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)。
+对于 v1.22，使用 [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)。
 v1beta1 配置结构需要使用 v1.23+ 版本；对于 v1.22 版本，可使用 v1alpha1。
 {{< /note >}}
-
-{{% /tab %}}
-{{% tab name="pod-security.admission.config.k8s.io/v1alpha1" %}}
-```yaml
-apiVersion: apiserver.config.k8s.io/v1
-kind: AdmissionConfiguration
-plugins:
-- name: PodSecurity
-  configuration:
-    apiVersion: pod-security.admission.config.k8s.io/v1alpha1
-    kind: PodSecurityConfiguration
-    # 当未设置 mode 标签时会应用的默认设置
-    #
-    # level 标签必须是以下取值之一：
-    # - "privileged" (默认)
-    # - "baseline"
-    # - "restricted"
-    #
-    # version 标签必须是如下取值之一：
-    # - "latest" (默认) 
-    # - 诸如 "v{{< skew currentVersion>}}" 这类版本号
-    defaults:
-      enforce: "privileged"
-      enforce-version: "latest"
-      audit: "privileged"
-      audit-version: "latest"
-      warn: "privileged"
-      warn-version: "latest"
-    exemptions:
-      # 要豁免的已认证用户名列表
-      usernames: []
-      # 要豁免的运行时类名称列表
-      runtimeClasses: []
-      # 要豁免的名字空间列表
-      namespaces: []
-```
-{{% /tab %}}
-{{< /tabs >}}
-


### PR DESCRIPTION
Sync with the en version
```
content/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
```
https://deploy-preview-36944--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller/