### PR TITLE
Add pt-br/docs/reference/glossary/code-contributor.md

### DIFF
--- a/content/pt-br/docs/reference/glossary/code-contributor.md
+++ b/content/pt-br/docs/reference/glossary/code-contributor.md
@@ -1,0 +1,18 @@
+---
+title: Colaborador de Código
+id: code-contributor
+date: 2018-04-12
+full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
+short_description: >
+ Uma pessoa que desenvolve e contribui com código para o código aberto do Kubernetes.
+
+aka: 
+tags:
+- community
+- user-type
+---
+ Uma pessoa que desenvolve e contribui com código para o código aberto do Kubernetes.
+
+<!--more--> 
+
+Eles também são ativos {{< glossary_tooltip text="membros da comunidade" term_id="member" >}} que participam de um ou mais {{< glossary_tooltip text="Grupos de Interesse Especial (SIGs)" term_id="sig" >}}.

--- a/content/pt-br/docs/reference/glossary/code-contributor.md
+++ b/content/pt-br/docs/reference/glossary/code-contributor.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more--> 
 
-Eles também são ativos {{< glossary_tooltip text="membros da comunidade" term_id="member" >}} que participam de um ou mais {{< glossary_tooltip text="Grupos de Interesse Especial (SIGs)" term_id="sig" >}}.
+Eles também são {{< glossary_tooltip text="membros da comunidade" term_id="member" >}} ativos que participam de um ou mais {{< glossary_tooltip text="Grupos de Interesse Especial (SIGs)" term_id="sig" >}}.


### PR DESCRIPTION
Added translation for portuguese of the glossary term code-contributor.