### PR TITLE
Add fragment IDs to each CVE row

### DIFF
--- a/content/en/docs/reference/issues-security/official-cve-feed.md
+++ b/content/en/docs/reference/issues-security/official-cve-feed.md
@@ -36,12 +36,8 @@ curl -Lv https://k8s.io/docs/reference/issues-security/official-cve-feed/feed.xm
 {{% /tab %}}
 {{< /tabs >}}
 
+<!-- don't ever repeat this shortcode in one page; it will break the id attributes -->
 {{< cve-feed >}}
-
-<!-- | CVE ID      | Issue Summary | CVE GitHub Issue URL |
-| ----------- | ----------- | --------- |
-| [CVE-2021-25741](https://www.cve.org/CVERecord?id=CVE-2021-25741)      | Symlink Exchange Can Allow Host Filesystem Access | [#104980](https://github.com/kubernetes/kubernetes/issues/104980) |
-| [CVE-2020-8565](https://www.cve.org/CVERecord?id=CVE-2020-8565)      | Incomplete fix for CVE-2019-11250 allows for token leak in logs when logLevel >= 9 | [#95623](https://github.com/kubernetes/kubernetes/issues/95623) | -->
 
 This feed is auto-refreshing with a noticeable but small lag (minutes to hours)
 from the time a CVE is announced to the time it is accessible in this feed.

--- a/layouts/shortcodes/cve-feed.html
+++ b/layouts/shortcodes/cve-feed.html
@@ -13,9 +13,9 @@
   </thead>
   <tbody>
   {{ range $feed.items }}
-  <tr>
-    <td><a href="{{ .url }}">{{ .id | htmlEscape | safeHTML }}</a></td>
-    <td>{{ .summary | htmlEscape | safeHTML }}</td>
+  <tr id="{{ .id | lower | htmlEscape | safeHTML }}">
+    <td><a href="{{ .external_url | safeHTML }}" target="_blank">{{ .id | htmlEscape | safeHTML }}</a></td>
+    <td>{{ .summary | htmlEscape | safeHTML }} <span class="cve-self-link"><a href="#{{ .id | lower | htmlEscape | safeHTML }}"><sup><i class="fa fa-link"></i></sup><a/></span></td>
     <td><a href="{{ .url }}">#{{ ._kubernetes_io.issue_number }}</a></td>
   </tr>
   {{ end }}


### PR DESCRIPTION
You can now hyperlink to a specific CVE ID in https://kubernetes.io/docs/reference/issues-security/official-cve-feed/ [[preview](https://deploy-preview-37851--kubernetes-io-main-staging.netlify.app/docs/reference/issues-security/official-cve-feed/#cve-2022-3294)]

The link in the first column is now to the CVE website (in a new window / tab).

Merge blocker: https://github.com/kubernetes/website/pull/37851#issuecomment-1311785266

/area web-development
/sig security