### PR TITLE
[ja] Fix broken links to localized pages

### DIFF
--- a/content/ja/docs/reference/_index.md
+++ b/content/ja/docs/reference/_index.md
@@ -32,7 +32,7 @@ content_type: concept
 
 * [kubectl](/ja/docs/reference/kubectl/overview/) - コマンドの実行やKubernetesクラスターの管理に使う主要なCLIツールです。
     * [JSONPath](/ja/docs/reference/kubectl/jsonpath/) - kubectlで[JSONPath記法](https://goessner.net/articles/JsonPath/)を使うための構文ガイドです。
-* [kubeadm](ja/docs/reference/setup-tools/kubeadm/) - セキュアなKubernetesクラスターを簡単にプロビジョニングするためのCLIツールです。
+* [kubeadm](/ja/docs/reference/setup-tools/kubeadm/) - セキュアなKubernetesクラスターを簡単にプロビジョニングするためのCLIツールです。
 
 ## コンポーネントリファレンス
 

--- a/content/ja/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/ja/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -178,7 +178,7 @@ kubectl delete namespace default-mem-example
 
 * [Configure Default CPU Requests and Limits for a Namespace](/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
 
-* [Namespaceに対する最小および最大メモリー制約の構成](ja/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/)
+* [Namespaceに対する最小および最大メモリー制約の構成](/ja/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/)
 
 * [Configure Minimum and Maximum CPU Constraints for a Namespace](/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)
 
@@ -190,8 +190,8 @@ kubectl delete namespace default-mem-example
 
 ### アプリケーション開発者向け
 
-* [コンテナおよびPodへのメモリーリソースの割り当て](ja/docs/tasks/configure-pod-container/assign-memory-resource/)
+* [コンテナおよびPodへのメモリーリソースの割り当て](/ja/docs/tasks/configure-pod-container/assign-memory-resource/)
 
-* [コンテナおよびPodへのCPUリソースの割り当て](ja/docs/tasks/configure-pod-container/assign-cpu-resource/)
+* [コンテナおよびPodへのCPUリソースの割り当て](/ja/docs/tasks/configure-pod-container/assign-cpu-resource/)
 
-* [PodにQuality of Serviceを設定する](ja/docs/tasks/configure-pod-container/quality-service-pod/)
+* [PodにQuality of Serviceを設定する](/ja/docs/tasks/configure-pod-container/quality-service-pod/)


### PR DESCRIPTION
This PR adds heading slash "/" on ja content link.
The link is (mainly) 404 without heading slash, that's why I create this commit.

The link is expanded as followings if we use `[something](ja/docs/something)` style:
https://kubernetes.io/ja/docs/reference/ja/docs/reference/setup-tools/kubeadm/ (<-Double "ja" in URL.)

The target pages on preview site:
- https://deploy-preview-38911--kubernetes-io-main-staging.netlify.app/ja/docs/reference/#cli%E3%83%AA%E3%83%95%E3%82%A1%E3%83%AC%E3%83%B3%E3%82%B9
- https://deploy-preview-38911--kubernetes-io-main-staging.netlify.app/ja/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/#%E6%AC%A1%E3%81%AE%E9%A0%85%E7%9B%AE