### PR TITLE
kms: updates website to document encryption config hot reload changes

### DIFF
--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -22,8 +22,7 @@ This page shows how to enable and configure encryption of secret data at rest.
 The `kube-apiserver` process accepts an argument `--encryption-provider-config`
 that controls how API data is encrypted in etcd.
 The configuration is provided as an API named
-[`EncryptionConfiguration`](/docs/reference/config-api/apiserver-encryption.v1/).
-An example configuration is provided below.
+[`EncryptionConfiguration`](/docs/reference/config-api/apiserver-encryption.v1/). `--encryption-provider-config-automatic-reload` boolean argument determines if the file set by `--encryption-provider-config` should be automatically reloaded if the disk contents change. This enables key rotation without API server restarts. An example configuration is provided below.
 
 {{< caution >}}
 **IMPORTANT:** For high-availability configurations (with two or more control plane nodes), the
@@ -305,4 +304,3 @@ kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 ## {{% heading "whatsnext" %}}
 
 * Learn more about the [EncryptionConfiguration configuration API (v1)](/docs/reference/config-api/apiserver-encryption.v1/).
-

--- a/content/en/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kms-provider.md
@@ -150,6 +150,8 @@ To encrypt the data:
 
 1. Set the `--encryption-provider-config` flag on the kube-apiserver to point to the location of the configuration file.
 
+1. `--encryption-provider-config-automatic-reload` boolean argument determines if the file set by `--encryption-provider-config` should be automatically reloaded if the disk contents change. This enables key rotation without API server restarts.
+
 1. Restart your API server.
 
 ### KMS v1 {#encrypting-your-data-with-the-kms-provider-kms-v1}
@@ -194,6 +196,23 @@ To encrypt the data:
              cachesize: 100
              timeout: 3s
    ```
+
+Setting `--encryption-provider-config-automatic-reload` to `true` collapses all health checks to a single health check endpoint. Individual health checks are only available when KMS v1 providers are in use and the encryption config is not auto-reloaded.
+
+Following table summarizes the health check endpoints for each KMS version:
+
+| KMS configurations        | Without Automatic Reload           | With Automatic Reload  |
+| ------------------------- |------------------------------------| -----------------------|
+| KMS v1 only               | Individual Healthchecks            | Single Healthcheck     |
+| KMS v2 only               | Single Healthcheck                 | Single Healthcheck     |
+| Both KMS v1 and v2        | Individual Healthchecks            | Single Healthcheck     |
+| No KMS                    | None                               | Single Healthcheck     |
+
+`Single Healthcheck` means that the only health check endpoint is `/healthz/kms-providers`.
+
+`Individual Healthchecks` means that each KMS plugin has an associated health check endpoint based on its location in the encryption config: `/healthz/kms-provider-0`, `/healthz/kms-provider-1` etc.
+
+These healthcheck endpoint paths are hard coded and generated/controlled by the server. The indices for individual healthchecks corresponds to the order in which the KMS encryption config is processed.
 
 Until the steps defined in [Ensuring all secrets are encrypted](#ensuring-all-secrets-are-encrypted) are performed, the `providers` list should end with the `identity: {}` provider to allow unencrypted data to be read.  Once all resources are encrypted, the `identity` provider should be removed to prevent the API server from honoring unencrypted data.
 


### PR DESCRIPTION
kms: updates website to document --encryption-provider-config-automatic-reload api server flag and healthcheck endpoint behavior

Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

fixes: https://github.com/kubernetes/kubernetes/issues/113631

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
