### PR TITLE
[en] Add missing required `type` field to LimitRange example

### DIFF
--- a/content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml
+++ b/content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml
@@ -12,3 +12,4 @@ spec:
       cpu: "1"
     min:
       cpu: 100m
+    type: Container

--- a/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
+++ b/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
@@ -12,3 +12,4 @@ spec:
       cpu: "1"
     min:
       cpu: 100m
+    type: Container

--- a/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
+++ b/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
@@ -12,4 +12,3 @@ spec:
       cpu: "1"
     min:
       cpu: 100m
-    type: Container


### PR DESCRIPTION
~~Closes~~
Relates #38705

With this fix, ~~these commands~~ this command shall not claim the validation error anymore.

```
kubectl create -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml
```

<details>
 <summary>Content before EDIT</summary>

```
kubectl create -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml
kubectl create -f https://raw.githubusercontent.com/kubernetes/website/main/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
```
</details>
