### PR TITLE
Fix broken link on Kubernetes Gateway API Graduates to Beta page

### DIFF
--- a/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
+++ b/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
@@ -145,7 +145,7 @@ workstream within the Gateway API subproject focused on Gateway API for Mesh
 Management and Administration.
 
 This group will deliver [enhancement
-proposals](https://gateway-api.sigs.k8s.io/v1beta1/contributing/gep/) consisting
+proposals](https://gateway-api.sigs.k8s.io/geps/overview/) consisting
 of resources, additions, and modifications to the Gateway API specification for
 mesh and mesh-adjacent use-cases.
 


### PR DESCRIPTION
Fixes #39373

Updated page [Kubernetes Gateway API Graduates to Beta](https://kubernetes.io/blog/2022/07/13/gateway-api-graduates-to-beta/)