### PR TITLE
Update volume mode change annotation in documentation

### DIFF
--- a/content/en/docs/concepts/storage/volume-snapshots.md
+++ b/content/en/docs/concepts/storage/volume-snapshots.md
@@ -227,7 +227,7 @@ $ kubectl get crd volumesnapshotcontent -o yaml
 
 If you want to allow users to create a `PersistentVolumeClaim` from an existing
 `VolumeSnapshot`, but with a different volume mode than the source, the annotation
-`snapshot.storage.kubernetes.io/allowVolumeModeChange: "true"`needs to be added to
+`snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"`needs to be added to
 the `VolumeSnapshotContent` that corresponds to the `VolumeSnapshot`.
 
 For pre-provisioned snapshots, `spec.sourceVolumeMode` needs to be populated
@@ -241,7 +241,7 @@ kind: VolumeSnapshotContent
 metadata:
   name: new-snapshot-content-test
   annotations:
-    - snapshot.storage.kubernetes.io/allowVolumeModeChange: "true"
+    - snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"
 spec:
   deletionPolicy: Delete
   driver: hostpath.csi.k8s.io

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -844,9 +844,9 @@ you through the steps you follow to apply a seccomp profile to a Pod or to one o
 its containers. That tutorial covers the supported mechanism for configuring seccomp in Kubernetes,
 based on setting `securityContext` within the Pod's `.spec`.
 
-### snapshot.storage.kubernetes.io/allowVolumeModeChange
+### snapshot.storage.kubernetes.io/allow-volume-mode-change
 
-Example: `snapshot.storage.kubernetes.io/allowVolumeModeChange: "true"`
+Example: `snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"`
 
 Used on: VolumeSnapshotContent
 


### PR DESCRIPTION
This PR updates the volume snapshot documentation to account for the change in annotation name to allow volume mode changes in a provision operation. KEP - https://github.com/kubernetes/enhancements/issues/3141

PR that changed the annotation name - https://github.com/kubernetes-csi/external-provisioner/pull/791 