### PR TITLE
Update page weights in /tasks/administer-cluster section

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -1,6 +1,7 @@
 ---
 title: Access Clusters Using the Kubernetes API
 content_type: task
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -1,7 +1,7 @@
 ---
 title: Generate Certificates Manually
 content_type: task
-weight: 20
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/change-default-storage-class.md
+++ b/content/en/docs/tasks/administer-cluster/change-default-storage-class.md
@@ -1,6 +1,7 @@
 ---
 title: Change the default StorageClass
 content_type: task
+weight: 90
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -1,6 +1,7 @@
 ---
 title: Change the Reclaim Policy of a PersistentVolume
 content_type: task
+weight: 100
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/cluster-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-upgrade.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade A Cluster
 content_type: task
+weight: 350
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -5,6 +5,7 @@ reviewers:
 - jpbetz
 title: Operating etcd clusters for Kubernetes
 content_type: task
+weight: 270
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/controller-manager-leader-migration.md
+++ b/content/en/docs/tasks/administer-cluster/controller-manager-leader-migration.md
@@ -5,6 +5,7 @@ reviewers:
 title: "Migrate Replicated Control Plane To Use Cloud Controller Manager"
 linkTitle: "Migrate Replicated Control Plane To Use Cloud Controller Manager"
 content_type: task
+weight: 250
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -4,6 +4,7 @@ reviewers:
 title: Using CoreDNS for Service Discovery
 min-kubernetes-server-version: v1.9
 content_type: task
+weight: 380
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -7,6 +7,7 @@ reviewers:
 
 content_type: task
 min-kubernetes-server-version: v1.26
+weight: 140
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -5,6 +5,7 @@ reviewers:
 title: Declare Network Policy
 min-kubernetes-server-version: v1.8
 content_type: task
+weight: 180
 ---
 <!-- overview -->
 This document helps you get started using the Kubernetes [NetworkPolicy API](/docs/concepts/services-networking/network-policies/) to declare network policies that govern how pods communicate with each other.

--- a/content/en/docs/tasks/administer-cluster/developing-cloud-controller-manager.md
+++ b/content/en/docs/tasks/administer-cluster/developing-cloud-controller-manager.md
@@ -5,6 +5,7 @@ reviewers:
 - wlan0
 title: Developing Cloud Controller Manager
 content_type: concept
+weight: 190
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -5,6 +5,7 @@ reviewers:
 title: Customizing DNS Service
 content_type: task
 min-kubernetes-server-version: v1.12
+weight: 160
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -5,6 +5,7 @@ reviewers:
 title:  Debugging DNS Resolution
 content_type: task
 min-kubernetes-server-version: v1.6
+weight: 170
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -1,6 +1,7 @@
 ---
 title: Autoscale the DNS Service in a Cluster
 content_type: task
+weight: 80
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/enable-disable-api.md
+++ b/content/en/docs/tasks/administer-cluster/enable-disable-api.md
@@ -1,6 +1,7 @@
 ---
 title: Enable Or Disable A Kubernetes API
 content_type: task
+weight: 200
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -5,6 +5,7 @@ reviewers:
 - enj
 content_type: task
 min-kubernetes-server-version: 1.13
+weight: 210
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/extended-resource-node.md
+++ b/content/en/docs/tasks/administer-cluster/extended-resource-node.md
@@ -1,6 +1,7 @@
 ---
 title: Advertise Extended Resources for a Node
 content_type: task
+weight: 70
 ---
 
 

--- a/content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -5,6 +5,7 @@ reviewers:
 - piosz
 title: Guaranteed Scheduling For Critical Add-On Pods
 content_type: concept
+weight: 220
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/ip-masq-agent.md
+++ b/content/en/docs/tasks/administer-cluster/ip-masq-agent.md
@@ -1,6 +1,7 @@
 ---
 title: IP Masquerade Agent User Guide
 content_type: task
+weight: 230
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kms-provider.md
@@ -4,6 +4,7 @@ reviewers:
 - enj
 title: Using a KMS provider for data encryption
 content_type: task
+weight: 370
 ---
 <!-- overview -->
 This page shows how to configure a Key Management Service (KMS) provider and plugin to enable secret data encryption. Currently there are two KMS API versions. KMS v1 will continue to work while v2 develops in maturity. If you are not sure which KMS API version to pick, choose v1. 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring a cgroup driver
 content_type: task
-weight: 10
+weight: 20
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
@@ -3,7 +3,7 @@ reviewers:
 - sig-cluster-lifecycle
 title: Reconfiguring a kubeadm cluster
 content_type: task
-weight: 10
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -3,7 +3,7 @@ reviewers:
 - sig-cluster-lifecycle
 title: Upgrading kubeadm clusters
 content_type: task
-weight: 20
+weight: 40
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -2,7 +2,7 @@
 title: Upgrading Windows nodes
 min-kubernetes-server-version: 1.17
 content_type: task
-weight: 40
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -4,6 +4,7 @@ reviewers:
 - dawnchen
 title: Set Kubelet parameters via a config file
 content_type: task
+weight: 330
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md
@@ -6,6 +6,7 @@ reviewers:
 description: Configure the kubelet's image credential provider plugin
 content_type: task
 min-kubernetes-server-version: v1.26
+weight: 120
 ---
 
 {{< feature-state for_k8s_version="v1.26" state="stable" >}}

--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -2,6 +2,7 @@
 title: Running Kubernetes Node Components as a Non-root User
 content_type: task
 min-kubernetes-server-version: 1.22
+weight: 300
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/limit-storage-consumption.md
+++ b/content/en/docs/tasks/administer-cluster/limit-storage-consumption.md
@@ -1,6 +1,7 @@
 ---
 title: Limit Storage Consumption
 content_type: task
