### PR TITLE
Fix errors on `ValidatingAdmissionPolicyBindings` for the CEL for Admission Control blog

### DIFF
--- a/content/en/blog/_posts/2022-12-20-validating-admission-policies-alpha/index.md
+++ b/content/en/blog/_posts/2022-12-20-validating-admission-policies-alpha/index.md
@@ -60,7 +60,7 @@ kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "demo-binding-test.example.com"
 spec:
-  policy: "demo-policy.example.com"
+  policyName: "demo-policy.example.com"
   matchResources:
     namespaceSelector:
     - key: environment,
@@ -115,8 +115,8 @@ kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "demo-binding-production.example.com"
 spec:
-  policy: "demo-policy.example.com"
-  paramsRef:
+  policyName: "demo-policy.example.com"
+  paramRef:
     name: "demo-params-production.example.com"
   matchResources:
     namespaceSelector:


### PR DESCRIPTION
Fix errors on ValidatingAdmissionPolicyBindings for the CEL for Admission Control blog.

As per official docs:
- https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/
- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#validatingadmissionpolicybindingspec-v1alpha1-admissionregistration-k8s-io

Otherwise getting errors:
- `unknown field "spec.policy"`
- `error: unknown field "spec.paramsRef"`