### PR TITLE
[zh-cn]sync list-all-running-container-images.md

### DIFF
--- a/content/zh-cn/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -32,20 +32,20 @@ of Containers for each.
 在本练习中，你将使用 kubectl 来获取集群中运行的所有 Pod，并格式化输出来提取每个 Pod 中的容器列表。
 
 <!--
-## List all Containers in all namespaces
+## List all Container images in all namespaces
 
 - Fetch all Pods in all namespaces using `kubectl get pods --all-namespaces`
 - Format the output to include only the list of Container image names
   using `-o jsonpath={.items[*].spec.containers[*].image}`.  This will recursively parse out the
   `image` field from the returned json.
-  - See the [jsonpath reference](/docs/user-guide/jsonpath/)
+  - See the [jsonpath reference](/docs/reference/kubectl/jsonpath/)
     for further information on how to use jsonpath.
 - Format the output using standard tools: `tr`, `sort`, `uniq`
   - Use `tr` to replace spaces with newlines
   - Use `sort` to sort the results
   - Use `uniq` to aggregate image counts
 -->
-## 列出所有命名空间下的所有容器
+## 列出所有命名空间下的所有容器镜像
 
 - 使用 `kubectl get pods --all-namespaces` 获取所有命名空间下的所有 Pod
 - 使用 `-o jsonpath={.items[*].spec.containers[*].image}` 来格式化输出，以仅包含容器镜像名称。
@@ -80,7 +80,7 @@ jsonpath 解释如下：
 - `.image`: 获取镜像
 
 <!--
-When fetching a single Pod by name, e.g. `kubectl get pod nginx`,
+When fetching a single Pod by name, for example `kubectl get pod nginx`,
 the `.items[*]` portion of the path should be omitted because a single
 Pod is returned instead of a list of items.
 -->
@@ -105,12 +105,12 @@ sort
 ```
 
 <!--
-## List Containers filtering by Pod label
+## List Container images filtering by Pod label
 
 To target only Pods matching a specific label, use the -l flag.  The
 following matches only Pods with labels matching `app=nginx`.
 -->
-## 列出以标签过滤后的 Pod 的所有容器
+## 列出以标签过滤后的 Pod 的所有容器镜像
 
 要获取匹配特定标签的 Pod，请使用 -l 参数。以下匹配仅与标签 `app=nginx` 相符的 Pod。
 
@@ -119,12 +119,12 @@ kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].ima
 ```
 
 <!--
-## List Containers filtering by Pod namespace
+## List Container images filtering by Pod namespace
 
 To target only pods in a specific namespace, use the namespace flag. The
 following matches only Pods in the `kube-system` namespace.
 -->
-## 列出以命名空间过滤后的 Pod 的所有容器
+## 列出以命名空间过滤后的 Pod 的所有容器镜像
 
 要获取匹配特定命名空间的 Pod，请使用 namespace 参数。以下仅匹配 `kube-system` 命名空间下的 Pod。
 
@@ -133,12 +133,12 @@ kubectl get pods --namespace kube-system -o jsonpath="{.items[*].spec.containers
 ```
 
 <!--
-## List Containers using a go-template instead of jsonpath
+## List Container images using a go-template instead of jsonpath
 
 As an alternative to jsonpath, Kubectl supports using [go-templates](https://golang.org/pkg/text/template/)
 for formatting the output:
 -->
-## 使用 go-template 代替 jsonpath 来获取容器
+## 使用 go-template 代替 jsonpath 来获取容器镜像
 
 作为 jsonpath 的替代，Kubectl 支持使用 [go-templates](https://golang.org/pkg/text/template/) 来格式化输出：
 


### PR DESCRIPTION
Sync `content/zh-cn/docs/tasks/access-application-cluster/list-all-running-container-images.md` with en page.