### PR TITLE
KEP-1880 alpha: IPAddresses

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -626,8 +626,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `MixedProtocolLBService`: Enable using different protocols in the same `LoadBalancer` type
   Service instance.
 - `MultiCIDRRangeAllocator`: Enables the MultiCIDR range allocator.
-- `MultiCIDRServiceAllocator`: Enables a new IPAddress object kind, and a new Service ClusterIP allocator.
-  The new allocator removes previous Service CIDR block size limitations for IPv4, and limits IPv6 size to a /64.
+- `MultiCIDRServiceAllocator`: Track IP address allocations for Service cluster IPs using IPAddress objects.
 - `NetworkPolicyEndPort`: Enable use of the field `endPort` in NetworkPolicy objects,
   allowing the selection of a port range instead of a single port.
 - `NetworkPolicyStatus`: Enable the `status` subresource for NetworkPolicy objects.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -146,6 +146,7 @@ For a reference to old feature gates that are removed, please refer to
 | `MinDomainsInPodTopologySpread` | `false` | Beta | 1.25 | |
 | `MinimizeIPTablesRestore` | `false` | Alpha | 1.26 | - |
 | `MultiCIDRRangeAllocator` | `false` | Alpha | 1.25 | |
+| `MultiCIDRServiceAllocator` | `false` | Alpha | 1.27 | |
 | `NetworkPolicyStatus` | `false` | Alpha | 1.24 |  |
 | `NodeInclusionPolicyInPodTopologySpread` | `false` | Alpha | 1.25 | 1.25 |
 | `NodeInclusionPolicyInPodTopologySpread` | `true` | Beta | 1.26 | |
@@ -625,6 +626,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `MixedProtocolLBService`: Enable using different protocols in the same `LoadBalancer` type
   Service instance.
 - `MultiCIDRRangeAllocator`: Enables the MultiCIDR range allocator.
+- `MultiCIDRServiceAllocator`: Enables a new IPAddress object kind, and a new Service ClusterIP allocator.
+  The new allocator removes previous Service CIDR block size limitations for IPv4, and limits IPv6 size to a /64.
 - `NetworkPolicyEndPort`: Enable use of the field `endPort` in NetworkPolicy objects,
   allowing the selection of a port range instead of a single port.
 - `NetworkPolicyStatus`: Enable the `status` subresource for NetworkPolicy objects.

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -271,6 +271,12 @@ When clients connect to the VIP, their traffic is automatically transported to a
 appropriate endpoint. The environment variables and DNS for Services are actually
 populated in terms of the Service's virtual IP address (and port).
 
