### PR TITLE
Add admission config API and fixes references to the API

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -9,12 +9,9 @@ content_type: concept
 no_list: true
 ---
 
-
 <!-- overview -->
 
 This section of the Kubernetes documentation contains references.
-
-
 
 <!-- body -->
 
@@ -76,6 +73,7 @@ operator to use or manage a cluster.
 
 
 * [kubeconfig (v1)](/docs/reference/config-api/kubeconfig.v1/)
+* [kube-apiserver admission (v1)](/docs/reference/config-api/apiserver-admission.v1/)
 * [kube-apiserver configuration (v1alpha1)](/docs/reference/config-api/apiserver-config.v1alpha1/) and
   [kube-apiserver configuration (v1)](/docs/reference/config-api/apiserver-config.v1/)
 * [kube-apiserver encryption (v1)](/docs/reference/config-api/apiserver-encryption.v1/)

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -20,23 +20,32 @@ This page provides an overview of Validating Admission Policy.
 
 Validating admission policies offer a declarative, in-process alternative to validating admission webhooks.
 
-Validating admission policies use the Common Expression Language (CEL) to declare the validation rules of a policy. 
-Validation admission policies are highly configurable, enabling policy authors to define policies that can be parameterized and scoped to resources as needed by cluster administrators.
+Validating admission policies use the Common Expression Language (CEL) to declare the validation
+rules of a policy. 
+Validation admission policies are highly configurable, enabling policy authors to define policies
+that can be parameterized and scoped to resources as needed by cluster administrators.
 
 ## What Resources Make a Policy
 
 A policy is generally made up of three resources:
 
-- The `ValidatingAdmissionPolicy` describes the abstract logic of a policy (think: "this policy makes sure a particular label is set to a particular value").
+- The `ValidatingAdmissionPolicy` describes the abstract logic of a policy
+  (think: "this policy makes sure a particular label is set to a particular value").
 
-- A `ValidatingAdmissionPolicyBinding` links the above resources together and provides scoping. If you only want to require an `owner` label to be set for `Pods`, the binding is where you would specify this restriction.
+- A `ValidatingAdmissionPolicyBinding` links the above resources together and provides scoping.
+  If you only want to require an `owner` label to be set for `Pods`, the binding is where you would
+  specify this restriction.
 
-- A parameter resource provides information to a ValidatingAdmissionPolicy to make it a concrete statement (think "the `owner` label must be set to something that ends in `.company.com`"). A native type such as ConfigMap or a CRD defines the schema of a parameter resource. `ValidatingAdmissionPolicy` objects specify what Kind they are expecting for their parameter resource.
+- A parameter resource provides information to a ValidatingAdmissionPolicy to make it a concrete
+  statement (think "the `owner` label must be set to something that ends in `.company.com`").
+  A native type such as ConfigMap or a CRD defines the schema of a parameter resource.
+  `ValidatingAdmissionPolicy` objects specify what Kind they are expecting for their parameter resource.
 
+At least a `ValidatingAdmissionPolicy` and a corresponding  `ValidatingAdmissionPolicyBinding`
+must be defined for a policy to have an effect.
 
-At least a `ValidatingAdmissionPolicy` and a corresponding  `ValidatingAdmissionPolicyBinding`  must be defined for a policy to have an effect.
-
-If a `ValidatingAdmissionPolicy` does not need to be configured via parameters, simply leave `spec.paramKind` in  `ValidatingAdmissionPolicy` unset.
+If a `ValidatingAdmissionPolicy` does not need to be configured via parameters, simply leave
+`spec.paramKind` in  `ValidatingAdmissionPolicy` unset.
 
 ## {{% heading "prerequisites" %}}
 
@@ -45,11 +54,13 @@ If a `ValidatingAdmissionPolicy` does not need to be configured via parameters, 
 
 ## Getting Started with Validating Admission Policy
 
