### PR TITLE
Add mast operator to list

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -119,11 +119,11 @@ operator.
 * [kubebuilder](https://book.kubebuilder.io/)
 * [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (.NET operator SDK)
 * [KUDO](https://kudo.dev/) (Kubernetes Universal Declarative Operator)
+* [Mast](https://docs.ansi.services/mast/user_guide/operator/) (Dynamic Declarative Operator for Ansible)
 * [Metacontroller](https://metacontroller.github.io/metacontroller/intro.html) along with WebHooks that
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
 * [shell-operator](https://github.com/flant/shell-operator)
-* [Mast](https://docs.ansi.services/mast/user_guide/operator/) (Dynamic Declarative Operator for Ansible)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -123,6 +123,7 @@ operator.
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
 * [shell-operator](https://github.com/flant/shell-operator)
+* [Mast](https://docs.ansi.services/mast/user_guide/operator/) (Dynamic Declarative Operator for Ansible)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -119,7 +119,7 @@ operator.
 * [kubebuilder](https://book.kubebuilder.io/)
 * [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (.NET operator SDK)
 * [KUDO](https://kudo.dev/) (Kubernetes Universal Declarative Operator)
-* [Mast](https://docs.ansi.services/mast/user_guide/operator/) (Dynamic Declarative Operator for Ansible)
+* [Mast](https://docs.ansi.services/mast/user_guide/operator/)
 * [Metacontroller](https://metacontroller.github.io/metacontroller/intro.html) along with WebHooks that
   you implement yourself
 * [Operator Framework](https://operatorframework.io)


### PR DESCRIPTION
#37354 - link to mast Operator

This change adds a link to Mast, which gives the option to use Declarative and Dynamic definitions to build operators that utilize Ansible. 