### PR TITLE
Update install-kubectl-macos.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -109,12 +109,12 @@ The following methods exist for installing kubectl on macOS:
 1. Test to ensure the version you installed is up-to-date:
 
    ```bash
-   kubectl version --client
+   kubectl version --output=yaml
    ```
    Or use this for detailed view of version:
 
    ```cmd
-   kubectl version --client --output=yaml
+   kubectl version --output=yaml
    ```
 
 ### Install with Homebrew on macOS
@@ -136,7 +136,7 @@ If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you 
 1. Test to ensure the version you installed is up-to-date:
 
    ```bash
-   kubectl version --client
+   kubectl version --output=yaml
    ```
 
 ### Install with Macports on macOS


### PR DESCRIPTION
Depreciation message using the --client flag.
```bash
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
```