### PR TITLE
blog: fix KEP URL in 2022-12-19-devicemanager-ga.md

### DIFF
--- a/content/en/blog/_posts/2022-12-19-devicemanager-ga.md/index.md
+++ b/content/en/blog/_posts/2022-12-19-devicemanager-ga.md/index.md
@@ -90,4 +90,4 @@ to service multiple plugin APIs at once. A per-API call with request/response ty
 would allow adding support for newer API versions without explicitly bumping the API.
 
 In addition to that, there are existing proposals in the community to introduce additional
-endpoints [KEP-3162: Add Deallocate and PostStopContainer to Device Manager API](https://github.com/kubernetes/kubernetes/pull/109016).
+endpoints [KEP-3162: Add Deallocate and PostStopContainer to Device Manager API](https://github.com/kubernetes/enhancements/issues/3162).


### PR DESCRIPTION
The blog post about device manager GA published on Dec 19th has a broken URL (pointing to a PR of something else). This fixes it.

/cc @swatisehgal 