### PR TITLE
[ja] fix a link in tools.md

### DIFF
--- a/content/ja/docs/reference/tools.md
+++ b/content/ja/docs/reference/tools.md
@@ -11,7 +11,7 @@ Kubernetesには、Kubernetesシステムの操作に役立ついくつかの組
 [`kubectl`](/ja/docs/tasks/tools/install-kubectl/)は、Kubernetesのためのコマンドラインツールです。このコマンドはKubernetes cluster managerを操作します。
 
 ## Kubeadm
-[`kubeadm`](docs/setup/production-environment/tools/kubeadm/install-kubeadm/)は、物理サーバやクラウドサーバ、仮想マシン上にKubernetesクラスタを容易にプロビジョニングするためのコマンドラインツールです(現在はアルファ版です)。
+[`kubeadm`](/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)は、物理サーバやクラウドサーバ、仮想マシン上にKubernetesクラスタを容易にプロビジョニングするためのコマンドラインツールです(現在はアルファ版です)。
 
 ## Minikube
 [`minikube`](https://minikube.sigs.k8s.io/docs/)は、開発やテストのためにワークステーション上でシングルノードのKubernetesクラスタをローカルで実行するツールです。


### PR DESCRIPTION
Fix a link that causes 404 now: https://kubernetes.io/ja/docs/reference/tools/

```
content/ja/docs/reference/tools.md
```
Preview: https://deploy-preview-38076--kubernetes-io-main-staging.netlify.app/ja/docs/reference/tools/