### PR TITLE
Add a blog post about Kluctl and its use of SSA

### DIFF
--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -80,7 +80,7 @@ which was still in beta at that time. Experimenting with it via
 SSA can not be easily leveraged by shelling out to `kubectl`.
 
 The way SSA is implemented in `kubectl` does not allow enough
-control about conflict resolution as it can only switch between 
+control over conflict resolution as it can only switch between
 "not force-applying anything and erroring out" and "force-applying everything
 without showing any mercy!".
 
@@ -109,7 +109,7 @@ that Kluctl wants to perform a SSA operation. The API server then
 responds with an OK response (HTTP status code 200), or with a Conflict response
 (HTTP status 409).
 
-In case of a Conflict response, the body of that response includes machine readable
+In case of a Conflict response, the body of that response includes machine-readable
 details about the conflicts. Kluctl can then use these details to figure out
 which fields are in conflict and which actors (field managers) have taken
 ownership of the conflicted fields.
@@ -131,9 +131,14 @@ Kluctl has a few simple rules to figure out if a conflict should be ignored
 or force-applied.
 
 It first checks the field's actor (the field manager) against a list of known
-tools that are frequently used to perform manual modifications. These
+field manager strings from tools that are frequently used to perform manual modifications. These
 are for example `kubectl` and `k9s`. Any modifications performed with these tools
 are considered "temporary" and will be overwritten by Kluctl.
+
+If you're using Kluctl along with `kubectl` where you don't want the changes from
+`kubectl` to be overwritten (for example, using in a script) then you can specify
+`--field-manager=<manager-name>` on the command line to `kubectl`, and Kluctl
+doesn't apply its special heuristic.
 
 If the field manager is not known by Kluctl, it will check if force-applying is
 requested for that field. Force-applying can be requested in different ways:
@@ -174,15 +179,15 @@ Server-side apply is a great feature and essential for the future of
 controllers and tools in Kubernetes. The amount of controllers involved
 will only get more and proper modes of working together are a must.
 
-I believe that CI/CD related controllers and tools should leverage
+I believe that CI/CD-related controllers and tools should leverage
 SSA to perform proper conflict resolution. I also believe that
 other controllers (e.g. Flux and ArgoCD) would benefit from the same kind
 of conflict resolution control on field-level.
 
 It might even be a good idea to come together and work on a standardized
-set of annotations to control conflict resolution for CI/CD related tooling.
+set of annotations to control conflict resolution for CI/CD-related tooling.
 
-On the other side, non CI/CD related controllers should ensure that they don't
+On the other side, non CI/CD-related controllers should ensure that they don't
 cause unnecessary conflicts when modifying objects. As of
 [the server-side apply documentation](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller),
 it is strongly recommended for controllers to always perform force-applying. When

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -124,7 +124,7 @@ the user can properly react (or ignore it forever...).
 That's basically it. That is all that is required to leverage server-side apply.
 Big thanks and thumbs-up to the Kubernetes developers who made this possible!
 
-## Deciding which conflicts to ignore and which to force-apply
+## Conflict Resolution
 
 Kluctl has a few simple rules to figure out if a conflict should be ignored
 or force-applied.
@@ -146,16 +146,9 @@ known to erroneously claim fields (the ECK operator does this to the nodeSets
 field for example), you can ensure that Kluctl always overwrites these fields
 to the original or a new value.
 
