### PR TITLE
fix(device-plugins): update FPGA device link

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -353,7 +353,7 @@ Here are some examples of device plugin implementations:
 * The [SocketCAN device plugin](https://github.com/collabora/k8s-socketcan)
 * The [Solarflare device plugin](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * The [SR-IOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
-* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin) for Xilinx FPGA devices
+* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-device-plugin) for Xilinx FPGA devices
 
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
Hi, I just stumbled upon a link that got renamed in the target repository.

The term "fpga" is not present anymore in the latest version of the FPGA_as_a_Service repository due to a the top-level directory that got renamed.