### PR TITLE
updated kubeadm certificate page misleading example

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -267,11 +267,16 @@ to download the certificates when additional control-plane nodes are joining, by
 The following phase command can be used to re-upload the certificates after expiration:
 
 ```shell
-kubeadm init phase upload-certs --upload-certs --certificate-key=SOME_VALUE --config=SOME_YAML_FILE
+kubeadm init phase upload-certs --upload-certs --config=SOME_YAML_FILE
 ```
+{{< note >}}
+The certificateKey can be passed in [InitConfiguration with `--config`] (https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/).
+{{< /note >}}
 
 If the flag `--certificate-key` is not passed to `kubeadm init` and
 `kubeadm init phase upload-certs` a new key will be generated automatically.
+
+
 
 The following command can be used to generate a new key on demand:
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1iwmw6z3xMmaIaYcTUZe5O4i43Jwb8eM8%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Q5QnU5B)

[#38251](https://github.com/kubernetes/website/issues/38251)
kubeadm certificate page has misleading example

this section
https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#uploading-control-plane-certificates-to-the-cluster

has this example

kubeadm init phase upload-certs --upload-certs --certificate-key=SOME_VALUE --config=SOME_YAML_FILE
but actually the mixture of --certificate-key and --config is not allowed

