### PR TITLE
statefulset: explicit apiVersion and kind for volumeClaimTemplates

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -102,7 +102,9 @@ spec:
         - name: www
           mountPath: /usr/share/nginx/html
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: www
     spec:
       accessModes: [ "ReadWriteOnce" ]


### PR DESCRIPTION
The conversion introduced by https://github.com/kubernetes/kubernetes/pull/87706 [caused](https://github.com/kubernetes/kubernetes/pull/87706#issuecomment-1386012884) ServerSide-apply to generate a diff when the applied `volumeClaimTemplates` item has no `apiVersion`  or `kind` .

This PR recommends setting `apiVersion`  and `kind` .

See https://github.com/argoproj/argo-cd/issues/11143.