### PR TITLE
Emphasize auto-generated pages

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -3,6 +3,12 @@
 
 # For "and", see [conjunction_1]
 
+[auto_generated_edit_notice]
+other = "(auto-generated page)"
+
+[auto_generated_pageinfo]
+other = """<p>This page is automatically generated.</p><p>If you plan to report an issue with this page, mention that the page is auto-generated in your issue description. The fix may need to happen elsewhere in the Kubernetes project.</p>"""
+
 [caution]
 other = "Caution:"
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -31,6 +31,11 @@
                   {{ partial "docs/thirdparty-disclaimer.html" . }}
                 {{- end -}}
               {{- end -}}
+              {{- if (.Param "auto_generated") -}}
+                {{ block "auto-generated-pageinfo" . }}
+                  {{ partial "docs/auto-generated-pageinfo.html" . }}
+                {{- end -}}
+              {{- end -}}
             {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
               {{ partial "feedback.html" .Site.Params.ui.feedback }}
             {{ end }}

--- a/layouts/partials/docs/auto-generated-pageinfo.html
+++ b/layouts/partials/docs/auto-generated-pageinfo.html
@@ -1,0 +1,3 @@
+<div class="pageinfo pageinfo-primary" id="auto-generated-edit-notice">
+{{ T "auto_generated_pageinfo" | safeHTML }}
+</div>

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -37,6 +37,9 @@
       {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
       <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
     {{ end }}
+    {{- if (.Param "auto_generated") -}}
+    <a href="#auto-generated-edit-notice" class="auto-generated-notice-link"><i class="fa fa-icon-circle fa-fw"></i> {{ T "auto_generated_edit_notice" | safeHTML }}</a>
+    {{- end -}}
 
   {{ end }}
   {{ with .CurrentSection.AlternativeOutputFormats.Get "print" }}


### PR DESCRIPTION
Tell the reader when they're viewing an autogenerated page, in case they want to report an issue - it should help make reports about autogenerated content stand out.

[Example](https://deploy-preview-36952--kubernetes-io-main-staging.netlify.app/docs/reference/kubernetes-api/workload-resources/)