### PR TITLE
feat: Add caution note about rules field override

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -317,6 +317,12 @@ objects with an `aggregationRule` set. The `aggregationRule` defines a label
 uses to match other ClusterRole objects that should be combined into the `rules`
 field of this one.
 
+{{< caution >}}
+The control plane overwrites any values that you manually specify in the `rules` field of an
+aggregate ClusterRole. If you want to change or add rules, do so in the `ClusterRole` objects
+that are selected by the `aggregationRule`.
+{{< /caution >}}
+
 Here is an example aggregated ClusterRole:
 
 ```yaml


### PR DESCRIPTION
Added caution note Add caution note about rules field override in aggregated ClusterRoles. 
rel #34816 

The text that was proposed by @shannonxtreme perfectly fits as I guess. 

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
