### PR TITLE
Add markup to fix skew output in documentation

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
+++ b/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
@@ -18,7 +18,7 @@ admission controller. This can be done effectively using a combination of dry-ru
 {{% version-check %}}
 
 If you are currently running a version of Kubernetes other than
-{{ skew currentVersion }}, you may want to switch to viewing this
+{{< skew currentVersion >}}, you may want to switch to viewing this
 page in the documentation for the version of Kubernetes that you
 are actually running.
 


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/#before-you-begin

<img width="661" alt="image" src="https://user-images.githubusercontent.com/2119212/218288877-23953019-7c93-4bd5-975f-40d67ad49eb1.png">
