### PR TITLE
Clarify node affinity API

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -2,7 +2,7 @@
 reviewers:
 - davidopp
 - kevin-wangzefeng
-- bsalamat
+- alculquicondor
 title: Assigning Pods to Nodes
 content_type: concept
 weight: 20
@@ -144,12 +144,12 @@ to repel Pods from specific nodes.
 If you specify both `nodeSelector` and `nodeAffinity`, *both* must be satisfied
 for the Pod to be scheduled onto a node.
 
-If you specify multiple `nodeSelectorTerms` associated with `nodeAffinity`
-types, then the Pod can be scheduled onto a node if one of the specified `nodeSelectorTerms` can be
-satisfied.
+If you specify multiple items in `nodeSelectorTerms` associated with `nodeAffinity`
+types, then the Pod can be scheduled onto a node if one of the specified items in `nodeSelectorTerms`
+can be satisfied.
 
-If you specify multiple `matchExpressions` associated with a single `nodeSelectorTerms`,
-then the Pod can be scheduled onto a node only if all the `matchExpressions` are
+If you specify multiple items in `matchExpressions` associated with a single item in `nodeSelectorTerms`,
+then the Pod can be scheduled onto a node only if all the items in `matchExpressions` are
 satisfied. 
 {{</note>}}
 

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -144,13 +144,12 @@ to repel Pods from specific nodes.
 If you specify both `nodeSelector` and `nodeAffinity`, *both* must be satisfied
 for the Pod to be scheduled onto a node.
 
-If you specify multiple items in `nodeSelectorTerms` associated with `nodeAffinity`
-types, then the Pod can be scheduled onto a node if one of the specified items in `nodeSelectorTerms`
-can be satisfied.
+If you specify multiple terms in `nodeSelectorTerms` associated with `nodeAffinity`
+types, then the Pod can be scheduled onto a node if one of the specified terms
+can be satisfied (terms are ORed).
 
-If you specify multiple items in `matchExpressions` associated with a single item in `nodeSelectorTerms`,
-then the Pod can be scheduled onto a node only if all the items in `matchExpressions` are
-satisfied. 
+If you specify multiple expressions in `matchExpressions` associated with a single term in `nodeSelectorTerms`,
+then the Pod can be scheduled onto a node only if all the expressions are satisfied. 
 {{</note>}}
 
 See [Assign Pods to Nodes using Node Affinity](/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -148,8 +148,9 @@ If you specify multiple terms in `nodeSelectorTerms` associated with `nodeAffini
 types, then the Pod can be scheduled onto a node if one of the specified terms
 can be satisfied (terms are ORed).
 
-If you specify multiple expressions in `matchExpressions` associated with a single term in `nodeSelectorTerms`,
-then the Pod can be scheduled onto a node only if all the expressions are satisfied. 
+If you specify multiple expressions in a single `matchExpressions` field associated with a
+term in `nodeSelectorTerms`, then the Pod can be scheduled onto a node only
+if all the expressions are satisfied (expressions are ANDed).
 {{</note>}}
 
 See [Assign Pods to Nodes using Node Affinity](/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)


### PR DESCRIPTION
Fixes #31769

I don't think there was anything wrong with the existing wording, but it was confusing. It was not clear whether it was referring to the mentions of the field or the items within the field.

Also replace @bsalamat with @alculquicondor, as a SIG Scheduling TL