### PR TITLE
[id] Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/content/id/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/id/docs/concepts/configuration/manage-compute-resources-container.md
@@ -314,7 +314,7 @@ Conditions:
 Events:
   FirstSeen                         LastSeen                         Count  From                              SubobjectPath                       Reason      Message
   Tue, 07 Jul 2015 12:53:51 -0700   Tue, 07 Jul 2015 12:53:51 -0700  1      {scheduler }                                                          scheduled   Successfully assigned simmemleak-hra99 to kubernetes-node-tf0f
-  Tue, 07 Jul 2015 12:53:51 -0700   Tue, 07 Jul 2015 12:53:51 -0700  1      {kubelet kubernetes-node-tf0f}    implicitly required container POD   pulled      Pod container image "k8s.gcr.io/pause:0.8.0" already present on machine
+  Tue, 07 Jul 2015 12:53:51 -0700   Tue, 07 Jul 2015 12:53:51 -0700  1      {kubelet kubernetes-node-tf0f}    implicitly required container POD   pulled      Pod container image "registry.k8s.io/pause:0.8.0" already present on machine
   Tue, 07 Jul 2015 12:53:51 -0700   Tue, 07 Jul 2015 12:53:51 -0700  1      {kubelet kubernetes-node-tf0f}    implicitly required container POD   created     Created with docker id 6a41280f516d
   Tue, 07 Jul 2015 12:53:51 -0700   Tue, 07 Jul 2015 12:53:51 -0700  1      {kubelet kubernetes-node-tf0f}    implicitly required container POD   started     Started with docker id 6a41280f516d
   Tue, 07 Jul 2015 12:53:51 -0700   Tue, 07 Jul 2015 12:53:51 -0700  1      {kubelet kubernetes-node-tf0f}    spec.containers{simmemleak}         created     Created with docker id 87348f12526a

--- a/content/id/docs/concepts/configuration/secret.md
+++ b/content/id/docs/concepts/configuration/secret.md
@@ -920,7 +920,7 @@ spec:
       secretName: dotfile-secret
   containers:
   - name: dotfile-test-container
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/busybox
     command:
     - ls
     - "-l"

--- a/content/id/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/id/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -67,7 +67,7 @@ metadata:
 spec:
   containers:
     - name: demo-container-1
-      image: k8s.gcr.io/pause:2.0
+      image: registry.k8s.io/pause:2.0
       resources:
         limits:
           hardware-vendor.example/foo: 2

--- a/content/id/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/id/docs/concepts/overview/working-with-objects/labels.md
@@ -116,7 +116,7 @@ metadata:
 spec:
   containers:
     - name: cuda-test
-      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      image: "registry.k8s.io/cuda-vector-add:v0.1"
       resources:
         limits:
           nvidia.com/gpu: 1

--- a/content/id/docs/concepts/policy/pod-security-policy.md
+++ b/content/id/docs/concepts/policy/pod-security-policy.md
@@ -165,7 +165,7 @@ metadata:
 spec:
   containers:
     - name:  pause
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
 EOF
 Error from server (Forbidden): error when creating "STDIN": pods "pause" is forbidden: unable to validate against any pod security policy: []
 ```
@@ -210,7 +210,7 @@ metadata:
 spec:
   containers:
     - name:  pause
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
 EOF
 pod "pause" created
 ```
@@ -226,7 +226,7 @@ metadata:
 spec:
   containers:
     - name:  pause
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
       securityContext:
         privileged: true
 EOF
