### PR TITLE
AdmissionConfiguration is a static configuration to the apiserver

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -52,6 +52,9 @@ plugins:
       # Array of namespaces to exempt.
       namespaces: []
 ```
+{{< note >}}
+The above manifest needs to be specified via the `--admission-control-config-file` to kube-apiserver.
+{{< /note >}}
 
 {{< note >}}
 `pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.


### PR DESCRIPTION
We cannot use `kubectl apply` to apply it to the cluster.

Doing that gives the following error:

    no matches for kind "AdmissionConfiguration" in version "apiserver.config.k8s.io/v1"

---

/assign @tallclair
/assign @liggitt 