### PR TITLE
Adjust CSS for Bing search result page

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -878,3 +878,17 @@ div.alert > em.javascript-required {
     color: #fff;
     background: #326de6;
 }
+
+// Adjust Bing search result page
+#bing-results-container {
+    padding: 1em;
+}
+#bing-pagination-container {
+    padding: 1em;
+    margin-bottom: 1em;
+
+    a.bing-page-anchor {
+        padding: 0.5em;
+        margin: 0.25em;
+    }
+}


### PR DESCRIPTION
resolves #21924

## Before
<img width="1246" alt="Screenshot 2023-02-08 at 17 54 22" src="https://user-images.githubusercontent.com/1425259/217481753-4cc5bb36-0877-48f8-8431-e6577bcf774b.png">

## After
<img width="1243" alt="Screenshot 2023-02-08 at 17 54 17" src="https://user-images.githubusercontent.com/1425259/217481763-a56919cb-0a7c-42de-937e-ee0d3af08ef8.png">

## How to test

You can show Bing search results by setting the cookie `is_china` to `True` on Dev Tool (the below is Google Chrome example):

<img width="537" alt="Screenshot 2023-02-08 at 17 53 30" src="https://user-images.githubusercontent.com/1425259/217481776-42fdf8cd-f977-486e-9f4b-f671e26a0272.png">
