### PR TITLE
docs: Update projected-volumes.md

### DIFF
--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -46,8 +46,7 @@ parameters are nearly the same with two exceptions:
   for each individual projection.
 
 ## serviceAccountToken projected volumes {#serviceaccounttoken}
-When the `TokenRequestProjection` feature is enabled, you can inject the token
-for the current [service account](/docs/reference/access-authn-authz/authentication/#service-account-tokens)
+You can inject the token for the current [service account](/docs/reference/access-authn-authz/authentication/#service-account-tokens)
 into a Pod at a specified path. For example:
 
 {{< codenew file="pods/storage/projected-service-account-token.yaml" >}}


### PR DESCRIPTION
### Issue

Closes #37790

### Changes

Removed _When the TokenRequestProjection feature is enabled_ because `TokenRequestProjection` has graduated and is always enabled. 