### PR TITLE
adding links to easy-rsa, cfssl and openssl in certificates.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -7,7 +7,7 @@ weight: 20
 <!-- overview -->
 
 When using client certificate authentication, you can generate certificates
-manually through `easyrsa`, `openssl` or `cfssl`.
+manually through [`easyrsa`](https://github.com/OpenVPN/easy-rsa), [`openssl`](https://github.com/openssl/openssl) or [`cfssl`](https://github.com/cloudflare/cfssl).
 
 <!-- body -->
 


### PR DESCRIPTION
# Description
Adding links of easyrsa, openssl and cfssl in [generate certificates manually](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) for better user experience and more information regarding the same.

/sig docs