### PR TITLE
Add reference to HostProcess containers in windows documentation

### DIFF
--- a/content/en/docs/concepts/windows/intro.md
+++ b/content/en/docs/concepts/windows/intro.md
@@ -212,7 +212,7 @@ work between Windows and Linux:
 * `securityContext.capabilities` -
    POSIX capabilities are not implemented on Windows
 * `securityContext.privileged` -
-   Windows doesn't support privileged containers
+   Windows doesn't support privileged containers, use [HostProcess Containers](/docs/tasks/configure-pod-container/create-hostprocess-pod/) instead
 * `securityContext.procMount` -
    Windows doesn't have a `/proc` filesystem
 * `securityContext.readOnlyRootFilesystem` -


### PR DESCRIPTION
Add reference to HostProcess containers when describing lack of privileged containers support on Windows
