### PR TITLE
Improve grammar in etcd glossary

### DIFF
--- a/content/en/docs/reference/glossary/etcd.md
+++ b/content/en/docs/reference/glossary/etcd.md
@@ -17,6 +17,6 @@ tags:
 
 If your Kubernetes cluster uses etcd as its backing store, make sure you have a
 [back up](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster) plan
-for those data.
+for the data.
 
 You can find in-depth information about etcd in the official [documentation](https://etcd.io/docs/).


### PR DESCRIPTION
# Summary

Microscopic fix in the `etcd` glossary entry. The use of `the` rather than `those` data makes more sense, as in this context `data` is a single object. 

Thank you! 