### PR TITLE
Tweak line wrapping in the custom-resource concept page

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -16,8 +16,9 @@ methods for adding custom resources and how to choose between them.
 <!-- body -->
 ## Custom resources
 
-A *resource* is an endpoint in the [Kubernetes API](/docs/concepts/overview/kubernetes-api/) that stores a collection of
-[API objects](/docs/concepts/overview/working-with-objects/kubernetes-objects/) of a certain kind; for example, the built-in *pods* resource contains a collection of Pod objects.
+A *resource* is an endpoint in the [Kubernetes API](/docs/concepts/overview/kubernetes-api/) that
+stores a collection of [API objects](/docs/concepts/overview/working-with-objects/kubernetes-objects/)
+of a certain kind; for example, the built-in *pods* resource contains a collection of Pod objects.
 
 A *custom resource* is an extension of the Kubernetes API that is not necessarily available in a default
 Kubernetes installation. It represents a customization of a particular Kubernetes installation. However,
@@ -68,63 +69,77 @@ or let your API stand alone.
 
 In a Declarative API, typically:
 
- - Your API consists of a relatively small number of relatively small objects (resources).
- - The objects define configuration of applications or infrastructure.
- - The objects are updated relatively infrequently.
- - Humans often need to read and write the objects.
- - The main operations on the objects are CRUD-y (creating, reading, updating and deleting).
- - Transactions across objects are not required: the API represents a desired state, not an exact state.
+- Your API consists of a relatively small number of relatively small objects (resources).
+- The objects define configuration of applications or infrastructure.
+- The objects are updated relatively infrequently.
+- Humans often need to read and write the objects.
+- The main operations on the objects are CRUD-y (creating, reading, updating and deleting).
+- Transactions across objects are not required: the API represents a desired state, not an exact state.
 
 Imperative APIs are not declarative.
 Signs that your API might not be declarative include:
 
- - The client says "do this", and then gets a synchronous response back when it is done.
- - The client says "do this", and then gets an operation ID back, and has to check a separate Operation object to determine completion of the request.
- - You talk about Remote Procedure Calls (RPCs).
- - Directly storing large amounts of data; for example, > a few kB per object, or > 1000s of objects.
- - High bandwidth access (10s of requests per second sustained) needed.
- - Store end-user data (such as images, PII, etc.) or other large-scale data processed by applications.
- - The natural operations on the objects are not CRUD-y.
- - The API is not easily modeled as objects.
- - You chose to represent pending operations with an operation ID or an operation object.
+- The client says "do this", and then gets a synchronous response back when it is done.
+- The client says "do this", and then gets an operation ID back, and has to check a separate
+  Operation object to determine completion of the request.
+- You talk about Remote Procedure Calls (RPCs).
+- Directly storing large amounts of data; for example, > a few kB per object, or > 1000s of objects.
+- High bandwidth access (10s of requests per second sustained) needed.
+- Store end-user data (such as images, PII, etc.) or other large-scale data processed by applications.
+- The natural operations on the objects are not CRUD-y.
+- The API is not easily modeled as objects.
+- You chose to represent pending operations with an operation ID or an operation object.
 
 ## Should I use a ConfigMap or a custom resource?
 
 Use a ConfigMap if any of the following apply:
 
-* There is an existing, well-documented configuration file format, such as a `mysql.cnf` or `pom.xml`.
+* There is an existing, well-documented configuration file format, such as a `mysql.cnf` or
+  `pom.xml`.
 * You want to put the entire configuration into one key of a ConfigMap.
-* The main use of the configuration file is for a program running in a Pod on your cluster to consume the file to configure itself.
-* Consumers of the file prefer to consume via file in a Pod or environment variable in a pod, rather than the Kubernetes API.
+* The main use of the configuration file is for a program running in a Pod on your cluster to
+  consume the file to configure itself.
+* Consumers of the file prefer to consume via file in a Pod or environment variable in a pod,
+  rather than the Kubernetes API.
 * You want to perform rolling updates via Deployment, etc., when the file is updated.
 
 {{< note >}}