@@ -244,7 +244,7 @@ kubectl-user delete pod pause
 Mari coba lagi, dengan cara yang sedikit berbeda:
 
 ```shell
-kubectl-user run pause --image=k8s.gcr.io/pause
+kubectl-user run pause --image=registry.k8s.io/pause
 deployment "pause" created
 
 kubectl-user get pods

--- a/content/id/docs/concepts/storage/persistent-volumes.md
+++ b/content/id/docs/concepts/storage/persistent-volumes.md
@@ -155,7 +155,7 @@ spec:
       path: /any/path/it/will/be/replaced
   containers:
   - name: pv-recycler
-    image: "k8s.gcr.io/busybox"
+    image: "registry.k8s.io/busybox"
     command: ["/bin/sh", "-c", "test -e /scrub && rm -rf /scrub/..?* /scrub/.[!.]* /scrub/*  && test -z \"$(ls -A /scrub)\" || exit 1"]
     volumeMounts:
     - name: vol

--- a/content/id/docs/concepts/storage/volumes.md
+++ b/content/id/docs/concepts/storage/volumes.md
@@ -94,7 +94,7 @@ metadata:
   name: test-ebs
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-ebs
@@ -164,7 +164,7 @@ metadata:
   name: test-cinder
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-cinder-container
     volumeMounts:
     - mountPath: /test-cinder
@@ -258,7 +258,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /cache
@@ -325,7 +325,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-pd
@@ -462,7 +462,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-pd
@@ -697,7 +697,7 @@ metadata:
   name: test-portworx-volume-pod
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /mnt
@@ -757,7 +757,7 @@ metadata:
   name: pod-0
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: pod-0
     volumeMounts:
     - mountPath: /test-pd
@@ -882,7 +882,7 @@ metadata:
   name: test-vmdk
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-vmdk

--- a/content/id/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/id/docs/concepts/workloads/controllers/statefulset.md
@@ -87,7 +87,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/content/id/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/id/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -268,7 +268,7 @@ spec:
   containers:
   - args:
     - /server
-    image: k8s.gcr.io/liveness
+    image: registry.k8s.io/liveness
     livenessProbe:
       httpGet:
         # ketika "host" tidak ditentukan, "PodIP" akan digunakan

--- a/content/id/docs/reference/kubectl/cheatsheet.md
+++ b/content/id/docs/reference/kubectl/cheatsheet.md
@@ -360,8 +360,8 @@ Contoh-contoh yang menggunakan `-o=custom-columns`:
 # All images running in a cluster
 kubectl get pods -A -o=custom-columns='DATA:spec.containers[*].image'
 
- # All images excluding "k8s.gcr.io/coredns:1.6.2"
-kubectl get pods -A -o=custom-columns='DATA:spec.containers[?(@.image!="k8s.gcr.io/coredns:1.6.2")].image'
+ # All images excluding "registry.k8s.io/coredns:1.6.2"
+kubectl get pods -A -o=custom-columns='DATA:spec.containers[?(@.image!="registry.k8s.io/coredns:1.6.2")].image'
 
 # All fields under metadata regardless of name
 kubectl get pods -A -o=custom-columns='DATA:metadata.*'

--- a/content/id/docs/tasks/administer-cluster/namespaces.md
+++ b/content/id/docs/tasks/administer-cluster/namespaces.md
@@ -185,7 +185,7 @@ Proses penghapusan ini asinkron, jadi untuk beberapa waktu kamu akan melihat Nam
     Untuk menunjukkan hal ini, mari kita jalankan Deployment dan Pod sederhana di dalam Namespace `development`.
 
     ```shell
-    kubectl create deployment snowflake --image=k8s.gcr.io/serve_hostname -n=development
+    kubectl create deployment snowflake --image=registry.k8s.io/serve_hostname -n=development
     kubectl scale deployment snowflake --replicas=2 -n=development
     ```
     Kita baru aja membuat sebuah Deployment yang memiliki ukuran replika dua yang menjalankan Pod dengan nama `snowflake` dengan sebuah Container dasar yang hanya melayani _hostname_.
@@ -221,7 +221,7 @@ Proses penghapusan ini asinkron, jadi untuk beberapa waktu kamu akan melihat Nam
     `Production` Namespace ingin menjalankan `cattle`, mari kita buat beberapa Pod `cattle`.
 
     ```shell
-    kubectl create deployment cattle --image=k8s.gcr.io/serve_hostname -n=production
+    kubectl create deployment cattle --image=registry.k8s.io/serve_hostname -n=production
     kubectl scale deployment cattle --replicas=5 -n=production
 
     kubectl get deployment -n=production

--- a/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -44,7 +44,7 @@ bertransisi ke _state_ yang rusak (_broken_), dan tidak dapat pulih kecuali diul
 Kubernetes menyediakan _probe liveness_ untuk mendeteksi dan memperbaiki situasi tersebut.
 
 Pada latihan ini, kamu akan membuat Pod yang menjalankan Container dari image
-`k8s.gcr.io/busybox`. Berikut ini adalah berkas konfigurasi untuk Pod tersebut:
+`registry.k8s.io/busybox`. Berikut ini adalah berkas konfigurasi untuk Pod tersebut:
 
 {{< codenew file="pods/probe/exec-liveness.yaml" >}}
 
