### PR TITLE
[ko] Update deprecated kubectl command in apparmor doc

### DIFF
--- a/content/ko/docs/tutorials/security/apparmor.md
+++ b/content/ko/docs/tutorials/security/apparmor.md
@@ -160,7 +160,7 @@ kubectl get events | grep Created
 컨테이너의 루트 프로세스가 올바른 프로파일로 실행되는지는 proc attr을 확인하여 직접 검증할 수 있다.
 
 ```shell
-kubectl exec <pod_name> cat /proc/1/attr/current
+kubectl exec <pod_name> -- cat /proc/1/attr/current
 ```
 ```
 k8s-apparmor-example-deny-write (enforce)


### PR DESCRIPTION
This updates example `kubectl exec` commands to avoid warnings. It is a follow-up change to kubernetes#37221.

Running `kubectl exec <pod_name> <command>` is deprecated:
```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead
```
It should be: `kubectl exec <pod_name> -- <command>`