### PR TITLE
Localization for glossary tag display names

### DIFF
--- a/data/canonical-tags/architecture.yaml
+++ b/data/canonical-tags/architecture.yaml
@@ -1,5 +1,1 @@
 id: architecture
-name: Architecture
-description: The inner components of Kubernetes.
-nameKey: canonical_tag_architecture_name
-descriptionKey: canonical_tag_architecture_description

--- a/data/canonical-tags/architecture.yaml
+++ b/data/canonical-tags/architecture.yaml
@@ -1,3 +1,5 @@
 id: architecture
 name: Architecture
 description: The inner components of Kubernetes.
+nameKey: canonical_tag_architecture_name
+descriptionKey: canonical_tag_architecture_description

--- a/data/canonical-tags/community.yaml
+++ b/data/canonical-tags/community.yaml
@@ -1,3 +1,5 @@
 id: community
 name: Community
 description: Related to Kubernetes open-source development.
+nameKey: canonical_tag_community_name
+descriptionKey: canonical_tag_community_description

--- a/data/canonical-tags/community.yaml
+++ b/data/canonical-tags/community.yaml
@@ -1,5 +1,1 @@
 id: community
-name: Community
-description: Related to Kubernetes open-source development.
-nameKey: canonical_tag_community_name
-descriptionKey: canonical_tag_community_description

--- a/data/canonical-tags/core-object.yaml
+++ b/data/canonical-tags/core-object.yaml
@@ -1,5 +1,1 @@
 id: core-object
-name: Core Object
-description: A resource type that Kubernetes supports by default.
-nameKey: canonical_tag_core_object_name
-descriptionKey: canonical_tag_core_object_description

--- a/data/canonical-tags/core-object.yaml
+++ b/data/canonical-tags/core-object.yaml
@@ -1,3 +1,5 @@
 id: core-object
 name: Core Object
 description: A resource type that Kubernetes supports by default.
+nameKey: canonical_tag_core_object_name
+descriptionKey: canonical_tag_core_object_description

--- a/data/canonical-tags/extension.yaml
+++ b/data/canonical-tags/extension.yaml
@@ -1,3 +1,5 @@
 id: extension
 name: Extension
 description: Supported customizations of Kubernetes.
+nameKey: canonical_tag_extension_name
+descriptionKey: canonical_tag_extension_description

--- a/data/canonical-tags/extension.yaml
+++ b/data/canonical-tags/extension.yaml
@@ -1,5 +1,1 @@
 id: extension
-name: Extension
-description: Supported customizations of Kubernetes.
-nameKey: canonical_tag_extension_name
-descriptionKey: canonical_tag_extension_description

--- a/data/canonical-tags/fundamental.yaml
+++ b/data/canonical-tags/fundamental.yaml
@@ -1,3 +1,5 @@
 id: fundamental
 name: Fundamental
 description: Relevant for a first-time user of Kubernetes.
+nameKey: canonical_tag_fundamental_name
+descriptionKey: canonical_tag_fundamental_description

--- a/data/canonical-tags/fundamental.yaml
+++ b/data/canonical-tags/fundamental.yaml
@@ -1,5 +1,1 @@
 id: fundamental
-name: Fundamental
-description: Relevant for a first-time user of Kubernetes.
-nameKey: canonical_tag_fundamental_name
-descriptionKey: canonical_tag_fundamental_description

--- a/data/canonical-tags/networking.yaml
+++ b/data/canonical-tags/networking.yaml
@@ -1,5 +1,1 @@
 id: networking
-name: Networking
-description: How Kubernetes components talk to each other (and to programs outside the cluster).
-nameKey: canonical_tag_networking_name
-descriptionKey: canonical_tag_networking_description

--- a/data/canonical-tags/networking.yaml
+++ b/data/canonical-tags/networking.yaml
@@ -1,3 +1,5 @@
 id: networking
 name: Networking
 description: How Kubernetes components talk to each other (and to programs outside the cluster).
+nameKey: canonical_tag_networking_name
+descriptionKey: canonical_tag_networking_description

