### PR TITLE
Update target date for December in patch releases document

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,7 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| December 2022         | 2022-12-02           | 2022-12-07  |
+| December 2022         | 2022-12-02           | 2022-12-08  |
 | January 2023          | 2023-01-13           | 2023-01-18  |
 | February 2023         | 2023-02-10           | 2023-02-15  |
 


### PR DESCRIPTION
This is a follow-up on #38233 -- I updated `data/releases/schedule.yaml`, but I forgot to update the patch releases page (`content/en/releases/patch-releases.md`).

/assign @cpanato @saschagrunert @ameukam 
cc @kubernetes/release-engineering 