### PR TITLE
Document that static pods can't have ephemeral containers

### DIFF
--- a/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
+++ b/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
@@ -52,6 +52,10 @@ possible to add an ephemeral container using `kubectl edit`.
 Like regular containers, you may not change or remove an ephemeral container
 after you have added it to a Pod.
 
+{{< note >}}
+Ephemeral containers are not supported by [static pods](/docs/tasks/configure-pod-container/static-pod/).
+{{< /note >}}
+
 ## Uses for ephemeral containers
 
 Ephemeral containers are useful for interactive troubleshooting when `kubectl

--- a/content/en/docs/reference/glossary/ephemeral-container.md
+++ b/content/en/docs/reference/glossary/ephemeral-container.md
@@ -16,3 +16,4 @@ A {{< glossary_tooltip term_id="container" >}} type that you can temporarily run
 
 If you want to investigate a Pod that's running with problems, you can add an ephemeral container to that Pod and carry out diagnostics. Ephemeral containers have no resource or scheduling guarantees, and you should not use them to run any part of the workload itself.
 
+Ephemeral containers are not supported by {{< glossary_tooltip text="static pods" term_id="static-pod" >}}.

--- a/content/en/docs/reference/glossary/static-pod.md
+++ b/content/en/docs/reference/glossary/static-pod.md
@@ -16,3 +16,5 @@ A {{< glossary_tooltip text="pod" term_id="pod" >}} managed directly by the kube
 <!--more-->
 
 without the API server observing it.
+
+Static Pods do not support {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}}.

--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -38,6 +38,10 @@ The `spec` of a static Pod cannot refer to other API objects
 {{< glossary_tooltip text="Secret" term_id="secret" >}}, etc).
 {{< /note >}}
 
+{{< note >}}
+Static pods do not support [ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/).
+{{< /note >}}
+
 ## {{% heading "prerequisites" %}}
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}


### PR DESCRIPTION
updated docs regarding ephemeral pods not being supported by static pods kubernetes/kubernetes#113935

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
