### PR TITLE
Fixes horizontal scroll on yaml code blocks

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -862,7 +862,6 @@ div.alert > em.javascript-required {
 // Consistent spacing for yaml code
 .language-yaml > span {
   height: 1.6em;
-  overflow: hidden;
 }
 
 .content__box


### PR DESCRIPTION
Removes `overflow: hidden` from markdown yaml code blocks to prevent the content from being cut off.

Resolves https://github.com/kubernetes/website/issues/37419

| Before      | After |
| ----------- | ----------- |
| ![before](https://user-images.githubusercontent.com/17005849/197350405-0f397acd-c7ad-401a-8a2d-a2fc3cee1555.png)      | ![after](https://user-images.githubusercontent.com/17005849/197350381-32e72b21-d7a3-4ae9-b80f-59aeaf71cb7b.gif)       |

The horizontal scroll behaviour was removed some days ago probably to adjust the right padding, that was being affected by the overflowing text...

But I believe that the overflowing text is a "feature" on this context, because we need to give the user a hint that this content is horizontally scrollable:

<img src="https://user-images.githubusercontent.com/17005849/197350916-fbb5e637-fe12-4197-b499-76d4b7475c79.gif" width="300">

In the example above, we can see that the scroll ignores tha padding right, just to give us a hint that the content is scrollable.

What you guys think?
