### PR TITLE
[pt-br] Add docs/concepts/architecture/cri.md

### DIFF
--- a/content/en/blog/_posts/2021-04-06-PodSecurityPolicy-Past-Present-and-Future.md
+++ b/content/en/blog/_posts/2021-04-06-PodSecurityPolicy-Past-Present-and-Future.md
@@ -4,8 +4,11 @@ title: "PodSecurityPolicy Deprecation: Past, Present, and Future"
 date: 2021-04-06
 slug: podsecuritypolicy-deprecation-past-present-and-future
 ---
-
 **Author:** Tabitha Sable (Kubernetes SIG Security)
+
+{{% pageinfo color="primary" %}}
+**Update:** *With the release of Kubernetes v1.25, PodSecurityPolicy has been removed.* *You can read more information about the removal of PodSecurityPolicy in the [Kubernetes 1.25 release notes](/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes).*
+{{% /pageinfo %}}
 
 PodSecurityPolicy (PSP) is being deprecated in Kubernetes 1.21, to be released later this week. This starts the countdown to its removal, but doesn’t change anything else. PodSecurityPolicy will continue to be fully functional for several more releases before being removed completely. In the meantime, we are developing a replacement for PSP that covers key use cases more easily and sustainably.
 

--- a/content/pt-br/docs/concepts/architecture/cri.md
+++ b/content/pt-br/docs/concepts/architecture/cri.md
@@ -15,7 +15,7 @@ Você precisa de um
 {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} possa iniciar
 {{< glossary_tooltip text="Pods" term_id="pod" >}} e seus contêineres.
 
-{{< glossary_definition prepend="A Interface do agente de execução de contêiner (CRI) é" term_id="container-runtime-interface" length="all" >}}
+{{< glossary_definition prepend="A interface do agente de execução de contêiner (CRI) é" term_id="container-runtime-interface" length="all" >}}
 
 <!-- body -->
 
