### PR TITLE
[hi] Localize glossary entry for "kube-proxy"

### DIFF
--- a/content/hi/docs/reference/glossary/kube-proxy.md
+++ b/content/hi/docs/reference/glossary/kube-proxy.md
@@ -1,0 +1,27 @@
+---
+title: kube-proxy
+id: kube-proxy
+date: 2018-04-12
+full_link: /docs/reference/command-line-tools-reference/kube-proxy/
+short_description: >
+  `kube-proxy` एक नेटवर्क प्रॉक्सी है जो क्लस्टर में प्रत्येक नोड पर चलता है।
+
+aka:
+tags:
+- fundamental
+- networking
+---
+kube-proxy एक नेटवर्क प्रॉक्सी है जो आपके क्लस्टर में प्रत्येक 
+{{< glossary_tooltip text="नोड" term_id="node" >}} पर चलता है,
+कुबेरनेट्स की {{< glossary_tooltip text="सर्विस" term_id="service">}} संकल्पना
+का भाग लागू करता है।
+
+<!--more-->
+
+[kube-proxy](/docs/reference/command-line-tools-reference/kube-proxy/)
+नोड्स पर नेटवर्क नियमों को बनाए रखता है। ये नेटवर्क नियम आपके क्लस्टर के अंदर या बाहर नेटवर्क सत्रों से
+आपके पॉड्स के साथ नेटवर्क संचार की अनुमति देते हैं।
+
+kube-proxy ऑपरेटिंग सिस्टम की पैकेट फ़िल्टरिंग परत का उपयोग करता है
+यदि ऐसी कोई परत मौजूद और उपलब्ध हो। अन्यथा, kube-proxy स्वयं ही 
+ट्रैफ़िक को आगे बढ़ाता है।


### PR DESCRIPTION
This PR:

Localizes the glossary entry for [kube-proxy](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/kube-proxy.md) `content/en/docs/reference/glossary/kube-proxy.md` into Hindi `content/hi/docs/reference/glossary/kube-proxy.md`.

Signed off by: Vitthal Kaul [vitthalsai2001@gmail.com](mailto:vitthalsai2001@gmail.com)
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
