### PR TITLE
Deleted {{< version-check >}} & Updated note

### DIFF
--- a/content/ja/docs/tasks/debug/debug-application/get-shell-running-container.md
+++ b/content/ja/docs/tasks/debug/debug-application/get-shell-running-container.md
@@ -46,9 +46,7 @@ kubectl get pod shell-demo
 kubectl exec --stdin --tty shell-demo -- /bin/bash
 ```
 {{< note >}}
-
 ダブルダッシュ(`--`)のセパレーターは、コマンドに渡す引数とkubectlの引数を分離します。
-
 {{< /note >}}
 
 シェル内で、ルートディレクトリーのファイル一覧を表示します:

--- a/content/ja/docs/tasks/debug/debug-application/get-shell-running-container.md
+++ b/content/ja/docs/tasks/debug/debug-application/get-shell-running-container.md
@@ -14,7 +14,7 @@ content_type: task
 ## {{% heading "prerequisites" %}}
 
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
 
 
@@ -47,7 +47,7 @@ kubectl exec --stdin --tty shell-demo -- /bin/bash
 ```
 {{< note >}}
 
-ダブルダッシュの記号 `--` はコマンドに渡す引数とkubectlの引数を分離します。
+ダブルダッシュ(`--`)のセパレーターは、コマンドに渡す引数とkubectlの引数を分離します。
 
 {{< /note >}}
 


### PR DESCRIPTION
#38655
We need to update `content/ja/docs/tasks/debug/debug-application/get-shell-running-container.md` according to the English text, because it is outdated.

1. Delete {{< version-check >}}
```text
{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
↓
{{< include "task-tutorial-prereqs.md" >}}
```

2.  Updated note
```text
{{< note >}}

ダブルダッシュの記号 `--` はコマンドに渡す引数とkubectlの引数を分離します。

{{< /note >}}
↓
{{< note >}}
ダブルダッシュ(`--`)のセパレーターは、コマンドに渡す引数とkubectlの引数を分離します。
{{< /note >}}
```