@@ -84,8 +84,8 @@ Keluaran dari perintah tersebut memperlihatkan bahwa belum ada _probe liveness_ 
 FirstSeen    LastSeen    Count   From            SubobjectPath           Type        Reason      Message
 --------- --------    -----   ----            -------------           --------    ------      -------
 24s       24s     1   {default-scheduler }                    Normal      Scheduled   Successfully assigned liveness-exec to worker0
-23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulling     pulling image "k8s.gcr.io/busybox"
-23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulled      Successfully pulled image "k8s.gcr.io/busybox"
+23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulling     pulling image "registry.k8s.io/busybox"
+23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulled      Successfully pulled image "registry.k8s.io/busybox"
 23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Created     Created container with docker id 86849c15382e; Security:[seccomp=unconfined]
 23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Started     Started container with docker id 86849c15382e
 ```
@@ -103,8 +103,8 @@ mengalami kegagalan, dan Container telah dimatikan dan dibuat ulang.
 FirstSeen LastSeen    Count   From            SubobjectPath           Type        Reason      Message
 --------- --------    -----   ----            -------------           --------    ------      -------
 37s       37s     1   {default-scheduler }                    Normal      Scheduled   Successfully assigned liveness-exec to worker0
-36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulling     pulling image "k8s.gcr.io/busybox"
-36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulled      Successfully pulled image "k8s.gcr.io/busybox"
+36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulling     pulling image "registry.k8s.io/busybox"
+36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulled      Successfully pulled image "registry.k8s.io/busybox"
 36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Created     Created container with docker id 86849c15382e; Security:[seccomp=unconfined]
 36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Started     Started container with docker id 86849c15382e
 2s        2s      1   {kubelet worker0}   spec.containers{liveness}   Warning     Unhealthy   Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory
@@ -126,7 +126,7 @@ liveness-exec   1/1       Running   1          1m
 ## Mendefinisikan probe liveness dengan permintaan HTTP
 
 Jenis kedua dari _probe liveness_ menggunakan sebuah permintaan GET HTTP. Berikut ini
-berkas konfigurasi untuk Pod yang menjalankan Container dari image `k8s.gcr.io/liveness`.
+berkas konfigurasi untuk Pod yang menjalankan Container dari image `registry.k8s.io/liveness`.
 
 {{< codenew file="pods/probe/http-liveness.yaml" >}}
 

--- a/content/id/docs/tutorials/hello-minikube.md
+++ b/content/id/docs/tutorials/hello-minikube.md
@@ -77,7 +77,7 @@ Pod kamu dan melakukan <i>restart</i> saat Kontainer di dalam Pod tersebut mati.
 Pod menjalankan Kontainer sesuai dengan image Docker yang telah diberikan.
 
     ```shell
-    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
+    kubectl create deployment hello-node --image=registry.k8s.io/echoserver:1.4
     ```
 
 2. Lihat Deployment:

--- a/content/id/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/id/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -606,9 +606,9 @@ Dapatkan Pod untuk melihat _image_ Container-nya:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
-k8s.gcr.io/nginx-slim:0.8
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 
 ```
 
@@ -640,7 +640,7 @@ statefulset.apps/web patched
 Lakukan _patch_ terhadap StatefulSet lagi, untuk mengubah _image_ Container:
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"k8s.gcr.io/nginx-slim:0.7"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.7"}]'
 ```
 ```
 statefulset.apps/web patched
@@ -674,7 +674,7 @@ Dapatkan _image_ Container Pod:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 Perhatikan, walaupun strategi pembaruan yang digunakan adalah `RollingUpdate`,
@@ -714,7 +714,7 @@ Dapatkan _image_ Container Pod:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
 
 ```
 
@@ -757,7 +757,7 @@ Dapatkan _image_ Container dari Pod `web-1`:
 kubectl get pod web-1 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-k8s.gcr.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
 ```
 
 `web-1` dikembalikan ke konfigurasinya yang semula karena urutan Pod lebih kecil
