### PR TITLE
Add reservedSystemCpus in KubeletConfiguration as the flag is not the same style

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -133,6 +133,7 @@ with `.slice` appended.
 {{< feature-state for_k8s_version="v1.17" state="stable" >}}
 
 **Kubelet Flag**: `--reserved-cpus=0-3`
+**KubeletConfiguration Flag**: `reservedSystemCpus: 0-3`
 
 `reserved-cpus` is meant to define an explicit CPU set for OS system daemons and
 kubernetes system daemons. `reserved-cpus` is for systems that do not intend to


### PR DESCRIPTION
I made a mistake in https://github.com/kubernetes/kubernetes/issues/114673.


In KubeletConfiguration, it is `reservedSystemCpus` and not `reservedCpus` for `--reserved-cpus`

> We should note the command line option name is different from the configuration file key: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L621