### PR TITLE
Correct the node authorizer permissions

### DIFF
--- a/content/en/docs/reference/access-authn-authz/node.md
+++ b/content/en/docs/reference/access-authn-authz/node.md
@@ -20,8 +20,6 @@ The Node authorizer allows a kubelet to perform API operations. This includes:
 
 Read operations:
 
-* services
-* endpoints
 * nodes
 * pods
 * secrets, configmaps, persistent volume claims and persistent volumes related to pods bound to the kubelet's node


### PR DESCRIPTION
Node authorization documentation mentions read permissions to services and endpoints, which are not authorized in code: https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/node/node_authorizer.go

This change simply removes apparently erroneous mentions of services and endpoints being authorized in `ModeNode`.
