### PR TITLE
replace docker run with crictl run in etcd HA setup with kubeadm

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -274,7 +274,7 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
 1. Optional: Check the cluster health.
 
     ```sh
-    docker run --rm -it \
+    crictl run --rm -it \
     --net host \
     -v /etc/kubernetes:/etc/kubernetes registry.k8s.io/etcd:${ETCD_TAG} etcdctl \
     --cert /etc/kubernetes/pki/etcd/peer.crt \


### PR DESCRIPTION
Fix https://github.com/kubernetes/website/issues/36533, 
Kubernetes doesn't support Docker Engine natively any more. replace `docker` command with `crictl `