### PR TITLE
[zh] sync safely-drain-node.md

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/safely-drain-node.md
@@ -19,8 +19,9 @@ weight: 310
 <!-- overview -->
 <!-- 
 This page shows how to safely drain a node, respecting the PodDisruptionBudget you have defined.
- -->
-本页展示了如何在确保 PodDisruptionBudget 的前提下，安全地清空一个{{< glossary_tooltip text="节点" term_id="node" >}}。
+-->
+本页展示了如何在确保 PodDisruptionBudget 的前提下，
+安全地清空一个{{< glossary_tooltip text="节点" term_id="node" >}}。
 
 ## {{% heading "prerequisites" %}}
 
@@ -56,9 +57,10 @@ If availability is important for any applications that run or could run on the n
 that you are draining, [configure a PodDisruptionBudgets](/docs/tasks/run-application/configure-pdb/)
 first and then continue following this guide.
 -->
-## （可选） 配置干扰预算 {#configure-poddisruptionbudget}
+## （可选）配置干扰预算 {#configure-poddisruptionbudget}
 
-为了确保你的负载在维护期间仍然可用，你可以配置一个 [PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/)。
+为了确保你的负载在维护期间仍然可用，你可以配置一个
+[PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/)。
 如果可用性对于正在清空的该节点上运行或可能在该节点上运行的任何应用程序很重要，
 首先 [配置一个 PodDisruptionBudgets](/zh-cn/docs/tasks/run-application/configure-pdb/) 并继续遵循本指南。
 
@@ -74,19 +76,18 @@ and will respect the `PodDisruptionBudgets` you have specified.
 ## 使用 `kubectl drain` 从服务中删除一个节点 {#use-kubectl-drain-to-remove-a-node-from-service}
 
 在对节点执行维护（例如内核升级、硬件维护等）之前，
-可以使用 `kubectl drain` 从节点安全地逐出所有 Pods。
-安全的驱逐过程允许 Pod 的容器
-[体面地终止](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)，
-并确保满足指定的 PodDisruptionBudgets。
+可以使用 `kubectl drain` 从节点安全地逐出所有 Pod。
+安全的驱逐过程允许 Pod 的容器[体面地终止](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)，
+并确保满足指定的 `PodDisruptionBudgets`。
 
+{{< note >}}
 <!-- 
 By default `kubectl drain` will ignore certain system pods on the node
 that cannot be killed; see
 the [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
 documentation for more details.
 -->
-{{< note >}}
-默认情况下， `kubectl drain` 将忽略节点上不能杀死的特定系统 Pod；
+默认情况下，`kubectl drain` 将忽略节点上不能杀死的特定系统 Pod；
 有关更多细节，请参阅
 [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) 文档。
 {{< /note >}}
@@ -101,7 +102,7 @@ cloud platform, deleting its virtual machine.
 
 First, identify the name of the node you wish to drain. You can list all of the nodes in your cluster with
 -->
-`kubectl drain` 的成功返回，表明所有的 Pods（除了上一段中描述的被排除的那些），
+`kubectl drain` 的成功返回，表明所有的 Pod（除了上一段中描述的被排除的那些），
 已经被安全地逐出（考虑到期望的终止宽限期和你定义的 PodDisruptionBudget）。
 然后就可以安全地关闭节点，
 比如关闭物理机器的电源，如果它运行在云平台上，则删除它的虚拟机。
@@ -118,7 +119,7 @@ Next, tell Kubernetes to drain the node:
 接下来，告诉 Kubernetes 清空节点：
 
 ```shell
-kubectl drain --ignore-daemonsets <node name>
+kubectl drain --ignore-daemonsets <节点名称>
 ```
 
 <!--
@@ -129,12 +130,12 @@ the DaemonSet controller (part of the control plane) immediately replaces missin
 new equivalent Pods. The DaemonSet controller also creates Pods that ignore unschedulable
 taints, which allows the new Pods to launch onto a node that you are draining.
 -->
-如果存在由 DaemonSet 管理的 Pod，你需要使用 `kubectl` 指定 `--ignore-daemonsets` 才能成功腾空节点。
-`kubectl drain` 子命令本身并不会实际腾空节点上的 DaemonSet Pod：
-DaemonSet 控制器（控制平面的一部分）立即创建新的等效 Pod 替换丢失的 Pod。
-DaemonSet 控制器还会创建忽略不可调度污点的 Pod，这允许新的 Pod 启动到你正在腾空的节点上。
+如果存在 DaemonSet 管理的 Pod，你将需要为 `kubectl` 设置 `--ignore-daemonsets` 以成功地清空节点。
+`kubectl drain` 子命令自身实际上不清空节点上的 DaemonSet Pod 集合：
+DaemonSet 控制器（作为控制平面的一部分）会立即用新的等效 Pod 替换缺少的 Pod。
+DaemonSet 控制器还会创建忽略不可调度污点的 Pod，这种污点允许在你正在清空的节点上启动新的 Pod。
 
-<!-- 
+<!--
 Once it returns (without giving an error), you can power down the node
 (or equivalently, if on a cloud platform, delete the virtual machine backing the node).
 If you leave the node in the cluster during the maintenance operation, you need to run
@@ -149,7 +150,7 @@ kubectl uncordon <node name>
 <!-- 
 afterwards to tell Kubernetes that it can resume scheduling new pods onto the node.
 -->
-然后告诉 Kubernetes，它可以继续在此节点上调度新的 Pods。
+然后告诉 Kubernetes，它可以继续在此节点上调度新的 Pod。
 
 <!-- 
 ## Draining multiple nodes in parallel
@@ -164,7 +165,7 @@ respect the `PodDisruptionBudget` you specify.
 
  `kubectl drain` 命令一次只能发送给一个节点。
  但是，你可以在不同的终端或后台为不同的节点并行地运行多个 `kubectl drain` 命令。
- 同时运行的多个 drain 命令仍然遵循你指定的 PodDisruptionBudget 。
+ 同时运行的多个 drain 命令仍然遵循你指定的 `PodDisruptionBudget`。
 
 <!-- 
 For example, if you have a StatefulSet with three replicas and have
@@ -196,9 +197,10 @@ eviction API.
 For more information, see [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/).
 -->
 ## 驱逐 API {#the-eviction-api}
+
 如果你不喜欢使用
 [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
-（比如避免调用外部命令，或者更细化地控制 pod 驱逐过程），
+（比如避免调用外部命令，或者更细化地控制 Pod 驱逐过程），
 你也可以用驱逐 API 通过编程的方式达到驱逐的效果。
 更多信息，请参阅 [API 发起的驱逐](/zh-cn/docs/concepts/scheduling-eviction/api-eviction/)。
 
@@ -207,5 +209,5 @@ For more information, see [API-initiated eviction](/docs/concepts/scheduling-evi
 <!-- 
 * Follow steps to protect your application by [configuring a Pod Disruption Budget](/docs/tasks/run-application/configure-pdb/).
 -->
-* 执行[配置 PDB](/zh-cn/docs/tasks/run-application/configure-pdb/)中的各个步骤，
-  保护你的应用
+* 执行[配置 PDB](/zh-cn/docs/tasks/run-application/configure-pdb/) 中的各个步骤，
+  保护你的应用。


### PR DESCRIPTION
Sync with en.

```
content/zh-cn/docs/tasks/administer-cluster/safely-drain-node.md
```
Preview: https://deploy-preview-39018--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/administer-cluster/safely-drain-node/