### PR TITLE
Tweak line wrapping in the apiserver aggregation page

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
@@ -10,25 +10,39 @@ weight: 20
 
 <!-- overview -->
 
-The aggregation layer allows Kubernetes to be extended with additional APIs, beyond what is offered by the core Kubernetes APIs.
-The additional APIs can either be ready-made solutions such as a [metrics server](https://github.com/kubernetes-sigs/metrics-server), or APIs that you develop yourself.
+The aggregation layer allows Kubernetes to be extended with additional APIs, beyond what is
+offered by the core Kubernetes APIs.
+The additional APIs can either be ready-made solutions such as a
+[metrics server](https://github.com/kubernetes-sigs/metrics-server), or APIs that you develop yourself.
 
-The aggregation layer is different from [Custom Resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/), which are a way to make the {{< glossary_tooltip term_id="kube-apiserver" text="kube-apiserver" >}} recognise new kinds of object.
+The aggregation layer is different from
+[Custom Resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/),
+which are a way to make the {{< glossary_tooltip term_id="kube-apiserver" text="kube-apiserver" >}}
+recognise new kinds of object.
 
 <!-- body -->
 
 ## Aggregation layer
 
-The aggregation layer runs in-process with the kube-apiserver. Until an extension resource is registered, the aggregation layer will do nothing. To register an API, you add an _APIService_ object, which "claims" the URL path in the Kubernetes API. At that point, the aggregation layer will proxy anything sent to that API path (e.g. `/apis/myextension.mycompany.io/v1/…`) to the registered APIService.
+The aggregation layer runs in-process with the kube-apiserver. Until an extension resource is
+registered, the aggregation layer will do nothing. To register an API, you add an _APIService_
+object, which "claims" the URL path in the Kubernetes API. At that point, the aggregation layer
+will proxy anything sent to that API path (e.g. `/apis/myextension.mycompany.io/v1/…`) to the
+registered APIService.
 
-The most common way to implement the APIService is to run an *extension API server* in Pod(s) that run in your cluster. If you're using the extension API server to manage resources in your cluster, the extension API server (also written as "extension-apiserver") is typically paired with one or more {{< glossary_tooltip text="controllers" term_id="controller" >}}. The apiserver-builder library provides a skeleton for both extension API servers and the associated controller(s).
+The most common way to implement the APIService is to run an *extension API server* in Pod(s) that
+run in your cluster. If you're using the extension API server to manage resources in your cluster,
+the extension API server (also written as "extension-apiserver") is typically paired with one or
+more {{< glossary_tooltip text="controllers" term_id="controller" >}}. The apiserver-builder
+library provides a skeleton for both extension API servers and the associated controller(s).
 
 ### Response latency
 
 Extension API servers should have low latency networking to and from the kube-apiserver.
 Discovery requests are required to round-trip from the kube-apiserver in five seconds or less.
 
-If your extension API server cannot achieve that latency requirement, consider making changes that let you meet it.
+If your extension API server cannot achieve that latency requirement, consider making changes that
+let you meet it.
 
 ## {{% heading "whatsnext" %}}
 
@@ -36,5 +50,6 @@ If your extension API server cannot achieve that latency requirement, consider m
 * Then, [setup an extension api-server](/docs/tasks/extend-kubernetes/setup-extension-api-server/) to work with the aggregation layer.
 * Read about [APIService](/docs/reference/kubernetes-api/cluster-resources/api-service-v1/) in the API reference
 
-Alternatively: learn how to [extend the Kubernetes API using Custom Resource Definitions](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
+Alternatively: learn how to
+[extend the Kubernetes API using Custom Resource Definitions](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
 


### PR DESCRIPTION
This PR fixes the long lines found in the apiserver-aggregation.md page.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
