### PR TITLE
improvement: kubectl install on windows verify command

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -56,7 +56,7 @@ The following methods exist for installing kubectl on Windows:
    - Using PowerShell to automate the verification using the `-eq` operator to get a `True` or `False` result:
 
      ```powershell
-     $($(CertUtil -hashfile .\kubectl.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl.exe.sha256)
+      $(Get-FileHash -Algorithm SHA256 .\kubectl.exe).Hash -eq $(Get-Content .\kubectl.exe.sha256)
      ```
 
 1. Append or prepend the `kubectl` binary folder to your `PATH` environment variable.


### PR DESCRIPTION
Make the verification command cleaner by using only PS cmdlets. certutil.exe returns 3 lines which need to be split to the hash, as opposed to `Get-FileHash` that returns an object with `.Hash`

Fixes #30833
