### PR TITLE
Updating service topology to a higher weight due to deprecation

### DIFF
--- a/content/en/docs/concepts/services-networking/service-topology.md
+++ b/content/en/docs/concepts/services-networking/service-topology.md
@@ -4,7 +4,7 @@ reviewers:
 - imroc
 title: Topology-aware traffic routing with topology keys
 content_type: concept
-weight: 20
+weight: 150
 ---
 
 


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/website/pull/37494; contributes to https://github.com/kubernetes/website/issues/35093

Updating service topology to a higher weight than any other page in its section as it is a deprecated feature.


/cc @haosdent @sftim 