### PR TITLE
Modify kube-scheduler/controller-manager port in jp install-kubeadm.md

### DIFF
--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -73,8 +73,8 @@ sysctl --system
 | TCP       | Inbound    | 6443*      | Kubernetes API server   | 全て                      |
 | TCP       | Inbound    | 2379-2380  | etcd server client API  | kube-apiserver、etcd      |
 | TCP       | Inbound    | 10250      | Kubelet API             | 自身、コントロールプレーン |
-| TCP       | Inbound    | 10251      | kube-scheduler          | 自身                      |
-| TCP       | Inbound    | 10252      | kube-controller-manager | 自身                      |
+| TCP       | Inbound    | 10259      | kube-scheduler          | 自身                      |
+| TCP       | Inbound    | 10257      | kube-controller-manager | 自身                      |
 
 ### ワーカーノード
 


### PR DESCRIPTION
The ports for kube-scheduler and kube-controller-manager built with kubeadm are different from the doc.

I think https://kubernetes.io/docs/reference/networking/ports-and-protocols/ is correct, so I have modified it to match.