### PR TITLE
[FR] Fix fix broken links for KubeletConfiguration struct

### DIFF
--- a/content/fr/docs/concepts/configuration/secret.md
+++ b/content/fr/docs/concepts/configuration/secret.md
@@ -563,7 +563,7 @@ Le programme dans un conteneur est responsable de la lecture des secrets des fic
 Lorsqu'un secret déjà consommé dans un volume est mis à jour, les clés projetées sont finalement mises à jour également.
 Kubelet vérifie si le secret monté est récent à chaque synchronisation périodique.
 Cependant, il utilise son cache local pour obtenir la valeur actuelle du Secret.
-Le type de cache est configurable à l'aide de le champ `ConfigMapAndSecretChangeDetectionStrategy` dans la structure [KubeletConfiguration](https://github.com/kubernetes/kubernetes/blob/{{< param "docsbranch" >}}/staging/src/k8s.io/kubelet/config/v1beta1/types.go).
+Le type de cache est configurable à l'aide de le champ `ConfigMapAndSecretChangeDetectionStrategy` dans la structure [KubeletConfiguration](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go).
 Il peut être soit propagé via watch (par défaut), basé sur ttl, ou simplement redirigé toutes les requêtes vers directement kube-apiserver.
 Par conséquent, le délai total entre le moment où le secret est mis à jour et le moment où de nouvelles clés sont projetées sur le pod peut être aussi long que la période de synchronisation du kubelet + le délai de propagation du cache, où le délai de propagation du cache dépend du type de cache choisi (cela équivaut au delai de propagation du watch, ttl du cache, ou bien zéro).
 


### PR DESCRIPTION
Hi!

For some configmap and secret documentation pages, links to the KubeletConfiguration struct are broken.
It's due to the usage of the docsbranch parameter which is evaluated to main. But the main branch doesn't exist in the [kubernetes](https://github.com/kubernetes/kubernetes) repo.

This PR replaces the parameter to an hardcoded value: master.

You can check that the link is currently broken here:

https://kubernetes.io/fr/docs/concepts/configuration/secret/#les-secrets-mont%C3%A9s-sont-mis-%C3%A0-jour-automatiquement (latest version)
https://v1-23.docs.kubernetes.io/fr/docs/concepts/configuration/secret/#les-secrets-mont%C3%A9s-sont-mis-%C3%A0-jour-automatiquement (v1.23 version)

This PR is a split of #34902