### PR TITLE
Add November patch releases and mark 1.22 release as End-of-Life (EOL)

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,8 +78,7 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| November 2022         | 2022-11-04           | 2022-11-09  |
-| December 2022         | 2022-12-09           | 2022-12-14  |
+| December 2022         | 2022-12-02           | 2022-12-07  |
 | January 2023          | 2023-01-13           | 2023-01-18  |
 | February 2023         | 2023-02-10           | 2023-02-15  |
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,10 +4,13 @@ schedules:
   maintenanceModeStartDate: 2023-08-28
   endOfLifeDate: 2023-10-27
   next:
-    release: 1.25.4
-    cherryPickDeadline: 2022-11-04
-    targetDate: 2022-11-09
+    release: 1.25.5
+    cherryPickDeadline: 2022-12-02
+    targetDate: 2022-12-07
   previousPatches:
+    - release: 1.25.4
+      cherryPickDeadline: 2022-11-04
+      targetDate: 2022-11-09
     - release: 1.25.3
       cherryPickDeadline: 2022-10-07
       targetDate: 2022-10-12
@@ -26,10 +29,13 @@ schedules:
   maintenanceModeStartDate: 2023-05-28
   endOfLifeDate: 2023-07-28
   next:
-    release: 1.24.8
-    cherryPickDeadline: 2022-11-04
-    targetDate: 2022-11-09
+    release: 1.24.9
+    cherryPickDeadline: 2022-12-02
+    targetDate: 2022-12-07
   previousPatches:
+    - release: 1.24.8
+      cherryPickDeadline: 2022-11-04
+      targetDate: 2022-11-09
     - release: 1.24.7
       cherryPickDeadline: 2022-10-07
       targetDate: 2022-10-12
@@ -60,10 +66,13 @@ schedules:
   maintenanceModeStartDate: 2022-12-28
   endOfLifeDate: 2023-02-28
   next:
-    release: 1.23.14
-    cherryPickDeadline: 2022-11-04
-    targetDate: 2022-11-09
+    release: 1.23.15
+    cherryPickDeadline: 2022-12-02
+    targetDate: 2022-12-07
   previousPatches:
+    - release: 1.23.14
+      cherryPickDeadline: 2022-11-04
+      targetDate: 2022-11-09
     - release: 1.23.13
       cherryPickDeadline: 2022-10-07
       targetDate: 2022-10-12


### PR DESCRIPTION
* Add November and upcoming December patch releases to the patch releases list
* Move December patch releases for a week earlier (2022-12-07): https://groups.google.com/a/kubernetes.io/g/dev/c/GDkqm5JtiNg/m/_OHgqDgWBQAJ

/assign @saschagrunert @cpanato @puerco @Verolop 
cc @kubernetes/release-engineering 