### PR TITLE
Add the ending mark of codeblock in install-kubectl-windows.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -30,6 +30,7 @@ The following methods exist for installing kubectl on Windows:
 
    ```powershell
    curl.exe -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe"
+   ```
 
    {{< note >}}
    To find out the latest stable version (for example, for scripting), take a look at [https://dl.k8s.io/release/stable.txt](https://dl.k8s.io/release/stable.txt).
@@ -98,7 +99,6 @@ If you have installed Docker Desktop before, you may need to place your `PATH` e
    {{% /tab %}}
    {{< /tabs >}}
 
-
 1. Test to ensure the version you installed is up-to-date:
 
    ```powershell
@@ -158,7 +158,7 @@ Below are the procedures to set up autocompletion for PowerShell.
    curl.exe -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe"
    ```
 
-1. Validate the binary (optional)
+1. Validate the binary (optional).
 
    Download the `kubectl-convert` checksum file:
 
@@ -183,7 +183,7 @@ Below are the procedures to set up autocompletion for PowerShell.
 
 1. Append or prepend the `kubectl-convert` binary folder to your `PATH` environment variable.
 
-1. Verify plugin is successfully installed
+1. Verify the plugin is successfully installed.
 
    ```shell
    kubectl convert --help


### PR DESCRIPTION
The powershell command needs an ending mark of \``` that is accidentally deleted in #36854 
```
content/en/docs/tasks/tools/install-kubectl-windows.md
```

[This codeblock](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/) looks not very good now:

<img width="802" alt="image" src="https://user-images.githubusercontent.com/79828097/199870703-6acbae03-e55d-4fb5-ba48-c9f0dde2a205.png">
