### PR TITLE
[fr] Replace old link with new link in deploying the dashboard ui doc.

### DIFF
--- a/content/fr/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/fr/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -29,7 +29,7 @@ L'interface utilisateur du tableau de bord n'est pas déployée par défaut.
 Pour le déployer, exécutez la commande suivante:
 
 ```text
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.6.1/aio/deploy/recommended.yaml
 ```
 
 ## Accès à l'interface utilisateur du tableau de bord


### PR DESCRIPTION
Description:
Update **Deploying the Dashboard UI** with the new link in french web-ui-dashboard doc.

Proposed Solution:
Updated link from 

`kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended.yaml`

 to 

`kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.6.1/aio/deploy/recommended.yaml
`

Page to Update:
https://kubernetes.io/fr/docs/tasks/access-application-cluster/web-ui-dashboard/#d%C3%A9ploiement-du-tableau-de-bord