### PR TITLE
[zh-cn] Fix incorrect spaces causing the list to display an error in blog

### DIFF
--- a/content/zh-cn/blog/_posts/2018-08-29-kubernetes-testing-ci-automating-contributor-experience.md
+++ b/content/zh-cn/blog/_posts/2018-08-29-kubernetes-testing-ci-automating-contributor-experience.md
@@ -39,7 +39,7 @@ This strategy worked. It worked so well that the project quickly scaled past its
 ## The Work
 -->
 
-##　工作
+## 工作
 
 <!--
 Initially, we focused on the fact that we needed to support the sheer volume of tests mandated by a complex distributed system such as Kubernetes. Real world failure scenarios had to be exercised via end-to-end (e2e) tests to ensure proper functionality. Unfortunately, e2e tests were susceptible to flakes (random failures) and took anywhere from an hour to a day to complete.


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
error display:
![image](https://user-images.githubusercontent.com/44460091/203899714-2d8e3232-f8c9-45c1-aeda-51837c4cae5d.png)

Incorrect spaces maybe caused by `tab` spaces.
page: https://kubernetes.io/zh-cn/blog/2019/08/29/the-machines-can-do-the-work-a-story-of-kubernetes-testing-ci-and-automating-the-contributor-experience/


preview page: https://deploy-preview-38061--kubernetes-io-main-staging.netlify.app/zh-cn/blog/2019/08/29/the-machines-can-do-the-work-a-story-of-kubernetes-testing-ci-and-automating-the-contributor-experience/