### PR TITLE
Use socks5 in https_proxy instead of socks5h

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/socks5-proxy-access-api.md
+++ b/content/en/docs/tasks/extend-kubernetes/socks5-proxy-access-api.md
@@ -80,7 +80,7 @@ the SOCKS5 proxy we created earlier.
 For command-line tools, set the `https_proxy` environment variable and pass it to commands that you run.
 
 ```shell
-export https_proxy=socks5h://localhost:1080
+export https_proxy=socks5://localhost:1080
 ```
 
 When you set the `https_proxy` variable, tools such as `curl` route HTTPS traffic through the proxy


### PR DESCRIPTION
https_proxy=socks5h://localhost:1080 kubectl ... gets: 
```
Unable to connect to the server: proxyconnect tcp: dial tcp: lookup socks5h: no such host
```
for both kubectl 1.24 and 1.25.

https_proxy=socks5://localhost:1080 kubectl works fine for both kubectl versions.
