### PR TITLE
[ja] Translate content/ja/docs/tasks/debug/debug-application/_index.md into Japanese

### DIFF
--- a/content/ja/docs/tasks/debug/debug-application/_index.md
+++ b/content/ja/docs/tasks/debug/debug-application/_index.md
@@ -1,7 +1,7 @@
 ---
 title: アプリケーションのトラブルシューティング
-description: Debugging common containerized application issues.
+description: コンテナ化されたアプリケーションの一般的な問題をデバッグします。
 weight: 20
 ---
 
-This doc contains a set of resources for fixing issues with containerized applications. It covers things like common issues with Kubernetes resources (like Pods, Services, or StatefulSets), advice on making sense of container termination messages, and ways to debug running containers.
+このドキュメントには、コンテナ化されたアプリケーションの問題を解決するための、一連のリソースが記載されています。Kubernetesリソース(Pod、Service、StatefulSetなど)に関する一般的な問題や、コンテナ終了メッセージを理解するためのアドバイス、実行中のコンテナをデバッグする方法などが網羅されています。


### PR DESCRIPTION
fixes #37349

Translate an overview part in https://kubernetes.io/ja/docs/tasks/debug/debug-application/.
By translating the contents of `content/ja/docs/tasks/debug/debug-application/_index.md`, this part will be in Japanese.

Preview:
https://deploy-preview-38275--kubernetes-io-main-staging.netlify.app/ja/docs/tasks/debug/debug-application/