### PR TITLE
[zh] sync enforce-standards-admission-controller.md

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -1,43 +1,66 @@
 ---
 title: 通过配置内置准入控制器实施 Pod 安全标准
 content_type: task
-min-kubernetes-server-version: v1.22
 ---
-
 <!--
 title: Enforce Pod Security Standards by Configuring the Built-in Admission Controller
 reviewers:
 - tallclair
 - liggitt
 content_type: task
-min-kubernetes-server-version: v1.22
 -->
 
 <!--
-As of v1.22, Kubernetes provides a built-in [admission controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
+Kubernetes provides a built-in [admission controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
 to enforce the [Pod Security Standards](/docs/concepts/security/pod-security-standards).
 You can configure this admission controller to set cluster-wide defaults and [exemptions](/docs/concepts/security/pod-security-admission/#exemptions).
 -->
-在 v1.22 版本中，Kubernetes 提供一种内置的[准入控制器](/zh-cn/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
-用来强制实施 [Pod 安全标准](/zh-cn/docs/concepts/security/pod-security-standards)。
+Kubernetes 提供一种内置的[准入控制器](/zh-cn/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
+用来强制实施 [Pod 安全性标准](/zh-cn/docs/concepts/security/pod-security-standards)。
 你可以配置此准入控制器来设置集群范围的默认值和[豁免选项](/zh-cn/docs/concepts/security/pod-security-admission/#exemptions)。
 
 ## {{% heading "prerequisites" %}}
 
+<!--
+Following an alpha release in Kubernetes v1.22,
+Pod Security Admission became available by default in Kubernetes v1.23, as
+a beta. From version 1.25 onwards, Pod Security Admission is generally
+available.
+-->
+Pod 安全性准入（Pod Security Admission）在 Kubernetes v1.22 作为 Alpha 特性发布，
+在 Kubernetes v1.23 中作为 Beta 特性默认可用。从 1.25 版本起，
+此特性进阶至正式发布（Generally Available）。
+
 {{% version-check %}}
 
 <!--
-- Ensure the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) is enabled.
+If you are not running Kubernetes {{< skew currentVersion >}}, you can switch
+to viewing this page in the documentation for the Kubernetes version that you
+are running.
 -->
-- 确保 `PodSecurity` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features)已被启用。
+如果未运行 Kubernetes {{< skew currentVersion >}}，
+你可以切换到与当前运行的 Kubernetes 版本所对应的文档。
 
 <!--
 ## Configure the Admission Controller
 -->
 ## 配置准入控制器    {#configure-the-admission-controller}
 
+{{< note >}}
+<!--
+`pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
+For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+-->
+`pod-security.admission.config.k8s.io/v1` 配置需要 v1.25+。
+对于 v1.23 和 v1.24，使用
+[v1beta1](https://v1-24.docs.kubernetes.io/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)。
+对于 v1.22，使用
+[v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)。
+{{< /note >}}
+
 ```yaml
-apiVersion: apiserver.config.k8s.io/v1
+apiVersion: apiserver.config.k8s.io/v1 # 查阅兼容性说明
 kind: AdmissionConfiguration
 plugins:
 - name: PodSecurity
@@ -77,13 +100,3 @@ The above manifest needs to be specified via the `--admission-control-config-fil
 上面的清单需要通过 `--admission-control-config-file` 指定给 kube-apiserver。
 {{< /note >}}
 
-{{< note >}}
-<!--
-`pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
-For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
-For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
--->
-`pod-security.admission.config.k8s.io/v1` 配置需要 v1.25+。
-对于 v1.23 和 v1.24，使用 [v1beta1](https://v1-24.docs.kubernetes.io/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)。
-对于 v1.22，使用 [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)。
-{{< /note >}}


### PR DESCRIPTION
Sync with en #37733. See [preview](https://deploy-preview-39475--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).

```
content/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
```