--- a/data/canonical-tags/operation.yaml
+++ b/data/canonical-tags/operation.yaml
@@ -1,3 +1,5 @@
 id: operation
 name: Operation
 description: Starting and maintaining Kubernetes.
+nameKey: canonical_tag_operation_name
+descriptionKey: canonical_tag_operation_description

--- a/data/canonical-tags/operation.yaml
+++ b/data/canonical-tags/operation.yaml
@@ -1,5 +1,1 @@
 id: operation
-name: Operation
-description: Starting and maintaining Kubernetes.
-nameKey: canonical_tag_operation_name
-descriptionKey: canonical_tag_operation_description

--- a/data/canonical-tags/security.yaml
+++ b/data/canonical-tags/security.yaml
@@ -1,3 +1,5 @@
 id: security
 name: Security
 description: Keeping Kubernetes applications safe and secure.
+nameKey: canonical_tag_security_name
+descriptionKey: canonical_tag_security_description

--- a/data/canonical-tags/security.yaml
+++ b/data/canonical-tags/security.yaml
@@ -1,5 +1,1 @@
 id: security
-name: Security
-description: Keeping Kubernetes applications safe and secure.
-nameKey: canonical_tag_security_name
-descriptionKey: canonical_tag_security_description

--- a/data/canonical-tags/storage.yaml
+++ b/data/canonical-tags/storage.yaml
@@ -1,5 +1,1 @@
 id: storage
-name: Storage
-description: How Kubernetes applications handle persistent data.
-nameKey: canonical_tag_storage_name
-descriptionKey: canonical_tag_storage_description

--- a/data/canonical-tags/storage.yaml
+++ b/data/canonical-tags/storage.yaml
@@ -1,3 +1,5 @@
 id: storage
 name: Storage
 description: How Kubernetes applications handle persistent data.
+nameKey: canonical_tag_storage_name
+descriptionKey: canonical_tag_storage_description

--- a/data/canonical-tags/tool.yaml
+++ b/data/canonical-tags/tool.yaml
@@ -1,5 +1,1 @@
 id: tool
-name: Tool
-description: Software that makes Kubernetes easier or better to use.
-nameKey: canonical_tag_tool_name
-descriptionKey: canonical_tag_tool_description

--- a/data/canonical-tags/tool.yaml
+++ b/data/canonical-tags/tool.yaml
@@ -1,3 +1,5 @@
 id: tool
 name: Tool
 description: Software that makes Kubernetes easier or better to use.
+nameKey: canonical_tag_tool_name
+descriptionKey: canonical_tag_tool_description

--- a/data/canonical-tags/user-type.yaml
+++ b/data/canonical-tags/user-type.yaml
@@ -1,3 +1,5 @@
 id: user-type
 name: User Type
 description: Represents a common type of Kubernetes user.
+nameKey: canonical_tag_user_type_name
+descriptionKey: canonical_tag_user_type_description

--- a/data/canonical-tags/user-type.yaml
+++ b/data/canonical-tags/user-type.yaml
@@ -1,5 +1,1 @@
 id: user-type
-name: User Type
-description: Represents a common type of Kubernetes user.
-nameKey: canonical_tag_user_type_name
-descriptionKey: canonical_tag_user_type_description

--- a/data/canonical-tags/workload.yaml
+++ b/data/canonical-tags/workload.yaml
@@ -1,3 +1,5 @@
 id: workload
 name: Workload
 description: Applications running on Kubernetes.
+nameKey: canonical_tag_workload_name
+descriptionKey: canonical_tag_workload_description

--- a/data/canonical-tags/workload.yaml
+++ b/data/canonical-tags/workload.yaml
@@ -1,5 +1,1 @@
 id: workload
-name: Workload
-description: Applications running on Kubernetes.
-nameKey: canonical_tag_workload_name
-descriptionKey: canonical_tag_workload_description

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -373,74 +373,74 @@ other = "Warning:"
 [whatsnext_heading]
 other = "What's next"
 
-[canonical_tag_architecture_name]
+[layout_docs_glossary_architecture_name]
 other = "Architecture"
 
