### PR TITLE
Document for "Wait for Pods to finish before considering Failed in Job"

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -301,6 +301,19 @@ sometimes be started twice.
 If you do specify `.spec.parallelism` and `.spec.completions` both greater than 1, then there may be
 multiple pods running at once.  Therefore, your pods must also be tolerant of concurrency.
 
+When the [feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
+`PodDisruptionConditions` and `JobPodFailurePolicy` are both enabled,
+and the `.spec.podFailurePolicy` field is set, the Job controller does not consider a terminating
+Pod (a pod that has a `.metadata.deletionTimestamp` field set) as a failure until that Pod is
+terminal (its `.status.phase` is `Failed` or `Succeeded`). However, the Job controller
+creates a replacement Pod as soon as the termination becomes apparent. Once the
+pod terminates, the Job controller evaluates `.backoffLimit` and `.podFailurePolicy`
+for the relevant Job, taking this now-terminated Pod into consideration.
+
+If either of these requirements is not satisfied, the Job controller counts
+a terminating Pod as an immediate failure, even if that Pod later terminates
+with `phase: "Succeeded"`.
+
 ### Pod backoff failure policy
 
 There are situations where you want to fail a Job after some amount of retries


### PR DESCRIPTION
Add a note to document changes in https://github.com/kubernetes/kubernetes/pull/113860

Tracking issue: [Retriable and non-retriable Pod failures for Jobs](https://github.com/kubernetes/enhancements/issues/3329)

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
