### PR TITLE
Add cleanup commands to kubectl MacOS install

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -19,7 +19,6 @@ Using the latest compatible version of kubectl helps avoid unforeseen issues.
 
 The following methods exist for installing kubectl on macOS:
 
-- [{{% heading "prerequisites" %}}](#-heading-prerequisites-)
 - [Install kubectl on macOS](#install-kubectl-on-macos)
   - [Install kubectl binary with curl on macOS](#install-kubectl-binary-with-curl-on-macos)
   - [Install with Homebrew on macOS](#install-with-homebrew-on-macos)

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -19,9 +19,16 @@ Using the latest compatible version of kubectl helps avoid unforeseen issues.
 
 The following methods exist for installing kubectl on macOS:
 
-- [Install kubectl binary with curl on macOS](#install-kubectl-binary-with-curl-on-macos)
-- [Install with Homebrew on macOS](#install-with-homebrew-on-macos)
-- [Install with Macports on macOS](#install-with-macports-on-macos)
+- [{{% heading "prerequisites" %}}](#-heading-prerequisites-)
+- [Install kubectl on macOS](#install-kubectl-on-macos)
+  - [Install kubectl binary with curl on macOS](#install-kubectl-binary-with-curl-on-macos)
+  - [Install with Homebrew on macOS](#install-with-homebrew-on-macos)
+  - [Install with Macports on macOS](#install-with-macports-on-macos)
+- [Verify kubectl configuration](#verify-kubectl-configuration)
+- [Optional kubectl configurations and plugins](#optional-kubectl-configurations-and-plugins)
+  - [Enable shell autocompletion](#enable-shell-autocompletion)
+  - [Install `kubectl convert` plugin](#install-kubectl-convert-plugin)
+- [{{% heading "whatsnext" %}}](#-heading-whatsnext-)
 
 ### Install kubectl binary with curl on macOS
 
@@ -115,6 +122,12 @@ The following methods exist for installing kubectl on macOS:
 
    ```cmd
    kubectl version --client --output=yaml
+   ```
+
+1. After installing the plugin, clean up the installation files:
+
+   ```bash
+   rm kubectl kubectl.sha256
    ```
 
 ### Install with Homebrew on macOS
@@ -249,6 +262,12 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    ```
 
    If you do not see an error, it means the plugin is successfully installed.
+
+1. After installing the plugin, clean up the installation files:
+
+   ```bash
+   rm kubectl kubectl.sha256
+   ```
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Expands on the fixes for https://github.com/kubernetes/website/issues/38702

Modifying the kubectl install docs for MacOS per this https://github.com/kubernetes/website/issues/38702.

Gives instructions about how to delete static files that will no longer be used after the installation is complete.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
