### PR TITLE
Add a note indicating when nodeName should be used

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -461,6 +461,12 @@ Some of the limitations of using `nodeName` to select nodes are:
 -   Node names in cloud environments are not always predictable or
     stable.
 
+{{< note >}}
+`nodeName` is intended for use by custom schedulers or advanced use cases where
+you need to bypass any configured schedulers. Using affinity or a `nodeSelector` is 
+the recommended way to assign a pod to a node.
+{{</ note >}}
+
 Here is an example of a Pod spec using the `nodeName` field:
 
 ```yaml

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -463,8 +463,8 @@ Some of the limitations of using `nodeName` to select nodes are:
 
 {{< note >}}
 `nodeName` is intended for use by custom schedulers or advanced use cases where
-you need to bypass any configured schedulers. Using affinity or a `nodeSelector` is 
-the recommended way to assign a pod to a node.
+you need to bypass any configured schedulers. Bypassing the schedulers might lead to
+failed Pods if the assigned Nodes get oversubscribed. You can use [node affinity](#node-affinity) or a the [`nodeselector` field](#nodeselector) to assign a Pod to a specific Node without bypassing the schedulers.
 {{</ note >}}
 
 Here is an example of a Pod spec using the `nodeName` field:


### PR DESCRIPTION
Add a node indicating that node affinity or a node selector is the preferred way to assign a pod to a node if you aren't trying to bypass the scheduler.  Using nodeName can cause issues that can be otherwise avoided entirely:

- https://github.com/kubernetes/kubernetes/issues/114005
- https://github.com/kubernetes/kubernetes/issues/113907