### PR TITLE
Update custom-resource-definition-versioning.md

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -297,11 +297,13 @@ spec:
   versions:
   - name: v1alpha1
     served: true
+    storage: false
     # This indicates the v1alpha1 version of the custom resource is deprecated.
     # API requests to this version receive a warning header in the server response.
     deprecated: true
     # This overrides the default warning returned to API clients making v1alpha1 API requests.
     deprecationWarning: "example.com/v1alpha1 CronTab is deprecated; see http://example.com/v1alpha1-v1 for instructions to migrate to example.com/v1 CronTab"
+    
     schema: ...
   - name: v1beta1
     served: true
@@ -334,6 +336,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
+    storage: false
     # This indicates the v1alpha1 version of the custom resource is deprecated.
     # API requests to this version receive a warning header in the server response.
     deprecated: true


### PR DESCRIPTION
Since there can be only one version that needs to be stored and storage option is required else the parsing fails. Adding the storage option and setting it false.

Schema Vaildation fails with error: error validating data: ValidationError(CustomResourceDefinition.spec.versions[1]): missing
 required field "storage" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion; if you choose to
 ignore these errors, turn validation off with --validate=false

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
