### PR TITLE
Mark automatic labelling on namespaces as stable since 1.22

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -147,7 +147,7 @@ kubectl api-resources --namespaced=false
 
 ## Automatic labelling
 
-{{< feature-state state="beta" for_k8s_version="1.21" >}}
+{{< feature-state for_k8s_version="1.22" state="stable" >}}
 
 The Kubernetes control plane sets an immutable {{< glossary_tooltip text="label" term_id="label" >}}
 `kubernetes.io/metadata.name` on all namespaces, provided that the `NamespaceDefaultLabelName`


### PR DESCRIPTION
Fixing this [namespace doc](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#automatic-labelling) to be consistent about the Automatic labelling on namespaces stable since 1.22 information like made on [this other page](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-namespace-by-its-name) by https://github.com/kubernetes/website/pull/32122.