### PR TITLE
Remove Base64'ing of file contents

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -42,11 +42,11 @@ characters.
 
 ### Use source files
 
-1.  Store the credentials in files with the values encoded in base64:
+1.  Store the credentials in files:
 
     ```shell
-    echo -n 'admin' | base64 > ./username.txt
-    echo -n 'S!B\*d$zDsb=' | base64 > ./password.txt
+    echo -n 'admin' > ./username.txt
+    echo -n 'S!B\*d$zDsb=' > ./password.txt
     ```
     The `-n` flag ensures that the generated files do not have an extra newline
     character at the end of the text. This is important because when `kubectl`


### PR DESCRIPTION
Updated example of reading secret values from a file so that it doesn't base64 the contents in the file before `kubectl` reads it.

Otherwise, if a user follows this guide they will end up with a Secret containing double Base64 encoded credentials, which means that when accessed from a Pod they will get the Base64 encoding of the credential they actually want.

This is also the case for one of the localised versions but I will PR for that separately.
