### PR TITLE
Try to improve consistency and fluency in leases.md

### DIFF
--- a/content/en/docs/concepts/architecture/leases.md
+++ b/content/en/docs/concepts/architecture/leases.md
@@ -6,18 +6,18 @@ weight: 30
 
 <!-- overview -->
 
-Distrbuted systems often have a need for "leases", which provides a mechanism to lock shared resources and coordinate activity between nodes.
+Distributed systems often have a need for "leases", which provides a mechanism to lock shared resources and coordinate activity between nodes.
 In Kubernetes, the "lease" concept is represented by `Lease` objects in the `coordination.k8s.io` API group, which are used for system-critical
-capabilities like node heart beats and component-level leader election.
+capabilities such as node heartbeats and component-level leader election.
 
 <!-- body -->
 
-## Node Heart Beats
+## Node Heartbeats
 
-Kubernetes uses the Lease API to communicate kubelet node heart beats to the Kubernetes API server.
+Kubernetes uses the Lease API to communicate kubelet node heartbeats to the Kubernetes API server.
 For every `Node` , there is a `Lease` object with a matching name in the `kube-node-lease`
-namespace. Under the hood, every kubelet heart beat is an UPDATE request to this `Lease` object, updating
-the `spec.renewTime` field for the Lease. The Kubernetes control plane uses the time stamp of this field
+namespace. Under the hood, every kubelet heartbeat is an UPDATE request to this `Lease` object, updating
+the `spec.renewTime` field for the Lease. The Kubernetes control plane uses the timestamp of this field
 to determine the availability of this `Node`.
 
 See [Node Lease objects](/docs/concepts/architecture/nodes/#heartbeats) for more details.
@@ -25,25 +25,30 @@ See [Node Lease objects](/docs/concepts/architecture/nodes/#heartbeats) for more
 ## Leader Election
 
 Leases are also used in Kubernetes to ensure only one instance of a component is running at any given time.
-This is used by control plane components like `kube-controller-manager` and `kube-scheduler` in
+This is used by control plane components such as `kube-controller-manager` and `kube-scheduler` in
 HA configurations, where only one instance of the component should be actively running while the other
-instances are on stand-by.
+instances are on standby.
 
 ## API Server Identity
 
 {{< feature-state for_k8s_version="v1.26" state="beta" >}}
 
 Starting in Kubernetes v1.26, each `kube-apiserver` uses the Lease API to publish its identity to the
-rest of the system. While not particularly useful on its own, this provides a mechanism for clients to
+rest of the system. While this may not be particularly useful on its own, it provides a mechanism for clients to
 discover how many instances of `kube-apiserver` are operating the Kubernetes control plane.
-Existence of kube-apiserver leases enables future capabilities that may require coordination between
+The existence of kube-apiserver leases enables future capabilities that may require coordination between
 each kube-apiserver.
 
 You can inspect Leases owned by each kube-apiserver by checking for lease objects in the `kube-system` namespace
 with the name `kube-apiserver-<sha256-hash>`. Alternatively you can use the label selector `k8s.io/component=kube-apiserver`:
 
 ```shell
-$ kubectl -n kube-system get lease -l k8s.io/component=kube-apiserver
+kubectl -n kube-system get lease -l k8s.io/component=kube-apiserver
+```
+
+The output is similar to:
+
+```
 NAME                                        HOLDER                                                                           AGE
 kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a   kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a_9cbf54e5-1136-44bd-8f9a-1dcd15c346b4   5m33s
 kube-apiserver-dz2dqprdpsgnm756t5rnov7yka   kube-apiserver-dz2dqprdpsgnm756t5rnov7yka_84f2a85d-37c1-4b14-b6b9-603e62e4896f   4m23s
@@ -52,11 +57,11 @@ kube-apiserver-fyloo45sdenffw2ugwaz3likua   kube-apiserver-fyloo45sdenffw2ugwaz3
 
 The SHA256 hash used in the lease name is based on the OS hostname as seen by kube-apiserver. Each kube-apiserver should be
 configured to use a hostname that is unique within the cluster. New instances of kube-apiserver that use the same hostname
-will take over existing Leases using a new holder identity, as opposed to instantiating new lease objects. You can check the
+will take over existing Leases using a new holder identity, instead of instantiating new lease objects. You can check the
 hostname used by kube-apisever by checking the value of the `kubernetes.io/hostname` label:
 
 ```shell
-$ kubectl -n kube-system get lease kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a -o yaml
+kubectl -n kube-system get lease kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a -o yaml
 ```
 
 ```yaml


### PR DESCRIPTION
Have a try to keep consistent style such as:
- terms: heartbeat, timestamp, standby
- separate a command from its output while removing `$`
```
content/en/docs/concepts/architecture/leases.md
```