### PR TITLE
Update documentation to reflect removal of `--network-plugin` command line parameter in Kubelet 1.24

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md
@@ -13,6 +13,12 @@ To avoid CNI plugin-related errors, verify that you are using or upgrading to a
 container runtime that has been tested to work correctly with your version of
 Kubernetes.
 
+{{<note>}} 
+
+From Kubernetes 1.24,the kubelet always uses CNI mode for networking since the legacy `--network-plugin`
+command line parameter has been removed from the binary. For more information, refer to [Troubleshooting Clusters](https://kubernetes.io/docs/tasks/debug/debug-cluster/) page.
+
+{{</note>}}
 ## About the "Incompatible CNI versions" and "Failed to destroy network for sandbox" errors
 
 Service issues exist for pod CNI network setup and tear down in containerd

--- a/content/en/docs/tasks/debug/debug-cluster/_index.md
+++ b/content/en/docs/tasks/debug/debug-cluster/_index.md
@@ -315,7 +315,8 @@ This is an incomplete list of things that could go wrong, and how to adjust your
   - Mitigates: Kubelet software fault
 
  {{<note>}} 
-Starting 1.24, since management of the CNI is no longer in scope for kubelet, the `--network-plugin` command line parameter has been removed from the binary and will throw the following error, if used:
+From Kubernetes 1.24,the kubelet always uses CNI mode for networking. The legacy `--network-plugin`
+command line parameter has been removed from the binary. If you try to specify `--network-plugin`, you see:
 
 `Error: failed to parse kubelet flag: unknown flag: --network-plugin`
 

--- a/content/en/docs/tasks/debug/debug-cluster/_index.md
+++ b/content/en/docs/tasks/debug/debug-cluster/_index.md
@@ -314,6 +314,14 @@ This is an incomplete list of things that could go wrong, and how to adjust your
   - Mitigates: Node shutdown
   - Mitigates: Kubelet software fault
 
+ {{<note>}} 
+Starting 1.24, since management of the CNI is no longer in scope for kubelet, the `--network-plugin` command line parameter has been removed from the binary and will throw the following error, if used:
+
+`Error: failed to parse kubelet flag: unknown flag: --network-plugin`
+
+To understand how to resolve this error, go through the [Migrating from dockershim](/docs/tasks/administer-cluster/migrating-from-dockershim/) guide.
+ 
+ {{</note>}} 
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Fixes #34756
Closed PR: #34764