### PR TITLE
updating Pod DNS config example to use documentation IP address

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -306,7 +306,7 @@ When the Pod above is created, the container `test` gets the following contents
 in its `/etc/resolv.conf` file:
 
 ```
-nameserver 1.2.3.4
+nameserver 192.0.2.1
 search ns1.svc.cluster-domain.example my.dns.search.suffix
 options ndots:2 edns0
 ```

--- a/content/en/examples/service/networking/custom-dns.yaml
+++ b/content/en/examples/service/networking/custom-dns.yaml
@@ -10,7 +10,7 @@ spec:
   dnsPolicy: "None"
   dnsConfig:
     nameservers:
-      - 192.0.2.1
+      - 192.0.2.1 # this is an example
     searches:
       - ns1.svc.cluster-domain.example
       - my.dns.search.suffix

--- a/content/en/examples/service/networking/custom-dns.yaml
+++ b/content/en/examples/service/networking/custom-dns.yaml
@@ -10,7 +10,7 @@ spec:
   dnsPolicy: "None"
   dnsConfig:
     nameservers:
-      - 1.2.3.4
+      - 192.0.2.1
     searches:
       - ns1.svc.cluster-domain.example
       - my.dns.search.suffix


### PR DESCRIPTION
Fix https://github.com/kubernetes/website/issues/39166
Problem:
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config uses 1.2.3.4 as the example DNS server. It's better to use an [IP address reserved for documentation](https://www.rfc-editor.org/rfc/rfc5737.html).

Proposed Solution:
Change the example manifest and web page to use IP address 192.0.2.1 ( from the 192.0.2.0/24 block)