### PR TITLE
Update kubectl version --client to --short inside installation guide

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -166,7 +166,7 @@ If you are on Ubuntu or another Linux distribution that supports the [snap](http
 
 ```shell
 snap install kubectl --classic
-kubectl version --client
+kubectl version --short
 ```
 
 {{% /tab %}}
@@ -176,7 +176,7 @@ If you are on Linux and using [Homebrew](https://docs.brew.sh/Homebrew-on-Linux)
 
 ```shell
 brew install kubectl
-kubectl version --client
+kubectl version --short
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
**Issue**
```kubectl version --client``` returns deprecation warning and ```kubectl version --short``` is proposed inside this warning

**Steps to reproduce**
Follow the installation guide. Once you get [here](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) you will have to enter the ```kubectl version --client``` command.

You will get the warning below:
```
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
```
