### PR TITLE
Fix bullet alignment errors in localization.md

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -17,7 +17,6 @@ This page shows you how to
 [localize](https://blog.mozilla.org/l10n/2011/12/14/i18n-vs-l10n-whats-the-diff/)
 the docs for a different language.
 
-
 <!-- body -->
 
 ## Contribute to an existing localization
@@ -28,8 +27,10 @@ localization. There is also a general [SIG Docs Localizations Slack
 channel](https://kubernetes.slack.com/messages/sig-docs-localizations) where you
 can say hello.
 
-{{< note >}} For extra details on how to contribute to a specific localization,
-look for a localized version of this page. {{< /note >}}
+{{< note >}}
+For extra details on how to contribute to a specific localization,
+look for a localized version of this page.
+{{< /note >}}
 
 ### Find your two-letter language code
 
@@ -360,16 +361,18 @@ release to target, referred to as the _target version_ below.
 To find source files for your target version:
 
 1. Navigate to the Kubernetes website repository at
-https://github.com/kubernetes/website. 2. Select a branch for your target
-version from the following table:
+   https://github.com/kubernetes/website.
 
-   Target version | Branch
-   -----|-----
-   Latest version | [`main`](https://github.com/kubernetes/website/tree/main)
-   Previous version | [`release-{{< skew prevMinorVersion >}}`](https://github.com/kubernetes/website/tree/release-{{< skew prevMinorVersion >}})
-   Next version | [`dev-{{< skew nextMinorVersion >}}`](https://github.com/kubernetes/website/tree/dev-{{< skew nextMinorVersion >}})
+2. Select a branch for your target version from the following table:
 
-The `main` branch holds content for the current release `{{< latest-version >}}`. The release team creates a `{{< release-branch >}}` branch before the next
+Target version | Branch
+-----|-----
+Latest version | [`main`](https://github.com/kubernetes/website/tree/main)
+Previous version | [`release-{{< skew prevMinorVersion >}}`](https://github.com/kubernetes/website/tree/release-{{< skew prevMinorVersion >}})
+Next version | [`dev-{{< skew nextMinorVersion >}}`](https://github.com/kubernetes/website/tree/dev-{{< skew nextMinorVersion >}})
+
+The `main` branch holds content for the current release `{{< latest-version >}}`.
+The release team creates a `{{< release-branch >}}` branch before the next
 release: v{{< skew nextMinorVersion >}}.
 
 ### Site strings in i18n
@@ -450,8 +453,8 @@ To collaborate on a localization branch:
 
    For example, an approver on a German localization team opens the localization
    branch `dev-1.12-de.1` directly against the `kubernetes/website` repository,
-
    based on the source branch for Kubernetes v1.12.
+
 2. Individual contributors open feature branches based on the localization
    branch.
 


### PR DESCRIPTION
When syncing with this file
```
content/en/docs/contribute/localization.md
```
find the list and table are incorrectly aligned.

![image](https://user-images.githubusercontent.com/79828097/197779545-3816a523-a19d-41a3-a6b7-52ee98436df6.png)


Corrected preview: https://deploy-preview-37510--kubernetes-io-main-staging.netlify.app/docs/contribute/localization/