### PR TITLE
Detail zonal provisioning for GCE PD

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -339,7 +339,7 @@ enabled, a GCE PD volume can be provisioned in a topology that does not match
 any nodes, but any pod trying to use that volume will fail to schedule. With
 legacy pre-migration GCE PD, in this case an error will be produced
 instead at provisioning time. GCE CSI Migration is enabled by default beginning
-in 1.23.
+from the Kubernetes 1.23 release.
 {{< /note >}}
 
 ### NFS

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -333,7 +333,13 @@ using `allowedTopologies`.
 
 {{< note >}}
 `zone` and `zones` parameters are deprecated and replaced with
-[allowedTopologies](#allowed-topologies)
+[allowedTopologies](#allowed-topologies). When [GCE CSI Migration](
+https://kubernetes.io/docs/concepts/storage/volumes/#gce-csi-migration) is
+enabled, a GCE PD volume can be provisioned in a topology that does not match
+any nodes, but any pod trying to use that volume will fail to schedule. With
+legacy pre-migration GCE PD, in this case an error will be produced
+instead at provisioning time. GCE CSI Migration is enabled by default beginning
+in 1.23.
 {{< /note >}}
 
 ### NFS

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -333,8 +333,8 @@ using `allowedTopologies`.
 
 {{< note >}}
 `zone` and `zones` parameters are deprecated and replaced with
-[allowedTopologies](#allowed-topologies). When [GCE CSI Migration](
-https://kubernetes.io/docs/concepts/storage/volumes/#gce-csi-migration) is
+[allowedTopologies](#allowed-topologies). When
+[GCE CSI Migration](/docs/concepts/storage/volumes/#gce-csi-migration) is
 enabled, a GCE PD volume can be provisioned in a topology that does not match
 any nodes, but any pod trying to use that volume will fail to schedule. With
 legacy pre-migration GCE PD, in this case an error will be produced


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/1005 for the context. This change clarifies how zonal provisioning will error depending on the state of CSI migration.

/cc @msau42 
/cc @jsafrane 