### PR TITLE
Update deprecated kubectl command in apparmor doc

### DIFF
--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -158,7 +158,7 @@ kubectl get events | grep Created
 You can also verify directly that the container's root process is running with the correct profile by checking its proc attr:
 
 ```shell
-kubectl exec <pod_name> cat /proc/1/attr/current
+kubectl exec <pod_name> -- cat /proc/1/attr/current
 ```
 ```
 k8s-apparmor-example-deny-write (enforce)


### PR DESCRIPTION
This PR updates an example `kubectl exec` command to avoid warnings.

Running `kubectl exec <pod_name> <command>` is deprecated:
```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead
```
It should be: `kubectl exec <pod_name> -- <command>`

The change can be previewed here:
https://deploy-preview-37221--kubernetes-io-main-staging.netlify.app/docs/tutorials/security/apparmor/#securing-a-pod
