### PR TITLE
Fix kubectl auto complete not usable by non-root user sometimes

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -36,6 +36,7 @@ echo 'source <(kubectl completion bash)' >>~/.bashrc
 {{< /tab >}}
 {{< tab name="System" codelang="bash" >}}
 kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl > /dev/null
+sudo chmod a+r /etc/bash_completion.d/kubectl
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION
The current instructions assume tee creates a file with global read permission. This may not always be the case, and we may ends up creating a bash completion file that is only usable by the root user

Adding a line to add the relevant file permission
