### PR TITLE
Correct misleading wording in Pod DNS Policies

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -220,13 +220,15 @@ following Pod-specific DNS policies. These policies are specified in the
   See [related discussion](/docs/tasks/administer-cluster/dns-custom-nameservers)
   for more details.
 - "`ClusterFirst`": Any DNS query that does not match the configured cluster
-  domain suffix, such as "`www.kubernetes.io`", is forwarded to the upstream
-  nameserver inherited from the node. Cluster administrators may have extra
+  domain suffix, such as "`www.kubernetes.io`", is forwarded to an upstream
+  nameserver by the DNS server. Cluster administrators may have extra
   stub-domain and upstream DNS servers configured.
   See [related discussion](/docs/tasks/administer-cluster/dns-custom-nameservers)
   for details on how DNS queries are handled in those cases.
 - "`ClusterFirstWithHostNet`": For Pods running with hostNetwork, you should
-  explicitly set its DNS policy "`ClusterFirstWithHostNet`".
+  explicitly set its DNS policy to "`ClusterFirstWithHostNet`". Otherwise, Pods
+  running with hostNetwork and `"ClusterFirst"` will fallback to the behavior
+  of the `"Default"` policy.
   - Note: This is not supported on Windows. See [below](#dns-windows) for details
 - "`None`": It allows a Pod to ignore DNS settings from the Kubernetes
   environment. All DNS settings are supposed to be provided using the


### PR DESCRIPTION
A debugging rabbit hole lead me to digging around kublet's behavior regarding certain DNS Policies.

This commit updates some potentially misleading wordings to more correctly convey kubelet's behavior which was discovered after some rabbit hole debugging of DNS Policies.

The ClusterFirst policy documentation would imply that the resolve.conf of a Pod would contain a fallback to the Node's nameserver. This is not the cause, [kubelet explicitly mentions](https://github.com/kubernetes/kubernetes/blob/4276ed36282405d026d8072e0ebed4f1da49070d/pkg/kubelet/network/dns/dns.go#L403-L407) that the fallback is handled by whatever system is running kube-dns or coredns which dramatically changes the behavior of the system when the cluster's DNS is unavailable.

The ClusterFirstWithHostNet policy is lacking any amount of detail as to why one would desire to use it. This commit doesn't go into complete detail but adds an important note about the [behavior of `hostNetwork` when not using the `ClusterFirstWIthHostNet` Policy](https://github.com/kubernetes/kubernetes/blob/4276ed36282405d026d8072e0ebed4f1da49070d/pkg/kubelet/network/dns/dns.go#L311-L318).

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
