### PR TITLE
Clean up /service-access-application-cluster.md

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -10,26 +10,15 @@ This page shows how to create a Kubernetes Service object that external
 clients can use to access an application running in a cluster. The Service
 provides load balancing for an application that has two running instances.
 
-
-
-
 ## {{% heading "prerequisites" %}}
-
 
 {{< include "task-tutorial-prereqs.md" >}}
 
-
-
-
 ## {{% heading "objectives" %}}
 
-
-* Run two instances of a Hello World application.
-* Create a Service object that exposes a node port.
-* Use the Service object to access the running application.
-
-
-
+- Run two instances of a Hello World application.
+- Create a Service object that exposes a node port.
+- Use the Service object to access the running application.
 
 <!-- lessoncontent -->
 
@@ -41,9 +30,11 @@ Here is the configuration file for the application Deployment:
 
 1. Run a Hello World application in your cluster:
    Create the application Deployment using the file above:
+
    ```shell
    kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
    ```
+
    The preceding command creates a
    {{< glossary_tooltip text="Deployment" term_id="deployment" >}}
    and an associated
@@ -52,30 +43,35 @@ Here is the configuration file for the application Deployment:
    {{< glossary_tooltip text="Pods" term_id="pod" >}}
    each of which runs the Hello World application.
 
-
 1. Display information about the Deployment:
+
    ```shell
    kubectl get deployments hello-world
    kubectl describe deployments hello-world
    ```
 
 1. Display information about your ReplicaSet objects:
+
    ```shell
    kubectl get replicasets
    kubectl describe replicasets
    ```
 
 1. Create a Service object that exposes the deployment:
+
    ```shell
    kubectl expose deployment hello-world --type=NodePort --name=example-service
    ```
 
 1. Display information about the Service:
+
    ```shell
    kubectl describe services example-service
    ```
+
    The output is similar to this:
-   ```shell
+
+   ```none
    Name:                   example-service
    Namespace:              default
    Labels:                 run=load-balancer-example
@@ -90,19 +86,24 @@ Here is the configuration file for the application Deployment:
    Session Affinity:       None
    Events:                 <none>
    ```
+
    Make a note of the NodePort value for the service. For example,
    in the preceding output, the NodePort value is 31496.
 
 1. List the pods that are running the Hello World application:
+
    ```shell
    kubectl get pods --selector="run=load-balancer-example" --output=wide
    ```
+
    The output is similar to this:
-   ```shell
+
+   ```none
    NAME                           READY   STATUS    ...  IP           NODE
    hello-world-2895499144-bsbk5   1/1     Running   ...  10.200.1.4   worker1
    hello-world-2895499144-m1pwt   1/1     Running   ...  10.200.2.5   worker2
    ```
+
 1. Get the public IP address of one of your nodes that is running
    a Hello World pod. How you get this address depends on how you set
    up your cluster. For example, if you are using Minikube, you can
@@ -117,13 +118,16 @@ Here is the configuration file for the application Deployment:
    cloud providers offer different ways of configuring firewall rules.
 
 1. Use the node address and node port to access the Hello World application:
+
    ```shell
    curl http://<public-node-ip>:<node-port>
    ```
+
    where `<public-node-ip>` is the public IP address of your node,
    and `<node-port>` is the NodePort value for your service. The
    response to a successful request is a hello message:
-   ```shell
+
+   ```none
    Hello Kubernetes!
    ```
 
@@ -133,11 +137,7 @@ As an alternative to using `kubectl expose`, you can use a
 [service configuration file](/docs/concepts/services-networking/service/)
 to create a Service.
 
-
-
-
 ## {{% heading "cleanup" %}}
-
 
 To delete the Service, enter this command:
 
@@ -147,9 +147,6 @@ To delete the Deployment, the ReplicaSet, and the Pods that are running
 the Hello World application, enter this command:
 
     kubectl delete deployment hello-world
-
-
-
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Performed 2 actions:

- Run `npx prettier -w` to remove extra blank lines or add a blank line between paras
- Add a code mark `none` if it is an output