### PR TITLE
blog: scheduler plugin reusing

### DIFF
--- a/content/en/blog/_posts/scheduler-plugin-reusing/diagram1.svg
+++ b/content/en/blog/_posts/scheduler-plugin-reusing/diagram1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="383px" preserveAspectRatio="none" style="width:173px;height:383px;background:#FFFFFF;" version="1.1" viewBox="0 0 173 383" width="173px" zoomAndPan="magnify"><defs/><g><!--MD5=[848822673f42b97e5537134580a00c68]
+class plugA--><g id="elem_plugA"><rect codeLine="1" fill="#F1F1F1" height="26.2969" id="plugA" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="61" x="55.5" y="7"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="55" x="58.5" y="24.9951">Plugin A</text></g><!--MD5=[f4dd66613959840e77311c02c0333b2e]
+class plugB--><g id="elem_plugB"><rect codeLine="2" fill="#F1F1F1" height="26.2969" id="plugB" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="62" x="7" y="179"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="56" x="10" y="196.9951">Plugin B</text></g><!--MD5=[32be580a8063dca15627328901a9e0b7]
+class plugC--><g id="elem_plugC"><rect codeLine="3" fill="#F1F1F1" height="26.2969" id="plugC" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="62" x="104" y="179"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="56" x="107" y="196.9951">Plugin C</text></g><!--MD5=[2d2d62b16bf9e31dcbe55defc64290f6]
+class cs1--><g id="elem_cs1"><rect codeLine="4" fill="#F1F1F1" height="26.2969" id="cs1" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="83" x="44.5" y="93"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="77" x="47.5" y="110.9951">Cycle State</text></g><!--MD5=[8e80e60e26345725f1c9185858284276]
+class cs2--><g id="elem_cs2"><rect codeLine="5" fill="#F1F1F1" height="26.2969" id="cs2" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="83" x="44.5" y="265"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="77" x="47.5" y="282.9951">Cycle State</text></g><!--MD5=[1f5026f7f0651e6765093293dfca62cc]
+class plugD--><g id="elem_plugD"><rect codeLine="6" fill="#F1F1F1" height="26.2969" id="plugD" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="63" x="54.5" y="351"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="57" x="57.5" y="368.9951">Plugin D</text></g><!--MD5=[c4b37eaf87bc42155596184ccfab2535]
+link plugA to cs1--><g id="link_plugA_cs1"><path codeLine="7" d="M86,33.04 C86,47.38 86,71.46 86,87.78 " fill="none" id="plugA-to-cs1" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="86,92.99,90,83.99,86,87.99,82,83.99,86,92.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[c4841a311986f476622c889a4d887e99]
+link cs1 to plugB--><g id="link_cs1_plugB"><path codeLine="8" d="M79.12,119.04 C70.78,133.63 56.68,158.3 47.36,174.62 " fill="none" id="cs1-to-plugB" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="44.86,178.99,52.7962,173.1575,47.3392,174.6479,45.8488,169.1909,44.86,178.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[21fd698ac1ce818700f93ed353ac9660]
+link cs1 to plugC--><g id="link_cs1_plugC"><path codeLine="9" d="M93.02,119.04 C101.53,133.63 115.93,158.3 125.45,174.62 " fill="none" id="cs1-to-plugC" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="127.99,178.99,126.9143,169.2001,125.4724,174.6701,120.0024,173.2282,127.99,178.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[1880f25f65012afc9eacebcc800739e8]
+link plugB to cs2--><g id="link_plugB_cs2"><path codeLine="10" d="M44.88,205.04 C53.22,219.63 67.32,244.3 76.64,260.62 " fill="none" id="plugB-to-cs2" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="79.14,264.99,78.1512,255.1909,76.6608,260.6479,71.2038,259.1575,79.14,264.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[76c46036bc686ba69c83981db89689d0]
+link plugC to cs2--><g id="link_plugC_cs2"><path codeLine="11" d="M127.98,205.04 C119.47,219.63 105.07,244.3 95.55,260.62 " fill="none" id="plugC-to-cs2" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="93.01,264.99,100.9976,259.2282,95.5276,260.6701,94.0857,255.2001,93.01,264.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[8445ffecd5715c1325650b9791b80f67]
+link cs2 to plugD--><g id="link_cs2_plugD"><path codeLine="12" d="M86,291.04 C86,305.38 86,329.46 86,345.78 " fill="none" id="cs2-to-plugD" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="86,350.99,90,341.99,86,345.99,82,341.99,86,350.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[2125520e0f49492eb8c552c0864a8776]
+@startuml
+class "Plugin A" as plugA
+class "Plugin B" as plugB
+class "Plugin C" as plugC
+class "Cycle State" as cs1
+class "Cycle State" as cs2
+class "Plugin D" as plugD
+plugA - -> cs1
+cs1 - -> plugB
+cs1 - -> plugC
+plugB - -> cs2
+plugC - -> cs2
+cs2 - -> plugD
+hide empty members
+hide circle
+@enduml
+
+PlantUML version 1.2022.7(Mon Aug 22 20:01:30 EEST 2022)
+(GPL source distribution)
+Java Runtime: OpenJDK Runtime Environment
+JVM: OpenJDK 64-Bit Server VM
+Default Encoding: UTF-8
+Language: en
+Country: US
+--></g></svg>

