### PR TITLE
Update MutatingWebhookConfiguration example to match surrounding text

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -605,7 +605,7 @@ webhooks:
   - operations: ["CREATE"]
     apiGroups: ["*"]
     apiVersions: ["*"]
-    resources: ["*"]
+    resources: ["*/*"]
     scope: "*"
 ```
 


### PR DESCRIPTION
Currently the explanation text says "would match a `CREATE` of any resource with the label `foo: bar`:" but it was previously only matching [resources, not subresources](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules).
This rectifies that