### PR TITLE
updated nginx version to follow examples correctly

### DIFF
--- a/content/en/examples/application/deployment-scale.yaml
+++ b/content/en/examples/application/deployment-scale.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: nginx:1.16.1
         ports:
         - containerPort: 80


### PR DESCRIPTION
following examples https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/#scaling-the-application-by-increasing-the-replica-count If you update replicas from 2 to 4 using the last deployment yaml, nginx version was 1.16.1, so 2 containers were already created and 2 new ones (that's why the table referenced as "The output is similar to this" shows AGE as 25s and 2m). If this deployment has nginx version 1.14.2, all containers will be recreated instead of just adding 2, so it can be confusing for the newcomers

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
