### PR TITLE
Update echoserver image in "Hello Minikube" tutorial for multiarch

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -94,7 +94,7 @@ recommended way to manage the creation and scaling of Pods.
 Pod runs a Container based on the provided Docker image.
 
     ```shell
-    kubectl create deployment hello-node --image=registry.k8s.io/echoserver:1.4
+    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.39 -- /agnhost netexec --http-port=8080
     ```
 
 2. View the Deployment:


### PR DESCRIPTION
Should fixes https://github.com/kubernetes/website/issues/36732 and https://github.com/kubernetes/website/pull/37361.

Preview available [here](https://deploy-preview-37383--kubernetes-io-main-staging.netlify.app/docs/tutorials/hello-minikube/#create-a-deployment).

I took the liberty to open a new PR because the author of [the one we worked on](https://github.com/kubernetes/website/pull/36731) was not answering anymore.

The previous version of the image did not support arm64. This one supports amd64, arm, arm64, ppc64le, s390x on Linux, and amd64 on multiple Windows versions.

More information and context in this PR https://github.com/kubernetes/website/pull/36731 and the discussion that lead to this solution [available here](https://kubernetes.slack.com/archives/CCK68P2Q2/p1666183862561759).

It works on amd64, to test the image on different architectures you can do:
```bash
docker run -p 8080:8080 registry.k8s.io/e2e-test-images/agnhost:2.39 netexec --http-port=8080
curl localhost:8080
# do not do the following if you have anything else running on your computer with docker
# because it will stop and remove every container
docker stop $(docker ps -a -q)
docker rm $(docker ps -a -q)
```

~However, the curl step failed with a LUA panic when I curled on the ARM Linux of a colleague. I got "empty reply from the server" on the curl side and `PANIC: unprotected error in call to Lua API (bad light userdata pointer)` in the server logs. So maybe sig testing people can help us on that topic.
I'll just hold in the meantime because it requires more testing on an architecture I don't personally have.~

EDIT: changed to `agnhost` image, now it works.

/hold

Unrelated: note that the `minikube service hello-node` in the browser step of the tutorial does not work on my intel mac but if I `minikube ssh` and `curl` directly the service, it works.

/cc @sftim
/sig testing
