### PR TITLE
Fix typo in Pod Topology Spread Constraints concept

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -98,7 +98,7 @@ your cluster. Those fields are:
 
   {{< note >}}
   The `minDomains` field is a beta field and enabled by default in 1.25. You can disable it by disabling the
-  `MinDomainsInPodToplogySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
+  `MinDomainsInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
   {{< /note >}}
 
   - The value of `minDomains` must be greater than 0, when specified.


### PR DESCRIPTION
Fix typo MinDomainsInPodToplogySpread -> MinDomainsInPodTopologySpread