### PR TITLE
Add DNS search domain list limits and remove resolved DNS issue

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -313,16 +313,24 @@ search default.svc.cluster-domain.example svc.cluster-domain.example cluster-dom
 options ndots:5
 ```
 
-#### Expanded DNS Configuration
+## DNS search domain list limits
 
-{{< feature-state for_k8s_version="1.22" state="alpha" >}}
+{{< feature-state for_k8s_version="1.26" state="beta" >}}
 
-By default, for Pod's DNS Config, Kubernetes allows at most 6 search domains and
-a list of search domains of up to 256 characters.
+Kubernetes itself does not limit the DNS Config until the length of the search
+domain list exceeds 32 or the total length of all search domains exceeds 2048.
+This limit applies to the node's resolver configuration file, the Pod's DNS
+Config, and the merged DNS Config respectively.
 
-If the feature gate `ExpandedDNSConfig` is enabled for the kube-apiserver and
-the kubelet, it is allowed for Kubernetes to have at most 32 search domains and
-a list of search domains of up to 2048 characters.
+{{< note >}}
+Some container runtimes of earlier versions may have their own restrictions on
+the number of DNS search domains. Depending on the container runtime
+environment, the pods with a large number of DNS search domains may get stuck in
+the pending state.
+
+It is known that containerd v1.5.5 or earlier and CRI-O v1.21 or earlier have
+this problem.
+{{< /note >}}
 
 ## DNS resolution on Windows nodes {#dns-windows}
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -99,7 +99,8 @@ different Kubernetes components.
 | `DownwardAPIHugePages` | `true` | Beta | 1.22 | |
 | `EndpointSliceTerminatingCondition` | `false` | Alpha | 1.20 | 1.21 |
 | `EndpointSliceTerminatingCondition` | `true` | Beta | 1.22 | |
-| `ExpandedDNSConfig` | `false` | Alpha | 1.22 | |
+| `ExpandedDNSConfig` | `false` | Alpha | 1.22 | 1.25 |
+| `ExpandedDNSConfig` | `true` | Beta | 1.26 | |
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | |
 | `GracefulNodeShutdown` | `false` | Alpha | 1.20 | 1.20 |
 | `GracefulNodeShutdown` | `true` | Beta | 1.21 | |
@@ -895,9 +896,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
   [readiness probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).
 - `ExpandCSIVolumes`: Enable the expanding of CSI volumes.
 - `ExpandedDNSConfig`: Enable kubelet and kube-apiserver to allow more DNS
-  search paths and longer list of DNS search paths. This feature requires container
-  runtime support(Containerd: v1.5.6 or higher, CRI-O: v1.22 or higher). See
-  [Expanded DNS Configuration](/docs/concepts/services-networking/dns-pod-service/#expanded-dns-configuration).
+  search paths and longer list of DNS search paths. See
+  [DNS search domain list limits](/docs/concepts/services-networking/dns-pod-service/#dns-search-domain-list-limits).
 - `ExpandInUsePersistentVolumes`: Enable expanding in-use PVCs. See
   [Resizing an in-use PersistentVolumeClaim](/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim).
 - `ExpandPersistentVolumes`: Enable the expanding of persistent volumes. See

--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -334,14 +334,12 @@ Kubernetes installs do not configure the nodes' `resolv.conf` files to use the
 cluster DNS by default, because that process is inherently distribution-specific.
 This should probably be implemented eventually.
 
-Linux's libc (a.k.a. glibc) has a limit for the DNS `nameserver` records to 3 by default. What's more, for the glibc versions which are older than glibc-2.17-222 ([the new versions update see this issue](https://access.redhat.com/solutions/58028)), the allowed number of DNS `search` records has been limited to 6 ([see this bug from 2005](https://bugzilla.redhat.com/show_bug.cgi?id=168253)). Kubernetes needs to consume 1 `nameserver` record and 3 `search` records. This means that if a local installation already uses 3 `nameserver`s or uses more than 3 `search`es while your glibc version is in the affected list, some of those settings will be lost. To work around the DNS `nameserver` records limit, the node can run `dnsmasq`, which will provide more `nameserver` entries. You can also use kubelet's `--resolv-conf` flag. To fix the DNS `search` records limit, consider upgrading your linux distribution or upgrading to an unaffected version of glibc.
-
-{{< note >}}
-
-With [Expanded DNS Configuration](/docs/concepts/services-networking/dns-pod-service/#expanded-dns-configuration),
-Kubernetes allows more DNS `search` records.
-
-{{< /note >}}
+Linux's libc (a.k.a. glibc) has a limit for the DNS `nameserver` records to 3 by
+default and Kubernetes needs to consume 1 `nameserver` record. This means that
+if a local installation already uses 3 `nameserver`s, some of those entries will
+be lost. To work around this limit, the node can run `dnsmasq`, which will
+provide more `nameserver` entries. You can also use kubelet's `--resolv-conf`
+flag.
 
 If you are using Alpine version 3.3 or earlier as your base image, DNS may not
 work properly due to a known issue with Alpine.


### PR DESCRIPTION
This adds DNS search domain list limits and removes the resolved DNS issue.

PRs:
kubernetes/kubernetes#112824

KEP:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2595-expanded-dns-config

Enhancement issue:
https://github.com/kubernetes/enhancements/issues/2595