### PR TITLE
[en]Update k8s.gcr.io to registry.k8s.io

### DIFF
--- a/content/en/blog/_posts/2019-12-02-gardener-project-update.md
+++ b/content/en/blog/_posts/2019-12-02-gardener-project-update.md
@@ -47,7 +47,7 @@ The essential idea is that so-called **seed** clusters are used to host the
 control planes of end-user clusters (botanically named **shoots**). \
 Gardener provides vanilla Kubernetes clusters as a service independent of the
 underlying infrastructure provider in a homogenous way, utilizing the upstream
-provided `k8s.gcr.io/*` images as open distribution. The project is built
+provided `registry.k8s.io/*` images as open distribution. The project is built
 entirely on top of Kubernetes extension concepts, and as such adds a custom API
 server, a controller-manager, and a scheduler to create and manage the lifecycle
 of Kubernetes clusters. It extends the Kubernetes API with custom resources,

--- a/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
+++ b/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
@@ -119,8 +119,8 @@ Here are some of the images we built：
 - `gcr.io/kubernetes-e2e-test-images/volume/iscsi:2.0`
 - `gcr.io/kubernetes-e2e-test-images/volume/nfs:1.0`
 - `gcr.io/kubernetes-e2e-test-images/volume/rbd:1.0.1`
-- `k8s.gcr.io/etcd:3.3.15`
-- `k8s.gcr.io/pause:3.1`
+- `registry.k8s.io/etcd:3.3.15`
+- `registry.k8s.io/pause:3.1`
 
 Finally, we ran the tests and got the test result, include `e2e.log`, which showed that all test cases passed. Additionally, we submitted our test result to [k8s-conformance](https://github.com/cncf/k8s-conformance) as a [pull request](https://github.com/cncf/k8s-conformance/pull/779).
 


### PR DESCRIPTION
PR updating all the existing references of `k8s.gcr.io` to `registry.k8s.io` for english docs. 
Fixes #39427 