### PR TITLE
[ja] Fix a typo in dynamic-provisioning.md

### DIFF
--- a/content/ja/docs/concepts/storage/dynamic-provisioning.md
+++ b/content/ja/docs/concepts/storage/dynamic-provisioning.md
@@ -52,7 +52,7 @@ parameters:
 
 ## 動的プロビジョニングの使用
 
-ユーザーは`PersistentVolumeClaim`リソース内でStorageClassを含むことで、動的にプロビジョンされたStorageをリクエストできます。Kubernetes v1.6以前では、この機能は`volume.beta.kubernetes.io/storage-class`アノテーションを介して使うことができました。しかしこのアノテーションはv1.9から廃止になりました。その代わりユーザーは現在では`PersistentVolumeClaim`オブジェクトの`storageClassName`を使う必要があります。このフィールドの値は、管理者によって設定された`StorageClass`の名前と一致しなければなりません([下記](#enabling-dynamic-provisioning)のセクションも参照ください)。
+ユーザーは`PersistentVolumeClaim`リソース内でStorageClassを含むことで、動的にプロビジョンされたStorageをリクエストできます。Kubernetes v1.6以前では、この機能は`volume.beta.kubernetes.io/storage-class`アノテーションを介して使うことができました。しかしこのアノテーションはv1.9から非推奨になりました。その代わりユーザーは現在では`PersistentVolumeClaim`オブジェクトの`storageClassName`を使う必要があります。このフィールドの値は、管理者によって設定された`StorageClass`の名前と一致しなければなりません([下記](#enabling-dynamic-provisioning)のセクションも参照ください)。
 
 "fast"というStorageClassを選択するために、例としてユーザーは下記のPersistentVolumeClaimを作成します。
 


### PR DESCRIPTION
It's a very old version and it will have little or no impact, but I think there is a typo as far as I referred the original manual.