### PR TITLE
 Add release schedule for 1.26 release

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,4 +1,12 @@
 schedules:
+- release: 1.26
+  releaseDate: 2022-12-08
+  maintenanceModeStartDate: 2023-12-28
+  endOfLifeDate: 2024-02-24
+  next:
+    release: 1.26.1
+    cherryPickDeadline: 2022-01-06
+    targetDate: 2023-01-11
 - release: 1.25
   releaseDate: 2022-08-23
   maintenanceModeStartDate: 2023-08-28

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,6 +1,6 @@
 schedules:
 - release: 1.26
-  releaseDate: 2022-12-08
+  releaseDate: 2022-12-09
   maintenanceModeStartDate: 2023-12-28
   endOfLifeDate: 2024-02-24
   next:


### PR DESCRIPTION
This PR adds 1.26 to the releases schedule for the 1.26.0 release. Following instruction [here](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#update-releases-page-the-week-before-the-release)
/milestone 1.26
/cc @reylejano @divya-mohan0209 @onlydole 