### PR TITLE
add version support to `fish` auto-completion

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -4,6 +4,10 @@ description: "Optional configuration to enable fish shell auto-completion."
 headless: true
 ---
 
+{{< note >}}
+Autocomplete for Fish requires kubectl 1.23 or later.
+{{< /note >}}
+
 The kubectl completion script for Fish can be generated with the command `kubectl completion fish`. Sourcing the completion script in your shell enables kubectl autocompletion.
 
 To do so in all your shell sessions, add the following line to your `~/.config/fish/config.fish` file:


### PR DESCRIPTION
Spent some time wondering why the recommended command did not worked and found https://github.com/kubernetes/website/pull/33972.

Suggestions have been applied but I took the liberty to put the note at the top of the page.

Preview link: https://deploy-preview-38302--kubernetes-io-main-staging.netlify.app/docs/tasks/tools/included/optional-kubectl-configs-fish/

Reference: https://github.com/kubernetes/kubectl/issues/1189