### PR TITLE
Add minimum and maximum values for PriorityClass

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -63,9 +63,10 @@ The name of a PriorityClass object must be a valid
 and it cannot be prefixed with `system-`.
 
 A PriorityClass object can have any 32-bit integer value smaller than or equal
-to 1 billion. Larger numbers are reserved for critical system Pods that should
-not normally be preempted or evicted. A cluster admin should create one
-PriorityClass object for each such mapping that they want.
+to 1 billion. This means that the range of values for a PriorityClass object is
+from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for 
+critical system Pods that should not normally be preempted or evicted. A cluster
+admin should create one PriorityClass object for each such mapping that they want.
 
 PriorityClass also has two optional fields: `globalDefault` and `description`.
 The `globalDefault` field indicates that the value of this PriorityClass should

--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -65,7 +65,7 @@ and it cannot be prefixed with `system-`.
 A PriorityClass object can have any 32-bit integer value smaller than or equal
 to 1 billion. This means that the range of values for a PriorityClass object is
 from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for 
-critical system Pods that should not normally be preempted or evicted. A cluster
+built-in PriorityClasses that represent critical system Pods. A cluster
 admin should create one PriorityClass object for each such mapping that they want.
 
 PriorityClass also has two optional fields: `globalDefault` and `description`.


### PR DESCRIPTION
This PR adds maximum and minimum permitted values for PriorityClass
Fixes: #35640


  **_Additional Info_**
   **Q) How the specified values were derived?**
      A) Int32 has value range of  −2,147,483,648 to 2,147,483,647 (i.e. −(2^31) to 2^31 − 1)
That makes the permitted values for PriorityClass from −2,147,483,648 to 1,000,000,000