### PR TITLE
Patch 1

### DIFF
--- a/content/en/docs/reference/glossary/kube-scheduler.md
+++ b/content/en/docs/reference/glossary/kube-scheduler.md
@@ -11,8 +11,8 @@ tags:
 - architecture
 ---
 Control plane component that watches for newly created
-{{< glossary_tooltip term_id="pod" text="Pods" >}} with no assigned
-{{< glossary_tooltip term_id="node" text="node">}}, and selects a node for them
+{{< glossary_tooltip term_id="pod" text="Pods" >}} that have not yet been assigned to any
+{{< glossary_tooltip term_id="nodes" text="nodes">}}, and selects a node for them
 to run on.
 
 <!--more-->

--- a/content/en/docs/reference/glossary/kube-scheduler.md
+++ b/content/en/docs/reference/glossary/kube-scheduler.md
@@ -4,7 +4,7 @@ id: kube-scheduler
 date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-scheduler/
 short_description: >
-  Control plane component that watches for newly created pods with no assigned node, and selects a node for them to run on.
+  Control plane component that watches for newly created Pods that have not yet been assigned to any nodes, and selects a node for them to run on.
 
 aka: 
 tags:


### PR DESCRIPTION
Here https://kubernetes.io/docs/concepts/overview/components/#kube-scheduler
The first line is a bit confusing "Control plane component that watches for newly created Pods with no assigned nodes,...."
I think it could be "Control plane component that watches for newly created Pods that have not yet been assigned to any nodes" just for sake of simplicity.

This docs is modified based on the issue #39562 .
The file modified :
https://github.com/kubernetes/website/blob/5f8fdc6abb0fdcfa3853fbe97560def89aac032c/content/en/docs/reference/glossary/kube-scheduler.md