### PR TITLE
Fix broken link on Submitting blog posts and case studies page

### DIFF
--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -91,7 +91,7 @@ To submit a blog post, follow these steps:
 - Blog posts should be relevant to Kubernetes users.
 
   - Topics related to participation in or results of Kubernetes SIGs activities are always on
-    topic (see the work in the [Upstream Marketing Team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/storytelling-resources/blog-guidelines.md#upstream-marketing-blog-guidelines)
+    topic (see the work in the [Contributor Comms Team](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/storytelling-resources/blog-guidelines.md#upstream-marketing-blog-guidelines)
     for support on these posts). 
   - The components of Kubernetes are purposely modular, so tools that use existing integration
     points like CNI and CSI are on topic. 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/37365

Updated page [Submitting blog posts and case studies](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/)

I was facing issues while committing so raised another PR.
old PR #37366 is closed.