### PR TITLE
Fix Introduction to Cilium link

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -10,7 +10,7 @@ weight: 30
 <!-- overview -->
 This page shows how to use Cilium for NetworkPolicy.
 
-For background on Cilium, read the [Introduction to Cilium](https://docs.cilium.io/en/stable/intro).
+For background on Cilium, read the [Introduction to Cilium](https://docs.cilium.io/en/stable/overview/intro).
 
 
 ## {{% heading "prerequisites" %}}


### PR DESCRIPTION
This PR fixes the 'Introduction to Cilium' link in [Use Cilium for NetworkPolicy](https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/) page.
Fixes: #39606 