### PR TITLE
Add code block in page configure-persistent-volume-storage, configure-pod-configmap.md, configure-pod-initialization

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -12,27 +12,24 @@ for storage.
 Here is a summary of the process:
 
 1. You, as cluster administrator, create a PersistentVolume backed by physical
-storage. You do not associate the volume with any Pod.
+   storage. You do not associate the volume with any Pod.
 
 1. You, now taking the role of a developer / cluster user, create a
-PersistentVolumeClaim that is automatically bound to a suitable
-PersistentVolume.
+   PersistentVolumeClaim that is automatically bound to a suitable
+   PersistentVolume.
 
 1. You create a Pod that uses the above PersistentVolumeClaim for storage.
 
-
-
 ## {{% heading "prerequisites" %}}
 
-
 * You need to have a Kubernetes cluster that has only one Node, and the
-{{< glossary_tooltip text="kubectl" term_id="kubectl" >}}
-command-line tool must be configured to communicate with your cluster. If you
-do not already have a single-node cluster, you can create one by using
-[Minikube](https://minikube.sigs.k8s.io/docs/).
+  {{< glossary_tooltip text="kubectl" term_id="kubectl" >}}
+  command-line tool must be configured to communicate with your cluster. If you
+  do not already have a single-node cluster, you can create one by using
+  [Minikube](https://minikube.sigs.k8s.io/docs/).
 
 * Familiarize yourself with the material in
-[Persistent Volumes](/docs/concepts/storage/persistent-volumes/).
+  [Persistent Volumes](/docs/concepts/storage/persistent-volumes/).
 
 <!-- steps -->
 
@@ -49,7 +46,6 @@ In your shell on that Node, create a `/mnt/data` directory:
 # as the superuser
 sudo mkdir /mnt/data
 ```
-
 
 In the `/mnt/data` directory, create an `index.html` file:
 
@@ -116,8 +112,10 @@ kubectl get pv task-pv-volume
 The output shows that the PersistentVolume has a `STATUS` of `Available`. This
 means it has not yet been bound to a PersistentVolumeClaim.
 
-    NAME             CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     STORAGECLASS   REASON    AGE
-    task-pv-volume   10Gi       RWO           Retain          Available             manual                   4s
+```
+NAME             CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     STORAGECLASS   REASON    AGE
+task-pv-volume   10Gi       RWO           Retain          Available             manual                   4s
+```
 
 ## Create a PersistentVolumeClaim
 
@@ -132,7 +130,9 @@ Here is the configuration file for the PersistentVolumeClaim:
 
 Create the PersistentVolumeClaim:
 
-    kubectl apply -f https://k8s.io/examples/pods/storage/pv-claim.yaml
+```shell
+kubectl apply -f https://k8s.io/examples/pods/storage/pv-claim.yaml
+```
 
 After you create the PersistentVolumeClaim, the Kubernetes control plane looks
 for a PersistentVolume that satisfies the claim's requirements. If the control
@@ -147,8 +147,10 @@ kubectl get pv task-pv-volume
 
 Now the output shows a `STATUS` of `Bound`.
 
-    NAME             CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM                   STORAGECLASS   REASON    AGE
-    task-pv-volume   10Gi       RWO           Retain          Bound     default/task-pv-claim   manual                   2m
+```
+NAME             CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM                   STORAGECLASS   REASON    AGE
+task-pv-volume   10Gi       RWO           Retain          Bound     default/task-pv-claim   manual                   2m
+```
 
 Look at the PersistentVolumeClaim:
 
@@ -159,8 +161,10 @@ kubectl get pvc task-pv-claim
 The output shows that the PersistentVolumeClaim is bound to your PersistentVolume,
 `task-pv-volume`.
 
-    NAME            STATUS    VOLUME           CAPACITY   ACCESSMODES   STORAGECLASS   AGE
-    task-pv-claim   Bound     task-pv-volume   10Gi       RWO           manual         30s
+```
+NAME            STATUS    VOLUME           CAPACITY   ACCESSMODES   STORAGECLASS   AGE
+task-pv-claim   Bound     task-pv-volume   10Gi       RWO           manual         30s
+```
 
 ## Create a Pod
 
@@ -206,15 +210,16 @@ curl http://localhost/
 The output shows the text that you wrote to the `index.html` file on the
 hostPath volume:
 
-    Hello from Kubernetes storage
-
+```
+Hello from Kubernetes storage
+```
 
 If you see that message, you have successfully configured a Pod to
 use storage from a PersistentVolumeClaim.
 
 ## Clean up
 
-Delete the Pod,  the PersistentVolumeClaim and the PersistentVolume:
+Delete the Pod, the PersistentVolumeClaim and the PersistentVolume:
 
 ```shell
 kubectl delete pod task-pv-pod
@@ -275,11 +280,7 @@ When a Pod consumes a PersistentVolume, the GIDs associated with the
 PersistentVolume are not present on the Pod resource itself.
 {{< /note >}}
 
-
-
-
 ## {{% heading "whatsnext" %}}
-
 
 * Learn more about [PersistentVolumes](/docs/concepts/storage/persistent-volumes/).
 * Read the [Persistent Storage design document](https://git.k8s.io/design-proposals-archive/storage/persistent-storage.md).
@@ -290,7 +291,3 @@ PersistentVolume are not present on the Pod resource itself.
 * [PersistentVolumeSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumespec-v1-core)
 * [PersistentVolumeClaim](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumeclaim-v1-core)
 * [PersistentVolumeClaimSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumeclaimspec-v1-core)
-
-
-
-

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -15,7 +15,8 @@ ConfigMaps are a Kubernetes mechanism that let you inject configuration data int
 
 The ConfigMap concept allow you to decouple configuration artifacts from image content to
 keep containerized applications portable. For example, you can download and run the same
-{{< glossary_tooltip text="container image" term_id="image" >}} to spin up containers for the purposes of local development, system test, or running a live end-user workload.
+{{< glossary_tooltip text="container image" term_id="image" >}} to spin up containers for 
+the purposes of local development, system test, or running a live end-user workload.
 
 This page provides a series of usage examples demonstrating how to create ConfigMaps and
 configure Pods using data stored in ConfigMaps.
@@ -29,7 +30,6 @@ such as `curl`, and you do not have `wget`, you will need to adapt the
 step that downloads example data.
 
 <!-- steps -->
-
 
 ## Create a ConfigMap
 
@@ -66,14 +66,14 @@ whose filename is a valid key in the directory and packages each of those files 
 ConfigMap. Any directory entries except regular files are ignored (for example: subdirectories,
 symlinks, devices, pipes, and more).
 
-
 {{< note >}}
-Each filename being used for ConfigMap creation must consist of only acceptable characters, which are: letters (`A` to `Z` and `a` to z`), digits (`0` to `9`), '-', '_', or '.'.
-If you use `kubectl create configmap` with a directory where any of the file names contains an unacceptable character, the `kubectl` command may fail.
+Each filename being used for ConfigMap creation must consist of only acceptable characters,
+which are: letters (`A` to `Z` and `a` to z`), digits (`0` to `9`), '-', '_', or '.'.
+If you use `kubectl create configmap` with a directory where any of the file names contains
+an unacceptable character, the `kubectl` command may fail.
 
 The `kubectl` command does not print an error when it encounters an invalid filename.
 {{< /note >}}
-
 
 Create the local directory:
 
@@ -396,7 +396,6 @@ data:
   special.type: charm
 ```
 
-
 ### Create a ConfigMap from generator
 
 You can also create a ConfigMap from generators and then apply it to create the object
@@ -543,7 +542,8 @@ section, and learn how to use these objects with Pods.
    kubectl create configmap special-config --from-literal=special.how=very
    ```
 
-2. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
+2. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY`
+   environment variable in the Pod specification.
 
    {{< codenew file="pods/pod-single-configmap-env-variable.yaml" >}}
 
@@ -597,7 +597,6 @@ Here is the manifest you will use:
   kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
   ```
 
-
 * Use `envFrom` to define all of the ConfigMap's data as container environment variables. The
   key from the ConfigMap becomes the environment variable name in the Pod.
 
@@ -627,7 +626,6 @@ For example, the following Pod manifest:
 
 Create that Pod, by running:
 
-
 ```shell
 kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-env-var-valueFrom.yaml
 ```
@@ -646,7 +644,7 @@ kubectl delete pod dapi-test-pod --now
 ## Add ConfigMap data to a Volume
 
 As explained in [Create ConfigMaps from files](#create-configmaps-from-files), when you create
-a ConfigMap using ``--from-file``, the filename becomes a key stored in the `data` section of
+a ConfigMap using `--from-file`, the filename becomes a key stored in the `data` section of
 the ConfigMap. The file contents become the key's value.
 
 The examples in this section refer to a ConfigMap named `special-config`:
@@ -682,7 +680,8 @@ SPECIAL_TYPE
 ```
 
 Text data is exposed as files using the UTF-8 character encoding. To use some other
-character encoding, use `binaryData` (see [ConfigMap object](/docs/concepts/configuration/configmap/#configmap-object) for more details).
+character encoding, use `binaryData`
+(see [ConfigMap object](/docs/concepts/configuration/configmap/#configmap-object) for more details).
 
 {{< note >}}
 If there are any files in the `/etc/config` directory of that container image, the volume
@@ -722,7 +721,6 @@ Delete that Pod:
 kubectl delete pod dapi-test-pod --now
 ```
 
-
 ### Project keys to specific paths and file permissions
 
 You can project keys to specific paths and specific permissions on a per-file
@@ -732,7 +730,7 @@ guide explains the syntax.
 
 ### Optional references
 
-A ConfigMap reference may be marked _optional_.  If the ConfigMap is non-existent, the mounted
+A ConfigMap reference may be marked _optional_. If the ConfigMap is non-existent, the mounted
 volume will be empty. If the ConfigMap exists, but the referenced key is non-existent, the path
 will be absent beneath the mount point. See [Optional ConfigMaps](#optional-configmaps) for more
 details.
@@ -751,7 +749,8 @@ minute by default) + TTL of ConfigMaps cache (1 minute by default) in kubelet. Y
 can trigger an immediate refresh by updating one of the pod's annotations.
 
 {{< note >}}
-A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath) volume will not receive ConfigMap updates.
+A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath)
+volume will not receive ConfigMap updates.
 {{< /note >}}
 
 <!-- discussion -->
@@ -821,7 +820,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh", "-c", "env" ]
+      command: ["/bin/sh", "-c", "env"]
       env:
         - name: SPECIAL_LEVEL_KEY
           valueFrom:
@@ -850,7 +849,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh", "-c", "ls /etc/config" ]
+      command: ["/bin/sh", "-c", "ls /etc/config"]
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config
@@ -875,7 +874,8 @@ are projected to the pod can be as long as kubelet sync period (1 minute by defa
 ConfigMaps cache (1 minute by default) in kubelet.
 
 {{< note >}}
-A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath) volume will not receive ConfigMap updates.
+A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath)
+volume will not receive ConfigMap updates.
 {{< /note >}}
 
 ## Restrictions
@@ -925,7 +925,6 @@ kubectl delete configmap -l 'game-config in (config-4,config-5)’
 
 If you created a directory `configure-pod-container` and no longer need it, you should remove that too,
 or move it into the trash can / deleted files location.
-
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md
@@ -5,17 +5,13 @@ weight: 170
 ---
 
 <!-- overview -->
+
 This page shows how to use an Init Container to initialize a Pod before an
 application Container runs.
 
-
-
 ## {{% heading "prerequisites" %}}
 
-
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-
 
 <!-- steps -->
 
@@ -37,55 +33,63 @@ shared Volume at `/work-dir`, and the application container mounts the shared
 Volume at `/usr/share/nginx/html`. The init container runs the following command
 and then terminates:
 
-    wget -O /work-dir/index.html http://info.cern.ch
+```shell
+wget -O /work-dir/index.html http://info.cern.ch
+```
 
 Notice that the init container writes the `index.html` file in the root directory
 of the nginx server.
 
 Create the Pod:
 
-    kubectl apply -f https://k8s.io/examples/pods/init-containers.yaml
+```shell
+kubectl apply -f https://k8s.io/examples/pods/init-containers.yaml
+```
 
 Verify that the nginx container is running:
 
-    kubectl get pod init-demo
+```shell
+kubectl get pod init-demo
+```
 
 The output shows that the nginx container is running:
 
-    NAME        READY     STATUS    RESTARTS   AGE
-    init-demo   1/1       Running   0          1m
+```
+NAME        READY     STATUS    RESTARTS   AGE
+init-demo   1/1       Running   0          1m
+```
 
 Get a shell into the nginx container running in the init-demo Pod:
 
-    kubectl exec -it init-demo -- /bin/bash
+```shell
+kubectl exec -it init-demo -- /bin/bash
+```
 
 In your shell, send a GET request to the nginx server:
 
-    root@nginx:~# apt-get update
-    root@nginx:~# apt-get install curl
-    root@nginx:~# curl localhost
+```
+root@nginx:~# apt-get update
+root@nginx:~# apt-get install curl
+root@nginx:~# curl localhost
+```
 
 The output shows that nginx is serving the web page that was written by the init container:
 
-    <html><head></head><body><header>
-    <title>http://info.cern.ch</title>
-    </header>
+```html
+<html><head></head><body><header>
+<title>http://info.cern.ch</title>
+</header>
 
-    <h1>http://info.cern.ch - home of the first website</h1>
-      ...
-      <li><a href="http://info.cern.ch/hypertext/WWW/TheProject.html">Browse the first website</a></li>
-      ...
-
-
+<h1>http://info.cern.ch - home of the first website</h1>
+  ...
+  <li><a href="http://info.cern.ch/hypertext/WWW/TheProject.html">Browse the first website</a></li>
+  ...
+```
 
 ## {{% heading "whatsnext" %}}
 
-
 * Learn more about
-[communicating between Containers running in the same Pod](/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/).
+  [communicating between Containers running in the same Pod](/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/).
 * Learn more about [Init Containers](/docs/concepts/workloads/pods/init-containers/).
 * Learn more about [Volumes](/docs/concepts/storage/volumes/).
 * Learn more about [Debugging Init Containers](/docs/tasks/debug/debug-application/debug-init-containers/)
-
-
-


### PR DESCRIPTION
This PR do these things:
1. Add code block in pages
2. Fix typo in page `content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md`
3. Removed redundant blank lines
4. Wrap the long lines manually for future  change tracking
5. Format YAML section