### PR TITLE
Fix default branch name in comment of netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 # This default build command adds the robots noindex directive to the site headers.
-# It is turned off for only for the production site by using [context.master] below
+# It is turned off for only for the production site by using [context.main] below
 # DO NOT REMOVE THIS (contact @kubernetes/sig-docs-leads)
 publish = "public"
 functions = "functions"


### PR DESCRIPTION
- The default branch name was updated from `master` to `main` via #30790, and you can see this change in `netlify.toml` line 25.
- It seems that the one occurrence of the name was missed in a comment -- this PR fixes that.