### PR TITLE
[zh] resync page in scheduling-eviction

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/kube-scheduler.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/kube-scheduler.md
@@ -51,7 +51,7 @@ page will help you learn about scheduling.
 ## kube-scheduler
 
 <!--
-[kube-scheduler](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/)
+[kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/)
 is the default scheduler for Kubernetes and runs as part of the
 {{< glossary_tooltip text="control plane" term_id="control-plane" >}}.
 kube-scheduler is designed so that, if you want and need to, you can
@@ -104,15 +104,15 @@ locality, inter-workload interference, and so on.
 亲和以及反亲和要求、数据局部性、负载间的干扰等等。
 
 <!--
-## Scheduling with kube-scheduler {#kube-scheduler-implementation}
+### Node selection in kube-scheduler {#kube-scheduler-implementation}
 -->
-## kube-scheduler 调度流程 {#kube-scheduler-implementation}
+### kube-scheduler 中的节点选择 {#kube-scheduler-implementation}
 
 <!--
 kube-scheduler selects a node for the pod in a 2-step operation:
 
 1. Filtering
-2. Scoring
+1. Scoring
 -->
 kube-scheduler 给一个 Pod 做调度选择时包含两个步骤：
 

--- a/content/zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -4,7 +4,7 @@ content_type: concept
 weight: 90
 ---
 
-<!-- 
+<!--
 reviewers:
 - davidopp
 - wojtek-t
@@ -17,7 +17,7 @@ weight: 90
 
 {{< feature-state for_k8s_version="v1.14" state="stable" >}}
 
-<!--  
+<!--
 [Pods](/docs/concepts/workloads/pods/) can have _priority_. Priority indicates the
 importance of a Pod relative to other Pods. If a Pod cannot be scheduled, the
 scheduler tries to preempt (evict) lower priority Pods to make scheduling of the
@@ -31,7 +31,7 @@ pending Pod possible.
 <!-- body -->
 
 {{< warning >}}
-<!-- 
+<!--
 In a cluster where not all users are trusted, a malicious user could create Pods
 at the highest possible priorities, causing other Pods to be evicted/not get
 scheduled.
@@ -48,7 +48,7 @@ for details.
 
 {{< /warning >}}
 
-<!--  
+<!--
 ## How to use priority and preemption
 
 To use priority and preemption:
@@ -75,7 +75,7 @@ Keep reading for more information about these steps.
 继续阅读以获取有关这些步骤的更多信息。
 
 {{< note >}}
