### PR TITLE
fix missing get on event command

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -226,7 +226,7 @@ kubectl get pods --all-namespaces -o jsonpath='{range .items[*].status.initConta
 kubectl get events --sort-by=.metadata.creationTimestamp
 
 # List all warning events
-kubectl events --types=Warning
+kubectl get events --types=Warning
 
 # Compares the current state of the cluster against the state that the cluster would be in if the manifest was applied.
 kubectl diff -f ./my-manifest.yaml


### PR DESCRIPTION
kubectl doesn't have event command, it should use get command; otherwise, it will return `error: unknown command "events" for "kubectl"`