### PR TITLE
[hi] Localize content/hi/docs/reference/glossary/etcd.md

### DIFF
--- a/content/hi/docs/reference/glossary/etcd.md
+++ b/content/hi/docs/reference/glossary/etcd.md
@@ -1,0 +1,20 @@
+---
+title: etcd
+id: etcd
+date: 2018-04-12
+full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
+short_description: >
+   सभी क्लस्टर डेटा के लिए कुबेरनेट्स के बैकिंग स्टोर के रूप में उपयोग किया जाने वाला सुसंगत और उच्च उपलब्धता की-वैल्यू स्टोर।
+
+aka: 
+tags:
+- architecture
+- storage
+---
+  सभी क्लस्टर डेटा के लिए कुबेरनेट्स के बैकिंग स्टोर के रूप में उपयोग किया जाने वाला सुसंगत और उच्च उपलब्धता की-वैल्यू स्टोर।
+
+<!--more-->
+
+यदि आपका कुबेरनेट्स क्लस्टर बैकिंग स्टोर के रूप में etcd का उपयोग करता है, तो सुनिश्चित करें कि आपके पास उन डेटा के लिए एक [बैकअप](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster) योजना है।
+
+आप आधिकारिक [प्रलेखन](https://etcd.io/docs/) में etcd के बारे में गहन जानकारी प्राप्त कर सकते हैं।


### PR DESCRIPTION
Signed-off-by: Amol Mote <amolmote201@gmail.com>

Fixes https://github.com/kubernetes/website/issues/35600 Localize content/en/docs/reference/glossary/etcd.md into content/hi/docs/reference/glossary/etcd.md


For Reviewers: These changes are already reviewed in another PR ( #36351)but due to some complications I am opening this new PR. 