### PR TITLE
Split out kubelet instrumentation details into reference page

### DIFF
--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -1,0 +1,55 @@
+---
+title: Node metrics data
+content_type: reference
+weight: 50
+description: >-
+  Mechanisms for accessing metrics at node, volume, pod and container level,
+  as seen by the kubelet.
+---
+
+The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
+gathers metric statistics at the node, volume, pod and container level,
+and emits this information in the
+[Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go).
+
+You can send a proxied request to the stats summary API via the
+Kubernetes API server.
+
+Here is an example of a Summary API request for a node named `minikube`:
+
+```shell
+kubectl get --raw "/api/v1/nodes/minikube/proxy/stats/summary"
+```
+
+Here is the same API call using `curl`:
+
+```shell
+# You need to run "kubectl proxy" first
+# Change 8080 to the port that "kubectl proxy" assigns
+curl http://localhost:8080/api/v1/nodes/minikube/proxy/stats/summary
+```
+
+{{< note >}}
+Beginning with `metrics-server` 0.6.x, `metrics-server` queries the `/metrics/resource`
+kubelet endpoint, and not `/stats/summary`.
+{{< /note >}}
+
+## Summary metrics API source {#summary-api-source}
+
+By default, Kubernetes fetches node summary metrics data using an embedded
+[cAdvisor](https://github.com/google/cadvisor) that runs within the kubelet.
+
+## Summary API data via CRI {#pod-and-container-stats-from-cri}
+
+{{< feature-state for_k8s_version="v1.23" state="alpha" >}}
+
+If you enable the `PodAndContainerStatsFromCRI`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) in your
+cluster, and you use a container runtime that supports statistics access via
+{{< glossary_tooltip term_id="cri" text="Container Runtime Interface">}} (CRI), then
+the kubelet fetches Pod- and container-level metric data using CRI, and not via cAdvisor.
+
+## {{% heading "whatsnext" %}}
+
+The task pages for [Troubleshooting Clusters](/docs/tasks/debug/debug-cluster/) discuss
+how to use a metrics pipeline that rely on these data.

--- a/content/en/docs/reference/node/_index.md
+++ b/content/en/docs/reference/node/_index.md
@@ -1,4 +1,17 @@
 ---
 title: Node Reference Information
 weight: 80
+no_list: true
 ---
+
+This section contains the following reference topics about nodes:
+
+* the kubelet's [checkpoint API](/docs/reference/node/kubelet-checkpoint-api/)
+* a list of [Articles on dockershim Removal and on Using CRI-compatible Runtimes](/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes/)
+
+You can also read node reference details from elsewhere in the
+Kubernetes documentation, including:
+
+* [Node Metrics Data](/docs/reference/instrumentation/node-metrics).
+
+

--- a/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -243,14 +243,17 @@ You can also check out the following:
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)
 * [Horizontal Pod Autoscaling](/docs/tasks/run-application/horizontal-pod-autoscale/)
 
-### Summary API source
+## Node metrics data
 
-The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) gathers stats at the node,
-volume, pod and container level, and emits this information in
-the [Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go)
-for consumers to read.
+The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
+gathers metric statistics at the node, volume, pod and container level,
+and emits this information in the
+[Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go).
 
-Here is an example of a Summary API request for a `minikube` node:
+You can send a proxied request to the stats summary API via the
+Kubernetes API server.
+
+Here is an example of a Summary API request for a node named `minikube`:
 
 ```shell
 kubectl get --raw "/api/v1/nodes/minikube/proxy/stats/summary"
@@ -263,6 +266,10 @@ curl http://localhost:8080/api/v1/nodes/minikube/proxy/stats/summary
 ```
 
 {{< note >}}
-The summary API `/stats/summary` endpoint will be replaced by the `/metrics/resource` endpoint
-beginning with metrics-server 0.6.x.
+Beginning with `metrics-server` 0.6.x, `metrics-server` queries the `/metrics/resource`
+kubelet endpoint, and not `/stats/summary`.
 {{< /note >}}
+
+
+By default, Kubernetes fetches node summary metrics data using an embedded
+[cAdvisor](https://github.com/google/cadvisor) that runs with in the kubelet.

--- a/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -270,6 +270,17 @@ Beginning with `metrics-server` 0.6.x, `metrics-server` queries the `/metrics/re
 kubelet endpoint, and not `/stats/summary`.
 {{< /note >}}
 
+### Summary metrics API source {#summary-api-source}
 
 By default, Kubernetes fetches node summary metrics data using an embedded
 [cAdvisor](https://github.com/google/cadvisor) that runs with in the kubelet.
+
+### Summary API data via CRI {#pod-and-container-stats-from-cri}
+
+{{< feature-state for_k8s_version="v1.23" state="alpha" >}}
+
+If you enable the `PodAndContainerStatsFromCRI`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) in your
+cluster, and you use a container runtime that supports statistics access via
+{{< glossary_tooltip term_id="cri" text="Container Runtime Interface">}} (CRI), then
+the kubelet fetches Pod- and container-level metric data using CRI, and not via cadvisor.

--- a/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -232,6 +232,8 @@ to collect metrics from each node. Depending on the metrics-server version it us
 * Metrics resource endpoint `/metrics/resource` in version v0.6.0+ or
 * Summary API endpoint `/stats/summary` in older versions
 
+## {{% heading "whatsnext" %}}
+
 To learn more about the metrics-server, see the
 [metrics-server repository](https://github.com/kubernetes-sigs/metrics-server).
 
@@ -243,44 +245,5 @@ You can also check out the following:
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)
 * [Horizontal Pod Autoscaling](/docs/tasks/run-application/horizontal-pod-autoscale/)
 
-## Node metrics data
-
-The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
-gathers metric statistics at the node, volume, pod and container level,
-and emits this information in the
-[Summary API](https://github.com/kubernetes/kubernetes/blob/7d309e0104fedb57280b261e5677d919cb2a0e2d/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go).
-
-You can send a proxied request to the stats summary API via the
-Kubernetes API server.
-
-Here is an example of a Summary API request for a node named `minikube`:
-
-```shell
-kubectl get --raw "/api/v1/nodes/minikube/proxy/stats/summary"
-```
-
-Here is the same API call using `curl`:
-
-```shell
-curl http://localhost:8080/api/v1/nodes/minikube/proxy/stats/summary
-```
-
-{{< note >}}
-Beginning with `metrics-server` 0.6.x, `metrics-server` queries the `/metrics/resource`
-kubelet endpoint, and not `/stats/summary`.
-{{< /note >}}
-
-### Summary metrics API source {#summary-api-source}
-
-By default, Kubernetes fetches node summary metrics data using an embedded
-[cAdvisor](https://github.com/google/cadvisor) that runs with in the kubelet.
-
-### Summary API data via CRI {#pod-and-container-stats-from-cri}
-
-{{< feature-state for_k8s_version="v1.23" state="alpha" >}}
-
-If you enable the `PodAndContainerStatsFromCRI`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) in your
-cluster, and you use a container runtime that supports statistics access via
-{{< glossary_tooltip term_id="cri" text="Container Runtime Interface">}} (CRI), then
-the kubelet fetches Pod- and container-level metric data using CRI, and not via cadvisor.
+To learn about how the kubelet serves node metrics, and how you can access those via
+the Kubernetes API, read [Node Metrics Data](/docs/reference/instrumentation/node-metrics).


### PR DESCRIPTION
Split https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#summary-api-source away from https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/ and into a new page within the reference section.

Also, reinstate some details about `PodAndContainerStatsFromCRI`.

/sig node
/sig instrumentation
/language en
/label refactor