### PR TITLE
Fix warning events listing command

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -226,7 +226,7 @@ kubectl get pods --all-namespaces -o jsonpath='{range .items[*].status.initConta
 kubectl get events --sort-by=.metadata.creationTimestamp
 
 # List all warning events
-kubectl events --types=Warning
+kubectl get events --field-selector type=Warning
 
 # Compares the current state of the cluster against the state that the cluster would be in if the manifest was applied.
 kubectl diff -f ./my-manifest.yaml


### PR DESCRIPTION
> Why should we make this change @pmuller? You didn't explain that in the https://github.com/kubernetes/website/pull/38528#issue-1501449179, so it's hard to comment on your thinking.

The command I've read in the reference document just doesn't work on my side:

```
$ kubectl events --types=Warning
error: unknown command "events" for "kubectl"
```

For reference:

```
$ kubectl version --client --output=yaml
clientVersion:
  buildDate: "2022-11-09T13:36:36Z"
  compiler: gc
  gitCommit: 872a965c6c6526caa949f0c6ac028ef7aff3fb78
  gitTreeState: clean
  gitVersion: v1.25.4
  goVersion: go1.19.3
  major: "1"
  minor: "25"
  platform: linux/amd64
kustomizeVersion: v4.5.7
```


Motivation: help other newcomers avoid confusion like I experienced.