### PR TITLE
Updating OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,7 @@ aliases:
     - sftim
   sig-docs-localization-owners: # Admins for localization content
     - a-mccarthy
+    - bradtopol
     - divya-mohan0209
     - jimangel
     - kbhawkey
@@ -32,6 +33,7 @@ aliases:
     - bradtopol
     - divya-mohan0209
     - jimangel
+    - jlbutler
     - kbhawkey
     - krol3
     - natalisucks
@@ -43,6 +45,7 @@ aliases:
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol
     - divya-mohan0209
+    - daminisatya
     - jimangel
     - kbhawkey
     - mehabhalodiya
@@ -50,6 +53,7 @@ aliases:
     - nate-double-u
     - onlydole
     - reylejano
+    - rajeshdeshpande02
     - sftim
     - shannonxtreme
     - tengqm


### PR DESCRIPTION
Ahead of preparing the PR wrangler calendar for 2023, SIG Docs leadership would like

- to seek clarity on whether @jlbutler wishes to continue as an approver for the English docs. 
- to seek clarity on whether @daminisatya & @rajeshdeshpande02 wish to continue as reviewers for the English docs.
- to off board @bradtopol as the localisation lead following his announcement on Slack. **He is required to confirm whether he'd like to stay on as approver & reviewer for SIG Docs.**

I've also alpha-sorted the English docs + blog reviewers & owners. 

I erroneously committed these changes to the main repo instead of my personal fork due to which I couldn't open a PR for further discussion.

This PR re-adds them & aims to gain confirmation from the respective folks by **5th December 2022** so that we can appropriately prepare the PR wrangler calendar for the next year.

Failing a response, we will be leaving the commit as-is.