-[canonical_tag_architecture_description]
+[layout_docs_glossary_architecture_description]
 other = "The inner components of Kubernetes."
 
-[canonical_tag_community_name]
+[layout_docs_glossary_community_name]
 other = "Community"
 
-[canonical_tag_community_description]
+[layout_docs_glossary_community_description]
 other = "Related to Kubernetes open-source development."
 
-[canonical_tag_core_object_name]
+[layout_docs_glossary_core-object_name]
 other = "Core Object"
 
-[canonical_tag_core_object_description]
+[layout_docs_glossary_core-object_description]
 other = "A resource type that Kubernetes supports by default."
 
-[canonical_tag_extension_name]
+[layout_docs_glossary_extension_name]
 other = "Extension"
 
-[canonical_tag_extension_description]
+[layout_docs_glossary_extension_description]
 other = "Supported customizations of Kubernetes."
 
-[canonical_tag_fundamental_name]
+[layout_docs_glossary_fundamental_name]
 other = "Fundamental"
 
-[canonical_tag_fundamental_description]
+[layout_docs_glossary_fundamental_description]
 other = "Relevant for a first-time user of Kubernetes."
 
-[canonical_tag_networking_name]
+[layout_docs_glossary_networking_name]
 other = "Networking"
 
-[canonical_tag_networking_description]
+[layout_docs_glossary_networking_description]
 other = "How Kubernetes components talk to each other (and to programs outside the cluster)."
 
-[canonical_tag_operation_name]
+[layout_docs_glossary_operation_name]
 other = "Operation"
 
-[canonical_tag_operation_description]
+[layout_docs_glossary_operation_description]
 other = "Starting and maintaining Kubernetes."
 
-[canonical_tag_security_name]
+[layout_docs_glossary_security_name]
 other = "Security"
 
-[canonical_tag_security_description]
+[layout_docs_glossary_security_description]
 other = "Keeping Kubernetes applications safe and secure."
 
-[canonical_tag_storage_name]
+[layout_docs_glossary_storage_name]
 other = "Storage"
 
-[canonical_tag_storage_description]
+[layout_docs_glossary_storage_description]
 other = "How Kubernetes applications handle persistent data."
 
-[canonical_tag_tool_name]
+[layout_docs_glossary_tool_name]
 other = "Tool"
 
-[canonical_tag_tool_description]
+[layout_docs_glossary_tool_description]
 other = "Software that makes Kubernetes easier or better to use."
 
-[canonical_tag_user_type_name]
+[layout_docs_glossary_user-type_name]
 other = "User Type"
 
-[canonical_tag_user_type_description]
+[layout_docs_glossary_user-type_description]
 other = "Represents a common type of Kubernetes user."
 
-[canonical_tag_workload_name]
+[layout_docs_glossary_workload_name]
 other = "Workload"
 
-[canonical_tag_workload_description]
+[layout_docs_glossary_workload_description]
 other = "Applications running on Kubernetes."

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -372,3 +372,75 @@ other = "Warning:"
 
 [whatsnext_heading]
 other = "What's next"
+
+[canonical_tag_architecture_name]
+other = "Architecture"
+
+[canonical_tag_architecture_description]
+other = "The inner components of Kubernetes."
+
+[canonical_tag_community_name]
+other = "Community"
+
+[canonical_tag_community_description]
+other = "Related to Kubernetes open-source development."
+
+[canonical_tag_core_object_name]
+other = "Core Object"
+
+[canonical_tag_core_object_description]
+other = "A resource type that Kubernetes supports by default."
+
+[canonical_tag_extension_name]
+other = "Extension"
+
+[canonical_tag_extension_description]
+other = "Supported customizations of Kubernetes."
+
+[canonical_tag_fundamental_name]
+other = "Fundamental"
+
+[canonical_tag_fundamental_description]
+other = "Relevant for a first-time user of Kubernetes."
+
+[canonical_tag_networking_name]
+other = "Networking"
+
+[canonical_tag_networking_description]
+other = "How Kubernetes components talk to each other (and to programs outside the cluster)."
+
+[canonical_tag_operation_name]
+other = "Operation"
+
+[canonical_tag_operation_description]
+other = "Starting and maintaining Kubernetes."
+
+[canonical_tag_security_name]
+other = "Security"
+
+[canonical_tag_security_description]
+other = "Keeping Kubernetes applications safe and secure."
+
+[canonical_tag_storage_name]
+other = "Storage"
+
+[canonical_tag_storage_description]
+other = "How Kubernetes applications handle persistent data."
+
+[canonical_tag_tool_name]
+other = "Tool"
+
+[canonical_tag_tool_description]
+other = "Software that makes Kubernetes easier or better to use."
+
+[canonical_tag_user_type_name]
+other = "User Type"
+
+[canonical_tag_user_type_description]
+other = "Represents a common type of Kubernetes user."
+
+[canonical_tag_workload_name]
+other = "Workload"
+
+[canonical_tag_workload_description]
+other = "Applications running on Kubernetes."