-Use a {{< glossary_tooltip text="Secret" term_id="secret" >}} for sensitive data, which is similar to a ConfigMap but more secure.
+Use a {{< glossary_tooltip text="Secret" term_id="secret" >}} for sensitive data, which is similar
+to a ConfigMap but more secure.
 {{< /note >}}
 
 Use a custom resource (CRD or Aggregated API) if most of the following apply:
 
 * You want to use Kubernetes client libraries and CLIs to create and update the new resource.
 * You want top-level support from `kubectl`; for example, `kubectl get my-object object-name`.
-* You want to build new automation that watches for updates on the new object, and then CRUD other objects, or vice versa.
+* You want to build new automation that watches for updates on the new object, and then CRUD other
+  objects, or vice versa.
 * You want to write automation that handles updates to the object.
 * You want to use Kubernetes API conventions like `.spec`, `.status`, and `.metadata`.
-* You want the object to be an abstraction over a collection of controlled resources, or a summarization of other resources.
+* You want the object to be an abstraction over a collection of controlled resources, or a
+  summarization of other resources.
 
 ## Adding custom resources
 
 Kubernetes provides two ways to add custom resources to your cluster:
 
 - CRDs are simple and can be created without any programming.
-- [API Aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) requires programming, but allows more control over API behaviors like how data is stored and conversion between API versions.
+- [API Aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)
+  requires programming, but allows more control over API behaviors like how data is stored and
+  conversion between API versions.
 
-Kubernetes provides these two options to meet the needs of different users, so that neither ease of use nor flexibility is compromised.
+Kubernetes provides these two options to meet the needs of different users, so that neither ease
+of use nor flexibility is compromised.
 
-Aggregated APIs are subordinate API servers that sit behind the primary API server, which acts as a proxy. This arrangement is called [API Aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) (AA). To users, the Kubernetes API appears extended.
+Aggregated APIs are subordinate API servers that sit behind the primary API server, which acts as
+a proxy. This arrangement is called [API Aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)(AA).
+To users, the Kubernetes API appears extended.
 
-CRDs allow users to create new types of resources without adding another API server. You do not need to understand API Aggregation to use CRDs.
+CRDs allow users to create new types of resources without adding another API server. You do not
+need to understand API Aggregation to use CRDs.
 
-Regardless of how they are installed, the new resources are referred to as Custom Resources to distinguish them from built-in Kubernetes resources (like pods).
+Regardless of how they are installed, the new resources are referred to as Custom Resources to
+distinguish them from built-in Kubernetes resources (like pods).
 
 {{< note >}}
 Avoid using a Custom Resource as data storage for application, end user, or monitoring data:
@@ -156,10 +171,14 @@ and use a controller to handle events.
 
 ## API server aggregation
 
