### PR TITLE
Add cleanup commands to kubectl Windows install

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -72,6 +72,12 @@ The following methods exist for installing kubectl on Windows:
    kubectl version --client --output=yaml
    ```
 
+1. After installing the plugin, clean up the installation files:
+
+   ```bash
+   del kubectl.exe kubectl.exe.sha256
+   ```
+
 {{< note >}}
 [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/#kubernetes) adds its own version of `kubectl` to `PATH`.
 If you have installed Docker Desktop before, you may need to place your `PATH` entry before the one added by the Docker Desktop installer or remove the Docker Desktop's `kubectl`.
@@ -190,6 +196,12 @@ Below are the procedures to set up autocompletion for PowerShell.
    ```
 
    If you do not see an error, it means the plugin is successfully installed.
+
+1. After installing the plugin, clean up the installation files:
+
+   ```bash
+   del kubectl-convert.exe kubectl-convert.exe.sha256
+   ```
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -74,7 +74,7 @@ The following methods exist for installing kubectl on Windows:
 
 1. After installing the plugin, clean up the installation files:
 
-   ```bash
+   ```powershell
    del kubectl.exe kubectl.exe.sha256
    ```
 
@@ -199,7 +199,7 @@ Below are the procedures to set up autocompletion for PowerShell.
 
 1. After installing the plugin, clean up the installation files:
 
-   ```bash
+   ```powershell
    del kubectl-convert.exe kubectl-convert.exe.sha256
    ```
 


### PR DESCRIPTION
Expands on the fixes for https://github.com/kubernetes/website/issues/38702

Modifying the kubectl install docs for Windows per this issue: https://github.com/kubernetes/website/issues/38702.

Gives instructions about how to delete static files that will no longer be used after the installation is complete.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
