### PR TITLE
Update kubectl install documentation

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -256,6 +256,12 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
 
    If you do not see an error, it means the plugin is successfully installed.
 
+1. After installing the plugin, clean up the installation files:
+
+   ```bash
+   rm kubectl-convert kubectl-convert.sha256
+   ```
+
 ## {{% heading "whatsnext" %}}
 
 {{< include "included/kubectl-whats-next.md" >}}

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -264,7 +264,7 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
 1. After installing the plugin, clean up the installation files:
 
    ```bash
-   rm kubectl kubectl.sha256
+   rm kubectl-convert kubectl-convert.sha256
    ```
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
Update kubectl-convert plugin installation.
- Add a missing section for removing the leftover files for linux setup
- Fix typos in macos setup