### PR TITLE
node: cpumgr: docs: Kubelet CPU Manager GA graduation

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -68,8 +68,6 @@ For a reference to old feature gates that are removed, please refer to
 | `AnyVolumeDataSource` | `false` | Alpha | 1.18 | 1.23 |
 | `AnyVolumeDataSource` | `true` | Beta | 1.24 | |
 | `AppArmor` | `true` | Beta | 1.4 | |
-| `CPUManager` | `false` | Alpha | 1.8 | 1.9 |
-| `CPUManager` | `true` | Beta | 1.10 | |
 | `CPUManagerPolicyAlphaOptions` | `false` | Alpha | 1.23 | |
 | `CPUManagerPolicyBetaOptions` | `true` | Beta | 1.23 | |
 | `CPUManagerPolicyOptions` | `false` | Alpha | 1.22 | 1.22 |
@@ -214,6 +212,9 @@ For a reference to old feature gates that are removed, please refer to
 | `AdvancedAuditing` | `false` | Alpha | 1.7 | 1.7 |
 | `AdvancedAuditing` | `true` | Beta | 1.8 | 1.11 |
 | `AdvancedAuditing` | `true` | GA | 1.12 | - |
+| `CPUManager` | `false` | Alpha | 1.8 | 1.9 |
+| `CPUManager` | `true` | Beta | 1.10 | 1.25 |
+| `CPUManager` | `true` | GA | 1.26 | - |
 | `CSIInlineVolume` | `false` | Alpha | 1.15 | 1.15 |
 | `CSIInlineVolume` | `true` | Beta | 1.16 | 1.24 |
 | `CSIInlineVolume` | `true` | GA | 1.25 | - |

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -4,12 +4,14 @@ reviewers:
 - sjenning
 - ConnorDoyle
 - balajismaniam
+
 content_type: task
+min-kubernetes-server-version: v1.26
 ---
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.12" state="beta" >}}
+{{< feature-state for_k8s_version="v1.26" state="stable" >}}
 
 Kubernetes keeps many aspects of how pods execute on nodes abstracted
 from the user. This is by design.  However, some workloads require
@@ -26,6 +28,7 @@ directives.
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
+If you are running an older version of Kubernetes, please look at the documentation for the version you are actually running.
 
 
 <!-- steps -->
@@ -61,10 +64,14 @@ duration as `--node-status-update-frequency`.
 
 The behavior of the static policy can be fine-tuned using the `--cpu-manager-policy-options` flag.
 The flag takes a comma-separated list of `key=value` policy options.
-This feature can be disabled completely using the `CPUManagerPolicyOptions` feature gate.
+If you disable the `CPUManagerPolicyOptions`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+then you cannot fine-tune CPU manager policies. In that case, the CPU manager
+operates only using its default settings.
 
-The policy options are split into two groups: alpha quality (hidden by default) and beta quality
-(visible by default). The groups are guarded respectively by the `CPUManagerPolicyAlphaOptions`
+In addition to the top-level `CPUManagerPolicyOptions` feature gate, the policy options are split
+into two groups: alpha quality (hidden by default) and beta quality (visible by default).
+The groups are guarded respectively by the `CPUManagerPolicyAlphaOptions`
 and `CPUManagerPolicyBetaOptions` feature gates. Diverging from the Kubernetes standard, these
 feature gates guard groups of options, because it would have been too cumbersome to add a feature
 gate for each individual option.


### PR DESCRIPTION
Docs update for Kubelet CPU Manager GA graduation.
Issue: https://github.com/kubernetes/enhancements/issues/3570

Replaces https://github.com/kubernetes/website/pull/37288 which was mistakenly filed against `main` branch

Signed-off-by: Francesco Romani <fromani@redhat.com>
