### PR TITLE
Use kubectl to wait for Jobs to succeed

### DIFF
--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -244,7 +244,13 @@ So, now run the Job:
 kubectl apply -f ./job.yaml
 ```
 
-Now wait a bit, then check on the job.
+You can wait for the Job to succeed, with a timeout:
+```shell
+# The check for condition name is case insensitive
+kubectl wait --for=condition=complete --timeout=300s job/job-wq-1
+```
+
+Next, check on the Job:
 
 ```shell
 kubectl describe jobs/job-wq-1
@@ -285,7 +291,9 @@ Events:
   14s        14s        1        {job }                   Normal    SuccessfulCreate    Created pod: job-wq-1-p17e0
 ```
 
-All our pods succeeded.  Yay.
+
+
+All the pods for that Job succeeded. Yay.
 
 
 

--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -208,9 +208,18 @@ Events:
   FirstSeen    LastSeen    Count    From            SubobjectPath    Type        Reason            Message
   ---------    --------    -----    ----            -------------    --------    ------            -------
   33s          33s         1        {job-controller }                Normal      SuccessfulCreate  Created pod: job-wq-2-lglf8
+```
 
+You can wait for the Job to succeed, with a timeout:
+```shell
+# The check for condition name is case insensitive
+kubectl wait --for=condition=complete --timeout=300s job/job-wq-2
+```
 
+```shell
 kubectl logs pods/job-wq-2-7r7b2
+```
+```
 Worker with sessionID: bbd72d0a-9e5c-4dd6-abf6-416cc267991f
 Initial queue state: empty=False
 Working on banana

--- a/content/en/docs/tasks/job/indexed-parallel-processing-static.md
+++ b/content/en/docs/tasks/job/indexed-parallel-processing-static.md
@@ -107,7 +107,14 @@ When you create this Job, the control plane creates a series of Pods, one for ea
 
 Because `.spec.parallelism` is less than `.spec.completions`, the control plane waits for some of the first Pods to complete before starting more of them.
 
-Once you have created the Job, wait a moment then check on progress:
+You can wait for the Job to succeed, with a timeout:
+```shell
+# The check for condition name is case insensitive
+kubectl wait --for=condition=complete --timeout=300s job/indexed-job
+```
+
+Now, describe the Job and check that it was successful.
+
 
 ```shell
 kubectl describe jobs/indexed-job


### PR DESCRIPTION
No need to poll: there's a subcommand for that.
Use `kubectl wait` rather than asking the reader to wait for a bit then check.