### PR TITLE
Fix broken link on Installing Addons page page

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -41,7 +41,7 @@ This page lists some of the available add-ons and links to their respective inst
 ## Visualization &amp; Control
 
 * [Dashboard](https://github.com/kubernetes/dashboard#kubernetes-dashboard) is a dashboard web interface for Kubernetes.
-* [Weave Scope](https://www.weave.works/documentation/scope-latest-installing/#k8s) is a tool for graphically visualizing your containers, pods, services etc. Use it in conjunction with a [Weave Cloud account](https://cloud.weave.works/) or host the UI yourself.
+* [Weave Scope](https://www.weave.works/docs/scope/latest/) is a tool for visualizing your containers, Pods, Services and more.
 
 ## Infrastructure
 


### PR DESCRIPTION
Fixes #37748

Updated page [Installing Addons](https://kubernetes.io/docs/concepts/cluster-administration/addons/)