### PR TITLE
[zh]sync /kubernetes-api/workload-resources/job-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -4,7 +4,7 @@ apiVersion: "batch/v1"
 import: "k8s.io/api/batch/v1"
 kind: "Job"
 content_type: "api_reference"
-description: "Job 表示单个作业的配置。"
+description: "Job 表示单个任务的配置。"
 title: "Job"
 weight: 9
 ---
@@ -30,12 +30,11 @@ auto_generated: true
 <!--
 Job represents the configuration of a single job.
 -->
-Job 表示单个作业的配置。
+Job 表示单个任务的配置。
 
 <hr>
 
 - **apiVersion**: batch/v1
-
 
 - **kind**: Job
 
@@ -55,7 +54,7 @@ Job 表示单个作业的配置。
 -->
 - **spec** (<a href="{{< ref "../workload-resources/job-v1#JobSpec" >}}">JobSpec</a>)
 
-  作业的预期行为的规约。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  任务的预期行为的规约。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 <!--
 - **status** (<a href="{{< ref "../workload-resources/job-v1#JobStatus" >}}">JobStatus</a>)
@@ -64,7 +63,7 @@ Job 表示单个作业的配置。
 -->
 - **status** (<a href="{{< ref "../workload-resources/job-v1#JobStatus" >}}">JobStatus</a>)
 
-  作业的当前状态。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  任务的当前状态。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 
 ## JobSpec {#JobSpec}
@@ -72,12 +71,11 @@ Job 表示单个作业的配置。
 <!--
 JobSpec describes how the job execution will look like.
 -->
-JobSpec 描述了作业执行的情况。
+JobSpec 描述了任务执行的情况。
 
 <hr>
 
 ### Replicas
-
 
 <!--
 - **template** (<a href="{{< ref "../workload-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
@@ -90,17 +88,16 @@ JobSpec 描述了作业执行的情况。
 -->
 - **template** (<a href="{{< ref "../workload-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), 必需
 
-  描述执行作业时将创建的 Pod。更多信息： https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+  描述执行任务时将创建的 Pod。更多信息： https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 
 - **parallelism** (int32)
 
-  指定作业应在任何给定时刻预期运行的 Pod 个数上限。
+  指定任务应在任何给定时刻预期运行的 Pod 个数上限。
   当(.spec.completions - .status.successful) \< .spec.parallelism 时，
   即当剩余的工作小于最大并行度时，在稳定状态下运行的 Pod 的实际数量将小于此数量。
   更多信息： https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 
 ### Lifecycle
-
 
 <!--
 - **completions** (int32)
@@ -109,8 +106,8 @@ JobSpec 描述了作业执行的情况。
 -->
 - **completions** (int32)
 
-  指定作业应该运行并预期成功完成的 Pod 个数。设置为 nil 意味着任何 Pod 的成功都标识着所有 Pod 的成功，
-  并允许 parallelism 设置为任何正值。设置为 1 意味着并行性被限制为 1，并且该 Pod 的成功标志着作业的成功。更多信息：
+  指定任务应该运行并预期成功完成的 Pod 个数。设置为 nil 意味着任何 Pod 的成功都标识着所有 Pod 的成功，
+  并允许 parallelism 设置为任何正值。设置为 1 意味着并行性被限制为 1，并且该 Pod 的成功标志着任务的成功。更多信息：
   https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 
 <!--
@@ -129,16 +126,18 @@ JobSpec 描述了作业执行的情况。
   <!--
   `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
   -->
+
   `Indexed` 意味着 Job 的各个 Pod 会获得对应的完成索引值，从 0 到（`.spec.completions - 1`），可在注解
-"batch.kubernetes.io/job-completion-index" 中找到。当每个索引都对应有一个成功完成的 Pod 时，
-该作业被认为是完成的。
-当值为 `Indexed` 时，必须指定 `.spec.completions` 并且 `.spec.parallelism` 必须小于或等于 10^5。
-此外，Pod 名称采用 `$(job-name)-$(index)-$(random-string)` 的形式，Pod 主机名采用
-`$(job-name)-$(index)` 的形式。
+  "batch.kubernetes.io/job-completion-index" 中找到。当每个索引都对应有一个成功完成的 Pod 时，
+  该任务被认为是完成的。
+  当值为 `Indexed` 时，必须指定 `.spec.completions` 并且 `.spec.parallelism` 必须小于或等于 10^5。
+  此外，Pod 名称采用 `$(job-name)-$(index)-$(random-string)` 的形式，Pod 主机名采用
+  `$(job-name)-$(index)` 的形式。
 
   <!--
   More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
   -->
+
   将来可能添加更多的完成模式。如果 Job 控制器发现它无法识别的模式
   （这种情况在升级期间由于版本偏差可能发生），则控制器会跳过 Job 的更新。
 
@@ -153,13 +152,13 @@ JobSpec 描述了作业执行的情况。
 -->
 - **backoffLimit** (int32)
 
-  指定标记此作业失败之前的重试次数。默认值为 6。
+  指定标记此任务失败之前的重试次数。默认值为 6。
 
 - **activeDeadlineSeconds** (int64)
 
-  系统尝试终止作业之前作业可以持续活跃的持续时间（秒），时间长度是相对于 startTime 的；
-  字段值必须为正整数。如果作业被挂起（在创建期间或因更新而挂起），
-  则当作业再次恢复时，此计时器会被停止并重置。
+  系统尝试终止任务之前任务可以持续活跃的持续时间（秒），时间长度是相对于 startTime 的；
+  字段值必须为正整数。如果任务被挂起（在创建期间或因更新而挂起），
+  则当任务再次恢复时，此计时器会被停止并重置。
 
 <!--
 - **ttlSecondsAfterFinished** (int32)
@@ -168,10 +167,10 @@ JobSpec 描述了作业执行的情况。
 -->
 - **ttlSecondsAfterFinished** (int32)
 
-  ttlSecondsAfterFinished 限制已完成执行（完成或失败）的作业的生命周期。如果设置了这个字段，
+  ttlSecondsAfterFinished 限制已完成执行（完成或失败）的任务的生命周期。如果设置了这个字段，
   在 Job 完成 ttlSecondsAfterFinished 秒之后，就可以被自动删除。
   当 Job 被删除时，它的生命周期保证（例如终结器）会被考察。
-  如果未设置此字段，则作业不会被自动删除。如果此字段设置为零，则作业在完成后即可立即删除。
+  如果未设置此字段，则任务不会被自动删除。如果此字段设置为零，则任务在完成后即可立即删除。
 
 <!--
 - **suspend** (boolean)
@@ -186,7 +185,6 @@ JobSpec 描述了作业执行的情况。
   也会重置 ActiveDeadlineSeconds 计时器。默认为 false。
 
 ### Selector
-
 
 <!--
 - **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
@@ -207,12 +205,200 @@ JobSpec 描述了作业执行的情况。
   manualSelector 控制 Pod 标签和 Pod 选择器的生成。除非你确定你在做什么，否则不要设置 `manualSelector`。
   当此字段为 false 或未设置时，系统会选择此 Pod 唯一的标签并将这些标签附加到 Pod 模板。
   当此字段为 true 时，用户负责选择唯一标签并指定选择器。
-  未能选择唯一标签可能会导致此作业和其他作业无法正常运行。
-  但是，你可能会在使用旧的 `extensions/v1beta1` API 创建的作业中看到 `manualSelector=true`。
+  未能选择唯一标签可能会导致此任务和其他任务无法正常运行。
+  但是，你可能会在使用旧的 `extensions/v1beta1` API 创建的任务中看到 `manualSelector=true`。
   更多信息： https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
 
-## JobStatus {#JobStatus}
+<!--
+### Alpha level
 
+- **podFailurePolicy** (PodFailurePolicy)
+
+  Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+-->
+### Alpha 级别
+
+- **podFailurePolicy** (PodFailurePolicy)
+
+  指定处理失效 Pod 的策略。特别是，它允许指定采取关联操作需要满足的一组操作和状况。
+  如果为空，则应用默认行为：由该任务的 .status.failed 字段表示的失效 Pod 的计数器将递增，
+  并针对 backoffLimit 进行检查。此字段不能与 restartPolicy=OnFailure 结合使用。
+
+  <!--
+  This field is alpha-level. To use this field, you must enable the `JobPodFailurePolicy` feature gate (disabled by default).
+
+  <a name="PodFailurePolicy"></a>
+  *PodFailurePolicy describes how failed pods influence the backoffLimit.*
+  -->
+
+  此字段是 Alpha 级别。要使用此字段，你必须启用 `JobPodFailurePolicy` 特性门控（默认被禁用）。
+
+  <a name="PodFailurePolicy"></a>
+  **PodFailurePolicy 描述失效的 Pod 如何影响 backoffLimit。**
+
+  <!--
+  - **podFailurePolicy.rules** ([]PodFailurePolicyRule), required
+
+    *Atomic: will be replaced during a merge*
+    
+    A list of pod failure policy rules. The rules are evaluated in order. Once a rule matches a Pod failure, the remaining of the rules are ignored. When no rule matches the Pod failure, the default handling applies - the counter of pod failures is incremented and it is checked against the backoffLimit. At most 20 elements are allowed.
+  -->
+
+  - **podFailurePolicy.rules** ([]PodFailurePolicyRule)，必需
+
+    **原子: 将在合并期间被替换**
+    
+    Pod 失效策略规则的列表。这些规则按顺序进行评估。一旦某规则匹配 Pod 失效，则其余规将被忽略。
+    当没有规则匹配 Pod 失效时，将应用默认的处理方式：
+    Pod 失效的计数器递增并针对 backoffLimit 进行检查。最多允许 20 个。
+
+    <!--
+    <a name="PodFailurePolicyRule"></a>
+    *PodFailurePolicyRule describes how a pod failure is handled when the requirements are met. One of OnExitCodes and onPodConditions, but not both, can be used in each rule.*
+    -->
+
+    <a name="PodFailurePolicyRule"></a>
+    **PodFailurePolicyRule 描述当满足要求时如何处理一个 Pod 失效。
+    在每个规则中可以使用 OnExitCodes 和 onPodConditions 之一，但不能同时使用二者。**
+
+    <!--
+    - **podFailurePolicy.rules.action** (string), required
+
+      Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are: - FailJob: indicates that the pod's job is marked as Failed and all
+        running pods are terminated.
+    -->
+
+    - **podFailurePolicy.rules.action** (string)，必需
+
+      指定当要求满足时对 Pod 失效采取的操作。可能的值是：
+
+      - FailJob：表示 Pod 的任务被标记为 Failed 且所有正在运行的 Pod 都被终止。
+
+      <!--
+      - Ignore: indicates that the counter towards the .backoffLimit is not
+        incremented and a replacement pod is created.
+      - Count: indicates that the pod is handled in the default way - the
+        counter towards the .backoffLimit is incremented.
+      Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+      -->
+
+      - Ignore：表示 .backoffLimit 的计数器没有递增，并创建了一个替代 Pod。
+
+      - Count：表示以默认方式处理该 Pod，计数器朝着 .backoffLimit 的方向递增。
+
+      后续会考虑增加其他值。客户端应通过跳过此规则对未知的操作做出反应。
+
+    <!--
+    - **podFailurePolicy.rules.onPodConditions** ([]PodFailurePolicyOnPodConditionsPattern), required
+
+      *Atomic: will be replaced during a merge*
+    -->
+
+    - **podFailurePolicy.rules.onPodConditions** ([]PodFailurePolicyOnPodConditionsPattern)，必需
+
+      **原子: 将在合并期间被替换**
+
+      <!--
+      Represents the requirement on the pod conditions. The requirement is represented as a list of pod condition patterns. The requirement is satisfied if at least one pattern matches an actual pod condition. At most 20 elements are allowed.
+
+      <a name="PodFailurePolicyOnPodConditionsPattern"></a>
+      *PodFailurePolicyOnPodConditionsPattern describes a pattern for matching an actual pod condition type.*
+      -->
+
+      表示对 Pod 状况的要求。该要求表示为 Pod 状况模式的一个列表。
+      如果至少一个模式与实际的 Pod 状况匹配，则满足此要求。最多允许 20 个。
+
+      <a name="PodFailurePolicyOnPodConditionsPattern"></a>
+      **PodFailurePolicyOnPodConditionsPattern 描述与实际 Pod 状况类型匹配的模式。**
+
+      <!--
+      - **podFailurePolicy.rules.onPodConditions.status** (string), required
+
+        Specifies the required Pod condition status. To match a pod condition it is required that the specified status equals the pod condition status. Defaults to True.
+
+      - **podFailurePolicy.rules.onPodConditions.type** (string), required
+
+        Specifies the required Pod condition type. To match a pod condition it is required that specified type equals the pod condition type.
+      -->
+
+      - **podFailurePolicy.rules.onPodConditions.status** (string)，必需
+
+        指定必需的 Pod 状况状态。要匹配一个 Pod 状况，指定的状态必须等于该 Pod 状况状态。默认为 True。
+
+      - **podFailurePolicy.rules.onPodConditions.type** (string)，必需
+
+        指定必需的 Pod 状况类型。要匹配一个 Pod 状况，指定的类型必须等于该 Pod 状况类型。
+
+    <!--
+    - **podFailurePolicy.rules.onExitCodes** (PodFailurePolicyOnExitCodesRequirement)
+
+      Represents the requirement on the container exit codes.
+
+      <a name="PodFailurePolicyOnExitCodesRequirement"></a>
+      *PodFailurePolicyOnExitCodesRequirement describes the requirement for handling a failed pod based on its container exit codes. In particular, it lookups the .state.terminated.exitCode for each app container and init container status, represented by the .status.containerStatuses and .status.initContainerStatuses fields in the Pod status, respectively. Containers completed with success (exit code 0) are excluded from the requirement check.*
+    -->
+
+    - **podFailurePolicy.rules.onExitCodes** (PodFailurePolicyOnExitCodesRequirement)
+
+      表示容器退出码有关的要求。
+
+      <a name="PodFailurePolicyOnExitCodesRequirement"></a>
+      **PodFailurePolicyOnExitCodesRequirement 描述根据容器退出码处理失效 Pod 的要求。
+      特别是，它为每个应用容器和 Init 容器状态查找在 Pod 状态中分别用 .status.containerStatuses 和
+      .status.initContainerStatuses 字段表示的 .state.terminated.exitCode。
+      成功完成的容器（退出码 0）被排除在此要求检查之外。**
+
+      <!--
+      - **podFailurePolicy.rules.onExitCodes.operator** (string), required
+
+        Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are: - In: the requirement is satisfied if at least one container exit code
+          (might be multiple if there are multiple containers not restricted
+          by the 'containerName' field) is in the set of specified values.
+        - NotIn: the requirement is satisfied if at least one container exit code
+          (might be multiple if there are multiple containers not restricted
+          by the 'containerName' field) is not in the set of specified values.
+        Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+      -->
+
+      - **podFailurePolicy.rules.onExitCodes.operator** (string)，必需
+
+        表示容器退出码和指定值之间的关系。成功完成的容器（退出码 0）被排除在此要求检查之外。可能的值为：
+        
+        - In：如果至少一个容器退出码（如果有多个容器不受 'containerName' 字段限制，则可能是多个退出码）
+          在一组指定值中，则满足要求。
+
+        - NotIn：如果至少一个容器退出码（如果有多个容器不受 'containerName' 字段限制，则可能是多个退出码）
+          不在一组指定值中，则满足要求。
+
+        后续会考虑增加其他值。客户端应通过假设不满足要求来对未知操作符做出反应。
+
+      <!--
+      - **podFailurePolicy.rules.onExitCodes.values** ([]int32), required
+
+        *Set: unique values will be kept during a merge*
+        
+        Specifies the set of values. Each returned container exit code (might be multiple in case of multiple containers) is checked against this set of values with respect to the operator. The list of values must be ordered and must not contain duplicates. Value '0' cannot be used for the In operator. At least one element is required. At most 255 elements are allowed.
+      -->
+
+      - **podFailurePolicy.rules.onExitCodes.values** ([]int32)，必需
+
+        **集合：合并期间保留唯一值**
+        
+        指定值集。每个返回的容器退出码（在多个容器的情况下可能是多个）将根据该操作符有关的这个值集进行检查。
+        值的列表必须有序且不得包含重复项。值 '0' 不能用于 In 操作符。至少需要 1 个。最多允许 255 个。
+
+      <!--
+      - **podFailurePolicy.rules.onExitCodes.containerName** (string)
+
+        Restricts the check for exit codes to the container with the specified name. When null, the rule applies to all containers. When specified, it should match one the container or initContainer names in the pod template.
+      -->
+
+      - **podFailurePolicy.rules.onExitCodes.containerName** (string)
+
+        将退出码的检查限制为具有指定名称的容器。当为 null 时，该规则适用于所有容器。
+        当被指定时，它应与 Pod 模板中的容器名称或 initContainer 名称之一匹配。
+
+## JobStatus {#JobStatus}
 
 <!--
 JobStatus represents the current state of a Job.
@@ -231,9 +417,8 @@ JobStatus 表示 Job 的当前状态。
 -->
 - **startTime** (Time)
 
-  表示作业控制器开始处理作业的时间。在挂起状态下创建 Job 时，直到第一次恢复时才会设置此字段。
-  每次从暂停中恢复作业时都会重置此字段。它表示为 RFC3339 格式的 UTC 时间。
-
+  表示任务控制器开始处理任务的时间。在挂起状态下创建 Job 时，直到第一次恢复时才会设置此字段。
+  每次从暂停中恢复任务时都会重置此字段。它表示为 RFC3339 格式的 UTC 时间。
 
   **Time 是 time.Time 的包装器，支持正确编码为 YAML 和 JSON。time 包提供的许多工厂方法都提供了包装器。**
 
@@ -247,8 +432,8 @@ JobStatus 表示 Job 的当前状态。
 -->
 - **completionTime** (Time)
 
-  表示作业完成的时间。不能保证对多个独立操作按发生的先后顺序设置。此字段表示为 RFC3339 格式的 UTC 时间。
-  仅当作业成功完成时才设置完成时间。
+  表示任务完成的时间。不能保证对多个独立操作按发生的先后顺序设置。此字段表示为 RFC3339 格式的 UTC 时间。
+  仅当任务成功完成时才设置完成时间。
 
   **Time 是 time.Time 的包装器，支持正确编码为 YAML 和 JSON。time 包提供的许多工厂方法都提供了包装器。**
 
@@ -303,15 +488,15 @@ JobStatus 表示 Job 的当前状态。
 
   **补丁策略：根据 `type` 键合并**
 
-  **原子：在合并过程中，将被替换。**
+  **原子: 将在合并期间被替换**
 
-  对象当前状态的最新可用观察结果。当作业失败时，其中一个状况的类型为 “Failed”，状态为 true。
-  当作业被暂停时，其中一个状况的类型为 “Suspended”，状态为true；当作业被恢复时，该状况的状态将变为 false。
-  作业完成时，其中一个状况的类型为 "Complete"，状态为 true。更多信息：
+  对象当前状态的最新可用观察结果。当任务失败时，其中一个状况的类型为 “Failed”，状态为 true。
+  当任务被暂停时，其中一个状况的类型为 “Suspended”，状态为true；当任务被恢复时，该状况的状态将变为 false。
+  任务完成时，其中一个状况的类型为 "Complete"，状态为 true。更多信息：
   https://kubernetes.io/zh-cn/docs/concepts/workloads/controllers/jobs-run-to-completion/
 
   <a name="JobCondition"></a>
-  **JobCondition 描述作业的当前状况。**
+  **JobCondition 描述任务的当前状况。**
 
   <!--
   - **conditions.status** (string), required
@@ -333,7 +518,7 @@ JobStatus 表示 Job 的当前状态。
 
   - **conditions.type** (string), 必需
 
-    作业状况的类型，Completed 或 Failed。
+    任务状况的类型，Completed 或 Failed。
 
   - **conditions.lastProbeTime** (Time)
 
@@ -392,9 +577,9 @@ JobStatus 表示 Job 的当前状态。
 
 - **uncountedTerminatedPods** (UncountedTerminatedPods)
 
-  UncountedTerminatedPods 保存已终止但尚未被作业控制器纳入状态计数器中的 Pod 的 UID 的集合。
+  UncountedTerminatedPods 保存已终止但尚未被任务控制器纳入状态计数器中的 Pod 的 UID 的集合。
 
-  作业控制器所创建 Pod 带有终结器。当 Pod 终止（成功或失败）时，控制器将执行三个步骤以在作业状态中对其进行说明：
+  任务控制器所创建 Pod 带有终结器。当 Pod 终止（成功或失败）时，控制器将执行三个步骤以在任务状态中对其进行说明：
   （1）将 Pod UID 添加到此字段的列表中。（2）去掉 Pod 中的终结器。（3）从数组中删除 Pod UID，同时为相应的计数器加一。
 
   <!--
@@ -403,8 +588,8 @@ JobStatus 表示 Job 的当前状态。
   <a name="UncountedTerminatedPods"></a>
   *UncountedTerminatedPods holds UIDs of Pods that have terminated but haven't been accounted in Job status counters.*
   -->
-  此字段为 Beta 级别。作业控制器仅在启用特性门控 JobTrackingWithFinalizers 时使用此字段（默认启用）。
-  使用此字段可能无法跟踪旧作业，在这种情况下，该字段保持为空。
+  此字段为 Beta 级别。任务控制器仅在启用特性门控 JobTrackingWithFinalizers 时使用此字段（默认启用）。
+  使用此字段可能无法跟踪旧任务，在这种情况下，该字段保持为空。
 
   <a name="UncountedTerminatedPods"></a>
   **UncountedTerminatedPods 持有已经终止的 Pod 的 UID，但还没有被计入工作状态计数器中。**
@@ -419,7 +604,7 @@ JobStatus 表示 Job 的当前状态。
 
   - **uncountedTerminatedPods.failed** ([]string)
 
-    **Set: 在合并过程中，唯一的值将被保留**
+    **集合：合并期间保留唯一值**
 
     failed 字段包含已失败 Pod 的 UID。
 
@@ -433,16 +618,14 @@ JobStatus 表示 Job 的当前状态。
 
   - **uncountedTerminatedPods.succeeded** ([]string)
 
-    **Set: 在合并过程中，唯一的值将被保留**
+    **集合：合并期间保留唯一值**
 
     succeeded 包含已成功的 Pod 的 UID。
 
 <!--
-### Alpha level
+### Beta level
 -->
-
-
-### Alpha 级别
+### Beta 级别
 
 <!--
 - **ready** (int32)
@@ -456,7 +639,7 @@ JobStatus 表示 Job 的当前状态。
 
   状况为 Ready 的 Pod 数量。
 
-  此字段为 Beta 级别。当特性门控 JobReadyPods 启用（默认启用）时，作业控制器会填充该字段。
+  此字段为 Beta 级别。当特性门控 JobReadyPods 启用（默认启用）时，任务控制器会填充该字段。
 
 ## JobList {#JobList}
 
@@ -468,7 +651,6 @@ JobList 是 Job 的集合。
 <hr>
 
 - **apiVersion**: batch/v1
-
 
 - **kind**: JobList
 
@@ -485,7 +667,6 @@ JobList 是 Job 的集合。
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
 
   标准列表元数据。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-
 
 - **items** ([]<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>), required
 
@@ -522,13 +703,12 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
 - **name** (**路径参数**)：string，必需
 
-  Job 的名字。
+  Job 的名称。
 
 <!--
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **pretty** (*in query*): string
 
@@ -538,7 +718,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -546,11 +725,9 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 401: Unauthorized
-
 
 ### `get` read status of the specified Job
 
@@ -567,7 +744,7 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
 401: Unauthorized
 
-### `get` 读取指定作业的状态
+### `get` 读取指定任务的状态
 
 #### HTTP 请求
 
@@ -580,11 +757,9 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   name of the Job
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **pretty** (*in query*): string
 
@@ -594,25 +769,20 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   Job 的名称。
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 401: Unauthorized
-
 
 ### `list` list or watch objects of kind Job
 
@@ -621,7 +791,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 GET /apis/batch/v1/namespaces/{namespace}/jobs
 
 #### Parameters
-
 
 - **namespace** (*in path*): string, required
 
@@ -629,7 +798,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 -->
 #### 响应
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 401: Unauthorized
@@ -651,7 +819,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
@@ -660,7 +827,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 - **allowWatchBookmarks** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
-
 
 - **continue** (**查询参数**): string
 
@@ -671,7 +837,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
@@ -680,7 +845,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **labelSelector** (**查询参数**): string
 
@@ -691,7 +855,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -700,7 +863,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -711,7 +873,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
@@ -720,7 +881,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (**查询参数**): string
 
@@ -731,7 +891,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -741,7 +900,6 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -749,11 +907,9 @@ GET /apis/batch/v1/namespaces/{namespace}/jobs
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#JobList" >}}">JobList</a>): OK
 
 401: Unauthorized
-
 
 ### `list` list or watch objects of kind Job
 
@@ -782,7 +938,6 @@ GET /apis/batch/v1/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
@@ -791,7 +946,6 @@ GET /apis/batch/v1/jobs
 - **allowWatchBookmarks** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
-
 
 - **continue** (**查询参数**): string
 
@@ -802,7 +956,6 @@ GET /apis/batch/v1/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
@@ -811,7 +964,6 @@ GET /apis/batch/v1/jobs
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **labelSelector** (**查询参数**): string
 
@@ -822,7 +974,6 @@ GET /apis/batch/v1/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -831,7 +982,6 @@ GET /apis/batch/v1/jobs
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -842,7 +992,6 @@ GET /apis/batch/v1/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
@@ -851,7 +1000,6 @@ GET /apis/batch/v1/jobs
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (**查询参数**): string
 
@@ -862,7 +1010,6 @@ GET /apis/batch/v1/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -872,7 +1019,6 @@ GET /apis/batch/v1/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
@@ -880,11 +1026,9 @@ GET /apis/batch/v1/jobs
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#JobList" >}}">JobList</a>): OK
 
 401: Unauthorized
-
 
 ### `create` create a Job
 
@@ -894,11 +1038,9 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 
 #### Parameters
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>, required
 -->
@@ -916,11 +1058,9 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 
 #### 参数
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>, 必需
 
@@ -928,7 +1068,6 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -939,7 +1078,6 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -948,7 +1086,6 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -959,14 +1096,12 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
@@ -975,7 +1110,6 @@ POST /apis/batch/v1/namespaces/{namespace}/jobs
 202 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Accepted
 
 401: Unauthorized
-
 
 ### `update` replace the specified Job
 
@@ -987,7 +1121,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 -->
 #### 响应
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
@@ -995,7 +1128,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 202 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Accepted
 
 401: Unauthorized
-
 
 ### `update` 替换指定的 Job
 
@@ -1010,11 +1142,9 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   name of the Job
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>, required
 -->
@@ -1023,11 +1153,9 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   Job 的名称。
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>, 必需
 
@@ -1035,7 +1163,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1046,7 +1173,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1055,7 +1181,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -1066,22 +1191,18 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `update` replace status of the specified Job
 
@@ -1093,13 +1214,11 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 -->
 #### 响应
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `update` 替换指定 Job 的状态
 
@@ -1114,24 +1233,20 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   name of the Job
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>, required
 -->
 
 - **name** (**路径参数**): string, 必需
 
-  Job 的名字
-
+  Job 的名称。
 
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>, 必需
 
@@ -1139,7 +1254,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1150,7 +1264,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1159,7 +1272,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -1170,7 +1282,6 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -1178,13 +1289,11 @@ PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `patch` partially update the specified Job
 
@@ -1194,13 +1303,11 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 -->
 #### 响应
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `patch` 部分更新指定的 Job
 
@@ -1211,31 +1318,25 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 <!--
 #### Parameters
 
-
 - **name** (*in path*): string, required
 
   name of the Job
-
 
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 -->
 #### 参数
-
 
 - **name** (**路径参数**): string, 必需
 
   Job 的名称。
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, 必需
 
@@ -1243,7 +1344,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1254,7 +1354,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1264,7 +1363,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **force** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
@@ -1273,7 +1371,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 - **fieldValidation** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **force** (**查询参数**): boolean
 
@@ -1292,13 +1389,11 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `patch` partially update status of the specified Job
 
@@ -1329,11 +1424,9 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   name of the Job
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 -->
@@ -1342,11 +1435,9 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   Job 的名称。
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, 必需
 
@@ -1354,7 +1445,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldManager** (*in query*): string
 
@@ -1365,7 +1455,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
@@ -1375,7 +1464,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **force** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
@@ -1384,7 +1472,6 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 - **fieldValidation** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **force** (**查询参数**): boolean
 
@@ -1403,13 +1490,11 @@ PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `delete` delete a Job
 
@@ -1423,18 +1508,15 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   name of the Job
 
-
 - **namespace** (*in path*): string, required
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): OK
 
 201 (<a href="{{< ref "../workload-resources/job-v1#Job" >}}">Job</a>): Created
 
 401: Unauthorized
-
 
 ### `delete` 删除一个 Job
 
@@ -1444,16 +1526,13 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
 #### 参数
 
-
 - **name** (**路径参数**): string, 必需
 
-  Job的名称
-
+  Job 的名称。
 
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 
@@ -1461,7 +1540,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **gracePeriodSeconds** (*in query*): integer
 
@@ -1472,7 +1550,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
@@ -1481,7 +1558,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **propagationPolicy** (*in query*): string
 
@@ -1492,7 +1568,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **propagationPolicy** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
@@ -1500,13 +1575,11 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 <!--
 #### Response
 
-
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
 202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
 
 401: Unauthorized
-
 
 ### `deletecollection` delete collection of Job
 
@@ -1515,7 +1588,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
 DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
 #### Parameters
-
 
 - **namespace** (*in path*): string, required
 -->
@@ -1539,14 +1611,12 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 
 <!--
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
-
 
 - **dryRun** (*in query*): string
 
@@ -1557,7 +1627,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
 
-
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
@@ -1566,7 +1635,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 - **fieldSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **gracePeriodSeconds** (*in query*): integer
 
@@ -1577,7 +1645,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
@@ -1586,7 +1653,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
-
 
 - **limit** (*in query*): integer
 
@@ -1597,7 +1663,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
 
-
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
@@ -1606,7 +1671,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **propagationPolicy** (*in query*): string
 
@@ -1617,7 +1681,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **propagationPolicy** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
@@ -1627,7 +1690,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
@@ -1636,7 +1698,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (**查询参数**): string
 
@@ -1654,7 +1715,6 @@ DELETE /apis/batch/v1/namespaces/{namespace}/jobs
 
 <!--
 #### Response
-
 
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 


### PR DESCRIPTION
- Sync with the en version
- Change the term `job` from `作业` to `任务` by following [glossary job](https://kubernetes.io/zh-cn/docs/reference/glossary/?fundamental=true#term-job)

```
content/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1.md
```
Preview: https://deploy-preview-37010--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1/