### PR TITLE
Add December 2022 patch releases and tentative release dates for March and April 2023

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,6 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| December 2022         | 2022-12-02           | 2022-12-08  |
 | January 2023          | 2023-01-13           | 2023-01-18  |
 | February 2023         | 2023-02-10           | 2023-02-15  |
 

--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -80,6 +80,8 @@ releases may also occur in between these.
 | --------------------- | -------------------- | ----------- |
 | January 2023          | 2023-01-13           | 2023-01-18  |
 | February 2023         | 2023-02-10           | 2023-02-15  |
+| March 2023            | 2023-03-10           | 2023-03-15  |
+| April 2023            | 2023-04-07           | 2023-04-12  |
 
 ## Detailed Release History for Active Branches
 

--- a/data/releases/eol.yaml
+++ b/data/releases/eol.yaml
@@ -3,7 +3,7 @@ branches:
     finalPatchRelease: "1.22.17"
     endOfLifeDate: 2022-12-08
     note: >-
-      1.22.17 will be released in December 2022 (after the EOL date) to backport registry changes and fix two critical issues.
+      1.22.17 was released in December 2022 (after the EOL date) to backport registry changes and fix two critical issues.
   - release: "1.22"
     finalPatchRelease: "1.22.16"
     endOfLifeDate: 2022-11-09

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -12,10 +12,13 @@ schedules:
   maintenanceModeStartDate: 2023-08-28
   endOfLifeDate: 2023-10-27
   next:
-    release: 1.25.5
-    cherryPickDeadline: 2022-12-02
-    targetDate: 2022-12-08
+    release: 1.25.6
+    cherryPickDeadline: 2023-01-13
+    targetDate: 2023-01-18
   previousPatches:
+    - release: 1.25.5
+      cherryPickDeadline: 2022-12-02
+      targetDate: 2022-12-08
     - release: 1.25.4
       cherryPickDeadline: 2022-11-04
       targetDate: 2022-11-09
@@ -37,10 +40,13 @@ schedules:
   maintenanceModeStartDate: 2023-05-28
   endOfLifeDate: 2023-07-28
   next:
-    release: 1.24.9
-    cherryPickDeadline: 2022-12-02
-    targetDate: 2022-12-08
+    release: 1.24.10
+    cherryPickDeadline: 2023-01-13
+    targetDate: 2023-01-18
   previousPatches:
+    - release: 1.24.9
+      cherryPickDeadline: 2022-12-02
+      targetDate: 2022-12-08
     - release: 1.24.8
       cherryPickDeadline: 2022-11-04
       targetDate: 2022-11-09
@@ -74,10 +80,13 @@ schedules:
   maintenanceModeStartDate: 2022-12-28
   endOfLifeDate: 2023-02-28
   next:
-    release: 1.23.15
-    cherryPickDeadline: 2022-12-02
-    targetDate: 2022-12-08
+    release: 1.23.16
+    cherryPickDeadline: 2023-01-13
+    targetDate: 2023-01-18
   previousPatches:
+    - release: 1.23.15
+      cherryPickDeadline: 2022-12-02
+      targetDate: 2022-12-08
     - release: 1.23.14
       cherryPickDeadline: 2022-11-04
       targetDate: 2022-11-09


### PR DESCRIPTION
- Add December 2022 patch releases to `schedule.yaml` (and the patch release page)
- Propose tentative release dates for March and April 2023 patch releases

/assign @puerco @palnabarun @Verolop 
cc @kubernetes/release-engineering 