-Usually, each resource in the Kubernetes API requires code that handles REST requests and manages persistent storage of objects. The main Kubernetes API server handles built-in resources like *pods* and *services*, and can also generically handle custom resources through [CRDs](#customresourcedefinitions).
+Usually, each resource in the Kubernetes API requires code that handles REST requests and manages
+persistent storage of objects. The main Kubernetes API server handles built-in resources like
+*pods* and *services*, and can also generically handle custom resources through
+[CRDs](#customresourcedefinitions).
 
-The [aggregation layer](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) allows you to provide specialized
-implementations for your custom resources by writing and deploying your own API server.
+The [aggregation layer](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)
+allows you to provide specialized implementations for your custom resources by writing and
+deploying your own API server.
 The main API server delegates requests to your API server for the custom resources that you handle,
 making them available to all of its clients.
 
@@ -170,7 +189,8 @@ CRDs are easier to use. Aggregated APIs are more flexible. Choose the method tha
 Typically, CRDs are a good fit if:
 
 * You have a handful of fields
-* You are using the resource within your company, or as part of a small open-source project (as opposed to a commercial product)
+* You are using the resource within your company, or as part of a small open-source project (as
+  opposed to a commercial product)
 
 ### Comparing ease of use
 
@@ -203,7 +223,8 @@ Aggregated APIs offer more advanced API features and customization of other feat
 
 ### Common Features
 
-When you create a custom resource, either via a CRD or an AA, you get many features for your API, compared to implementing it outside the Kubernetes platform:
+When you create a custom resource, either via a CRD or an AA, you get many features for your API,
+compared to implementing it outside the Kubernetes platform:
 
 | Feature | What it does |
 | ------- | ------------ |
@@ -228,42 +249,51 @@ There are several points to be aware of before adding a custom resource to your 
 
 ### Third party code and new points of failure
 
-While creating a CRD does not automatically add any new points of failure (for example, by causing third party code to run on your API server), packages (for example, Charts) or other installation bundles often include CRDs as well as a Deployment of third-party code that implements the business logic for a new custom resource.
+While creating a CRD does not automatically add any new points of failure (for example, by causing
+third party code to run on your API server), packages (for example, Charts) or other installation
+bundles often include CRDs as well as a Deployment of third-party code that implements the
+business logic for a new custom resource.
 
 Installing an Aggregated API server always involves running a new Deployment.
 
 ### Storage
 
-Custom resources consume storage space in the same way that ConfigMaps do. Creating too many custom resources may overload your API server's storage space.
+Custom resources consume storage space in the same way that ConfigMaps do. Creating too many
+custom resources may overload your API server's storage space.
 
-Aggregated API servers may use the same storage as the main API server, in which case the same warning applies.
+Aggregated API servers may use the same storage as the main API server, in which case the same
+warning applies.
 
 ### Authentication, authorization, and auditing
 
-CRDs always use the same authentication, authorization, and audit logging as the built-in resources of your API server.
+CRDs always use the same authentication, authorization, and audit logging as the built-in
+resources of your API server.
 
-If you use RBAC for authorization, most RBAC roles will not grant access to the new resources (except the cluster-admin role or any role created with wildcard rules). You'll need to explicitly grant access to the new resources. CRDs and Aggregated APIs often come bundled with new role definitions for the types they add.
+If you use RBAC for authorization, most RBAC roles will not grant access to the new resources
+(except the cluster-admin role or any role created with wildcard rules). You'll need to explicitly
+grant access to the new resources. CRDs and Aggregated APIs often come bundled with new role
+definitions for the types they add.
 
-Aggregated API servers may or may not use the same authentication, authorization, and auditing as the primary API server.
+Aggregated API servers may or may not use the same authentication, authorization, and auditing as
+the primary API server.
 
 ## Accessing a custom resource
 
-Kubernetes [client libraries](/docs/reference/using-api/client-libraries/) can be used to access custom resources. Not all client libraries support custom resources. The _Go_ and _Python_ client libraries do.
+Kubernetes [client libraries](/docs/reference/using-api/client-libraries/) can be used to access
+custom resources. Not all client libraries support custom resources. The _Go_ and _Python_ client
+libraries do.
 
 When you add a custom resource, you can access it using:
 
 - `kubectl`
 - The Kubernetes dynamic client.
 - A REST client that you write.
-- A client generated using [Kubernetes client generation tools](https://github.com/kubernetes/code-generator) (generating one is an advanced undertaking, but some projects may provide a client along with the CRD or AA).
-
-
+- A client generated using [Kubernetes client generation tools](https://github.com/kubernetes/code-generator)
+  (generating one is an advanced undertaking, but some projects may provide a client along with
+  the CRD or AA).
 
 ## {{% heading "whatsnext" %}}
 
-
 * Learn how to [Extend the Kubernetes API with the aggregation layer](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/).
-
 * Learn how to [Extend the Kubernetes API with CustomResourceDefinition](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
-
 


### PR DESCRIPTION
This PR fixes the long line problems found in the custom-resources.md concept page. Saddly, there are some markdown tables we cannot fix yet in this PR. Maybe a HTML table is a better alternative.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
