### PR TITLE
Use Google Analytics 4 (GA4) site tag for v1.25

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,13 +8,13 @@
 {{- end -}}
 {{- if in (slice "production" "nonprod") hugo.Environment -}}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-36037335-10"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JPP6RFM2BP"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-36037335-10');
+  gtag('config', 'G-JPP6RFM2BP');
 </script>
 {{- end -}}
 


### PR DESCRIPTION
- Contributes to #35299
- Applies the same solution (hard-coded GA4 ID) as for all other older releases (from 1.21 to 1.24) instead of back porting the GA4 solution that was applied to `main`.

/cc @nate-double-u @sftim @reylejano @a-mccarthy 