@@ -23,15 +23,14 @@ Você precisa de um
 
 {{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
-O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e tempo de execução devem estar disponíveis no tempo de execução do contêiner, que pode ser configurado separadamente no kubelet usando os sinais de opções de linha de comando 
-`--image-service-endpoint` e `--container-runtime-endpoint` [command line
-flags](/docs/reference/command-line-tools-reference/kubelet)
+O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e agente de execução devem estar disponíveis no agente de execução do contêiner, que pode ser configurado separadamente no kubelet usando as [opções de linha de comando](/docs/reference/command-line-tools-reference/kubelet)
+`--image-service-endpoint` e `--container-runtime-endpoint`.
 
 
-Para Kubernetes v{{< skew currentVersion >}}, o kubelet prefere usar CRI `v1`.
-Se um tempo de execução de contêiner não oferecer suporte à `v1` do CRI, 
+No Kubernetes v{{< skew currentVersion >}}, o kubelet prefere usar CRI `v1`.
+Se um agente de execução de contêiner não oferecer suporte à versão `v1` do CRI, 
 o kubelet tentará negociar qualquer versão compatível mais antiga.
-O kubelet v{{< skew currentVersion >}}  também pode negociar CRI `v1alpha2`, 
+O kubelet v{{< skew currentVersion >}}  também pode negociar a versão do CRI `v1alpha2`, 
 mas esta versão é considerada obsoleta. 
 Se o kubelet não puder negociar uma versão CRI suportada, 
 o kubelet desiste e não se registra como um nó.
@@ -39,9 +38,9 @@ o kubelet desiste e não se registra como um nó.
 
 ## Atualizando
 
-Ao atualizar o Kubernetes, o kubelet tenta selecionar automaticamente a versão mais recente do CRI na reinicialização do componente. Se isso falhar, o fallback ocorrerá conforme mencionado acima. Se uma rediscagem gRPC foi necessária porque o tempo de execução do contêiner foi atualizado, o tempo de execução do contêiner também deve oferecer suporte à versão inicialmente selecionada ou a rediscagem deve falhar. Isso requer uma reinicialização do kubelet.
+Ao atualizar o Kubernetes, o kubelet tenta selecionar automaticamente a versão mais recente do CRI na reinicialização do componente. Se isso falhar, o fallback ocorrerá conforme mencionado acima. Se uma rediscagem gRPC foi necessária porque o agente de execução do contêiner foi atualizado, o agente de execução do contêiner também deve oferecer suporte à versão inicialmente selecionada ou a rediscagem deve falhar. Isso requer uma reinicialização do kubelet.
 
 
 ## {{% heading "whatsnext" %}}
 
-- Leia mais [protocol definition](https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto)
+- Leia mais sobre a [definição do protocolo](https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto) do CRI

--- a/content/pt-br/docs/concepts/architecture/cri.md
+++ b/content/pt-br/docs/concepts/architecture/cri.md
@@ -23,8 +23,8 @@ Você precisa de um
 
 {{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
-O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e tempo de execução devem estar disponíveis no tempo de execução do contêiner, que pode ser configurado separadamente no kubelet usando os sinalizadores de opções de linha de comando 
-`--image-service-endpoint` and `--container-runtime-endpoint` [command line
+O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e tempo de execução devem estar disponíveis no tempo de execução do contêiner, que pode ser configurado separadamente no kubelet usando os sinais de opções de linha de comando 
+`--image-service-endpoint` e `--container-runtime-endpoint` [command line
 flags](/docs/reference/command-line-tools-reference/kubelet)
 
 

--- a/content/pt-br/docs/concepts/architecture/cri.md
+++ b/content/pt-br/docs/concepts/architecture/cri.md
@@ -11,11 +11,11 @@ O CRI é uma interface de plug-in que permite ao kubelet usar uma ampla variedad
  os componentes do cluster.
 
 Você precisa de um
-{{<glossary_tooltip text="tempo de execução de contêiner" term_id="container-runtime">}} em funcionamento em cada nó em seu cluster,
+{{<glossary_tooltip text="agente de execução de contêiner" term_id="container-runtime">}} em cada nó em seu cluster, para que o
 {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} possa iniciar
 {{< glossary_tooltip text="Pods" term_id="pod" >}} e seus contêineres.
 
-{{< glossary_definition prepend="The Container Runtime Interface (CRI) is" term_id="container-runtime-interface" length="all" >}}
+{{< glossary_definition prepend="A Interface do agente de execução de contêiner (CRI) é" term_id="container-runtime-interface" length="all" >}}
 
 <!-- body -->
 
@@ -23,10 +23,7 @@ Você precisa de um
 
 {{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
-O kubelet atua como um cliente ao se conectar ao tempo de execução do contêiner 
-via GRPC. Os endpoints de serviço de imagem e tempo de execução devem estar 
-disponíveis no tempo de execução do contêiner, que pode ser configurado 
-paradamente no kubelet usando os sinalizadores de linha de comando 
+O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e tempo de execução devem estar disponíveis no tempo de execução do contêiner, que pode ser configurado separadamente no kubelet usando os sinalizadores de opções de linha de comando 
 `--image-service-endpoint` and `--container-runtime-endpoint` [command line
 flags](/docs/reference/command-line-tools-reference/kubelet)
 
@@ -47,4 +44,4 @@ Ao atualizar o Kubernetes, o kubelet tenta selecionar automaticamente a versão 
 
 ## {{% heading "whatsnext" %}}
 
-- Saiba mais sobre a definição do protocolo CRI [protocol definition](https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto)
+- Leia mais [protocol definition](https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto)

--- a/content/pt-br/docs/concepts/architecture/cri.md
+++ b/content/pt-br/docs/concepts/architecture/cri.md
@@ -23,8 +23,8 @@ Você precisa de um
 
 {{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
-O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e tempo de execução devem estar disponíveis no tempo de execução do contêiner, que pode ser configurado separadamente no kubelet usando os sinais de opções de linha de comando 
-`--image-service-endpoint` e `--container-runtime-endpoint` [command line
+O kubelet atua como um cliente ao se conectar ao agente de execução de contêiner via gRPC. Os endpoints de serviço de imagem e tempo de execução devem estar disponíveis no tempo de execução do contêiner, que pode ser configurado separadamente no kubelet usando os sinalizadores de opções de linha de comando 
+`--image-service-endpoint` and `--container-runtime-endpoint` [command line
 flags](/docs/reference/command-line-tools-reference/kubelet)
 
 

--- a/content/pt-br/docs/concepts/architecture/cri.md
+++ b/content/pt-br/docs/concepts/architecture/cri.md
@@ -1,6 +1,6 @@
 ---
-título: Container Runtime Interface (CRI)
-tipo de conteúdo: concept
+title: Container Runtime Interface (CRI)
+content_type: concept
 weight: 60
 ---
 

--- a/content/pt-br/docs/concepts/architecture/cri.md
+++ b/content/pt-br/docs/concepts/architecture/cri.md
@@ -1,0 +1,50 @@
+---
+título: Container Runtime Interface (CRI)
+tipo de conteúdo: concept
+weight: 60
+---
+
+<!-- overview -->
+
+O CRI é uma interface de plug-in que permite ao kubelet usar uma ampla variedade
+ de tempos de execução de contêiner, sem a necessidade de recompilar 
+ os componentes do cluster.
+
+Você precisa de um
+{{<glossary_tooltip text="tempo de execução de contêiner" term_id="container-runtime">}} em funcionamento em cada nó em seu cluster,
+{{< glossary_tooltip text="kubelet" term_id="kubelet" >}} possa iniciar
+{{< glossary_tooltip text="Pods" term_id="pod" >}} e seus contêineres.
+
+{{< glossary_definition prepend="The Container Runtime Interface (CRI) is" term_id="container-runtime-interface" length="all" >}}
+
+<!-- body -->
+
+## A API {#api}
+
+{{< feature-state for_k8s_version="v1.23" state="stable" >}}
+
+O kubelet atua como um cliente ao se conectar ao tempo de execução do contêiner 
+via GRPC. Os endpoints de serviço de imagem e tempo de execução devem estar 
+disponíveis no tempo de execução do contêiner, que pode ser configurado 
+paradamente no kubelet usando os sinalizadores de linha de comando 
+`--image-service-endpoint` and `--container-runtime-endpoint` [command line
+flags](/docs/reference/command-line-tools-reference/kubelet)
+
+
+Para Kubernetes v{{< skew currentVersion >}}, o kubelet prefere usar CRI `v1`.
+Se um tempo de execução de contêiner não oferecer suporte à `v1` do CRI, 
+o kubelet tentará negociar qualquer versão compatível mais antiga.
+O kubelet v{{< skew currentVersion >}}  também pode negociar CRI `v1alpha2`, 
+mas esta versão é considerada obsoleta. 
+Se o kubelet não puder negociar uma versão CRI suportada, 
+o kubelet desiste e não se registra como um nó.
+
+
+## Atualizando
+
+Ao atualizar o Kubernetes, o kubelet tenta selecionar automaticamente a versão mais recente do CRI na reinicialização do componente. Se isso falhar, o fallback ocorrerá conforme mencionado acima. Se uma rediscagem gRPC foi necessária porque o tempo de execução do contêiner foi atualizado, o tempo de execução do contêiner também deve oferecer suporte à versão inicialmente selecionada ou a rediscagem deve falhar. Isso requer uma reinicialização do kubelet.
+
+
+## {{% heading "whatsnext" %}}
+
+- Saiba mais sobre a definição do protocolo CRI [protocol definition](https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto)

--- a/content/pt-br/docs/reference/glossary/container-runtime-interface.md
+++ b/content/pt-br/docs/reference/glossary/container-runtime-interface.md
@@ -1,0 +1,18 @@
+---
+title: Container runtime interface (CRI)
+id: cri
+date: 2019-03-07
+full_link: /docs/concepts/overview/components/#container-runtime
+short_description: >
+    Uma API para agentes de execução de contêineres se integrarem com o kubelet
+
+
+aka:
+tags:
+- fundamental
+---
+A interface de execução de contêiner (CRI) é uma API para agentes de execução de
+contêineres se integrarem com o kubelet em um nó.
+<!--more-->
+
+Para maiores informações, veja as APIs e especificações do [CRI](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).

--- a/content/pt-br/docs/reference/glossary/container-runtime-interface.md
+++ b/content/pt-br/docs/reference/glossary/container-runtime-interface.md
@@ -1,18 +1,19 @@
 ---
-title: Container runtime interface (CRI)
-id: cri
+title: Container runtime interface
+id: container-runtime-interface
 date: 2019-03-07
-full_link: /docs/concepts/overview/components/#container-runtime
+full_link: /docs/concepts/architecture/cri
 short_description: >
-    Uma API para agentes de execução de contêineres se integrarem com o kubelet
-
+    O principal protocolo para a comunicação entre o kubelet e os agentes de execução de contêineres.
 
 aka:
 tags:
-- fundamental
+- cri
 ---
-A interface de execução de contêiner (CRI) é uma API para agentes de execução de
-contêineres se integrarem com o kubelet em um nó.
+
+O principal protocolo para a comunicação entre o kubelet e os agentes de execução de contêineres.
+
 <!--more-->
 
-Para maiores informações, veja as APIs e especificações do [CRI](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
+A interface do agente de execução de contêiner do Kubernetes (CRI) define o principal protocolo [gRPC](https://grpc.io) para a comunicação entre os [componentes de cluster](/docs/concepts/overview/components/#node-components)
+{{< glossary_tooltip text="kubelet" term_id="kubelet" >}} e o {{< glossary_tooltip text="agente de execução de contêiner" term_id="container-runtime" >}}.

--- a/content/pt-br/docs/reference/glossary/cri.md
+++ b/content/pt-br/docs/reference/glossary/cri.md
@@ -1,18 +1,18 @@
 ---
 title: Container runtime interface (CRI)
-id: cri
+id: container-runtime-interface
 date: 2019-03-07
-full_link: /docs/concepts/overview/components/#container-runtime
+full_link: /docs/concepts/architecture/cri
 short_description: >
-    Uma API para agentes de execução de contêineres se integrarem com o kubelet
+    O principal protocolo para comunicação entre o kubelet e os agentes de execução de contêineres.
 
 
 aka:
 tags:
 - fundamental
 ---
-A interface de execução de contêiner (CRI) é uma API para agentes de execução de
-contêineres se integrarem com o kubelet em um nó.
+O principal protocolo para comunicação entre o kubelet e os agentes de execução de contêineres.
+
 <!--more-->
 
-Para maiores informações, veja as APIs e especificações do [CRI](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
+A interface de execução de contêiner (CRI) do Kubernetes define o principal protocolo [ gRPC ](https://grpc.io) para a comunicação entre os [ componentes de cluster ](/docs/concepts/overview/components.md)

--- a/content/pt-br/docs/tasks/debug/debug-aplication/debug-init-containers.md
+++ b/content/pt-br/docs/tasks/debug/debug-aplication/debug-init-containers.md
@@ -1,0 +1,124 @@
+---
+reviewers:
+- bprashanth
+- enisoc
+- erictune
+- foxish
+- janetkuo
+- kow3ns
+- smarterclayton
+title: Debug Init Containers
+content_type: task
+weight: 40
+---
+
+<!-- overview -->
+
+Esta página mostra como investigar problemas relacionados à execução de
+inicialização de Contêineres. As linhas de comando de exemplo abaixo 
+referem-se ao pod como `<pod-name>` e a inicialização de contêineres como `<init-container-1>` e
+`<init-container-2>`.
+
+## {{% heading "prerequisites" %}}
+
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+* Você deve estar familiarizado com os fundamentos da
+  [inicialização de Contêineres](/docs/concepts/workloads/pods/init-containers/).
+* Você deve ter [Configurado uma Inicialização de Contêiner](/docs/tasks/configure-pod-container/configure-pod-initialization/#creating-a-pod-that-has-an-init-container/).
+
+<!-- steps -->
+
+## Verificando o status das inicializações de contêineres
+
+Exiba o status do seu pod:
+
+```shell
+kubectl get pod <pod-name>
+```
+
+Por exemplo, um status de `Init:1/2` indica que uma das duas inicializações de contêineres
+concluíram com sucesso:
+
+```
+NAME         READY     STATUS     RESTARTS   AGE
+<pod-name>   0/1       Init:1/2   0          7s
+```
+
+Consulte [Entendendo sobre o status do pod](#understanding-pod-status) para obter mais exemplos de
+valores de status e seus significados.
+
+## Obtendo detalhes sobre a Inicialização de Contêineres
+
+Veja informações mais detalhadas sobre a execução da Inicialização de Contêineres:
+
+```shell
+kubectl describe pod <pod-name>
+```
+
+Por exemplo, um pod com duas inicializações de contêineres pode mostrar o seguinte:
+
+```
+Init Containers:
+  <init-container-1>:
+    Container ID:    ...
+    ...
+    State:           Terminated
+      Reason:        Completed
+      Exit Code:     0
+      Started:       ...
+      Finished:      ...
+    Ready:           True
+    Restart Count:   0
+    ...
+  <init-container-2>:
+    Container ID:    ...
+    ...
+    State:           Waiting
+      Reason:        CrashLoopBackOff
+    Last State:      Terminated
+      Reason:        Error
+      Exit Code:     1
+      Started:       ...
+      Finished:      ...
+    Ready:           False
+    Restart Count:   3
+    ...
+```
+
+Você também pode acessar programaticamente os status das inicializações de contêineres,
+lendo o campo `status.initContainerStatuses` nas especificações do pod:
+
+```shell
+kubectl get pod nginx --template '{{.status.initContainerStatuses}}'
+```
+
+Este comando retornará as mesmas informações acima em JSON bruto.
+
+## Acessando logs de inicialização de contêineres
+
+Passe o nome da inicialização de contêineres junto com o nome do Pod
+para acessar seus logs.
+
+```shell
+kubectl logs <pod-name> -c <init-container-2>
+```
+
+Inicializações de contêineres que executam uma impressão de comandos de script de shell
+à medida que são executados. Por exemplo, você pode fazer isso no Bash executando `set -x` no início do script.
+
+<!-- discussion -->
+
+## Entendendo sobre o status do pod
+
+Um status do Pod começando com `Init:` resume o status da execução da inicialização de contêineres. 
+A tabela abaixo descreve alguns valores de status de exemplo que você pode ver durante a depuração de Init Containers.
+
+Status | Significado
+------ | -------
+`Init:N/M` | O pod tem inicializações de contêineres `M` e `N` que foram concluídas até agora.
+`Init:Error` | Uma inicialização de contêiner falhou ao executar.
+`Init:CrashLoopBackOff` | Uma inicialização de contêiner falhou repetidamente.
+`Pending` | O pod ainda não começou a executar a inicialização de contêineres.
+`PodInitializing` ou `Running` | O pod já concluiu a execução das inicializações de contêineres.


### PR DESCRIPTION
Hello everyone,

Brazilian portuguese translation for the [Container Runtime Interface](https://github.com/kubernetes/website/blob/main/content/en/docs/concepts/architecture/cri.md) page.
Related issues
https://github.com/kubernetes/website/issues/13939