### PR TITLE
Added Hyperlink to RFC7468

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -442,7 +442,7 @@ M1fLPhLyR54fGaY+7/X8P9AZzPefAkwizeXwe9ii6/a08vWoiE4=
 ```
 
 Non-PEM content may appear before or after the CERTIFICATE PEM blocks and is unvalidated,
-to allow for explanatory text as described in section 5.2 of RFC7468.
+to allow for explanatory text as described in [section 5.2 of RFC7468](https://www.rfc-editor.org/rfc/rfc7468#section-5.2).
 
 When encoded in JSON or YAML, this field is base-64 encoded.
 A CertificateSigningRequest containing the example certificate above would look like this:


### PR DESCRIPTION
This PR added a Hyperlink to RFC7468 in [certificate-signing-request](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#signer-api)

Fixes: #37358