### PR TITLE
Append triple backticks with shell for code snippet

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -268,7 +268,7 @@ The certificate value is in Base64-encoded format under `status.certificate`.
 
 Export the issued certificate from the CertificateSigningRequest.
 
-```
+```shell
 kubectl get csr myuser -o jsonpath='{.status.certificate}'| base64 -d > myuser.crt
 ```
 

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -295,20 +295,20 @@ The last step is to add this user into the kubeconfig file.
 
 First, you need to add new credentials:
 
-```
+```shell
 kubectl config set-credentials myuser --client-key=myuser.key --client-certificate=myuser.crt --embed-certs=true
 
 ```
 
 Then, you need to add the context:
 
-```
+```shell
 kubectl config set-context myuser --cluster=kubernetes --user=myuser
 ```
 
 To test it, change the context to `myuser`:
 
-```
+```shell
 kubectl config use-context myuser
 ```
 


### PR DESCRIPTION
This PR added the shell (```shell) instead of only triple backticks(```)  for the commands `kubectl get csr myuser -o jsonpath='{.status.certificate}'| base64 -d > myuser.crt` mention under the[ Get the certificate](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#get-the-certificate) because we can't able to move the code snippet to see the full command with triple backticks.

Current (```):
![Screenshot from 2022-11-22 13-51-15](https://user-images.githubusercontent.com/50987400/203262529-f57f7ecd-de7e-49a7-b399-0e3d5d89cf30.png)

After adding shell(```shell)
![Screenshot from 2022-11-22 13-36-23](https://user-images.githubusercontent.com/50987400/203262712-c29cc674-cf5e-4a6b-8283-c9de41e16714.png)
