### PR TITLE
Tweak reference docs section index

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/quickstart.md
+++ b/content/en/docs/contribute/generate-ref-docs/quickstart.md
@@ -1,7 +1,9 @@
 ---
-title: Quickstart
+title: Reference Documentation Quickstart
+linkTitle: Quickstart
 content_type: task
-weight: 40
+weight: 10
+hide_summary: true
 ---
 
 <!-- overview -->


### PR DESCRIPTION
No need to mention the quickstart twice, so don't.

Existing page: https://kubernetes.io/docs/contribute/generate-ref-docs/quickstart/