### PR TITLE
Don't check Kubernetes version for using Service API

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -16,7 +16,7 @@ provides load balancing for an application that has two running instances.
 ## {{% heading "prerequisites" %}}
 
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
 
 


### PR DESCRIPTION
Split out from https://github.com/kubernetes/website/pull/30817

All supported Kubernetes versions let you access Services within your cluster, so there is no special need to check what version you're running.

Omit the check.