### PR TITLE
[pt-br] Update docs/concepts/scheduling-eviction/_index.md

### DIFF
--- a/content/pt-br/docs/concepts/scheduling-eviction/_index.md
+++ b/content/pt-br/docs/concepts/scheduling-eviction/_index.md
@@ -1,8 +1,30 @@
 ---
-title: "Escalonamento"
-weight: 90
+title: "Escalonamento, preempção e expulsão"
+weight: 95
+content_type: concept
 description: >
-   No Kubernetes, agendamento refere-se a garantia de que os pods correspondam aos nós para que o kubelet possa executá-los.
-   Remoção é o processo de falha proativa de um ou mais pods em nós com falta de recursos.
+  No Kubernetes, escalonamento refere-se a garantia de que os Pods correspondam aos Nós para que o kubelet possa executá-los. Preempção é o processo de finalizar Pods com menor prioridade, para que os Pods com maior prioridade possam ser escalonados nos Nós. Expulsão é o processo de finalização proativa de um ou mais Pods em Nós com poucos recursos.
+no_list: true
 ---
 
+No Kubernetes, escalonamento refere-se a certeza de que {{<glossary_tooltip text="Pods" term_id="pod">}}
+correspondam aos {{<glossary_tooltip text="Nós" term_id="node">}} para que o
+{{<glossary_tooltip text="Kubelet" term_id="kubelet">}} possa executá-los. Preempção é o processo de finalizar Pods com menor {{<glossary_tooltip text="prioridade" term_id="pod-priority">}}
+para que os Pods com maior prioridade possam ser escalonados nos Nós. Expulsão é o processo de finalização proativa de um ou mais Pods em Nós poucos recursos.
+
+## Escalonamento
+
+* [Escalonador do Kubernetes](/pt-br/docs/concepts/scheduling-eviction/kube-scheduler/)
+* [Atribuindo Pods à Nós](/docs/concepts/scheduling-eviction/assign-pod-node/)
+* [Sobrecarga de Pod](/pt-br/docs/concepts/scheduling-eviction/pod-overhead/)
+* [Restrições de propagação da topologia do Pod](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+* [Taints e Tolerâncias](/pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/)
+* [Framework do escalonador](/docs/concepts/scheduling-eviction/scheduling-framework)
+* [Refinando a performance do escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
+* [Empacotamento de recursos para recursos ampliados](/docs/concepts/scheduling-eviction/resource-bin-packing/)
+
+## Interrupção do Pod
+
+* [Prioridade e Preempção do Pod](/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+* [Expulsão por pressão do Nó](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+* [Expulsão iniciada por API](/docs/concepts/scheduling-eviction/api-eviction/)

--- a/content/pt-br/docs/concepts/scheduling-eviction/_index.md
+++ b/content/pt-br/docs/concepts/scheduling-eviction/_index.md
@@ -10,7 +10,7 @@ no_list: true
 No Kubernetes, escalonamento refere-se à certeza de que {{<glossary_tooltip text="Pods" term_id="pod">}}
 correspondam aos {{<glossary_tooltip text="nós" term_id="node">}} para que o
 {{<glossary_tooltip text="Kubelet" term_id="kubelet">}} possa executá-los. Preempção é o processo de finalizar Pods com menor {{<glossary_tooltip text="prioridade" term_id="pod-priority">}}
-para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização proativa de um ou mais Pods em nós com poucos recursos.
+para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização de um ou mais Pods em nós.
 
 ## Escalonamento
 

--- a/content/pt-br/docs/concepts/scheduling-eviction/_index.md
+++ b/content/pt-br/docs/concepts/scheduling-eviction/_index.md
@@ -3,11 +3,11 @@ title: "Escalonamento, preempção e remoção"
 weight: 95
 content_type: concept
 description: >
-  No Kubernetes, escalonamento refere-se a certeza de que os Pods correspondam aos nós para que o kubelet possa executá-los. Preempção é o processo de finalizar Pods com menor prioridade, para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização proativa de um ou mais Pods em nós com poucos recursos.
+  No Kubernetes, escalonamento refere-se à certeza de que os Pods correspondam aos nós para que o kubelet possa executá-los. Preempção é o processo de finalizar Pods com menor prioridade, para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização proativa de um ou mais Pods em nós com poucos recursos.
 no_list: true
 ---
 
-No Kubernetes, escalonamento refere-se a certeza de que {{<glossary_tooltip text="Pods" term_id="pod">}}
+No Kubernetes, escalonamento refere-se à certeza de que {{<glossary_tooltip text="Pods" term_id="pod">}}
 correspondam aos {{<glossary_tooltip text="nós" term_id="node">}} para que o
 {{<glossary_tooltip text="Kubelet" term_id="kubelet">}} possa executá-los. Preempção é o processo de finalizar Pods com menor {{<glossary_tooltip text="prioridade" term_id="pod-priority">}}
 para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização proativa de um ou mais Pods em nós com poucos recursos.
@@ -23,7 +23,7 @@ para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção
 - [Refinando a Performance do Escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
 - [Empacotamento de Recursos para Recursos Estendidos](/docs/concepts/scheduling-eviction/resource-bin-packing/)
 
-## Interrupção do Pod
+## Disrupção do Pod
 
 {{<glossary_definition term_id="pod-disruption" length="all">}}
 

--- a/content/pt-br/docs/concepts/scheduling-eviction/_index.md
+++ b/content/pt-br/docs/concepts/scheduling-eviction/_index.md
@@ -14,17 +14,19 @@ para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção
 
 ## Escalonamento
 
-* [Escalonador do Kubernetes](/pt-br/docs/concepts/scheduling-eviction/kube-scheduler/)
-* [Atribuindo Pods à Nós](/docs/concepts/scheduling-eviction/assign-pod-node/)
-* [Sobrecarga de Pod](/pt-br/docs/concepts/scheduling-eviction/pod-overhead/)
-* [Restrições de Propagação da Topologia do Pod](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
-* [Taints e Tolerâncias](/pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/)
-* [Framework do Escalonador](/docs/concepts/scheduling-eviction/scheduling-framework)
-* [Refinando a Performance do Escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
-* [Empacotamento de Recursos para Recursos Estendidos](/docs/concepts/scheduling-eviction/resource-bin-packing/)
+- [Escalonador do Kubernetes](/pt-br/docs/concepts/scheduling-eviction/kube-scheduler/)
+- [Atribuindo Pods à Nós](/docs/concepts/scheduling-eviction/assign-pod-node/)
+- [Sobrecarga de Pod](/pt-br/docs/concepts/scheduling-eviction/pod-overhead/)
+- [Restrições de Propagação da Topologia do Pod](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+- [Taints e Tolerâncias](/pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/)
+- [Framework do Escalonador](/docs/concepts/scheduling-eviction/scheduling-framework)
+- [Refinando a Performance do Escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
+- [Empacotamento de Recursos para Recursos Estendidos](/docs/concepts/scheduling-eviction/resource-bin-packing/)
 
 ## Interrupção do Pod
 
-* [Prioridade e Preempção do Pod](/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-* [Remoção por Pressão do Nó](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
-* [Remoção Iniciada por API](/docs/concepts/scheduling-eviction/api-eviction/)
+{{<glossary_definition term_id="pod-disruption" length="all">}}
+
+- [Prioridade e Preempção do Pod](/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+- [Remoção por Pressão do Nó](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+- [Remoção Iniciada por API](/docs/concepts/scheduling-eviction/api-eviction/)

--- a/content/pt-br/docs/concepts/scheduling-eviction/_index.md
+++ b/content/pt-br/docs/concepts/scheduling-eviction/_index.md
@@ -1,30 +1,30 @@
 ---
-title: "Escalonamento, preempção e expulsão"
+title: "Escalonamento, preempção e remoção"
 weight: 95
 content_type: concept
 description: >
-  No Kubernetes, escalonamento refere-se a garantia de que os Pods correspondam aos Nós para que o kubelet possa executá-los. Preempção é o processo de finalizar Pods com menor prioridade, para que os Pods com maior prioridade possam ser escalonados nos Nós. Expulsão é o processo de finalização proativa de um ou mais Pods em Nós com poucos recursos.
+  No Kubernetes, escalonamento refere-se a certeza de que os Pods correspondam aos nós para que o kubelet possa executá-los. Preempção é o processo de finalizar Pods com menor prioridade, para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização proativa de um ou mais Pods em nós com poucos recursos.
 no_list: true
 ---
 
 No Kubernetes, escalonamento refere-se a certeza de que {{<glossary_tooltip text="Pods" term_id="pod">}}
-correspondam aos {{<glossary_tooltip text="Nós" term_id="node">}} para que o
+correspondam aos {{<glossary_tooltip text="nós" term_id="node">}} para que o
 {{<glossary_tooltip text="Kubelet" term_id="kubelet">}} possa executá-los. Preempção é o processo de finalizar Pods com menor {{<glossary_tooltip text="prioridade" term_id="pod-priority">}}
-para que os Pods com maior prioridade possam ser escalonados nos Nós. Expulsão é o processo de finalização proativa de um ou mais Pods em Nós poucos recursos.
+para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção é o processo de finalização proativa de um ou mais Pods em nós com poucos recursos.
 
 ## Escalonamento
 
 * [Escalonador do Kubernetes](/pt-br/docs/concepts/scheduling-eviction/kube-scheduler/)
 * [Atribuindo Pods à Nós](/docs/concepts/scheduling-eviction/assign-pod-node/)
 * [Sobrecarga de Pod](/pt-br/docs/concepts/scheduling-eviction/pod-overhead/)
-* [Restrições de propagação da topologia do Pod](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+* [Restrições de Propagação da Topologia do Pod](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 * [Taints e Tolerâncias](/pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/)
-* [Framework do escalonador](/docs/concepts/scheduling-eviction/scheduling-framework)
-* [Refinando a performance do escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
-* [Empacotamento de recursos para recursos ampliados](/docs/concepts/scheduling-eviction/resource-bin-packing/)
+* [Framework do Escalonador](/docs/concepts/scheduling-eviction/scheduling-framework)
+* [Refinando a Performance do Escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
+* [Empacotamento de Recursos para Recursos Estendidos](/docs/concepts/scheduling-eviction/resource-bin-packing/)
 
 ## Interrupção do Pod
 
 * [Prioridade e Preempção do Pod](/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-* [Expulsão por pressão do Nó](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
-* [Expulsão iniciada por API](/docs/concepts/scheduling-eviction/api-eviction/)
+* [Remoção por Pressão do Nó](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+* [Remoção Iniciada por API](/docs/concepts/scheduling-eviction/api-eviction/)

--- a/content/pt-br/docs/reference/glossary/pod-disruption.md
+++ b/content/pt-br/docs/reference/glossary/pod-disruption.md
@@ -1,0 +1,21 @@
+---
+id: pod-disruption
+title: Pod Disruption
+full_link: /docs/concepts/workloads/pods/disruptions/
+date: 2021-05-12
+short_description: >
+  O processo pelo qual Pods ou Nós são interrompidos de forma voluntária ou involuntária.
+
+aka:
+related:
+  - pod
+  - container
+tags:
+  - operation
+---
+
+[Interrupção do Pod](/docs/concepts/workloads/pods/disruptions/) é o processo pelo qual Pods ou Nós são interrompidos de forma voluntária ou involuntária.
+
+<!--more-->
+
+Interrupções voluntárias são iniciadas intencionalmente pelos donos das aplicações ou administradores dos clusters. Interrupções involuntárias não são intencionais e podem ser encadeadas por problemas inevitáveis como Nós com poucos recursos, ou por exclusões acidentais.

--- a/content/pt-br/docs/reference/glossary/pod-disruption.md
+++ b/content/pt-br/docs/reference/glossary/pod-disruption.md
@@ -1,10 +1,10 @@
 ---
 id: pod-disruption
-title: Interrupção do Pod
+title: Disrupção do Pod
 full_link: /docs/concepts/workloads/pods/disruptions/
 date: 2021-05-12
 short_description: >
-  O processo pelo qual Pods ou Nós são interrompidos de forma voluntária ou involuntária.
+  O processo pelo qual Pods ou nós são interrompidos de forma voluntária ou involuntária.
 
 aka:
 related:
@@ -14,8 +14,8 @@ tags:
   - operation
 ---
 
-[Interrupção do Pod](/docs/concepts/workloads/pods/disruptions/) é o processo pelo qual Pods ou Nós são interrompidos de forma voluntária ou involuntária.
+[Disrupção do Pod](/docs/concepts/workloads/pods/disruptions/) é o processo pelo qual Pods ou nós são interrompidos de forma voluntária ou involuntária.
 
 <!--more-->
 
-Interrupções voluntárias são iniciadas intencionalmente pelos donos das aplicações ou administradores dos clusters. Interrupções involuntárias não são intencionais e podem ser encadeadas por problemas inevitáveis como Nós com poucos recursos, ou por exclusões acidentais.
+Disrupções voluntárias são iniciadas intencionalmente pelos donos das aplicações ou administradores dos clusters. Disrupções involuntárias não são intencionais e podem ser encadeadas por problemas inevitáveis como Nós com poucos recursos, ou por exclusões acidentais.

--- a/content/pt-br/docs/reference/glossary/pod-disruption.md
+++ b/content/pt-br/docs/reference/glossary/pod-disruption.md
@@ -1,6 +1,6 @@
 ---
 id: pod-disruption
-title: Pod Disruption
+title: Interrupção do Pod
 full_link: /docs/concepts/workloads/pods/disruptions/
 date: 2021-05-12
 short_description: >


### PR DESCRIPTION
Hello everyone,

Brazilian portuguese translation for the [Scheduling, Preemption and Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/) page. There was already a page in Brazilian Portuguese but it's outdated [Escalonamento](https://kubernetes.io/pt-br/docs/concepts/scheduling-eviction/).

Related issues: #13939 