### PR TITLE
Add verify-spelling.sh for ja content

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@
 | `lsync.sh` | This script checks if the English version of a page has changed since a localized page has been committed. |
 | `replace-capture.sh` | This script sets K8S_WEBSITE in your env to your docs website root or rely on this script to determine it automatically |
 | `check-ctrlcode.py` | This script finds control-code(0x00-0x1f) in text files. |
+| `ja/verify-spelling.sh` | This script finds Japanese words that are against the guideline. |
 
 
 
@@ -177,4 +178,13 @@ The output is following format.
   {2} : The column number that a control-code exists.
   {3} : The found control-code.
   {4} : The one-line strings in the file.
+```
+
+## ja/verify-spelling.sh
+
+This script finds Japanese words that are against the guideline[1]
+[1] https://kubernetes.io/ja/docs/contribute/localization/#%E9%A0%BB%E5%87%BA%E5%8D%98%E8%AA%9E
+
+```
+Usage: ./ja/verify-spelling.sh
 ```

--- a/scripts/ja/OWNERS
+++ b/scripts/ja/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the localization project for Japanese.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-ja-reviews
+
+approvers:
+- sig-docs-ja-owners
+
+labels:
+- language/ja

--- a/scripts/ja/verify-spelling.sh
+++ b/scripts/ja/verify-spelling.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########
+
+# cd to the root path
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+CONTENT_DIR="content/ja"
+cd "${ROOT}/${CONTENT_DIR}"
+
+TARGET_WORDS=""               # invalid:valid
+TARGET_WORDS="${TARGET_WORDS} コンテナー:コンテナ"
+TARGET_WORDS="${TARGET_WORDS} アーキテクチャー:アーキテクチャ"
+TARGET_WORDS="${TARGET_WORDS} コントローラ[^ー]:コントローラー"
+TARGET_WORDS="${TARGET_WORDS} オペレータ[^ー]:オペレーター"
+TARGET_WORDS="${TARGET_WORDS} パラメータ[^ー]:パラメーター"
+
+INVALID_CONTAINED=""
+
+for word_set in $(echo ${TARGET_WORDS})
+do
+	invalid=$(echo ${word_set} | awk -F: '{print $1}')
+	valid=$(echo ${word_set} | awk -F: '{print $2}')
+	grep -E "${invalid}" * -R
+	if [ $? -eq 0 ]; then
+		echo "Invalid word ${invalid} is contained under ${CONTENT_DIR}."
+		echo "Please replace ${invalid} with ${valid}."
+		echo
+		INVALID_CONTAINED="TRUE"
+	fi
+done
+
+if [ "${INVALID_CONTAINED}" != "" ]; then
+	exit 1
+fi


### PR DESCRIPTION
We have the translation guideline as [1], and that contains what are valid Japanese words for the corresponding English words. This adds a script to verify those words based on the guideline.

[1]: https://kubernetes.io/ja/docs/contribute/localization/

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
