### PR TITLE
31483: clarify monitoring language

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
@@ -57,10 +57,17 @@ respond to these metrics by  automatically scaling or adapting the cluster
 based on its current state, using mechanisms such as the Horizontal Pod
 Autoscaler. The monitoring pipeline fetches metrics from the kubelet and
 then exposes them to Kubernetes via an adapter by implementing either the
-`custom.metrics.k8s.io` or `external.metrics.k8s.io` API. 
+`custom.metrics.k8s.io` or `external.metrics.k8s.io` API.
 
-[Prometheus](https://prometheus.io), a CNCF project, can natively monitor Kubernetes, nodes, and Prometheus itself.
-Full metrics pipeline projects that are not part of the CNCF are outside the scope of Kubernetes documentation.  
+Integration of a full metrics pipeline into your Kubernetes implementation is outside
+the scope of Kubernetes documentation because of the very wide scope of possible
+solutions.
+
+The choice of monitoring platform depends heavily on your needs, budget, and technical resources.
+Kubernetes does not recommend any specific metrics pipeline; [many options](https://landscape.cncf.io/card-mode?category=monitoring&project=graduated,incubating,member,no&grouping=category&sort=stars) are available.
+Your monitoring system should be capable of handling the [OpenMetrics](https://openmetrics.io/) metrics
+transmission standard, and needs to chosen to best fit in to your overall design and deployment of
+your infrastructure platform.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
 - Original wording seemed to be tacitly encouraging Prometheus as the preferred monitoring solution, and was confusing to non-native speakers as written.
 - Remove direct references to Prometheus.
 - Emphasize that the Kubernetes docs are not in the business of telling you how to monitor Kubernetes.
 - Note that any monitoring should understand OpenMetrics.
 - Link to the CNCF landscape site, picking out the options for anyone who isn't sure what options they have
 - Note that the specific choice is part of the overall design of the infrastructure platform.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
