### PR TITLE
fix [zh-cn]/docs/concepts/services-networking/topology-aware-hints.md

### DIFF
--- a/content/zh-cn/docs/concepts/services-networking/topology-aware-hints.md
+++ b/content/zh-cn/docs/concepts/services-networking/topology-aware-hints.md
@@ -284,4 +284,4 @@ Kubernetes 控制平面和每个节点上的 kube-proxy，在使用拓扑感知�
 <!-- 
 * Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)
 -->
-* 参阅[通过服务连通应用](/zh-cn/docs/concepts/services-networking/connect-applications-service/)
+* 参阅[ 使用 Service 连接到应用](/zh-cn/docs/tutorials/services/connect-applications-service/)


### PR DESCRIPTION
Document connection address changed!
original:
/zh-cn/docs/concepts/services-networking/connect-applications-service/
![image](https://user-images.githubusercontent.com/103416248/210054008-72ee2902-bfa6-496c-bf9d-92f9df09d3dc.png)
now:
https://kubernetes.io/zh-cn/docs/tutorials/services/connect-applications-service/
