### PR TITLE
[JA] Fix broken links for KubeletConfiguration struct

### DIFF
--- a/content/ja/docs/concepts/configuration/configmap.md
+++ b/content/ja/docs/concepts/configuration/configmap.md
@@ -164,7 +164,7 @@ Pod内に複数のコンテナが存在する場合、各コンテナにそれ�
 
 #### マウントしたConfigMapの自動的な更新
 
-ボリューム内で現在使用中のConfigMapが更新されると、射影されたキーも最終的に(eventually)更新されます。kubeletは定期的な同期のたびにマウントされたConfigMapが新しいかどうか確認します。しかし、kubeletが現在のConfigMapの値を取得するときにはローカルキャッシュを使用します。キャッシュの種類は、[KubeletConfiguration構造体](https://github.com/kubernetes/kubernetes/blob/{{< param "docsbranch" >}}/staging/src/k8s.io/kubelet/config/v1beta1/types.go)の中の`ConfigMapAndSecretChangeDetectionStrategy`フィールドで設定可能です。ConfigMapは、監視(デフォルト)、ttlベース、またはすべてのリクエストを直接APIサーバーへ単純にリダイレクトする方法のいずれかによって伝搬されます。その結果、ConfigMapが更新された瞬間から、新しいキーがPodに射影されるまでの遅延の合計は、最長でkubeletの同期期間+キャッシュの伝搬遅延になります。ここで、キャッシュの伝搬遅延は選択したキャッシュの種類に依存します(監視の伝搬遅延、キャッシュのttl、または0に等しくなります)。
+ボリューム内で現在使用中のConfigMapが更新されると、射影されたキーも最終的に(eventually)更新されます。kubeletは定期的な同期のたびにマウントされたConfigMapが新しいかどうか確認します。しかし、kubeletが現在のConfigMapの値を取得するときにはローカルキャッシュを使用します。キャッシュの種類は、[KubeletConfiguration構造体](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go)の中の`ConfigMapAndSecretChangeDetectionStrategy`フィールドで設定可能です。ConfigMapは、監視(デフォルト)、ttlベース、またはすべてのリクエストを直接APIサーバーへ単純にリダイレクトする方法のいずれかによって伝搬されます。その結果、ConfigMapが更新された瞬間から、新しいキーがPodに射影されるまでの遅延の合計は、最長でkubeletの同期期間+キャッシュの伝搬遅延になります。ここで、キャッシュの伝搬遅延は選択したキャッシュの種類に依存します(監視の伝搬遅延、キャッシュのttl、または0に等しくなります)。
 
 環境変数として使用されるConfigMapは自動的に更新されないため、ポッドを再起動する必要があります。
 ## イミュータブルなConfigMap {#configmap-immutable}

--- a/content/ja/docs/concepts/configuration/secret.md
+++ b/content/ja/docs/concepts/configuration/secret.md
@@ -582,7 +582,7 @@ cat /etc/foo/password
 ボリュームとして使用されているSecretが更新されると、やがて割り当てられたキーも同様に更新されます。
 kubeletは定期的な同期のたびにマウントされたSecretが新しいかどうかを確認します。
 しかしながら、kubeletはSecretの現在の値の取得にローカルキャッシュを使用します。
-このキャッシュは[KubeletConfiguration struct](https://github.com/kubernetes/kubernetes/blob/{{< param "docsbranch" >}}/staging/src/k8s.io/kubelet/config/v1beta1/types.go)内の`ConfigMapAndSecretChangeDetectionStrategy`フィールドによって設定可能です。
+このキャッシュは[KubeletConfiguration struct](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go)内の`ConfigMapAndSecretChangeDetectionStrategy`フィールドによって設定可能です。
 Secretはwatch（デフォルト）、TTLベース、単に全てのリクエストをAPIサーバーへリダイレクトすることのいずれかによって伝搬します。
 結果として、Secretが更新された時点からPodに新しいキーが反映されるまでの遅延時間の合計は、kubeletの同期間隔 + キャッシュの伝搬遅延となります。
 キャッシュの遅延は、キャッシュの種別により、それぞれwatchの伝搬遅延、キャッシュのTTL、0になります。


### PR DESCRIPTION
Hi!

For some configmap and secret documentation pages, links to the KubeletConfiguration struct are broken.
It's due to the usage of the docsbranch parameter which is evaluated to main. But the main branch doesn't exist in the [kubernetes](https://github.com/kubernetes/kubernetes) repo.

This PR replaces the parameter to an hardcoded value: master.

You can check that the link is currently broken here:

https://kubernetes.io/fr/docs/concepts/configuration/secret/#les-secrets-mont%C3%A9s-sont-mis-%C3%A0-jour-automatiquement (latest version)
https://v1-23.docs.kubernetes.io/fr/docs/concepts/configuration/secret/#les-secrets-mont%C3%A9s-sont-mis-%C3%A0-jour-automatiquement (v1.23 version)

This PR is a split of https://github.com/kubernetes/website/pull/34902