### PR TITLE
Fix typo in configure-service-account en

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -174,7 +174,7 @@ Suppose you have an existing service account named "build-robot" as mentioned ea
 You can get a time-limited API token for that ServiceAccount using `kubectl`:
 
 ```shell
-kubectl create token admin-user
+kubectl create token build-robot
 ```
 
 The output from that command is a token that you can use to authenticate as that


### PR DESCRIPTION
In [Manually create an API token for a ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount), all examples use the ServiceAccount name "build-robot", but this one example references an "admin-user" ServiceAccount that wasn't mentioned before.

![Screenshot 2022-12-08 at 12-28-04 Configure Service Accounts for Pods](https://user-images.githubusercontent.com/48807108/206446501-7b503ea8-21c6-4e72-97b7-fa506d58fff8.png)