### PR TITLE
Fix command in task “Using NodeLocal DNSCache in Kubernetes Clusters”

### DIFF
--- a/content/en/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/en/docs/tasks/administer-cluster/nodelocaldns.md
@@ -108,7 +108,7 @@ This feature can be enabled using the following steps:
   * If kube-proxy is running in IPVS mode:
 
     ``` bash
-    sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/__PILLAR__DNS__SERVER__//g; s/__PILLAR__CLUSTER__DNS__/$kubedns/g" nodelocaldns.yaml
+    sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/,__PILLAR__DNS__SERVER__//g; s/__PILLAR__CLUSTER__DNS__/$kubedns/g" nodelocaldns.yaml
     ```
 
     In this mode, the `node-local-dns` pods listen only on `<node-local-address>`.


### PR DESCRIPTION
## Fixes :- #37057
## Closes :- #37057
## description :- 
 In this page https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/ of V1.25
 in the `If kube-proxy is running in IPVS mode:` section command a `,` is missing between `s/` and `__PILLAR__DNS__SERVER__//g;`
 ```bash
sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/__PILLAR__DNS__SERVER__//g; s/__PILLAR__CLUSTER__DNS__/$kubedns/g" nodelocaldns.yaml
```
whereas in other versions a `,` is there. I think for which cluster got crashed error is coming.