### PR TITLE
Update page weights in tutorial/security section

### DIFF
--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -3,7 +3,7 @@ reviewers:
 - stclair
 title: Restrict a Container's Access to Resources with AppArmor
 content_type: tutorial
-weight: 10
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/tutorials/security/ns-level-pss.md
+++ b/content/en/docs/tutorials/security/ns-level-pss.md
@@ -1,7 +1,7 @@
 ---
 title: Apply Pod Security Standards at the Namespace Level
 content_type: tutorial
-weight: 10
+weight: 20
 ---
 
 {{% alert title="Note" %}}

--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -5,7 +5,7 @@ reviewers:
 - saschagrunert
 title: Restrict a Container's Syscalls with seccomp
 content_type: tutorial
-weight: 20
+weight: 40
 min-kubernetes-server-version: v1.22
 ---
 


### PR DESCRIPTION
This PR updates the page weights for the tutorial/security section, https://kubernetes.io/docs/tutorials/security/. It is part of our larger effort to update the page weights in the english docs, as described in https://github.com/kubernetes/website/issues/35093. To summarize, when page weights are missing or duplicated the site will default sort the page in alphabetical order based on page title. This causes problems in localized content because the page titles are different, making the page order different between the english and localized content. 

https://github.com/kubernetes/website/issues/38850 was filed recently calling out a problem with the page weights in the tutorial/security section. 
