### PR TITLE
[pt-br] Add docs/tasks/access-application-cluster/configure-dns-cluster.md

### DIFF
--- a/content/pt-br/docs/tasks/access-application-cluster/configure-dns-cluster.md
+++ b/content/pt-br/docs/tasks/access-application-cluster/configure-dns-cluster.md
@@ -1,0 +1,13 @@
+---
+title: Configurar DNS para um Cluster.
+weight: 120
+content_type: concept
+---
+
+<!-- overview -->
+Kubernetes oferece um complemento de DNS para os clusters, que a maioria dos ambientes suportados o tem habilitado por padrão. Na versão do Kubernetes 1.11 e posterior, o CoreDNS é recomendado e instalado por padrão com o kubeadm.
+
+<!-- body -->
+Para mais informações sobre como configurar o CoreDNS para um cluster Kubernetes, veja o [Personalização do Serviço de DNS](/docs/tasks/administer-cluster/dns-custom-nameservers/). Um exemplo que demonstra como usar o DNS do Kubernetes com o kube-dns, veja o [Plugin de exemplo para DNS](https://github.com/kubernetes/examples/tree/master/staging/cluster-dns).
+
+

--- a/content/pt-br/docs/tasks/access-application-cluster/configure-dns-cluster.md
+++ b/content/pt-br/docs/tasks/access-application-cluster/configure-dns-cluster.md
@@ -1,13 +1,13 @@
 ---
-title: Configurar DNS para um Cluster
+title: Configurar DNS em um cluster
 weight: 120
 content_type: concept
 ---
 
 <!-- overview -->
-Kubernetes oferece um complemento de DNS para os clusters, que a maioria dos ambientes suportados o tem habilitado por padrão. Na versão do Kubernetes 1.11 e posterior, o CoreDNS é recomendado e instalado por padrão com o kubeadm.
+O Kubernetes oferece um complemento de DNS para os clusters, que a maioria dos ambientes suportados habilitam por padrão. Na versão do Kubernetes 1.11 e posterior, o CoreDNS é recomendado e instalado por padrão com o kubeadm.
 
 <!-- body -->
-Para mais informações sobre como configurar o CoreDNS para um cluster Kubernetes, veja o [Personalização do Serviço de DNS](/docs/tasks/administer-cluster/dns-custom-nameservers/). Um exemplo que demonstra como usar o DNS do Kubernetes com o kube-dns, consulte [Plugin de exemplo para DNS](https://github.com/kubernetes/examples/tree/master/staging/cluster-dns).
+Para mais informações sobre como configurar o CoreDNS para um cluster Kubernetes, veja [Personalização do Serviço de DNS](/docs/tasks/administer-cluster/dns-custom-nameservers/). Para ver um exemplo que demonstra como usar o DNS do Kubernetes com o kube-dns, consulte [Plugin de exemplo para DNS](https://github.com/kubernetes/examples/tree/master/staging/cluster-dns).
 
 

--- a/content/pt-br/docs/tasks/access-application-cluster/configure-dns-cluster.md
+++ b/content/pt-br/docs/tasks/access-application-cluster/configure-dns-cluster.md
@@ -1,5 +1,5 @@
 ---
-title: Configurar DNS para um Cluster.
+title: Configurar DNS para um Cluster
 weight: 120
 content_type: concept
 ---
@@ -8,6 +8,6 @@ content_type: concept
 Kubernetes oferece um complemento de DNS para os clusters, que a maioria dos ambientes suportados o tem habilitado por padrão. Na versão do Kubernetes 1.11 e posterior, o CoreDNS é recomendado e instalado por padrão com o kubeadm.
 
 <!-- body -->
-Para mais informações sobre como configurar o CoreDNS para um cluster Kubernetes, veja o [Personalização do Serviço de DNS](/docs/tasks/administer-cluster/dns-custom-nameservers/). Um exemplo que demonstra como usar o DNS do Kubernetes com o kube-dns, veja o [Plugin de exemplo para DNS](https://github.com/kubernetes/examples/tree/master/staging/cluster-dns).
+Para mais informações sobre como configurar o CoreDNS para um cluster Kubernetes, veja o [Personalização do Serviço de DNS](/docs/tasks/administer-cluster/dns-custom-nameservers/). Um exemplo que demonstra como usar o DNS do Kubernetes com o kube-dns, consulte [Plugin de exemplo para DNS](https://github.com/kubernetes/examples/tree/master/staging/cluster-dns).
 
 


### PR DESCRIPTION
### Changes

Brazilian portuguese translation of the [Configure DNS for a Cluster](https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/access-application-cluster/configure-dns-cluster.md)

### Related Docs.
This document, configure DNS for a cluster, does a reference to another document that I am translating too but it is a WIP at the moment.

https://github.com/kubernetes/website/pull/38481

### Related Issue

https://github.com/kubernetes/website/issues/13939