### PR TITLE
[zh] sync automated-tasks-with-cron-jobs.md

### DIFF
--- a/content/zh-cn/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/zh-cn/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -16,31 +16,10 @@ weight: 10
 <!-- overview -->
 
 <!--
-You can use a {{< glossary_tooltip text="CronJob" term_id="cronjob" >}} to run {{< glossary_tooltip text="Jobs" term_id="job" >}}
-on a time-based schedule.
-These automated jobs run like [Cron](https://en.wikipedia.org/wiki/Cron) tasks on a Linux or UNIX system.
-
-Cron jobs are useful for creating periodic and recurring tasks, like running backups or sending emails.
-Cron jobs can also schedule individual tasks for a specific time, such as if you want to schedule a job for a low activity period.
+This page shows how to run automated tasks using Kubernetes {{< glossary_tooltip text="CronJob" term_id="cronjob" >}} object.
 -->
-你可以利用 {{< glossary_tooltip text="CronJob" term_id="cronjob" >}}
-执行基于时间调度的 {{< glossary_tooltip text="Job" term_id="job" >}}。
-这些自动化任务和 Linux 或者 Unix 系统的 [Cron](https://zh.wikipedia.org/wiki/Cron) 任务类似。
-
-CronJob 在创建周期性以及重复性的任务时很有帮助，例如执行备份操作或者发送邮件。
-CronJob 也可以在特定时间调度单个任务，例如你想调度低活跃周期的任务。
-
-<!--
-Cron jobs have limitations and idiosyncrasies.
-For example, in certain circumstances, a single cron job can create multiple jobs.
-Therefore, jobs should be idempotent.
-For more limitations, see [CronJobs](/docs/concepts/workloads/controllers/cron-jobs).
--->
-CronJob 有一些限制和特点。
-例如，在特定状况下，同一个 CronJob 可以创建多个任务。
-因此，任务应该是幂等的。
-
-有关更多限制，请参考 [CronJob](/zh-cn/docs/concepts/workloads/controllers/cron-jobs)。
+本页演示如何使用 Kubernetes {{< glossary_tooltip text="CronJob" term_id="cronjob" >}}
+对象运行自动化任务。
 
 ## {{% heading "prerequisites" %}}
 
@@ -49,12 +28,12 @@ CronJob 有一些限制和特点。
 <!-- steps -->
 
 <!--
-## Creating a CronJob
+## Creating a CronJob {#creating-a-cron-job}
 
 Cron jobs require a config file.
 Here is a manifest for a CronJob that runs a simple demonstration task every minute:
 -->
-## 创建 CronJob {#creating-a-cronjob}
+## 创建 CronJob {#creating-a-cron-job}
 
 CronJob 需要一个配置文件。
 以下是针对一个 CronJob 的清单，该 CronJob 每分钟运行一个简单的演示任务：
@@ -201,182 +180,3 @@ You can read more about removing jobs in [garbage collection](/docs/concepts/arc
 -->
 删除 CronJob 会清除它创建的所有任务和 Pod，并阻止它创建额外的任务。
 你可以查阅[垃圾收集](/zh-cn/docs/concepts/architecture/garbage-collection/)。
-
-<!--
-## Writing a CronJob Spec
-
-As with all other Kubernetes objects, a CronJob must have `apiVersion`, `kind`, and `metadata` fields.
-For more information about working with Kubernetes objects and their
-{{< glossary_tooltip text="manifests" term_id="manifest" >}}, see the
-[managing resources](/docs/concepts/cluster-administration/manage-deployment/),
-and [using kubectl to manage resources](/docs/concepts/overview/working-with-objects/object-management/) documents.
-Each manifest for a CronJob also needs a [`.spec`](/docs/concepts/overview/working-with-objects/kubernetes-objects/#object-spec-and-status) section.
-
--->
-## 编写 CronJob 声明信息 {#writing-a-cronjob-spec}
-
-像 Kubernetes 的其他对象一样，CronJob 需要 `apiVersion`、`kind` 和 `metadata` 字段。
-有关 Kubernetes 对象及它们的{{< glossary_tooltip text="清单" term_id="manifest" >}}的更多信息，
-请参考[资源管理](/zh-cn/docs/concepts/cluster-administration/manage-deployment/)和
-[使用 kubectl 管理资源](/zh-cn/docs/concepts/overview/working-with-objects/object-management/)文档。
-
-CronJob 配置也需要包括
-[`.spec`](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) 部分。
-
-{{< note >}}
-<!--
-If you modify a CronJob, the changes you make will apply to new jobs that start to run after your modification
-is complete. Jobs (and their Pods) that have already started continue to run without changes.
-That is, the CronJob does _not_ update existing jobs, even if those remain running.
--->
-如果你修改了一个 CronJob，你所做的修改将只被应用到将来所运行的任务上，
-对当前 CronJob 内处于运行中的 Job 集合（和 Job 里面的 Pod）不会产生任何变化，它们将继续运行。
-也就是说，对 CronJob 的修改不更新现有的任务，即使这些任务处于运行状态。
-{{< /note >}}
-
-<!--
-### Schedule
-
-The `.spec.schedule` is a required field of the `.spec`.
-It takes a [Cron](https://en.wikipedia.org/wiki/Cron) format string, such as `0 * * * *` or `@hourly`,
-as schedule time of its jobs to be created and executed.
--->
-### 排期表 {#schedule}
-
-`.spec.schedule` 是 `.spec` 中的必需字段。它接受 [Cron](https://zh.wikipedia.org/wiki/Cron)
-格式串，例如 `0 * * * *` or `@hourly`，作为它的任务被创建和执行的调度时间。
-
-<!--
-The format also includes extended "Vixie cron" step values. As explained in the
-[FreeBSD manual](https://www.freebsd.org/cgi/man.cgi?crontab%285%29):
--->
-该格式也包含了扩展的 “Vixie cron” 步长值。
-[FreeBSD 手册](https://www.freebsd.org/cgi/man.cgi?crontab%285%29)中解释如下:
-
-<!--
-> Step values can be used in conjunction with ranges. Following a range
-> with `/<number>` specifies skips of the number's value through the
-> range. For example, `0-23/2` can be used in the hours field to specify
-> command execution every other hour (the alternative in the V7 standard is
-> `0,2,4,6,8,10,12,14,16,18,20,22`). Steps are also permitted after an
-> asterisk, so if you want to say "every two hours", just use `*/2`.
--->
-
-> 步长可被用于范围组合。范围后面带有 `/<数字>` 可以声明范围内的步幅数值。
-> 例如，`0-23/2` 可被用在小时字段来声明命令在其他数值的小时数执行
-> （V7 标准中对应的方法是 `0,2,4,6,8,10,12,14,16,18,20,22`）。
-> 步长也可以放在通配符后面，因此如果你想表达 “每两小时”，就用 `*/2` 。
-
-<!--
-A question mark (`?`) in the schedule has the same meaning as an asterisk `*`, that is, it stands for any of available value for a given field.
--->
-{{< note >}}
-调度中的问号 (`?`) 和星号 `*` 含义相同，它们用来表示给定字段的任何可用值。
-{{< /note >}}
-
-<!--
-### Job Template
-
-The `.spec.jobTemplate` is the template for the job, and it is required.
-It has exactly the same schema as a [Job](/docs/concepts/workloads/controllers/job/), 
-except that it is nested and does not have an `apiVersion` or `kind`.
-For information about writing a job `.spec`, see
-[Writing a Job Spec](/docs/concepts/workloads/controllers/job/#writing-a-job-spec).
--->
-### 任务模板 {#job-template}
-
-`.spec.jobTemplate` 是任务的模板，它是必需的。它和
-[Job](/zh-cn/docs/concepts/workloads/controllers/job/) 的语法完全一样，
-只不过它是嵌套的，没有 `apiVersion` 和 `kind`。
-有关如何编写一个任务的 `.spec`，
-请参考[编写 Job 规约](/zh-cn/docs/concepts/workloads/controllers/job/#writing-a-job-spec)。
-
-<!--
-### Starting Deadline
-
-The `.spec.startingDeadlineSeconds` field is optional.
-It stands for the deadline in seconds for starting the job if it misses its scheduled time for any reason.
-After the deadline, the cron job does not start the job.
-Jobs that do not meet their deadline in this way count as failed jobs.
-If this field is not specified, the jobs have no deadline.
--->
-### 开始的最后期限 {#starting-deadline}
-
-`.spec.startingDeadlineSeconds` 字段是可选的。
-它表示任务如果由于某种原因错过了调度时间，开始该任务的截止时间的秒数。
-过了截止时间，CronJob 就不会开始任务。
-不满足这种最后期限的任务会被统计为失败任务。如果此字段未设置，那任务就没有最后期限。
-
-<!--
-If the `.spec.startingDeadlineSeconds` field is set (not null), the CronJob
-controller measures the time between when a job is expected to be created and
-now. If the difference is higher than that limit, it will skip this execution.
-
-For example, if it is set to `200`, it allows a job to be created for up to 200
-seconds after the actual schedule.
--->
-如果 `.spec.startingDeadlineSeconds` 字段被设置（非空），
-CronJob 控制器将会计算从预期创建 Job 到当前时间的时间差。
-如果时间差大于该限制，则跳过此次执行。
-
-例如，如果将其设置为 `200`，则 Job 控制器允许在实际调度之后最多 200 秒内创建 Job。
-
-<!--
-### Concurrency Policy
-
-The `.spec.concurrencyPolicy` field is also optional.
-It specifies how to treat concurrent executions of a job that is created by this cron job.
-the spec may specify only one of the following concurrency policies:
-
-* `Allow` (default): The cron job allows concurrently running jobs
-* `Forbid`: The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
-* `Replace`: If it is time for a new job run and the previous job run hasn't finished yet, the cron job replaces the currently running job run with a new job run
-
-Note that concurrency policy only applies to the jobs created by the same cron job.
-If there are multiple cron jobs, their respective jobs are always allowed to run concurrently.
--->
-### 并发性规则 {#concurrency-policy}
-
-`.spec.concurrencyPolicy` 也是可选的。它声明了 CronJob 创建的任务执行时发生重叠如何处理。
-spec 仅能声明下列规则中的一种：
-
-* `Allow`（默认）：CronJob 允许并发任务执行。
-* `Forbid`： CronJob 不允许并发任务执行；如果新任务的执行时间到了而老任务没有执行完，CronJob 会忽略新任务的执行。
-* `Replace`：如果新任务的执行时间到了而老任务没有执行完，CronJob 会用新任务替换当前正在运行的任务。
-
-请注意，并发性规则仅适用于相同 CronJob 创建的任务。如果有多个 CronJob，它们相应的任务总是允许并发执行的。
-
-<!--
-### Suspend
-
-The `.spec.suspend` field is also optional.
-If it is set to `true`, all subsequent executions are suspended.
-This setting does not apply to already started executions.
-Defaults to false.
--->
-### 挂起 {#suspend}
-
-`.spec.suspend` 字段也是可选的。如果设置为 `true` ，后续发生的执行都会被挂起。
-这个设置对已经开始的执行不起作用。默认是 `false`。
-
-<!--
-Executions that are suspended during their scheduled time count as missed jobs.
-When `.spec.suspend` changes from `true` to `false` on an existing cron job without a [starting deadline](#starting-deadline), the missed jobs are scheduled immediately.
--->
-{{< caution >}}
-在调度时间内挂起的执行都会被统计为错过的任务。当 `.spec.suspend` 从 `true` 改为 `false` 时，
-且没有[开始的最后期限](#starting-deadline)，错过的任务会被立即调度。
-{{< /caution >}}
-
-<!--
-### Jobs History Limits
-
-The `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields are optional.
-These fields specify how many completed and failed jobs should be kept.
-By default, they are set to 3 and 1 respectively.  Setting a limit to `0` corresponds to keeping none of the corresponding kind of jobs after they finish.
--->
-### 任务历史限制 {#jobs-history-limits}
-
-`.spec.successfulJobsHistoryLimit` 和 `.spec.failedJobsHistoryLimit` 是可选的。
-这两个字段指定应保留多少已完成和失败的任务。
-默认设置分别为 3 和 1。设置为 `0` 代表相应类型的任务完成后不会保留。


### PR DESCRIPTION
Sync with en. Some content is moved to the concept page that will be included in another PR.

```
content/zh-cn/docs/tasks/job/automated-tasks-with-cron-jobs.md
```