### PR TITLE
Mentioned required cosign version for the `--certificate` flag

### DIFF
--- a/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
@@ -47,6 +47,9 @@ Then verify the blob by using `cosign`:
 cosign verify-blob "$BINARY" --signature "$BINARY".sig --certificate "$BINARY".cert
 ```
 
+cosign v1.9.0 is required to be able to use the `--certificate` flag. Please use
+`--cert` for older versions of cosign.
+
 {{< note >}}
 To learn more about keyless signing, please refer to [Keyless
 Signatures](https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures).


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/38473