### PR TITLE
document kubectl explain openapi v3

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -351,6 +351,16 @@ kubectl [flags]
 <td></td><td style="line-height: 130%; word-wrap: break-word;">When set to false, turns off extra HTTP headers detailing invoked kubectl command (Kubernetes version v1.22 or later)</td>
 </tr>
 
+
+
+<tr>
+<td colspan="2">KUBECTL_EXPLAIN_OPENAPIV3</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">Toggles whether calls to `kubectl explain` use the new OpenAPIv3 data source available. OpenAPIV3 is enabled by default since Kubernetes 1.24.
+</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
re: https://github.com/kubernetes/enhancements/issues/3515

this enhancement changes the data backing for `kubectl explain` to use OpenAPIv3 instead of v2 as earlier. It is toggled by en environment variable `KUBECTL_EXPLAIN_OPENAPIV3=true`. 
