### PR TITLE
Updated the steps to verify the modules and system variables

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -56,11 +56,21 @@ For more information, see [Network Plugin Requirements](/docs/concepts/extend-ku
 
 ### Forwarding IPv4 and letting iptables see bridged traffic
 
-Verify that the `br_netfilter` module is loaded by running `lsmod | grep br_netfilter`. 
+Verify that the below modules are loaded:   
+Verify `br_netfilter` module is loaded by running `lsmod | grep br_netfilter`.   
+Verify `overlay` module is loaded by running `lsmod | grep overlay`. 
 
-To load it explicitly, run `sudo modprobe br_netfilter`.
+To load the modules explicitly, run:   
+`sudo modprobe br_netfilter`   
+`sudo modprobe overlay`
 
-In order for a Linux node's iptables to correctly view bridged traffic, verify that `net.bridge.bridge-nf-call-iptables` is set to 1 in your `sysctl` config. For example:
+In order for a Linux node's iptables to correctly view bridged traffic, verify that following system variables are set to 1 in your `sysctl` config: `net.bridge.bridge-nf-call-iptables`, `net.bridge.bridge-nf-call-ip6tables`, `net.ipv4.ip_forward`.
+
+To verify, run the below command to get the values of system variables:   
+`sysctl -n net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward`
+
+
+Follow the below mentioned steps if any of the above verification fails:
 
 ```bash
 cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -56,21 +56,7 @@ For more information, see [Network Plugin Requirements](/docs/concepts/extend-ku
 
 ### Forwarding IPv4 and letting iptables see bridged traffic
 
-Verify that the below modules are loaded:   
-Verify `br_netfilter` module is loaded by running `lsmod | grep br_netfilter`.   
-Verify `overlay` module is loaded by running `lsmod | grep overlay`. 
-
-To load the modules explicitly, run:   
-`sudo modprobe br_netfilter`   
-`sudo modprobe overlay`
-
-In order for a Linux node's iptables to correctly view bridged traffic, verify that following system variables are set to 1 in your `sysctl` config: `net.bridge.bridge-nf-call-iptables`, `net.bridge.bridge-nf-call-ip6tables`, `net.ipv4.ip_forward`.
-
-To verify, run the below command to get the values of system variables:   
-`sysctl -n net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward`
-
-
-Follow the below mentioned steps if any of the above verification fails:
+Execute the below mentioned instructions:
 
 ```bash
 cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
@@ -90,6 +76,18 @@ EOF
 
 # Apply sysctl params without reboot
 sudo sysctl --system
+```
+
+Verify that the `br_netfilter`, `overlay` modules are loaded by running below instructions:   
+
+```bash
+lsmod | grep br_netfilter
+lsmod | grep overlay
+```
+
+Verify that the `net.bridge.bridge-nf-call-iptables`, `net.bridge.bridge-nf-call-ip6tables`, `net.ipv4.ip_forward` system variables are set to 1 in your `sysctl` config by running below instruction:   
+```bash
+sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
 ```
 
 ## Cgroup drivers


### PR DESCRIPTION
The steps mentioned under the topic _[Forwarding IPv4 and letting iptables see bridged traffic](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic)_ were not clear.

I have updated the steps to be more understandble and easy to follow.

Previously mentioned steps were suggesting it as an example even-though it should have been the exact steps to be followed in case the verification of modules and system variables fail.

Thank you.