### PR TITLE
Update for kubectl events command

### DIFF
--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -136,7 +136,7 @@ Operation       | Syntax    |       Description
 `diff`        | `kubectl diff -f FILENAME [flags]`| Diff file or stdin against live configuration.
 `drain`    | `kubectl drain NODE [options]` | Drain node in preparation for maintenance.
 `edit`        | <code>kubectl edit (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) [flags]</code> | Edit and update the definition of one or more resources on the server by using the default editor.
-`events`      | `kubectl events` | List events
+`events`      | `kubectl get events` | List events
 `exec`        | `kubectl exec POD [-c CONTAINER] [-i] [-t] [flags] [-- COMMAND [args...]]` | Execute a command against a container in a pod.
 `explain`    | `kubectl explain  [--recursive=false] [flags]` | Get documentation of various resources. For instance pods, nodes, services, etc.
 `expose`        | <code>kubectl expose (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) [--port=port] [--protocol=TCP&#124;UDP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type] [flags]</code> | Expose a replication controller, service, or pod as a new Kubernetes service.


### PR DESCRIPTION
Update `kubectl events` as `kubectl get events` 

`
❯ kubectl version --short
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Client Version: v1.25.2
Kustomize Version: v4.5.7
Server Version: v1.25.2

❯ kubectl events
error: unknown command "events" for "kubectl"

❯ kubectl get events
LAST SEEN   TYPE      REASON                    OBJECT                MESSAGE
11m         Normal    Starting                  node/docker-desktop   Starting kubelet.
`
