### PR TITLE
fix: zh-cn learning environment page redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -542,7 +542,7 @@
 /id/docs/setup/minikube/     /id/docs/tasks/tools/ 302
 /docs/setup/learning-environment/     /docs/tasks/tools/  302!
 /id/docs/setup/learning-environment/     /id/docs/tasks/tools/  302!
-/zh/docs/setup/learning-environment/     /zh-cn/docs/tasks/tools/  302!
+/zh-cn/docs/setup/learning-environment/     /zh-cn/docs/tasks/tools/  302!
 /hi/docs/setup/learning-environment/     /hi/docs/tasks/tools/ 302!
 /docs/setup/learning-environment/kind/  /docs/tasks/tools/  302
 /id/docs/setup/learning-environment/kind/  /id/docs/tasks/tools/  302


### PR DESCRIPTION
https://kubernetes.io/zh-cn/docs/setup/learning-environment/, align with EN version

Before:
No redirect

After:
Will redirect to https://kubernetes.io/zh-cn/docs/tasks/tools/