### PR TITLE
[zh] updated glossary/ephemeral-container.md

### DIFF
--- a/content/zh-cn/docs/reference/glossary/ephemeral-container.md
+++ b/content/zh-cn/docs/reference/glossary/ephemeral-container.md
@@ -31,8 +31,10 @@ A {{< glossary_tooltip term_id="container" >}} type that you can temporarily run
 
 <!--
 If you want to investigate a Pod that's running with problems, you can add an ephemeral container to that Pod and carry out diagnostics. Ephemeral containers have no resource or scheduling guarantees, and you should not use them to run any part of the workload itself.
+
 Ephemeral containers are not supported by {{< glossary_tooltip text="static pods" term_id="static-pod" >}}.
 -->
 如果想要调查运行中有问题的 Pod，可以向该 Pod 添加一个临时容器（Ephemeral Container）并进行诊断。
-临时容器没有资源或调度保证，因此不应该使用它们来运行任何部分的工作负荷本身。
-{{{< glossary_tooltip text="静态 Pod" term_id="static-pod" >}} 不支持临时容器。
+临时容器没有资源或调度保证，因此不应该使用它们来运行工作负载本身的任何部分。
+
+{{< glossary_tooltip text="静态 Pod" term_id="static-pod" >}} 不支持临时容器。


### PR DESCRIPTION
Remove an extra `{` and give a blank line to keep consistent with en.

```
content/zh-cn/docs/reference/glossary/ephemeral-container.md
```