### PR TITLE
Tweak tasks/configmap-secret

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -238,4 +238,3 @@ kubectl delete secret mysecret
 - Read more about the [Secret concept](/docs/concepts/configuration/secret/)
 - Learn how to [manage Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
 - Learn how to [manage Secrets using kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
-

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -33,7 +33,7 @@ Run the following command:
 
 ```shell
 kubectl create secret generic db-user-pass \
-    --from-literal=username=devuser \
+    --from-literal=username=admin \
     --from-literal=password='S!B\*d$zDsb='
 ```
 You must use single quotes `''` to escape special characters such as `$`, `\`,
@@ -87,8 +87,8 @@ kubectl get secrets
 The output is similar to:
 
 ```
-NAME                  TYPE                                  DATA      AGE
-db-user-pass          Opaque                                2         51s
+NAME              TYPE       DATA      AGE
+db-user-pass      Opaque     2         51s
 ```
 
 View the details of the Secret:
@@ -143,11 +143,13 @@ accidentally, or from being stored in a terminal log.
     S!B\*d$zDsb=
     ```
 
-    {{<caution>}}This is an example for documentation purposes. In practice,
+    {{< caution >}}
+    This is an example for documentation purposes. In practice,
     this method could cause the command with the encoded data to be stored in
     your shell history. Anyone with access to your computer could find the
     command and decode the secret. A better approach is to combine the view and
-    decode commands.{{</caution>}}
+    decode commands.
+    {{< /caution >}}
 
     ```shell
     kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
@@ -193,10 +195,8 @@ To delete a Secret, run the following command:
 kubectl delete secret db-user-pass
 ```
 
-<!-- discussion -->
-
 ## {{% heading "whatsnext" %}}
 
 - Read more about the [Secret concept](/docs/concepts/configuration/secret/)
-- Learn how to [manage Secrets using config files](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
+- Learn how to [manage Secrets using config file](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
 - Learn how to [manage Secrets using kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -90,8 +90,7 @@ the Secret data and appending the hash value to the name. This ensures that
 a new Secret is generated each time the data is modified.
 
 To verify that the Secret was created and to decode the Secret data, refer to
-[Managing Secrets using
-kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
+[Managing Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
 ## Edit a Secret {#edit-secret}
 
@@ -117,12 +116,11 @@ your Pods.
 To delete a Secret, use `kubectl`:
 
 ```shell
-kubectl delete secret <secret-name>
+kubectl delete secret db-user-pass
 ```
 
-<!-- Optional section; add links to information related to this topic. -->
 ## {{% heading "whatsnext" %}}
 
 - Read more about the [Secret concept](/docs/concepts/configuration/secret/)
-- Learn how to [manage Secrets with the `kubectl` command](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- Learn how to [manage Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
 - Learn how to [manage Secrets using config file](/docs/tasks/configmap-secret/managing-secret-using-config-file/)


### PR DESCRIPTION
The long console output cannot be display in current [version](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
```
NAME                  TYPE                                  DATA  ...
db-user-pass          Opaque                                2     ...
```

Change it to shorter version:
```
NAME              TYPE       DATA      AGE
db-user-pass      Opaque     2         51s
```

And sync footer format for three related files.

Preview: https://deploy-preview-37864--kubernetes-io-main-staging.netlify.app/docs/tasks/configmap-secret/managing-secret-using-kubectl/