### PR TITLE
[zh] Update configure-redis-using-configmap.md

### DIFF
--- a/content/zh-cn/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/zh-cn/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -103,7 +103,7 @@ ConfigMap above as `/redis-master/redis.conf` inside the Pod.
 
 * 由 `spec.volumes[1]` 创建一个名为 `config` 的卷。
 * `spec.volumes[1].items[0]` 下的 `key` 和 `path` 会将来自 `example-redis-config`
-  ConfigMap 中的 `redis-config` 密钥公开在 `config` 卷上一个名为 `redis-config` 的文件中。
+  ConfigMap 中的 `redis-config` 密钥公开在 `config` 卷上一个名为 `redis.conf` 的文件中。
 * 然后 `config` 卷被 `spec.containers[0].volumeMounts[1]` 挂载在 `/redis-master`。
 
 这样做的最终效果是将上面 `example-redis-config` 配置中 `data.redis-config`


### PR DESCRIPTION
English Doc: The key and path under spec.volumes[1].items[0] exposes the redis-config key from the example-redis-config ConfigMap as a file named redis.conf on the config volume.

Chinese Doc: spec.volumes[1].items[0] 下的 key 和 path 会将来自 example-redis-config ConfigMap 中的 redis-config 密钥公开在 config 卷上一个名为 redis-config 的文件中。