### PR TITLE
OWNERS_ALIASES cleanup part 2

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -60,16 +60,16 @@ aliases:
     - electrocucaracha
     - raelga
   sig-docs-fr-owners: # Admins for French content
-    - awkif
+    # awkif
     - feloy
-    - perriea
-    - rekcah78
+    # perriea
+    # rekcah78
     - remyleone
   sig-docs-fr-reviews: # PR reviews for French content
-    - awkif
+    # awkif
     - feloy
-    - perriea
-    - rekcah78
+    # perriea
+    # rekcah78
     - remyleone
   sig-docs-hi-owners: # Admins for Hindi content
     - anubha-v-ardhan
@@ -82,14 +82,14 @@ aliases:
     - Garima-Negi
     - verma-kunal
   sig-docs-id-owners: # Admins for Indonesian content
-    - ariscahyadi
-    - danninov
-    - girikuncoro
+    # ariscahyadi
+    # danninov
+    # girikuncoro
     - habibrosyad
   sig-docs-id-reviews: # PR reviews for Indonesian content
-    - ariscahyadi
-    - danninov
-    - girikuncoro
+    # ariscahyadi
+    # danninov
+    # girikuncoro
     - habibrosyad
   sig-docs-it-owners: # Admins for Italian content
     - fabriziopandini
@@ -106,11 +106,11 @@ aliases:
     - atoato88
     - bells17
     - kakts
-    - makocchi-git
+    # makocchi-git
     - ptux
     - t-inu
   sig-docs-ko-owners: # Admins for Korean content
-    - ClaudiaJKang
+    # ClaudiaJKang
     - gochist
     - ianychoi
     - jihoon-seo
@@ -118,7 +118,7 @@ aliases:
     - yoonian
     - ysyukr
   sig-docs-ko-reviews: # PR reviews for Korean content
-    - ClaudiaJKang
+    # ClaudiaJKang
     - gochist
     - ianychoi
     - jihoon-seo
@@ -163,28 +163,28 @@ aliases:
     - devlware
     - edsoncelio
     - femrtnz
-    - jailton
+    # jailton
     - jcjesus
-    - jhonmike
+    # jhonmike
     - rikatz
     - stormqueen1990
-    - yagonobre
+    # yagonobre
   sig-docs-pt-reviews: # PR reviews for Portugese content
     - devlware
     - edsoncelio
     - femrtnz
-    - jailton
+    # jailton
     - jcjesus
-    - jhonmike
+    # jhonmike
     - rikatz
     - stormqueen1990
-    - yagonobre
+    # yagonobre
   sig-docs-vi-owners: # Admins for Vietnamese content
-    - huynguyennovem
-    - truongnh1992
+    # huynguyennovem
+    # truongnh1992
   sig-docs-vi-reviews: # PR reviews for Vietnamese content
-    - huynguyennovem
-    - truongnh1992
+    # huynguyennovem
+    # truongnh1992
   sig-docs-ru-owners: # Admins for Russian content
     - Arhell
     - shurup
@@ -193,20 +193,20 @@ aliases:
     - shurup
   sig-docs-pl-owners: # Admins for Polish content
     - mfilocha
-    - nvtkaszpir
+    # nvtkaszpir
   sig-docs-pl-reviews: # PR reviews for Polish content
-    - kpucynski
+    # kpucynski
     - mfilocha
-    - nvtkaszpir
+    # nvtkaszpir
   sig-docs-uk-owners: # Admins for Ukrainian content
     - anastyakulyk
     - Arhell
     - butuzov
-    - MaxymVlasov
+    # MaxymVlasov
   sig-docs-uk-reviews: # PR reviews for Ukrainian content
     - Arhell
     - idvoretskyi
-    - MaxymVlasov
+    # MaxymVlasov
     - Potapy4
   # authoritative source: git.k8s.io/community/OWNERS_ALIASES
   committee-steering: # provide PR approvals for announcements


### PR DESCRIPTION
# Context

This is the second PR in the series, starting with #38719. We've used the [maintainers tool](https://github.com/kubernetes-sigs/maintainers) to parse the OWNERS file for inactive/low-activity GitHub handles based on their devstats contributions for 2022. This was done in late November & you can view the complete output on the [#sig-docs-maintainers](https://kubernetes.slack.com/archives/CA1MMM1HU/p1669446015269699) slack channel. Some part of the pruning was already completed via PRs by [@saschagrunert](https://github.com/kubernetes/website/commit/74f7e4e0ace59a25fc0174704facfbae644d45ef) and [me](https://github.com/kubernetes/website/commit/1d8f4528e7e5db011d7907609406328ad62d9db1) in early December/late November.

## What this PR does?

The following approvers and reviewers in the OWNERS_ALIASES file have had low reviews/approvals in the past year (GH pr comments <= 10 && devstats <=20). This PR prunes them from the OWNERS_ALIASES file, failing any response from their side. 

## What do I need to do?

Please comment on this PR if you have been tagged on the list below and still have time/interest to contribute. If you'd prefer to let us know your decision via DM, please initiate a group chat with **@natalisucks, @reylejano, and me on Slack** by **17th January 2023 EOD**.

## Further steps

I'll also email the SIG Docs google group and post threads on the #sig-docs and #sig-docs-maintainers slack channels for further visibility.

@ClaudiaJKang 
@MaxymVlasov 
@ariscahyadi 
@AWKIF 
@danninov 
@girikuncoro 
@huynguyennovem 
@jailton 
@jhonmike 
@kpucynski 
@makocchi-git 
@nvtkaszpir 
@perriea 
@rekcah78 
@truongnh1992 
@yagonobre 

/assign @a-mccarthy @kbhawkey @natalisucks @onlydole @sftim @tengqm @reylejano 

Explicit hold for discussions till 17th January 2023.
/hold