### PR TITLE
Updates page weights in reference docs section

### DIFF
--- a/content/en/docs/reference/access-authn-authz/_index.md
+++ b/content/en/docs/reference/access-authn-authz/_index.md
@@ -1,6 +1,6 @@
 ---
 title: API Access Control
-weight: 15
+weight: 30
 no_list: true
 ---
 

--- a/content/en/docs/reference/command-line-tools-reference/_index.md
+++ b/content/en/docs/reference/command-line-tools-reference/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Component tools
-weight: 60
+weight: 120
 ---

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -1,7 +1,7 @@
 ---
 title: kubelet
 content_type: tool-reference
-weight: 28
+weight: 20
 ---
 
 ## {{% heading "synopsis" %}}

--- a/content/en/docs/reference/config-api/_index.md
+++ b/content/en/docs/reference/config-api/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Configuration APIs 
-weight: 65
+weight: 130
 ---
 

--- a/content/en/docs/reference/instrumentation/_index.md
+++ b/content/en/docs/reference/instrumentation/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Instrumentation
-weight: 40
+weight: 60
 ---

--- a/content/en/docs/reference/issues-security/_index.md
+++ b/content/en/docs/reference/issues-security/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Kubernetes Issues and Security
-weight: 40
+weight: 70
 ---

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Command line tool (kubectl)
 content_type: reference
-weight: 60
+weight: 110
 no_list: true
 card:
   name: reference

--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -3,6 +3,7 @@ title: kubectl Usage Conventions
 reviewers:
 - janetkuo
 content_type: concept
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -4,6 +4,7 @@ content_type: concept
 reviewers:
 - brendandburns
 - thockin
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -1,6 +1,7 @@
 ---
 title: JSONPath Support
 content_type: concept
+weight: 40
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/kubernetes-api/_index.md
+++ b/content/en/docs/reference/kubernetes-api/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Kubernetes API"
-weight: 30
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Well-Known Labels, Annotations and Taints
 content_type: concept
-weight: 20
+weight: 40
 no_list: true
 ---
 

--- a/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
+++ b/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
@@ -1,6 +1,6 @@
 ---
 title: "Audit Annotations"
-weight: 1
+weight: 10
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/node/_index.md
+++ b/content/en/docs/reference/node/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Node Reference Information
-weight: 40
+weight: 80
 ---

--- a/content/en/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes.md
+++ b/content/en/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes.md
@@ -1,6 +1,7 @@
 ---
 title: Articles on dockershim Removal and on Using CRI-compatible Runtimes
 content_type: reference
+weight: 20
 ---
 <!-- overview -->
 This is a list of articles and other pages that are either

--- a/content/en/docs/reference/ports-and-protocols.md
+++ b/content/en/docs/reference/ports-and-protocols.md
@@ -1,7 +1,7 @@
 ---
 title: Ports and Protocols
 content_type: reference
-weight: 50
+weight: 90
 ---
 
 When running Kubernetes in an environment with strict network boundaries, such 

--- a/content/en/docs/reference/scheduling/_index.md
+++ b/content/en/docs/reference/scheduling/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Scheduling
-weight: 70
+weight: 140
 toc-hide: true
 ---

--- a/content/en/docs/reference/scheduling/policies.md
+++ b/content/en/docs/reference/scheduling/policies.md
@@ -3,6 +3,7 @@ title: Scheduling Policies
 content_type: concept
 sitemap:
   priority: 0.2 # Scheduling priorities are deprecated
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/setup-tools/_index.md
+++ b/content/en/docs/reference/setup-tools/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Setup tools
-weight: 50
+weight: 100
 ---

--- a/content/en/docs/reference/tools/_index.md
+++ b/content/en/docs/reference/tools/_index.md
@@ -3,7 +3,7 @@ title: Other Tools
 reviewers:
 - janetkuo
 content_type: concept
-weight: 80
+weight: 150
 no_list: true
 ---
 

--- a/content/en/docs/reference/tools/map-crictl-dockercli.md
+++ b/content/en/docs/reference/tools/map-crictl-dockercli.md
@@ -1,6 +1,7 @@
 ---
 title: Mapping from dockercli to crictl
 content_type: reference
+weight: 10
 ---
 
 {{% thirdparty-content %}}

--- a/content/en/docs/reference/using-api/_index.md
+++ b/content/en/docs/reference/using-api/_index.md
@@ -5,7 +5,7 @@ reviewers:
 - lavalamp
 - jbeda
 content_type: concept
-weight: 10
+weight: 20
 no_list: true
 card:
   name: reference


### PR DESCRIPTION
Some of these pages in the reference section are autogenerated, but not all. This PR updates the pages and folders that are not autogenerated within the docs/en/reference section. Please let me know if i've accidentally included a fix to an autogenerated page :) 

Related to #35093 and cleanup work from the Kubecon NA docs sprint.

related to #37486 as this PR updates all the non-autogenerated pages within the reference section. 