### PR TITLE
Fix advice about opening a pull request

### DIFF
--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -65,8 +65,7 @@ class id1 k8s
 
 Figure 1. Steps for opening a PR using GitHub.
 
-1. On the page where you see the issue, select the pencil icon at the top right.
-   You can also scroll to the bottom of the page and select **Edit this page**.
+1. On the page where you see the issue, select the **Edit this page** option in the right-hand side navigation panel.
 
 1. Make your changes in the GitHub markdown editor.
 


### PR DESCRIPTION
Improved the **step 1 for opening a PR using GitHub**, by **more accurately pointing** the **location of the 'Edit this page' option**.
This is to **fix the issue**: https://github.com/kubernetes/website/issues/38650