### PR TITLE
Update deprecated kubectl command in apparmor doc

### DIFF
--- a/content/ja/docs/tutorials/clusters/apparmor.md
+++ b/content/ja/docs/tutorials/clusters/apparmor.md
@@ -111,7 +111,7 @@ kubectl get events | grep Created
 proc attrを調べることで、コンテナのルートプロセスが正しいプロファイルで実行されているかどうかを直接確認することもできます。
 
 ```shell
-kubectl exec <pod_name> cat /proc/1/attr/current
+kubectl exec <pod_name> -- cat /proc/1/attr/current
 ```
 ```
 k8s-apparmor-example-deny-write (enforce)


### PR DESCRIPTION
This PR updates example `kubectl exec` commands to avoid warnings.
It is a follow-up PR to #37221 that also updates the localizations.

Running `kubectl exec <pod_name> <command>` is deprecated:
```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead
```
It should be: `kubectl exec <pod_name> -- <command>`
