### PR TITLE
Show minor (`.0`) releases in the patch releases calendar

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -11,6 +11,9 @@ schedules:
     - release: 1.26.1
       cherryPickDeadline: 2023-01-13
       targetDate: 2023-01-18
+    - release: 1.26.0
+      cherryPickDeadline: 2022-12-09
+      targetDate: 2022-12-09
 - release: 1.25
   releaseDate: 2022-08-23
   maintenanceModeStartDate: 2023-08-28
@@ -42,6 +45,9 @@ schedules:
       targetDate: 2022-09-14
       note: >-
         [Regression](https://groups.google.com/a/kubernetes.io/g/dev/c/tA6LNOQTR4Q/m/zL73maPTAQAJ)
+    - release: 1.25.0
+      cherryPickDeadline: 2022-08-23
+      targetDate: 2022-08-23
 - release: 1.24
   releaseDate: 2022-05-03
   maintenanceModeStartDate: 2023-05-28
@@ -85,6 +91,9 @@ schedules:
     - release: 1.24.1
       cherryPickDeadline: 2022-05-20
       targetDate: 2022-05-24
+    - release: 1.24.0
+      cherryPickDeadline: 2022-05-03
+      targetDate: 2022-05-03
 - release: 1.23
   releaseDate: 2021-12-07
   maintenanceModeStartDate: 2022-12-28
@@ -148,3 +157,6 @@ schedules:
     - release: 1.23.1
       cherryPickDeadline: 2021-12-14
       targetDate: 2021-12-16
+    - release: 1.23.0
+      cherryPickDeadline: 2021-12-07
+      targetDate: 2021-12-07

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -12,7 +12,7 @@ schedules:
       cherryPickDeadline: 2023-01-13
       targetDate: 2023-01-18
     - release: 1.26.0
-      cherryPickDeadline: 2022-12-09
+      cherryPickDeadline: ""
       targetDate: 2022-12-09
 - release: 1.25
   releaseDate: 2022-08-23
@@ -46,7 +46,7 @@ schedules:
       note: >-
         [Regression](https://groups.google.com/a/kubernetes.io/g/dev/c/tA6LNOQTR4Q/m/zL73maPTAQAJ)
     - release: 1.25.0
-      cherryPickDeadline: 2022-08-23
+      cherryPickDeadline: ""
       targetDate: 2022-08-23
 - release: 1.24
   releaseDate: 2022-05-03
@@ -92,7 +92,7 @@ schedules:
       cherryPickDeadline: 2022-05-20
       targetDate: 2022-05-24
     - release: 1.24.0
-      cherryPickDeadline: 2022-05-03
+      cherryPickDeadline: ""
       targetDate: 2022-05-03
 - release: 1.23
   releaseDate: 2021-12-07
@@ -158,5 +158,5 @@ schedules:
       cherryPickDeadline: 2021-12-14
       targetDate: 2021-12-16
     - release: 1.23.0
-      cherryPickDeadline: 2021-12-07
+      cherryPickDeadline: ""
       targetDate: 2021-12-07


### PR DESCRIPTION
This PR adds minor (`.0`) releases to the patch releases calendar. This is based on the Slack discussion: https://kubernetes.slack.com/archives/C2C40FMNF/p1674214109801969

We think it would be very useful to show release dates for the minor (`.0`) releases. Right now, this information is only available in the:

* `schedule.yaml` file
* sig-release repo

Neither of those places is easily accessible by maintainers and end users. The purpose of this change is to make this information easily accessible and discoverable.

I thought about two approaches for implementing this, described below.

#### Approach 1: add `.0` release date to the table

![image](https://user-images.githubusercontent.com/18719127/214329794-df025491-e071-44a3-8dd6-af985e805765.png)

This is my favorite approach because we keep the flow. At the top we show the latest patch release, going to the bottom where we show the first (`.0`) release. However, this approach has a problem:

I don't know what to put as a cherry-pick deadline date. Technically, we don't have cherry-pick deadline for minor releases, we only have a code freeze date, but I think it would be confusing to put the code freeze date as the cherry-pick deadline date. On the other side, I'm worried that leaving this field empty might break parsing the `schedule.yaml` file. In this PR, I decided to put the release date for the cherry-pick deadline. This might be an acceptable solution.

#### Approach 2: put it somewhere in the text

![image](https://user-images.githubusercontent.com/18719127/214331136-e0b6f327-f170-449e-a15b-99525233ebfd.png)

In this case, I extended the maintenance mode/EOL text with the release date. This approach doesn't require changing `schedule.yaml` (we already have a release date there), so from that standpoint, it's better. We also don't have to care about the cherry-pick deadline date. However, I preferred the first reason so that we have all releases in the table.

This PR implements the first approach, but I can easily modify it to the second approach (I already have the code ready).

/assign @jeremyrickard @justaugustus @Verolop @saschagrunert @cpanato @puerco 
cc @kubernetes/release-engineering @liggitt @sftim 
/hold for discussion