+weight: 240
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/manage-resources/_index.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Manage Memory, CPU, and API Resources
-weight: 20
+weight: 40
 ---

--- a/content/en/docs/tasks/administer-cluster/memory-manager.md
+++ b/content/en/docs/tasks/administer-cluster/memory-manager.md
@@ -7,6 +7,7 @@ reviewers:
 
 content_type: task
 min-kubernetes-server-version: v1.21
+weight: 410
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating from dockershim"
-weight: 10
+weight: 20
 content_type: task
 no_list: true
 ---

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
@@ -1,6 +1,6 @@
 ---
 title: "Changing the Container Runtime on a Node from Docker Engine to containerd"
-weight: 8
+weight: 10
 content_type: task 
 ---
 

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-removal-affects-you.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-removal-affects-you.md
@@ -3,7 +3,7 @@ title: Check whether dockershim removal affects you
 content_type: task
 reviewers:
 - SergeyKanzhelev
-weight: 20
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -3,7 +3,7 @@ title: Find Out What Container Runtime is Used on a Node
 content_type: task
 reviewers:
 - SergeyKanzhelev
-weight: 10
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrate Docker Engine nodes from dockershim to cri-dockerd"
-weight: 9
+weight: 20
 content_type: task 
 ---
 

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents.md
@@ -3,7 +3,7 @@ title: Migrating telemetry and security agents from dockershim
 content_type: task 
 reviewers:
 - SergeyKanzhelev
-weight: 70
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md
@@ -4,7 +4,7 @@ content_type: task
 reviewers:
 - mikebrow
 - divya-mohan0209
-weight: 10
+weight: 40
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -4,6 +4,7 @@ reviewers:
 - janetkuo
 title: Namespaces Walkthrough
 content_type: task
+weight: 260
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/namespaces.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces.md
@@ -4,6 +4,7 @@ reviewers:
 - janetkuo
 title: Share a Cluster with Namespaces
 content_type: task
+weight: 340
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/_index.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Install a Network Policy Provider
-weight: 30
+weight: 50
 ---

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy.md
@@ -3,7 +3,7 @@ reviewers:
 - caseydavenport
 title: Use Calico for NetworkPolicy
 content_type: task
-weight: 10
+weight: 20
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -4,7 +4,7 @@ reviewers:
 - aanm
 title: Use Cilium for NetworkPolicy
 content_type: task
-weight: 20
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy.md
@@ -3,7 +3,7 @@ reviewers:
 - murali-reddy
 title: Use Kube-router for NetworkPolicy
 content_type: task
-weight: 30
+weight: 40
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
@@ -3,7 +3,7 @@ reviewers:
 - chrismarino
 title: Romana for NetworkPolicy
 content_type: task
-weight: 40
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy.md
@@ -3,7 +3,7 @@ reviewers:
 - bboreham
 title: Weave Net for NetworkPolicy
 content_type: task
-weight: 50
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/en/docs/tasks/administer-cluster/nodelocaldns.md
@@ -5,6 +5,7 @@ reviewers:
 - sftim
 title: Using NodeLocal DNSCache in Kubernetes Clusters
 content_type: task
+weight: 390
 ---
  
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/quota-api-object.md
+++ b/content/en/docs/tasks/administer-cluster/quota-api-object.md
@@ -1,6 +1,7 @@
 ---
 title: Configure Quotas for API Objects
 content_type: task
+weight: 130
 ---
 
 

--- a/content/en/docs/tasks/administer-cluster/reconfigure-kubelet.md
+++ b/content/en/docs/tasks/administer-cluster/reconfigure-kubelet.md
@@ -5,6 +5,7 @@ reviewers:
 title: Reconfigure a Node's Kubelet in a Live Cluster
 content_type: task
 min-kubernetes-server-version: v1.11
+weight: 280
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -6,6 +6,7 @@ reviewers:
 title: Reserve Compute Resources for System Daemons
 content_type: task
 min-kubernetes-server-version: 1.8
+weight: 290
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -5,6 +5,7 @@ reviewers:
 - wlan0
 title: Cloud Controller Manager Administration
 content_type: concept
+weight: 110
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -7,6 +7,7 @@ reviewers:
 title: Safely Drain a Node
 content_type: task
 min-kubernetes-server-version: 1.5
+weight: 310
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -5,6 +5,7 @@ reviewers:
 - enj
 title: Securing a Cluster
 content_type: task
+weight: 320
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -3,6 +3,7 @@ title: Using sysctls in a Kubernetes Cluster
 reviewers:
 - sttts
 content_type: task
+weight: 400
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -10,6 +10,7 @@ reviewers:
 
 content_type: task
 min-kubernetes-server-version: v1.18
+weight: 150
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/use-cascading-deletion.md
+++ b/content/en/docs/tasks/administer-cluster/use-cascading-deletion.md
@@ -1,6 +1,7 @@
 ---
 title: Use Cascading Deletion in a Cluster
 content_type: task
+weight: 360
 ---
 
 <!--overview-->

--- a/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
@@ -2,6 +2,7 @@
 title: Verify Signed Kubernetes Artifacts
 content_type: task
 min-kubernetes-server-version: v1.26
+weight: 420
 ---
 
 <!-- overview -->


### PR DESCRIPTION
This PR updates the page weights for the tasks/adminster-cluster section, https://github.com/kubernetes/website/tree/main/content/en/docs/tasks/administer-cluster. 


It is part of our larger effort to update the page weights in the english docs, as described in https://github.com/kubernetes/website/issues/35093. To summarize, when page weights are missing or duplicated the site will default sort the page in alphabetical order based on page title. This causes problems in localized content because the page titles are different, making the page order different between the english and localized content.