--- a/content/en/blog/_posts/scheduler-plugin-reusing/diagram2.svg
+++ b/content/en/blog/_posts/scheduler-plugin-reusing/diagram2.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="211px" preserveAspectRatio="none" style="width:148px;height:211px;background:#FFFFFF;" version="1.1" viewBox="0 0 148 211" width="148px" zoomAndPan="magnify"><defs/><g><!--MD5=[848822673f42b97e5537134580a00c68]
+class plugA--><g id="elem_plugA"><rect codeLine="1" fill="#F1F1F1" height="26.2969" id="plugA" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="134" x="7" y="7"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="128" x="10" y="24.9951">NodeResourcesFit</text></g><!--MD5=[f4dd66613959840e77311c02c0333b2e]
+class plugB--><g id="elem_plugB"><rect codeLine="2" fill="#F1F1F1" height="26.2969" id="plugB" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="115" x="16.5" y="179"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="109" x="19.5" y="196.9951">TopologyScorer</text></g><!--MD5=[2d2d62b16bf9e31dcbe55defc64290f6]
+class cs1--><g id="elem_cs1"><rect codeLine="3" fill="#F1F1F1" height="26.2969" id="cs1" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="83" x="32.5" y="93"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="77" x="35.5" y="110.9951">Cycle State</text></g><!--MD5=[c4b37eaf87bc42155596184ccfab2535]
+link plugA to cs1--><g id="link_plugA_cs1"><path codeLine="4" d="M74,33.04 C74,47.38 74,71.46 74,87.78 " fill="none" id="plugA-to-cs1" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="74,92.99,78,83.99,74,87.99,70,83.99,74,92.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[c4841a311986f476622c889a4d887e99]
+link cs1 to plugB--><g id="link_cs1_plugB"><path codeLine="5" d="M74,119.04 C74,133.38 74,157.46 74,173.78 " fill="none" id="cs1-to-plugB" style="stroke:#181818;stroke-width:1.0;"/><polygon fill="#181818" points="74,178.99,78,169.99,74,173.99,70,169.99,74,178.99" style="stroke:#181818;stroke-width:1.0;"/></g><!--MD5=[22936359cd9a7b6cc2d6dc112fdf2d3b]
+@startuml
+class "NodeResourcesFit" as plugA
+class "TopologyScorer" as plugB
+class "Cycle State" as cs1
+plugA - -> cs1
+cs1 - -> plugB
+hide empty members
+hide circle
+@enduml
+
+PlantUML version 1.2022.7(Mon Aug 22 20:01:30 EEST 2022)
+(GPL source distribution)
+Java Runtime: OpenJDK Runtime Environment
+JVM: OpenJDK 64-Bit Server VM
+Default Encoding: UTF-8
+Language: en
+Country: US
+--></g></svg>

