### PR TITLE
Fix wording, punctuation and Markdown for ServiceAccount concept page

### DIFF
--- a/content/en/docs/concepts/security/service-accounts.md
+++ b/content/en/docs/concepts/security/service-accounts.md
@@ -209,7 +209,7 @@ checks the token against the Secret.
 For more information about the authentication process, refer to
 [Authentication](/docs/reference/access-authn-authz/authentication/#service-account-tokens).
 
-### Authenticating service account credentials in your own code {authenticating-in-code}
+### Authenticating service account credentials in your own code {#authenticating-in-code}
 
 If you have services of your own that need to validate Kubernetes service
 account credentials, you can use the following methods:


### PR DESCRIPTION
Fixups for PR #38289

Fixes #28285 

Page changed: https://kubernetes.io/docs/concepts/security/service-accounts/