### PR TITLE
Use https://dl.k8s.io/

### DIFF
--- a/content/en/blog/_posts/2022-12-12-kubernetes-release-artifact-signing.md
+++ b/content/en/blog/_posts/2022-12-12-kubernetes-release-artifact-signing.md
@@ -31,8 +31,8 @@ files side by side to the artifacts for verifying their integrity.
 
 [tarballs]: https://github.com/kubernetes/kubernetes/blob/release-1.26/CHANGELOG/CHANGELOG-1.26.md#downloads-for-v1260
 [binaries]: https://gcsweb.k8s.io/gcs/kubernetes-release/release/v1.26.0/bin
-[sboms]: https://storage.googleapis.com/kubernetes-release/release/v1.26.0/kubernetes-release.spdx
-[provenance]: https://storage.googleapis.com/kubernetes-release/release/v1.26.0/provenance.json
+[sboms]: https://dl.k8s.io/release/v1.26.0/kubernetes-release.spdx
+[provenance]: https://dl.k8s.io/kubernetes-release/release/v1.26.0/provenance.json
 [cosign]: https://github.com/sigstore/cosign
 
 To verify an artifact, for example `kubectl`, you can download the

--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -18,7 +18,7 @@ manually through [`easyrsa`](https://github.com/OpenVPN/easy-rsa), [`openssl`](h
 1. Download, unpack, and initialize the patched version of `easyrsa3`.
 
    ```shell
-   curl -LO https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
+   curl -LO https://dl.k8s.io/easy-rsa/easy-rsa.tar.gz
    tar xzf easy-rsa.tar.gz
    cd easy-rsa-master/easyrsa3
    ./easyrsa init-pki


### PR DESCRIPTION
Don't rely on using https://storage.googleapis.com/kubernetes-release/ - use the redirector service instead.

This fixes recent blog articles and the English docs. Helps with https://github.com/kubernetes/kubernetes/issues/116019.