### PR TITLE
KubeCon Docs Sprint: Update page weights for content/en/docs/concepts…

### DIFF
--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -5,7 +5,7 @@ reviewers:
 - thockin
 title: Connecting Applications with Services
 content_type: concept
-weight: 30
+weight: 40
 ---
 
 

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -4,7 +4,7 @@ reviewers:
 - thockin
 title: DNS for Services and Pods
 content_type: concept
-weight: 60
+weight: 80
 description: >-
   Your workload can discover Services within your cluster using DNS;
   this page explains how that works.

--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -14,7 +14,7 @@ reviewers:
   - khenidak
   - aramase
   - bridgetkromhout
-weight: 70
+weight: 90
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -3,7 +3,7 @@ reviewers:
 - freehan
 title: EndpointSlices
 content_type: concept
-weight: 45
+weight: 60
 description: >-
   The EndpointSlice API is the mechanism that Kubernetes uses to let your Service
   scale to handle large numbers of backends, and allows the cluster to update its

--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -6,7 +6,7 @@ description: >-
   You need to select at least one ingress controller and make sure it is set up in your cluster.  
   This page lists common ingress controllers that you can deploy.
 content_type: concept
-weight: 30
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -8,7 +8,7 @@ description: >-
   mechanism, that understands web concepts like URIs, hostnames, paths, and more.
   The Ingress concept lets you map traffic to different backends based on rules you define
   via the Kubernetes API.
-weight: 20
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -5,7 +5,7 @@ reviewers:
 - danwinship
 title: Network Policies
 content_type: concept
-weight: 50
+weight: 70
 description: >-
   If you want to control traffic flow at the IP address or port level (OSI layer 3 or 4),
   NetworkPolicies allow you to specify rules for traffic flow within your cluster, and

--- a/content/en/docs/concepts/services-networking/service-topology.md
+++ b/content/en/docs/concepts/services-networking/service-topology.md
@@ -4,7 +4,7 @@ reviewers:
 - imroc
 title: Topology-aware traffic routing with topology keys
 content_type: concept
-weight: 10
+weight: 20
 ---
 
 

--- a/content/en/docs/concepts/services-networking/service-traffic-policy.md
+++ b/content/en/docs/concepts/services-networking/service-traffic-policy.md
@@ -3,7 +3,7 @@ reviewers:
 - maplain
 title: Service Internal Traffic Policy
 content_type: concept
-weight: 75
+weight: 120
 description: >-
   If two Pods in your cluster want to communicate, and both Pods are actually running on
   the same node, use _Service Internal Traffic Policy_ to keep network traffic within that node.

--- a/content/en/docs/concepts/services-networking/topology-aware-hints.md
+++ b/content/en/docs/concepts/services-networking/topology-aware-hints.md
@@ -3,7 +3,7 @@ reviewers:
 - robscott
 title: Topology Aware Hints
 content_type: concept
-weight: 70
+weight: 100
 description: >-
   _Topology Aware Hints_ provides a mechanism to help keep network traffic within the zone
   where it originated. Preferring same-zone traffic between Pods in your cluster can help

--- a/content/en/docs/concepts/services-networking/windows-networking.md
+++ b/content/en/docs/concepts/services-networking/windows-networking.md
@@ -6,7 +6,7 @@ reviewers:
 - marosset
 title: Networking on Windows
 content_type: concept
-weight: 75
+weight: 110
 ---
 
 <!-- overview -->


### PR DESCRIPTION
contributes to https://github.com/kubernetes/website/issues/35093

Updates page weights in content/en/docs/concepts/services-networking

Before my changes:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/950759/197611326-217802c6-e818-4af0-8f1e-93396feb81b2.png">
After my changes:
<img width="260" alt="image" src="https://user-images.githubusercontent.com/950759/197611441-91376797-0486-45ae-8a17-9d3269e4e57e.png">
