### PR TITLE
chore:  update release-1.25 config.toml for release 1.26

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -142,9 +142,9 @@ latest = "v1.26"
 
 fullversion = "v1.25.4"
 version = "v1.25"
-githubbranch = "v1.25.4"
-docsbranch = "release-1.25"
-deprecated = true
+githubbranch = "main"
+docsbranch = "main"
+deprecated = false
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 

--- a/config.toml
+++ b/config.toml
@@ -209,9 +209,9 @@ docsbranch = "release-1.23"
 url = "https://v1-23.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.22.17"
+fullversion = "v1.22.16"
 version = "v1.22"
-githubbranch = "v1.22.17"
+githubbranch = "v1.22.16"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
 

--- a/config.toml
+++ b/config.toml
@@ -209,9 +209,9 @@ docsbranch = "release-1.23"
 url = "https://v1-23.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.22.11"
+fullversion = "v1.22.17"
 version = "v1.22"
-githubbranch = "v1.22.11"
+githubbranch = "v1.22.17"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
 

--- a/config.toml
+++ b/config.toml
@@ -140,10 +140,10 @@ showedit = true
 
 latest = "v1.26"
 
-fullversion = "v1.26.0"
-version = "v1.26"
-githubbranch = "v1.26.0"
-docsbranch = "release-1.26"
+fullversion = "v1.25.4"
+version = "v1.25"
+githubbranch = "v1.25.4"
+docsbranch = "release-1.25"
 deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"

--- a/config.toml
+++ b/config.toml
@@ -138,13 +138,13 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.25"
+latest = "v1.26"
 
-fullversion = "v1.25.0"
-version = "v1.25"
-githubbranch = "main"
-docsbranch = "main"
-deprecated = false
+fullversion = "v1.26.0"
+version = "v1.26"
+githubbranch = "v1.26.0"
+docsbranch = "release-1.26"
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 
@@ -181,23 +181,30 @@ js = [
 ]
 
 [[params.versions]]
-fullversion = "v1.25.0"
-version = "v1.25"
-githubbranch = "v1.25.0"
+fullversion = "v1.26.0"
+version = "v1.26"
+githubbranch = "v1.26.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.24.2"
+fullversion = "v1.25.4"
+version = "v1.25"
+githubbranch = "v1.25.4"
+docsbranch = "release-1.25"
+url = "https://v1-25.docs.kubernetes.io"
+
+[[params.versions]]
+fullversion = "v1.24.8"
 version = "v1.24"
-githubbranch = "v1.24.2"
+githubbranch = "v1.24.8"
 docsbranch = "release-1.24"
 url = "https://v1-24.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.23.8"
+fullversion = "v1.23.14"
 version = "v1.23"
-githubbranch = "v1.23.8"
+githubbranch = "v1.23.14"
 docsbranch = "release-1.23"
 url = "https://v1-23.docs.kubernetes.io"
 
@@ -207,13 +214,6 @@ version = "v1.22"
 githubbranch = "v1.22.11"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
-
-[[params.versions]]
-fullversion = "v1.21.14"
-version = "v1.21"
-githubbranch = "v1.21.14"
-docsbranch = "release-1.21"
-url = "https://v1-21.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]
@@ -445,7 +445,7 @@ language_alternatives = ["en"]
 [languages.hi]
 title = "Kubernetes"
 description = "प्रोडक्शन-ग्रेड कंटेनर ऑर्केस्ट्रेशन"
-languageName = "हिन्दी (Hindi)"  
+languageName = "हिन्दी (Hindi)"
 languageNameLatinScript = "Hindi"
 weight = 12
 contentDir = "content/hi"


### PR DESCRIPTION
Updated config.toml for release v1.26
Versions were updated based on [latest patch releases](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md)

Following the instruction of handbook [here](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#update-the-site-configuration-files-for-previous-releases)

/hold until 1.26 release day
cc: @reylejano  @onlydole @divya-mohan0209 