-Validating Admission Policy is part of the cluster control-plane. You should write and deploy them with great caution. The following describes how to quickly experiment with Validating Admission Policy.
+Validating Admission Policy is part of the cluster control-plane. You should write and deploy them
+with great caution. The following describes how to quickly experiment with Validating Admission Policy.
 
 ### Creating a ValidatingAdmissionPolicy
 
 The following is an example of a ValidatingAdmissionPolicy.
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicy
@@ -66,10 +77,14 @@ spec:
   validations:
     - expression: "object.spec.replicas <= 5"
 ```
-`spec.validations` contains CEL expressions which use the [Common Expression Language (CEL)](https://github.com/google/cel-spec)
-to validate the request. If an expression evaluates to false, the validation check is enforced according to the `spec.failurePolicy` field.
 
-To configure a validating admission policy for use in a cluster, a binding is required. The following is an example of a ValidatingAdmissionPolicyBinding.:
+`spec.validations` contains CEL expressions which use the [Common Expression Language (CEL)](https://github.com/google/cel-spec)
+to validate the request. If an expression evaluates to false, the validation check is enforced
+according to the `spec.failurePolicy` field.
+
+To configure a validating admission policy for use in a cluster, a binding is required.
+The following is an example of a ValidatingAdmissionPolicyBinding.:
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
@@ -83,8 +98,10 @@ spec:
         environment: test
 ```
 
-When trying to create a deployment with replicas set not satisfying the validation expression, an error will return containing message:
-```
+When trying to create a deployment with replicas set not satisfying the validation expression, an
+error will return containing message:
+
+```none
 ValidatingAdmissionPolicy 'demo-policy.example.com' with binding 'demo-binding-test.example.com' denied request: failed expression: object.spec.replicas <= 5
 ```
 
@@ -96,7 +113,9 @@ Parameter resources allow a policy configuration to be separate from its definit
 A policy can define paramKind, which outlines GVK of the parameter resource, 
 and then a policy binding ties a policy by name (via policyName) to a particular parameter resource via paramRef.
 
-If parameter configuration is needed, the following is an example of a ValidatingAdmissionPolicy with parameter configuration.
+If parameter configuration is needed, the following is an example of a ValidatingAdmissionPolicy
+with parameter configuration.
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicy
@@ -117,16 +136,22 @@ spec:
     - expression: "object.spec.replicas <= params.maxReplicas"
       reason: Invalid
 ```
-The `spec.paramKind` field of the ValidatingAdmissionPolicy specifies the kind of resources used to parameterize this policy. For this example, it is configured by ReplicaLimit custom resources. 
-Note in this example how the CEL expression references the parameters via the CEL params variable, e.g. `params.maxReplicas`.
-spec.matchConstraints specifies what resources this policy is designed to validate.
-Note that the native types such like `ConfigMap` could also be used as parameter reference.
 
-The `spec.validations` fields contain CEL expressions. If an expression evaluates to false, the validation check is enforced according to the `spec.failurePolicy` field.
+The `spec.paramKind` field of the ValidatingAdmissionPolicy specifies the kind of resources used
+to parameterize this policy. For this example, it is configured by ReplicaLimit custom resources. 
+Note in this example how the CEL expression references the parameters via the CEL params variable,
+e.g. `params.maxReplicas`. `spec.matchConstraints` specifies what resources this policy is
+designed to validate. Note that the native types such like `ConfigMap` could also be used as
+parameter reference.
+
+The `spec.validations` fields contain CEL expressions. If an expression evaluates to false, the
+validation check is enforced according to the `spec.failurePolicy` field.
 
 The validating admission policy author is responsible for providing the ReplicaLimit parameter CRD.
 
-To configure an validating admission policy for use in a cluster, a binding and parameter resource are created. The following is an example of a ValidatingAdmissionPolicyBinding.
+To configure an validating admission policy for use in a cluster, a binding and parameter resource
+are created. The following is an example of a ValidatingAdmissionPolicyBinding.
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
@@ -141,7 +166,9 @@ spec:
       matchLabels:
         environment: test
 ```
+
 The parameter resource could be as following:
+
 ```yaml
 apiVersion: rules.example.com/v1
 kind: ReplicaLimit
@@ -149,8 +176,11 @@ metadata:
   name: "replica-limit-test.example.com"
 maxReplicas: 3
 ```
-This policy parameter resource limits deployments to a max of 3 replicas in all namespaces in the test environment.
-An admission policy may have multiple bindings. To bind all other environments environment to have a maxReplicas limit of 100, create another ValidatingAdmissionPolicyBinding:
+
+This policy parameter resource limits deployments to a max of 3 replicas in all namespaces in the
+test environment. An admission policy may have multiple bindings. To bind all other environments
+environment to have a maxReplicas limit of 100, create another ValidatingAdmissionPolicyBinding:
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
@@ -167,7 +197,9 @@ spec:
         operator: NotIn,
         values: ["test"]
 ```
