### PR TITLE
Update target date for December patch releases

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -6,7 +6,7 @@ schedules:
   next:
     release: 1.25.5
     cherryPickDeadline: 2022-12-02
-    targetDate: 2022-12-07
+    targetDate: 2022-12-08
   previousPatches:
     - release: 1.25.4
       cherryPickDeadline: 2022-11-04
@@ -31,7 +31,7 @@ schedules:
   next:
     release: 1.24.9
     cherryPickDeadline: 2022-12-02
-    targetDate: 2022-12-07
+    targetDate: 2022-12-08
   previousPatches:
     - release: 1.24.8
       cherryPickDeadline: 2022-11-04
@@ -68,7 +68,7 @@ schedules:
   next:
     release: 1.23.15
     cherryPickDeadline: 2022-12-02
-    targetDate: 2022-12-07
+    targetDate: 2022-12-08
   previousPatches:
     - release: 1.23.14
       cherryPickDeadline: 2022-11-04


### PR DESCRIPTION
This PR updates the target date for the December patch releases to Thursday, December 8, 2022.

The idea is to delay the December patch releases for one day so that we have enough time to incorporate the upcoming Go security patch releases.

Slack discussion: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669990966899019

/assign @saschagrunert @cpanato @puerco @jeremyrickard 
cc @kubernetes/release-engineering 