### PR TITLE
Fix incorrect information on disruption budgets

### DIFF
--- a/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
+++ b/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
@@ -69,7 +69,7 @@ has 5 replicas, with `maxUnavailable` set to 2 and `partition` set to 0.
 I can trigger a rolling update by changing the image to `k8s.gcr.io/nginx-slim:0.9`. Once I initiate the rolling update, I can 
 watch the pods update 2 at a time as the current value of maxUnavailable is 2. The below output shows a span of time and is not 
 complete.  The maxUnavailable can be an absolute number (for example, 2) or a percentage of desired Pods (for example, 10%). The 
-absolute number is calculated from percentage by rounding down.  
+absolute number is calculated from percentage by rounding up to the nearest integer.  
 ```
 kubectl get pods --watch 
 ```


### PR DESCRIPTION
Absolute numbers for disruption budgets are calculated from percentages by rounding up, not down. As confirmed here: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#rounding-logic-when-specifying-percentages

<!-- ℹ️

 Hello!

 Noticed this information on pod disruption budgets was incorrect as evidenced by the documentation here: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#rounding-logic-when-specifying-percentages

-->
