### PR TITLE
[en] Document when country codes are used in the Kubernetes documentation

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -39,6 +39,10 @@ standard](https://www.loc.gov/standards/iso639-2/php/code_list.php) to find your
 localization's two-letter language code. For example, the two-letter code for
 Korean is `ko`.
 
+Some languages use a lowercase version of the country code as defined by the
+ISO-3166 along with their language codes. For example, the Brazilian Portuguese
+language code is `pt-br`.
+
 ### Fork and clone the repo
 
 First, [create your own
@@ -87,6 +91,11 @@ You'll need to know the two-letter language code for your language. Consult the
 [ISO 639-1 standard](https://www.loc.gov/standards/iso639-2/php/code_list.php)
 to find your localization's two-letter language code. For example, the
 two-letter code for Korean is `ko`.
+
+If the language you are starting a localization for is spoken in various places
+with significative differences between the variants, it might make sense to
+combine the lowercased ISO-3166 country code with the language two-letter code.
+For example, Brazilian Portuguese is localized as `pt-br`.
 
 When you start a new localization, you must localize all the
 [minimum required content](#minimum-required-content) before

--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -93,7 +93,7 @@ to find your localization's two-letter language code. For example, the
 two-letter code for Korean is `ko`.
 
 If the language you are starting a localization for is spoken in various places
-with significative differences between the variants, it might make sense to
+with significant differences between the variants, it might make sense to
 combine the lowercased ISO-3166 country code with the language two-letter code.
 For example, Brazilian Portuguese is localized as `pt-br`.
 


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
### Changes

* Add a brief explanation of when country codes are being used along with the language codes in Kubernetes documentation.

Fixes #38451 

/cc @a-mccarthy
