### PR TITLE
Add Nate Waddington as an approver for docs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -37,6 +37,7 @@ aliases:
     - kbhawkey
     - krol3
     - natalisucks
+    - nate-double-u
     - onlydole
     - reylejano
     - sftim


### PR DESCRIPTION
As Nate is a blog approver and will now be doing PR Wrangling, he needs to be added to our approver list to unlock this work.

Congratulations, Nate! 🎉 

@reylejano @sftim @divya-mohan0209 