### PR TITLE
Update Release Manager (Associates)

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -88,6 +88,7 @@ GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kuber
 
 - Adolfo García Veytia ([@puerco](https://github.com/puerco))
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
+- Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard))
 - Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))
 - Nabarun Pal ([@palnabarun](https://github.com/palnabarun))
 - Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
@@ -134,14 +135,8 @@ GitHub Mentions: @kubernetes/release-engineering
 
 - Arnaud Meukam ([@ameukam](https://github.com/ameukam))
 - Cici Huang ([@cici37](https://github.com/cici37))
-- Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard))
 - Jim Angel ([@jimangel](https://github.com/jimangel))
 - Joseph Sandoval ([@jrsapi](https://github.com/jrsapi))
-- Joyce Kung ([@thejoycekung](https://github.com/thejoycekung))
-- Max Körbächer ([@mkorbi](https://github.com/mkorbi))
-- Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
-- Taylor Dolezal ([@onlydole](https://github.com/onlydole))
-- Wilson Husin ([@wilsonehusin](https://github.com/wilsonehusin))
 - Xander Grzywinski([@salaxander](https://github.com/salaxander))
 
 ### Becoming a Release Manager Associate


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/release/pull/2773

We now reflect the latest changes to the SIG Release OWNERS_ALIASES: https://github.com/kubernetes/release/blob/3ee765b9f1ee1a56fc72a775d0253e25abcec8ce/OWNERS_ALIASES#L11-L25

/sig release
cc @kubernetes/release-managers @kubernetes/sig-release-leads 