### PR TITLE
[zh] sync folder: /concepts/scheduling-eviction/

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/api-eviction.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/api-eviction.md
@@ -1,13 +1,13 @@
 ---
 title: API 发起的驱逐
 content_type: concept
-weight: 70
+weight: 110
 ---
 <!-- 
 ---
 title: API-initiated Eviction
 content_type: concept
-weight: 70
+weight: 110
 ---
 -->
 {{< glossary_definition term_id="api-eviction" length="short" >}} </br>

--- a/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -1,12 +1,12 @@
 ---
 title: 节点压力驱逐
 content_type: concept
-weight: 60
+weight: 100
 ---
 <!-- 
 title: Node-pressure Eviction
 content_type: concept
-weight: 60 
+weight: 100
 -->
 
 {{<glossary_definition term_id="node-pressure-eviction" length="short">}}</br>

--- a/content/zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -1,7 +1,7 @@
 ---
 title: Pod 优先级和抢占
 content_type: concept
-weight: 50
+weight: 90
 ---
 
 <!-- 
@@ -10,7 +10,7 @@ reviewers:
 - wojtek-t
 title: Pod Priority and Preemption
 content_type: concept
-weight: 50
+weight: 90
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -1,7 +1,7 @@
 ---
 title: 调度器性能调优
 content_type: concept
-weight: 100
+weight: 70
 ---
 <!--
 ---
@@ -9,7 +9,7 @@ reviewers:
 - bsalamat
 title: Scheduler Performance Tuning
 content_type: concept
-weight: 100
+weight: 70
 ---
 -->
 

--- a/content/zh-cn/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -1,7 +1,7 @@
 ---
 title: 调度框架
 content_type: concept
-weight: 90
+weight: 60
 ---
 
 <!--
@@ -10,7 +10,7 @@ reviewers:
 - ahg-g
 title: Scheduling Framework
 content_type: concept
-weight: 90
+weight: 60
 ---
 -->
 

--- a/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -1,9 +1,17 @@
 ---
 title: 污点和容忍度
 content_type: concept
-weight: 40
+weight: 50
 ---
-
+<!--
+reviewers:
+- davidopp
+- kevin-wangzefeng
+- bsalamat
+title: Taints and Tolerations
+content_type: concept
+weight: 50
+-->
 
 <!-- overview -->
 <!--

--- a/content/zh-cn/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -887,7 +887,8 @@ or more scattered.
 
 `podAffinity`
 : attracts Pods; you can try to pack any number of Pods into qualifying
-  topology domain(s)
+  topology domain(s).
+
 `podAntiAffinity`
 : repels Pods. If you set this to `requiredDuringSchedulingIgnoredDuringExecution` mode then
   only a single Pod can be scheduled into a single topology domain; if you choose
@@ -896,13 +897,17 @@ or more scattered.
 -->
 ## 比较 podAffinity 和 podAntiAffinity {#comparison-with-podaffinity-podantiaffinity}
 
-在 Kubernetes 中，Pod 间亲和性和反亲和性控制 Pod 彼此的调度方式（更密集或更分散）。
+在 Kubernetes 中，
+[Pod 间亲和性和反亲和性](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)控制
+Pod 彼此的调度方式（更密集或更分散）。
 
-对于 `podAffinity`：吸引 Pod；你可以尝试将任意数量的 Pod 集中到符合条件的拓扑域中。
+`podAffinity`
+: 吸引 Pod；你可以尝试将任意数量的 Pod 集中到符合条件的拓扑域中。
 
-对于 `podAntiAffinity`：驱逐 Pod。如果将此设为 `requiredDuringSchedulingIgnoredDuringExecution` 模式，
-则只有单个 Pod 可以调度到单个拓扑域；如果你选择 `preferredDuringSchedulingIgnoredDuringExecution`，
-则你将丢失强制执行此约束的能力。
+`podAntiAffinity`
+: 驱逐 Pod。如果将此设为 `requiredDuringSchedulingIgnoredDuringExecution` 模式，
+  则只有单个 Pod 可以调度到单个拓扑域；如果你选择 `preferredDuringSchedulingIgnoredDuringExecution`，
+  则你将丢失强制执行此约束的能力。
 
 <!--
 For finer control, you can specify topology spread constraints to distribute


### PR DESCRIPTION
- Sync with en #37511 
- Checked each file with `./scripts/lsync.sh` and cleared all differences in this folder

```
kube-scheduler.md:weight: 10
assign-pod-node.md:weight: 20
pod-overhead.md:weight: 30
topology-spread-constraints.md:weight: 40
taint-and-toleration.md:weight: 50
scheduling-framework.md:weight: 60
scheduler-perf-tuning.md:weight: 70
resource-bin-packing.md:weight: 80
pod-priority-preemption.md:weight: 90
node-pressure-eviction.md:weight: 100
api-eviction.md:weight: 110
```
Preview: https://deploy-preview-37526--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/scheduling-eviction/topology-spread-constraints/