--- a/content/en/blog/_posts/scheduler-plugin-reusing/index.md
+++ b/content/en/blog/_posts/scheduler-plugin-reusing/index.md
@@ -20,7 +20,7 @@ Resource calculations and scoring of nodes is currently done quite nicely and wi
 > **Warning**
 > The simplest and probably most frowned upon code-reuse practice is of course copy-paste. Due to well known issues with copy-paste code, this approach can't be recommended, and is mentioned here only as an example of what not to do. Copy-pasting won't be any faster anyway, as you will see below.
 
-### Plugin Composition
+### Plugin composition
 
 Typically a valid option for reusing something is composition. Nothing really stops instantiating an existing plugin in the factory function of a new plugin, and then wrapping things up so that the implementation of the already existing plugin gets reused instead of rewriting the code.
 
@@ -32,16 +32,16 @@ type CompositionExample struct {
 }
 ```
 
-There we have a placeholder for the ScorePlugin composite in the new plugin's type. Next, it needs to be instantiated in the new plugin's factory function:
+The new plugin's type now has a placeholder for the ScorePlugin composite. Next, it needs to be instantiated in the new plugin's factory function:
 
 ```go
 fit, err := noderesources.NewFit(args.CompositeArgs, handle, fts)
 if err != nil {
-    return nil, fmt.Errorf("fit instantiation failed: %w", err)
+	return nil, fmt.Errorf("fit instantiation failed: %w", err)
 }
 
 ce := CompositionExample{
-    ScorePlugin: fit.(framework.ScorePlugin),
+	ScorePlugin: fit.(framework.ScorePlugin),
 }
 ```
 
@@ -54,7 +54,7 @@ Putting these unfortunate drawbacks aside, getting the newly calculated node res
 ```go
 // NormalizeScore implements framework.ScoreExtensions.
 func (ce *CompositionExample) NormalizeScore(ctx context.Context, state *framework.CycleState, p *v1.Pod, scores framework.NodeScoreList) *framework.Status {
-    // logic for using and adjusting the incoming scores goes here
+	// logic for using and adjusting the incoming scores goes here
 	return nil
 }
 

