### PR TITLE
kubectl_bash_autocompletion minor correction

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -32,7 +32,7 @@ You now need to ensure that the kubectl completion script gets sourced in all yo
 
 {{< tabs name="kubectl_bash_autocompletion" >}}
 {{< tab name="User" codelang="bash" >}}
-echo 'source <(kubectl completion bash)' >>~/.bashrc
+echo "source $(kubectl completion bash)" >>~/.bashrc
 {{< /tab >}}
 {{< tab name="System" codelang="bash" >}}
 kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl > /dev/null


### PR DESCRIPTION
autocompletion in ~/.bashrc file don't expand kubectl completion functions

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
