### PR TITLE
[en] Remove excessive line breaks from table in docs/contribute/style/style-guide.md

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -459,12 +459,8 @@ Do | Don't
 Update the title in the front matter of the page or blog post. | Use first level heading, as Hugo automatically converts the title in the front matter of the page into a first-level heading.
 Use ordered headings to provide a meaningful high-level outline of your content. | Use headings level 4 through 6, unless it is absolutely necessary. If your content is that detailed, it may need to be broken into separate articles.
 Use pound or hash signs (`#`) for non-blog post content. | Use underlines (`---` or `===`) to designate first-level headings.
-Use sentence case for headings in the page body. For example,
-**Extend kubectl with plugins** | Use title case for headings in the page body. For example, **Extend Kubectl With Plugins**
-Use title case for the page title in the front matter. For example,
-`title: Kubernetes API Server Bypass Risks` | Use sentence case for page titles
-in the front matter. For example, don't use
-`title: Kubernetes API server bypass risks`
+Use sentence case for headings in the page body. For example, **Extend kubectl with plugins** | Use title case for headings in the page body. For example, **Extend Kubectl With Plugins**
+Use title case for the page title in the front matter. For example, `title: Kubernetes API Server Bypass Risks` | Use sentence case for page titles in the front matter. For example, don't use `title: Kubernetes API server bypass risks`
 {{< /table >}}
 
 ### Paragraphs


### PR DESCRIPTION
### Changes

The subsection Headings and Titles of this document contains a dos and don'ts table that is not rendering correctly do to a few surplus line breaks inside the Markdown for the table, causing a single cell to render into several different cells instead. This PR removes these spaces so the table renders correctly.