### PR TITLE
Small grammar fix

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -434,7 +434,7 @@ kubectl patch deployment patch-demo --patch '{"spec": {"template": {"spec": {"co
 The flag `--subresource=[subresource-name]` is used with kubectl commands like get, patch,
 edit and replace to fetch and update `status` and `scale` subresources of the resources
 (applicable for kubectl version v1.24 or more). This flag is used with all the API resources
-(built-in and CRs) which has `status` or `scale` subresource. Deployment is one of the
+(built-in and CRs) that have `status` or `scale` subresource. Deployment is one of the
 examples which supports these subresources.
 
 Here's a manifest for a Deployment that has two replicas:


### PR DESCRIPTION
I've noticed that "has" is used instead of "have" with plural "API resources".
Additionally, "which has `status` or `scale` subresource" is restrictive / defining clause, so "that" should be used instead of "which".

Links:
- https://www.dictionary.com/e/that-vs-which/
- https://www.grammarly.com/blog/which-vs-that/