### PR TITLE
[zh-cn] Use kubectl to wait for Jobs to succeed

### DIFF
--- a/content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -329,14 +329,19 @@ Events:
   33s          33s         1        {job-controller }                Normal      SuccessfulCreate  Created pod: job-wq-2-lglf8
 ```
 
-运行以下命令查看日志：
+<!--
+You can wait for the Job to succeed, with a timeout:
+-->
+你可以等待 Job 在某个超时时间后成功：
+
+```shell
+# 状况名称的检查不区分大小写
+kubectl wait --for=condition=complete --timeout=300s job/job-wq-2
+```
 
 ```shell
 kubectl logs pods/job-wq-2-7r7b2
 ```
-
-日志类似于：
-
 ```
 Worker with sessionID: bbd72d0a-9e5c-4dd6-abf6-416cc267991f
 Initial queue state: empty=False

--- a/content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md
+++ b/content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md
@@ -190,7 +190,7 @@ When you create this Job, the control plane creates a series of Pods, one for ea
 
 Because `.spec.parallelism` is less than `.spec.completions`, the control plane waits for some of the first Pods to complete before starting more of them.
 
-Once you have created the Job, wait a moment then check on progress:
+You can wait for the Job to succeed, with a timeout:
 -->
 当你创建此 Job 时，控制平面会创建一系列 Pod，你指定的每个索引都会运行一个 Pod。
 `.spec.parallelism` 的值决定了一次可以运行多少个 Pod，
@@ -199,7 +199,17 @@ Once you have created the Job, wait a moment then check on progress:
 因为 `.spec.parallelism` 小于 `.spec.completions`，
 所以控制平面在启动更多 Pod 之前，将等待第一批的某些 Pod 完成。
 
-创建 Job 后，稍等片刻，就能检查进度：
+你可以等待 Job 在某个超时时间后成功：
+
+```shell
+# 状况名称的检查不区分大小写
+kubectl wait --for=condition=complete --timeout=300s job/indexed-job
+```
+
+<!--
+Now, describe the Job and check that it was successful.
+-->
+现在，描述 Job 并检查它是否成功。
 
 ```shell
 kubectl describe jobs/indexed-job


### PR DESCRIPTION
Refer to PR https://github.com/kubernetes/website/pull/37596,

Sync two files:

`content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md`

`content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md`


And,

the file `content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md` has been synced in [PR #39020 37985](https://github.com/kubernetes/website/pull/37985/files#diff-a51dfada7551c3c8158e71f1710d9f7e6cad13167ed6a350791b8a2dd61e3acbR399)
