### PR TITLE
remove glusterfs references from the docs 

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -297,7 +297,6 @@ the following types of volumes:
 * {{< glossary_tooltip text="csi" term_id="csi" >}}
 * flexVolume (deprecated)
 * gcePersistentDisk
-* glusterfs (deprecated)
 * rbd
 * portworxVolume
 
@@ -438,8 +437,6 @@ The following types of PersistentVolume are deprecated. This means that support 
   (**deprecated** in v1.23)
 * [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk) - GCE Persistent Disk
   (**deprecated** in v1.17)
-* [`glusterfs`](/docs/concepts/storage/volumes/#glusterfs) - Glusterfs volume
-  (**deprecated** in v1.25)
 * [`portworxVolume`](/docs/concepts/storage/volumes/#portworxvolume) - Portworx volume
   (**deprecated** in v1.25)
 * [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume) - vSphere VMDK volume
@@ -616,7 +613,6 @@ The following volume types support mount options:
 * `cephfs`
 * `cinder` (**deprecated** in v1.18)
 * `gcePersistentDisk`
-* `glusterfs` (**deprecated** in v1.25)
 * `iscsi`
 * `nfs`
 * `rbd`

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -72,7 +72,6 @@ for provisioning PVs. This field must be specified.
 | FC                   | -                   | -                                    |
 | FlexVolume           | -                   | -                                    |
 | GCEPersistentDisk    | &#x2713;            | [GCE PD](#gce-pd)                          |
-| Glusterfs            | &#x2713;            | [Glusterfs](#glusterfs)              |
 | iSCSI                | -                   | -                                    |
 | NFS                  | -                   | [NFS](#nfs)       |
 | RBD                  | &#x2713;            | [Ceph RBD](#ceph-rbd)                |
@@ -123,7 +122,6 @@ Volume type | Required Kubernetes version
 gcePersistentDisk | 1.11
 awsElasticBlockStore | 1.11
 Cinder | 1.11
-glusterfs | 1.11
 rbd | 1.11
 Azure File | 1.11
 Azure Disk | 1.11
@@ -337,87 +335,6 @@ using `allowedTopologies`.
 `zone` and `zones` parameters are deprecated and replaced with
 [allowedTopologies](#allowed-topologies)
 {{< /note >}}
-
-### Glusterfs (deprecated) {#glusterfs}
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: slow
-provisioner: kubernetes.io/glusterfs
-parameters:
-  resturl: "http://127.0.0.1:8081"
-  clusterid: "630372ccdc720a92c681fb928f27b53f"
-  restauthenabled: "true"
-  restuser: "admin"
-  secretNamespace: "default"
-  secretName: "heketi-secret"
-  gidMin: "40000"
-  gidMax: "50000"
-  volumetype: "replicate:3"
-```
-
-* `resturl`: Gluster REST service/Heketi service url which provision gluster
-  volumes on demand. The general format should be `IPaddress:Port` and this is
-  a mandatory parameter for GlusterFS dynamic provisioner. If Heketi service is
-  exposed as a routable service in openshift/kubernetes setup, this can have a
-  format similar to `http://heketi-storage-project.cloudapps.mystorage.com`
-  where the fqdn is a resolvable Heketi service url.
-* `restauthenabled` : Gluster REST service authentication boolean that enables
-  authentication to the REST server. If this value is `"true"`, `restuser` and
-  `restuserkey` or `secretNamespace` + `secretName` have to be filled. This
-  option is deprecated, authentication is enabled when any of `restuser`,
-  `restuserkey`, `secretName` or `secretNamespace` is specified.
-* `restuser` : Gluster REST service/Heketi user who has access to create volumes
-  in the Gluster Trusted Pool.
-* `restuserkey` : Gluster REST service/Heketi user's password which will be used
-  for authentication to the REST server. This parameter is deprecated in favor
-  of `secretNamespace` + `secretName`.
-* `secretNamespace`, `secretName` : Identification of Secret instance that
-  contains user password to use when talking to Gluster REST service. These
-  parameters are optional, empty password will be used when both
-  `secretNamespace` and `secretName` are omitted. The provided secret must have
-  type `"kubernetes.io/glusterfs"`, for example created in this way:
-
-    ```
-    kubectl create secret generic heketi-secret \
-      --type="kubernetes.io/glusterfs" --from-literal=key='opensesame' \
-      --namespace=default
-    ```
-
-    Example of a secret can be found in
-    [glusterfs-provisioning-secret.yaml](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/glusterfs/glusterfs-secret.yaml).
-
-* `clusterid`: `630372ccdc720a92c681fb928f27b53f` is the ID of the cluster
-  which will be used by Heketi when provisioning the volume. It can also be a
-  list of clusterids, for example:
-  `"8452344e2becec931ece4e33c4674e4e,42982310de6c63381718ccfa6d8cf397"`. This
-  is an optional parameter.
-* `gidMin`, `gidMax` : The minimum and maximum value of GID range for the
-  StorageClass. A unique value (GID) in this range ( gidMin-gidMax ) will be
-  used for dynamically provisioned volumes. These are optional values. If not
-  specified, the volume will be provisioned with a value between 2000-2147483647
-  which are defaults for gidMin and gidMax respectively.
-* `volumetype` : The volume type and its parameters can be configured with this
-  optional value. If the volume type is not mentioned, it's up to the provisioner
-  to decide the volume type.
-
-    For example:
-    * Replica volume: `volumetype: replicate:3` where '3' is replica count.
-    * Disperse/EC volume: `volumetype: disperse:4:2` where '4' is data and '2' is the redundancy count.
-    * Distribute volume: `volumetype: none`
-
-    For available volume types and administration options, refer to the
-    [Administration Guide](https://access.redhat.com/documentation/en-us/red_hat_gluster_storage/).
-
-    For further reference information, see
-    [How to configure Heketi](https://github.com/heketi/heketi/wiki/Setting-up-the-topology).
-
-    When persistent volumes are dynamically provisioned, the Gluster plugin
-    automatically creates an endpoint and a headless service in the name
-    `gluster-dynamic-<claimname>`. The dynamic endpoint and service are automatically
-    deleted when the persistent volume claim is deleted.
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -542,24 +542,15 @@ spec:
       repository: "git@somewhere:me/my-git-repository.git"
       revision: "22f1d8406d464b0c0874075539c1f2e96c253775"
 ```
+### glusterfs (removed) {#glusterfs}
 
-### glusterfs (deprecated) {#glusterfs}
+<!-- maintenance note: OK to remove all mention of glusterfs once the v1.25 release of
+Kubernetes has gone out of support -->
+-
+Kubernetes {{< skew currentVersion >}} does not include a `glusterfs` volume type.
 
-{{< feature-state for_k8s_version="v1.25" state="deprecated" >}}
-
-A `glusterfs` volume allows a [Glusterfs](https://www.gluster.org) (an open
-source networked filesystem) volume to be mounted into your Pod. Unlike
-`emptyDir`, which is erased when a Pod is removed, the contents of a
-`glusterfs` volume are preserved and the volume is merely unmounted. This
-means that a `glusterfs` volume can be pre-populated with data, and that data can
-be shared between pods. GlusterFS can be mounted by multiple writers
-simultaneously.
-
-{{< note >}}
-You must have your own GlusterFS installation running before you can use it.
-{{< /note >}}
-
-See the [GlusterFS example](https://github.com/kubernetes/examples/tree/master/volumes/glusterfs) for more details.
+The GlusterFS in-tree storage driver was deprecated in the Kubernetes v1.25 release
+and then removed entirely in the v1.26 release.
 
 ### hostPath {#hostpath}
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -519,29 +519,6 @@ PersistentVolumeSpec is the specification of a persistent volume.
 
     readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
-- **glusterfs** (GlusterfsPersistentVolumeSource)
-
-  glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md
-
-  <a name="GlusterfsPersistentVolumeSource"></a>
-  *Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.*
-
-  - **glusterfs.endpoints** (string), required
-
-    endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
-  - **glusterfs.path** (string), required
-
-    path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
-  - **glusterfs.endpointsNamespace** (string)
-
-    endpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
-  - **glusterfs.readOnly** (boolean)
-
-    readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
 - **iscsi** (ISCSIPersistentVolumeSource)
 
   iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
@@ -541,25 +541,6 @@ Volume represents a named volume in a pod that may be accessed by any container 
 
     readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
-- **glusterfs** (GlusterfsVolumeSource)
-
-  glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
-
-  <a name="GlusterfsVolumeSource"></a>
-  *Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.*
-
-  - **glusterfs.endpoints** (string), required
-
-    endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
-  - **glusterfs.path** (string), required
-
-    path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
-  - **glusterfs.readOnly** (boolean)
-
-    readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
-
 - **iscsi** (ISCSIVolumeSource)
 
   iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md


### PR DESCRIPTION
we have removed glusterfs in-tree driver in this release (v1.26) via https://github.com/kubernetes/kubernetes/pull/112749 .
This PR remove the references from the docs.