### PR TITLE
Tidy concepts pages within Label and Annotation

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/annotations.md
+++ b/content/en/docs/concepts/overview/working-with-objects/annotations.md
@@ -8,7 +8,6 @@ weight: 60
 You can use Kubernetes annotations to attach arbitrary non-identifying metadata
 to objects. Clients such as tools and libraries can retrieve this metadata.
 
-
 <!-- body -->
 ## Attaching metadata to objects
 
@@ -74,10 +73,9 @@ If the prefix is omitted, the annotation Key is presumed to be private to the us
 
 The `kubernetes.io/` and `k8s.io/` prefixes are reserved for Kubernetes core components.
 
-For example, here's the configuration file for a Pod that has the annotation `imageregistry: https://hub.docker.com/` :
+For example, here's a manifest for a Pod that has the annotation `imageregistry: https://hub.docker.com/` :
 
 ```yaml
-
 apiVersion: v1
 kind: Pod
 metadata:
@@ -90,14 +88,8 @@ spec:
     image: nginx:1.14.2
     ports:
     - containerPort: 80
-
 ```
-
-
 
 ## {{% heading "whatsnext" %}}
 
 Learn more about [Labels and Selectors](/docs/concepts/overview/working-with-objects/labels/).
-
-
-

--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -79,7 +79,7 @@ Valid label value:
 * unless empty, must begin and end with an alphanumeric character (`[a-z0-9A-Z]`),
 * could contain dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
 
-For example, here's the configuration file for a Pod that has two labels
+For example, here's a manifest for a Pod that has two labels
 `environment: production` and `app: nginx`:
 
 ```yaml
@@ -259,7 +259,7 @@ or
 
 ```yaml
 selector:
-    component: redis
+  component: redis
 ```
 
 This selector (respectively in `json` or `yaml` format) is equivalent to
@@ -278,8 +278,8 @@ selector:
   matchLabels:
     component: redis
   matchExpressions:
-    - {key: tier, operator: In, values: [cache]}
-    - {key: environment, operator: NotIn, values: [dev]}
+    - { key: tier, operator: In, values: [cache] }
+    - { key: environment, operator: NotIn, values: [dev] }
 ```
 
 `matchLabels` is a map of `{key,value}` pairs. A single `{key,value}` in the


### PR DESCRIPTION
Tidying for the [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/), [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).

1. call a manifest a manifest
2. format YAML segment
3. remove extra lines 