### PR TITLE
Updated Owners and Dependents page with glossary tooltip and reference links

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/owners-dependents.md
+++ b/content/en/docs/concepts/overview/working-with-objects/owners-dependents.md
@@ -84,8 +84,6 @@ object.
 
 ## {{% heading "whatsnext" %}}
 
-Learn more about the following:
-* [Kubernetes finalizers](/docs/concepts/overview/working-with-objects/finalizers/).
-* [garbage collection](/docs/concepts/architecture/garbage-collection).
-* API reference for [object metadata](/docs/reference/kubernetes-api/common-definitions/object-meta/#System).
-* Objets such as [ReplicaSets](/docs/concepts/workloads/controllers/replicaset/), [DaemonSets](/docs/concepts/workloads/controllers/daemonset/), [Deployments](/docs/concepts/workloads/controllers/deployment/), [Jobs](/docs/concepts/workloads/controllers/job/), [CronJobs](/docs/concepts/workloads/controllers/cron-jobs/) and [ReplicationControllers](/docs/concepts/workloads/controllers/replicationcontroller/). 
+* Learn more about [Kubernetes finalizers](/docs/concepts/overview/working-with-objects/finalizers/).
+* Learn about [garbage collection](/docs/concepts/architecture/garbage-collection).
+* Read the API reference for [object metadata](/docs/reference/kubernetes-api/common-definitions/object-meta/#System).

--- a/content/en/docs/concepts/overview/working-with-objects/owners-dependents.md
+++ b/content/en/docs/concepts/overview/working-with-objects/owners-dependents.md
@@ -6,13 +6,13 @@ weight: 90
 
 <!-- overview -->
 
-In Kubernetes, some objects are *owners* of other objects. For example, a
-{{<glossary_tooltip text="ReplicaSet" term_id="replica-set">}} is the owner of a set of Pods. These owned objects are *dependents*
+In Kubernetes, some {{< glossary_tooltip text="objects" term_id="Object" >}} are *owners* of other objects. For example, a
+{{<glossary_tooltip text="ReplicaSet" term_id="replica-set">}} is the owner of a set of {{<glossary_tooltip text="Pods" term_id="pod">}}. These owned objects are *dependents*
 of their owner. 
 
 Ownership is different from the [labels and selectors](/docs/concepts/overview/working-with-objects/labels/)
 mechanism that some resources also use. For example, consider a Service that 
-creates `EndpointSlice` objects. The Service uses labels to allow the control plane to
+creates `EndpointSlice` objects. The Service uses {{<glossary_tooltip text="labels" term_id="label">}} to allow the control plane to
 determine which `EndpointSlice` objects are used for that Service. In addition
 to the labels, each `EndpointSlice` that is managed on behalf of a Service has
 an owner reference. Owner references help different parts of Kubernetes avoid
@@ -21,8 +21,8 @@ interfering with objects they don’t control.
 ## Owner references in object specifications
 
 Dependent objects have a `metadata.ownerReferences` field that references their
-owner object. A valid owner reference consists of the object name and a UID
-within the same namespace as the dependent object. Kubernetes sets the value of
+owner object. A valid owner reference consists of the object name and a {{<glossary_tooltip text="UID" term_id="uid">}} 
+within the same {{<glossary_tooltip text="namespace" term_id="namespace">}} as the dependent object. Kubernetes sets the value of
 this field automatically for objects that are dependents of other objects like
 ReplicaSets, DaemonSets, Deployments, Jobs and CronJobs, and ReplicationControllers.
 You can also configure these relationships manually by changing the value of
@@ -66,10 +66,10 @@ When you tell Kubernetes to delete a resource, the API server allows the
 managing controller to process any [finalizer rules](/docs/concepts/overview/working-with-objects/finalizers/)
 for the resource. {{<glossary_tooltip text="Finalizers" term_id="finalizer">}}
 prevent accidental deletion of resources your cluster may still need to function
-correctly. For example, if you try to delete a `PersistentVolume` that is still
+correctly. For example, if you try to delete a [PersistentVolume](/docs/concepts/storage/persistent-volumes/) that is still
 in use by a Pod, the deletion does not happen immediately because the
 `PersistentVolume` has the `kubernetes.io/pv-protection` finalizer on it.
-Instead, the volume remains in the `Terminating` status until Kubernetes clears
+Instead, the [volume](/docs/concepts/storage/volumes/) remains in the `Terminating` status until Kubernetes clears
 the finalizer, which only happens after the `PersistentVolume` is no longer
 bound to a Pod. 
 
@@ -84,6 +84,8 @@ object.
 
 ## {{% heading "whatsnext" %}}
 
-* Learn more about [Kubernetes finalizers](/docs/concepts/overview/working-with-objects/finalizers/).
-* Learn about [garbage collection](/docs/concepts/architecture/garbage-collection).
-* Read the API reference for [object metadata](/docs/reference/kubernetes-api/common-definitions/object-meta/#System).
+Learn more about the following:
+* [Kubernetes finalizers](/docs/concepts/overview/working-with-objects/finalizers/).
+* [garbage collection](/docs/concepts/architecture/garbage-collection).
+* API reference for [object metadata](/docs/reference/kubernetes-api/common-definitions/object-meta/#System).
+* Objets such as [ReplicaSets](/docs/concepts/workloads/controllers/replicaset/), [DaemonSets](/docs/concepts/workloads/controllers/daemonset/), [Deployments](/docs/concepts/workloads/controllers/deployment/), [Jobs](/docs/concepts/workloads/controllers/job/), [CronJobs](/docs/concepts/workloads/controllers/cron-jobs/) and [ReplicationControllers](/docs/concepts/workloads/controllers/replicationcontroller/). 


### PR DESCRIPTION
This PR updated `Owners and Dependents` page by adding few glossary tooltips and reference links to the terms which were not having previously. Also updated what's next section.

Fixes #38136.
