### PR TITLE
[zh] Sync blog: free-katacoda-kubernetes-tutorials-are-shutting-down

### DIFF
--- a/content/zh-cn/blog/_posts/free-katacoda-kubernetes-tutorials-are-shutting-down.md
+++ b/content/zh-cn/blog/_posts/free-katacoda-kubernetes-tutorials-are-shutting-down.md
@@ -1,0 +1,79 @@
+---
+layout: blog
+title: "免费的 Katacoda Kubernetes 教程即将关闭"
+date: 2023-02-14
+slug: kubernetes-katacoda-tutorials-stop-from-2023-03-31
+evergreen: true
+---
+<!--
+layout: blog
+title: "Free Katacoda Kubernetes Tutorials Are Shutting Down"
+date: 2023-02-14
+slug: kubernetes-katacoda-tutorials-stop-from-2023-03-31
+evergreen: true
+-->
+
+<!--
+**Author**: Natali Vlatko, SIG Docs Co-Chair for Kubernetes
+-->
+**作者**：Natali Vlatko，Kubernetes SIG Docs 联合主席
+
+**译者**：Michael Yao (DaoCloud)
+
+<!--
+[Katacoda](https://katacoda.com/kubernetes), the popular learning platform from O’Reilly that has been helping people learn all about 
+Java, Docker, Kubernetes, Python, Go, C++, and more, [shut down for public use in June 2022](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html). 
+However, tutorials specifically for Kubernetes, linked from the Kubernetes website for our project’s 
+users and contributors, remained available and active after this change. Unfortunately, this will no 
+longer be the case, and Katacoda tutorials for learning Kubernetes will cease working after March 31st, 2023.
+-->
+[Katacoda](https://katacoda.com/kubernetes) 是 O’Reilly 开设的热门学习平台，
+帮助人们学习 Java、Docker、Kubernetes、Python、Go、C++ 和其他更多内容，
+这个学习平台于 [2022 年 6 月停止对公众开放](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html)。
+但是，从 Kubernetes 网站为相关项目用户和贡献者关联的 Kubernetes 专门教程在那次变更后仍然可用并处于活跃状态。
+遗憾的是，接下来情况将发生变化，Katacoda 上有关学习 Kubernetes 的教程将在 2023 年 3 月 31 日之后彻底关闭。
+
+<!--
+The Kubernetes Project wishes to thank O'Reilly Media for the many years it has supported the community 
+via the Katacoda learning platform. You can read more about [the decision to shutter katacoda.com](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html) 
+on O'Reilly's own site. With this change, we’ll be focusing on the work needed to remove links to 
+their various tutorials. We have a general issue tracking this topic at [#33936](https://github.com/kubernetes/website/issues/33936) and [GitHub discussion](https://github.com/kubernetes/website/discussions/38878). We’re also 
+interested in researching what other learning platforms could be beneficial for the Kubernetes community, 
+replacing Katacoda with a link to a platform or service that has a similar user experience. However, 
+this research will take time, so we’re actively looking for volunteers to help with this work. 
+If a replacement is found, it will need to be supported by Kubernetes leadership, specifically, 
+SIG Contributor Experience, SIG Docs, and the Kubernetes Steering Committee.
+-->
+Kubernetes 项目感谢 O'Reilly Media 多年来通过 Katacoda 学习平台对 Kubernetes 社区的支持。
+你可以在 O'Reilly 自有的网站上阅读
+[the decision to shutter katacoda.com](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html)
+有关的更多信息。此次变更之后，我们将专注于移除指向 Katacoda 各种教程的链接。
+我们通过 [Issue #33936](https://github.com/kubernetes/website/issues/33936)
+和 [GitHub 讨论](https://github.com/kubernetes/website/discussions/38878)跟踪此主题相关的常规问题。
+我们也有兴趣调研其他哪些学习平台可能对 Kubernetes 社区有益，尝试将 Katacoda 链接替换为具有类似用户体验的平台或服务。
+然而，这项调研需要时间，因此我们正在积极寻觅志愿者来协助完成这项工作。
+如果找到替代的平台，需要得到 Kubernetes 领导层的支持，特别是
+SIG Contributor Experience、SIG Docs 和 Kubernetes Steering Committee。
+
+<!--
+The Katacoda shutdown affects 25 tutorial pages, their localizations, as well as the Katacoda 
+Scenario repository: [github.com/katacoda-scenarios/kubernetes-bootcamp-scenarios](https://github.com/katacoda-scenarios/kubernetes-bootcamp-scenarios). We recommend 
+that any links, guides, or documentation you have that points to the Katacoda learning platform be 
+updated immediately to reflect this change. While we have yet to find a replacement learning solution, 
+the Kubernetes website contains a lot of helpful documentation to support your continued learning and growth. 
+You can find all of our available documentation tutorials for Kubernetes at https://k8s.io/docs/tutorials/.
+-->
+Katacoda 的关闭会影响 25 个英文教程页面、对应的多语言页面以及 Katacoda Scenario仓库：
+[github.com/katacoda-scenarios/kubernetes-bootcamp-scenarios](https://github.com/katacoda-scenarios/kubernetes-bootcamp-scenarios)。
+我们建议你立即更新指向 Katacoda 学习平台的所有链接、指南或文档，以反映这一变化。
+虽然我们还没有找到替代这个学习平台的解决方案，但 Kubernetes 网站本身就包含了大量有用的文档可助你继续学习和成长。
+你可以在 https://k8s.io/docs/tutorials/ 找到所有可用的 Kubernetes 文档教程。
+
+<!--
+If you have any questions regarding the Katacoda shutdown, or subsequent link removal from Kubernetes 
+tutorial pages, please feel free to comment on the [general issue tracking the shutdown](https://github.com/kubernetes/website/issues/33936), 
+or visit the #sig-docs channel on the Kubernetes Slack.
+-->
+如果你对 Katacoda 关闭或后续从 Kubernetes 教程页面移除相关链接有任何疑问，
+请在 [general issue tracking the shutdown](https://github.com/kubernetes/website/issues/33936)
+上发表评论，或加入 Kubernetes Slack 的 #sig-docs 频道。


### PR DESCRIPTION
Fix #39465. See [preview](https://deploy-preview-39466--kubernetes-io-main-staging.netlify.app/zh-cn/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/).

Add zh text to this blog:
```
content/zh-cn/blog/_posts/free-katacoda-kubernetes-tutorials-are-shutting-down.md
```