@@ -813,9 +813,9 @@ Dapatkan detail _image_ Container dari Pod pada StatefulSet:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-k8s.gcr.io/nginx-slim:0.7
-k8s.gcr.io/nginx-slim:0.7
-k8s.gcr.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.7
 ```
 
 Dengan mengubah nilai `partition` menjadi `0`, kamu mengizinkan StatefulSet

--- a/content/id/examples/admin/dns/dnsutils.yaml
+++ b/content/id/examples/admin/dns/dnsutils.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
+    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
     command:
       - sleep
       - "3600"

--- a/content/id/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
+++ b/content/id/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
@@ -22,7 +22,7 @@ spec:
     - name: varlog
       mountPath: /var/log
   - name: count-agent
-    image: k8s.gcr.io/fluentd-gcp:1.30
+    image: registry.k8s.io/fluentd-gcp:1.30
     env:
     - name: FLUENTD_ARGS
       value: -c /etc/fluentd-config/fluentd.conf

--- a/content/id/examples/application/php-apache.yaml
+++ b/content/id/examples/application/php-apache.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: php-apache
-        image: k8s.gcr.io/hpa-example
+        image: registry.k8s.io/hpa-example
         ports:
         - containerPort: 80
         resources:

--- a/content/id/examples/application/web/web-parallel.yaml
+++ b/content/id/examples/application/web/web-parallel.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/content/id/examples/application/web/web.yaml
+++ b/content/id/examples/application/web/web.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/content/id/examples/pods/pod-configmap-env-var-valueFrom.yaml
+++ b/content/id/examples/pods/pod-configmap-env-var-valueFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "echo $(SPECIAL_LEVEL_KEY) $(SPECIAL_TYPE_KEY)" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/id/examples/pods/pod-configmap-envFrom.yaml
+++ b/content/id/examples/pods/pod-configmap-envFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       envFrom:
       - configMapRef:

--- a/content/id/examples/pods/pod-configmap-volume-specific-key.yaml
+++ b/content/id/examples/pods/pod-configmap-volume-specific-key.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh","-c","cat /etc/config/keys" ]
       volumeMounts:
       - name: config-volume

--- a/content/id/examples/pods/pod-configmap-volume.yaml
+++ b/content/id/examples/pods/pod-configmap-volume.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "ls /etc/config/" ]
       volumeMounts:
       - name: config-volume

--- a/content/id/examples/pods/pod-multiple-configmap-env-variable.yaml
+++ b/content/id/examples/pods/pod-multiple-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/id/examples/pods/pod-single-configmap-env-variable.yaml
+++ b/content/id/examples/pods/pod-single-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         # Tentukan variabel environment

--- a/content/id/examples/pods/pod-with-node-affinity.yaml
+++ b/content/id/examples/pods/pod-with-node-affinity.yaml
@@ -23,4 +23,4 @@ spec:
             - another-node-label-value
   containers:
   - name: with-node-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/id/examples/pods/pod-with-pod-affinity.yaml
+++ b/content/id/examples/pods/pod-with-pod-affinity.yaml
@@ -26,4 +26,4 @@ spec:
           topologyKey: failure-domain.beta.kubernetes.io/zone
   containers:
   - name: with-pod-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0

--- a/content/id/examples/pods/probe/exec-liveness.yaml
+++ b/content/id/examples/pods/probe/exec-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/busybox
     args:
     - /bin/sh
     - -c

--- a/content/id/examples/pods/probe/http-liveness.yaml
+++ b/content/id/examples/pods/probe/http-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/liveness
+    image: registry.k8s.io/liveness
     args:
     - /server
     livenessProbe:

--- a/content/id/examples/pods/probe/tcp-liveness-readiness.yaml
+++ b/content/id/examples/pods/probe/tcp-liveness-readiness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: goproxy
-    image: k8s.gcr.io/goproxy:0.1
+    image: registry.k8s.io/goproxy:0.1
     ports:
     - containerPort: 8080
     readinessProbe:

--- a/content/id/examples/pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml
+++ b/content/id/examples/pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml
@@ -23,4 +23,4 @@ spec:
             - zoneC
   containers:
   - name: pause
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.1

--- a/content/id/examples/pods/topology-spread-constraints/one-constraint.yaml
+++ b/content/id/examples/pods/topology-spread-constraints/one-constraint.yaml
@@ -14,4 +14,4 @@ spec:
         foo: bar
   containers:
   - name: pause
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.1

--- a/content/id/examples/pods/topology-spread-constraints/two-constraints.yaml
+++ b/content/id/examples/pods/topology-spread-constraints/two-constraints.yaml
@@ -20,4 +20,4 @@ spec:
         foo: bar
   containers:
   - name: pause
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.1


### PR DESCRIPTION
Split from #39236

Bahasa Indonesia changes only. I haven't verified that these are level with upstream (English); however, these changes are _equivalent_ and appropriate to make.

The example manifests _are_ level with English.