### PR TITLE
[zh]sync networking.md and services-networking files

### DIFF
--- a/content/zh-cn/docs/concepts/cluster-administration/networking.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/networking.md
@@ -20,17 +20,17 @@ problems to address:
 1. Highly-coupled container-to-container communications: this is solved by
    {{< glossary_tooltip text="Pods" term_id="pod" >}} and `localhost` communications.
 2. Pod-to-Pod communications: this is the primary focus of this document.
-3. Pod-to-Service communications: this is covered by [services](/docs/concepts/services-networking/service/).
-4. External-to-Service communications: this is covered by [services](/docs/concepts/services-networking/service/).
+3. Pod-to-Service communications: this is covered by [Services](/docs/concepts/services-networking/service/).
+4. External-to-Service communications: this is also covered by Services.
 -->
 集群网络系统是 Kubernetes 的核心部分，但是想要准确了解它的工作原理可是个不小的挑战。
 下面列出的是网络系统的的四个主要问题：
 
-1. 高度耦合的容器间通信：这个已经被 {{< glossary_tooltip text="Pods" term_id="pod" >}}
+1. 高度耦合的容器间通信：这个已经被 {{< glossary_tooltip text="Pod" term_id="pod" >}}
    和 `localhost` 通信解决了。
-2. Pod 间通信：本文档讲述重点。
-3. Pod 和服务间通信：由[服务](/zh-cn/docs/concepts/services-networking/service/)负责。
-4. 外部和服务间通信：也由[服务](/zh-cn/docs/concepts/services-networking/service/)负责。
+2. Pod 间通信：这是本文档讲述的重点。
+3. Pod 与 Service 间通信：涵盖在 [Service](/zh-cn/docs/concepts/services-networking/service/) 中。
+4. 外部与 Service 间通信：也涵盖在 Service 中。
 
 <!-- body -->
 

--- a/content/zh-cn/docs/concepts/services-networking/_index.md
+++ b/content/zh-cn/docs/concepts/services-networking/_index.md
@@ -89,15 +89,24 @@ blind to the existence or non-existence of host ports.
 Kubernetes networking addresses four concerns:
 - Containers within a Pod [use networking to communicate](/docs/concepts/services-networking/dns-pod-service/) via loopback.
 - Cluster networking provides communication between different Pods.
-- The [Service resource](/docs/concepts/services-networking/service/) lets you [expose an application running in Pods](/docs/concepts/services-networking/connect-applications-service/) to be reachable from outside your cluster.
-- You can also use Services to [publish services only for consumption inside your cluster](/docs/concepts/services-networking/service-traffic-policy/).
+- The [Service](/docs/concepts/services-networking/service/) resource lets you
+  [expose an application running in Pods](/docs/concepts/services-networking/connect-applications-service/)
+  to be reachable from outside your cluster.
+  - [Ingress](/docs/concepts/services-networking/ingress/) provides extra functionality
+    specifically for exposing HTTP applications, websites and APIs.
+- You can also use Services to
+  [publish services only for consumption inside your cluster](/docs/concepts/services-networking/service-traffic-policy/).
 -->
-
 Kubernetes 网络解决四方面的问题：
 
 - 一个 Pod 中的容器之间[通过本地回路（loopback）通信](/zh-cn/docs/concepts/services-networking/dns-pod-service/)。
-- 集群网络在不同 pod 之间提供通信。
+- 集群网络在不同 Pod 之间提供通信。
 - [Service 资源](/zh-cn/docs/concepts/services-networking/service/)允许你
-  [向外暴露 Pods 中运行的应用](/zh-cn/docs/concepts/services-networking/connect-applications-service/)，
+  [向外暴露 Pod 中运行的应用](/zh-cn/docs/concepts/services-networking/connect-applications-service/)，
   以支持来自于集群外部的访问。
-- 可以使用 Services 来[发布仅供集群内部使用的服务](/zh-cn/docs/concepts/services-networking/service-traffic-policy/)。
+  - [Ingress](/zh-cn/docs/concepts/services-networking/ingress/)
+    提供专门用于暴露 HTTP 应用程序、网站和 API 的额外功能。
+- 你也可以使用 Service
+  来[发布仅供集群内部使用的服务](/zh-cn/docs/concepts/services-networking/service-traffic-policy/)。
+
+

--- a/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
@@ -1,7 +1,9 @@
 ---
-title: Pod 与 Service 的 DNS
+title: Service 与 Pod 的 DNS
 content_type: concept
-weight: 20
+weight: 60
+description: >-
+  你的工作负载可以使用 DNS 发现集群内的 Service，本页说明具体工作原理。
 ---
 <!--
 reviewers:
