### PR TITLE
[ja] Change paths of debug pages (case 3)

### DIFF
--- a/content/ja/docs/concepts/cluster-administration/cluster-administration-overview.md
+++ b/content/ja/docs/concepts/cluster-administration/cluster-administration-overview.md
@@ -49,7 +49,7 @@ Kubernetesクラスターの計画、セットアップ、設定の例を知る�
 
 * [Kubernetesクラスターでのsysctlの使用](/docs/concepts/cluster-administration/sysctl-cluster/)では、管理者向けにカーネルパラメーターを設定するため`sysctl`コマンドラインツールの使用方法について解説します。
 
-* [クラスターの監査](/docs/tasks/debug-application-cluster/audit/)では、Kubernetesの監査ログの扱い方について解説します。
+* [クラスターの監査](/ja/docs/tasks/debug/debug-cluster/audit/)では、Kubernetesの監査ログの扱い方について解説します。
 
 ### kubeletをセキュアにする
   * [マスターとノードのコミュニケーション](/ja/docs/concepts/architecture/master-node-communication/)
@@ -61,7 +61,3 @@ Kubernetesクラスターの計画、セットアップ、設定の例を知る�
 * [DNSのインテグレーション](/ja/docs/concepts/services-networking/dns-pod-service/)では、DNS名をKubernetes Serviceに直接名前解決する方法を解説します。
 
 * [クラスターアクティビィのロギングと監視](/docs/concepts/cluster-administration/logging/)では、Kubernetesにおけるロギングがどのように行われ、どう実装されているかについて解説します。
-
-
-
-

--- a/content/ja/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/ja/docs/concepts/cluster-administration/manage-deployment.md
@@ -1,6 +1,6 @@
 ---
 reviewers:
-- 
+-
 title: リソースの管理
 content_type: concept
 weight: 40
@@ -449,6 +449,5 @@ kubectl edit deployment/my-nginx
 
 ## {{% heading "whatsnext" %}}
 
-- [アプリケーションの調査とデバッグのための`kubectl`の使用方法](/docs/tasks/debug-application-cluster/debug-application-introspection/)について学んでください。
+- [アプリケーションの調査とデバッグのための`kubectl`の使用方法](/ja/docs/tasks/debug/debug-application/debug-running-pod/)について学んでください。
 - [設定のベストプラクティスとTIPS](/ja/docs/concepts/configuration/overview/)を参照してください。
-

--- a/content/ja/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/ja/docs/concepts/configuration/manage-resources-containers.md
@@ -170,7 +170,7 @@ Dockerを使用する場合:
 
 Podのリソース使用量は、Podのステータスの一部として報告されます。
 
