### PR TITLE
[hi] localize content/en/docs/reference/glossary/limitrange.md

### DIFF
--- a/content/hi/docs/reference/glossary/limitrange.md
+++ b/content/hi/docs/reference/glossary/limitrange.md
@@ -1,0 +1,23 @@
+---
+title: लिमिटरेंज (LimitRange)
+id: limitrange
+date: 2019-04-15
+full_link:  /docs/concepts/policy/limit-range/
+short_description: >
+  नामस्थान (namespace) में प्रति कंटेनर या पॉड में संसाधन खपत को सीमित करने के लिए प्रतिबंध प्रदान करता है।
+
+aka: 
+tags:
+- core-object
+- fundamental
+- architecture
+related:
+ - pod
+ - container
+
+---
+ नामस्थान (namespace) में प्रति {{< glossary_tooltip text="कंटेनर" term_id="container" >}} या {{< glossary_tooltip text="पॉड" term_id="pod" >}} में संसाधन खपत को सीमित करने के लिए प्रतिबंध प्रदान करता है।
+
+<!--more--> 
+लिमिटरेंज (LimitRange) टाइप (type) द्वारा बनाई जा सकने वाली वस्तुओं की मात्रा को सीमित रहता है,
+साथ ही एक नामस्थान (namespace) में अलग-अलग {{< glossary_tooltip text="कंटेनर" term_id="container" >}} या {{< glossary_tooltip text="पॉड" term_id="pod" >}} द्वारा अनुरोधित/उपभोग किए जा सकने वाले कंप्यूट संसाधनों की मात्रा को भी।

--- a/content/hi/docs/reference/glossary/limitrange.md
+++ b/content/hi/docs/reference/glossary/limitrange.md
@@ -4,7 +4,7 @@ id: limitrange
 date: 2019-04-15
 full_link:  /docs/concepts/policy/limit-range/
 short_description: >
-  नामस्थान (namespace) में प्रति कंटेनर या पॉड में संसाधन खपत को सीमित करने के लिए प्रतिबंध प्रदान करता है।
+  नेमस्पेस में प्रति कंटेनर या पॉड में संसाधन खपत को सीमित करने के लिए प्रतिबंध प्रदान करता है।
 
 aka: 
 tags:
@@ -16,8 +16,7 @@ related:
  - container
 
 ---
- नामस्थान (namespace) में प्रति {{< glossary_tooltip text="कंटेनर" term_id="container" >}} या {{< glossary_tooltip text="पॉड" term_id="pod" >}} में संसाधन खपत को सीमित करने के लिए प्रतिबंध प्रदान करता है।
+ नेमस्पेस में प्रति {{< glossary_tooltip text="कंटेनर" term_id="container" >}} या {{< glossary_tooltip text="पॉड" term_id="pod" >}} में संसाधन खपत को सीमित करने के लिए प्रतिबंध प्रदान करता है।
 
 <!--more--> 
-लिमिटरेंज (LimitRange) टाइप (type) द्वारा बनाई जा सकने वाली वस्तुओं की मात्रा को सीमित रहता है,
-साथ ही एक नामस्थान (namespace) में अलग-अलग {{< glossary_tooltip text="कंटेनर" term_id="container" >}} या {{< glossary_tooltip text="पॉड" term_id="pod" >}} द्वारा अनुरोधित/उपभोग किए जा सकने वाले कंप्यूट संसाधनों की मात्रा को भी।
+लिमिटरेंज, टाइप (type) द्वारा बनाई जा सकने वाले ऑब्जेक्ट्स और साथ ही नेमस्पेस में अलग-अलग {{< glossary_tooltip text="कंटेनर" term_id="container" >}} या {{< glossary_tooltip text="पॉड" term_id="pod" >}} द्वारा अनुरोध/उपभोग किए जा सकने वाले कंप्यूट संसाधनों की मात्रा को सीमित करता है।


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

Localized the content of `content/en/docs/reference/glossary/limitrange.md` into Hindi language in the file `content/hi/docs/reference/glossary/limitrange.md`

Fixes https://github.com/kubernetes/website/issues/37856 and https://github.com/kubernetes/website/issues/35600

