### PR TITLE
Update config.toml in release-1.25 branch to change deprecated to true

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -143,7 +143,7 @@ fullversion = "v1.25.4"
 version = "v1.25"
 githubbranch = "main"
 docsbranch = "main"
-deprecated = false
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/38412
This PR updates the config.toml in the release-1.25 branch to change the deprecated field from false to true.
This will add a banner/box for users viewing the 1.25 docs that the 1.25 docs are no longer maintained.
At this time, the current release is 1.26