### PR TITLE
Fix configure-multiple-schedulers.md (#37843)

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -37,6 +37,7 @@ and build the source.
 ```shell
 git clone https://github.com/kubernetes/kubernetes.git
 cd kubernetes
+git reset --hard $(kubectl version --short=true | grep "Server Version" | awk '{print $3}')
 make
 ```
 


### PR DESCRIPTION
Signed-off-by: chenxinlong <chenxinlong2009@gmail.com>

I met a few problems by following this doc page step by step, most of it is because I'm working on a old kubernetes version but according to this doc I'll build the latest kubernetes, just like https://github.com/kubernetes/website/issues/37843 .

So the cloned repo should be reset to the tag same with the kubernetes version before build it.