### PR TITLE
device-mgr-doc: Add caution closing tag

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -176,7 +176,7 @@ guaranteed to be non-breaking.
 Although the Device Manager component of Kubernetes is a generally available feature,
 the _device plugin API_ is not stable. For information on the device plugin API and
 version compatibility, read [Device Plugin API versions](/docs/reference/node/device-plugin-api-versions/).
-{{< caution >}}
+{{< /caution >}}
 
 As a project, Kubernetes recommends that device plugin developers:
 

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -172,11 +172,11 @@ Beta graduation of this feature. Because of this, kubelet upgrades should be sea
 but there still may be changes in the API before stabilization making upgrades not
 guaranteed to be non-breaking.
 
-{{< caution >}}
+{{< note >}}
 Although the Device Manager component of Kubernetes is a generally available feature,
 the _device plugin API_ is not stable. For information on the device plugin API and
 version compatibility, read [Device Plugin API versions](/docs/reference/node/device-plugin-api-versions/).
-{{< /caution >}}
+{{< /note >}}
 
 As a project, Kubernetes recommends that device plugin developers:
 


### PR DESCRIPTION
To ensure that this page is rendered correctly on the Kubernetes website, the caution tag needs to be closed.

This was missed during the doc write up and review process of https://github.com/kubernetes/website/pull/37273.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
