### PR TITLE
fix documentation for RotateKubeletClientCertificate

### DIFF
--- a/content/en/docs/reference/access-authn-authz/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-tls-bootstrapping.md
@@ -404,23 +404,25 @@ However, you _can_ enable its server certificate, at least partially, via certif
 
 ### Certificate Rotation
 
-Kubernetes v1.8 and higher kubelet implements __beta__ features for enabling
-rotation of its client and/or serving certificates.  These can be enabled through
-the respective `RotateKubeletClientCertificate` and
-`RotateKubeletServerCertificate` feature flags on the kubelet and are enabled by
-default.
+Kubernetes v1.8 and higher kubelet implements features for enabling
+rotation of its client and/or serving certificates. Note, rotation of serving
+certificate is a __beta__ feature and requires the `RotateKubeletServerCertificate`
+feature flag on the kubelet (enabled by default).
 
-`RotateKubeletClientCertificate` causes the kubelet to rotate its client
-certificates by creating new CSRs as its existing credentials expire. To enable
-this feature pass the following flag to the kubelet:
+You can configure the kubelet to rotate its client certificates by creating new CSRs
+as its existing credentials expire. To enable this feature, use the `rotateCertificates`
+field of [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/)
+or pass the following command line argument to the kubelet (deprecated):
 
 ```
 --rotate-certificates
 ```
 
-`RotateKubeletServerCertificate` causes the kubelet **both** to request a serving
+Enabling `RotateKubeletServerCertificate` causes the kubelet **both** to request a serving
 certificate after bootstrapping its client credentials **and** to rotate that
-certificate. To enable this feature pass the following flag to the kubelet:
+certificate. To enable this behavior, use the field `serverTLSBootstrap`  of 
+the [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/)
+or pass the following command line argument to the kubelet (deprecated):
 
 ```
 --rotate-server-certificates


### PR DESCRIPTION
/kind cleanup

Documentation may be improved. For now I simply fixed factual issue as config based configuration is recommended and feature gate mentioned was already removed.

/sig node
/sig auth

References:
- https://github.com/kubernetes/kubernetes/pull/96532 (feature gate removed)
- https://github.com/kubernetes/kubernetes/pull/63912 (flag moved to kubelet config)
- https://github.com/kubernetes/kubernetes/pull/62352 (flag serverTLSBootstrap is introduced)
