### PR TITLE
Announce Katacoda shutdown

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -130,3 +130,24 @@ announcements:
   message: |
     5 days of incredible opportunities to collaborate, learn + share with the entire community!<br />
     October 24 - 28, 2022.
+
+- name: Katacoda removal
+  startTime: 2023-03-27T08:00:00
+  endTime: 2023-04-04T00:00:00
+  # CNCF stone gray on a very dark blue
+  #
+  # A pastel yellow for the banner title
+  style: >-
+    background: #181834;
+    color: rgb(229,229,229);
+  title: |
+    <span style="color: #d6d693;">Shutdown of interactive tutorials</span>
+  message: |
+    The interactive tutorials on the Kubernetes website are being shut down.
+    The Kubernetes project hopes to reinstate a similar interactive learning option in the long term future.
+
+    The shutdown follows O'Reilly Media's 2019 [acquisition](https://www.oreilly.com/content/oreilly-acquires-katacoda-and-a-new-way-for-2-5m-customers-to-learn/) of Katacoda.
+    Kubernetes is grateful to O'Reilly and Katacoda for many years of helping
+    people take their first steps in learning Kubernetes.
+
+    The tutorials will cease to function after the 31<sup>st</sup> of March 2023.


### PR DESCRIPTION
Announce the removal of Katacoda. https://github.com/kubernetes/website/discussions/38878 tracks the discussion of potential replacements.

![Screenshot](https://user-images.githubusercontent.com/22591623/216783940-06ce7a7b-1127-4443-9bfc-19ce9c82e3fd.png)
_Preview_

WIP because the actual shutdown date is not agreed with O'Reilly yet.

Also relevant to PR #39414.