### PR TITLE
[zh-cn] fix the shell of appending kubeconfig

### DIFF
--- a/content/zh-cn/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -523,7 +523,7 @@ For example:
 ### Linux
 
 ```shell
-export KUBECONFIG="${KUBECONFIG}:$HOME/.kube/config"
+export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/config"
 ```
 
 ### Windows Powershell


### PR DESCRIPTION
Add curly brackets to make the shell execute correctly