### PR TITLE
Fix tiny typo in NFS Volume example.

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -788,7 +788,7 @@ spec:
     nfs:
       server: my-nfs-server.example.com
       path: /my-nfs-volume
-      readonly: true
+      readOnly: true
 ```
 
 {{< note >}}


### PR DESCRIPTION
`Pod.spec.volumes.nfs.readOnly` was subtly misspelled `readonly`, which was breaking the example.

```
$ k explain Pod.spec.volumes.nfs.readonly
error: field "readonly" does not exist
$ k explain Pod.spec.volumes.nfs.readOnly
KIND:     Pod
VERSION:  v1

FIELD:    readOnly <boolean>
...
```