### PR TITLE
Switch back to older push target for hugo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
       - -c
       - |
         gcloud auth configure-docker \
-        && make docker-push
+        && make container-push
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
`buildx` is not available in the environment, let's just go back to the older make target and we can try this again after 1.26 release is over

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
