### PR TITLE
Correcting format of cloud-controller-md What's Next section

### DIFF
--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -206,24 +206,21 @@ rules:
 
 ## {{% heading "whatsnext" %}}
 
-[Cloud Controller Manager Administration](/docs/tasks/administer-cluster/running-cloud-controller/#cloud-controller-manager)
+* [Cloud Controller Manager Administration](/docs/tasks/administer-cluster/running-cloud-controller/#cloud-controller-manager)
 has instructions on running and managing the cloud controller manager.
 
-To upgrade a HA control plane to use the cloud controller manager, see
+* To upgrade a HA control plane to use the cloud controller manager, see 
 [Migrate Replicated Control Plane To Use Cloud Controller Manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/).
 
-Want to know how to implement your own cloud controller manager, or extend an existing project?
+* Want to know how to implement your own cloud controller manager, or extend an existing project?
 
-The cloud controller manager uses Go interfaces to allow implementations from any cloud to be plugged in.
-Specifically, it uses the `CloudProvider` interface defined in
-[`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.26/cloud.go#L43-L69) from
-[kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider).
-
-The implementation of the shared controllers highlighted in this document (Node, Route, and Service),
-and some scaffolding along with the shared cloudprovider interface, is part of the Kubernetes core.
-Implementations specific to cloud providers are outside the core of Kubernetes and implement the
-`CloudProvider` interface.
-
-For more information about developing plugins, see
-[Developing Cloud Controller Manager](/docs/tasks/administer-cluster/developing-cloud-controller-manager/).
-
+  - The cloud controller manager uses Go interfaces, specifically, `CloudProvider` interface defined in
+	    [`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.21/cloud.go#L42-L69)
+	    from [kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider) to allow
+	    implementations from any cloud to be plugged in.
+  - The implementation of the shared controllers highlighted in this document (Node, Route, and Service),
+	    and some scaffolding along with the shared cloudprovider interface, is part of the Kubernetes core.
+	    Implementations specific to cloud providers are outside the core of Kubernetes and implement
+	    the `CloudProvider` interface.
+  - For more information about developing plugins,
+	    see [Developing Cloud Controller Manager](/docs/tasks/administer-cluster/developing-cloud-controller-manager/).

--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -207,20 +207,20 @@ rules:
 ## {{% heading "whatsnext" %}}
 
 * [Cloud Controller Manager Administration](/docs/tasks/administer-cluster/running-cloud-controller/#cloud-controller-manager)
-has instructions on running and managing the cloud controller manager.
+  has instructions on running and managing the cloud controller manager.
 
 * To upgrade a HA control plane to use the cloud controller manager, see 
-[Migrate Replicated Control Plane To Use Cloud Controller Manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/).
+  [Migrate Replicated Control Plane To Use Cloud Controller Manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/).
 
 * Want to know how to implement your own cloud controller manager, or extend an existing project?
 
   - The cloud controller manager uses Go interfaces, specifically, `CloudProvider` interface defined in
-	    [`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.21/cloud.go#L42-L69)
-	    from [kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider) to allow
-	    implementations from any cloud to be plugged in.
+    [`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.21/cloud.go#L42-L69)
+    from [kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider) to allow
+    implementations from any cloud to be plugged in.
   - The implementation of the shared controllers highlighted in this document (Node, Route, and Service),
-	    and some scaffolding along with the shared cloudprovider interface, is part of the Kubernetes core.
-	    Implementations specific to cloud providers are outside the core of Kubernetes and implement
-	    the `CloudProvider` interface.
+    and some scaffolding along with the shared cloudprovider interface, is part of the Kubernetes core.
+    Implementations specific to cloud providers are outside the core of Kubernetes and implement
+    the `CloudProvider` interface.
   - For more information about developing plugins,
-	    see [Developing Cloud Controller Manager](/docs/tasks/administer-cluster/developing-cloud-controller-manager/).
+    see [Developing Cloud Controller Manager](/docs/tasks/administer-cluster/developing-cloud-controller-manager/).


### PR DESCRIPTION
# Description
What's next section in the [cloud-controller.md](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) has wrong format as well as changing some text to brief one.

Resolves : #38128 