### PR TITLE
Replace an image with mermaid

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -47,7 +47,30 @@ horizontal pod autoscaling.
 
 ## How does a HorizontalPodAutoscaler work?
 
-{{< figure src="/images/docs/horizontal-pod-autoscaler.svg" caption="HorizontalPodAutoscaler controls the scale of a Deployment and its ReplicaSet" class="diagram-medium">}}
+{{< mermaid >}}
+graph BT
+
+hpa[Horizontal Pod Autoscaler] --> scale[Scale]
+
+subgraph rc[RC / Deployment]
+    scale
+end
+
+scale -.-> pod1[Pod 1]
+scale -.-> pod2[Pod 2]
+scale -.-> pod3[Pod N]
+
+classDef hpa fill:#D5A6BD,stroke:#1E1E1D,stroke-width:1px,color:#1E1E1D;
+classDef rc fill:#F9CB9C,stroke:#1E1E1D,stroke-width:1px,color:#1E1E1D;
+classDef scale fill:#B6D7A8,stroke:#1E1E1D,stroke-width:1px,color:#1E1E1D;
+classDef pod fill:#9FC5E8,stroke:#1E1E1D,stroke-width:1px,color:#1E1E1D;
+class hpa hpa;
+class rc rc;
+class scale scale;
+class pod1,pod2,pod3 pod
+{{< /mermaid >}}
+
+Figure 1. HorizontalPodAutoscaler controls the scale of a Deployment and its ReplicaSet
 
 Kubernetes implements horizontal pod autoscaling as a control loop that runs intermittently
 (it is not a continuous process). The interval is set by the


### PR DESCRIPTION
An image on the [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) page looks not good enough. 

Have a try to replace it with mermaid that may be easy to read, change, and localize.

Preview: https://deploy-preview-38086--kubernetes-io-main-staging.netlify.app/docs/tasks/run-application/horizontal-pod-autoscale/


![image](https://user-images.githubusercontent.com/79828097/204073875-6314e6ea-0f1e-4f93-9aeb-ad4c659cc315.png)