### PR TITLE
Update incorrect Debian install instructions in install-kubectl-linux.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -133,7 +133,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y kubectl
+   sudo apt-get install -y kubernetes-client
    ```
 
 {{% /tab %}}


### PR DESCRIPTION
I think there might be a problem with the Debian install instructions. The last command "sudo apt-get install -y kubectl" did not work for me on the latest version of Debian 11, with a freshly installed OS, with updated, and upgraded packages. When I checked Debian.org, I could not find the "kubectl" package. Only a man page reference to the kubectl command, under the "unstable" section. I found a package named "kubernetes-client", with "(kubectl)" in brackets, in the description. This seems to be the correct package in my case.

Manpage for kubectl : https://manpages.debian.org/unstable/kubernetes-client/kubectl.1.en.html
Suspected correct package: https://packages.debian.org/sid/admin/kubernetes-client