### PR TITLE
Tweak page about PodSecurityPolicy removal

### DIFF
--- a/content/en/docs/concepts/security/pod-security-policy.md
+++ b/content/en/docs/concepts/security/pod-security-policy.md
@@ -1,7 +1,4 @@
 ---
-reviewers:
-- liggitt
-- tallclair
 title: Pod Security Policies
 content_type: concept
 weight: 30
@@ -9,11 +6,11 @@ weight: 30
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.21" state="deprecated" >}}
-
-{{< note >}}
+{{% alert title="Removed feature" color="warning" %}}
 PodSecurityPolicy was [deprecated](/blog/2021/04/08/kubernetes-1-21-release-announcement/#podsecuritypolicy-deprecation)
 in Kubernetes v1.21, and removed from Kubernetes in v1.25.
+{{% /alert %}}
+
 Instead of using PodSecurityPolicy, you can enforce similar restrictions on Pods using
 either or both:
 
@@ -26,4 +23,3 @@ see [PodSecurityPolicy Deprecation: Past, Present, and Future](/blog/2021/04/06/
 
 If you are not running Kubernetes v{{< skew currentVersion >}}, check the documentation for
 your version of Kubernetes.
-{{< /note >}}


### PR DESCRIPTION
Update https://kubernetes.io/docs/concepts/security/pod-security-policy/ [[preview](https://deploy-preview-37731--kubernetes-io-main-staging.netlify.app/docs/concepts/security/pod-security-policy/)]

- Use semi-custom Docsy callout to note the removal
  - (this is not our first use of Docsy's built-in callouts)
- Stop stating that the API is deprecated; it's now actually removed.
and
- Remove reviewers (feature was removed)