### PR TITLE
CVE feed: add RSS feed format

### DIFF
--- a/content/en/docs/reference/issues-security/official-cve-feed.md
+++ b/content/en/docs/reference/issues-security/official-cve-feed.md
@@ -1,9 +1,11 @@
 ---
 title: Official CVE Feed
+linkTitle: CVE feed
 weight: 25
 outputs:
   - json
-  - html 
+  - html
+  - rss
 layout: cve-feed
 ---
 
@@ -14,19 +16,25 @@ the Kubernetes Security Response Committee. See
 [Kubernetes Security and Disclosure Information](/docs/reference/issues-security/security/)
 for more details.
 
-The Kubernetes project publishes a programmatically accessible
-[JSON Feed](/docs/reference/issues-security/official-cve-feed/index.json) of 
-published security issues. You can access it by executing the following command:
+The Kubernetes project publishes a programmatically accessible feed of published
+security issues in [JSON feed](/docs/reference/issues-security/official-cve-feed/index.json)
+and [RSS feed](/docs/reference/issues-security/official-cve-feed/feed.xml)
+formats. You can access it by executing the following commands:
 
-{{< comment >}}
-`replace` is used to bypass known issue with rendering ">"
-: https://github.com/gohugoio/hugo/issues/7229 in JSON layouts template
-`layouts/_default/cve-feed.json`
-{{< /comment >}}
-
+{{< tabs name="CVE feeds" >}}
+{{% tab name="JSON feed" %}}
+[Link to JSON format](/docs/reference/issues-security/official-cve-feed/index.json)
 ```shell
 curl -Lv https://k8s.io/docs/reference/issues-security/official-cve-feed/index.json
 ```
+{{% /tab %}}
+{{% tab name="RSS feed" %}}
+[Link to RSS format](/docs/reference/issues-security/official-cve-feed/feed.xml)
+```shell
+curl -Lv https://k8s.io/docs/reference/issues-security/official-cve-feed/feed.xml
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 {{< cve-feed >}}
 

--- a/layouts/_default/cve-feed.rss.xml
+++ b/layouts/_default/cve-feed.rss.xml
@@ -1,0 +1,25 @@
+{{ $feed := getJSON .Site.Params.cveFeedBucket -}}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ $feed.title }}</title>
+    <link>{{ .Site.BaseURL }}docs/reference/issues-security/official-cve-feed/</link>
+    <description>{{ $feed.description }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-US</language>
+	<copyright>{{ .Site.Params.Copyright_k8s }}</copyright>
+    <lastBuildDate>{{ time.Format "Mon, 02 Jan 2006 15:04:05 -0700" $feed._kubernetes_io.updated_at | safeHTML }}</lastBuildDate>
+    {{ with .OutputFormats.Get "RSS" -}}
+	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end -}}
+    {{ range $feed.items -}}
+    <item>
+      <title>{{ .id }}</title>
+      <link>{{ .url }}</link>
+      <pubDate>{{ time.Format "Mon, 02 Jan 2006 15:04:05 -0700" .date_published | safeHTML }}</pubDate>
+      <guid>{{ .external_url }}</guid>
+      <description>{{ htmlEscape .summary }}</description>
+    </item>
+    {{ end -}}
+  </channel>
+</rss>
+


### PR DESCRIPTION
This PR fixes https://github.com/kubernetes/sig-security/issues/77.

### Preview [here](https://deploy-preview-39513--kubernetes-io-main-staging.netlify.app/docs/reference/issues-security/official-cve-feed/) and [RSS feed here](https://deploy-preview-39513--kubernetes-io-main-staging.netlify.app/docs/reference/issues-security/official-cve-feed/feed.xml).

~~It's based on the commits of this PR https://github.com/kubernetes/website/pull/38579 and thus should be merged after. Only the last commit is unique.~~
~~/hold~~

I choose the value of the fields based on this spec https://validator.w3.org/feed/docs/rss2.html, maybe some choices can be discussed (like `guid`).

Here is an extract of what it looks like:
```xml
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>Auto-refreshing Official CVE Feed</title>
    <link>http://localhost:1313/docs/reference/issues-security/official-cve-feed/</link>
    <description>Auto-refreshing official CVE feed for Kubernetes repository</description>
    <generator>Hugo -- gohugo.io</generator>
    <language>en-US</language>
	<copyright>The Kubernetes Authors</copyright>
    <lastBuildDate>Tue, 20 Dec 2022 15:12:31 +0000</lastBuildDate>
    <atom:link href="http://localhost:1313/docs/reference/issues-security/official-cve-feed/feed.xml" rel="self" type="application/rss+xml" />
    <item>
      <title>CVE-2022-3294</title>
      <link>https://github.com/kubernetes/kubernetes/issues/113757</link>
      <pubDate>Tue, 08 Nov 2022 21:33:26 +0000</pubDate>
      <guid>https://www.cve.org/cverecord?id=CVE-2022-3294</guid>
      <description>Node address isn&amp;#39;t always verified when proxying</description>
    </item>
    <item>
      <title>CVE-2022-3162</title>
      <link>https://github.com/kubernetes/kubernetes/issues/113756</link>
      <pubDate>Tue, 08 Nov 2022 21:33:07 +0000</pubDate>
      <guid>https://www.cve.org/cverecord?id=CVE-2022-3162</guid>
      <description>Unauthorized read of Custom Resources</description>
    </item>
    <item>
      <title>CVE-2022-3172</title>
      <link>https://github.com/kubernetes/kubernetes/issues/112513</link>
      <pubDate>Fri, 16 Sep 2022 13:14:50 +0000</pubDate>
      <guid>https://www.cve.org/cverecord?id=CVE-2022-3172</guid>
      <description>Aggregated API server can cause clients to be redirected (SSRF)</description>
    </item>
    [...]
```

/sig security
cc @PushkarJ @nehaLohia27 
