### PR TITLE
docs(hpa): fix typo in 1.23 blog announcement

### DIFF
--- a/content/en/blog/_posts/2021-12-07-kubernetes-release-1.23.md
+++ b/content/en/blog/_posts/2021-12-07-kubernetes-release-1.23.md
@@ -32,7 +32,7 @@ Kubernetes releases now generate provenance attestation files describing the sta
 
 ### HorizontalPodAutoscaler v2 graduates to GA
 
-The HorizontalPodAutscaler `autoscaling/v2` stable API moved to GA in 1.23. The HorizontalPodAutoscaler `autoscaling/v2beta2` API has been deprecated.
+The HorizontalPodAutoscaler `autoscaling/v2` stable API moved to GA in 1.23. The HorizontalPodAutoscaler `autoscaling/v2beta2` API has been deprecated.
 
 ### Generic Ephemeral Volume feature graduates to GA
 


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Minor typo correction to the [Kubernetes 1.23 release announcement blog](https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/) on the `HorizontalPodAutoscaler` section.
