### PR TITLE
Change a https// to https://

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -783,7 +783,7 @@ should connect to. This is used mainly for etcd cluster health check purposes.
 
 ### kubeadm.kubernetes.io/kube-apiserver.advertise-address.endpoint
 
-Example: `kubeadm.kubernetes.io/kube-apiserver.advertise-address.endpoint: https//172.17.0.18:6443`
+Example: `kubeadm.kubernetes.io/kube-apiserver.advertise-address.endpoint: https://172.17.0.18:6443`
 
 Used on: Pod
 


### PR DESCRIPTION
Find a colon `:` is missing in this example of url:

```
https//172.17.0.18:6443
```