### PR TITLE
registry change in docs (k8s.gcr.io -> registry.k8s.io)

### DIFF
--- a/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
+++ b/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
@@ -1,3 +1,4 @@
+git log -2
 ---
 layout: blog
 title: 'Kubernetes 1.14: Local Persistent Volumes GA'
@@ -129,7 +130,7 @@ spec:
     spec:
       containers:
       - name: test-container
-        image: k8s.gcr.io/busybox
+        image: registry.k8s.io/busybox
         command:
         - "/bin/sh"
         args:

--- a/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
+++ b/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
@@ -1,4 +1,3 @@
-git log -2
 ---
 layout: blog
 title: 'Kubernetes 1.14: Local Persistent Volumes GA'

--- a/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
+++ b/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
@@ -129,7 +129,7 @@ spec:
     spec:
       containers:
       - name: test-container
-        image: registry.k8s.io/busybox
+        image: registry.k8s.io/busybox # updated after publication (previously used k8s.gcr.io/busybox)
         command:
         - "/bin/sh"
         args:

--- a/content/en/blog/_posts/2020-05-27-An-Introduction-to-the-K8s-Infrastructure-Working-Group.md
+++ b/content/en/blog/_posts/2020-05-27-An-Introduction-to-the-K8s-Infrastructure-Working-Group.md
@@ -55,7 +55,7 @@ The team has made progress in the last few months that is well worth celebrating
 
 - The K8s-Infrastructure Working Group released an automated billing report that they start every meeting off by reviewing as a group. 
 - DNS for k8s.io and kubernetes.io are also fully [community-owned](https://groups.google.com/g/kubernetes-dev/c/LZTYJorGh7c/m/u-ydk-yNEgAJ), with community members able to [file issues](https://github.com/kubernetes/k8s.io/issues/new?assignees=&labels=wg%2Fk8s-infra&template=dns-request.md&title=DNS+REQUEST%3A+%3Cyour-dns-record%3E) to manage records.
-- The container registry [k8s.gcr.io](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io) is also fully community-owned and available for all Kubernetes subprojects to use. 
+- The container registry [registry.k8s.io](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io) is also fully community-owned and available for all Kubernetes subprojects to use. 
 _Note:_ The container registry has changed to registry.k8s.io. Updated on August 25, 2022.
 - The Kubernetes [publishing-bot](https://github.com/kubernetes/publishing-bot) responsible for keeping k8s.io/kubernetes/staging repositories published to their own top-level repos (For example: [kubernetes/api](https://github.com/kubernetes/api)) runs on a community-owned cluster.
 - The gcsweb.k8s.io service used to provide anonymous access to GCS buckets for kubernetes artifacts runs on a community-owned cluster.

--- a/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md
+++ b/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md
@@ -115,6 +115,7 @@ metadata:
 spec:
   containers:
   - name: agnhost
+    # image changed since publication (previously used registry "k8s.gcr.io")
     image: registry.k8s.io/e2e-test-images/agnhost:2.35
     command: ["/agnhost", "grpc-health-checking"]
     ports:

--- a/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md
+++ b/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md
@@ -115,7 +115,7 @@ metadata:
 spec:
   containers:
   - name: agnhost
-    image: k8s.gcr.io/e2e-test-images/agnhost:2.35
+    image: registry.k8s.io/e2e-test-images/agnhost:2.35
     command: ["/agnhost", "grpc-health-checking"]
     ports:
     - containerPort: 5000

--- a/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
+++ b/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
@@ -50,6 +50,7 @@ spec:
         app: nginx
     spec:
       containers:
+      # image changed since publication (previously used registry "k8s.gcr.io")
       - image: registry.k8s.io/nginx-slim:0.8
         imagePullPolicy: IfNotPresent
         name: nginx

--- a/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
+++ b/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
@@ -50,7 +50,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: k8s.gcr.io/nginx-slim:0.8
+      - image: registry.k8s.io/nginx-slim:0.8
         imagePullPolicy: IfNotPresent
         name: nginx
   updateStrategy:
@@ -66,7 +66,7 @@ If you enable the new feature and you don't specify a value for `maxUnavailable`
 I'll run through a scenario based on that example manifest to demonstrate how this feature works. I will deploy a StatefulSet that
 has 5 replicas, with `maxUnavailable` set to 2 and `partition` set to 0.
 
-I can trigger a rolling update by changing the image to `k8s.gcr.io/nginx-slim:0.9`. Once I initiate the rolling update, I can 
+I can trigger a rolling update by changing the image to `registry.k8s.io/nginx-slim:0.9`. Once I initiate the rolling update, I can 
 watch the pods update 2 at a time as the current value of maxUnavailable is 2. The below output shows a span of time and is not 
 complete.  The maxUnavailable can be an absolute number (for example, 2) or a percentage of desired Pods (for example, 10%). The 
 absolute number is calculated from percentage by rounding up to the nearest integer.  


### PR DESCRIPTION
I'm not sure if this was discussed before, I didn't find an issue tracking this work. 

Context: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/

/sig release
/sig node

/kind cleanup
/priority important-longterm

CC @BenTheElder 