### PR TITLE
[hi] Localize glossary entry for "kube-apiserver"

### DIFF
--- a/content/hi/docs/reference/glossary/kube-apiserver.md
+++ b/content/hi/docs/reference/glossary/kube-apiserver.md
@@ -1,0 +1,22 @@
+---
+title: API सर्वर
+id: kube-apiserver
+date: 2018-04-12
+full_link: /docs/concepts/overview/components/#kube-apiserver
+short_description: >
+  एक कंट्रोल प्लेन घटक जो कुबेरनेट्स API की सेवाएं प्रदान करता है।।
+
+aka:
+- kube-apiserver
+tags:
+- architecture
+- fundamental
+---
+ API सर्वर कुबेरनेट्स {{< glossary_tooltip text="कंट्रोल प्लेन" term_id="control-plane" >}} का एक घटक है जो कुबेरनेट्स API को उजागर करता है।
+API सर्वर कुबेरनेट्स कंट्रोल प्लेन का फ्रंट एंड है।
+
+<!--more-->
+
+कुबेरनेट्स API सर्वर का मुख्य कार्यान्वयन [kube-apiserver](/docs/reference/generated/kube-apiserver/) है।
+kube-apiserver को हॉरिज़ॉन्टल रूप से स्केल करने के लिए बनाया गया है&mdash; अर्थात, आप अधिक इंस्टेंस को डिप्लॉय करके स्केल कर सकते हैं।
+आप kube-apiserver के कई इंस्टेंस चला सकते हैं और उनके बीच ट्रैफ़िक को संतुलित कर सकते हैं।


### PR DESCRIPTION
This PR:

- Localizes the glossary entry for [kube-apiserver](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/kube-apiserver.md) `content/en/docs/reference/glossary/kube-apiserver.md`  into Hindi `content/hi/docs/reference/glossary/kube-apiserver.md`.

Signed off by: Vitthal Kaul vitthalsai2001@gmail.com

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
