### PR TITLE
Mark “PodSecurityPolicy: The Historical Context” article as evergreen

### DIFF
--- a/content/en/blog/_posts/2022-08-16-PSP-historical-context/index.md
+++ b/content/en/blog/_posts/2022-08-16-PSP-historical-context/index.md
@@ -3,6 +3,7 @@ layout: blog
 title: "PodSecurityPolicy: The Historical Context"
 date: 2022-08-23T15:00:00-0800
 slug: podsecuritypolicy-the-historical-context
+evergreen: true
 ---
 
 **Author:** Mahé Tardy (Quarkslab)


### PR DESCRIPTION
Mark [PodSecurityPolicy: The Historical Context](https://kubernetes.io/blog/2022/08/23/podsecuritypolicy-the-historical-context/) as evergreen.
This means a stale content message doesn't show, ever. I think this article will be relevant for years to come.

Improvement for https://github.com/kubernetes/website/pull/36021

/language en
/area blog