### PR TITLE
KubeCon Docs Sprint: Update Weights for reference/k8s-api/cluster-res…

### DIFF
--- a/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "APIService represents a server for a particular GroupVersion."
 title: "APIService"
-weight: 4
+weight: 40
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/binding-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "Binding ties one object to another; for example, a pod is bound to a node by a scheduler."
 title: "Binding"
-weight: 9
+weight: 90
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/cluster-cidr-v1alpha1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/cluster-cidr-v1alpha1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager)."
 title: "ClusterCIDR v1alpha1"
-weight: 11
+weight: 110
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/component-status-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/component-status-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "ComponentStatus (and ComponentStatusList) holds the cluster validation info."
 title: "ComponentStatus"
-weight: 10
+weight: 100
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/event-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/event-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "Event is a report of an event somewhere in the cluster."
 title: "Event"
-weight: 3
+weight: 30
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/flow-schema-v1beta2.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/flow-schema-v1beta2.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "FlowSchema defines the schema of a group of flows."
 title: "FlowSchema v1beta2"
-weight: 7
+weight: 70
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "Lease defines a lease concept."
 title: "Lease"
-weight: 5
+weight: 50
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "Namespace provides a scope for Names."
 title: "Namespace"
-weight: 2
+weight: 20
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "Node is a worker node in Kubernetes."
 title: "Node"
-weight: 1
+weight: 10
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/priority-level-configuration-v1beta2.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/priority-level-configuration-v1beta2.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "PriorityLevelConfiguration represents the configuration of a priority level."
 title: "PriorityLevelConfiguration v1beta2"
-weight: 8
+weight: 80
 auto_generated: true
 ---
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "RuntimeClass defines a class of container runtime supported in the cluster."
 title: "RuntimeClass"
-weight: 6
+weight: 60
 auto_generated: true
 ---
 


### PR DESCRIPTION
This PR updates the weights to be spaced by 10 in case of added pages in the future.

Note: This PR changes auto-generated pages, we will also be updating the generator to weight pages by 10s here: https://github.com/kubernetes/website/issues/37486
Related # https://github.com/kubernetes/website/issues/35093