### PR TITLE
Fix shell block on Job task page

### DIFF
--- a/content/en/docs/tasks/job/job-with-pod-to-pod-communication.md
+++ b/content/en/docs/tasks/job/job-with-pod-to-pod-communication.md
@@ -109,6 +109,7 @@ spec:
 
 After applying the example above, reach each other over the network
 using: `<pod-hostname>.<headless-service-name>`. You should see output similar to the following:
+
 ```shell
 kubectl logs example-job-0-qws42
 ```
@@ -119,7 +120,7 @@ Successfully pinged pod: example-job-0.headless-svc
 Successfully pinged pod: example-job-1.headless-svc
 Successfully pinged pod: example-job-2.headless-svc
 ```
-```
+
 {{<note>}}
 Keep in mind that the `<pod-hostname>.<headless-service-name>` name format used
 in this example would not work with DNS policy set to `None` or `Default`.


### PR DESCRIPTION
https://github.com/kubernetes/website/pull/37771 was just merged with an extra "```" line included below a shell block, which results in some slightly funky formatting at the bottom of the page (a shell/code block with a "Note" template inside of it). 

See: https://kubernetes.io/docs/tasks/job/job-with-pod-to-pod-communication/ (scroll to the bottom)

This PR removes the extra "```" and fixes the formatting. Confirmed this by running `make container-serve` locally and verifying the formatting in my browser.