### PR TITLE
To resolve banner text color for https://k8s.io/partners/

### DIFF
--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -23,7 +23,7 @@
             {{ .title | markdownify }}
         </h4>
         {{ end }}
-        <p>{{ .message | markdownify }}</p>
+        <p style="color: rgb(256,256,256)">{{ .message | markdownify }}</p>
       </div>
     </aside>
   </div>


### PR DESCRIPTION
Fixes #33426

Add exclusive CSS style to the paragraph element in the announcement.html file.
The paragraph text inherited the black color of gridPage class CSS, which is only for specific pages. Changing the class CSS will affect other sections like paragraph elements of the Case Studies page. So, I found the above solution appropriate.