### PR TITLE
[ko] Fix typo, It should be modified to 'replicas: 3'

### DIFF
--- a/content/ko/examples/service/access/backend-deployment.yaml
+++ b/content/ko/examples/service/access/backend-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       app: hello
       tier: backend
       track: stable
-  replicas: 7
+  replicas: 3
   template:
     metadata:
       labels:


### PR DESCRIPTION
'website/content/ko/examples/service/access/backend-deployment.yaml' different from   
'website/content/en/examples/service/access/backend-deployment.yaml'

It should be modified to 3 depending on the context.
[check here](https://github.com/kubernetes/website/edit/main/content/ko/docs/tasks/access-application-cluster/connecting-frontend-backend.md)
첫 pull request 로 일전에 main 에서 분기하여 main 에 병합요청 넣었던 것을 바로 잡아주셔서 감사합니다 😂