### PR TITLE
Updated concepts/workloads/pods/_index.html as followup to PR 38673

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -296,14 +296,14 @@ Your {{< glossary_tooltip text="container runtime" term_id="container-runtime" >
 Any container in a pod can run in privileged mode to use operating system administrative capabilities
 that would otherwise be inaccessible. This is available for both Windows and Linux.
 
-### Linux containers
+### Linux priviledged containers
 
 In Linux, any container in a Pod can enable privileged mode using the `privileged` (Linux) flag
 on the [security context](/docs/tasks/configure-pod-container/security-context/) of the
 container spec. This is useful for containers that want to use operating system administrative
 capabilities such as manipulating the network stack or accessing hardware devices.
 
-### Windows containers
+### Windows priviledged containers
 
 {{< feature-state for_k8s_version="v1.26" state="stable" >}}
 
@@ -311,7 +311,7 @@ In Windows, you can create a [Windows HostProcess pod](/docs/tasks/configure-pod
 by setting the `windowsOptions.hostProcess` flag on the security context of the pod spec. All containers in these
 pods must run as Windows HostProcess containers. HostProcess pods run directly on the host and can also be used
 to perform administrative tasks as is done with Linux privileged containers. In order to use this feature, the
-`WindowsHostProcessContainers`[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
+`WindowsHostProcessContainers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
 
 
 ## Static Pods


### PR DESCRIPTION
This PR is a follow-up to PR https://github.com/kubernetes/website/pull/38673
Addresses the following comments:
- https://github.com/kubernetes/website/pull/38673/files#r1098354034
  -  Have clearer subheadings to prevent any confusion on the feature/enhancement that went stable in 1.26
See the KEP for Windows privileged container support: https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support

- https://github.com/kubernetes/website/pull/38673/files#r1068961877
  - add a space between a feature gate and a link

Preview of updated page: https://deploy-preview-39324--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/pods/