### PR TITLE
Add noindex for Netlify sites

### DIFF
--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -32,7 +32,9 @@
   {{- end -}}
 {{- end }}
 {{- end -}}
+{{ if strings.Contains .Site.BaseURL ".netlify.app" }}
+X-Robots-Tag: noindex
+{{ end }}
 {{- else }}
-/*
-  X-Robots-Tag: noindex
+X-Robots-Tag: noindex
 {{- end }}


### PR DESCRIPTION
Try to prevent search engine to use pages under https://kubernetes.netlify.app/ site.

We can verify that every HTML pages have added `<link rel="canonical">` metadata.
e.g., https://deploy-preview-38932--kubernetes-io-main-staging.netlify.app/es/docs/concepts/overview/what-is-kubernetes/

Ref: [Slack thread](https://kubernetes.slack.com/archives/C1J0BPD2M/p1673435799235499)