### PR TITLE
[zh-cn] Resync 2022-05-27-maxunavailable-for-statefulset.md

### DIFF
--- a/content/zh-cn/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
+++ b/content/zh-cn/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
@@ -14,6 +14,8 @@ slug: maxunavailable-for-statefulset
 -->
 **作者：** Mayank Kumar (Salesforce)
 
+**译者：** Xiaoyang Zhang（Huawei）
+
 <!--
 Kubernetes [StatefulSets](/docs/concepts/workloads/controllers/statefulset/), since their introduction in 
 1.5 and becoming stable in 1.9, have been widely used to run stateful applications. They provide stable pod identity, persistent
@@ -33,7 +35,7 @@ Kubernetes [StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/
 Here are some examples:
 
 -  I am using a StatefulSet to orchestrate a multi-instance, cache based application where the size of the cache is large. The cache 
-   starts cold and requires some siginificant amount of time before the container can start. There could be more initial startup tasks
+   starts cold and requires some significant amount of time before the container can start. There could be more initial startup tasks
    that are required. A RollingUpdate on this StatefulSet would take a lot of time before the application is fully updated. If the 
    StatefulSet supported updating more than one pod at a time, it would result in a much faster update.
 -->
@@ -82,7 +84,8 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: k8s.gcr.io/nginx-slim:0.8
+      # 镜像自发布以来已更改（以前使用的仓库为 "k8s.gcr.io"）
+      - image: registry.k8s.io/nginx-slim:0.8
         imagePullPolicy: IfNotPresent
         name: nginx
   updateStrategy:
@@ -107,15 +110,15 @@ has 5 replicas, with `maxUnavailable` set to 2 and `partition` set to 0.
 `maxUnavailable` 设置为 2 并将 `partition` 设置为 0。
 
 <!--
-I can trigger a rolling update by changing the image to `k8s.gcr.io/nginx-slim:0.9`. Once I initiate the rolling update, I can 
+I can trigger a rolling update by changing the image to `registry.k8s.io/nginx-slim:0.9`. Once I initiate the rolling update, I can 
 watch the pods update 2 at a time as the current value of maxUnavailable is 2. The below output shows a span of time and is not 
 complete.  The maxUnavailable can be an absolute number (for example, 2) or a percentage of desired Pods (for example, 10%). The 
-absolute number is calculated from percentage by rounding down. 
+absolute number is calculated from percentage by rounding up to the nearest integer.
 -->
-我可以通过将镜像更改为 `k8s.gcr.io/nginx-slim:0.9` 来触发滚动更新。一旦开始滚动更新，
+我可以通过将镜像更改为 `registry.k8s.io/nginx-slim:0.9` 来触发滚动更新。一旦开始滚动更新，
 就可以看到一次更新 2 个 Pod，因为 `maxUnavailable` 的当前值是 2。
 下面的输出显示了一个时间段内的结果，但并不是完整过程。`maxUnavailable` 可以是绝对数值（例如 2）或所需 Pod
-的百分比（例如 10%），绝对数是通过百分比计算结果进行四舍五入得出的。
+的百分比（例如 10%），绝对数是通过百分比计算结果进行四舍五入到最接近的整数得出的。
 
 ```
 kubectl get pods --watch 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Part of https://github.com/kubernetes/website/issues/39417

Here is the [preview page](https://deploy-preview-39420--kubernetes-io-main-staging.netlify.app/zh-cn/blog/2022/05/13/grpc-probes-now-in-beta/).