### PR TITLE
[ja] Translate title and linkTitle for Blogs page

### DIFF
--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -1,4 +1,16 @@
 ---
-linktitle: Kubernetesブログ
 title: Kubernetesブログ
+linkTitle: ブログ
+menu:
+  main:
+    title: "ブログ"
+    weight: 40
+    post: >
+       <p>Kubernetesやコンテナ全般に関する最新ニュースを読んで、技術的なハウツーをいち早く入手しましょう。</p>
 ---
+{{< comment >}}
+
+ブログへの寄稿についての情報は、以下を参照してください
+https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/#write-a-blog-post
+
+{{< /comment >}}

--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -1,4 +1,4 @@
 ---
 linktitle: Kubernetesブログ
-title: ドキュメント
+title: ブログ
 ---

--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -1,4 +1,4 @@
 ---
 linktitle: Kubernetesブログ
-title: ブログ
+title: Kubernetesブログ
 ---

--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -1,0 +1,4 @@
+---
+linktitle: Kubernetesブログ
+title: ドキュメント
+---


### PR DESCRIPTION
Improvement suggestions for the following

- Blogs --> Kubernetesブログ
- The preview page: [Link](https://deploy-preview-39650--kubernetes-io-main-staging.netlify.app/ja/blog/)

<img width="1510" alt="Screenshot 2023-02-24 at 2 36 41 PM" src="https://user-images.githubusercontent.com/49085460/221100544-8df5d876-9b75-4454-a5d7-3d95ed8adaf3.png">

<img width="1512" alt="Screenshot 2023-02-24 at 2 37 12 PM" src="https://user-images.githubusercontent.com/49085460/221100615-0649627c-4da6-4c85-b2e1-76f0cd217233.png">
