### PR TITLE
[id] Fix successfulJobsHistoryLimit and failedJobHistoryLimit fields in CronJob tasks

### DIFF
--- a/content/id/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/id/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -208,7 +208,7 @@ Ketika `.spec.suspend` diubah dari `true` ke `false` pada CronJob yang memiliki 
 
 ### Batas Riwayat Pekerjaan
 
-_Field_ `.spec.successfulJobHistoryLimit` dan `.spec.failedJobHistoryLimit` juga opsional.
+_Field_ `.spec.successfulJobsHistoryLimit` dan `.spec.failedJobsHistoryLimit` juga opsional.
 _Field_ tersebut menentukan berapa banyak Job yang sudah selesai dan gagal yang harus disimpan.
 Secara bawaan, masing-masing _field_ tersebut disetel 3 dan 1. Mensetel batas ke `0` untuk menjaga tidak ada Job yang sesuai setelah Job tersebut selesai.
 


### PR DESCRIPTION
successfulJobHistoryLimit and failedJobHistoryLimit should be successfulJobsHistoryLimit and failedJobsHistoryLimit

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
