### PR TITLE
Removed Reference from the removed Feature Gates.

### DIFF
--- a/content/en/docs/concepts/policy/pid-limiting.md
+++ b/content/en/docs/concepts/policy/pid-limiting.md
@@ -75,9 +75,7 @@ respectively.
 
 {{< note >}}
 Before Kubernetes version 1.20, PID resource limiting with Node-level
-reservations required enabling the [feature
-gate](/docs/reference/command-line-tools-reference/feature-gates/)
-`SupportNodePidsLimit` to work.
+reservations required enabling the feature gate `SupportNodePidsLimit` to work.
 {{< /note >}}
 
 ## Pod PID limits
@@ -91,8 +89,7 @@ to the kubelet, or set `PodPidsLimit` in the kubelet
 
 {{< note >}}
 Before Kubernetes version 1.20, PID resource limiting for Pods required enabling
-the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-`SupportPodPidsLimit` to work.
+the feature gate `SupportPodPidsLimit` to work.
 {{< /note >}}
 
 ## PID based eviction

--- a/content/en/docs/concepts/policy/pid-limiting.md
+++ b/content/en/docs/concepts/policy/pid-limiting.md
@@ -73,11 +73,6 @@ The value you specified declares that the specified number of process IDs will
 be reserved for the system as a whole and for Kubernetes system daemons
 respectively.
 
-{{< note >}}
-Before Kubernetes version 1.20, PID resource limiting with Node-level
-reservations required enabling the feature gate `SupportNodePidsLimit` to work.
-{{< /note >}}
-
 ## Pod PID limits
 
 Kubernetes allows you to limit the number of processes running in a Pod. You
@@ -86,11 +81,6 @@ limit for a particular Pod. Each Node can have a different PID limit.
 To configure the limit, you can specify the command line parameter `--pod-max-pids`
 to the kubelet, or set `PodPidsLimit` in the kubelet
 [configuration file](/docs/tasks/administer-cluster/kubelet-config-file/).
-
-{{< note >}}
-Before Kubernetes version 1.20, PID resource limiting for Pods required enabling
-the feature gate `SupportPodPidsLimit` to work.
-{{< /note >}}
 
 ## PID based eviction
 


### PR DESCRIPTION
This PR removed the Feature Gate reference from `SupportNodePidsLimit` and `SupportPodPidsLimit`, as these are gratuated and removed.
Fixes #38118