### PR TITLE
Remove what-next in install-kubectl-macos.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -27,7 +27,6 @@ The following methods exist for installing kubectl on macOS:
 - [Optional kubectl configurations and plugins](#optional-kubectl-configurations-and-plugins)
   - [Enable shell autocompletion](#enable-shell-autocompletion)
   - [Install `kubectl convert` plugin](#install-kubectl-convert-plugin)
-- [{{% heading "whatsnext" %}}](#-heading-whatsnext-)
 
 ### Install kubectl binary with curl on macOS
 


### PR DESCRIPTION
`whatsnext` does not belong to `The following methods exist for installing kubectl on macOS`.