### PR TITLE
Add a use case, where job should be run only manually

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -91,6 +91,10 @@ For example, the line below states that the task must be started every Friday at
 
 To generate CronJob schedule expressions, you can also use web tools like [crontab.guru](https://crontab.guru/).
 
+In rear cases, when it is necessary to create a job, that should be triggered _only_ manually, and never - automatically, use 31st of February:
+
+`0 0 31 2 0`
+
 ## Time zones
 For CronJobs with no time zone specified, the kube-controller-manager interprets schedules relative to its local time zone.
 

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -91,7 +91,7 @@ For example, the line below states that the task must be started every Friday at
 
 To generate CronJob schedule expressions, you can also use web tools like [crontab.guru](https://crontab.guru/).
 
-In rear cases, when it is necessary to create a job, that should be triggered _only_ manually, and never - automatically, use 31st of February:
+In rare cases, when it is necessary to create a job, that should be triggered _only_ manually, and never - automatically, use 31st of February:
 
 `0 0 31 2 0`
 


### PR DESCRIPTION
Improving official documentation on a use case mentioned in https://stackoverflow.com/questions/57954002/schedule-cron-job-to-never-happen.
Use case example: a batch import of large amount of assets (e.g. images, videos).
A standard job will not work, as it runs at deployment, which in case of development environment can happen often.

