### PR TITLE
kep-1965: update doc references for APIServerIdentity

### DIFF
--- a/content/en/docs/concepts/architecture/leases.md
+++ b/content/en/docs/concepts/architecture/leases.md
@@ -1,0 +1,40 @@
+---
+title: Leases
+content_type: concept
+weight: 30
+---
+
+<!-- overview -->
+
+Distrbuted systems often have a need for "leases", which provides a mechanism to lock shared resources and coordinate activity between nodes.
+In Kubernetes, the "lease" concept is represented by `Lease` objects in the `coordination.k8s.io` API group, which are used for system-critical
+capabilities like node heart beats and component-level leader election.
+
+<!-- body -->
+
+## Node Heart Beats
+
+Kubernetes uses the Lease API to communicate kubelet node heart beats to the Kubernetes API server.
+For every `Node` , there is a `Lease` object with a matching name in the `kube-node-lease`
+namespace. Under the hood, every kubelet heart beat is an UPDATE request to this `Lease` object, updating
+the `spec.renewTime` field for the Lease. The Kubernetes control plane uses the time stamp of this field
+to determine the availability of this `Node`.
+
+See [Node Lease objects](/docs/concepts/architecture/nodes/#heartbeats) for more details.
+
+## Leader Election
+
+Leases are also used in Kubernetes to ensure only one instance of a component is running at any given time.
+This is used by control plane components like `kube-controller-manager` and `kube-scheduler` in
+HA configurations, where only one instance of the component should be actively running while the other
+instances are on stand-by.
+
+## kube-apiserver identity
+
+{{< feature-state for_k8s_version="v1.26" state="beta" >}}
+
+Starting in Kubernetes v1.26, each `kube-apiserver` uses the Lease API to publish its identity to the
+rest of the system. While not particularly useful on its own, this provides a mechanism for clients to
+discover how many instances of `kube-apiserver` are operating the Kubernetes control plane.
+Existence of kube-apiserver leases enables future capabilities that may require coordination between
+each kube-apiserver.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -63,7 +63,8 @@ For a reference to old feature gates that are removed, please refer to
 | `APIResponseCompression` | `false` | Alpha | 1.7 | 1.15 |
 | `APIResponseCompression` | `true` | Beta | 1.16 | |
 | `APISelfSubjectAttributesReview` | `false` | Alpha | 1.26 | |
-| `APIServerIdentity` | `false` | Alpha | 1.20 | |
+| `APIServerIdentity` | `false` | Alpha | 1.20 | 1.25 |
+| `APIServerIdentity` | `true` | Beta | 1.26 | |
 | `APIServerTracing` | `false` | Alpha | 1.22 | |
 | `AllowInsecureBackendProxy` | `true` | Beta | 1.17 | |
 | `AnyVolumeDataSource` | `false` | Alpha | 1.18 | 1.23 |
@@ -646,7 +647,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   filesystem walk for better performance and accuracy.
 - `LogarithmicScaleDown`: Enable semi-random selection of pods to evict on controller scaledown
   based on logarithmic bucketing of pod timestamps.
-- `MatchLabelKeysInPodTopologySpread`: Enable the `matchLabelKeys` field for 
+- `MatchLabelKeysInPodTopologySpread`: Enable the `matchLabelKeys` field for
   [Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/).
 - `MaxUnavailableStatefulSet`: Enables setting the `maxUnavailable` field for the
   [rolling update strategy](/docs/concepts/workloads/controllers/statefulset/#rolling-updates)


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

Update feature gate reference for APIServerIdentity. Currently on the fence about whether we want more comprehensive documentation for this feature. In it's current state it is mainly going to be used for internal optimizations (i.e. StorageVersion API) and likely won't see too much use from users.