+
 And have a parameter resource like:
+
 ```yaml
 apiVersion: rules.example.com/v1
 kind: ReplicaLimit
@@ -175,7 +207,10 @@ metadata:
   name: "replica-limit-clusterwide.example.com"
 maxReplicas: 100
 ```
-Bindings can have overlapping match criteria. The policy is evaluated for each matching binding. In the above example, the "nontest" policy binding could instead have been defined as a global policy:
+
+Bindings can have overlapping match criteria. The policy is evaluated for each matching binding.
+In the above example, the "nontest" policy binding could instead have been defined as a global policy:
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
@@ -191,42 +226,56 @@ spec:
         operator: Exists
 ```
 
-The params object representing a parameter resource will not be set if a parameter resource has not been bound, 
-so for policies requiring a parameter resource, 
-it can be useful to add a check to ensure one has been bound.
+The params object representing a parameter resource will not be set if a parameter resource has
+not been bound, so for policies requiring a parameter resource, it can be useful to add a check to
+ensure one has been bound.
 
-For the use cases require parameter configuration, 
-we recommend to add a param check in `spec.validations[0].expression`:
+For the use cases require parameter configuration, we recommend to add a param check in
+`spec.validations[0].expression`:
+
 ```
 - expression: "params != null"
   message: "params missing but required to bind to this policy"
 ```
 
-It can be convenient to be able to have optional parameters as part of a parameter resource, and only validate them if present. 
-CEL provides has(), which checks if the key passed to it exists. CEL also implements Boolean short-circuiting: 
-If the first half of a logical OR evaluates to true, it won’t evaluate the other half (since the result of the entire OR will be true regardless). 
+It can be convenient to be able to have optional parameters as part of a parameter resource, and
+only validate them if present. CEL provides `has()`, which checks if the key passed to it exists.
+CEL also implements Boolean short-circuiting. If the first half of a logical OR evaluates to true,
+it won’t evaluate the other half (since the result of the entire OR will be true regardless). 
+
 Combining the two, we can provide a way to validate optional parameters:
+
 `!has(params.optionalNumber) || (params.optionalNumber >= 5 && params.optionalNumber <= 10)`
+
 Here, we first check that the optional parameter is present with `!has(params.optionalNumber)`. 
-If `optionalNumber` hasn’t been defined, then the expression short-circuits since `!has(params.optionalNumber)` will evaluate to true. 
-If `optionalNumber` has been defined, then the latter half of the CEL expression will be evaluated, and optionalNumber will be checked to ensure that it contains a value between 5 and 10 inclusive.
+
+- If `optionalNumber` hasn’t been defined, then the expression short-circuits since
+  `!has(params.optionalNumber)` will evaluate to true. 
+- If `optionalNumber` has been defined, then the latter half of the CEL expression will be
+  evaluated, and optionalNumber will be checked to ensure that it contains a value between 5 and
+  10 inclusive.
 
 #### Authorization Check
 
 We introduced the authorization check for parameter resources.
-User is expected to have `read` access to the resources referenced by `paramKind` in `ValidatingAdmissionPolicy` and `paramRef` in `ValidatingAdmissionPolicyBinding`.
+User is expected to have `read` access to the resources referenced by `paramKind` in
+`ValidatingAdmissionPolicy` and `paramRef` in `ValidatingAdmissionPolicyBinding`.
 
-Note that if a resource in `paramKind` fails resolving via the restmapper, `read` access to all resources of groups is required.
+Note that if a resource in `paramKind` fails resolving via the restmapper, `read` access to all
+resources of groups is required.
 
 ### Failure Policy
 
-`failurePolicy` defines how mis-configurations and CEL expressions evaluating to error from the admission policy are handled. 
-Allowed values are `Ignore` or `Fail`.
+`failurePolicy` defines how mis-configurations and CEL expressions evaluating to error from the
+admission policy are handled. Allowed values are `Ignore` or `Fail`.
 
-- `Ignore` means that an error calling the ValidatingAdmissionPolicy is ignored and the API request is allowed to continue.
-- `Fail` means that an error calling the ValidatingAdmissionPolicy causes the admission to fail and the API request to be rejected.
+- `Ignore` means that an error calling the ValidatingAdmissionPolicy is ignored and the API
+  request is allowed to continue.
+- `Fail` means that an error calling the ValidatingAdmissionPolicy causes the admission to fail
+  and the API request to be rejected.
 
 Note that the `failurePolicy` is defined inside `ValidatingAdmissionPolicy`:
+
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicy
@@ -241,19 +290,21 @@ validations:
 
 `spec.validations[i].expression` represents the expression which will be evaluated by CEL.
 To learn more, see the [CEL language specification](https://github.com/google/cel-spec)
-CEL expressions have access to the contents of the Admission request/response, organized into CEL variables as well as some other useful variables:
+CEL expressions have access to the contents of the Admission request/response, organized into CEL
+variables as well as some other useful variables:
 
 - 'object' - The object from the incoming request. The value is null for DELETE requests.
 - 'oldObject' - The existing object. The value is null for CREATE requests.
 - 'request' - Attributes of the [admission request](/docs/reference/config-api/apiserver-admission.v1/#admission-k8s-io-v1-AdmissionRequest).
-- 'params' - Parameter resource referred to by the policy binding being evaluated. The value is null if `ParamKind` is unset.
+- 'params' - Parameter resource referred to by the policy binding being evaluated. The value is
+  null if `ParamKind` is unset.
 	
-The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the
-object. No other metadata properties are accessible.
+The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from
+the root of the object. No other metadata properties are accessible.
 	
 Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
-Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
-Accessible property names are escaped according to the following rules when accessed in the expression:
+Accessible property names are escaped according to the following rules when accessed in the
+expression:
 
 | escape sequence         | property name equivalent  |
 | ----------------------- | -----------------------|
@@ -304,10 +355,12 @@ Concatenation on arrays with x-kubernetes-list-type use the semantics of the lis
 | `size(object.names) == size(object.details) && object.names.all(n, n in object.details)`     | Validate the 'details' map is keyed by the items in the 'names' listSet           |
 | `size(object.clusters.filter(c, c.name == object.primary)) == 1`                             | Validate that the 'primary' property has one and only one occurrence in the 'clusters' listMap           |
 
-Read [Supported evaluation on CEL](https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#evaluation) for more information about CEL rules.
+Read [Supported evaluation on CEL](https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#evaluation)
+for more information about CEL rules.
 
 `spec.validation[i].reason` represents a machine-readable description of why this validation failed.
-If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the
-HTTP response to the client.
+If this is the first validation in the list to fail, this reason, as well as the corresponding
+HTTP response code, are used in the HTTP response to the client.
 The currently supported reasons are: `Unauthorized`, `Forbidden`, `Invalid`, `RequestEntityTooLarge`.
 If not set, `StatusReasonInvalid` is used in the response to the client.
+

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -242,9 +242,10 @@ validations:
 `spec.validations[i].expression` represents the expression which will be evaluated by CEL.
 To learn more, see the [CEL language specification](https://github.com/google/cel-spec)
 CEL expressions have access to the contents of the Admission request/response, organized into CEL variables as well as some other useful variables:
+
 - 'object' - The object from the incoming request. The value is null for DELETE requests.
 - 'oldObject' - The existing object. The value is null for CREATE requests.
-- 'request' - Attributes of the [admission request](/pkg/apis/admission/types.go#AdmissionRequest).
+- 'request' - Attributes of the [admission request](/docs/reference/config-api/apiserver-admission.v1/#admission-k8s-io-v1-AdmissionRequest).
 - 'params' - Parameter resource referred to by the policy binding being evaluated. The value is null if `ParamKind` is unset.
 	
 The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the

--- a/content/en/docs/reference/config-api/apiserver-admission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-admission.v1.md
@@ -1,0 +1,301 @@
+---
+title: kube-apiserver Admission (v1)
+content_type: tool-reference
+package: admission.k8s.io/v1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [AdmissionReview](#admission-k8s-io-v1-AdmissionReview)
+  
+    
+
+## `AdmissionReview`     {#admission-k8s-io-v1-AdmissionReview}
+    
+
+
+<p>AdmissionReview describes an admission review request/response.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>admission.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>AdmissionReview</code></td></tr>
+    
+  
+<tr><td><code>request</code><br/>
+<a href="#admission-k8s-io-v1-AdmissionRequest"><code>AdmissionRequest</code></a>
+</td>
+<td>
+   <p>Request describes the attributes for the admission request.</p>
+</td>
+</tr>
+<tr><td><code>response</code><br/>
+<a href="#admission-k8s-io-v1-AdmissionResponse"><code>AdmissionResponse</code></a>
+</td>
+<td>
+   <p>Response describes the attributes for the admission response.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionRequest`     {#admission-k8s-io-v1-AdmissionRequest}
+    
+
+**Appears in:**
+
+- [AdmissionReview](#admission-k8s-io-v1-AdmissionReview)
+
+
+<p>AdmissionRequest describes the admission.Attributes for the admission request.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>uid</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
+</td>
+<td>
+   <p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
+It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
+</td>
+</tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#groupversionkind-v1-meta"><code>meta/v1.GroupVersionKind</code></a>
+</td>
+<td>
+   <p>Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)</p>
+</td>
+</tr>
+<tr><td><code>resource</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#groupversionresource-v1-meta"><code>meta/v1.GroupVersionResource</code></a>
+</td>
+<td>
+   <p>Resource is the fully-qualified resource being requested (for example, v1.pods)</p>
+</td>
+</tr>
+<tr><td><code>subResource</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>SubResource is the subresource being requested, if any (for example, &quot;status&quot; or &quot;scale&quot;)</p>
+</td>
+</tr>
+<tr><td><code>requestKind</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#groupversionkind-v1-meta"><code>meta/v1.GroupVersionKind</code></a>
+</td>
+<td>
+   <p>RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale).
+If this is specified and differs from the value in &quot;kind&quot;, an equivalent match and conversion was performed.</p>
+<p>For example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of
+<code>apiGroups:[&quot;apps&quot;], apiVersions:[&quot;v1&quot;], resources: [&quot;deployments&quot;]</code> and <code>matchPolicy: Equivalent</code>,
+an API request to apps/v1beta1 deployments would be converted and sent to the webhook
+with <code>kind: {group:&quot;apps&quot;, version:&quot;v1&quot;, kind:&quot;Deployment&quot;}</code> (matching the rule the webhook registered for),
+and <code>requestKind: {group:&quot;apps&quot;, version:&quot;v1beta1&quot;, kind:&quot;Deployment&quot;}</code> (indicating the kind of the original API request).</p>
+<p>See documentation for the &quot;matchPolicy&quot; field in the webhook configuration type for more details.</p>
+</td>
+</tr>
+<tr><td><code>requestResource</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#groupversionresource-v1-meta"><code>meta/v1.GroupVersionResource</code></a>
+</td>
+<td>
+   <p>RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).
+If this is specified and differs from the value in &quot;resource&quot;, an equivalent match and conversion was performed.</p>
+<p>For example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of
+<code>apiGroups:[&quot;apps&quot;], apiVersions:[&quot;v1&quot;], resources: [&quot;deployments&quot;]</code> and <code>matchPolicy: Equivalent</code>,
+an API request to apps/v1beta1 deployments would be converted and sent to the webhook
+with <code>resource: {group:&quot;apps&quot;, version:&quot;v1&quot;, resource:&quot;deployments&quot;}</code> (matching the resource the webhook registered for),
+and <code>requestResource: {group:&quot;apps&quot;, version:&quot;v1beta1&quot;, resource:&quot;deployments&quot;}</code> (indicating the resource of the original API request).</p>
+<p>See documentation for the &quot;matchPolicy&quot; field in the webhook configuration type.</p>
+</td>
+</tr>
+<tr><td><code>requestSubResource</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>RequestSubResource is the name of the subresource of the original API request, if any (for example, &quot;status&quot; or &quot;scale&quot;)
+If this is specified and differs from the value in &quot;subResource&quot;, an equivalent match and conversion was performed.
+See documentation for the &quot;matchPolicy&quot; field in the webhook configuration type.</p>
+</td>
+</tr>
+<tr><td><code>name</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the name of the object as presented in the request.  On a CREATE operation, the client may omit name and
+rely on the server to generate the name.  If that is the case, this field will contain an empty string.</p>
+</td>
+</tr>
+<tr><td><code>namespace</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Namespace is the namespace associated with the request (if any).</p>
+</td>
+</tr>
+<tr><td><code>operation</code> <B>[Required]</B><br/>
+<a href="#admission-k8s-io-v1-Operation"><code>Operation</code></a>
+</td>
+<td>
+   <p>Operation is the operation being performed. This may be different than the operation
+requested. e.g. a patch can result in either a CREATE or UPDATE Operation.</p>
+</td>
+</tr>
+<tr><td><code>userInfo</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#userinfo-v1-authentication"><code>authentication/v1.UserInfo</code></a>
+</td>
+<td>
+   <p>UserInfo is information about the requesting user</p>
+</td>
+</tr>
+<tr><td><code>object</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   <p>Object is the object from the incoming request.</p>
+</td>
+</tr>
+<tr><td><code>oldObject</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   <p>OldObject is the existing object. Only populated for DELETE and UPDATE requests.</p>
+</td>
+</tr>
+<tr><td><code>dryRun</code><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>DryRun indicates that modifications will definitely not be persisted for this request.
+Defaults to false.</p>
+</td>
+</tr>
+<tr><td><code>options</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   <p>Options is the operation option structure of the operation being performed.
+e.g. <code>meta.k8s.io/v1.DeleteOptions</code> or <code>meta.k8s.io/v1.CreateOptions</code>. This may be
+different than the options the caller provided. e.g. for a patch request the performed
+Operation might be a CREATE, in which case the Options will a
+<code>meta.k8s.io/v1.CreateOptions</code> even though the caller provided <code>meta.k8s.io/v1.PatchOptions</code>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionResponse`     {#admission-k8s-io-v1-AdmissionResponse}
+    
+
+**Appears in:**
+
+- [AdmissionReview](#admission-k8s-io-v1-AdmissionReview)
+
+
+<p>AdmissionResponse describes an admission response.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>uid</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
+</td>
+<td>
+   <p>UID is an identifier for the individual request/response.
+This must be copied over from the corresponding AdmissionRequest.</p>
+</td>
+</tr>
+<tr><td><code>allowed</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>Allowed indicates whether or not the admission request was permitted.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#status-v1-meta"><code>meta/v1.Status</code></a>
+</td>
+<td>
+   <p>Result contains extra details into why an admission request was denied.
+This field IS NOT consulted in any way if &quot;Allowed&quot; is &quot;true&quot;.</p>
+</td>
+</tr>
+<tr><td><code>patch</code><br/>
+<code>[]byte</code>
+</td>
+<td>
+   <p>The patch body. Currently we only support &quot;JSONPatch&quot; which implements RFC 6902.</p>
+</td>
+</tr>
+<tr><td><code>patchType</code><br/>
+<a href="#admission-k8s-io-v1-PatchType"><code>PatchType</code></a>
+</td>
+<td>
+   <p>The type of Patch. Currently we only allow &quot;JSONPatch&quot;.</p>
+</td>
+</tr>
+<tr><td><code>auditAnnotations</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>AuditAnnotations is an unstructured key value map set by remote admission controller (e.g. error=image-blacklisted).
+MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission controller will prefix the keys with
+admission webhook name (e.g. imagepolicy.example.com/error=image-blacklisted). AuditAnnotations will be provided by
+the admission webhook to add additional context to the audit log for this request.</p>
+</td>
+</tr>
+<tr><td><code>warnings</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>warnings is a list of warning messages to return to the requesting API client.
+Warning messages describe a problem the client making the API request should correct or be aware of.
+Limit warnings to 120 characters if possible.
+Warnings over 256 characters and large numbers of warnings may be truncated.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Operation`     {#admission-k8s-io-v1-Operation}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [AdmissionRequest](#admission-k8s-io-v1-AdmissionRequest)
+
+
+<p>Operation is the type of resource operation being checked for admission control</p>
+
+
+
+
+## `PatchType`     {#admission-k8s-io-v1-PatchType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [AdmissionResponse](#admission-k8s-io-v1-AdmissionResponse)
+
+
+<p>PatchType is the type of patch being used to represent the mutated object</p>
+
+
+
+  


### PR DESCRIPTION
**Rationale**:

The `admission.k8s.io/v1` API group is not generated into the v2/v3 OpenAPI specification as part of Kubernetes API because it is not officially "served". However, the structs in the API group are used in other APIs that are user-facing.
This PR addes the reference API and fixes references to it.

**Organization**:

This PR has two commits, one is about the introduction of the `admission.k8s.io/v1` API group. A follow-up commit reformats the validating-admission-policy reference page since it doesn't deserve a separate PR. No contents is changed, just long line wrapping.

closes: #38518

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