-オプションの[監視ツール](/docs/tasks/debug-application-cluster/resource-usage-monitoring/)がクラスターにおいて利用可能な場合、Podのリソース使用量は[メトリクスAPI](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#the-metrics-api)から直接、もしくは監視ツールから取得できます。
+オプションの[監視ツール](/ja/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)がクラスターにおいて利用可能な場合、Podのリソース使用量は[メトリクスAPI](/ja/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#the-metrics-api)から直接、もしくは監視ツールから取得できます。
 
 ## ローカルのエフェメラルストレージ {#local-ephemeral-storage}
 

--- a/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
@@ -346,7 +346,7 @@ GAになってからさらなる変更を加えることは現実的ではない
 各フィーチャーゲートは特定の機能を有効/無効にするように設計されています。
 
 - `Accelerators`: DockerでのNvidia GPUのサポートを有効にします。
-- `AdvancedAuditing`: [高度な監査機能](/docs/tasks/debug-application-cluster/audit/#advanced-audit)を有効にします。
+- `AdvancedAuditing`: [高度な監査機能](/ja/docs/tasks/debug/debug-cluster/audit/#advanced-audit)を有効にします。
 - `AffinityInAnnotations`(*非推奨*): [Podのアフィニティまたはアンチアフィニティ](/ja/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)を有効にします。
 - `AnyVolumeDataSource`: {{< glossary_tooltip text="PVC" term_id="persistent-volume-claim" >}}の`DataSource`としてカスタムリソースの使用を有効にします。
 - `AllowExtTrafficLocalEndpoints`: サービスが外部へのリクエストをノードのローカルエンドポイントにルーティングできるようにします。
@@ -387,7 +387,7 @@ GAになってからさらなる変更を加えることは現実的ではない
 - `CustomResourceWebhookConversion`: [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)から作成されたリソースのWebhookベースの変換を有効にします。
 - `DevicePlugins`: [device-plugins](/docs/concepts/cluster-administration/device-plugins/)によるノードでのリソースプロビジョニングを有効にします。
 - `DryRun`: サーバーサイドでの[dry run](/docs/reference/using-api/api-concepts/#dry-run)リクエストを有効にします。
-- `DynamicAuditing`: [動的監査](/docs/tasks/debug-application-cluster/audit/#dynamic-backend)を有効にします。
+- `DynamicAuditing`: [動的監査](/docs/tasks/debug/debug-cluster/audit/#dynamic-backend)を有効にします。
 - `DynamicKubeletConfig`: kubeletの動的構成を有効にします。[kubeletの再設定](/docs/tasks/administer-cluster/reconfigure-kubelet/)を参照してください。
 - `DynamicProvisioningScheduling`: デフォルトのスケジューラーを拡張してボリュームトポロジーを認識しPVプロビジョニングを処理します。この機能は、v1.12の`VolumeScheduling`機能に完全に置き換えられました。
 - `DynamicVolumeProvisioning`(*非推奨*): Podへの永続ボリュームの[動的プロビジョニング](/ja/docs/concepts/storage/dynamic-provisioning/)を有効にします。

--- a/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
@@ -387,7 +387,6 @@ GAになってからさらなる変更を加えることは現実的ではない
 - `CustomResourceWebhookConversion`: [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)から作成されたリソースのWebhookベースの変換を有効にします。
 - `DevicePlugins`: [device-plugins](/docs/concepts/cluster-administration/device-plugins/)によるノードでのリソースプロビジョニングを有効にします。
 - `DryRun`: サーバーサイドでの[dry run](/docs/reference/using-api/api-concepts/#dry-run)リクエストを有効にします。
-- `DynamicAuditing`: [動的監査](/docs/tasks/debug/debug-cluster/audit/#dynamic-backend)を有効にします。
 - `DynamicKubeletConfig`: kubeletの動的構成を有効にします。[kubeletの再設定](/docs/tasks/administer-cluster/reconfigure-kubelet/)を参照してください。
 - `DynamicProvisioningScheduling`: デフォルトのスケジューラーを拡張してボリュームトポロジーを認識しPVプロビジョニングを処理します。この機能は、v1.12の`VolumeScheduling`機能に完全に置き換えられました。
 - `DynamicVolumeProvisioning`(*非推奨*): Podへの永続ボリュームの[動的プロビジョニング](/ja/docs/concepts/storage/dynamic-provisioning/)を有効にします。

--- a/content/ja/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/ja/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -365,7 +365,7 @@ Windowsでは、PodSecurityContextフィールドはどれも機能しません�
 
 ## ヘルプとトラブルシューティングを学ぶ {#troubleshooting}
 
-Kubernetesクラスターのトラブルシューティングの主なヘルプソースは、[トラブルシューティング](/ja/docs/tasks/debug/)ページから始める必要があります。このページには、いくつか追加的な、Windows固有のトラブルシューティングヘルプが含まれています。ログは、Kubernetesにおけるトラブルシューティング問題の重要な要素です。他のコントリビューターからトラブルシューティングの支援を求めるときは、必ずそれらを含めてください。SIG-Windows[ログ収集に関するコントリビュートガイド](https://github.com/kubernetes/community/blob/master/sig-windows/CONTRIBUTING.md#gathering-logs)の指示に従ってください。
+Kubernetesクラスターのトラブルシューティングの主なヘルプソースは、[トラブルシューティング](/ja/docs/tasks/debug/)ページから始める必要があります。このセクションには、いくつか追加的な、Windows固有のトラブルシューティングヘルプが含まれています。ログは、Kubernetesにおけるトラブルシューティング問題の重要な要素です。他のコントリビューターからトラブルシューティングの支援を求めるときは、必ずそれらを含めてください。SIG-Windows[ログ収集に関するコントリビュートガイド](https://github.com/kubernetes/community/blob/master/sig-windows/CONTRIBUTING.md#gathering-logs)の指示に従ってください。
 
 1. start.ps1が正常に完了したことをどのように確認できますか？
 

--- a/content/ja/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/ja/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -365,7 +365,7 @@ Windowsでは、PodSecurityContextフィールドはどれも機能しません�
 
 ## ヘルプとトラブルシューティングを学ぶ {#troubleshooting}
 
-Kubernetesクラスターのトラブルシューティングの主なヘルプソースは、この[セクション](/docs/tasks/debug-application-cluster/troubleshooting/)から始める必要があります。このセクションには、いくつか追加的な、Windows固有のトラブルシューティングヘルプが含まれています。ログは、Kubernetesにおけるトラブルシューティング問題の重要な要素です。他のコントリビューターからトラブルシューティングの支援を求めるときは、必ずそれらを含めてください。SIG-Windows[ログ収集に関するコントリビュートガイド](https://github.com/kubernetes/community/blob/master/sig-windows/CONTRIBUTING.md#gathering-logs)の指示に従ってください。
+Kubernetesクラスターのトラブルシューティングの主なヘルプソースは、[トラブルシューティング](/ja/docs/tasks/debug/)ページから始める必要があります。このページには、いくつか追加的な、Windows固有のトラブルシューティングヘルプが含まれています。ログは、Kubernetesにおけるトラブルシューティング問題の重要な要素です。他のコントリビューターからトラブルシューティングの支援を求めるときは、必ずそれらを含めてください。SIG-Windows[ログ収集に関するコントリビュートガイド](https://github.com/kubernetes/community/blob/master/sig-windows/CONTRIBUTING.md#gathering-logs)の指示に従ってください。
 
 1. start.ps1が正常に完了したことをどのように確認できますか？
 

--- a/content/ja/docs/tasks/debug/debug-cluster/local-debugging.md
+++ b/content/ja/docs/tasks/debug/debug-cluster/local-debugging.md
@@ -5,7 +5,7 @@ content_type: task
 
 <!-- overview -->
 
-Kubernetesアプリケーションは通常、複数の独立したサービスから構成され、それぞれが独自のコンテナで動作しています。これらのサービスをリモートのKubernetesクラスター上で開発・デバッグするには、[get a shell on a running container](/docs/task/debug-application-cluster/get-shell-running-container/)してリモートシェル内でツールを実行しなければならず面倒な場合があります。
+Kubernetesアプリケーションは通常、複数の独立したサービスから構成され、それぞれが独自のコンテナで動作しています。これらのサービスをリモートのKubernetesクラスター上で開発・デバッグするには、[get a shell on a running container](/ja/docs/task/debug/debug-application/get-shell-running-container/)してリモートシェル内でツールを実行しなければならず面倒な場合があります。
 
 `telepresence`は、リモートKubernetesクラスターにサービスをプロキシーしながら、ローカルでサービスを開発・デバッグするプロセスを容易にするためのツールです。
 `telepresence` を使用すると、デバッガーやIDEなどのカスタムツールをローカルサービスで使用でき、ConfigMapやsecret、リモートクラスター上で動作しているサービスへのフルアクセスをサービスに提供します。

--- a/content/ja/docs/tasks/debug/debug-cluster/local-debugging.md
+++ b/content/ja/docs/tasks/debug/debug-cluster/local-debugging.md
@@ -5,7 +5,7 @@ content_type: task
 
 <!-- overview -->
 
-Kubernetesアプリケーションは通常、複数の独立したサービスから構成され、それぞれが独自のコンテナで動作しています。これらのサービスをリモートのKubernetesクラスター上で開発・デバッグするには、[get a shell on a running container](/ja/docs/task/debug/debug-application/get-shell-running-container/)してリモートシェル内でツールを実行しなければならず面倒な場合があります。
+Kubernetesアプリケーションは通常、複数の独立したサービスから構成され、それぞれが独自のコンテナで動作しています。これらのサービスをリモートのKubernetesクラスター上で開発・デバッグするには、[実行中のコンテナへのシェルを取得](/ja/docs/tasks/debug/debug-application/get-shell-running-container/)してリモートシェル内でツールを実行しなければならず面倒な場合があります。
 
 `telepresence`は、リモートKubernetesクラスターにサービスをプロキシーしながら、ローカルでサービスを開発・デバッグするプロセスを容易にするためのツールです。
 `telepresence` を使用すると、デバッガーやIDEなどのカスタムツールをローカルサービスで使用でき、ConfigMapやsecret、リモートクラスター上で動作しているサービスへのフルアクセスをサービスに提供します。

--- a/content/ja/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
+++ b/content/ja/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
@@ -456,7 +456,7 @@ DeploymentとServiceを削除すると、実行中のすべてのPodも削除さ
 
 ## {{% heading "whatsnext" %}}
 
-* [リソースを監視するためのツール](/docs/tasks/debug-application-cluster/resource-usage-monitoring/)について学ぶ。
+* [リソースを監視するためのツール](/ja/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)について学ぶ。
 * [ロギングのアーキテクチャ](/docs/concepts/cluster-administration/logging/)についてもっと読む。
 * [アプリケーションのイントロスペクションとデバッグ](/ja/docs/tasks/debug/debug-application/)についてもっと読む。
-* [アプリケーションのトラブルシューティング](/docs/tasks/debug-application-cluster/resource-usage-monitoring/)についてもっと読む。
+* [アプリケーションのトラブルシューティング](/ja/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)についてもっと読む。


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/38797

This PR changes the paths of debug pages. The example shown on the issue is below.

- Change path and add "/ja"
  - e.g.: /docs/tasks/debug-application-cluster/resource-usage-monitoring/ -> /ja/docs/tasks/debug/debug-cluster/resource-usage-monitoring/


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
