### PR TITLE
Fix EOL dates for 1.25 and 1.26

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -2,7 +2,7 @@ schedules:
 - release: 1.26
   releaseDate: 2022-12-09
   maintenanceModeStartDate: 2023-12-28
-  endOfLifeDate: 2024-02-24
+  endOfLifeDate: 2024-02-28
   next:
     release: 1.26.1
     cherryPickDeadline: 2022-01-06
@@ -10,7 +10,7 @@ schedules:
 - release: 1.25
   releaseDate: 2022-08-23
   maintenanceModeStartDate: 2023-08-28
-  endOfLifeDate: 2023-10-27
+  endOfLifeDate: 2023-10-28
   next:
     release: 1.25.6
     cherryPickDeadline: 2023-01-13


### PR DESCRIPTION
@xmudrii mentioned that the EOL dates were wrong and followed (kind of) the old rules for choosing such dates.

In https://github.com/kubernetes/sig-release/pull/2134 I have already adjusted the rules and this PR will fix the dates for 1.25 and 1.26 accordingly.