### PR TITLE
Update docs given that Services with type=LoadBalancer is stable

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -731,14 +731,9 @@ or [CreatingLoadBalancerFailed on AKS cluster with advanced networking](https://
 
 #### Load balancers with mixed protocol types
 
-{{< feature-state for_k8s_version="v1.24" state="beta" >}}
+{{< feature-state for_k8s_version="v1.26" state="stable" >}}
 
-By default, for LoadBalancer type of Services, when there is more than one port defined, all
-ports must have the same protocol, and the protocol must be one which is supported
-by the cloud provider.
-
-The feature gate `MixedProtocolLBService` (enabled by default for the kube-apiserver as of v1.24) allows the use of
-different protocols for LoadBalancer type of Services, when there is more than one port defined.
+You can use different protocols for LoadBalancer type of Services, when there is more than one port defined.
 
 {{< note >}}
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -144,8 +144,6 @@ different Kubernetes components.
 | `MemoryQoS` | `false` | Alpha | 1.22 | |
 | `MinDomainsInPodTopologySpread` | `false` | Alpha | 1.24 | 1.24 |
 | `MinDomainsInPodTopologySpread` | `true` | Beta | 1.25 | |
-| `MixedProtocolLBService` | `false` | Alpha | 1.20 | 1.23 |
-| `MixedProtocolLBService` | `true` | Beta | 1.24 | |
 | `NetworkPolicyStatus` | `false` | Alpha | 1.24 |  |
 | `NodeInclusionPolicyInPodTopologySpread` | `false` | Alpha | 1.25 | |
 | `NodeSwap` | `false` | Alpha | 1.22 | |
@@ -408,6 +406,9 @@ different Kubernetes components.
 | `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | 1.9 |
 | `LocalStorageCapacityIsolation` | `true` | Beta | 1.10 | 1.24 |
 | `LocalStorageCapacityIsolation` | `true` | GA | 1.25 | - |
+| `MixedProtocolLBService` | `false` | Alpha | 1.20 | 1.23 |
+| `MixedProtocolLBService` | `true` | Beta | 1.24 | 1.25 |
+| `MixedProtocolLBService` | `true` | GA | 1.26 | - |
 | `MountContainers` | `false` | Alpha | 1.9 | 1.16 |
 | `MountContainers` | `false` | Deprecated | 1.17 | - |
 | `MountPropagation` | `false` | Alpha | 1.8 | 1.9 |


### PR DESCRIPTION
The feature gate MixedProtocolLBService moves to GA state in 1.26. The documentation of the support of different protocols in the same LB Service is updated.

k/k PR: https://github.com/kubernetes/kubernetes/pull/112895
k/enhancement issue: https://github.com/kubernetes/enhancements/issues/1435