-## Future work in regard to conflict resolution
-
-I plan to add more ways to control the behaviour of conflict resolution. For
-example:
-
-1. It will be possible to force-apply on field level via the CLI.
-2. It will be possible to force-apply on field level but only for specific field managers.
-3. It will be possible to modify the list of known actors for which fields are always force-applied.
-4. Exclude fields from force-apply even if the field manager is in the list of well known tools.
-5. If more is needed, you can [open an issue](https://github.com/kluctl/kluctl/issues).
+In the future, Kluctl will allow even more control about conflict resolution.
+For example, the CLI will allow to force-apply on field level or specify which
+field manager to always ignore or always force-apply.
 
 ## DevOps vs Controllers
 

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -51,7 +51,7 @@ thing at that time.
 
 The way client-side apply worked had some serious drawbacks. The most obvious one
 (it was guaranteed that you'd stumble on this by yourself if enough time passed)
-is that it relied on an annotation (kubectl.kubernetes.io/last-applied-configuration)
+is that it relied on an annotation (`kubectl.kubernetes.io/last-applied-configuration`)
 being added to the object, bringing in all the limitations and issues with huge
 annotation values. A good example of such issues are
 [CRDs being so large](https://github.com/prometheus-operator/prometheus-operator/issues/4439),
@@ -157,20 +157,20 @@ example:
 4. Exclude fields from force-apply even if the field manager is in the list of well known tools.
 5. If more is needed, you can [open an issue](https://github.com/kluctl/kluctl/issues).
 
-## DevOps vs. PipelineOps vs. GitOps vs. Controllers
+## DevOps vs Controllers
 
 So how does server-side apply in Kluctl lead to "live and let live"?
 
-It allows the co-existence of classical DevOps, PipelineOps, GitOps and
-controllers. You can use a GitOps style deployment pipeline (check 
-[flux-kluctl-controller](https://github.com/kluctl/flux-kluctl-controller))
-while having the proper tools (e.g. conflict resolution via annotations) to
-act on expected or unexpected modifications to your objects from other
-actors. The same applies to classical pipeline based deployments
-(e.g. Github Actions or Gitlab CI).
+It allows the co-existence of classical pipelines (e.g. Github Actions or
+Gitlab CI), controllers (e.g. the HPA controller or GitOps style controllers)
+and even admins running deployments from their local machines.
 
-You can intervene with your admin permissions if required and run a `kubectl`
-command that will modify a field and prevent Kluctl from overwriting it. You'd
-just have to switch to a field-manager (e.g. "admin-override") that is not
-overwritten by Kluctl.
+Wherever you are on your infrastructure automation journey, Kluctl has a place
+for you. From running deployments using a script on your PC, all the way to
+fully automated CI/CD with the pipelines themselves defined in code, Kluctl
+aims to complement the workflow that's right for you.
 
+And even after fully automating everything, you can intervene with your admin
+permissions if required and run a `kubectl` command that will modify a field
+and prevent Kluctl from overwriting it. You'd just have to switch to a
+field-manager (e.g. "admin-override") that is not overwritten by Kluctl.

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -11,7 +11,7 @@ This blog post was inspired by a previous Kubernetes blog post about
 [Advanced Server Side Apply](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/).
 The author of this blog post listed multiple benefits for applications and
 controllers when switching to Server-side apply. Especially the chapter about
-[CI/CD systems {#ci-cd-systems}](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/#cicd-systems-ci-cd-systems)
+[CI/CD systems](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/#ci-cd-systems)
 motivated me to respond and write down my thoughts and experiences.
 
 These thoughts and experiences are the results of me working on [Kluctl](https://kluctl.io)

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -141,6 +141,11 @@ requested for that field. A force-apply can be requested in different ways:
 2. By adding the [`kluctl.io/force-apply=true`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply) annotation to the object in question. This will cause all fields of that object to be force-applied on conflicts.
 3. By adding the [`kluctl.io/force-apply-field=my.json.path`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply-field) annotation to the object in question. This cause only fields matching the JSON path to be force-applied on conflicts.
 
+Marking a field to be force-applied is required whenever some other actor is
+known to erroneously claim fields (the ECK operator does this to the nodeSets
+field for example), you can ensure that Kluctl always overwrites these fields
+to the original or a new value.
+
 ## Future work in regard to conflict resolution
 
 I plan to add more ways to control the behaviour of conflict resolution. For
@@ -169,6 +174,3 @@ command that will modify a field and prevent Kluctl from overwriting it. You'd
 just have to switch to a field-manager (e.g. "admin-override") that is not
 overwritten by Kluctl.
 
-If a controller is known to erroneously claim fields (the ECK operator does this
-to the nodeSets field for example), you can ensure that Kluctl always overwrites
-these fields to the original or a new value.

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -44,7 +44,7 @@ decisions.
 
 ## The days before Server-side apply
 
-The first versions of Kluctl were based on shelling out to kubectl and thus
+The first versions of Kluctl were based on shelling out to `kubectl` and thus
 implicitly relied on client-side apply. At that time, Server-side apply was
 still alpha and quite buggy. And to be honest, I didn't even know it was a
 thing at that time.
@@ -59,10 +59,10 @@ that they don't fit into the annotation's value anymore.
 
 Another drawback can be seen just by looking at the name (**client**-side apply).
 Being **client** side means that each client has to provide the apply-logic on
-its own, which at that time was only properly implemented inside kubectl,
+its own, which at that time was only properly implemented inside `kubectl`,
 making it hard to be replicated inside controllers.
 
-This added kubectl as a dependency (either as an executable or in the form of
+This added `kubectl` as a dependency (either as an executable or in the form of
 Go packages) to all controllers that wanted to leverage the apply-logic.
 
 However, even if one managed to get client-side apply running from inside a
@@ -78,19 +78,19 @@ which was still in beta at that time. Experimenting with it via
 `kubectl apply --server-side` revealed immediately that the true power of
 server-side apply can not be easily leveraged by shelling out to `kubectl`.
 
-The way Server-side apply is implemented in kubectl does not allow enough
+The way server-side apply is implemented in `kubectl` does not allow enough
 control about conflict resolution as it can only switch between 
 "not force-applying anything and erroring out" and "force-apply everything
 without showing any mercy!".
 
-The API documentation however made it clear that Server-side apply is able to
+The API documentation however made it clear that server-side apply is able to
 control conflict resolution on field level, simply by choosing which fields
 to include and which fields to omit from the supplied object.
 
 ## Moving away from kubectl
 
-This meant that Kluctl had to move away from shelling out to kubectl first. Only
-after that was done, I would have been able to properly implement Server-side
+This meant that Kluctl had to move away from shelling out to `kubectl` first. Only
+after that was done, I would have been able to properly implement server-side
 apply with powerful conflict resolution.
 
 To achieve this, I first implemented access to the target clusters via a
@@ -99,9 +99,9 @@ speeding up Kluctl as well. It also improved the security and usability of
 Kluctl by ensuring that a running Kluctl command could not be messed around
 with by externally modifying the kubeconfig while it was running.
 
-## Implementing Server-side apply
+## Implementing server-side apply
 
-After switching to a Kubernetes client library, leveraging Server-side apply
+After switching to a Kubernetes client library, leveraging server-side apply
 felt easy. Kluctl now has to send each manifest to the API server as part of a
 `PATCH` request, which signals
 that Kluctl wants to perform a server-side apply operation. The API server then
@@ -121,7 +121,7 @@ flag being set on the API call.
 In case a conflict is ignored, Kluctl will issue a warning to the user so that
 the user can properly react (or ignore it forever...).
 
-That's basically it. That is all that is required to leverage Server-side apply.
+That's basically it. That is all that is required to leverage server-side apply.
 Big thanks and thumbs-up to the Kubernetes developers who made this possible!
 
 ## Deciding which conflicts to ignore and which to force-apply
@@ -131,7 +131,7 @@ or force-applied.
 
 It first checks the field's actor (the field manager) against a list of known
 tools that are well known to be used to perform manual modifications. These
-are for example kubectl and k9s. Any modifications performed with these tools
+are for example `kubectl` and `k9s`. Any modifications performed with these tools
 are considered "temporary" and will be overwritten by Kluctl.
 
 If the field manager is not known by Kluctl, it will check if a force-apply is
@@ -154,7 +154,7 @@ example:
 
 ## DevOps vs. PipelineOps vs. GitOps vs. Controllers
 
-So how does Server-side apply in Kluctl lead to "live and let live"?
+So how does server-side apply in Kluctl lead to "live and let live"?
 
 It allows the co-existence of classical DevOps, PipelineOps, GitOps and
 controllers. You can use a GitOps style deployment pipeline (check 
@@ -164,7 +164,7 @@ act on expected or unexpected modifications to your objects from other
 actors. The same applies to classical pipeline based deployments
 (e.g. Github Actions or Gitlab CI).
 
-You can intervene with your admin permissions if required and run a kubectl
+You can intervene with your admin permissions if required and run a `kubectl`
 command that will modify a field and prevent Kluctl from overwriting it. You'd
 just have to switch to a field-manager (e.g. "admin-override") that is not
 overwritten by Kluctl.

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -1,0 +1,172 @@
+---
+layout: blog
+title: "Live and let live with Kluctl and Server Side Apply"
+date: 2022-10-27
+slug: live-and-let-live-with-kluctl-and-ssa
+---
+
+**Author:** Alexander Block (@codablock)
+
+This blog post was inspired by a previous Kubernetes blog post about
+[Advanced Server Side Apply](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/).
+The author of this blog post listed multiple benefits for applications and
+controllers when switching to Server-side apply. Especially the chapter about
+[CI/CD systems {#ci-cd-systems}](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/#cicd-systems-ci-cd-systems)
+motivated me to respond and write down my thoughts and experiences.
+
+These thoughts and experiences are the results of me working on [Kluctl](https://kluctl.io)
+for the past 2 years. I describe Kluctl as "The missing glue to put together
+large Kubernetes deployments, composed of multiple smaller parts
+(Helm/Kustomize/...) in a manageable and unified way."
+
+To get a basic understanding of Kluctl, I suggest to visit the [kluctl.io](https://kluctlio)
+website and read through the documentation and tutorials, for example the 
+[microservices demo tutorial](https://kluctl.io/docs/guides/tutorials/microservices-demo/).
+As an alternative, you can watch [this video](https://www.youtube.com/watch?v=9LoYLjDjOdg)
+from the Rawkode Academy YouTube channel which shows a hands-on demo session.
+
+There is also a [Kluctl delivery scenario](https://github.com/podtato-head/podtato-head/tree/main/delivery/kluctl)
+available in the [podtato-head](https://github.com/podtato-head/podtato-head) demo project.
+
+## Live and let live
+
+One of the main philosophies that Kluctl follows is ["live and let live"](https://kluctl.io/docs/philosophy/#live-and-let-live),
+meaning that it will try its best to work in conjunction with any other tool or
+controller running outside or inside your clusters. Kluctl will not overwrite
+any fields that it lost ownership of, unless you explicitly tell it to do so.
+
+Achieving this would not have been possible (or at least be several magnitudes
+harder) without the use of Server-side apply. Server-side apply allows Kluctl
+to detect when ownership for a field got lost, for example when another controller
+or operator updates that field to another value. Kluctl can then decide on a 
+field-by-field basis if a force-apply is required and then retry based on these
+decisions.
+
+## The days before Server-side apply
+
+The first versions of Kluctl were based on shelling out to kubectl and thus
+implicitly relied on client-side apply. At that time, Server-side apply was
+still alpha and quite buggy. And to be honest, I didn't even know it was a
+thing at that time.
+
+The way client-side apply worked had some serious drawbacks. The most obvious one
+(it was guaranteed that you'd stumble on this by yourself if enough time passed)
+is that it relied on an annotation (kubectl.kubernetes.io/last-applied-configuration)
+being added to the object, bringing in all the limitations and issues with huge
+annotation values. A good example of such issues are
+[CRDs being so large](https://github.com/prometheus-operator/prometheus-operator/issues/4439),
+that they don't fit into the annotation's value anymore.
+
+Another drawback can be seen just by looking at the name (**client**-side apply).
+Being **client** side means that each client has to provide the apply-logic on
+its own, which at that time was only properly implemented inside kubectl,
+making it hard to be replicated inside controllers.
+
+This added kubectl as a dependency (either as an executable or in the form of
+Go packages) to all controllers that wanted to leverage the apply-logic.
+
+However, even if one managed to get client-side apply running from inside a
+controller, you ended up with a solution that gave no control about how it
+worked internally. As an example, there was no way to individually decide which
+fields to overwrite in case of external changes and which ones to let go. 
+
+## Discovering Server-side apply
+
+I was never happy with the solution described above and then somehow stumbled
+across [Server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/),
+which was still in beta at that time. Experimenting with it via
+`kubectl apply --server-side` revealed immediately that the true power of
+Server-side apply can not be easily leveraged by shelling out to kubectl.
+
+The way Server-side apply is implemented in kubectl does not allow enough
+control about conflict resolution as it can only switch between 
+"not force-applying anything and erroring out" and "force-apply everything
+without showing any mercy!".
+
+The API documentation however made it clear that Server-side apply is able to
+control conflict resolution on field level, simply by choosing which fields
+to include and which fields to omit from the supplied object.
+
+## Moving away from kubectl
+
+This meant that Kluctl had to move away from shelling out to kubectl first. Only
+after that was done, I would have been able to properly implement Server-side
+apply with powerful conflict resolution.
+
+To achieve this, I first implemented access to the target clusters via a
+Kubernetes client library. This had the nice side effect of dramatically
+speeding up Kluctl as well. It also improved the security and usability of
+Kluctl by ensuring that a running Kluctl command could not be messed around
+with by externally modifying the kubeconfig while it was running.
+
+## Implementing Server-side apply
+
+After switching to a Kubernetes client library, leveraging Server-side apply
+was easy. Kluctl just has to send each manifest to the apiserver and indicate
+that it wants to perform a Server-side apply operation. The apiserver will then
+either respond with an OK response or with a CONFLICT response.
+
+In case of a CONFLICT response, the apiserver also sends a status object with
+details about the conflicts. Kluctl can then use these details to figure out
+which fields are in conflict and which actors (field managers) have taken
+ownership of the conflicted fields.
+
+Then, for each field, Kluctl will decide if the conflict should be ignored or
+if it should be force-applied. If any field needs to be force-applied, Kluctl
+will retry the apply operation with the ignored fields omitted and the `force`
+flag being set on the API call.
+
+In case a conflict is ignored, Kluctl will issue a warning to the user so that
+the user can properly react (or ignore it forever...).
+
+That's basically it. That is all that is required to leverage Server-side apply.
+Big thanks and thumbs-up to the Kubernetes developers who made this possible!
+
+## Deciding which conflicts to ignore and which to force-apply
+
+Kluctl has a few simple rules to figure out if a conflict should be ignored
+or force-applied.
+
+It first checks the field's actor (the field manager) against a list of known
+tools that are well known to be used to perform manual modifications. These
+are for example kubectl and k9s. Any modifications performed with these tools
+are considered "temporary" and will be overwritten by Kluctl.
+
+If the field manager is not known by Kluctl, it will check if a force-apply is
+requested for that field. A force-apply can be requested in different ways:
+
+1. By passing `--force-apply` to Kluctl. This will cause ALL fields to be force-applied on conflicts.
+2. By adding the [`kluctl.io/force-apply=true`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply) annotation to the object in question. This will cause all fields of that object to be force-applied on conflicts.
+3. By adding the [`kluctl.io/force-apply-field=my.json.path`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply-field) annotation to the object in question. This cause only fields matching the JSON path to be force-applied on conflicts.
+
+## Future work in regard to conflict resolution
+
+I plan to add more ways to control the behaviour of conflict resolution. For
+example:
+
+1. It will be possible to force-apply on field level via the CLI.
+2. It will be possible to force-apply on field level but only for specific field managers.
+3. It will be possible to modify the list of known actors for which fields are always force-applied.
+4. Exclude fields from force-apply even if the field manager is in the list of well known tools.
+5. If more is needed, you can [open an issue](https://github.com/kluctl/kluctl/issues).
+
+## DevOps vs. PipelineOps vs. GitOps vs. Controllers
+
+So how does Server-side apply in Kluctl lead to "live and let live"?
+
+It allows the co-existence of classical DevOps, PipelineOps, GitOps and
+controllers. You can use a GitOps style deployment pipeline (check 
+[flux-kluctl-controller](https://github.com/kluctl/flux-kluctl-controller))
+while having the proper tools (e.g. conflict resolution via annotations) to
+act on expected or unexpected modifications to your objects from other
+actors. The same applies to classical pipeline based deployments
+(e.g. Github Actions or Gitlab CI).
+
+You can intervene with your admin permissions if required and run a kubectl
+command that will modify a field and prevent Kluctl from overwriting it. You'd
+just have to switch to a field-manager (e.g. "admin-override") that is not
+overwritten by Kluctl.
+
+If a controller is known to erroneously claim fields (the ECK operator does this
+to the nodeSets field for example), you can ensure that Kluctl always overwrites
+these fields to the original or a new value.

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -22,7 +22,7 @@ large Kubernetes deployments, composed of multiple smaller parts
 To get a basic understanding of Kluctl, I suggest to visit the [kluctl.io](https://kluctlio)
 website and read through the documentation and tutorials, for example the 
 [microservices demo tutorial](https://kluctl.io/docs/guides/tutorials/microservices-demo/).
-As an alternative, you can watch [this video](https://www.youtube.com/watch?v=9LoYLjDjOdg)
+As an alternative, you can watch [Hands-on Introduction to kluctl](https://www.youtube.com/watch?v=9LoYLjDjOdg)
 from the Rawkode Academy YouTube channel which shows a hands-on demo session.
 
 There is also a [Kluctl delivery scenario](https://github.com/podtato-head/podtato-head/tree/main/delivery/kluctl)
@@ -73,10 +73,10 @@ fields to overwrite in case of external changes and which ones to let go.
 ## Discovering Server-side apply
 
 I was never happy with the solution described above and then somehow stumbled
-across [Server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/),
+across [server-side apply](/docs/reference/using-api/server-side-apply/),
 which was still in beta at that time. Experimenting with it via
 `kubectl apply --server-side` revealed immediately that the true power of
-Server-side apply can not be easily leveraged by shelling out to kubectl.
+server-side apply can not be easily leveraged by shelling out to `kubectl`.
 
 The way Server-side apply is implemented in kubectl does not allow enough
 control about conflict resolution as it can only switch between 
@@ -102,11 +102,13 @@ with by externally modifying the kubeconfig while it was running.
 ## Implementing Server-side apply
 
 After switching to a Kubernetes client library, leveraging Server-side apply
-was easy. Kluctl just has to send each manifest to the apiserver and indicate
-that it wants to perform a Server-side apply operation. The apiserver will then
-either respond with an OK response or with a CONFLICT response.
+felt easy. Kluctl now has to send each manifest to the API server as part of a
+`PATCH` request, which signals
+that Kluctl wants to perform a server-side apply operation. The API server then
+responds with an OK response (HTTP status code 200), or with a Conflict response
+(HTTP status 409).
 
-In case of a CONFLICT response, the apiserver also sends a status object with
+In case of a Conflict response, the body of that response includes machine readable
 details about the conflicts. Kluctl can then use these details to figure out
 which fields are in conflict and which actors (field managers) have taken
 ownership of the conflicted fields.

--- a/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-10-27-live-and-let-live-with-kluctl-and-ssa.md
@@ -9,7 +9,7 @@ slug: live-and-let-live-with-kluctl-and-ssa
 
 This blog post was inspired by a previous Kubernetes blog post about
 [Advanced Server Side Apply](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/).
-The author of this blog post listed multiple benefits for applications and
+The author of said blog post listed multiple benefits for applications and
 controllers when switching to Server-side apply. Especially the chapter about
 [CI/CD systems](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/#ci-cd-systems)
 motivated me to respond and write down my thoughts and experiences.
@@ -35,11 +35,11 @@ meaning that it will try its best to work in conjunction with any other tool or
 controller running outside or inside your clusters. Kluctl will not overwrite
 any fields that it lost ownership of, unless you explicitly tell it to do so.
 
-Achieving this would not have been possible (or at least be several magnitudes
+Achieving this would not have been possible (or at least several magnitudes
 harder) without the use of Server-side apply. Server-side apply allows Kluctl
 to detect when ownership for a field got lost, for example when another controller
 or operator updates that field to another value. Kluctl can then decide on a 
-field-by-field basis if a force-apply is required and then retry based on these
+field-by-field basis if force-applying is required before retrying based on these
 decisions.
 
 ## The days before Server-side apply
@@ -66,7 +66,7 @@ This added `kubectl` as a dependency (either as an executable or in the form of
 Go packages) to all controllers that wanted to leverage the apply-logic.
 
 However, even if one managed to get client-side apply running from inside a
-controller, you ended up with a solution that gave no control about how it
+controller, you ended up with a solution that gave no control over how it
 worked internally. As an example, there was no way to individually decide which
 fields to overwrite in case of external changes and which ones to let go. 
 
@@ -80,7 +80,7 @@ server-side apply can not be easily leveraged by shelling out to `kubectl`.
 
 The way server-side apply is implemented in `kubectl` does not allow enough
 control about conflict resolution as it can only switch between 
-"not force-applying anything and erroring out" and "force-apply everything
+"not force-applying anything and erroring out" and "force-applying everything
 without showing any mercy!".
 
 The API documentation however made it clear that server-side apply is able to
@@ -91,7 +91,7 @@ to include and which fields to omit from the supplied object.
 
 This meant that Kluctl had to move away from shelling out to `kubectl` first. Only
 after that was done, I would have been able to properly implement server-side
-apply with powerful conflict resolution.
+apply with its powerful conflict resolution.
 
 To achieve this, I first implemented access to the target clusters via a
 Kubernetes client library. This had the nice side effect of dramatically
@@ -119,7 +119,7 @@ will retry the apply operation with the ignored fields omitted and the `force`
 flag being set on the API call.
 
 In case a conflict is ignored, Kluctl will issue a warning to the user so that
-the user can properly react (or ignore it forever...).
+the user can react properly (or ignore it forever...).
 
 That's basically it. That is all that is required to leverage server-side apply.
 Big thanks and thumbs-up to the Kubernetes developers who made this possible!
@@ -130,16 +130,16 @@ Kluctl has a few simple rules to figure out if a conflict should be ignored
 or force-applied.
 
 It first checks the field's actor (the field manager) against a list of known
-tools that are well known to be used to perform manual modifications. These
+tools that are frequently used to perform manual modifications. These
 are for example `kubectl` and `k9s`. Any modifications performed with these tools
 are considered "temporary" and will be overwritten by Kluctl.
 
-If the field manager is not known by Kluctl, it will check if a force-apply is
-requested for that field. A force-apply can be requested in different ways:
+If the field manager is not known by Kluctl, it will check if force-applying is
+requested for that field. Force-applying can be requested in different ways:
 
 1. By passing `--force-apply` to Kluctl. This will cause ALL fields to be force-applied on conflicts.
 2. By adding the [`kluctl.io/force-apply=true`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply) annotation to the object in question. This will cause all fields of that object to be force-applied on conflicts.
-3. By adding the [`kluctl.io/force-apply-field=my.json.path`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply-field) annotation to the object in question. This cause only fields matching the JSON path to be force-applied on conflicts.
+3. By adding the [`kluctl.io/force-apply-field=my.json.path`](https://kluctl.io/docs/reference/deployments/annotations/all-resources/#kluctlioforce-apply-field) annotation to the object in question. This causes only fields matching the JSON path to be force-applied on conflicts.
 
 Marking a field to be force-applied is required whenever some other actor is
 known to erroneously claim fields (the ECK operator does this to the nodeSets
@@ -147,8 +147,7 @@ field for example), you can ensure that Kluctl always overwrites these fields
 to the original or a new value.
 
 In the future, Kluctl will allow even more control about conflict resolution.
-For example, the CLI will allow to force-apply on field level or specify which
-field manager to always ignore or always force-apply.
+For example, the CLI will allow to control force-applying on field level.
 
 ## DevOps vs Controllers
 
@@ -185,7 +184,7 @@ set of annotations to control conflict resolution for CI/CD related tooling.
 On the other side, non CI/CD related controllers should ensure that they don't
 cause unnecessary conflicts when modifying objects. As of
 [the server-side apply documentation](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller),
-it is strongly recommended for controllers to always use force-apply. When
+it is strongly recommended for controllers to always perform force-applying. When
 following this recommendation, controllers should really make sure that only
 fields related to the controller are included in the applied object.
 Otherwise, unnecessary conflicts are guaranteed.

--- a/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
@@ -5,7 +5,7 @@ date: 2022-11-04
 slug: live-and-let-live-with-kluctl-and-ssa
 ---
 
-**Author:** Alexander Block (@codablock)
+**Author:** Alexander Block
 
 This blog post was inspired by a previous Kubernetes blog post about
 [Advanced Server Side Apply](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/).

--- a/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
@@ -26,8 +26,8 @@ website and read through the documentation and tutorials, for example the
 As an alternative, you can watch [Hands-on Introduction to kluctl](https://www.youtube.com/watch?v=9LoYLjDjOdg)
 from the Rawkode Academy YouTube channel which shows a hands-on demo session.
 
-There is also a [Kluctl delivery scenario](https://github.com/podtato-head/podtato-head/tree/main/delivery/kluctl)
-available in the [podtato-head](https://github.com/podtato-head/podtato-head) demo project.
+There is also a [Kluctl delivery scenario](https://github.com/codablock/podtato-head/tree/kluctl/delivery/kluctl)
+available in the [podtato-head](https://github.com/codablock/podtato-head) demo project.
 
 ## Live and let live
 

--- a/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
@@ -27,7 +27,7 @@ As an alternative, you can watch [Hands-on Introduction to kluctl](https://www.y
 from the Rawkode Academy YouTube channel which shows a hands-on demo session.
 
 There is also a [Kluctl delivery scenario](https://github.com/codablock/podtato-head/tree/kluctl/delivery/kluctl)
-available in the [podtato-head](https://github.com/codablock/podtato-head) demo project.
+available in my fork of the [podtato-head](https://github.com/codablock/podtato-head) demo project.
 
 ## Live and let live
 

--- a/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Live and let live with Kluctl and Server Side Apply"
-date: 2022-10-27
+date: 2022-11-04
 slug: live-and-let-live-with-kluctl-and-ssa
 ---
 


### PR DESCRIPTION
This PR proposes a blog post about the use of SSA in Kluctl. Creating this post was suggested to me when I contacted #sig-api-machinery after reading the recent "Server Side Apply Is Great And You Should Be Using It" blog post.

I hope this post is of some value for the Kubernetes blog. I'm not sure how reviews are usually performed here and hope that it's ok that I used this early draft to directly create the PR. If preferred, I can also copy this into a Google Doc and let review happen there first.

The post also contains a link to the podtato-head repository. This link is currently dead as it refers to a directory that did not get merged yet. The PR for this can be found [here](https://github.com/podtato-head/podtato-head/pull/178). Until then, you can check [this](https://github.com/codablock/podtato-head/tree/kluctl/delivery/kluctl) link for now to see what will be shown behind that link in the future.