### PR TITLE
Bump Hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = "git submodule update --init --recursive --depth 1 && make non-product
 
 [build.environment]
 NODE_VERSION = "10.20.0"
-HUGO_VERSION = "0.101.0"
+HUGO_VERSION = "0.110.0"
 RUBY_VERSION = "3.0.1"
 
 [context.production.environment]


### PR DESCRIPTION
Use [Hugo 0.110.0](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) to build the site ([preview](https://deploy-preview-39522--kubernetes-io-main-staging.netlify.app/)).
Hugo 0.110.0 was the latest available at time I checked.