### PR TITLE
Fix Cilium Kubernetes Installation Guide link

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -82,7 +82,7 @@ policies using an example application.
 ## Deploying Cilium for Production Use
 
 For detailed instructions around deploying Cilium for production, see:
-[Cilium Kubernetes Installation Guide](https://docs.cilium.io/en/stable/concepts/kubernetes/intro/)
+[Cilium Kubernetes Installation Guide](https://docs.cilium.io/en/stable/network/kubernetes/concepts/)
 This documentation includes detailed requirements, instructions and example
 production DaemonSet files.
 


### PR DESCRIPTION
This PR fixes the 'Cilium Kubernetes Installation Guide' link in Deploying Cilium for Production Use [section](https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/#deploying-cilium-for-production-use).
Fixes: #39627