### PR TITLE
Use Google Analytics 4 (GA4) site tag for v1.25

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,8 +116,7 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-# Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
-id = "UA-00000000-0"
+id = "G-JPP6RFM2BP"
 
 [params]
 copyright_k8s = "The Kubernetes Authors"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,7 +25,7 @@
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
-{{- if hugo.IsProduction -}}
+{{- if in hugo.Environment "prod" -}}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 {{ partialCached "head-css.html" . "asdf" }}


### PR DESCRIPTION
- Contributes to #35299
- This is take 2 of #37669
- Applies the same solution (hard-coded GA4 ID) as for all other older releases (from 1.21 to 1.24).

/cc @nate-double-u @sftim @reylejano @a-mccarthy 