### PR TITLE
[en] Fix homebrew prefix error in bash-completion of kubectl

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -51,8 +51,7 @@ brew install bash-completion@2
 As stated in the output of this command, add the following to your `~/.bash_profile` file:
 
 ```bash
-export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
-[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+brew_etc="$(brew --prefix)/etc" && [[ -r "${brew_etc}/profile.d/bash_completion.sh" ]] && . "${brew_etc}/profile.d/bash_completion.sh"
 ```
 
 Reload your shell and verify that bash-completion v2 is correctly installed with `type _init_completion`.


### PR DESCRIPTION
## 1. `export` is unnecessary

Here is the current doc:

<img width="935" alt="image" src="https://user-images.githubusercontent.com/36830265/191684387-f8830cec-dd13-4f74-84da-ac97574ab078.png">

However, the output of `bash-completion` has been updated:

https://github.com/Homebrew/homebrew-core/blob/a844122643dcf8c2e74144bfb3dc18844db4e458/Formula/bash-completion%402.rb#L49-L54

So, the `export` is unnecessary( moved since [this commit](https://github.com/Homebrew/homebrew-core/commit/d89d20efe3432a90212ef909db46bcd36d554323) in Homebrew Formula)

## 2. path to `etc` is not always correct

https://github.com/Homebrew/homebrew-core/blob/a844122643dcf8c2e74144bfb3dc18844db4e458/Formula/bash-completion%402.rb#L52

As you can see, the path of `etc` is `#{etc}`, not always be `/usr/local/etc/`.

And here is the information of **how homebrew generate #{etc}**:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/36830265/191685774-e9d83997-60a4-4de7-b6d9-60010d6cc5cb.png">

(link: https://docs.brew.sh/Formula-Cookbook#variables-for-directory-locations)

## 3. Sreenshots

![8DqUo31yeO](https://user-images.githubusercontent.com/36830265/191685895-645a2468-4407-4868-9d2c-938e134a4c1c.jpg)




