### PR TITLE
Document generating SHA256 CA certificate

### DIFF
--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -140,7 +140,7 @@ manually through `easyrsa`, `openssl` or `cfssl`.
    ```shell
    openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
        -CAcreateserial -out server.crt -days 10000 \
-       -extensions v3_ext -extfile csr.conf
+       -extensions v3_ext -extfile csr.conf -sha256
    ```
 
 1. View the certificate signing request:


### PR DESCRIPTION
The flag -sha256 is not set and hence the certs are SHA1 based and this is being disabled. Fixed the openssl command for server crt