### PR TITLE
[ja] Update install-kubeadm.md

### DIFF
--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -153,16 +153,32 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
 
 {{< tabs name="k8s_install" >}}
 {{% tab name="Ubuntu、Debian、またはHypriotOS" %}}
-```bash
-sudo apt-get update && sudo apt-get install -y apt-transport-https curl
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
-deb https://apt.kubernetes.io/ kubernetes-xenial main
-EOF
-sudo apt-get update
-sudo apt-get install -y kubelet kubeadm kubectl
-sudo apt-mark hold kubelet kubeadm kubectl
-```
+1. `apt` のパッケージ一覧を更新し、Kubernetesの `apt` リポジトリを利用するのに必要なパッケージをインストールします。:
+
+   ```shell
+   sudo apt-get update
+   sudo apt-get install -y apt-transport-https ca-certificates curl
+   ```
+
+2. Google Cloudの公開鍵をダウンロード:
+
+   ```shell
+   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   ```
+
+3. Kubernetesの `apt` リポジトリを追加:
+
+   ```shell
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   ```
+
+4. `apt` のパッケージ一覧を更新し、kubelet、kubeadm、kubectlをインストールします。そしてバージョンを固定します。:
+
+   ```shell
+   sudo apt-get update
+   sudo apt-get install -y kubelet kubeadm kubectl
+   sudo apt-mark hold kubelet kubeadm kubectl
+   ```
 {{% /tab %}}
 {{% tab name="CentOS、RHEL、またはFedora" %}}
 ```bash

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -153,7 +153,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
 
 {{< tabs name="k8s_install" >}}
 {{% tab name="Ubuntu、Debian、またはHypriotOS" %}}
-1. `apt` のパッケージ一覧を更新し、Kubernetesの `apt` リポジトリを利用するのに必要なパッケージをインストールします。:
+1. `apt`のパッケージ一覧を更新し、Kubernetesの`apt`リポジトリを利用するのに必要なパッケージをインストールします:
 
    ```shell
    sudo apt-get update

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -179,6 +179,11 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
    sudo apt-get install -y kubelet kubeadm kubectl
    sudo apt-mark hold kubelet kubeadm kubectl
    ```
+{{< note >}}
+Debian 12やUbuntu 22.04より古いリリースでは、`/etc/apt/keyrings`はデフォルトでは存在しません。
+必要に応じてこのディレクトリを作成し、誰でも読み取り可能で、管理者のみ書き込み可能にすることができます。
+{{< /note >}}
+
 {{% /tab %}}
 {{% tab name="CentOS、RHEL、またはFedora" %}}
 ```bash

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -160,7 +160,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
    sudo apt-get install -y apt-transport-https ca-certificates curl
    ```
 
-2. Google Cloudの公開鍵をダウンロード:
+2. Google Cloudの公開鍵をダウンロードします:
 
    ```shell
    sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -172,7 +172,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-4. `apt` のパッケージ一覧を更新し、kubelet、kubeadm、kubectlをインストールします。そしてバージョンを固定します。:
+4. `apt`のパッケージ一覧を更新し、kubelet、kubeadm、kubectlをインストールします。そしてバージョンを固定します:
 
    ```shell
    sudo apt-get update

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -166,7 +166,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
    sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
    ```
 
-3. Kubernetesの `apt` リポジトリを追加:
+3. Kubernetesの`apt`リポジトリを追加します:
 
    ```shell
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
In Japanese page,it says old method  ```curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -``` .   
But,recent versions of Ubuntu,they shows warning about apt-key add .  
 and I also see English page, it says newer method.   
so I copied English page's code and translate some comments in Japanese.

