### PR TITLE
[zh] sync calico-network-policy.md

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy.md
@@ -3,6 +3,13 @@ title: 使用 Calico 提供 NetworkPolicy
 content_type: task
 weight: 10
 ---
+<!--
+reviewers:
+- caseydavenport
+title: Use Calico for NetworkPolicy
+content_type: task
+weight: 10
+-->
 
 <!-- overview -->
 <!--
@@ -26,44 +33,45 @@ Decide whether you want to deploy a [cloud](#creating-a-calico-cluster-with-goog
 -->
 ## 在 Google Kubernetes Engine (GKE) 上创建一个 Calico 集群 {#gke-cluster}
 
-**先决条件**: [gcloud](https://cloud.google.com/sdk/docs/quickstarts)
+**先决条件**：[gcloud](https://cloud.google.com/sdk/docs/quickstarts)
 
 <!--
-1.  To launch a GKE cluster with Calico, include the `--enable-network-policy` flag.
+1. To launch a GKE cluster with Calico, include the `--enable-network-policy` flag.
 -->
-1.  启动一个带有 Calico 的 GKE 集群，需要加上参数 `--enable-network-policy`。
+1. 启动一个带有 Calico 的 GKE 集群，需要加上参数 `--enable-network-policy`。
 
-    **语法**
-    ```shell
-    gcloud container clusters create [CLUSTER_NAME] --enable-network-policy
-    ```
+   **语法**
+   ```shell
+   gcloud container clusters create [CLUSTER_NAME] --enable-network-policy
+   ```
 
-    **示例**
-    ```shell
-    gcloud container clusters create my-calico-cluster --enable-network-policy
-    ```
+   **示例**
+   ```shell
+   gcloud container clusters create my-calico-cluster --enable-network-policy
+   ```
 
 <!--
-1.  To verify the deployment, use the following command.
+1. To verify the deployment, use the following command.
 -->
-2.  使用如下命令验证部署是否正确。
+2. 使用如下命令验证部署是否正确。
 
-    ```shell
-    kubectl get pods --namespace=kube-system
-    ```
+   ```shell
+   kubectl get pods --namespace=kube-system
+   ```
 
-    <!--
-    The Calico pods begin with `calico`. Check to make sure each one has a status of `Running`.
-    -->
-    Calico 的 pods 名以 `calico` 打头，检查确认每个 pods 状态为 `Running`。
+   <!--
+   The Calico pods begin with `calico`. Check to make sure each one has a status of `Running`.
+   -->
+
+   Calico 的 Pod 名以 `calico` 打头，检查确认每个 Pod 状态为 `Running`。
 
 <!-- 
 ## Creating a local Calico cluster with kubeadm
 
-To get a local single-host Calico cluster in fifteen minutes using kubeadm, refer to the
+To get a local single-host Calico cluster in fifteen minutes using kubeadm, refer to the 
 [Calico Quickstart](https://docs.projectcalico.org/latest/getting-started/kubernetes/).
 -->
-## 使用 kubeadm 创建一个本地 Calico 集群   {#local-cluster} 
+## 使用 kubeadm 创建一个本地 Calico 集群   {#local-cluster}
 
 使用 kubeadm 在 15 分钟内得到一个本地单主机 Calico 集群，请参考
 [Calico 快速入门](https://docs.projectcalico.org/latest/getting-started/kubernetes/)。
@@ -73,6 +81,7 @@ To get a local single-host Calico cluster in fifteen minutes using kubeadm, refe
 <!--
 Once your cluster is running, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy.
 -->
-集群运行后，你可以按照[声明网络策略](/zh-cn/docs/tasks/administer-cluster/declare-network-policy/)
-去尝试使用 Kubernetes NetworkPolicy。
+集群运行后，
+你可以按照[声明网络策略](/zh-cn/docs/tasks/administer-cluster/declare-network-policy/)去尝试使用
+Kubernetes NetworkPolicy。
 


### PR DESCRIPTION
Mainly fix this alignment issue:

![image](https://user-images.githubusercontent.com/79828097/202885642-43a92172-a5d3-4c83-aaaf-ec3b1d8d397d.png)

in 
```
content/zh-cn/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy.md
```
Preview: https://deploy-preview-37984--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy/