### PR TITLE
Add October patch releases and update release dates

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,10 +78,10 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| September 2022        | 2022-09-09           | 2022-09-14  |
-| October 2022          | 2022-10-07           | 2022-10-12  |
-| November 2022         | 2022-11-11           | 2022-11-16  |
+| November 2022         | 2022-11-04           | 2022-11-09  |
 | December 2022         | 2022-12-09           | 2022-12-14  |
+| January 2023          | 2023-01-13           | 2023-01-18  |
+| February 2023         | 2023-02-10           | 2023-02-15  |
 
 ## Detailed Release History for Active Branches
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,10 +4,13 @@ schedules:
   maintenanceModeStartDate: 2023-08-28
   endOfLifeDate: 2023-10-27
   next:
-    release: 1.25.3
-    cherryPickDeadline: 2022-10-07
-    targetDate: 2022-10-12
+    release: 1.25.4
+    cherryPickDeadline: 2022-11-04
+    targetDate: 2022-11-09
   previousPatches:
+    - release: 1.25.3
+      cherryPickDeadline: 2022-10-07
+      targetDate: 2022-10-12
     - release: 1.25.2
       cherryPickDeadline: 2022-09-20
       targetDate: 2022-09-21
@@ -23,10 +26,13 @@ schedules:
   maintenanceModeStartDate: 2023-05-28
   endOfLifeDate: 2023-07-28
   next:
-    release: 1.24.7
-    cherryPickDeadline: 2022-10-07
-    targetDate: 2022-10-12
+    release: 1.24.8
+    cherryPickDeadline: 2022-11-04
+    targetDate: 2022-11-09
   previousPatches:
+    - release: 1.24.7
+      cherryPickDeadline: 2022-10-07
+      targetDate: 2022-10-12
     - release: 1.24.6
       cherryPickDeadline: 2022-09-20
       targetDate: 2022-09-21
@@ -54,10 +60,13 @@ schedules:
   maintenanceModeStartDate: 2022-12-28
   endOfLifeDate: 2023-02-28
   next:
-    release: 1.23.13
-    cherryPickDeadline: 2022-10-07
-    targetDate: 2022-10-12
+    release: 1.23.14
+    cherryPickDeadline: 2022-11-04
+    targetDate: 2022-11-09
   previousPatches:
+    - release: 1.23.13
+      cherryPickDeadline: 2022-10-07
+      targetDate: 2022-10-12
     - release: 1.23.12
       cherryPickDeadline: 2022-09-20
       targetDate: 2022-09-21


### PR DESCRIPTION
This PR:

* Adds October and upcoming November patch releases to the patch releases list
* Moves November releases a week earlier (to 2022-11-09)
* Proposes dates for January and February patch releases

The original date for November releases is 2022-11-16 which is a week before Thanksgiving. Considering that some folks might take PTO around that time, we decided to move November releases a week earlier to avoid any potential staffing issues.

/assign @saschagrunert @cpanato @puerco @Verolop 
cc @kubernetes/release-engineering 