### PR TITLE
Broken link to v1.25 docs fixed for the branch release-1.24

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -190,7 +190,7 @@ fullversion = "v1.25.4"
 version = "v1.25"
 githubbranch = "v1.25.4"
 docsbranch = "release-1.25"
-url = "https://v1-25.kubernetes.io"
+url = "https://v1-25.docs.kubernetes.io"
 
 [[params.versions]]
 fullversion = "v1.24.8"


### PR DESCRIPTION
The link in the 1.24 doc is updated to https://v1-25.docs.kubernetes.io/docs/home/supported-doc-versions/ 
#38512 