### PR TITLE
Optimize link text in /dynamic-provisioning.md

### DIFF
--- a/content/en/docs/concepts/storage/dynamic-provisioning.md
+++ b/content/en/docs/concepts/storage/dynamic-provisioning.md
@@ -19,9 +19,6 @@ to represent them in Kubernetes. The dynamic provisioning feature eliminates
 the need for cluster administrators to pre-provision storage. Instead, it
 automatically provisions storage when it is requested by users.
 
-
-
-
 <!-- body -->
 
 ## Background
@@ -116,7 +113,7 @@ can enable this behavior by:
   is enabled on the API server.
 
 An administrator can mark a specific `StorageClass` as default by adding the
-`storageclass.kubernetes.io/is-default-class` [annotation](/docs/reference/labels-annotations-taints/#storageclass-kubernetes-io-is-default-class) to it.
+[`storageclass.kubernetes.io/is-default-class` annotation](/docs/reference/labels-annotations-taints/#storageclass-kubernetes-io-is-default-class) to it.
 When a default `StorageClass` exists in a cluster and a user creates a
 `PersistentVolumeClaim` with `storageClassName` unspecified, the
 `DefaultStorageClass` admission controller automatically adds the
@@ -128,9 +125,9 @@ be created.
 
 ## Topology Awareness
 
-In [Multi-Zone](/docs/setup/multiple-zones) clusters, Pods can be spread across
+In [Multi-Zone](/docs/setup/best-practices/multiple-zones/) clusters, Pods can be spread across
 Zones in a Region. Single-Zone storage backends should be provisioned in the Zones where
-Pods are scheduled. This can be accomplished by setting the [Volume Binding
-Mode](/docs/concepts/storage/storage-classes/#volume-binding-mode).
+Pods are scheduled. This can be accomplished by setting the
+[Volume Binding Mode](/docs/concepts/storage/storage-classes/#volume-binding-mode).
 
 


### PR DESCRIPTION
1. Give an accurate link text
2. A redirected link works not very well if directly localized such as `/zh-cn/docs/setup/multiple-zones` and more langs
3. Remove the newline char between link text
```
content/en/docs/concepts/storage/dynamic-provisioning.md
```
Preview: https://deploy-preview-37704--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/dynamic-provisioning/