### PR TITLE
Register and document volumes.kubernetes.io/controller-managed-attach-detach annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -355,6 +355,17 @@ Used on: PersistentVolumeClaim
 
 This annotation will be added to dynamic provisioning required PVC.
 
+### volumes.kubernetes.io/controller-managed-attach-detach
+
+Used on: Node
+
+If a node has set the annotation `volumes.kubernetes.io/controller-managed-attach-detach`
+on itself, then its storage attach and detach operations are being managed
+by the attach/detach controller running in kube-controller-manager.
+
+The value of the annotation isn't important; if this annotation exists on a node,
+then attach and detached are controller managed.
+
 ### node.kubernetes.io/windows-build {#nodekubernetesiowindows-build}
 
 Example: `node.kubernetes.io/windows-build: "10.0.17763"`

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -361,7 +361,9 @@ Used on: Node
 
 If a node has set the annotation `volumes.kubernetes.io/controller-managed-attach-detach`
 on itself, then its storage attach and detach operations are being managed
-by the attach/detach controller running in kube-controller-manager.
+by the _volume attach/detach_
+{{< glossary_tooltip text="controller" term_id="controller" >}} running within the
+{{< glossary_tooltip term_id="kube-controller-manager" text="kube-controller-manager" >}}.
 
 The value of the annotation isn't important; if this annotation exists on a node,
 then storage attaches and detaches are controller managed.

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -364,7 +364,7 @@ on itself, then its storage attach and detach operations are being managed
 by the attach/detach controller running in kube-controller-manager.
 
 The value of the annotation isn't important; if this annotation exists on a node,
-then attach and detached are controller managed.
+then storage attaches and detaches are controller managed.
 
 ### node.kubernetes.io/windows-build {#nodekubernetesiowindows-build}
 


### PR DESCRIPTION
Fixes #36656 

This PR registered `volumes.kubernetes.io/controller-managed-attach-detach` annotation. 