### PR TITLE
[zh] sync /workloads/pods/_index.md

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/pods/_index.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/_index.md
@@ -537,23 +537,8 @@ Pod 中的容器所看到的系统主机名与为 Pod 配置的 `name` 属性值
 
 <!--
 ## Privileged mode for containers
-
-In Linux, any container in a Pod can enable privileged mode using the `privileged` (Linux) flag on the [security context](/docs/tasks/configure-pod-container/security-context/) of the container spec. This is useful for containers that want to use operating system administrative capabilities such as manipulating the network stack or accessing hardware devices.
-
-If your cluster has the `WindowsHostProcessContainers` feature enabled, you can create a [Windows HostProcess pod](/docs/tasks/configure-pod-container/create-hostprocess-pod) by setting the `windowsOptions.hostProcess` flag on the security context of the pod spec. All containers in these pods must run as Windows HostProcess containers. HostProcess pods run directly on the host and can also be used to perform administrative tasks as is done with Linux privileged containers.
 -->
 ## 容器的特权模式     {#privileged-mode-for-containers}
-
-在 Linux 中，Pod 中的任何容器都可以使用容器规约中的
-[安全性上下文](/zh-cn/docs/tasks/configure-pod-container/security-context/)中的
-`privileged`（Linux）参数启用特权模式。
-这对于想要使用操作系统管理权能（Capabilities，如操纵网络堆栈和访问设备）的容器很有用。
-
-如果你的集群启用了 `WindowsHostProcessContainers` 特性，你可以使用 Pod 规约中安全上下文的
-`windowsOptions.hostProcess` 参数来创建
-[Windows HostProcess Pod](/zh-cn/docs/tasks/configure-pod-container/create-hostprocess-pod/)。
-这些 Pod 中的所有容器都必须以 Windows HostProcess 容器方式运行。
-HostProcess Pod 可以直接运行在主机上，它也能像 Linux 特权容器一样，用于执行管理任务。
 
 {{< note >}}
 <!--
@@ -561,6 +546,49 @@ Your {{< glossary_tooltip text="container runtime" term_id="container-runtime" >
 -->
 你的{{< glossary_tooltip text="容器运行时" term_id="container-runtime" >}}必须支持特权容器的概念才能使用这一配置。
 {{< /note >}}
+
+<!--
+Any container in a pod can run in privileged mode to use operating system administrative capabilities
+that would otherwise be inaccessible. This is available for both Windows and Linux.
+-->
+Pod 中的所有容器都可以在特权模式下运行，以使用原本无法访问的操作系统管理权能。
+此模式同时适用于 Windows 和 Linux。
+
+<!--
+### Linux priviledged containers
+
+In Linux, any container in a Pod can enable privileged mode using the `privileged` (Linux) flag
+on the [security context](/docs/tasks/configure-pod-container/security-context/) of the
+container spec. This is useful for containers that want to use operating system administrative
+capabilities such as manipulating the network stack or accessing hardware devices.
+-->
+### Linux 特权容器   {#linux-priviledged-containers}
+
+在 Linux 中，Pod 中的所有容器都可以使用容器规约中的
+[安全性上下文](/zh-cn/docs/tasks/configure-pod-container/security-context/)中的
+`privileged`（Linux）参数启用特权模式。
+这对于想要使用操作系统管理权能（Capabilities，如操纵网络堆栈和访问硬件设备）的容器很有用。
+
+<!--
+### Windows priviledged containers
+-->
+### Windows 特权容器   {#windows-priviledged-containers}
+
+{{< feature-state for_k8s_version="v1.26" state="stable" >}}
+
+<!--
+In Windows, you can create a [Windows HostProcess pod](/docs/tasks/configure-pod-container/create-hostprocess-pod)
+by setting the `windowsOptions.hostProcess` flag on the security context of the pod spec. All containers in these
+pods must run as Windows HostProcess containers. HostProcess pods run directly on the host and can also be used
+to perform administrative tasks as is done with Linux privileged containers. In order to use this feature, the
+`WindowsHostProcessContainers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
+-->
+在 Windows 中，你可以使用 Pod 规约中安全上下文的 `windowsOptions.hostProcess` 参数来创建
+[Windows HostProcess Pod](/zh-cn/docs/tasks/configure-pod-container/create-hostprocess-pod/)。
+这些 Pod 中的所有容器都必须以 Windows HostProcess 容器方式运行。
+HostProcess Pod 可以直接运行在主机上，它也能像 Linux 特权容器一样，用于执行管理任务。
+想要使用此特性，`WindowsHostProcessContainers`
+[特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)必须被启用。
 
 <!--
 ## Static Pods


### PR DESCRIPTION
Sync with en #38673 and #39324 . 
See [preview](https://deploy-preview-39323--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/workloads/pods/).
```
content/zh-cn/docs/concepts/workloads/pods/_index.md
```