### PR TITLE
Make scope for `Configure Probes` more clear (add startupProbe)

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -376,11 +376,11 @@ Eventually, some of this section could be moved to a concept topic.
 {{< /comment >}}
 
 [Probes](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#probe-v1-core) have a number of fields that
-you can use to more precisely control the behavior of liveness and readiness
+you can use to more precisely control the behavior of startup, liveness and readiness
 checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started
-before liveness or readiness probes are initiated. Defaults to 0 seconds. Minimum value is 0.
+before startup, liveness or readiness probes are initiated. Defaults to 0 seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10
 seconds. Minimum value is 1.
 * `timeoutSeconds`: Number of seconds after which the probe times out. Defaults


### PR DESCRIPTION
Configure Probes section does not mention startup probes. 

I just tried to check, what the default options for a startupProbe are and stumbled the second time over this. I think it would be benefitial to make it clear, that these probe options also apply to the startupProbe.

