### PR TITLE
Fix up 2023 SIG Instrumentation spotlight article

### DIFF
--- a/content/en/blog/_posts/2023-02-03-sig-instrumentation-spotlight.md
+++ b/content/en/blog/_posts/2023-02-03-sig-instrumentation-spotlight.md
@@ -10,7 +10,7 @@ canonicalUrl: https://www.kubernetes.dev/blog/2023/02/03/sig-instrumentation-spo
 
 Observability requires the right data at the right time for the right consumer (human or piece of software) to make the right decision. In the context of Kubernetes, having best practices for cluster observability across all Kubernetes components is crucial.
 
-SIG Instrumentation helps to address this issue by providing best practices and tools that all other SIGs use to instrument Kubernetes components-like the *Api server*, *scheduler*, *kubelet* and *kube-controller-manager*.
+SIG Instrumentation helps to address this issue by providing best practices and tools that all other SIGs use to instrument Kubernetes components-like the *API server*, *scheduler*, *kubelet* and *kube-controller-manager*.
 
 In this SIG Instrumentation spotlight, [Imran Noor Mohamed](https://www.linkedin.com/in/imrannoormohamed/), SIG ContribEx-Comms tech lead talked with [Elana Hashman](https://twitter.com/ehashdn), and [Han Kang](https://www.linkedin.com/in/hankang), chairs of SIG Instrumentation, on how the SIG is organized, what are the current challenges and how anyone can get involved and contribute. 
 


### PR DESCRIPTION
Correct a minor capitalization issue in upcoming article https://blog.k8s.io/2023/02/03/sig-instrumentation-spotlight-2023/

(fixing up https://github.com/kubernetes/website/pull/39204)

Equivalent to https://github.com/kubernetes/contributor-site/pull/372