### PR TITLE
Update coarse-parallel-processing-work-queue.md

### DIFF
--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -21,7 +21,7 @@ Here is an overview of the steps in this example:
 1. **Create a queue, and fill it with messages.**  Each message represents one task to be done.  In
    this example, a message is an integer that we will do a lengthy computation on.
 1. **Start a Job that works on tasks from the queue**.  The Job starts several pods.  Each pod takes
-   one task from the message queue, processes it, and repeats until the end of the queue is reached.
+   one task from the message queue, processes it, and exits.
 
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
Changes:
* Update detailed description to match overview: each pod exits after processing one entry.

The overview says that each pod processes one entry and exits, but in the details it says each pods repeats - which is identical to the fine-grained detail.

NOTE: I think there's a larger problem with these examples. They are _both_ examples of fine-grained parallelism. If anything, the fine-grained example is coarser than the coarse-grained example.

The Coarse vs Fine distinction deals with partition size, and in each of these examples the partition size is identical.