### PR TITLE
[ja] Add ja to the paths of debug pages

### DIFF
--- a/content/ja/docs/concepts/containers/runtime-class.md
+++ b/content/ja/docs/concepts/containers/runtime-class.md
@@ -82,7 +82,7 @@ spec:
 ```
 
 これは、kubeletに対してPodを稼働させるためのRuntimeClassを使うように指示します。もし設定されたRuntimeClassが存在しない場合や、CRIが対応するハンドラーを実行できない場合、そのPodは`Failed`という[フェーズ](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)になります。
-エラーメッセージに関しては対応する[イベント](/docs/tasks/debug/debug-application/debug-running-pod/)を参照して下さい。
+エラーメッセージに関しては対応する[イベント](/ja/docs/tasks/debug/debug-application/debug-running-pod/)を参照して下さい。
 
 もし`runtimeClassName`が指定されていない場合、デフォルトのRuntimeHandlerが使用され、これはRuntimeClassの機能が無効であるときのふるまいと同じものとなります。
 
@@ -99,7 +99,7 @@ CRIランタイムのセットアップに関するさらなる詳細は、[CRI�
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${HANDLER_NAME}]
 ```
 
-詳細はcontainerdの[設定に関するドキュメント](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)を参照してください。 
+詳細はcontainerdの[設定に関するドキュメント](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)を参照してください。
 
 #### {{< glossary_tooltip term_id="cri-o" >}}
 

--- a/content/ja/docs/concepts/workloads/pods/ephemeral-containers.md
+++ b/content/ja/docs/concepts/workloads/pods/ephemeral-containers.md
@@ -42,7 +42,7 @@ weight: 80
 
 エフェメラルコンテナを利用する場合には、他のコンテナ内のプロセスにアクセスできるように、[プロセス名前空間の共有](/ja/docs/tasks/configure-pod-container/share-process-namespace/)を有効にすると便利です。
 
-エフェメラルコンテナを利用してトラブルシューティングを行う例については、[デバッグ用のエフェメラルコンテナを使用してデバッグする](/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container)を参照してください。
+エフェメラルコンテナを利用してトラブルシューティングを行う例については、[デバッグ用のエフェメラルコンテナを使用してデバッグする](/ja/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container)を参照してください。
 
 ## Ephemeral containers API
 

--- a/content/ja/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/ja/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -154,7 +154,7 @@ API用のetcdバックエンドへの書き込みアクセスは、クラスタ�
 
 ### 監査ログの有効
 
-[audit logger](/docs/tasks/debug/debug-cluster/audit/)はベータ版の機能で、APIによって行われたアクションを記録し、侵害があった場合に後から分析できるようにするものです。
+[audit logger](/ja/docs/tasks/debug/debug-cluster/audit/)はベータ版の機能で、APIによって行われたアクションを記録し、侵害があった場合に後から分析できるようにするものです。
 
 監査ログを有効にして、ログファイルを安全なサーバーにアーカイブすることをお勧めします。
 

--- a/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -234,7 +234,7 @@ WordPressのインストールをこのページのまま放置してはいけ�
 ## {{% heading "whatsnext" %}}
 
 
-* [イントロスペクションとデバッグ](/ja/docs/tasks/debug/debug-application)についてさらに学ぶ
+* [イントロスペクションとデバッグ](/ja/docs/tasks/debug/debug-application/debug-running-pod/)についてさらに学ぶ
 * [Job](/docs/concepts/workloads/controllers/job/)についてさらに学ぶ
 * [Portフォワーディング](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)についてさらに学ぶ
 * [コンテナへのシェルを取得する](/ja/docs/tasks/debug/debug-application/get-shell-running-container/)方法について学ぶ

--- a/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -234,7 +234,7 @@ WordPressのインストールをこのページのまま放置してはいけ�
 ## {{% heading "whatsnext" %}}
 
 
-* [イントロスペクションとデバッグ](/docs/tasks/debug/debug-application)についてさらに学ぶ
+* [イントロスペクションとデバッグ](/ja/docs/tasks/debug/debug-application)についてさらに学ぶ
 * [Job](/docs/concepts/workloads/controllers/job/)についてさらに学ぶ
 * [Portフォワーディング](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)についてさらに学ぶ
 * [コンテナへのシェルを取得する](/ja/docs/tasks/debug/debug-application/get-shell-running-container/)方法について学ぶ


### PR DESCRIPTION
Signed-off-by: Shogo Hida <shogo.hida@gmail.com>

Fixes #38797 

This PR changes the paths of debug pages. The example shown on the issue is below.

- Only add "/ja"
  - e.g.: /docs/tasks/debug/debug-cluster/audit/ -> /ja/docs/tasks/debug/debug-cluster/audit/

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
