### PR TITLE
Fix tabs shortcode CSS

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -861,6 +861,10 @@ section#cncf {
 // nav-tabs and tab-content
 .nav-tabs {
   border-bottom: none !important;
+
+  .nav-item {
+    margin-bottom: 0;
+  }
 }
 
 .td-content .tab-content .highlight {


### PR DESCRIPTION
It seems in a Docsy/Hugo update that some CSS values changed and modified the look of the tabs.

If you look at the left side of the tabs (and right on mouse hover) you can see they're not connected to the container and are floating above. 

**Before:**
![Screenshot 2022-12-28 at 1 58 06 PM](https://user-images.githubusercontent.com/44844360/209876567-6a79fd6a-ff30-4f0f-98e6-b44eb448f76a.png)
![Screenshot 2022-12-28 at 1 58 19 PM](https://user-images.githubusercontent.com/44844360/209876583-cc07ed24-7ab5-409e-98e1-36f4ff00291d.png)



**After:**
![Screenshot 2022-12-28 at 1 57 22 PM](https://user-images.githubusercontent.com/44844360/209876607-558a46d5-81a4-4190-9f58-d5ee5a7d11ce.png)
![Screenshot 2022-12-28 at 1 57 36 PM](https://user-images.githubusercontent.com/44844360/209876610-58cdf1d6-349a-498b-bbe8-910664956817.png)

