### PR TITLE
[zh-cn] Add missing required `type` field to LimitRange example

### DIFF
--- a/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
+++ b/content/zh-cn/examples/concepts/policy/limit-range/problematic-limit-range.yaml
@@ -12,3 +12,4 @@ spec:
       cpu: "1"
     min:
       cpu: 100m
+    type: Container


### PR DESCRIPTION
Porting PR https://github.com/kubernetes/website/pull/38706 as Issue https://github.com/kubernetes/website/issues/38705 also affects zh-cn.