### PR TITLE
Fix typo in full-pcpus-only option

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -293,7 +293,7 @@ policy option is not compatible with `TopologyManager` `single-numa-node`
 policy and does not apply to hardware where the number of sockets is greater
 than number of NUMA nodes.
 
-The `full-pcpus-only` option can be enabled by adding `full-pcups-only=true` to
+The `full-pcpus-only` option can be enabled by adding `full-pcpus-only=true` to
 the CPUManager policy options.
 Likewise, the `distribute-cpus-across-numa` option can be enabled by adding
 `distribute-cpus-across-numa=true` to the CPUManager policy options.


### PR DESCRIPTION
Noticed a typo in the full-pcpus-only option when I copied and pasted from the documentation. Here is a fix.
