### PR TITLE
[ID] Fix broken links for KubeletConfiguration struct

### DIFF
--- a/content/id/docs/concepts/configuration/secret.md
+++ b/content/id/docs/concepts/configuration/secret.md
@@ -559,7 +559,7 @@ apakah  terdapat perubahan pada Secret yang telah di-_mount_. Meskipun demikian,
 proses pengecekan ini dilakukan dengan menggunakan _cache_ lokal untuk mendapatkan _value_ saat ini 
 dari sebuah Secret. Tipe _cache_ yang ada dapat diatur dengan menggunakan 
 (_field_ `ConfigMapAndSecretChangeDetectionStrategy` pada
-[_struct_ KubeletConfiguration](https://github.com/kubernetes/kubernetes/blob/{{< param "docsbranch" >}}/staging/src/k8s.io/kubelet/config/v1beta1/types.go)).
+[KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/)).
 Mekanisme ini kemudian dapat diteruskan dengan mekanisme _watch_(_default_), ttl, atau melakukan pengalihan semua 
 _request_ secara langsung pada kube-apiserver.
 Sebagai hasilnya, _delay_ total dari pertama kali Secret diubah hingga dilakukannya mekanisme 


### PR DESCRIPTION
Hi!

For some configmap and secret documentation pages, links to the KubeletConfiguration struct are broken.
It's due to the usage of the docsbranch parameter which is evaluated to main. But the main branch doesn't exist in the [kubernetes](https://github.com/kubernetes/kubernetes) repo.

This PR replaces the parameter to an hardcoded value: master.

You can check that the link is currently broken here:

https://kubernetes.io/fr/docs/concepts/configuration/secret/#les-secrets-mont%C3%A9s-sont-mis-%C3%A0-jour-automatiquement (latest version)
https://v1-23.docs.kubernetes.io/fr/docs/concepts/configuration/secret/#les-secrets-mont%C3%A9s-sont-mis-%C3%A0-jour-automatiquement (v1.23 version)

This PR is a split of https://github.com/kubernetes/website/pull/34902