### PR TITLE
Move canonical link earlier in metadata

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
-    {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
     {{ with .Params.canonicalUrl }}
     <link rel="canonical" href="{{ . }}">
     {{ end }}
+    {{ partial "head.html" . }}
+    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
   </head>
   <body class="td-{{ .Kind }} td-blog">
     <header>


### PR DESCRIPTION
To help search engines, make the canonical URL appear near the start of the `<head>` HTML element. This improves the chance of a search engine paying attention; some indexers only read part of the page and ignore information that appears later within the `<head>` element.

/area web-development

This is mainly useful for blog articles that we mirror from another site, such as https://k8s.dev/blog/