### PR TITLE
[zh] sync /compute-storage-net/device-plugins.md

### DIFF
--- a/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -1,9 +1,15 @@
 ---
 title: 设备插件
-description: 使用 Kubernetes 设备插件框架来实现适用于 GPU、NIC、FPGA、InfiniBand 以及类似的需要特定于供应商设置的资源的插件。
+description: 设备插件可以让你配置集群以支持需要特定于供应商设置的设备或资源，例如 GPU、NIC、FPGA 或非易失性主存储器。
 content_type: concept
 weight: 20
 ---
+<!--
+title: Device Plugins
+description: Device plugins let you configure your cluster with support for devices or resources that require vendor-specific setup, such as GPUs, NICs, FPGAs, or non-volatile main memory.
+content_type: concept
+weight: 20
+-->
 
 <!-- overview -->
 {{< feature-state for_k8s_version="v1.10" state="beta" >}}
@@ -20,7 +26,8 @@ and other similar computing resources that may require vendor specific initializ
 and setup.
 -->
 Kubernetes 提供了一个
-[设备插件框架](https://git.k8s.io/design-proposals-archive/resource-management/device-plugin.md)，你可以用它来将系统硬件资源发布到 {{< glossary_tooltip term_id="kubelet" >}}。
+[设备插件框架](https://git.k8s.io/design-proposals-archive/resource-management/device-plugin.md)，
+你可以用它来将系统硬件资源发布到 {{< glossary_tooltip term_id="kubelet" >}}。
 
 供应商可以实现设备插件，由你手动部署或作为 {{< glossary_tooltip term_id="daemonset" >}}
 来部署，而不必定制 Kubernetes 本身的代码。目标设备包括 GPU、高性能 NIC、FPGA、
@@ -66,15 +73,15 @@ to advertise that the node has 2 "Foo" devices installed and available.
 
 * 设备插件的 Unix 套接字。
 * 设备插件的 API 版本。
-* `ResourceName` 是需要公布的。这里 `ResourceName` 需要遵循
-  [扩展资源命名方案](/zh-cn/docs/concepts/configuration/manage-resources-containers/#extended-resources)，
+* `ResourceName` 是需要公布的。这里 `ResourceName`
+  需要遵循[扩展资源命名方案](/zh-cn/docs/concepts/configuration/manage-resources-containers/#extended-resources)，
   类似于 `vendor-domain/resourcetype`。（比如 NVIDIA GPU 就被公布为 `nvidia.com/gpu`。）
 
 成功注册后，设备插件就向 kubelet 发送它所管理的设备列表，然后 kubelet
 负责将这些资源发布到 API 服务器，作为 kubelet 节点状态更新的一部分。
 
-比如，设备插件在 kubelet 中注册了 `hardware-vendor.example/foo` 并报告了
-节点上的两个运行状况良好的设备后，节点状态将更新以通告该节点已安装 2 个
+比如，设备插件在 kubelet 中注册了 `hardware-vendor.example/foo`
+并报告了节点上的两个运行状况良好的设备后，节点状态将更新以通告该节点已安装 2 个
 "Foo" 设备并且是可用的。
 
 <!--
@@ -139,11 +146,10 @@ The general workflow of a device plugin includes the following steps:
 
 * 初始化。在这个阶段，设备插件将执行供应商特定的初始化和设置，
   以确保设备处于就绪状态。
-* 插件使用主机路径 `/var/lib/kubelet/device-plugins/` 下的 Unix 套接字启动
-  一个 gRPC 服务，该服务实现以下接口：
+* 插件使用主机路径 `/var/lib/kubelet/device-plugins/` 下的 Unix 套接字启动一个
+  gRPC 服务，该服务实现以下接口：
 
   <!--
-
   ```gRPC
   service DevicePlugin {
         // GetDevicePluginOptions returns options to be communicated with Device Manager.
@@ -208,8 +214,8 @@ The general workflow of a device plugin includes the following steps:
   always call `GetDevicePluginOptions()` to see which optional functions are
   available, before calling any of them directly.
   -->
-  插件并非必须为 `GetPreferredAllocation()` 或 `PreStartContainer()` 提供有用
-  的实现逻辑，调用 `GetDevicePluginOptions()` 时所返回的 `DevicePluginOptions`
+  插件并非必须为 `GetPreferredAllocation()` 或 `PreStartContainer()` 提供有用的实现逻辑，
+  调用 `GetDevicePluginOptions()` 时所返回的 `DevicePluginOptions`
   消息中应该设置这些调用是否可用。`kubelet` 在真正调用这些函数之前，总会调用
   `GetDevicePluginOptions()` 来查看是否存在这些可选的函数。
   {{< /note >}}
@@ -242,7 +248,7 @@ kubelet instance. In the current implementation, a new kubelet instance deletes 
 under `/var/lib/kubelet/device-plugins` when it starts. A device plugin can monitor the deletion
 of its Unix socket and re-register itself upon such an event.
 -->
-### 处理 kubelet 重启
+### 处理 kubelet 重启   {#handling-kubelet-restarts}
 
 设备插件应能监测到 kubelet 重启，并且向新的 kubelet 实例来重新注册自己。
 在当前实现中，当 kubelet 重启的时候，新的 kubelet 实例会删除 `/var/lib/kubelet/device-plugins`
@@ -265,12 +271,12 @@ in the plugin's
 If you choose the DaemonSet approach you can rely on Kubernetes to: place the device plugin's
 Pod onto Nodes, to restart the daemon Pod after failure, and to help automate upgrades.
 -->
-## 设备插件部署
+## 设备插件部署   {#device-plugin-depoloyments}
 
 你可以将你的设备插件作为节点操作系统的软件包来部署、作为 DaemonSet 来部署或者手动部署。
 
-规范目录 `/var/lib/kubelet/device-plugins` 是需要特权访问的，所以设备插件
-必须要在被授权的安全的上下文中运行。
+规范目录 `/var/lib/kubelet/device-plugins` 是需要特权访问的，
+所以设备插件必须要在被授权的安全的上下文中运行。
 如果你将设备插件部署为 DaemonSet，`/var/lib/kubelet/device-plugins` 目录必须要在插件的
 [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core)
 中声明作为 {{< glossary_tooltip term_id="volume" >}} 被挂载到插件中。
@@ -292,7 +298,7 @@ a Kubernetes release with a newer device plugin API version, upgrade your device
 to support both versions before upgrading these nodes. Taking that approach will
 ensure the continuous functioning of the device allocations during the upgrade.
 -->
-## API 兼容性
+## API 兼容性   {#api-compatibility}
 
 Kubernetes 设备插件支持还处于 beta 版本。所以在稳定版本出来之前 API 会以不兼容的方式进行更改。
 作为一个项目，Kubernetes 建议设备插件开发者：
@@ -306,9 +312,12 @@ Kubernetes 设备插件支持还处于 beta 版本。所以在稳定版本出来
 
 <!--
 ## Monitoring Device Plugin Resources
+-->
+## 监控设备插件资源   {#monitoring-device-plugin-resources}
 
 {{< feature-state for_k8s_version="v1.15" state="beta" >}}
 
+<!--
 In order to monitor resources provided by device plugins, monitoring agents need to be able to
 discover the set of devices that are in-use on the node and obtain metadata to describe which
 container the metric should be associated with. [Prometheus](https://prometheus.io/) metrics
@@ -316,10 +325,6 @@ exposed by device monitoring agents should follow the
 [Kubernetes Instrumentation Guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/instrumentation.md),
 identifying containers using `pod`, `namespace`, and `container` prometheus labels.
 -->
-## 监控设备插件资源
-
-{{< feature-state for_k8s_version="v1.15" state="beta" >}}
-
 为了监控设备插件提供的资源，监控代理程序需要能够发现节点上正在使用的设备，
 并获取元数据来描述哪个指标与容器相关联。
 设备监控代理暴露给 [Prometheus](https://prometheus.io/) 的指标应该遵循
@@ -346,8 +351,7 @@ service PodResourcesLister {
 <!--
 The `List` endpoint provides information on resources of running pods, with details such as the
 id of exclusively allocated CPUs, device id as it was reported by device plugins and id of
-the NUMA node where these devices are allocated. Also, for NUMA-based machines, it contains
-the information about memory and hugepages reserved for a container.
+the NUMA node where these devices are allocated. Also, for NUMA-based machines, it contains the information about memory and hugepages reserved for a container.
 -->
 这一 `List` 端点提供运行中 Pod 的资源信息，包括类似独占式分配的
 CPU ID、设备插件所报告的设备 ID 以及这些设备分配所处的 NUMA 节点 ID。
@@ -399,8 +403,8 @@ message ContainerDevices {
 }
 ```
 
-<!--
 {{< note >}}
+<!--
 cpu_ids in the `ContainerResources` in the `List` endpoint correspond to exclusive CPUs allocated
 to a partilar container. If the goal is to evaluate CPUs that belong to the shared pool, the `List`
 endpoint needs to be used in conjunction with the `GetAllocatableResources` endpoint as explained
@@ -408,9 +412,7 @@ below:
 1. Call `GetAllocatableResources` to get a list of all the allocatable CPUs
 2. Call `GetCpuIds` on all `ContainerResources` in the system
 3. Subtract out all of the CPUs from the `GetCpuIds` calls from the `GetAllocatableResources` call
-{{< /note >}}
 -->
-{{< note >}}
 `List` 端点中的 `ContainerResources` 中的 cpu_ids 对应于分配给某个容器的专属 CPU。
 如果要统计共享池中的 CPU，`List` 端点需要与 `GetAllocatableResources` 端点一起使用，如下所述:
 
@@ -419,6 +421,9 @@ below:
 3. 用 `GetAllocatableResources` 获取的 CPU 数减去 `GetCpuIds` 获取的 CPU 数。
 {{< /note >}}
 
+<!--
+### `GetAllocatableResources` gRPC endpoint {#grpc-endpoint-getallocatableresources}
+-->
 ### `GetAllocatableResources` gRPC 端点 {#grpc-endpoint-getallocatableresources}
 
 {{< feature-state state="beta" for_k8s_version="v1.23" >}}
@@ -448,7 +453,6 @@ update and Kubelet needs to be restarted to reflect the correct resource capacit
 然而，调用 `GetAllocatableResources` 端点在 cpu、内存被更新的情况下是不够的，
 Kubelet 需要重新启动以获取正确的资源容量和可分配的资源。
 {{< /note >}}
-
 
 ```gRPC
 // AllocatableResourcesResponses 包含 kubelet 所了解到的所有设备的信息
@@ -505,8 +509,8 @@ gRPC 服务通过 `/var/lib/kubelet/pod-resources/kubelet.sock` 的 UNIX 套接�
 所以监控代理程序必须要在获得授权的安全的上下文中运行。
 如果设备监控代理以 DaemonSet 形式运行，必须要在插件的
 [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core)
-中声明将 `/var/lib/kubelet/pod-resources` 目录以
-{{< glossary_tooltip text="卷" term_id="volume" >}}的形式被挂载到设备监控代理中。
+中声明将 `/var/lib/kubelet/pod-resources`
+目录以{{< glossary_tooltip text="卷" term_id="volume" >}}的形式被挂载到设备监控代理中。
 
 对 “PodResourcesLister 服务”的支持要求启用 `KubeletPodResources`
 [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)。
@@ -514,21 +518,20 @@ gRPC 服务通过 `/var/lib/kubelet/pod-resources/kubelet.sock` 的 UNIX 套接�
 
 <!--
 ## Device plugin integration with the Topology Manager
+-->
+## 设备插件与拓扑管理器的集成   {#device-plugin-integration-with-the-topology-manager}
 
 {{< feature-state for_k8s_version="v1.18" state="beta" >}}
 
+<!--
 The Topology Manager is a Kubelet component that allows resources to be co-ordinated in a Topology aligned manner. In order to do this, the Device Plugin API was extended to include a `TopologyInfo` struct.
 -->
-## 设备插件与拓扑管理器的集成
-
-{{< feature-state for_k8s_version="v1.18" state="beta" >}}
-
 拓扑管理器是 Kubelet 的一个组件，它允许以拓扑对齐方式来调度资源。
 为了做到这一点，设备插件 API 进行了扩展来包括一个 `TopologyInfo` 结构体。
 
 ```gRPC
 message TopologyInfo {
- repeated NUMANode nodes = 1;
+    repeated NUMANode nodes = 1;
 }
 
 message NUMANode {
@@ -563,10 +566,14 @@ NUMA 节点列表表示设备插件没有该设备的 NUMA 亲和偏好。
 ```
 pluginapi.Device{ID: "25102017", Health: pluginapi.Healthy, Topology:&pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{&pluginapi.NUMANode{ID: 0,},}}}
 ```
-
 <!--
 ## Device plugin examples {#examples}
+-->
+## 设备插件示例 {#examples}
 
+{{% thirdparty-content %}}
+
+<!--
 Here are some examples of device plugin implementations:
 
 * The [AMD GPU device plugin](https://github.com/RadeonOpenCompute/k8s-device-plugin)
@@ -577,10 +584,8 @@ Here are some examples of device plugin implementations:
 * The [SocketCAN device plugin](https://github.com/collabora/k8s-socketcan)
 * The [Solarflare device plugin](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * The [SR-IOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
-* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin) for Xilinx FPGA devices
+* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-device-plugin) for Xilinx FPGA devices
 -->
-## 设备插件示例 {#examples}
-
 下面是一些设备插件实现的示例：
 
 * [AMD GPU 设备插件](https://github.com/RadeonOpenCompute/k8s-device-plugin)
@@ -591,7 +596,7 @@ Here are some examples of device plugin implementations:
 * [SocketCAN 设备插件](https://github.com/collabora/k8s-socketcan)
 * [Solarflare 设备插件](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * [SR-IOV 网络设备插件](https://github.com/intel/sriov-network-device-plugin)
-* [Xilinx FPGA 设备插件](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin)
+* [Xilinx FPGA 设备插件](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-device-plugin)
 
 ## {{% heading "whatsnext" %}}
 
@@ -601,7 +606,7 @@ Here are some examples of device plugin implementations:
 * Learn about the [Topology Manager](/docs/tasks/administer-cluster/topology-manager/)
 * Read about using [hardware acceleration for TLS ingress](/blog/2019/04/24/hardware-accelerated-ssl/tls-termination-in-ingress-controllers-using-kubernetes-device-plugins-and-runtimeclass/) with Kubernetes
 -->
-* 查看[调度 GPU 资源](/zh-cn/docs/tasks/manage-gpus/scheduling-gpus/) 来学习使用设备插件
+* 查看[调度 GPU 资源](/zh-cn/docs/tasks/manage-gpus/scheduling-gpus/)来学习使用设备插件
 * 查看在上如何[公布节点上的扩展资源](/zh-cn/docs/tasks/administer-cluster/extended-resource-node/)
 * 学习[拓扑管理器](/zh-cn/docs/tasks/administer-cluster/topology-manager/)
 * 阅读如何在 Kubernetes 中使用 [TLS Ingress 的硬件加速](/zh-cn/blog/2019/04/24/hardware-accelerated-ssl/tls-termination-in-ingress-controllers-using-kubernetes-device-plugins-and-runtimeclass/)


### PR DESCRIPTION
Sync with the en version.
```
content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
```
Preview: https://deploy-preview-37371--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/