### PR TITLE
Split a combined deletion command in "Run a Single-Instance Stateful Application"

### DIFF
--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -176,7 +176,8 @@ specific to stateful apps:
 Delete the deployed objects by name:
 
 ```
-kubectl delete deployment,svc mysql
+kubectl delete deployment mysql
+kubectl delete svc mysql
 kubectl delete pvc mysql-pv-claim
 kubectl delete pv mysql-pv-volume
 ```


### PR DESCRIPTION
`kubectl delete deployment,svc mysql` is not a viable command and could be confusing for learners trying to clean their workspace.

Separating the command into two lines simplifies the clean-up process for readers.

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
