### PR TITLE
Verify key name in API Server and in etcd

### DIFF
--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -235,7 +235,7 @@ program to retrieve the contents of your Secret.
 1. Verify the stored Secret is prefixed with `k8s:enc:aescbc:v1:` which indicates
    the `aescbc` provider has encrypted the resulting data. Confirm that the key name shown in `etcd`
    matches the key name specified in the `EncryptionConfiguration` mentioned above. In this example,
-   we can see that the key named `key1` is used in `etcd` and in `EncryptionConfiguration`.
+   you can see that the encryption key named `key1` is used in `etcd` and in `EncryptionConfiguration`.
 
 1. Verify the Secret is correctly decrypted when retrieved via the API:
 

--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -233,7 +233,9 @@ program to retrieve the contents of your Secret.
    ```
 
 1. Verify the stored Secret is prefixed with `k8s:enc:aescbc:v1:` which indicates
-   the `aescbc` provider has encrypted the resulting data.
+   the `aescbc` provider has encrypted the resulting data. Confirm that the key name shown in `etcd`
+   matches the key name specified in the `EncryptionConfiguration` mentioned above. In this example,
+   we can see that the key named `key1` is used in `etcd` and in `EncryptionConfiguration`.
 
 1. Verify the Secret is correctly decrypted when retrieved via the API:
 


### PR DESCRIPTION
* Add a simple best practice to manually verify that the key used in etcd and the key stored on disk are indeed the same.

Fixes https://github.com/kubernetes/website/issues/37651