--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -12,14 +12,14 @@
 	<div class="tag-description invisible" id="placeholder">.</div>
 	{{ range (index site.Data "canonical-tags") }}
 	<div class="tag-description hide" id="{{ printf "tag-%s-description" .id  }}">
-		<i>{{ T .descriptionKey }}</i>
+		<i>{{ T (printf "layout_docs_glossary_%s_description" .id) }}</i>
 	</div>
 	{{ end }}
-	{{ $sorted_tags := sort (index site.Data "canonical-tags") "nameKey" }}
+	{{ $sorted_tags := sort (index site.Data "canonical-tags") "id" }}
 	{{ range $sorted_tags }}
 	{{ $full_tag_name := printf "tag-%s" .id }}
 	<span id="{{ $full_tag_name  }}" class="tag-option canonical-tag" data-target="{{ $full_tag_name  }}">
-		<a href="javascript:void(0)">{{ T .nameKey  }}</a>
+		<a href="javascript:void(0)">{{ T (printf "layout_docs_glossary_%s_name" .id)  }}</a>
 	</span>
 	{{ end }}
 	<span class="tag-option"><a id="select-all-tags" href="javascript:void(0)">{{ T "layouts_docs_glossary_select_all" }}</a></span>

--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -12,14 +12,14 @@
 	<div class="tag-description invisible" id="placeholder">.</div>
 	{{ range (index site.Data "canonical-tags") }}
 	<div class="tag-description hide" id="{{ printf "tag-%s-description" .id  }}">
-		<i>{{ .description }}</i>
+		<i>{{ T .descriptionKey }}</i>
 	</div>
 	{{ end }}
-	{{ $sorted_tags := sort (index site.Data "canonical-tags") "name" }}
+	{{ $sorted_tags := sort (index site.Data "canonical-tags") "nameKey" }}
 	{{ range $sorted_tags }}
 	{{ $full_tag_name := printf "tag-%s" .id }}
 	<span id="{{ $full_tag_name  }}" class="tag-option canonical-tag" data-target="{{ $full_tag_name  }}">
-		<a href="javascript:void(0)">{{  .name  }}</a>
+		<a href="javascript:void(0)">{{ T .nameKey  }}</a>
 	</span>
 	{{ end }}
 	<span class="tag-option"><a id="select-all-tags" href="javascript:void(0)">{{ T "layouts_docs_glossary_select_all" }}</a></span>


### PR DESCRIPTION
### Changes

* First attempt at localizing glossary tag display names.
* Kept the original YAML files for canonical tags to serve as a template, as it is the easiest way to iterate over terms in a Hugo template.
* Added new keys to the original YAML files for canonical tags, indicating under which keys in the translations the localized terms can be found.
* Changed the template in `layout/docs/glossary.html` to get localized terms based on the new keys in the YAML files for canonical tags.

### Open questions
* Is it acceptable to sort by the new `.nameKey` field?
  This page originally had alphabetical order sorting. Some characteristics of having the tags be sorted on this field include the original order being maintained, as well as keeping the same ordering regardless of localization.
* Should the original names and descriptions in the canonical tag YAMLs be kept for future reference?

Fixes kubernetes/website#30016

/area localization
/cc @a-mccarthy @seokho-son @sftim