### PR TITLE
[ja] use $HOSTNAME env variable instead of hostname command

### DIFF
--- a/content/ja/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/ja/examples/application/mysql/mysql-statefulset.yaml
@@ -22,7 +22,7 @@ spec:
         - |
           set -ex
           # Generate mysql server-id from pod ordinal index.
-          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+          [[ $HOSTNAME =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           echo [mysqld] > /mnt/conf.d/server-id.cnf
           # Add an offset to avoid reserved server-id=0 value.


### PR DESCRIPTION
en PR https://github.com/kubernetes/website/pull/36596/files
/assign @atoato88
/assign @nasa9084