@@ -9,7 +11,10 @@ reviewers:
 - thockin
 title: DNS for Services and Pods
 content_type: concept
-weight: 20
+weight: 60
+description: >-
+  Your workload can discover Services within your cluster using DNS;
+  this page explains how that works.
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/services-networking/dual-stack.md
+++ b/content/zh-cn/docs/concepts/services-networking/dual-stack.md
@@ -1,5 +1,8 @@
 ---
 title: IPv4/IPv6 双协议栈
+description: >-
+  Kubernetes 允许你配置单协议栈 IPv4 网络、单协议栈 IPv6
+  网络或同时激活这两种网络的双协议栈网络。本页说明具体配置方法。
 feature:
   title: IPv4/IPv6 双协议栈
   description: >
@@ -10,16 +13,20 @@ weight: 70
 
 <!--
 title: IPv4/IPv6 dual-stack
+description: >-
+  Kubernetes lets you configure single-stack IPv4 networking,
+  single-stack IPv6 networking, or dual stack networking with
+  both network families active. This page explains how.
 feature:
   title: IPv4/IPv6 dual-stack
   description: >
     Allocation of IPv4 and IPv6 addresses to Pods and Services
 content_type: concept
 reviewers:
-- lachie83
-- khenidak
-- aramase
-- bridgetkromhout
+  - lachie83
+  - khenidak
+  - aramase
+  - bridgetkromhout
 weight: 70
 -->
 

--- a/content/zh-cn/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/zh-cn/docs/concepts/services-networking/endpoint-slices.md
@@ -1,15 +1,22 @@
 ---
-title: 端点切片（Endpoint Slices）
+title: EndpointSlice
 content_type: concept
 weight: 45
+description: >-
+  EndpointSlice API 是 Kubernetes 用于扩缩 Service
+  以处理大量后端的机制，还允许集群高效更新其健康后端的列表。
 ---
 
 <!--
 reviewers:
 - freehan
-title: Endpoint Slices
+title: EndpointSlices
 content_type: concept
 weight: 45
+description: >-
+  The EndpointSlice API is the mechanism that Kubernetes uses to let your Service
+  scale to handle large numbers of backends, and allows the cluster to update its
+  list of healthy backends efficiently.
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/zh-cn/docs/concepts/services-networking/ingress-controllers.md
@@ -1,13 +1,22 @@
 ---
 title: Ingress 控制器
+description: >-
+  为了让 [Ingress](/zh-cn/docs/concepts/services-networking/ingress/) 在你的集群中工作，
+  必须有一个 Ingress 控制器正在运行。你需要选择至少一个 Ingress 控制器并确保其已被部署到你的集群中。
+  本页列出了你可以部署的常见 Ingress 控制器。
 content_type: concept
-weight: 40
+weight: 30
 ---
 
 <!--
 title: Ingress Controllers
+description: >-
+  In order for an [Ingress](/docs/concepts/services-networking/ingress/) to work in your cluster,
+  there must be an _ingress controller_ running.
+  You need to select at least one ingress controller and make sure it is set up in your cluster.  
+  This page lists common ingress controllers that you can deploy.
 content_type: concept
-weight: 40
+weight: 30
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/services-networking/ingress.md
+++ b/content/zh-cn/docs/concepts/services-networking/ingress.md
@@ -1,12 +1,22 @@
 ---
 title: Ingress
 content_type: concept
-weight: 40
+description: >-
+  使用一种能感知协议配置的机制来理解 URI、主机名称、路径和更多 Web 概念，使得 HTTP（或 HTTPS）网络服务可用。
+  Ingress 概念允许你通过 Kubernetes API 定义的规则将流量映射到不同的后端。
+weight: 20
 ---
 <!--
+reviewers:
+- bprashanth
 title: Ingress
 content_type: concept
-weight: 40
+description: >-
+  Make your HTTP (or HTTPS) network service available using a protocol-aware configuration
+  mechanism, that understands web concepts like URIs, hostnames, paths, and more.
+  The Ingress concept lets you map traffic to different backends based on rules you define
+  via the Kubernetes API.
+weight: 20
 -->
 
 <!-- overview -->


### PR DESCRIPTION
Sync with the en version #36671 

```
content/zh-cn/docs/concepts/cluster-administration/networking.md
content/zh-cn/docs/concepts/services-networking/_index.md
content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
content/zh-cn/docs/concepts/services-networking/dual-stack.md
content/zh-cn/docs/concepts/services-networking/endpoint-slices.md
content/zh-cn/docs/concepts/services-networking/ingress-controllers.md
content/zh-cn/docs/concepts/services-networking/ingress.md
```