### PR TITLE
Update network-policies.md

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -101,7 +101,7 @@ __namespaceSelector__ *and* __podSelector__: A single `to`/`from` entry that spe
     - namespaceSelector:
         matchLabels:
           user: alice
-      podSelector:
+    - podSelector:
         matchLabels:
           role: client
   ...


### PR DESCRIPTION
Updates YAML to match the other YAML on the same page

This adds a missing `-` to table 2 on the page.
