### PR TITLE
Add /logs API to security checklist

### DIFF
--- a/content/en/docs/concepts/security/security-checklist.md
+++ b/content/en/docs/concepts/security/security-checklist.md
@@ -206,6 +206,25 @@ SELinux is only available on Linux nodes, and enabled in
 [some Linux distributions](https://en.wikipedia.org/wiki/Security-Enhanced_Linux#Implementations).
 {{< /note >}}
 
+## Logs and auditing
+
+- [ ] Audit logs, if enabled, are protected from general access.
+- [ ] The `/logs` API is disabled (you are running kube-apiserver with
+  `--enable-logs-handler=false`).
+
+  Kubernetes includes a `/logs` API endpoint, enabled by default,
+  that lets users request the contents of the API server's `/var/log` directory over HTTP. Accessing
+  that endpoint requires authentication.
+
+Allowing broad access to Kubernetes logs can make security information
+available to a potential attacker.
+
+As a good practice, set up a separate means to collect and aggregate
+control plane logs, and do not use the `/logs` API endpoint.
+Alternatively, if you run your control plane with the `/logs` API endpoint
+and limit the content of `/var/log` (within the host or container where the API server is running) to
+Kubernetes API server logs only.
+
 ## Pod placement
 
 - [ ] Pod placement is done in accordance with the tiers of sensitivity of the


### PR DESCRIPTION
It's best to disable this API, which is already deprecated. When it's enabled, a user with access can query `/logs` on an API server to read the contents of `/var/log`.

More context: https://groups.google.com/a/kubernetes.io/g/dev/c/OkSc6KLmD0Q

/sig security
/sig api-machinery