### PR TITLE
[ru] Remove inactive users from sig-docs-ru

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -210,17 +210,9 @@ aliases:
     - truongnh1992
   sig-docs-ru-owners: # Admins for Russian content
     - Arhell
-    - msheldyakov
-    - aisonaku
-    - potapy4
-    - dianaabv
     - shurup
   sig-docs-ru-reviews: # PR reviews for Russian content
     - Arhell
-    - msheldyakov
-    - aisonaku
-    - potapy4
-    - dianaabv
     - shurup
   sig-docs-pl-owners: # Admins for Polish content
     - mfilocha


### PR DESCRIPTION
Following [a recent Slack post](https://kubernetes.slack.com/archives/CPZ9KD9TN/p1671102168789339), I'm raising this PR to remove four inactive members of `sig-docs-ru-owners` and `sig-docs-ru-reviews`. Namely, they are:
* @msheldyakov 
* @aisonaku 
* @Potapy4 
* @dianaabv 

They didn't have any activity for a long time (for years) in this repo. Thus, having them among current team members brings unnecessary delays in handling new PRs related to Russian localisation.

Based on a lazy consensus, **we're waiting for any reaction from them until January 15th**. If nothing happens, we'll proceed with this PR.