### PR TITLE
Annotations are mappings, not sequences

### DIFF
--- a/content/en/examples/secret/serviceaccount/mysecretname.yaml
+++ b/content/en/examples/secret/serviceaccount/mysecretname.yaml
@@ -4,4 +4,4 @@ type: kubernetes.io/service-account-token
 metadata:
   name: mysecretname
   annotations:
-    - kubernetes.io/service-account.name: myserviceaccount
+    kubernetes.io/service-account.name: myserviceaccount


### PR DESCRIPTION
> The provided example is invalid because in the example, `annotations:` is a sequence.
> 
> Annotations are mappings, as explained [in the documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
> 
> A reviewer can check for themselves that the provided example doesn't work (if they try to `kubectl apply -f` the provided YAML) while the fixed one does.