### PR TITLE
Fix broken link on Writing a new topic Page

### DIFF
--- a/content/en/docs/contribute/style/write-new-topic.md
+++ b/content/en/docs/contribute/style/write-new-topic.md
@@ -102,7 +102,7 @@ following cases (not an exhaustive list):
 - The code is not generic enough for users to try out. As an example, you can
   embed the YAML
   file for creating a Pod which depends on a specific
-  [FlexVolume](/docs/concepts/storage/volumes#flexvolume) implementation.
+  [FlexVolume](/docs/concepts/storage/volumes/#flexvolume-deprecated) implementation.
 - The code is an incomplete example because its purpose is to highlight a
   portion of a larger file. For example, when describing ways to
   customize a [RoleBinding](/docs/reference/access-authn-authz/rbac/#role-binding-examples),


### PR DESCRIPTION
Fixes #37605

Updated page [Writing a new topic](https://kubernetes.io/docs/contribute/style/write-new-topic/#embedding-code-in-your-topic)