### PR TITLE
Cleanup after 1.25 release and add nate-double-u as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -35,7 +35,6 @@ aliases:
     - jimangel
     - jlbutler
     - kbhawkey
-    - kcmartin
     - krol3
     - natalisucks
     - onlydole
@@ -50,6 +49,7 @@ aliases:
     - kbhawkey
     - mehabhalodiya
     - natalisucks
+    - nate-double-u
     - onlydole
     - rajeshdeshpande02
     - reylejano


### PR DESCRIPTION
This PR does the following:
  - cleanup after the 1.25 release cycle and remove the 1.25 release docs lead from [sig-docs-en-owners](https://github.com/orgs/kubernetes/teams/sig-docs-en-owners) see https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#clean-up-access
  - add @nate-double-u as a SIG Docs reviewer, @nate-double-u is already an existing blog reviewer