### PR TITLE
Add advice about PSP migration

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
+++ b/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
@@ -17,7 +17,10 @@ admission controller. This can be done effectively using a combination of dry-ru
 
 {{% version-check %}}
 
-- Ensure the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) is enabled.
+If you are currently running a version of Kubernetes other than
+{{ skew currentVersion }}, you may want to switch to viewing this
+page in the documentation for the version of Kubernetes that you
+are actually running.
 
 This page assumes you are already familiar with the basic [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
 concepts.


### PR DESCRIPTION
You can't upgrade from PSA to PSA if you are already running a version of Kubernetes that doesn't include PSP. Tweak wording accordingly.