### PR TITLE
Tell crawlers not to index print pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,11 +1,12 @@
 {{- $isBlogPost := eq .Section "blog" }}
 {{- $ogType := cond (.IsHome) "website" "article" }}
-<!-- per-page robot indexing controls -->
-{{- if hugo.IsProduction -}}
-<meta name="ROBOTS" content="INDEX, FOLLOW">
-{{- else -}}
-<meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
-{{- end -}}
+
+{{ $outputFormat := partial "outputformat.html" . -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
+<meta name="robots" content="index, follow">
+{{ else -}}
+<meta name="robots" content="noindex, nofollow">
+{{ end -}}
 
 <!-- alternative translations -->
 {{ range .Translations -}}


### PR DESCRIPTION
This logic is copied from the way that the [Docsy code](https://github.com/google/docsy/blob/v0.2.0/layouts/partials/head.html#L8-L13) handles this.

Before this change, crawlers were indexing the print versions of pages, which is not what we want to happen.