### PR TITLE
add probe to glossary

### DIFF
--- a/content/en/docs/reference/glossary/Probe.md
+++ b/content/en/docs/reference/glossary/Probe.md
@@ -1,0 +1,22 @@
+---
+title: probe
+id: probe
+date: 2023-02-23
+full_link: /docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+short_description: >
+  A diagnostic performed periodically by the kubelet on a container. To perform a diagnostic, the kubelet either executes code within the container, or makes a network request.
+
+aka: 
+tags:
+- fundamental
+- architecture
+---
+ A diagnostic performed periodically by the kubelet on a container. To perform a diagnostic, the kubelet either executes code within the container, or makes a network request.
+
+<!--more-->
+
+The kubelet uses liveness probes to know when to restart a container. For example, liveness probes could catch a deadlock, where an application is running, but unable to make progress. Restarting a container in such a state can help to make the application more available despite bugs.
+
+The kubelet uses readiness probes to know when a container is ready to start accepting traffic. A Pod is considered ready when all of its containers are ready. One use of this signal is to control which Pods are used as backends for Services. When a Pod is not ready, it is removed from Service load balancers.
+
+The kubelet uses startup probes to know when a container application has started. If such a probe is configured, it disables liveness and readiness checks until it succeeds, making sure those probes don't interfere with the application startup. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.


### PR DESCRIPTION
Add Probe definition to glossary



Probe - a diagnostic performed periodically by the [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) on a container. To perform a diagnostic, the kubelet either executes code within the container, or makes a network request. 
 
/retitle Add glossary entry for probe
/language en
/kind feature


