### PR TITLE
Add page weights to concepts -> security pages

### DIFF
--- a/content/en/docs/concepts/security/api-server-bypass-risks.md
+++ b/content/en/docs/concepts/security/api-server-bypass-risks.md
@@ -3,6 +3,7 @@ title: Kubernetes API Server Bypass Risks
 description: >
   Security architecture information relating to the API server and other components
 content_type: concept
+weight: 90
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/security/security-checklist.md
+++ b/content/en/docs/concepts/security/security-checklist.md
@@ -3,6 +3,7 @@ title: Security Checklist
 description: >
   Baseline checklist for ensuring security in Kubernetes clusters.
 content_type: concept
+weight: 100
 ---
 
 <!-- overview -->
@@ -12,6 +13,7 @@ comprehensive documentation on each topic. It does not claim to be exhaustive
 and is meant to evolve.
 
 On how to read and use this document:
+
 - The order of topics does not reflect an order of priority.
 - Some checklist items are detailed in the paragraph below the list of each section.
 


### PR DESCRIPTION
Adding page weights to two security pages that are missing them. This is done to help make the order more consistent when the docs are produced for different localizations, per [Issue #35093](https://github.com/kubernetes/website/issues/35093). 