### PR TITLE
Remove duplicate entry for SELinuxMountReadWriteOncePod

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -685,9 +685,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `RotateKubeletServerCertificate`: Enable the rotation of the server TLS certificate on the kubelet.
   See [kubelet configuration](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)
   for more details.
-- `SELinuxMountReadWriteOncePod`: Speed up container startup by mounting volumes with the correct
-  SELinux label instead of changing each file on the volumes recursively. The initial implementation
-  focused on ReadWriteOncePod volumes.
+- `SELinuxMountReadWriteOncePod`: Speeds up container startup by allowing kubelet to mount volumes
+  for a Pod directly with the correct SELinux label instead of changing each file on the volumes
+  recursively. The initial implementation focused on ReadWriteOncePod volumes.
 - `SeccompDefault`: Enables the use of `RuntimeDefault` as the default seccomp profile
   for all workloads.
   The seccomp profile is specified in the `securityContext` of a Pod and/or a Container.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -691,9 +691,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `SeccompDefault`: Enables the use of `RuntimeDefault` as the default seccomp profile
   for all workloads.
   The seccomp profile is specified in the `securityContext` of a Pod and/or a Container.
-- `SELinuxMountReadWriteOncePod`: Allows kubelet to mount volumes for a Pod directly with the
-  right SELinux label instead of applying the SELinux label recursively on every file on the
-  volume.
 - `ServerSideApply`: Enables the [Sever Side Apply (SSA)](/docs/reference/using-api/server-side-apply/)
   feature on the API Server.
 - `ServerSideFieldValidation`: Enables server-side field validation. This means the validation


### PR DESCRIPTION
In the `feature-gates.md` documentation there are 2 entries for SELinuxMountReadWriteOncePod. Although they have different descriptions, the most recent one seems to summarize the previous one.