### PR TITLE
Remove Base64'ing of file contents (Chinese)

### DIFF
--- a/content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -76,13 +76,13 @@ characters.
 ### 使用源文件
 
 <!-- 
-1.  Store the credentials in files with the values encoded in base64: 
+1.  Store the credentials in files: 
 -->
-1. 对凭证的取值作 base64 编码后保存到文件中：
+1. 将凭据保存到文件：
 
    ```shell
-   echo -n 'admin' | base64 > ./username.txt
-   echo -n 'S!B\*d$zDsb=' | base64 > ./password.txt
+   echo -n 'admin' > ./username.txt
+   echo -n 'S!B\*d$zDsb=' > ./password.txt
    ```
 
    <!-- 


### PR DESCRIPTION
Updated example of reading secret values from a file so that it doesn't base64 the contents in the file before kubectl reads it.

This is the same as the change made in English in #38375.

I have used Google Translate for the small translation change, I hope this is okay. Apologies in advance if it isn't accurate or if this isn't the recommended approach.
