### PR TITLE
[ru] Update KubeCon dates for 2023

### DIFF
--- a/content/ru/_index.html
+++ b/content/ru/_index.html
@@ -43,12 +43,12 @@ Kubernetes — это проект с открытым исходным кодо
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Смотреть видео</button>
         <br>
         <br>
-         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna22" button id="desktopKCButton">Посетите KubeCon в Северной Америке, 24-28 октября 2022 года</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Европе, 18-21 апреля 2023 года</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2023/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu23" button id="desktopKCButton">Посетите KubeCon в Европе, 17-21 апреля 2023 года</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Северной Америке, 6-9 ноября 2023 года</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Updating KubeCon events links for the Russian website index page — propagating the changes from #38862.