+{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+If you enable the `MultiCIDRServiceAllocator`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
+the `ClusterIP` address associated to each `Service` will have a referenced
+`IPAddress` object.
+
 ### Avoiding collisions
 
 One of the primary philosophies of Kubernetes is that you should not be

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -308,6 +308,25 @@ associated to each `Service` will have a referenced IPAddress object.
 The background allocator is also replaced by a new one to handle the new IPAddress
 objects and the migration from the old allocator model.
 
+One of the main benefits of the new allocator is that it removes the size limitations
+for the `service-cluster-ip-range`, there is no limitations for IPv4 and for IPv6
+users can use masks equal or larger than /64 (previously it was /108).
+
+Users now will be able to inspect the IP addresses assigned to their Services, and
+new network APIs, like Gateway API, can use this new object to extend the Kubernetes
+networking capabilities overcoming the limitations of current Services API.
+
+```bash
+$ kubectl get services
+NAME         TYPE        CLUSTER-IP        EXTERNAL-IP   PORT(S)   AGE
+kubernetes   ClusterIP   2001:db8:1:2::1   <none>        443/TCP   3d1h
+
+$ kubectl get ipaddresses
+NAME              PARENTREF
+2001:db8:1:2::1   services/default/kubernetes
+2001:db8:1:2::a   services/kube-system/kube-dns
+```
+
 #### IP address ranges for Service virtual IP addresses {#service-ip-static-sub-range}
 
 {{< feature-state for_k8s_version="v1.25" state="beta" >}}

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -305,7 +305,7 @@ the control plane replaces the existing etcd allocator with a new one, using IPA
 objects instead of an internal global allocation map.  The ClusterIP address
 associated to each `Service` will have a referenced IPAddress object.
 
-The background allocator is also replaced by a new one to handle the new IPAddress
+The background controller is also replaced by a new one to handle the new IPAddress
 objects and the migration from the old allocator model.
 
 One of the main benefits of the new allocator is that it removes the size limitations

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -271,24 +271,20 @@ When clients connect to the VIP, their traffic is automatically transported to a
 appropriate endpoint. The environment variables and DNS for Services are actually
 populated in terms of the Service's virtual IP address (and port).
 
-{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
-If you enable the `MultiCIDRServiceAllocator`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
-the `ClusterIP` address associated to each `Service` will have a referenced
-`IPAddress` object.
-
 ### Avoiding collisions
 
 One of the primary philosophies of Kubernetes is that you should not be
 exposed to situations that could cause your actions to fail through no fault
 of your own. For the design of the Service resource, this means not making
-you choose your own port number if that choice might collide with
+you choose your own IP address if that choice might collide with
 someone else's choice.  That is an isolation failure.
 
-In order to allow you to choose a port number for your Services, we must
+In order to allow you to choose an IP address for your Services, we must
 ensure that no two Services can collide. Kubernetes does that by allocating each
 Service its own IP address from within the `service-cluster-ip-range`
 CIDR range that is configured for the {{< glossary_tooltip term_id="kube-apiserver" text="API Server" >}}.
+
+#### IP address allocation tracking
 
 To ensure each Service receives a unique IP, an internal allocator atomically
 updates a global allocation map in {{< glossary_tooltip term_id="etcd" >}}
@@ -301,6 +297,16 @@ map (needed to support migrating from older versions of Kubernetes that used
 in-memory locking). Kubernetes also uses controllers to check for invalid
 assignments (e.g. due to administrator intervention) and for cleaning up allocated
 IP addresses that are no longer used by any Services.
+
+{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+If you enable the `MultiCIDRServiceAllocator`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
+the control plane replaces the existing etcd allocator with a new one, using IPAddress
+objects instead of an internal global allocation map.  The ClusterIP address
+associated to each `Service` will have a referenced IPAddress object.
+
+The background allocator is also replaced by a new one to handle the new IPAddress
+objects and the migration from the old allocator model.
 
 #### IP address ranges for Service virtual IP addresses {#service-ip-static-sub-range}
 

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -316,12 +316,17 @@ Users now will be able to inspect the IP addresses assigned to their Services, a
 new network APIs, like Gateway API, can use this new object to extend the Kubernetes
 networking capabilities overcoming the limitations of current Services API.
 
-```bash
-$ kubectl get services
+```shell
+kubectl get services
+```
+```
 NAME         TYPE        CLUSTER-IP        EXTERNAL-IP   PORT(S)   AGE
 kubernetes   ClusterIP   2001:db8:1:2::1   <none>        443/TCP   3d1h
-
-$ kubectl get ipaddresses
+```
+```shell
+kubectl get ipaddresses
+```
+```
 NAME              PARENTREF
 2001:db8:1:2::1   services/default/kubernetes
 2001:db8:1:2::a   services/kube-system/kube-dns

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -304,7 +304,7 @@ If you enable the `MultiCIDRServiceAllocator`
 [`networking.k8s.io/v1alpha1` API group](/docs/tasks/administer-cluster/enable-disable-api/),
 the control plane replaces the existing etcd allocator with a new one, using IPAddress
 objects instead of an internal global allocation map.  The ClusterIP address
-associated to each `Service` will have a referenced IPAddress object.
+associated to each Service will have a referenced IPAddress object.
 
 The background controller is also replaced by a new one to handle the new IPAddress
 objects and the migration from the old allocator model.

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -300,7 +300,8 @@ IP addresses that are no longer used by any Services.
 
 {{< feature-state for_k8s_version="v1.27" state="alpha" >}}
 If you enable the `MultiCIDRServiceAllocator`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and the
+[networking.k8s.io/v1alpha1 API group](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/),
 the control plane replaces the existing etcd allocator with a new one, using IPAddress
 objects instead of an internal global allocation map.  The ClusterIP address
 associated to each `Service` will have a referenced IPAddress object.

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -314,8 +314,9 @@ for the `service-cluster-ip-range`, there is no limitations for IPv4 and for IPv
 users can use masks equal or larger than /64 (previously it was /108).
 
 Users now will be able to inspect the IP addresses assigned to their Services, and
-new network APIs, like Gateway API, can use this new object to extend the Kubernetes
-networking capabilities overcoming the limitations of current Services API.
+Kubernetes extensions such as the [Gateway](https://gateway-api.sigs.k8s.io/) API, can use this new
+IPAddress object kind to enhance the Kubernetes networking capabilities, going beyond the limitations of
+the built-in Service API.
 
 ```shell
 kubectl get services

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -301,7 +301,7 @@ IP addresses that are no longer used by any Services.
 {{< feature-state for_k8s_version="v1.27" state="alpha" >}}
 If you enable the `MultiCIDRServiceAllocator`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and the
-[networking.k8s.io/v1alpha1 API group](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/),
+[`networking.k8s.io/v1alpha1` API group](/docs/tasks/administer-cluster/enable-disable-api/),
 the control plane replaces the existing etcd allocator with a new one, using IPAddress
 objects instead of an internal global allocation map.  The ClusterIP address
 associated to each `Service` will have a referenced IPAddress object.


### PR DESCRIPTION
The KEP-1880 introduces two new types: IPAddress and ServiceCIDR.

KEP-1880 is meant to address the main problems with the IP allocation on Services.
During the implementation. phase, we realized the need to align the use of ServiceCIDR with the other KEP that is introducing multiple ClusterCIDR as a new type https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2593-multiple-cluster-cidrs.
This is required because otherwise users can cause networking problems due to misconfigurations in their cluster.

Because of that, in this first iteration of the KEP-1880, only the new IPAddress object and its ClusterIP allocator is introduced.

https://github.com/kubernetes/enhancements/issues/1880