### PR TITLE
Update configure-multiple-schedulers.md

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -31,7 +31,7 @@ in the Kubernetes source directory for a canonical example.
 
 Package your scheduler binary into a container image. For the purposes of this example,
 you can use the default scheduler (kube-scheduler) as your second scheduler.
-Clone the [Kubernetes source code from GitHub](https://github.com/kubernetes/kubernetes) with the exact same branch as per the kubernetes cluster version in use and build the source.
+While cloning the [Kubernetes source code from GitHub](https://github.com/kubernetes/kubernetes), you need to specify the exact Kubernetes version in use with `--branch="version"` and then, build the source using the `make` command.
 
 ```shell
 git clone --branch="version" https://github.com/kubernetes/kubernetes.git

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -31,11 +31,11 @@ in the Kubernetes source directory for a canonical example.
 
 Package your scheduler binary into a container image. For the purposes of this example,
 you can use the default scheduler (kube-scheduler) as your second scheduler.
-Clone the [Kubernetes source code from GitHub](https://github.com/kubernetes/kubernetes)
+Clone the [Kubernetes source code from GitHub](https://github.com/kubernetes/kubernetes) with the exact same branch as per the kubernetes version in use
 and build the source.
 
 ```shell
-git clone https://github.com/kubernetes/kubernetes.git
+git clone --branch=`kubectl version --short | grep 'Server' | awk '{print $3}'` https://github.com/kubernetes/kubernetes.git
 cd kubernetes
 make
 ```

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -31,14 +31,14 @@ in the Kubernetes source directory for a canonical example.
 
 Package your scheduler binary into a container image. For the purposes of this example,
 you can use the default scheduler (kube-scheduler) as your second scheduler.
-Clone the [Kubernetes source code from GitHub](https://github.com/kubernetes/kubernetes) with the exact same branch as per the kubernetes version in use
-and build the source.
+Clone the [Kubernetes source code from GitHub](https://github.com/kubernetes/kubernetes) with the exact same branch as per the kubernetes cluster version in use and build the source.
 
 ```shell
-git clone --branch=`kubectl version --short | grep 'Server' | awk '{print $3}'` https://github.com/kubernetes/kubernetes.git
+git clone --branch="version" https://github.com/kubernetes/kubernetes.git
 cd kubernetes
 make
 ```
+Where "version" can be for example "v1.25.4". Run `kubectl version` command to find your kubernetes cluster version in use.
 
 Create a container image containing the kube-scheduler binary. Here is the `Dockerfile`
 to build the image:


### PR DESCRIPTION
### Reason for suggesting the change.
The existing `git clone` command clones the latest available version of kubernetes and the docs of each version has same command. So if the user running that git command is having the k8s cluster of version v1.22.x then the command will clone the latest available version of that time say v1.25.x. This will later create issues because the apiVersion of few resources changes with each version, it also happens that a few resources/objects that are available in newer versions are not there in earlier versions at all.

All these create issues at a later stage when the custom objects are being created via yamls(not at the time of cloning) in the cluster.

Having a `--branch` option in the git command will help in cloning the exact same k8s version which the user's cluster is currently on and will avoid all future issue.

I personally faced this issue when I was creating a custom kube scheduler on my v1.21.x cluster. That git command cloned v1.25.x which was latest version at that time and I faced many issues later while creating resources in my v1.21.x cluster. When I specifically cloned the right version using `--branch` option, I didn't faced those issues again.