### PR TITLE
chore: update-1.22 config.tml for release 1.26

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -139,11 +139,11 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.25"
+latest = "v1.26"
 
-fullversion = "v1.22.13"
+fullversion = "v1.22.16"
 version = "v1.22"
-githubbranch = "v1.22.13"
+githubbranch = "v1.22.16"
 docsbranch = "release-1.22"
 deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
@@ -179,39 +179,39 @@ js = [
 ]
 
 [[params.versions]]
-fullversion = "v1.25.0"
-version = "v1.25"
-githubbranch = "v1.25.0"
+fullversion = "v1.26.0"
+version = "v1.26"
+githubbranch = "v1.26.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.24.4"
+fullversion = "v1.25.4"
+version = "v1.25"
+githubbranch = "v1.25.4"
+docsbranch = "release-1.25"
+url = "https://v1-25.docs.kubernetes.io"
+
+[[params.versions]]
+fullversion = "v1.24.8"
 version = "v1.24"
-githubbranch = "v1.24.4"
+githubbranch = "v1.24.8"
 docsbranch = "release-1.24"
 url = "https://v1-24.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.23.10"
+fullversion = "v1.23.14"
 version = "v1.23"
-githubbranch = "v1.23.10"
+githubbranch = "v1.23.14"
 docsbranch = "release-1.23"
 url = "https://v1-23.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.22.13"
+fullversion = "v1.22.16"
 version = "v1.22"
-githubbranch = "v1.22.13"
+githubbranch = "v1.22.16"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
-
-[[params.versions]]
-fullversion = "v1.21.14"
-version = "v1.21"
-githubbranch = "v1.21.14"
-docsbranch = "release-1.21"
-url = "https://v1-21.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Updated config.toml for release v1.26
Versions were updated based on [latest patch releases](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md)

Following the instruction of handbook [here](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#update-the-site-configuration-files-for-previous-releases)

/hold until 1.26 release day
cc: @reylejano  @onlydole @divya-mohan0209 