### PR TITLE
Jim Angel going emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,7 @@ emeritus_approvers:
 # - chenopis, commented out to disable PR assignments
 # - irvifa, commented out to disable PR assignments
 # - jaredbhatti, commented out to disable PR assignments
+# - jimangel, commented out to disable PR assignments
 # - kbarnard10, commented out to disable PR assignments
 # - steveperry-53, commented out to disable PR assignments
 - stewart-yu

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -31,7 +31,6 @@ aliases:
     - annajung
     - bradtopol
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - krol3
     - natalisucks
@@ -43,7 +42,6 @@ aliases:
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - mehabhalodiya
     - natalisucks
@@ -128,7 +126,6 @@ aliases:
     - ysyukr
   sig-docs-leads: # Website chairs and tech leads
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - natalisucks
     - onlydole

--- a/content/en/docs/contribute/advanced.md
+++ b/content/en/docs/contribute/advanced.md
@@ -190,3 +190,7 @@ When you're ready to start the recording, click Record to Cloud.
 When you're ready to stop recording, click Stop.
 
 The video uploads automatically to YouTube.
+
+### Offboarding a SIG Co-chair (Emeritus)
+
+See: [k/community/sig-docs/offboarding.md](https://github.com/kubernetes/community/blob/master/sig-docs/offboarding.md)


### PR DESCRIPTION
**TL;DR:** This PR removes myself as an approver/reviewer in SIG Docs.

Related PRs:
- https://github.com/kubernetes/org/pull/3931
- https://github.com/kubernetes/community/pull/7035

After [stepping down](https://groups.google.com/g/kubernetes-sig-docs/c/hspG6mzgkrs) as co-chair in early 2022, I welcomed my first child into the world and did my best "homer fade away" for about 6 months while I discovered fatherhood.

![homer into bushes](https://user-images.githubusercontent.com/4601051/211471576-e06219ea-dc5d-4dd1-9195-3f7a4c74e975.gif)

It took a bit longer for me to finally get around to removing the permissions (this PR) and I want to apologize to the community for leaving my dormant permissions in place. Having a non-active approver / reviewer does not help the community thrive.

I've always said that I write the documentation that I wish existed when I needed it. That includes docs around moving to emeritus. This PR also includes a link to k/community with a starting point for offboarding instructions (as discussed in https://github.com/kubernetes/website/discussions/38842).

There's **way too many folks** to thank for sharing my journey in SIG Docs, but I wanted to name a couple of people that impacted me greatly:

- Thank you @zacharysarah: my first "welcome" to SIG Docs. I recall in one of my first SIG Docs meetings watching Sarah tactfully discussing the nuances of various docs issues. They ensured to provide context to the newcomers (me) as well as welcomed input from everyone regardless of role. I've learned a lot from them and continue to learn. ❤️
- Thank you @jaredbhatti and @Bradamant3: the other two active co-chairs when I joined SIG Docs. When I was figuring things out, you both supported me without hesitation, and I continue to enjoy our conversations / friendship today. ❤️
- Thank you @parispittman: at my first KubeCon ('18 Seattle), I ran into you and you acted like, "of course I know you!" even though I felt invisible as a new contributor. Many years and interactions later, you came in and helped me manage my burnout and the leadership transition for SIG Docs. Your good vibes and personal impact is not taken for granted. ❤️

It has been my absolute pleasure to serve this AMAZING community, and I hope to lurk as a docs individual contributor moving forward. I plan on staying active in the community with SIG Release, and other SIGs, as I evolve. Cheers!