### PR TITLE
Update RBAC Good Practices for PersistentVolumes

### DIFF
--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -121,8 +121,12 @@ considered weak.
 
 ### Persistent volume creation
 
-As noted in the [PodSecurityPolicy](/docs/concepts/security/pod-security-policy/#volumes-and-file-systems)
-documentation, access to create PersistentVolumes can allow for escalation of access to the underlying host.
+Creation of PersistentVolumes includes creation of `hostPath`-typed volumes, providing access to the underlying host filesystem.
+
+There are many ways a container with unrestricted access to the host filesystem can escalate privileges, including 
+reading data from other containers, and abusing the credentials of system services, such as Kubelet.
+
+Only trusted users should be granted permission to create PersistentVolume objects.
 Where access to persistent storage is required trusted administrators should create 
 PersistentVolumes, and constrained users should use PersistentVolumeClaims to access that storage.
 

--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -130,10 +130,10 @@ reading data from other containers, and abusing the credentials of system servic
 
 You should only allow access to create PersistentVolume objects for:
 
-- users (cluster operators) that need this access for their work, and who you trust
-- the Kubernetes control plane, which creates PersistentVolumes based on PersistentVolumeClaims
+- users (cluster operators) that need this access for their work, and who you trust,
+- the Kubernetes control plane components which creates PersistentVolumes based on PersistentVolumeClaims
   that are configured for automatic provisioning.
-  (Kubernetes usually sets up that access for the control plane when you deploy a cluster).
+  This is usually setup by the Kubernetes provider or by the operator when installing a CSI driver.
 
 Where access to persistent storage is required trusted administrators should create 
 PersistentVolumes, and constrained users should use PersistentVolumeClaims to access that storage.

--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -128,7 +128,13 @@ to the underlying host filesystem(s) on the associated node. Granting that abili
 There are many ways a container with unrestricted access to the host filesystem can escalate privileges, including 
 reading data from other containers, and abusing the credentials of system services, such as Kubelet.
 
-Only trusted users should be granted permission to create PersistentVolume objects.
+You should only allow access to create PersistentVolume objects for:
+
+- users (cluster operators) that need this access for their work, and who you trust
+- the Kubernetes control plane, which creates PersistentVolumes based on PersistentVolumeClaims
+  that are configured for automatic provisioning.
+  (Kubernetes usually sets up that access for the control plane when you deploy a cluster).
+
 Where access to persistent storage is required trusted administrators should create 
 PersistentVolumes, and constrained users should use PersistentVolumeClaims to access that storage.
 

--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -121,7 +121,9 @@ considered weak.
 
 ### Persistent volume creation
 
-Creation of PersistentVolumes includes creation of `hostPath`-typed volumes, providing access to the underlying host filesystem.
+If someone - or some application - is allowed to create arbitrary PersistentVolumes, that access
+includes the creation of `hostPath` volumes, which then means that a Pod would get access
+to the underlying host filesystem(s) on the associated node. Granting that ability is a security risk.
 
 There are many ways a container with unrestricted access to the host filesystem can escalate privileges, including 
 reading data from other containers, and abusing the credentials of system services, such as Kubelet.


### PR DESCRIPTION
The docs previously referred to the reader to the now defunct PodSecurityPolicy page to explain how PersistentVolumes can be a path of privilege escalation, burrying the lede.

Now that PodSecurityPolicy is gone, update this bit to actually explain that it it is unfettered access to creating hostPath-typed PersistentVolumes that are a problem. Some words lifted from the 1.24 PodSecurityPolicy docs.

Signed-off-by: Mike Waychison <mike@waychison.com>
