### PR TITLE
[ja] Update page weights under content/ja/docs/concepts/overview.

### DIFF
--- a/content/ja/docs/concepts/overview/kubernetes-api.md
+++ b/content/ja/docs/concepts/overview/kubernetes-api.md
@@ -2,7 +2,7 @@
 reviewers:
 title: Kubernetes API
 content_type: concept
-weight: 30
+weight: 40
 description: >
   Kubernetes APIを使用すると、Kubernetes内のオブジェクトの状態をクエリで操作できます。
   Kubernetesのコントロールプレーンの中核は、APIサーバーとそれが公開するHTTP APIです。ユーザー、クラスターのさまざまな部分、および外部コンポーネントはすべて、APIサーバーを介して互いに通信します。


### PR DESCRIPTION
This PR updates the page weights under content/ja/docs/concepts/overview.
This will update the page order to the same order as en.

Related: #37479

* kubernetes-api.md : Fix in this PR
* components.md : Fixed in #38547
* working-with-objects/field-selectors.md : Fix in #38913
* working-with-objects/namespaces.md : Fix in #38913

