### PR TITLE
Removed Duplicated words in Security-Context

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -173,7 +173,7 @@ for a volume.
   This field only applies to volume types that support `fsGroup` controlled ownership and permissions.
   This field has two possible values:
 
-* _OnRootMismatch_: Only change permissions and ownership if
+* _OnRootMismatch_: Only change permissions and ownership if the permission and the ownership of
   root directory does not match with expected permissions of the volume.
   This could help shorten the time it takes to change ownership and permission of a volume.
 * _Always_: Always change permission and ownership of the volume when volume is mounted.

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -173,7 +173,7 @@ for a volume.
   This field only applies to volume types that support `fsGroup` controlled ownership and permissions.
   This field has two possible values:
 
-* _OnRootMismatch_: Only change permissions and ownership if permission and ownership if
+* _OnRootMismatch_: Only change permissions and ownership if
   root directory does not match with expected permissions of the volume.
   This could help shorten the time it takes to change ownership and permission of a volume.
 * _Always_: Always change permission and ownership of the volume when volume is mounted.


### PR DESCRIPTION

 Hello!

Removed the duplicated Words in security-context.md. This will make the changes on the kubernetes website as well.
Solving the issue #37046 
