### PR TITLE
Bump pod security admission feature to stable in "Enforcing Pod Security Standards" page

### DIFF
--- a/content/en/docs/setup/best-practices/enforcing-pod-security-standards.md
+++ b/content/en/docs/setup/best-practices/enforcing-pod-security-standards.md
@@ -15,7 +15,7 @@ This page provides an overview of best practices when it comes to enforcing
 
 ## Using the built-in Pod Security Admission Controller
 
-{{< feature-state for_k8s_version="v1.23" state="beta" >}}
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
 The [Pod Security Admission Controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
 intends to replace the deprecated PodSecurityPolicies. 


### PR DESCRIPTION
Fix the issue raised in this comment https://github.com/kubernetes/website/pull/36930#issuecomment-1253188956.

[Preview here](https://deploy-preview-36966--kubernetes-io-main-staging.netlify.app/docs/setup/best-practices/enforcing-pod-security-standards/)