### PR TITLE
Update documentation for PodSecurityPolicy removal

### DIFF
--- a/content/en/docs/concepts/security/pod-security-admission.md
+++ b/content/en/docs/concepts/security/pod-security-admission.md
@@ -131,4 +131,7 @@ current policy level:
 - [Enforcing Pod Security Standards](/docs/setup/best-practices/enforcing-pod-security-standards)
 - [Enforce Pod Security Standards by Configuring the Built-in Admission Controller](/docs/tasks/configure-pod-container/enforce-standards-admission-controller)
 - [Enforce Pod Security Standards with Namespace Labels](/docs/tasks/configure-pod-container/enforce-standards-namespace-labels)
-- [Migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller](/docs/tasks/configure-pod-container/migrate-from-psp)
+
+If you are running an older version of Kubernetes and want to upgrade
+to a version of Kubernetes that does not include PodSecurityPolicies,
+read [migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller](/docs/tasks/configure-pod-container/migrate-from-psp).

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -663,23 +663,15 @@ admission plugin, which allows preventing pods from running on specifically tain
 
 {{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
-This is the replacement for the deprecated [PodSecurityPolicy](#podsecuritypolicy) admission controller
-defined in the next section. This admission controller acts on creation and modification of the pod and
-determines if it should be admitted based on the requested security context and the 
-[Pod Security Standards](/docs/concepts/security/pod-security-standards/).
+The PodSecurity admission controller checks new Pods before they are
+admitted, determines if it should be admitted based on the requested security context and the restrictions on permitted
+[Pod Security Standards](/docs/concepts/security/pod-security-standards/)
+for the namespace that the Pod would be in.
 
-See the [Pod Security Admission documentation](/docs/concepts/security/pod-security-admission/)
-for more information.
+See the [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
+documentation for more information.
 
-### PodSecurityPolicy {#podsecuritypolicy}
-
-{{< feature-state for_k8s_version="v1.21" state="deprecated" >}}
-
-This admission controller acts on creation and modification of the pod and determines if it should be admitted
-based on the requested security context and the available Pod Security Policies.
-
-See also the [PodSecurityPolicy](/docs/concepts/security/pod-security-policy/) documentation
-for more information.
+PodSecurity replaced an older admission controller named PodSecurityPolicy.
 
 ### PodTolerationRestriction {#podtolerationrestriction}
 

--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -4,23 +4,34 @@ reviewers:
 - tallclair
 - liggitt
 content_type: task
-min-kubernetes-server-version: v1.22
 ---
 
-As of v1.22, Kubernetes provides a built-in [admission controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
+Kubernetes provides a built-in [admission controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
 to enforce the [Pod Security Standards](/docs/concepts/security/pod-security-standards).
 You can configure this admission controller to set cluster-wide defaults and [exemptions](/docs/concepts/security/pod-security-admission/#exemptions).
 
 ## {{% heading "prerequisites" %}}
 
-{{% version-check %}}
+Following an alpha release in Kubernetes v1.22,
+Pod Security Admission becaome available by default in Kubernetes v1.23, as
+a beta. From version 1.25 onwards, Pod Security Admission is generally
+available. {{% version-check %}}
 
-- Ensure the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) is enabled.
+If you are not running Kubernetes {{< skew currentVersion >}}, you can switch
+to viewing this page in the documentation for the Kubernetes version that you
+are running.
 
 ## Configure the Admission Controller
 
+{{< note >}}
+`pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
+For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+{{< /note >}}
+
+
 ```yaml
-apiVersion: apiserver.config.k8s.io/v1
+apiVersion: apiserver.config.k8s.io/v1 # see compatibility note
 kind: AdmissionConfiguration
 plugins:
 - name: PodSecurity
@@ -56,8 +67,3 @@ plugins:
 The above manifest needs to be specified via the `--admission-control-config-file` to kube-apiserver.
 {{< /note >}}
 
-{{< note >}}
-`pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
-For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
-For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
-{{< /note >}}

--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-namespace-labels.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-namespace-labels.md
@@ -4,7 +4,6 @@ reviewers:
 - tallclair
 - liggitt
 content_type: task
-min-kubernetes-server-version: v1.22
 ---
 
 Namespaces can be labeled to enforce the [Pod Security Standards](/docs/concepts/security/pod-security-standards). The three policies
@@ -15,9 +14,11 @@ text="admission controller" term_id="admission-controller" >}}.
 
 ## {{% heading "prerequisites" %}}
 
-{{% version-check %}}
+Pod Security Admission was available by default in Kubernetes v1.23, as
+a beta. From version 1.25 onwards, Pod Security Admission is generally
+available.
 
-- Ensure the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) is enabled.
+{{% version-check %}}
 
 ## Requiring the `baseline` Pod Security Standard with namespace labels
 


### PR DESCRIPTION
Really mark PSP as removed.

- cut out some references to PSP
- treat PSA as stable (but hint that older releases might provide it - which they do, in beta)

### Pages changed


1. [original](https://k8s.io/docs/concepts/security/pod-security-admission/) / [preview](https://deploy-preview-37733--kubernetes-io-vnext-staging.netlify.app/docs/concepts/security/pod-security-admission/)
1. [original](https://k8s.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/) / [preview](https://deploy-preview-37733--kubernetes-io-vnext-staging.netlify.app/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)
1. [original](https://k8s.io/docs/reference/access-authn-authz/admission-controllers/) / [preview](https://deploy-preview-37733--kubernetes-io-vnext-staging.netlify.app/docs/reference/access-authn-authz/admission-controllers/)
1. [original](https://k8s.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/) / [preview](https://deploy-preview-37733--kubernetes-io-vnext-staging.netlify.app/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/)
1. ~[original](https://k8s.io/docs/concepts/security/rbac-good-practices/) / [preview](https://deploy-preview-37733--kubernetes-io-vnext-staging.netlify.app/docs/concepts/security/rbac-good-practices/)~


/kind cleanup