### PR TITLE
[pt-br] Add /docs/reference/glossary/cronjob.md

### DIFF
--- a/content/pt-br/docs/reference/glossary/cronjob.md
+++ b/content/pt-br/docs/reference/glossary/cronjob.md
@@ -1,0 +1,18 @@
+---
+title: CronJob
+id: cronjob
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/cron-jobs/
+short_description: >
+  Uma tarefa repetida (um trabalho) que é executada regularmente.
+
+aka: 
+tags:
+- core-object
+- workload
+---
+ Gerencia uma [tarefa](/docs/concepts/workloads/controllers/job/) que é executada periodicamente.
+
+<!--more-->
+
+Semelhante a uma linha em um arquivo *crontab*, um objeto CronJob especifica um cronograma usando o formato [cron](https://pt.wikipedia.org/wiki/Cron).


### PR DESCRIPTION

Added translation for portuguese of the glossary term cronjob.