### PR TITLE
[zh-cn] Fix bold format

### DIFF
--- a/content/zh-cn/docs/concepts/cluster-administration/_index.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/_index.md
@@ -76,7 +76,7 @@ Before choosing a guide, here are some considerations:
   作为代替，你可以建立多个集群。
 - **如果你在本地配置 Kubernetes**，
   需要考虑哪种[网络模型](/zh-cn/docs/concepts/cluster-administration/networking/)最适合。
-- 你的 Kubernetes 在**裸金属硬件**上还是**虚拟机（VM）**上运行？
+- 你的 Kubernetes 在**裸机**上还是**虚拟机（VM）** 上运行？
 - 你是想**运行一个集群**，还是打算**参与开发 Kubernetes 项目代码**？
   如果是后者，请选择一个处于开发状态的发行版。
   某些发行版只提供二进制发布版，但提供更多的选择。
@@ -93,7 +93,7 @@ Before choosing a guide, here are some considerations:
 
 * 学习如何[管理节点](/zh-cn/docs/concepts/architecture/nodes/)。
 
-* 学习如何设定和管理集群共享的[资源配额](/zh-cn/docs/concepts/policy/resource-quotas/) 。
+* 学习如何设定和管理集群共享的[资源配额](/zh-cn/docs/concepts/policy/resource-quotas/)。
 
 <!--
 ## Securing a cluster

