### PR TITLE
Update minikube ingress documentation

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -87,7 +87,7 @@ storage-provisioner                         1/1       Running   0          2m
 1. Create a Deployment using the following command:
 
    ```shell
-   kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
+   kubectl create deployment web --image=kicbase/echo-server:1.0
    ```
 
    The output should be:
@@ -138,9 +138,11 @@ storage-provisioner                         1/1       Running   0          2m
    The output is similar to:
 
    ```
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: 172.17.0.15:31637
    ```
 
    You can now access the sample app via the Minikube IP address and NodePort. The next step lets you access
@@ -148,7 +150,7 @@ storage-provisioner                         1/1       Running   0          2m
 
 ## Create an Ingress
 
-The following manifest defines an Ingress that sends traffic to your Service via hello-world.info.
+The following manifest defines an Ingress that sends traffic to your Service via hello-minikube.info.
 
 1. Create `example-ingress.yaml` from the following file:
 
@@ -177,44 +179,47 @@ The following manifest defines an Ingress that sends traffic to your Service via
    You should see an IPv4 address in the ADDRESS column; for example:
 
    ```
-   NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
-   example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
+   NAME              CLASS   HOSTS                 ADDRESS        PORTS   AGE
+   example-ingress   nginx   hello-minikube.info   172.17.0.15    80      38s
    ```
 
 1. Add the following line to the bottom of the `/etc/hosts` file on
    your computer (you will need administrator access):
 
     ```
-    172.17.0.15 hello-world.info
+    172.17.0.15 hello-minikube.info
     ```
 
    {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP address displayed within the ingress list will be the internal IP.{{< /note >}}
+   {{< note >}}If using Docker Desktop as the minikube driver, for the above IP use `127.0.0.1` and in a new terminal window run `minikube tunnel` to get ingress working.{{< /note >}}
 
     After you make this change, your web browser sends requests for
-    hello-world.info URLs to Minikube.
+    hello-minikube.info URLs to Minikube.
 
 1. Verify that the Ingress controller is directing traffic:
 
     ```shell
-    curl hello-world.info
+    curl hello-minikube.info
     ```
 
     You should see:
 
     ```
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
+    Request served by web-6bc55d4d95-nk4cp
+
+    HTTP/1.1 GET /
+
+    Host: hello-minikube.info
     ```
 
-    {{< note >}}If you are running Minikube locally, you can visit hello-world.info from your browser.{{< /note >}}
+    {{< note >}}If you are running Minikube locally, you can visit hello-minikube.info from your browser.{{< /note >}}
 
 ## Create a second Deployment
 
 1. Create another Deployment using the following command:
 
    ```shell
-   kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
+   kubectl create deployment web2 --image=kicbase/echo-server:1.0
    ```
    The output should be:
 
@@ -266,32 +271,36 @@ The following manifest defines an Ingress that sends traffic to your Service via
 1. Access the 1st version of the Hello World app.
 
    ```shell
-   curl hello-world.info
+   curl hello-minikube.info
    ```
 
    The output is similar to:
 
    ```
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: hello-minikube.info
    ```
 
 1. Access the 2nd version of the Hello World app.
 
    ```shell
-   curl hello-world.info/v2
+   curl hello-minikube.info/v2
    ```
 
    The output is similar to:
 
    ```
-   Hello, world!
-   Version: 2.0.0
-   Hostname: web2-75cd47646f-t8cjk
+   Request served by web2-68795ffb5-fz5xh
+
+   HTTP/1.1 GET /v2
+
+   Host: hello-minikube.info
    ```
 
-   {{< note >}}If you are running Minikube locally, you can visit hello-world.info and hello-world.info/v2 from your browser.{{< /note >}}
+   {{< note >}}If you are running Minikube locally, you can visit hello-minikube.info and hello-minikube.info/v2 from your browser.{{< /note >}}
 
 
 

--- a/content/en/examples/service/networking/example-ingress.yaml
+++ b/content/en/examples/service/networking/example-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
-    - host: hello-world.info
+    - host: hello-minikube.info
       http:
         paths:
           - path: /

--- a/content/ja/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/ja/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -68,7 +68,7 @@ weight: 100
 1. 次のコマンドを実行して、Deploymentを作成します。
 
     ```shell
-    kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
+    kubectl create deployment web --image=kicbase/echo-server:1.0
     ```
 
     出力は次のようになります。
@@ -121,16 +121,18 @@ weight: 100
     出力は次のようになります。
 
     ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
+    Request served by web-6bc55d4d95-nk4cp
+
+    HTTP/1.1 GET /
+
+    Host: 172.17.0.15:31637
     ```
 
     これで、MinikubeのIPアドレスとNodePort経由で、サンプルアプリにアクセスできるようになりました。次のステップでは、Ingressリソースを使用してアプリにアクセスできるように設定します。
 
 ## Ingressリソースを作成する
 
-以下に示すファイルは、hello-world.info経由で送られたトラフィックをServiceに送信するIngressリソースです。
+以下に示すファイルは、hello-minikube.info経由で送られたトラフィックをServiceに送信するIngressリソースです。
 
 1. 以下の内容で`example-ingress.yaml`を作成します。
 
@@ -159,8 +161,8 @@ weight: 100
     {{< /note >}}
 
     ```shell
-    NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
-    example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
+    NAME              CLASS   HOSTS                 ADDRESS        PORTS   AGE
+    example-ingress   nginx   hello-minikube.info   172.17.0.15    80      38s
     ```
 
 1. 次の行を`/etc/hosts`ファイルの最後に書きます。
@@ -168,29 +170,32 @@ weight: 100
     {{< note >}}
     Minikubeをローカル環境で実行している場合、`minikube ip`コマンドを使用すると外部のIPが取得できます。Ingressのリスト内に表示されるIPアドレスは、内部のIPになるはずです。
     {{< /note >}}
+    {{< note >}}If using Docker Desktop as the minikube driver, for the below IP use `127.0.0.1` and in a new terminal window run `minikube tunnel` to get ingress working.{{< /note >}}
 
     ```
-    172.17.0.15 hello-world.info
+    172.17.0.15 hello-minikube.info
     ```
 
-    この設定により、リクエストがhello-world.infoからMinikubeに送信されるようになります。
+    この設定により、リクエストがhello-minikube.infoからMinikubeに送信されるようになります。
 
 1. Ingressコントローラーがトラフィックを制御していることを確認します。
 
     ```shell
-    curl hello-world.info
+    curl hello-minikube.info
     ```
 
     出力は次のようになります。
 
     ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
+    Request served by web-6bc55d4d95-nk4cp
+
+    HTTP/1.1 GET /
+
+    Host: hello-minikube.info
     ```
 
     {{< note >}}
-    Minikubeをローカル環境で実行している場合、ブラウザからhello-world.infoにアクセスできます。
+    Minikubeをローカル環境で実行している場合、ブラウザからhello-minikube.infoにアクセスできます。
     {{< /note >}}
 
 ## 2番目のDeploymentを作成する
@@ -198,7 +203,7 @@ weight: 100
 1. 次のコマンドを実行して、v2のDeploymentを作成します。
 
     ```shell
-    kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
+    kubectl create deployment web2 --image=kicbase/echo-server:1.0
     ```
 
     出力は次のようになります。
@@ -250,33 +255,37 @@ weight: 100
 1. Hello Worldアプリの1番目のバージョンにアクセスします。
 
     ```shell
-    curl hello-world.info
+    curl hello-minikube.info
     ```
 
     出力は次のようになります。
 
     ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
+    Request served by web-6bc55d4d95-nk4cp
+
+    HTTP/1.1 GET /
+
+    Host: hello-minikube.info
     ```
 
 1. Hello Worldアプリの2番目のバージョンにアクセスします。
 
     ```shell
-    curl hello-world.info/v2
+    curl hello-minikube.info/v2
     ```
 
     出力は次のようになります。
 
     ```shell
-    Hello, world!
-    Version: 2.0.0
-    Hostname: web2-75cd47646f-t8cjk
+    Request served by web2-68795ffb5-fz5xh
+
+    HTTP/1.1 GET /v2
+
+    Host: hello-minikube.info
     ```
 
     {{< note >}}
-    Minikubeをローカル環境で実行している場合、ブラウザからhello-world.infoおよびhello-world.info/v2にアクセスできます。
+    Minikubeをローカル環境で実行している場合、ブラウザからhello-minikube.infoおよびhello-minikube.info/v2にアクセスできます。
     {{< /note >}}
 
 

--- a/content/ja/examples/service/networking/example-ingress.yaml
+++ b/content/ja/examples/service/networking/example-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
-    - host: hello-world.info
+    - host: hello-minikube.info
       http:
         paths:
           - path: /

--- a/content/ko/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/ko/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -87,7 +87,7 @@ storage-provisioner                         1/1       Running   0          2m
 1. 다음 명령을 사용하여 디플로이먼트(Deployment)를 생성한다.
 
    ```shell
-   kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
+   kubectl create deployment web --image=kicbase/echo-server:1.0
    ```
 
    결과는 다음과 같다.
@@ -138,9 +138,11 @@ storage-provisioner                         1/1       Running   0          2m
    결과는 다음과 같다.
 
    ```
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: 172.17.0.15:31637
    ```
 
    이제 Minikube IP 주소와 노드포트를 통해 샘플 앱에 액세스할 수 있다. 다음 단계에서는 
@@ -148,7 +150,7 @@ storage-provisioner                         1/1       Running   0          2m
 
 ## 인그레스 생성하기
 
-다음 매니페스트는 hello-world.info를 통해 서비스로 트래픽을 보내는 인그레스를 정의한다.
+다음 매니페스트는 hello-minikube.info를 통해 서비스로 트래픽을 보내는 인그레스를 정의한다.
 
 1. 다음 파일을 통해 `example-ingress.yaml`을 만든다.
 
@@ -177,44 +179,47 @@ storage-provisioner                         1/1       Running   0          2m
 다음 예시와 같이, ADDRESS 열에서 IPv4 주소를 확인할 수 있다.
 
    ```
-   NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
-   example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
+   NAME              CLASS   HOSTS                 ADDRESS        PORTS   AGE
+   example-ingress   nginx   hello-minikube.info   172.17.0.15    80      38s
    ```
 
 1. 호스트 컴퓨터의 `/etc/hosts` 파일 맨 아래에 
    다음 행을 추가한다 (관리자 권한 필요).
 
     ```
-    172.17.0.15 hello-world.info
+    172.17.0.15 hello-minikube.info
     ```
 
    {{< note >}}Minikube를 로컬에서 실행하는 경우 'minikube ip'를 사용하여 외부 IP를 가져온다. 인그레스 목록에 표시되는 IP 주소는 내부 IP가 된다.{{< /note >}}
+   {{< note >}}If using Docker Desktop as the minikube driver, for the above IP use `127.0.0.1` and in a new terminal window run `minikube tunnel` to get ingress working.{{< /note >}}
 
     이렇게 하면, 웹 브라우저가 
-    hello-world.info URL에 대한 요청을 Minikube로 전송한다.
+    hello-minikube.info URL에 대한 요청을 Minikube로 전송한다.
 
 1. 인그레스 컨트롤러가 트래픽을 전달하는지 확인한다.
 
     ```shell
-    curl hello-world.info
+    curl hello-minikube.info
     ```
 
     결과는 다음과 같다.
 
     ```
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
+    Request served by web-6bc55d4d95-nk4cp
+
+    HTTP/1.1 GET /
+
+    Host: hello-minikube.info
     ```
 
-    {{< note >}}Minikube를 로컬에서 실행하는 경우 브라우저에서 hello-world.info에 접속할 수 있다.{{< /note >}}
+    {{< note >}}Minikube를 로컬에서 실행하는 경우 브라우저에서 hello-minikube.info에 접속할 수 있다.{{< /note >}}
 
 ## 두 번째 디플로이먼트 생성하기
 
 1. 다음 명령을 사용하여 두 번째 디플로이먼트를 생성한다.
 
    ```shell
-   kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
+   kubectl create deployment web2 --image=kicbase/echo-server:1.0
    ```
    결과는 다음과 같다.
 
@@ -266,32 +271,36 @@ storage-provisioner                         1/1       Running   0          2m
 1. Hello World 앱의 첫 번째 버전에 액세스한다.
 
    ```shell
-   curl hello-world.info
+   curl hello-minikube.info
    ```
 
    결과는 다음과 같다.
 
    ```
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: hello-minikube.info
    ```
 
 1. Hello World 앱의 두 번째 버전에 액세스한다.
 
    ```shell
-   curl hello-world.info/v2
+   curl hello-minikube.info/v2
    ```
 
    결과는 다음과 같다.
 
    ```
-   Hello, world!
-   Version: 2.0.0
-   Hostname: web2-75cd47646f-t8cjk
+   Request served by web2-68795ffb5-fz5xh
+
+   HTTP/1.1 GET /v2
+
+   Host: hello-minikube.info
    ```
 
-   {{< note >}}Minikube를 로컬에서 실행하는 경우 브라우저에서 hello-world.info 및 hello-world.info/v2에 접속할 수 있다.{{< /note >}}
+   {{< note >}}Minikube를 로컬에서 실행하는 경우 브라우저에서 hello-minikube.info 및 hello-minikube.info/v2에 접속할 수 있다.{{< /note >}}
 
 
 

--- a/content/ko/examples/service/networking/example-ingress.yaml
+++ b/content/ko/examples/service/networking/example-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
-    - host: hello-world.info
+    - host: hello-minikube.info
       http:
         paths:
           - path: /

--- a/content/zh-cn/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -123,7 +123,7 @@ storage-provisioner                         1/1       Running   0          2m
 1. 使用下面的命令创建一个 Deployment：
 
    ```shell
-   kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
+   kubectl create deployment web --image=kicbase/echo-server:1.0
    ```
 
    <!--The output should be:-->
@@ -195,9 +195,11 @@ storage-provisioner                         1/1       Running   0          2m
    输出类似于：
 
    ```shell
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: 172.17.0.15:31637
    ```
 
    <!--
@@ -210,13 +212,13 @@ storage-provisioner                         1/1       Running   0          2m
 <!--
 ## Create an Ingress
 
-The following manifest defines an Ingress that sends traffic to your Service via hello-world.info.
+The following manifest defines an Ingress that sends traffic to your Service via hello-minikube.info.
 
 1. Create `example-ingress.yaml` from the following file:
 -->
 ## 创建一个 Ingress
 
-下面是一个定义 Ingress 的配置文件，负责通过 `hello-world.info` 将请求
+下面是一个定义 Ingress 的配置文件，负责通过 `hello-minikube.info` 将请求
 转发到你的服务。
 
 1. 根据下面的 YAML 创建文件 `example-ingress.yaml`：
@@ -257,8 +259,8 @@ The following manifest defines an Ingress that sends traffic to your Service via
    接下来你将会在ADDRESS列中看到IPv4地址，例如：
 
    ```
-   NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
-   example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
+   NAME              CLASS   HOSTS                 ADDRESS        PORTS   AGE
+   example-ingress   nginx   hello-minikube.info   172.17.0.15    80      38s
    ```
 
 <!--
@@ -274,15 +276,16 @@ The following manifest defines an Ingress that sends traffic to your Service via
    如果你在本地运行 Minikube 环境，需要使用 `minikube ip` 获得外部 IP 地址。
    Ingress 列表中显示的 IP 地址会是内部 IP 地址。
    {{< /note >}}
+   {{< note >}}If using Docker Desktop as the minikube driver, for the below IP use `127.0.0.1` and in a new terminal window run `minikube tunnel` to get ingress working.{{< /note >}}
    ```
-   172.17.0.15 hello-world.info
+   172.17.0.15 hello-minikube.info
    ```
 
    <!--     
    After you make this change, your web browser sends requests for
-   hello-world.info URLs to Minikube.
+   hello-minikube.info URLs to Minikube.
    -->
-   添加完成后，在浏览器中访问URL `hello-world.info`，请求将被发送到 Minikube。
+   添加完成后，在浏览器中访问URL `hello-minikube.info`，请求将被发送到 Minikube。
 
 <!--
 1. Verify that the Ingress controller is directing traffic:
@@ -290,23 +293,25 @@ The following manifest defines an Ingress that sends traffic to your Service via
 5. 验证 Ingress 控制器能够转发请求流量：
 
    ```shell
-   curl hello-world.info
+   curl hello-minikube.info
    ```
 
    <!-- You should see: -->
    你应该看到类似输出：
 
    ```
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: hello-minikube.info
    ```
 
    <!--
-   If you are running Minikube locally, you can visit hello-world.info from your browser.
+   If you are running Minikube locally, you can visit hello-minikube.info from your browser.
    -->
    {{< note >}}
-   如果你在使用本地 Minikube 环境，你可以从浏览器中访问 hello-world.info。
+   如果你在使用本地 Minikube 环境，你可以从浏览器中访问 hello-minikube.info。
    {{< /note >}}
 
 <!--
@@ -319,7 +324,7 @@ The following manifest defines an Ingress that sends traffic to your Service via
 1. 使用下面的命令创建第二个 Deployment：
 
    ```shell
-   kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
+   kubectl create deployment web2 --image=kicbase/echo-server:1.0
    ```
 
    <!-- The output should be: -->
@@ -392,16 +397,18 @@ The following manifest defines an Ingress that sends traffic to your Service via
 1. 访问 HelloWorld 应用的第一个版本：
 
    ```shell
-   curl hello-world.info
+   curl hello-minikube.info
    ```
 
    <!-- The output is similar to: -->
    输出类似于：
 
    ```
-   Hello, world!
-   Version: 1.0.0
-   Hostname: web-55b8c6998d-8k564
+   Request served by web-6bc55d4d95-nk4cp
+
+   HTTP/1.1 GET /
+
+   Host: hello-minikube.info
    ```
 
 <!--
@@ -410,24 +417,26 @@ The following manifest defines an Ingress that sends traffic to your Service via
 2. 访问 HelloWorld 应用的第二个版本：
 
    ```shell
-   curl hello-world.info/v2
+   curl hello-minikube.info/v2
    ```
 
    <!-- The output is similar to: -->
    输出类似于：
 
    ```
-   Hello, world!
-   Version: 2.0.0
-   Hostname: web2-75cd47646f-t8cjk
+   Request served by web2-68795ffb5-fz5xh
+
+   HTTP/1.1 GET /v2
+
+   Host: hello-minikube.info
    ```
 
    <!--
-   If you are running Minikube locally, you can visit hello-world.info and hello-world.info/v2 from your browser.
+   If you are running Minikube locally, you can visit hello-minikube.info and hello-minikube.info/v2 from your browser.
    -->
    {{< note >}}
    如果你在本地运行 Minikube 环境，你可以使用浏览器来访问
-   hello-world.info 和 hello-world.info/v2。
+   hello-minikube.info 和 hello-minikube.info/v2。
    {{< /note >}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/zh-cn/examples/service/networking/example-ingress.yaml
+++ b/content/zh-cn/examples/service/networking/example-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
-    - host: hello-world.info
+    - host: hello-minikube.info
       http:
         paths:
           - path: /


### PR DESCRIPTION
- Updated the image in the example from `gcr.io/google-samples/hello-app` to `kicbase/echo-server`
  - The `gcr.io/google-samples/hello-app` image doesn't work on arm64 machines as the image is only built for amd64
  - `kicbase` is minikube's Docker Hub repo, it's an echo server that supports both amd64 and arm64
- Updated host from `hello-world.info` to `hello-minikube.info`
  - Someone registered the domain `hello-world.info` so curling it results in hitting their website instead of the expected pods
- Added note for users using minikube with Docker Desktop, as additional steps are required
  - These steps are included in the output of the `minikube addons enable ingress` command but someone following the tutorial could easily miss it if they're strictly reading the doc and ignoring the outputs

Question: Is the file at https://k8s.io/examples/service/networking/example-ingress.yaml going to be automatically updated from this change or is another step required?