### PR TITLE
Improving Installation method in en and pt-br

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -102,13 +102,13 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    ```
    You can ignore this warning. You are only checking the version of `kubectl` that you
    have installed.
-   
+
    {{< /note >}}
-   
+
    Or use this for detailed view of version:
 
    ```cmd
-   kubectl version --client --output=yaml    
+   kubectl version --client --output=yaml
    ```
 
 ### Install using native package management
@@ -143,6 +143,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
    ```shell
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   ```
 
 4. Update `apt` package index with the new repository and install kubectl:
 

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -139,6 +139,11 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
+   3.1 To Ubuntu Jammy (22.04 LTS):
+
+   ```shell
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
 4. Update `apt` package index with the new repository and install kubectl:
 
    ```shell

--- a/content/pt-br/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/pt-br/docs/tasks/tools/install-kubectl-linux.md
@@ -97,7 +97,7 @@ Por exemplo, para fazer download da versão {{< param "fullversion" >}} no Linux
    Ou use isso para visualizar mais detalhes da versão:
 
    ```cmd
-   kubectl version --client --output=yaml    
+   kubectl version --client --output=yaml
    ```
 
 ### Instale usando o gerenciador de pacotes nativo
@@ -111,7 +111,7 @@ Por exemplo, para fazer download da versão {{< param "fullversion" >}} no Linux
    sudo apt-get update
    sudo apt-get install -y ca-certificates curl
    ```
-   
+
    Se você usa o Debian 9 (stretch) ou anterior, também precisará instalar o `apt-transport-https`:
    ```shell
    sudo apt-get install -y apt-transport-https
@@ -132,7 +132,8 @@ Por exemplo, para fazer download da versão {{< param "fullversion" >}} no Linux
    3.1 To Ubuntu Jammy (22.04 LTS):
 
    ```shell
-   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror" | sudo tee /etc/apt/sources.list.d/kubernetes.list   
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   ```
 
 4. Atualize o índice do `apt` com o novo repositório e instale o kubectl:
 
@@ -141,7 +142,7 @@ Por exemplo, para fazer download da versão {{< param "fullversion" >}} no Linux
    sudo apt-get install -y kubectl
    ```
 {{< note >}}
-Em versões anteriores ao Debian 12 e Ubuntu 22.04, o `/etc/apt/keyrings` não existe por padrão. 
+Em versões anteriores ao Debian 12 e Ubuntu 22.04, o `/etc/apt/keyrings` não existe por padrão.
 Você pode criar este diretório se precisar, tornando-o visível para todos, mas com permissão de escrita apenas aos administradores.
 {{< /note >}}
 
@@ -192,8 +193,8 @@ kubectl version --client
 
 {{< include "included/verify-kubectl.md" >}}
 
-## Configurações e plugins opcionais do kubectl 
-### Ative o autocompletar no shell 
+## Configurações e plugins opcionais do kubectl
+### Ative o autocompletar no shell
 
 O kubectl oferece recursos de autocompletar para Bash, Zsh, Fish e PowerShell, o que pode economizar muita digitação.
 

--- a/content/pt-br/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/pt-br/docs/tasks/tools/install-kubectl-linux.md
@@ -129,6 +129,11 @@ Por exemplo, para fazer download da versão {{< param "fullversion" >}} no Linux
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
+   3.1 To Ubuntu Jammy (22.04 LTS):
+
+   ```shell
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror" | sudo tee /etc/apt/sources.list.d/kubernetes.list   
+
 4. Atualize o índice do `apt` com o novo repositório e instale o kubectl:
 
    ```shell


### PR DESCRIPTION
# TL & DR
In the main guide have been defined the installation to Ubuntu Xenial, but actually the Ubuntu distro's is Jammy (22.04LTS). 
I've I search I found the up to date release to actual Ubuntu version [here](https://packages.cloud.google.com/apt/dists/ubuntu-jammy-mirror/main).

I just fix in my local machine, works and now Iḿ submitting this pull request where I just include for the languages `en` and `pt-br`