### PR TITLE
Use Google Analytics 4 (GA4) site tag for v1.21

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,13 +7,13 @@
 <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
 {{- end -}}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-36037335-10"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JPP6RFM2BP"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-36037335-10');
+  gtag('config', 'G-JPP6RFM2BP');
 </script>
 
 <!-- alternative translations -->


### PR DESCRIPTION
- Contributes to #35299
- v1.21 counterpart to, for example, #36322
- Note that v1.21 is the oldest release for which we'll update the analytics ID.

/cc @nate-double-u @sftim @reylejano 