### PR TITLE
Updated `<node-to-drain>` to `<node-to-uncordon>` in kubeadm-upgrade

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -208,8 +208,8 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 - Bring the node back online by marking it schedulable:
 
   ```shell
-  # replace <node-to-drain> with the name of your node
-  kubectl uncordon <node-to-drain>
+  # replace <node-to-uncordon> with the name of your node
+  kubectl uncordon <node-to-uncordon>
   ```
 
 ## Upgrade worker nodes
@@ -289,8 +289,8 @@ without compromising the minimum required capacity for running your workloads.
 - Bring the node back online by marking it schedulable:
 
   ```shell
-  # replace <node-to-drain> with the name of your node
-  kubectl uncordon <node-to-drain>
+  # replace <node-to-uncordon> with the name of your node
+  kubectl uncordon <node-to-uncordon>
   ```
 
 ## Verify the status of the cluster


### PR DESCRIPTION
Fixes:- #37517 
Closes:- #37517

The command before 
```bash
# replace <node-to-drain> with the name of your node
kubectl uncordon <node-to-drain>
```
updated to 

```bash
# replace <node-to-uncordon> with the name of your node
kubectl uncordon <node-to-uncordon>
```
as it is already in drained state!