### PR TITLE
[zh] Fix index misspelling of custom-resource-definitions.md

### DIFF
--- a/content/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1930,7 +1930,7 @@ Avoid nested lists and maps if possible where validation rules are used.
 <!--
 ### Defaulting
 -->
-### 设置默认值   {#efaulting}
+### 设置默认值   {#defaulting}
 
 {{< note >}}
 <!--


### PR DESCRIPTION
Signed-off-by: lonelyCZ <chengzhe@zju.edu.cn>

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fix index misspelling of custom-resource-definitions.md

https://kubernetes.io/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#efaulting
