### PR TITLE
Fixed typo in documentation

### DIFF
--- a/content/en/docs/tasks/administer-cluster/enable-disable-api.md
+++ b/content/en/docs/tasks/administer-cluster/enable-disable-api.md
@@ -20,7 +20,7 @@ The `runtime-config` command line argument also supports 2 special keys:
 - `api/legacy`, representing only legacy APIs. Legacy APIs are any APIs that have been
    explicitly [deprecated](/docs/reference/using-api/deprecation-policy/).
 
-For example, to turning off all API versions except v1, pass `--runtime-config=api/all=false,api/v1=true`
+For example, to turn off all API versions except v1, pass `--runtime-config=api/all=false,api/v1=true`
 to the `kube-apiserver`.
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
On [https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/) there is a typo at the line 

"For example, **to turning off** all API versions except v1"

This above typo has been fixed to

"For example, **to turn off** all API versions except v1"

Fixes [#38502 ](https://github.com/kubernetes/website/issues/38502)