### PR TITLE
Update Cosign verify command with identity

### DIFF
--- a/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
@@ -43,7 +43,9 @@ done
 Then verify the blob by using `cosign`:
 
 ```shell
-cosign verify-blob "$BINARY" --signature "$BINARY".sig --certificate "$BINARY".cert
+cosign verify-blob "$BINARY" --signature "$BINARY".sig --certificate "$BINARY".cert \
+  --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
+  --certificate-oidc-issuer https://accounts.google.com
 ```
 
 {{< note >}}
@@ -60,7 +62,9 @@ Let's pick one image from this list and verify its signature using
 the `cosign verify` command:
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/kube-apiserver-amd64:v{{< skew currentVersion >}}.0
+COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/kube-apiserver-amd64:v{{< skew currentVersion >}}.0 \
+  --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
+  --certificate-oidc-issuer https://accounts.google.com
 ```
 
 {{< note >}}
@@ -78,7 +82,9 @@ curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/re
 input=images.txt
 while IFS= read -r image
 do
-  COSIGN_EXPERIMENTAL=1 cosign verify "$image"
+  COSIGN_EXPERIMENTAL=1 cosign verify "$image" \
+  --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
+  --certificate-oidc-issuer https://accounts.google.com
 done < "$input"
 ```
 

--- a/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
@@ -63,7 +63,7 @@ the `cosign verify` command:
 
 ```shell
 COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/kube-apiserver-amd64:v{{< skew currentVersion >}}.0 \
-  --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
+  --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com \
   --certificate-oidc-issuer https://accounts.google.com
 ```
 
@@ -83,7 +83,7 @@ input=images.txt
 while IFS= read -r image
 do
   COSIGN_EXPERIMENTAL=1 cosign verify "$image" \
-  --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
+  --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com \
   --certificate-oidc-issuer https://accounts.google.com
 done < "$input"
 ```


### PR DESCRIPTION
Verification of the identity of the signer is a critical part of Sigstore verification. Otherwise, you are only verifying that there is some signature that is valid, instead of checking that the signature was generated by someone you trust.

For more information, https://github.com/sigstore/cosign/issues/2056 contains some discussion around why we want to require these flags, and https://github.com/sigstore/cosign/issues/1947 for why we require both of these flags.

An open question for you is if this specified identity (which came from the certificate) will change between releases. If so, how would you like users to know which identity signed a release?