### PR TITLE
[ko] Update outdated files in dev-1.26-ko.1 (M134-M142)

### DIFF
--- a/content/ko/docs/setup/_index.md
+++ b/content/ko/docs/setup/_index.md
@@ -27,7 +27,7 @@ card:
 [쿠버네티스를 다운로드](/releases/download/)하여 
 로컬 머신에, 클라우드에, 데이터센터에 쿠버네티스 클러스터를 구축할 수 있다.
 
-`kube-apiserver`나 `kube-proxy`와 같은 몇몇 [쿠버네티스 컴포넌트](/releases/download/)들은
+{{< glossary_tooltip text="kube-apiserver" term_id="kube-apiserver" >}}나 {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}와 같은 몇몇 [쿠버네티스 컴포넌트](/releases/download/)들은
 클러스터 내에서 [컨테이너 이미지](/releases/download/#container-images)를 통해 배포할 수 있다.
 
 쿠버네티스 컴포넌트들은 가급적 컨테이너 이미지로 실행하는 것을 **추천**하며,

--- a/content/ko/docs/setup/best-practices/certificates.md
+++ b/content/ko/docs/setup/best-practices/certificates.md
@@ -3,7 +3,7 @@ title: PKI 인증서 및 요구 사항
 # reviewers:
 # - sig-cluster-lifecycle
 content_type: concept
-weight: 40
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/ko/docs/setup/best-practices/cluster-large.md
+++ b/content/ko/docs/setup/best-practices/cluster-large.md
@@ -3,7 +3,7 @@
 # - davidopp
 # - lavalamp
 title: 대형 클러스터에 대한 고려 사항
-weight: 20
+weight: 10
 ---
 
 클러스터는 {{< glossary_tooltip text="컨트롤 플레인" term_id="control-plane" >}}에서 관리하는

--- a/content/ko/docs/setup/best-practices/enforcing-pod-security-standards.md
+++ b/content/ko/docs/setup/best-practices/enforcing-pod-security-standards.md
@@ -15,7 +15,7 @@ weight: 40
 
 ## 내장된 파드 시큐리티 어드미션 컨트롤러 사용
 
-{{< feature-state for_k8s_version="v1.23" state="beta" >}}
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
 [파드 시큐리티 어드미션 컨트롤러(Pod Security Admission Controller)](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)는
 더 이상 사용되지 않는 파드시큐리티폴리시(PodSecurityPolicy)를 대체한다. 
@@ -28,7 +28,7 @@ weight: 40
 레이블이 없는 네임스페이스는 아직 평가되지 않았음을 표시해야 한다.
 
 모든 네임스페이스의 모든 워크로드에 동일한 보안 요구 사항이 있는 시나리오에서, 
-파드 시큐리티 레이블을 대량으로 적용할 수 있는 방법을 보여주는 [예시](/docs/concepts/security/pod-security-admission/#applying-to-all-namespaces)를 
+파드 시큐리티 레이블을 대량으로 적용할 수 있는 방법을 보여주는 [예시](/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/#applying-to-all-namespaces)를 
 제공한다.
 
 ### 최소 권한 원칙 수용

--- a/content/ko/docs/setup/production-environment/_index.md
+++ b/content/ko/docs/setup/production-environment/_index.md
@@ -117,7 +117,7 @@ no_list: true
   또는 추가 보안 및 가용성을 위해 별도의 시스템에서 실행될 수 있다. 
   etcd는 클러스터 구성 데이터를 저장하므로 
   필요한 경우 해당 데이터베이스를 복구할 수 있도록 etcd 데이터베이스를 정기적으로 백업해야 한다.
-  [etcd FAQ](https://etcd.io/docs/v3.4/faq/)에서 etcd 구성 및 사용 상세를 확인한다.
+  [etcd FAQ](https://etcd.io/docs/v3.5/faq/)에서 etcd 구성 및 사용 상세를 확인한다.
   [쿠버네티스를 위한 etcd 클러스터 운영하기](/docs/tasks/administer-cluster/configure-upgrade-etcd/)와 
   [kubeadm을 이용하여 고가용성 etcd 생성하기](/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)에서 
   상세 사항을 확인한다.

--- a/content/ko/docs/setup/production-environment/tools/kops.md
+++ b/content/ko/docs/setup/production-environment/tools/kops.md
@@ -1,5 +1,5 @@
 ---
-title: Kops로 쿠버네티스 설치하기
+title: kOps로 쿠버네티스 설치하기
 content_type: task
 weight: 20
 ---
@@ -7,14 +7,14 @@ weight: 20
 <!-- overview -->
 
 이곳 빠른 시작에서는 사용자가 얼마나 쉽게 AWS에 쿠버네티스 클러스터를 설치할 수 있는지 보여준다.
-[`kops`](https://github.com/kubernetes/kops)라는 이름의 툴을 이용할 것이다.
+[`kOps`](https://github.com/kubernetes/kops)라는 이름의 툴을 이용할 것이다.
 
-kops는 자동화된 프로비저닝 시스템인데,
+kOps는 자동화된 프로비저닝 시스템인데,
 
 * 완전 자동화된 설치
 * DNS를 통해 클러스터들의 신원 확인
 * 자체 복구: 모든 자원이 Auto-Scaling Groups에서 실행
-* 다양한 OS 지원(Debian, Ubuntu 16.04 supported, CentOS & RHEL, Amazon Linux and CoreOS) - [images.md](https://github.com/kubernetes/kops/blob/master/docs/operations/images.md) 보기
+* 다양한 OS 지원(Amazon Linux, Debian, Flatcar, RHEL, Rocky and Ubuntu) - [images.md](https://github.com/kubernetes/kops/blob/master/docs/operations/images.md) 보기
 * 고가용성 지원 - [high_availability.md](https://github.com/kubernetes/kops/blob/master/docs/operations/high_availability.md) 보기
 * 직접 프로비저닝 하거나 또는 할 수 있도록 terraform 매니페스트를 생성 - [terraform.md](https://github.com/kubernetes/kops/blob/master/docs/terraform.md) 보기
 
@@ -232,6 +232,6 @@ kops는 클러스터에 사용될 설정을 생성할것이다. 여기서 주의
 
 
 * 쿠버네티스 [개념](/ko/docs/concepts/) 과 [`kubectl`](/ko/docs/reference/kubectl/)에 대해 더 알아보기.
-* 튜토리얼, 모범사례 및 고급 구성 옵션에 대한 `kops` [고급 사용법](https://kops.sigs.k8s.io/)에 대해 더 자세히 알아본다.
-* 슬랙(Slack)에서 `kops` 커뮤니티 토론을 할 수 있다: [커뮤니티 토론](https://github.com/kubernetes/kops#other-ways-to-communicate-with-the-contributors)
-* 문제를 해결하거나 이슈를 제기하여 `kops` 에 기여한다. [깃헙 이슈](https://github.com/kubernetes/kops/issues)
+* 튜토리얼, 모범사례 및 고급 구성 옵션에 대한 `kOps` [고급 사용법](https://kops.sigs.k8s.io/)에 대해 더 자세히 알아본다.
+* 슬랙(Slack)에서 `kOps` 커뮤니티 토론을 할 수 있다: [커뮤니티 토론](https://github.com/kubernetes/kops#other-ways-to-communicate-with-the-contributors)
+* 문제를 해결하거나 이슈를 제기하여 `kOps` 에 기여한다. [깃헙 이슈](https://github.com/kubernetes/kops/issues)

--- a/content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -156,13 +156,13 @@ kubeadm은 `kubelet` 또는 `kubectl` 을 설치하거나 관리하지 **않으�
 2. 구글 클라우드의 공개 사이닝 키를 다운로드 한다.
 
    ```shell
-   sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
    ```
 
 3. 쿠버네티스 `apt` 리포지터리를 추가한다.
 
    ```shell
-   echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
 4. `apt` 패키지 색인을 업데이트하고, kubelet, kubeadm, kubectl을 설치하고 해당 버전을 고정한다.
@@ -172,6 +172,10 @@ kubeadm은 `kubelet` 또는 `kubectl` 을 설치하거나 관리하지 **않으�
    sudo apt-get install -y kubelet kubeadm kubectl
    sudo apt-mark hold kubelet kubeadm kubectl
    ```
+{{< note >}}
+Debian 12 및 Ubuntu 22.04 이전 릴리스에서는 `/etc/apt/keyring`이 기본적으로 존재하지 않는다.
+필요한 경우 이 디렉토리를 생성하여, 누구나 읽을 수 있지만 관리자만 쓸 수 있도록 만들 수 있다.
+{{< /note >}}
 
 {{% /tab %}}
 {{% tab name="레드햇 기반 배포판" %}}

--- a/content/ko/docs/setup/production-environment/tools/kubespray.md
+++ b/content/ko/docs/setup/production-environment/tools/kubespray.md
@@ -17,13 +17,14 @@ Kubespray 지원 사항
   - Flatcar Container Linux by Kinvolk
   - Debian Bullseye, Buster, Jessie, Stretch
   - Ubuntu 16.04, 18.04, 20.04, 22.04
-  - CentOS/RHEL 7, 8
-  - Fedora 34, 35
+  - CentOS/RHEL 7, 8, 9
+  - Fedora 35, 36
   - Fedora CoreOS
   - openSUSE Leap 15.x/Tumbleweed
-  - Oracle Linux 7, 8
-  - Alma Linux 8
-  - Rocky Linux 8
+  - Oracle Linux 7, 8, 9
+  - Alma Linux 8, 9
+  - Rocky Linux 8, 9
+  - Kylin Linux Advanced Server V10
   - Amazon Linux 2
 * 지속적인 통합 (CI) 테스트
 

--- a/content/ko/docs/setup/production-environment/turnkey-solutions.md
+++ b/content/ko/docs/setup/production-environment/turnkey-solutions.md
@@ -1,7 +1,7 @@
 ---
 title: 턴키 클라우드 솔루션
 content_type: concept
-weight: 30
+weight: 40
 ---
 <!-- overview -->
 


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Related Issue: #38458

Updated outdated files in `content/en/docs/setup/`.

**9 files to be modified**

- [x] M134.  `content/en/docs/setup/_index.md` | 1(+XS) 1(-)
- [x] M135.  `content/en/docs/setup/best-practices/certificates.md` | 1(+XS) 1(-)
- [x] M136.  `content/en/docs/setup/best-practices/cluster-large.md` | 1(+XS) 1(-)
- [x] M137.  `content/en/docs/setup/best-practices/enforcing-pod-security-standards.md` | 2(+XS) 2(-)
- [x] M138.  `content/en/docs/setup/production-environment/_index.md` | 1(+XS) 1(-)
- [x] M139.  `content/en/docs/setup/production-environment/tools/kops.md` | 8(+XS) 20(-)
- [x] M140.  `content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md` | 11(+S) 5(-)
- [x] M141.  `content/en/docs/setup/production-environment/tools/kubespray.md` | 7(+XS) 6(-)
- [x] M142.  `content/en/docs/setup/production-environment/turnkey-solutions.md` | 1(+XS) 1(-)