### PR TITLE
fix: Remove release_complete string since it's unused

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -286,15 +286,9 @@ other = "2006-01-02"
 [release_cherry_pick_deadline]
 other = "Cherry Pick Deadline"
 
-# Deprecated. Planned for removal in a future release.
-# Use [release_full_details_initial_text] instead.
-[release_complete]
-other = "Complete"
-
 [release_end_of_life_date]
 other = "End Of Life Date"
 
-# Replace [release_complete] with [release_full_details_initial_text]
 [release_full_details_initial_text]
 other = "Complete"
 


### PR DESCRIPTION
Removed `release_complete` string as discussed in https://github.com/kubernetes/website/issues/36839

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