--- a/content/zh-cn/docs/concepts/extend-kubernetes/_index.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/_index.md
@@ -192,7 +192,7 @@ and [CNI network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/n
 and by kubectl (see [Extend kubectl with plugins](/docs/tasks/extend-kubectl/kubectl-plugins/)).
 -->
 在 Webhook 模型中，Kubernetes 向远程服务发起网络请求。
-在另一种称作**可执行文件插件（Binary Plugin）**模型中，Kubernetes 执行某个可执行文件（程序）。
+在另一种称作**可执行文件插件（Binary Plugin）** 模型中，Kubernetes 执行某个可执行文件（程序）。
 这些可执行文件插件由 kubelet（例如，[CSI 存储插件](https://kubernetes-csi.github.io/docs/)和
 [CNI 网络插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)）
 和 kubectl 使用。
@@ -239,7 +239,7 @@ clients that access it.
    基于其内容阻止请求、编辑请求内容、处理删除操作等等。
    这些扩展点在 [API 访问扩展](#api-access-extensions)节详述。
 
-3. API 服务器能提供各种类型的**资源（Resources）**服务。
+3. API 服务器能提供各种类型的**资源（Resources）** 服务。
    诸如 `pods` 的**内置资源类型**是由 Kubernetes 项目所定义的，无法改变。
    请查阅 [API 扩展](#api-extensions)了解如何扩展 Kubernetes API。
 
@@ -297,7 +297,7 @@ several types of extensions.
 
 <!-- image source for flowchart: https://docs.google.com/drawings/d/1sdviU6lDz4BpnzJNHfNpQrqI9F19QZ07KnhnxVrp2yg/edit -->
 {{< figure src="/zh-cn/docs/concepts/extend-kubernetes/flowchart.png"
-    alt="附带使用场景问题和实现指南的流程图。 绿圈表示是； 红圈表示否。"
+    alt="附带使用场景问题和实现指南的流程图。绿圈表示是；红圈表示否。"
     class="diagram-large" caption="选择一个扩展方式的流程图指导" >}}
 
 ---

--- a/content/zh-cn/docs/concepts/services-networking/topology-aware-hints.md
+++ b/content/zh-cn/docs/concepts/services-networking/topology-aware-hints.md
@@ -3,7 +3,7 @@ title: 拓扑感知提示
 content_type: concept
 weight: 70
 description: >-
-  **拓扑感知提示（Topology Aware Hints）**提供了一种机制来帮助将网络流量保持在其请求方所在的区域内。
+  **拓扑感知提示（Topology Aware Hints）** 提供了一种机制来帮助将网络流量保持在其请求方所在的区域内。
   在集群中的 Pod 之间优先选用相同区域的流量有助于提高可靠性、增强性能（网络延迟和吞吐量）或降低成本。
 ---
 <!--
@@ -25,14 +25,14 @@ description: >-
 <!-- 
 _Topology Aware Hints_ enable topology aware routing by including suggestions
 for how clients should consume endpoints. This approach adds metadata to enable
-consumers of EndpointSlice and / or Endpoints objects, so that traffic to
+consumers of EndpointSlice (or Endpoints) objects, so that traffic to
 those network endpoints can be routed closer to where it originated.
 
 For example, you can route traffic within a locality to reduce
 costs, or to improve network performance.
 -->
 **拓扑感知提示**包含客户怎么使用服务端点的建议，从而实现了拓扑感知的路由功能。
-这种方法添加了元数据，以启用 EndpointSlice 和/或 Endpoints 对象的调用者，
+这种方法添加了元数据，以启用 EndpointSlice（或 Endpoints）对象的调用者，
 这样，访问这些网络端点的请求流量就可以在它的发起点附近就近路由。
 
 例如，你可以在一个地域内路由流量，以降低通信成本，或提高网络性能。
@@ -284,5 +284,4 @@ Kubernetes 控制平面和每个节点上的 kube-proxy，在使用拓扑感知�
 <!-- 
 * Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
 -->
-
 * 参阅[通过服务连通应用](/zh-cn/docs/concepts/services-networking/connect-applications-service/)

--- a/content/zh-cn/docs/concepts/workloads/pods/_index.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/_index.md
@@ -331,7 +331,7 @@ PodTemplates are specifications for creating Pods, and are included in workload 
 ### Pod 模板    {#pod-templates}
 
 {{< glossary_tooltip text="工作负载" term_id="workload" >}}资源的控制器通常使用
-**Pod 模板（Pod Template）**来替你创建 Pod 并管理它们。
+**Pod 模板（Pod Template）** 来替你创建 Pod 并管理它们。
 
 Pod 模板是包含在工作负载对象中的规范，用来创建 Pod。这类负载资源包括
 [Deployment](/zh-cn/docs/concepts/workloads/controllers/deployment/)、
@@ -457,7 +457,7 @@ Kubernetes 并不禁止你直接管理 Pod。对运行中的 Pod 的某些字段
 - Pod 更新不可以改变除 `spec.containers[*].image`、`spec.initContainers[*].image`、
   `spec.activeDeadlineSeconds` 或 `spec.tolerations` 之外的字段。
   对于 `spec.tolerations`，你只被允许添加新的条目到其中。
-- 在更新`spec.activeDeadlineSeconds` 字段时，以下两种更新操作是被允许的：
+- 在更新 `spec.activeDeadlineSeconds` 字段时，以下两种更新操作是被允许的：
 
   1. 如果该字段尚未设置，可以将其设置为一个正数；
   1. 如果该字段已经设置为一个正数，可以将其设置为一个更小的、非负的整数。
@@ -569,7 +569,7 @@ Pods, the kubelet directly supervises each static Pod (and restarts it if it fai
 -->
 ## 静态 Pod    {#static-pods}
 
-**静态 Pod（Static Pod）**直接由特定节点上的 `kubelet` 守护进程管理，
+**静态 Pod（Static Pod）** 直接由特定节点上的 `kubelet` 守护进程管理，
 不需要 {{< glossary_tooltip text="API 服务器" term_id="kube-apiserver" >}}看到它们。
 尽管大多数 Pod 都是通过控制面（例如，{{< glossary_tooltip text="Deployment" term_id="deployment" >}}）
 来管理的，对于静态 Pod 而言，`kubelet` 直接监控每个 Pod，并在其失效时重启之。

--- a/content/zh-cn/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -162,7 +162,7 @@ The deploy wizard expects that you provide the following information:
 <!--
 - **App name** (mandatory): Name for your application. A [label](/docs/concepts/overview/working-with-objects/labels/) with the name will be added to the Deployment and Service, if any, that will be deployed.
 -->
-- **应用名称**（必填）：应用的名称。内容为`应用名称`的
+- **应用名称**（必填）：应用的名称。内容为 `应用名称` 的
   [标签](/zh-cn/docs/concepts/overview/working-with-objects/labels/)
   会被添加到任何将被部署的 Deployment 和 Service。
 
@@ -196,7 +196,7 @@ The deploy wizard expects that you provide the following information:
 - **Service** (optional): For some parts of your application (e.g. frontends) you may want to expose a [Service](/docs/concepts/services-networking/service/) onto an external, maybe public IP address outside of your cluster (external Service).
  -->
 - **服务**（可选）：对于部分应用（比如前端），你可能想对外暴露一个
-  [Service](/zh-cn/docs/concepts/services-networking/service/) ，这个 Service
+  [Service](/zh-cn/docs/concepts/services-networking/service/)，这个 Service
   可能用的是集群之外的公网 IP 地址（外部 Service）。
 
   <!-- 
@@ -312,7 +312,7 @@ If needed, you can expand the **Advanced options** section where you can specify
 <!--
 - **CPU requirement (cores)** and **Memory requirement (MiB)**: You can specify the minimum [resource limits](/docs/tasks/configure-pod-container/limit-range/) for the container. By default, Pods run with unbounded CPU and memory limits.
  -->
-- **CPU 需求（核数）**和**内存需求（MiB）**：你可以为容器定义最小的
+- **CPU 需求（核数）** 和 **内存需求（MiB）**：你可以为容器定义最小的
   [资源限制](/zh-cn/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)。
   默认情况下，Pod 没有 CPU 和内存限制。
 
@@ -393,7 +393,7 @@ allocated resources, events and pods running on the node.
 -->
 #### 管理概述
 
-集群和名字空间管理的视图, Dashboard 会列出节点、名字空间和持久卷，并且有它们的详细视图。
+集群和名字空间管理的视图，Dashboard 会列出节点、名字空间和持久卷，并且有它们的详细视图。
 节点列表视图包含从所有节点聚合的 CPU 和内存使用的度量值。
 详细信息视图显示了一个节点的度量值，它的规格、状态、分配的资源、事件和这个节点上运行的 Pod。
 


### PR DESCRIPTION
In this Markdown parser, the format `中文**字串（English）**中文` will not parsed as bold.

In `web-ui-dashboard.md`, `**CPU 需求（核数）**和**内存需求（MiB）**` is parsed as `<b>CPU 需求（核數）<b>和</b>記憶體需求（MiB）</b>`.