### PR TITLE
Reinstate legacy taint for control plane nodes

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -738,10 +738,20 @@ Used on: Node
 
 Label that kubeadm applies on the control plane nodes that it manages.
 
-### node-role.kubernetes.io/control-plane
+### node-role.kubernetes.io/control-plane {#node-role-kubernetes-io-control-plane-taint}
 
 Used on: Node
 
 Example: `node-role.kubernetes.io/control-plane:NoSchedule`
 
 Taint that kubeadm applies on control plane nodes to allow only critical workloads to schedule on them.
+
+### node-role.kubernetes.io/master (deprecated) {#node-role-kubernetes-io-master-taint}
+
+Used on: Node
+
+Example: `node-role.kubernetes.io/master:NoSchedule`
+
+Taint that kubeadm previously applied on control plane nodes to allow only critical workloads to schedule on them.
+Replaced by [`node-role.kubernetes.io/control-plane`](#node-role-kubernetes-io-control-plane-taint); kubeadm
+no longer sets or uses this deprecated taint.


### PR DESCRIPTION
The change from PR #36173 has got lost (in a merge, I think), so reinstate it.

Similar to APIs, we don't delete legacy taints and labels from the page, we leave them there and mark them as deprecated.

Reinstate taint `node-role.kubernetes.io/master`.