-<!-- 
+<!--
 Kubernetes already ships with two PriorityClasses:
 `system-cluster-critical` and `system-node-critical`.
 These are common classes and are used to [ensure that critical components are always scheduled first](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
@@ -85,7 +85,7 @@ Kubernetes 已经提供了 2 个 PriorityClass：
 这些是常见的类，用于[确保始终优先调度关键组件](/zh-cn/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)。
 {{< /note >}}
 
-<!-- 
+<!--
 ## PriorityClass
 
 A PriorityClass is a non-namespaced object that defines a mapping from a
@@ -106,10 +106,10 @@ PriorityClass 对象的名称必须是有效的
 [DNS 子域名](/zh-cn/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)，
 并且它不能以 `system-` 为前缀。
 
-<!--  
+<!--
 A PriorityClass object can have any 32-bit integer value smaller than or equal
 to 1 billion. This means that the range of values for a PriorityClass object is
-from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for 
+from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for
 built-in PriorityClasses that represent critical system Pods. A cluster
 admin should create one PriorityClass object for each such mapping that they want.
 
@@ -137,7 +137,7 @@ PriorityClass 还有两个可选字段：`globalDefault` 和 `description`。
 `description` 字段是一个任意字符串。
 它用来告诉集群用户何时应该使用此 PriorityClass。
 
-<!--  
+<!--
 ### Notes about PodPriority and existing clusters
 
 -   If you upgrade an existing cluster without this feature, the priority
@@ -153,13 +153,13 @@ PriorityClass 还有两个可选字段：`globalDefault` 和 `description`。
 -->
 ### 关于 PodPriority 和现有集群的注意事项 {#notes-about-podpriority-and-existing-clusters}
 
--   如果你升级一个已经存在的但尚未使用此特性的集群，该集群中已经存在的 Pod 的优先级等效于零。
+- 如果你升级一个已经存在的但尚未使用此特性的集群，该集群中已经存在的 Pod 的优先级等效于零。
 
--   添加一个将 `globalDefault` 设置为 `true` 的 PriorityClass 不会改变现有 Pod 的优先级。
-    此类 PriorityClass 的值仅用于添加 PriorityClass 后创建的 Pod。
+- 添加一个将 `globalDefault` 设置为 `true` 的 PriorityClass 不会改变现有 Pod 的优先级。
+  此类 PriorityClass 的值仅用于添加 PriorityClass 后创建的 Pod。
 
--   如果你删除了某个 PriorityClass 对象，则使用被删除的 PriorityClass 名称的现有 Pod 保持不变，
-    但是你不能再创建使用已删除的 PriorityClass 名称的 Pod。
+- 如果你删除了某个 PriorityClass 对象，则使用被删除的 PriorityClass 名称的现有 Pod 保持不变，
+  但是你不能再创建使用已删除的 PriorityClass 名称的 Pod。
 
 <!--
 ### Example PriorityClass
@@ -176,7 +176,7 @@ globalDefault: false
 description: "此优先级类应仅用于 XYZ 服务 Pod。"
 ```
 
-<!--  
+<!--
 ## Non-preempting PriorityClass {#non-preempting-priority-class}
 
 {{< feature-state for_k8s_version="v1.24" state="stable" >}}
@@ -209,7 +209,7 @@ high-priority pods.
 
 非抢占式 Pod 仍可能被其他高优先级 Pod 抢占。
 
-<!--  
+<!--
 `preemptionPolicy` defaults to `PreemptLowerPriority`,
 which will allow pods of that PriorityClass to preempt lower-priority pods
 (as is existing default behavior).
@@ -248,7 +248,7 @@ globalDefault: false
 description: "This priority class will not cause other pods to be preempted."
 ```
 
-<!-- 
+<!--
 ## Pod priority
 
 After you have one or more PriorityClasses, you can create Pods that specify one
@@ -286,7 +286,7 @@ spec:
   priorityClassName: high-priority
 ```
 
-<!--  
+<!--
 ### Effect of Pod priority on scheduling order
 
 When Pod priority is enabled, the scheduler orders pending Pods by
@@ -303,7 +303,7 @@ scheduler will continue and tries to schedule other lower priority Pods.
 因此，如果满足调度要求，较高优先级的 Pod 可能会比具有较低优先级的 Pod 更早调度。
 如果无法调度此类 Pod，调度程序将继续并尝试调度其他较低优先级的 Pod。
 
-<!-- 
+<!--
 ## Preemption
 
 When Pods are created, they go to a queue and wait to be scheduled. The
@@ -325,7 +325,7 @@ Pod 被创建后会进入队列等待调度。
 如果找到这样的节点，一个或多个优先级较低的 Pod 会被从节点中驱逐。
 被驱逐的 Pod 消失后，P 可以被调度到该节点上。
 
-<!--  
+<!--
 ### User exposed information
 
 When Pod P preempts one or more Pods on Node N, `nominatedNodeName` field of Pod
@@ -361,7 +361,7 @@ Pod P 状态的 `nominatedNodeName` 字段被设置为节点 N 的名称。
 在这种情况下，调度程序会清除 Pod P 的 `nominatedNodeName`。
 通过这样做，调度程序使 Pod P 有资格抢占另一个节点上的 Pod。
 
-<!-- 
+<!--
 ### Limitations of preemption
 
 #### Graceful termination of preemption victims
@@ -385,14 +385,14 @@ priority Pods to zero or a small number.
 当 Pod 被抢占时，牺牲者会得到他们的
 [体面终止期](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)。
 它们可以在体面终止期内完成工作并退出。如果它们不这样做就会被杀死。
-这个体面终止期在调度程序抢占 Pod 的时间点和待处理的 Pod (P) 
+这个体面终止期在调度程序抢占 Pod 的时间点和待处理的 Pod (P)
 可以在节点 (N) 上调度的时间点之间划分出了一个时间跨度。
 同时，调度器会继续调度其他待处理的 Pod。当牺牲者退出或被终止时，
 调度程序会尝试在待处理队列中调度 Pod。
 因此，调度器抢占牺牲者的时间点与 Pod P 被调度的时间点之间通常存在时间间隔。
 为了最小化这个差距，可以将低优先级 Pod 的体面终止时间设置为零或一个小数字。
 
-<!-- 
+<!--
 #### PodDisruptionBudget is supported, but not guaranteed
 
 A [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/) (PDB)
@@ -405,13 +405,13 @@ despite their PDBs being violated.
 -->
 #### 支持 PodDisruptionBudget，但不保证
 
-[PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/) 
+[PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/)
 (PDB) 允许多副本应用程序的所有者限制因自愿性质的干扰而同时终止的 Pod 数量。
 Kubernetes 在抢占 Pod 时支持 PDB，但对 PDB 的支持是基于尽力而为原则的。
 调度器会尝试寻找不会因被抢占而违反 PDB 的牺牲者，但如果没有找到这样的牺牲者，
 抢占仍然会发生，并且即使违反了 PDB 约束也会删除优先级较低的 Pod。
 
-<!-- 
+<!--
 #### Inter-Pod affinity on lower-priority Pods
 
 A Node is considered for preemption only when the answer to this question is
@@ -438,12 +438,12 @@ the Node is not considered for preemption.
 如果答案是否定的，则不考虑在该节点上执行抢占。
 {{< /note >}}
 
-<!-- 
+<!--
 If a pending Pod has inter-pod {{< glossary_tooltip text="affinity" term_id="affinity" >}}
 to one or more of the lower-priority Pods on the Node, the inter-Pod affinity
-rule cannot be satisfied in the absence of those lower-priority Pods. In this case, 
+rule cannot be satisfied in the absence of those lower-priority Pods. In this case,
 the scheduler does not preempt any Pods on the Node. Instead, it looks for another
-Node. The scheduler might find a suitable Node or it might not. There is no 
+Node. The scheduler might find a suitable Node or it might not. There is no
 guarantee that the pending Pod can be scheduled.
 
 Our recommended solution for this problem is to create inter-Pod affinity only
@@ -457,7 +457,7 @@ towards equal or higher priority Pods.
 
 我们针对此问题推荐的解决方案是仅针对同等或更高优先级的 Pod 设置 Pod 间亲和性。
 
-<!-- 
+<!--
 #### Cross node preemption
 
 Suppose a Node N is being considered for preemption so that a pending Pod P can
@@ -486,12 +486,12 @@ enough demand and if we find an algorithm with reasonable performance.
 只有当另一个节点上的 Pod 被抢占时，P 才可能在 N 上变得可行。
 下面是一个例子：
 
-*   正在考虑将 Pod P 调度到节点 N 上。
-*   Pod Q 正在与节点 N 位于同一区域的另一个节点上运行。
-*   Pod P 与 Pod Q 具有 Zone 维度的反亲和（`topologyKey:topology.kubernetes.io/zone`）。
-*   Pod P 与 Zone 中的其他 Pod 之间没有其他反亲和性设置。
-*   为了在节点 N 上调度 Pod P，可以抢占 Pod Q，但调度器不会进行跨节点抢占。
-    因此，Pod P 将被视为在节点 N 上不可调度。
+* 调度器正在考虑将 Pod P 调度到节点 N 上。
+* Pod Q 正在与节点 N 位于同一区域的另一个节点上运行。
+* Pod P 与 Pod Q 具有 Zone 维度的反亲和（`topologyKey:topology.kubernetes.io/zone`）设置。
+* Pod P 与 Zone 中的其他 Pod 之间没有其他反亲和性设置。
+* 为了在节点 N 上调度 Pod P，可以抢占 Pod Q，但调度器不会进行跨节点抢占。
+  因此，Pod P 将被视为在节点 N 上不可调度。
 
 如果将 Pod Q 从所在节点中移除，则不会违反 Pod 间反亲和性约束，
 并且 Pod P 可能会被调度到节点 N 上。
@@ -499,7 +499,7 @@ enough demand and if we find an algorithm with reasonable performance.
 如果有足够的需求，并且如果我们找到性能合理的算法，
 我们可能会考虑在未来版本中添加跨节点抢占。
 
-<!-- 
+<!--
 ## Troubleshooting
 
 Pod priority and pre-emption can have unwanted side effects. Here are some
@@ -509,7 +509,7 @@ examples of potential problems and ways to deal with them.
 
 Pod 优先级和抢占可能会产生不必要的副作用。以下是一些潜在问题的示例以及处理这些问题的方法。
 
-<!--  
+<!--
 ### Pods are preempted unnecessarily
 
 Preemption removes existing Pods from a cluster under resource pressure to make
@@ -532,7 +532,7 @@ than the victims. If preemption happens in such scenarios, please file an issue.
 -->
 ### Pod 被不必要地抢占
 
-抢占在资源压​​力较大时从集群中删除现有 Pod，为更高优先级的悬决 Pod 腾出空间。
+抢占在资源压力较大时从集群中删除现有 Pod，为更高优先级的悬决 Pod 腾出空间。
 如果你错误地为某些 Pod 设置了高优先级，这些无意的高优先级 Pod 可能会导致集群中出现抢占行为。
 Pod 优先级是通过设置 Pod 规约中的 `priorityClassName` 字段来指定的。
 优先级的整数值然后被解析并填充到 `podSpec` 的 `priority` 字段。
@@ -545,7 +545,7 @@ Pod 优先级是通过设置 Pod 规约中的 `priorityClassName` 字段来指�
 当没有悬决 Pod，或者悬决 Pod 的优先级等于或低于牺牲者时，不得发生抢占。
 如果在这种情况下发生抢占，请提出问题。
 
-<!-- 
+<!--
 ### Pods are preempted, but the preemptor is not scheduled
 
 When pods are preempted, they receive their requested graceful termination
@@ -571,7 +571,7 @@ of a Pod with a lower priority.
 
 这是预期的行为：具有较高优先级的 Pod 应该取代具有较低优先级的 Pod。
 
-<!-- 
+<!--
 ### Higher priority Pods are preempted before lower priority pods
 
 The scheduler tries to find nodes that can run a pending Pod. If no node is
@@ -604,7 +604,7 @@ the scheduler chooses a node with the lowest priority.
 
 当存在多个节点抢占且上述场景均不适用时，调度器会选择优先级最低的节点。
 
-<!-- 
+<!--
 ## Interactions between Pod priority and quality of service {#interactions-of-pod-priority-and-qos}
 
 Pod priority and {{< glossary_tooltip text="QoS class" term_id="qos-class" >}}
@@ -626,14 +626,14 @@ Pod 优先级和 {{<glossary_tooltip text="QoS 类" term_id="qos-class" >}}
 仅当移除优先级最低的 Pod 不足以让调度程序调度抢占式 Pod，
 或者最低优先级的 Pod 受 PodDisruptionBudget 保护时，才会考虑优先级较高的 Pod。
 
-<!-- 
+<!--
 The kubelet uses Priority to determine pod order for [node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/).
 You can use the QoS class to estimate the order in which pods are most likely
 to get evicted. The kubelet ranks pods for eviction based on the following factors:
 
   1. Whether the starved resource usage exceeds requests
   1. Pod Priority
-  1. Amount of resource usage relative to requests 
+  1. Amount of resource usage relative to requests
 
 See [Pod selection for kubelet eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction)
 for more details.
@@ -647,9 +647,9 @@ kubelet 使用优先级来确定
 [节点压力驱逐](/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction/) Pod 的顺序。
 你可以使用 QoS 类来估计 Pod 最有可能被驱逐的顺序。kubelet 根据以下因素对 Pod 进行驱逐排名：
 
-  1. 对紧俏资源的使用是否超过请求值
-  1. Pod 优先级
-  1. 相对于请求的资源使用量
+1. 对紧俏资源的使用是否超过请求值
+1. Pod 优先级
+1. 相对于请求的资源使用量
 
 有关更多详细信息，请参阅
 [kubelet 驱逐时 Pod 的选择](/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction)。
@@ -660,7 +660,7 @@ kubelet 使用优先级来确定
 
 ## {{% heading "whatsnext" %}}
 
-<!-- 
+<!--
 * Read about using ResourceQuotas in connection with PriorityClasses: [limit Priority Class consumption by default](/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default)
 * Learn about [Pod Disruption](/docs/concepts/workloads/pods/disruptions/)
 * Learn about [API-initiated Eviction](/docs/concepts/scheduling-eviction/api-eviction/)

--- a/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -27,8 +27,10 @@ hard requirement). _Taints_ are the opposite -- they allow a node to repel a set
 **污点（Taint）** 则相反——它使节点能够排斥一类特定的 Pod。
 
 <!--
-
-_Tolerations_ are applied to pods. Tolerations allow the scheduler to schedule pods with matching taints. Tolerations allow scheduling but don't guarantee scheduling: the scheduler also [evaluates other parameters](/docs/concepts/scheduling-eviction/pod-priority-preemption/) as part of its function.
+_Tolerations_ are applied to pods. Tolerations allow the scheduler to schedule pods with matching
+taints. Tolerations allow scheduling but don't guarantee scheduling: the scheduler also
+[evaluates other parameters](/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+as part of its function.
 
 Taints and tolerations work together to ensure that pods are not scheduled
 onto inappropriate nodes. One or more taints are applied to a node; this
@@ -482,7 +484,7 @@ decisions. This ensures that node conditions don't directly affect scheduling.
 For example, if the `DiskPressure` node condition is active, the control plane
 adds the `node.kubernetes.io/disk-pressure` taint and does not schedule new pods
 onto the affected node. If the `MemoryPressure` node condition is active, the
-control plane adds the `node.kubernetes.io/memory-pressure` taint. 
+control plane adds the `node.kubernetes.io/memory-pressure` taint.
 -->
 调度器在进行调度时检查污点，而不是检查节点状况。这确保节点状况不会直接影响调度。
 例如，如果 `DiskPressure` 节点状况处于活跃状态，则控制平面添加
@@ -492,12 +494,12 @@ control plane adds the `node.kubernetes.io/memory-pressure` taint.
 
 <!--
 You can ignore node conditions for newly created pods by adding the corresponding
-Pod tolerations. The control plane also adds the `node.kubernetes.io/memory-pressure` 
-toleration on pods that have a {{< glossary_tooltip text="QoS class" term_id="qos-class" >}} 
-other than `BestEffort`. This is because Kubernetes treats pods in the `Guaranteed` 
+Pod tolerations. The control plane also adds the `node.kubernetes.io/memory-pressure`
+toleration on pods that have a {{< glossary_tooltip text="QoS class" term_id="qos-class" >}}
+other than `BestEffort`. This is because Kubernetes treats pods in the `Guaranteed`
 or `Burstable` QoS classes (even pods with no memory request set) as if they are
 able to cope with memory pressure, while new `BestEffort` pods are not scheduled
-onto the affected node. 
+onto the affected node.
 -->
 对于新创建的 Pod，可以通过添加相应的 Pod 容忍度来忽略节点状况。
 控制平面还在具有除 `BestEffort` 之外的


### PR DESCRIPTION
SInce the PR changed a lot of files, I seperate them into two PR, the other one is #39677.

This PR resync these pages:

- `content/zh-cn/docs/concepts/scheduling-eviction/kube-scheduler.md`
- `content/zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption.md`
- `content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md`