### PR TITLE
Fix a link in new-features.md

### DIFF
--- a/content/en/docs/contribute/new-content/new-features.md
+++ b/content/en/docs/contribute/new-content/new-features.md
@@ -1,5 +1,5 @@
 ---
-title:  Documenting a feature for a release
+title: Documenting a feature for a release
 linktitle: Documenting for a release
 content_type: concept
 main_menu: true
@@ -7,7 +7,7 @@ weight: 20
 card:
   name: contribute
   weight: 45
-  title:  Documenting a feature for a release
+  title: Documenting a feature for a release
 ---
 <!-- overview -->
 
@@ -128,7 +128,7 @@ make sure you add it to [Alpha/Beta Feature gates](/docs/reference/command-line-
 table as part of your pull request. With new feature gates, a description of
 the feature gate is also required. If your feature is GA'ed or deprecated,
 make sure to move it from the
-[Feature gates for Alpha/Feature](docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) table
+[Feature gates for Alpha/Feature](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) table
 to [Feature gates for graduated or deprecated features](/docs/reference/command-line-tools-reference/feature-gates-removed/#feature-gates-that-are-removed)
 table with Alpha and Beta history intact.
 


### PR DESCRIPTION
Added a `/` to the beginning of a url.
```
content/en/docs/contribute/new-content/new-features.md
```