### PR TITLE
For namespace walkthrough, switch example manifests to YAML

### DIFF
--- a/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -70,24 +70,24 @@ One pattern this organization could follow is to partition the Kubernetes cluste
 
 Let's create two new namespaces to hold our work.
 
-Use the file [`namespace-dev.json`](/examples/admin/namespace-dev.json) which describes a `development` namespace:
+Use the file [`namespace-dev.yaml`](/examples/admin/namespace-dev.yaml) which describes a `development` namespace:
 
-{{< codenew language="json" file="admin/namespace-dev.json" >}}
+{{< codenew language="yaml" file="admin/namespace-dev.yaml" >}}
 
 Create the `development` namespace using kubectl.
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/namespace-dev.json
+kubectl create -f https://k8s.io/examples/admin/namespace-dev.yaml
 ```
 
-Save the following contents into file [`namespace-prod.json`](/examples/admin/namespace-prod.json) which describes a `production` namespace:
+Save the following contents into file [`namespace-prod.yaml`](/examples/admin/namespace-prod.yaml) which describes a `production` namespace:
 
-{{< codenew language="json" file="admin/namespace-prod.json" >}}
+{{< codenew language="yaml" file="admin/namespace-prod.yaml" >}}
 
 And then let's create the `production` namespace using kubectl.
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/namespace-prod.json
+kubectl create -f https://k8s.io/examples/admin/namespace-prod.yaml
 ```
 
 To be sure things are right, let's list all of the namespaces in our cluster.

--- a/content/en/examples/admin/namespace-dev.yaml
+++ b/content/en/examples/admin/namespace-dev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: development
+  labels:
+    name: development

--- a/content/en/examples/admin/namespace-prod.yaml
+++ b/content/en/examples/admin/namespace-prod.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production
+  labels:
+    name: production


### PR DESCRIPTION
Signed-off-by: Bishal Das <bishalhnj127@gmail.com>

Fixes :- #37160

Closes:- #37160

`Json` manifest has changed into `yaml` manifest in namespace walkthrough

Filelink:- https://kubernetes.io/docs/tasks/administer-cluster/namespaces-walkthrough/#create-new-namespaces