### PR TITLE
Change some links in ja to proper en pages

### DIFF
--- a/content/ja/docs/concepts/workloads/controllers/job.md
+++ b/content/ja/docs/concepts/workloads/controllers/job.md
@@ -482,7 +482,7 @@ Events:
 {{< feature-state for_k8s_version="v1.23" state="beta" >}}
 
 {{< note >}}
-この機能を使うためには、[APIサーバー](/ja/docs/reference/command-line-tools-reference/kube-apiserver/)上で`JobMutableNodeSchedulingDirectives`[フィーチャーゲート](/ja/docs/reference/command-line-tools-reference/feature-gates/)を有効にする必要があります。
+この機能を使うためには、[APIサーバー](/docs/reference/command-line-tools-reference/kube-apiserver/)上で`JobMutableNodeSchedulingDirectives`[フィーチャーゲート](/ja/docs/reference/command-line-tools-reference/feature-gates/)を有効にする必要があります。
 デフォルトで有効になっています。
 {{< /note >}}
 
@@ -549,7 +549,7 @@ spec:
 {{< feature-state for_k8s_version="v1.23" state="beta" >}}
 
 {{< note >}}
-この機能を使うためには、[APIサーバー](/ja/docs/reference/command-line-tools-reference/kube-apiserver/)と[コントローラーマネージャー](/docs/reference/command-line-tools-reference/kube-controller-manager/)で`JobTrackingWithFinalizers`
+この機能を使うためには、[APIサーバー](/docs/reference/command-line-tools-reference/kube-apiserver/)と[コントローラーマネージャー](/docs/reference/command-line-tools-reference/kube-controller-manager/)で`JobTrackingWithFinalizers`
 [フィーチャーゲート](/ja/docs/reference/command-line-tools-reference/feature-gates/)を有効にする必要があります。
 
 有効にした場合、コントロールプレーンは下記に示す機能で新しいJobを追跡します。この機能が有効になる前に作成されたJobは影響を受けません。ユーザーとして実感できる唯一の違いは、コントロールプレーンのJob完了ステータス追跡がより正確になるということだけです。


### PR DESCRIPTION
This PR updates some links in ja docs to proper en pages.
related to: #37247 

If #37247 is merged, we need to update some links to those pages.
1. change link `ja/docs/reference/command-line-tools-reference/kube-apiserver` to `docs/reference/command-line-tools-reference/kube-apiserver`
2. change link `ja/docs/reference/config-api/apiserver-audit.v1` to `docs/reference/config-api/apiserver-audit.v1` 


I found 1 page for being changed by grep command.
```
$ grep "ja/docs/reference/command-line-tools-reference/kube-apiserver" -r ./ja -l                                            
./ja/docs/concepts/workloads/controllers/job.md  #<-- just 1 file is matched
$ grep "ja/docs/reference/config-api/apiserver-audit.v1" -r ./ja -l
# no files are matched
```

That's why I updated `ja/docs/concepts/workloads/controllers/job.md` in this PR.