### PR TITLE
Fixed the Link for API compatibility and Kubelet Device Manager API Versions.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cluster-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-upgrade.md
@@ -100,4 +100,4 @@ release with a newer device plugin API version, device plugins must be upgraded 
 both version before the node is upgraded in order to guarantee that device allocations
 continue to complete successfully during the upgrade.
 
-Refer to [API compatiblity](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#api-compatibility) and [Kubelet Device Manager API Versions](/docs/reference/node/device-plugin-api-versions/) for more details.
+Refer to [API compatibility](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#api-compatibility) and [Kubelet Device Manager API Versions](/docs/reference/node/device-plugin-api-versions/) for more details.


### PR DESCRIPTION
This PR fixed the links for **API compatibility** and **Kubelet Device Manager API Versions**  in [Upgrade A Cluster](https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/) task.

Fixes #38858
