### PR TITLE
Fixed overlap of nav-links with other content in certain screen sizes

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -163,7 +163,7 @@ body.td-404 main .error-details {
     margin-top: 3.5rem !important;
   }
 
-  @media only screen and (min-width: 1075px) {
+  @media only screen and (min-width: 1170px) {
     margin-top: 1rem !important;
   }
 }

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }} flex-column flex-md-row td-navbar" data-auto-burger="primary">
-        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}"></a>
+        <a class="navbar-brand img-fluid" href="{{ .Site.Home.RelPermalink }}"></a>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		
 		<ul class="navbar-nav mt-2 mt-lg-0">
@@ -15,12 +15,12 @@
 			{{ end }}
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown">
+			<li class="nav-item mr-n3 mr-lg-0 dropdown">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}
-			<li class="nav-item dropdown">
+			<li class="nav-item mr-n4 mr-lg-0  dropdown">
 				{{ partial "navbar-lang-selector.html" . }}
 			</li>
 			{{ end }}


### PR DESCRIPTION
Fixed overlap of the navigation bar links with, the kubernetes logo and the title description.
This fixes the issue: https://github.com/kubernetes/website/issues/38739