--- a/content/en/blog/_posts/scheduler-plugin-reusing/index.md
+++ b/content/en/blog/_posts/scheduler-plugin-reusing/index.md
@@ -1,0 +1,115 @@
+---
+layout: blog
+title: "Scheduler plugin reusing"
+---
+
+**Authors:** Ukri Niemimuukko (Intel)
+
+The Kubernetes Scheduler comes with a well-established [scheduling framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) which allows for creating both in-tree and out-of-tree plugins. By the nature and design of the plugins, they do not have much in terms of dependencies between each other. This is intentional and a good thing, plugins can be disabled and enabled at will. But even such entities which aim to be cohesive and without coupling, could occasionally benefit from being able to reuse the code from existing plugins.
+
+## The use-case
+
+A particular use-case for such plugin reuse arose from the need of getting a score for topologies within a cluster based on the resource status of the topology, such as a rack, instead of scoring just the resource status of the individual nodes in that rack. The aim there, was to be able to bin-pack Pods to racks, and at other times to be able to find a rack for a Pod with very little resources in use at the moment. A plugin which gives the nodes in the best rack a score of 100, and the nodes in the worst rack a score of 0, and then gives nodes in other racks scores linearly between the two, would enable that.
+
+Resource calculations and scoring of nodes is currently done quite nicely and with a well configurable interface within the _NodeResourcesFit_ plugin. It can be [configured](https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-NodeResourcesFitArgs) to use different scoring strategies such as _LeastAllocated_ and _MostAllocated_. It does the job, and it does it well. Reinventing the wheel which has been implemented in _NodeResourcesFit_ for calculating of node resources, would seem like a lot of unnecessary, duplicated work. Ideally, one would take up topology resource calculations and scoring from where _NodeResourcesFit_ plugin left off, and form the topology score based on the scores already calculated for individual nodes.
+
+## Alternative approaches for plugin reuse
+
+### Ctrl-C, Ctrl-V
+
+> **Warning**
+> The simplest and probably most frowned upon code-reuse practice is of course copy-paste. Due to well known issues with copy-paste code, this approach can't be recommended, and is mentioned here only as an example of what not to do. Copy-pasting won't be any faster anyway, as you will see below.
+
+### Plugin Composition
+
+Typically a valid option for reusing something is composition. Nothing really stops instantiating an existing plugin in the factory function of a new plugin, and then wrapping things up so that the implementation of the already existing plugin gets reused instead of rewriting the code.
+
+A minimal example of such plugin composite reduces to three main parts. First, one declares the composite plugin interface(s) inside the new plugin's type:
+
+```go
+type CompositionExample struct {
+	framework.ScorePlugin
+}
+```
+
+There we have a placeholder for the ScorePlugin composite in the new plugin's type. Next, it needs to be instantiated in the new plugin's factory function:
+
+```go
+fit, err := noderesources.NewFit(args.CompositeArgs, handle, fts)
+if err != nil {
+    return nil, fmt.Errorf("fit instantiation failed: %w", err)
+}
+
+ce := CompositionExample{
+    ScorePlugin: fit.(framework.ScorePlugin),
+}
+```
+
+Above are the essential parts in order to get NodeResourceFit scores calculated, and it certainly didn't take too many lines of code. Normal plugin boilerplate is required of course as well, and the new plugin needs to be configured as an enabled score-plugin in the scheduler profile.
+
+There are some caveats, as usual. Arguments for the composite are needed, which basically means the args of the new plugin needs to contain and validate the args for the composite also. That may look rather redundant in the scheduler configuration, especially in case the args match exactly what the _NodeResourcesFit_ plugin is doing for individual node scoring, anyhow. The other caveat is, that the new plugin is then running the same node resource calculations another time, which isn't ideal.
+
+Putting these unfortunate drawbacks aside, getting the newly calculated node resource scores back to the new plugin is now only lacking a little bit of code:
+
+```go
+// NormalizeScore implements framework.ScoreExtensions.
+func (ce *CompositionExample) NormalizeScore(ctx context.Context, state *framework.CycleState, p *v1.Pod, scores framework.NodeScoreList) *framework.Status {
+    // logic for using and adjusting the incoming scores goes here
+	return nil
+}
+
+// ScoreExtensions of the Score plugin.
+func (ce *CompositionExample) ScoreExtensions() framework.ScoreExtensions {
+	return ce
+}
+```
+
+Notably `ScoreExtensions` function wasn't used from the composite, instead it was implemented again. By not returning nil it tells the framework to call the `NormalizeScore` function. That then receives the calculated node scores, which can be adjusted as necessary. Also the `NormalizeScore` of the composite could be called, but in the case of _NodeResourcesFit_ it isn't implemented. And there you have it, a composite plugin based on another plugin. Hook it up, generate all the boilerplate code which is needed for all new plugins, configure it with proper args and it will run.
+
+The dependency to the composite does require some understanding of the composite code, and there may be some introduced fragility with having that dependency. For example, looking into the _NodeResourceFit_ plugin internals reveals that it utilizes the [framework.CycleState](https://github.com/kubernetes/kubernetes/blob/2f977fd8c400971deed365dcc437e519bce475f0/pkg/scheduler/framework/cycle_state.go#L42-L47) during running of other Plugin interfaces. Luckily during running of the `ScorePlugin` interface parts no such state is utilized, so in this case it wasn't necessary to add and run those other plugin interfaces. However should such a thing change in the composite plugin, then running of the composite using plugin might also require changes.
+
+### More efficient and flexible alternative, plugin pipelining
+
+Going through the exercise of building a new plugin via composition and realizing the caveats of such reuse raised some questions related to if and how things could be better in an ideal world. Such as:
+
+* Could a plugin utilize scores from multiple other plugins?
+* Could multiple new plugins utilize scores from the same plugin, without running the same scoring logic N times?
+* Could the dependency to the reused plugin be made less fragile, reducing the coupling?
+* Could reuse be achieved without duplicated args and configuring same algorithms the same way, twice (or more)?
+* Could things be configured more dynamically instead of hard-coding to the sources one plugin uses another plugin?
+
+These questions had the author thinking about finding a better solution than just composition. Also the documentation of the [framework.CycleState](https://github.com/kubernetes/kubernetes/blob/2f977fd8c400971deed365dcc437e519bce475f0/pkg/scheduler/framework/cycle_state.go#L42-L47) was looking rather tempting.
+
+> **Warning**
+> The following section is speculative and based on proof-of-concepting by the author. It doesn't represent what you can do with the Kubernetes scheduler at the time of writing. Some day the concept below might be part of Kubernetes, should the PoC develop into a successful KEP. For now, this is merely a scheduling-sig discussion item which shows the potential of the CycleState.
+
+Ideally, a new plugin could ask for getting the scores from another plugin, or multiple plugins, without rerunning them. The tricky thing is, that plugins run highly parallel in order to execute faster. Thus proper synchronization would be needed. Also it would be ideal, if no changes to existing plugins would be required, and the framework would provide for plugins in need of reusing other plugins' results.
+
+This got the author thinking, that if the `framework.CycleState` object could contain a channel for the scores, and if the framework would create such a channel when it is needed, then the parallel running plugins which are interested in score reuse, could wait for the scores to appear from such "ScoreChannels".
+
+```go
+// ScoreChannel for giving score results to other plugins.
+type ScoreChannel struct {
+	C chan framework.NodeScoreList
+}
+```
+
+A little less than 80 framework lines of PoC-code later the now very dirty scheduler was able to pick up from the arguments of plugins, whether they wanted to use scores from other plugins, and it was creating such "ScoreChannels" into the `framework.CycleState` and wrote scores to them as requested. A couple of experimental plugins later it was possible to verify that indeed, plugin scoring graphs such as the following were entirely possible:
+
+{{< figure src="diagram1.svg" alt="Plugins A, B, C and D with connections A->B, A->C, B->D, C->D">}}
+
+Which makes a nice demo of the one-to-many and many-to-one pipelining possibilities for plugin score reusing.
+
+However, the real use-case has a much more simplistic graph:
+
+{{< figure src="diagram2.svg" alt="Plugins NodeResourcesFit and TopologyScorer with connection NodeResourcesFit->TopologyScorer">}}
+
+But even such a simple graph can reveal a lot of potential over simple composition. Namely:
+ * It doesn't run node resource scoring twice
+ * It doesn't require configuring node resource scoring for two plugins
+ * It only depends on the reused plugin being able to provide node scores. Internal changes to the reused plugin won't break the plugin which reuses the results, as long as scores are created.
+ * It allows changing the connected node score source plugin with a single value in plugin args. What used to be a hard-coded topology resource scorer composite, became a generic TopologyScorer which can use any other score plugin as the source. There are no changes needed to the reused plugins.
+
+## Summary
+
+There are several ways to do Kubernetes scheduler plugin reusing, ranging from strictly not recommended copy-pasting to composition and all the way to modifying the scheduler framework, depending on how efficient you need things to be. The scheduler framework includes built-in utilities such as the `CycleState`, and by no means does it prevent plugins from passing information between each other. The pieces are there, only thing currently missing is perhaps a bit of assisting from the side of the Scheduler framework runtime.


### PR DESCRIPTION
A blog post about scheduler plugin reusing as a followup of scheduling-sig discussions. In its own folder, because of the svg-images that are used.

