### PR TITLE
remove unnecessary space between back and end

### DIFF
--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -39,7 +39,7 @@ network proxying service on a computer.  Although the `kube-proxy` executable su
 to use as-is.
 
 <a id="example"></a>
-Some of the details in this reference refer to an example: the back end Pods for a stateless
+Some of the details in this reference refer to an example: the backend Pods for a stateless
 image-processing workload, running with three replicas. Those replicas are
 fungible&mdash;frontends do not care which backend they use.  While the actual Pods that
 compose the backend set may change, the frontend clients should not need to be aware of that,


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Hello! here is a PR for just removing a space between back and end.
.. the back end Pods for ... -> ... the backend Pods for ...

markdown : [virtual-ips.md](https://github.com/kubernetes/website/tree/main/content/en/docs/reference/networking/virtual-ips.md)
kubernetes.io : [virtual-ips](https://kubernetes.io/docs/reference/networking/virtual-ips/)