### PR TITLE
Add the "cancelled" reason for rejection in docs

### DIFF
--- a/content/en/docs/concepts/cluster-administration/flow-control.md
+++ b/content/en/docs/concepts/cluster-administration/flow-control.md
@@ -450,7 +450,7 @@ poorly-behaved workloads that may be harming system health.
     queue excess requests, or
   * `time-out`, indicating that the request was still in the queue
     when its queuing time limit expired.
-  * `cancelled`, indicating that the request it is not purge locked
+  * `cancelled`, indicating that the request is not purge locked
     and has been ejected from the queue.
 
 * `apiserver_flowcontrol_dispatched_requests_total` is a counter

--- a/content/en/docs/concepts/cluster-administration/flow-control.md
+++ b/content/en/docs/concepts/cluster-administration/flow-control.md
@@ -450,6 +450,8 @@ poorly-behaved workloads that may be harming system health.
     queue excess requests, or
   * `time-out`, indicating that the request was still in the queue
     when its queuing time limit expired.
+  * `cancelled`, indicating that the request it is not purge locked
+    and has been ejected from the queue.
 
 * `apiserver_flowcontrol_dispatched_requests_total` is a counter
   vector (cumulative since server start) of requests that began


### PR DESCRIPTION
In the "API Priority and Fairness" documentation, the "cancelled" reason for rejection is not documented. This PR adds this to the documentation.

Closes #36894