### PR TITLE
Update to MySQL version from 5.6 to 8.0

### DIFF
--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -80,7 +80,7 @@ for a secure solution.
           Labels:       app=mysql
           Containers:
            mysql:
-            Image:      mysql:5.8
+            Image:      mysql:8.0
             Port:       3306/TCP
             Environment:
               MYSQL_ROOT_PASSWORD:      password

--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -141,7 +141,7 @@ behind a Service and you don't intend to increase the number of Pods.
 Run a MySQL client to connect to the server:
 
 ```
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.0 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 This command creates a new Pod in the cluster running a MySQL client

--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -80,7 +80,7 @@ for a secure solution.
           Labels:       app=mysql
           Containers:
            mysql:
-            Image:      mysql:5.6
+            Image:      mysql:5.8
             Port:       3306/TCP
             Environment:
               MYSQL_ROOT_PASSWORD:      password

--- a/content/en/examples/application/mysql/mysql-deployment.yaml
+++ b/content/en/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:5.8
         name: mysql
         env:
           # Use secret in real usage


### PR DESCRIPTION
Current version 5.6 throws error related entry point file. 5.6 is not compatible anymore to run the latest version, k8s.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
