### PR TITLE
Removed spec.Replicas from example application deployment manifest for HPA scaling walkthrough

### DIFF
--- a/content/en/examples/application/php-apache.yaml
+++ b/content/en/examples/application/php-apache.yaml
@@ -6,7 +6,6 @@ spec:
   selector:
     matchLabels:
       run: php-apache
-  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
The php-apache.yaml file deploys a sample application which is used as part of the [HPA walkthrough guide](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/). This PR removes the `spec.replicas` count from the Deployment manifest because if this is set when HPA is enabled, when a change to the deployment manifest is applied Kubernetes will scale the current number of pods to the the value of `spec.replicas` in the deployment manifest. This could result in pods terminating, which could impact the performance of a scaled workload were `spec.replicas` is less than the HPA `spec.maxReplicas`.

More information can be found in the Kubernetes [documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling).