### PR TITLE
Clean up redirects for 'docs/user-guide/...' entries

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -82,7 +82,7 @@ needs to enable the `DefaultStorageClass`
 on the API server. This can be done, for example, by ensuring that `DefaultStorageClass` is
 among the comma-delimited, ordered list of values for the `--enable-admission-plugins` flag of
 the API server component. For more information on API server command-line flags,
-check [kube-apiserver](/docs/admin/kube-apiserver/) documentation.
+check [kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/) documentation.
 
 ### Binding
 

--- a/content/en/docs/reference/access-authn-authz/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-tls-bootstrapping.md
@@ -307,7 +307,7 @@ roleRef:
 ```
 
 The `csrapproving` controller that ships as part of
-[kube-controller-manager](/docs/admin/kube-controller-manager/) and is enabled
+[kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/) and is enabled
 by default. The controller uses the
 [`SubjectAccessReview` API](/docs/reference/access-authn-authz/authorization/#checking-api-access) to
 determine if a given user is authorized to request a CSR, then approves based on

--- a/content/en/docs/reference/glossary/kubeadm.md
+++ b/content/en/docs/reference/glossary/kubeadm.md
@@ -2,7 +2,7 @@
 title: Kubeadm
 id: kubeadm
 date: 2018-04-12
-full_link: /docs/admin/kubeadm/
+full_link: /docs/reference/setup-tools/kubeadm/
 short_description: >
   A tool for quickly installing Kubernetes and setting up a secure cluster.
 

--- a/content/en/docs/reference/glossary/kubectl.md
+++ b/content/en/docs/reference/glossary/kubectl.md
@@ -2,7 +2,7 @@
 title: Kubectl
 id: kubectl
 date: 2018-04-12
-full_link: /docs/user-guide/kubectl-overview/
+full_link: /docs/reference/kubectl/
 short_description: >
   A command line tool for communicating with a Kubernetes cluster.
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -84,7 +84,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
 
-                <p>Scaling out a Deployment will ensure new Pods are created and scheduled to Nodes with available resources. Scaling will increase the number of Pods to the new desired state. Kubernetes also supports <a href="/docs/user-guide/horizontal-pod-autoscaling/">autoscaling</a> of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also possible, and it will terminate all Pods of the specified Deployment.</p>
+                <p>Scaling out a Deployment will ensure new Pods are created and scheduled to Nodes with available resources. Scaling will increase the number of Pods to the new desired state. Kubernetes also supports <a href="/docs/tasks/run-application/horizontal-pod-autoscale/">autoscaling</a> of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also possible, and it will terminate all Pods of the specified Deployment.</p>
 
                 <p>Running multiple instances of an application will require a way to distribute the traffic to all of them. Services have an integrated load-balancer that will distribute network traffic to all Pods of an exposed Deployment. Services will monitor continuously the running Pods using endpoints, to ensure the traffic is sent only to available Pods.</p>
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -198,7 +198,6 @@
 
 /docs/roadmap/     https://github.com/kubernetes/kubernetes/milestones/ 301
 /docs/samples/     /docs/tutorials/ 301
-/docs/stable/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/ 301
 
 /docs/tasks/access-application-cluster/access-cluster.md     /docs/tasks/access-application-cluster/access-cluster/ 301!
 /docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/     /docs/tasks/access-application-cluster/configure-access-multiple-clusters/ 301
@@ -343,106 +342,7 @@
 /docs/tutorials/stateless-application/run-stateless-ap-replication-controller/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 /docs/tutorials/stateless-application/run-stateless-application-deployment/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 
-/docs/user-guide/     /docs/home/ 301
-/docs/user-guide/accessing-the-cluster/     /docs/tasks/access-application-cluster/access-cluster/ 301
-/docs/user-guide/add-entries-to-pod-etc-hosts-with-host-aliases/     /docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ 301
-/docs/user-guide/annotations/     /docs/concepts/overview/working-with-objects/annotations/ 301
-/docs/user-guide/application-troubleshooting/     /docs/tasks/debug/debug-application/debug-pods/ 301
-/docs/user-guide/compute-resources/     /docs/concepts/configuration/manage-compute-resources-container/ 301
-/docs/user-guide/config-best-practices/     /docs/concepts/configuration/overview/ 301
-/docs/user-guide/configmap/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
-/docs/user-guide/configmap/README/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
-/docs/user-guide/configuring-containers/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
-/docs/user-guide/connecting-applications/     /docs/tutorials/services/connect-applications-service/ 301
-/docs/user-guide/connecting-to-applications-port-forward/     /docs/tasks/access-application-cluster/port-forward-access-application-cluster/ 301
-/docs/user-guide/connecting-to-applications-proxy/     /docs/tasks/access-kubernetes-api/http-proxy-access-api/ 301
-/docs/user-guide/container-environment/     /docs/concepts/containers/container-lifecycle-hooks/ 301
-/docs/user-guide/containers/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
-/docs/user-guide/cron-jobs/     /docs/concepts/workloads/controllers/cron-jobs/ 301
-/docs/user-guide/debugging-pods-and-replication-controllers/     /docs/tasks/debug/debug-application/debug-pods/ 301
-/docs/user-guide/debugging-services/     /docs/tasks/debug/debug-application/debug-service/ 301
-/docs/user-guide/deploying-applications/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
-/docs/user-guide/deployments/     /docs/concepts/workloads/controllers/deployment/ 301
-/docs/user-guide/docker-cli-to-kubectl/     /docs/reference/kubectl/docker-cli-to-kubectl/
-/docs/user-guide/downward-api/     /docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/ 301
-/docs/user-guide/downward-api/README/     /docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/ 301
-/docs/user-guide/downward-api/volume/     /docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/ 301
-/docs/user-guide/environment-guide/     /docs/tasks/inject-data-application/environment-variable-expose-pod-information/ 301
-/docs/user-guide/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
-/docs/user-guide/garbage-collector/*     /docs/concepts/workloads/controllers/garbage-collection/ 301
-/docs/user-guide/gpus/     /docs/tasks/manage-gpus/scheduling-gpus/ 301
-/docs/user-guide/horizontal-pod-autoscaler/*     /docs/tasks/run-application/horizontal-pod-autoscale/ 301
-/docs/user-guide/horizontal-pod-autoscaling/     /docs/tasks/run-application/horizontal-pod-autoscale/ 301
-/docs/user-guide/horizontal-pod-autoscaling/walkthrough/     /docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ 301
-/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md     /docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ 301
-/docs/user-guide/identifiers/     /docs/concepts/overview/working-with-objects/names/ 301
-/docs/user-guide/images/     /docs/concepts/containers/images/ 301
-/docs/user-guide/ingress/     /docs/concepts/services-networking/ingress/ 301
-/docs/user-guide/ingress.md     /docs/concepts/services-networking/ingress/ 301
-/docs/user-guide/introspection-and-debugging/     /docs/tasks/debug/debug-application/debug-running-pod/ 301
-/docs/user-guide/jsonpath/     /docs/reference/kubectl/jsonpath/
-/docs/user-guide/jobs/     /docs/concepts/workloads/controllers/job/ 301
-/id/docs/user-guide/jobs/     /id/docs/concepts/workloads/controllers/job/ 301
-/docs/user-guide/jobs/expansions/     /docs/tasks/job/parallel-processing-expansion/ 301
-/docs/user-guide/jobs/work-queue-1/     /docs/tasks/job/coarse-parallel-processing-work-queue/ 301
-/docs/user-guide/jobs/work-queue-2/     /docs/tasks/job/fine-parallel-processing-work-queue/ 301
-/docs/user-guide/kubeconfig-file/     /docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/ 301
-/docs/user-guide/kubectl-overview/     /docs/reference/kubectl/ 301
-/docs/user-guide/kubectl/     /docs/reference/generated/kubectl/kubectl-options/
-/docs/user-guide/kubectl-conventions/     /docs/reference/kubectl/conventions/
-/docs/user-guide/kubectl-cheatsheet/     /docs/reference/kubectl/cheatsheet/
 /cheatsheet /docs/reference/kubectl/cheatsheet/ 302
-/docs/user-guide/kubectl/kubectl_*     /docs/reference/generated/kubectl/kubectl-commands#:splat 301
-/docs/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/ 301
-/docs/user-guide/liveness/     /docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ 301
-/docs/user-guide/load-balancer/     /docs/tasks/access-application-cluster/create-external-load-balancer/ 301
-/docs/user-guide/logging/     /docs/concepts/cluster-administration/logging/ 301
-/docs/user-guide/logging/overview/     /docs/concepts/cluster-administration/logging/ 301
-/docs/user-guide/managing-deployments/     /docs/concepts/cluster-administration/manage-deployment/ 301
-/docs/user-guide/monitoring/     /docs/tasks/debug/debug-cluster/resource-usage-monitoring/ 301
-/docs/user-guide/namespaces/     /docs/concepts/overview/working-with-objects/namespaces/ 301
-/docs/user-guide/networkpolicies/     /docs/concepts/services-networking/network-policies/ 301
-/docs/user-guide/node-selection/     /docs/concepts/scheduling-eviction/assign-pod-node/ 301
-/docs/user-guide/node-selection/README     /docs/concepts/scheduling-eviction/assign-pod-node/ 301
-/docs/user-guide/overview/     /docs/concepts/overview/what-is-kubernetes/ 301
-/docs/user-guide/persistent-volumes/     /docs/concepts/storage/persistent-volumes/ 301
-/docs/user-guide/persistent-volumes/index     /docs/concepts/storage/persistent-volumes/ 301
-/docs/user-guide/persistent-volumes/index.md     /docs/concepts/storage/persistent-volumes/ 301
-/docs/user-guide/persistent-volumes/walkthrough/     /docs/tasks/configure-pod-container/configure-persistent-volume-storage/ 301
-/docs/user-guide/pod-security-policy/     /docs/concepts/security/pod-security-policy/ 301
-/docs/user-guide/pod-states/     /docs/concepts/workloads/pods/pod-lifecycle/ 301
-/docs/user-guide/pod-templates/     /docs/concepts/workloads/pods/#pod-templates 301
-/docs/user-guide/pods/     /docs/concepts/workloads/pods/pod/ 301
-/docs/user-guide/pods/init-container/     /docs/concepts/workloads/pods/init-containers/ 301
-/docs/user-guide/pods/multi-container/     /docs/concepts/workloads/pods/#using-pods 301
-/docs/user-guide/pods/single-container/     /docs/concepts/workloads/pods/#using-pods 301
-/docs/user-guide/prereqs/     /docs/tasks/tools/install-kubectl/ 301
-/docs/user-guide/production-pods/     /docs/tasks/ 301
-/docs/user-guide/projected-volume/     /docs/tasks/configure-pod-container/configure-projected-volume-storage/ 301
-/docs/user-guide/quick-start/     /docs/tasks/access-application-cluster/service-access-application-cluster/ 301
-/docs/user-guide/replicasets/     /docs/concepts/workloads/controllers/replicaset/ 301
-/docs/user-guide/replication-controller/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
-/docs/user-guide/replication-controller/operations/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
-/docs/user-guide/resizing-a-replication-controller/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
-/docs/user-guide/rolling-updates/     /docs/tasks/run-application/rolling-update-replication-controller/ 301
-/docs/user-guide/scheduled-jobs/     /docs/concepts/workloads/controllers/cron-jobs/ 301
-/docs/user-guide/secrets/     /docs/concepts/configuration/secret/ 301
-/docs/user-guide/secrets/walkthrough/     /docs/tasks/inject-data-application/distribute-credentials-secure/ 301
-/docs/user-guide/security-context/     /docs/tasks/configure-pod-container/security-context/ 301
-/docs/user-guide/service-accounts/     /docs/tasks/configure-pod-container/configure-service-account/ 301
-/docs/user-guide/service-accounts/working-with-resources/     /docs/concepts/overview/object-management-kubectl/overview/ 301
-/docs/user-guide/services/     /docs/concepts/services-networking/service/ 301
-/docs/user-guide/services-firewalls/     /docs/tasks/access-application-cluster/configure-cloud-provider-firewall/ 301
-/docs/user-guide/services/operations/     /docs/tasks/access-application-cluster/connecting-frontend-backend/ 301
-/docs/user-guide/sharing-clusters/     /docs/tasks/administer-cluster/share-configuration/ 301
-/docs/user-guide/simple-nginx/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
-/docs/user-guide/StatefulSet/     /docs/concepts/workloads/controllers/statefulset/ 301
-/docs/user-guide/ui/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
-/docs/user-guide/ui-access/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
-/docs/user-guide/update-dem/     /docs/tasks/run-application/rolling-update-replication-controller/ 301
-/docs/user-guide/update-demo/     /docs/tasks/run-application/rolling-update-replication-controller/ 301
-/docs/user-guide/volumes/     /docs/concepts/storage/volumes/ 301
-/docs/user-guide/working-with-resources/     /docs/concepts/overview/object-management-kubectl/overview/ 301
 
 /docs/whatisk8s/     /docs/concepts/overview/what-is-kubernetes/ 301
 /events/     /docs/community     301

--- a/static/_redirects
+++ b/static/_redirects
@@ -23,50 +23,6 @@
 /zh-cn/docs/     /zh-cn/docs/home/ 301!
 /blog/2018/03/kubernetes-1.10-stabilizing-storage-security-networking/     /blog/2018/03/26/kubernetes-1.10-stabilizing-storage-security-networking/     301!
 /blog/2020/08/25/kubernetes-release-1.19-accentuate-the-paw-sitive/     /blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/     301!
-/docs/admin/     /docs/concepts/cluster-administration/ 301
-/docs/admin/add-ons/     /docs/concepts/cluster-administration/addons/ 301
-/docs/admin/addons/     /docs/concepts/cluster-administration/addons/ 301
-/docs/admin/apparmor/     /docs/tutorials/clusters/apparmor/ 301
-/docs/admin/audit/     /docs/tasks/debug/debug-cluster/audit/ 301
-/docs/admin/authorization/rbac.md     /docs/admin/authorization/rbac/ 301
-/docs/admin/cluster-components/     /docs/concepts/overview/components/ 301
-/docs/admin/cluster-management/     /docs/tasks/administer-cluster/ 302
-/id/docs/admin/cluster-management/     /id/docs/tasks/administer-cluster/ 302
-/docs/admin/cluster-troubleshooting/     /docs/tasks/debug/debug-cluster/ 301
-/docs/admin/daemons/     /docs/concepts/workloads/controllers/daemonset/ 301
-/docs/admin/disruptions/     /docs/concepts/workloads/pods/disruptions/ 301
-/docs/admin/dns/     /docs/concepts/services-networking/dns-pod-service/ 301
-/docs/admin/etcd/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
-/docs/admin/etcd_upgrade/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
-/docs/admin/extensible-admission-controllers.md     /docs/reference/access-authn-authz/extensible-admission-controllers/ 301
-/docs/admin/garbage-collection/     /docs/concepts/cluster-administration/kubelet-garbage-collection/ 301
-/docs/admin/ha-master-gce/     /docs/setup/production-environment/#production-control-plane 301
-/docs/admin/ha-master-gce.md/     /docs/setup/production-environment/#production-control-plane 301
-/docs/admin/high-availability/      /docs/setup/production-environment/tools/kubeadm/high-availability/   301
-/docs/admin/kubelet-authentication-authorization/     /docs/reference/access-authn-authz/kubelet-authn-authz/ 301
-/docs/admin/kubelet-tls-bootstrapping/     /docs/reference/access-authn-authz/kubelet-tls-bootstrapping/ 301
-/docs/admin/limitrange/     /docs/tasks/administer-cluster/cpu-memory-limit/ 301
-/docs/admin/limitrange/Limits/     /docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage/ 301
-/docs/admin/master-node-communication/     /docs/concepts/architecture/master-node-communication/ 301
-/docs/admin/multiple-schedulers/     /docs/tasks/administer-cluster/configure-multiple-schedulers/ 301
-/docs/admin/namespaces/     /docs/tasks/administer-cluster/namespaces/ 301
-/docs/admin/namespaces/walkthrough/     /docs/tasks/administer-cluster/namespaces-walkthrough/ 301
-/docs/admin/network-plugins/     /docs/concepts/cluster-administration/network-plugins/ 301
-/docs/admin/networking/     /docs/concepts/cluster-administration/networking/ 301
-/docs/admin/node/     /docs/concepts/architecture/nodes/ 301
-/docs/admin/node-allocatable/     /docs/tasks/administer-cluster/reserve-compute-resources/ 301
-/docs/admin/node-allocatable.md     /docs/tasks/administer-cluster/reserve-compute-resources/ 301
-/docs/admin/node-conformance.md     /docs/admin/node-conformance/ 301
-/docs/admin/node-conformance/       /docs/setup/best-practices/node-conformance/ 301
-/docs/admin/node-problem/     /docs/tasks/debug/debug-cluster/monitor-node-health/ 301
-/docs/admin/out-of-resource/     /docs/concepts/scheduling-eviction/node-pressure-eviction/ 301
-/docs/admin/rescheduler/     /docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/ 301
-/docs/admin/resourcequota/*     /docs/concepts/policy/resource-quotas/ 301
-/docs/admin/resourcequota/limitstorageconsumption/     /docs/tasks/administer-cluster/limit-storage-consumption/ 301
-/docs/admin/resourcequota/walkthrough/     /docs/tasks/administer-cluster/quota-api-object/ 301
-/docs/admin/static-pods/     /docs/tasks/administer-cluster/static-pod/ 301
-/docs/admin/sysctls/     /docs/tasks/administer-cluster/sysctl-cluster/ 301
-/docs/admin/resource-quota/     /docs/concepts/policy/resource-quotas/     301
 
 /docs/api/     /docs/concepts/overview/kubernetes-api/ 301
 
@@ -501,40 +457,17 @@
 /serviceaccount/token/     /docs/tasks/configure-pod-container/configure-service-account/ 301
 /third_party/swagger-ui/*     /docs/reference/ 301
 
-/docs/admin/cloud-controller-manager/     /docs/reference/generated/cloud-controller-manager/ 301
-/docs/admin/kube-apiserver/     /docs/reference/generated/kube-apiserver/ 301
-/docs/admin/kube-controller-manager/     /docs/reference/generated/kube-controller-manager/ 301
-/docs/admin/kube-proxy/     /docs/reference/generated/kube-proxy/ 301
-/docs/admin/kube-scheduler/     /docs/reference/generated/kube-scheduler/ 301
-/docs/admin/kubeadm/     /docs/reference/generated/kubeadm/ 301
-/docs/admin/kubelet/      /docs/reference/generated/kubelet/ 301
-
 /docs/reference/generated/kubeadm/     /docs/reference/setup-tools/kubeadm/ 301
 /docs/reference/setup-tools/kubeadm/kubeadm/     /docs/reference/setup-tools/kubeadm/ 301
 
 /editdocs/     /docs/contribute/     301
 /docs/home/editdocs/  /docs/contribute/ 301
 
-/docs/admin/accessing-the-api/     /docs/concepts/overview/kubernetes-api/ 301
-/docs/admin/admission-controllers/     /docs/reference/access-authn-authz/admission-controllers/ 301
-/docs/admin/authentication/     /docs/reference/access-authn-authz/authentication/ 301
-/docs/admin/bootstrap-tokens/     /docs/reference/access-authn-authz/bootstrap-tokens/ 301
-
-/docs/admin/extensible-admission-controllers/     /docs/reference/access-authn-authz/extensible-admission-controllers/ 301
-/docs/admin/service-accounts-admin/     /docs/reference/access-authn-authz/service-accounts-admin/ 301
-/docs/admin/authorization/abac/     /docs/reference/access-authn-authz/abac/ 301
-/docs/admin/authorization/node/     /docs/reference/access-authn-authz/node/ 301
-/docs/admin/authorization/rbac/     /docs/reference/access-authn-authz/rbac/ 301
-/docs/admin/authorization/webhook/     /docs/reference/access-authn-authz/webhook/ 301
-/docs/admin/authorization/     /docs/reference/access-authn-authz/authorization/ 301
-/docs/admin/high-availability/building/     /docs/setup/production-environment/tools/kubeadm/high-availability/   301
-
 /code-of-conduct/     /community/code-of-conduct/   301
 /values/     /community/values/   302
 
 /dockershim /blog/2022/02/17/dockershim-faq/ 302
 /dockershim/ /blog/2022/02/17/dockershim-faq/ 302
-
 
 /docs/setup/release/notes/     /releases/notes/   302
 /docs/setup/release/                 /releases/   301


### PR DESCRIPTION
This is the second PR for cleaning up old redirection entries that are more than 4 years old. The `docs/user-guide` directory was removed in June, 2018. It should be okay to remove these entries since those old bookmarks are no longer useful anyway.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
