### PR TITLE
[Kubectl] Update installation docs for Ubuntu Jammy

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -138,6 +138,11 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    ```shell
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
+   3.1 For Ubuntu Jammy (22.04 LTS)
+
+   ```shell
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   ```
 
 4. Update `apt` package index with the new repository and install kubectl:
 

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -151,7 +151,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    sudo apt-get install -y kubectl
    ```
 {{< note >}}
-In releases older than Debian 12 and Ubuntu 22.04, `/etc/apt/keyrings` does not exist by default.
+In releases older than Debian 12, `/etc/apt/keyrings` does not exist by default.
 You can create this directory if you need to, making it world-readable but writeable only by admins.
 {{< /note >}}
 

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -151,7 +151,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    sudo apt-get install -y kubectl
    ```
 {{< note >}}
-In releases older than Debian 12, `/etc/apt/keyrings` does not exist by default.
+In releases older than Debian 12 and Ubuntu 21.10 `/etc/apt/keyrings` does not exist by default.
 You can create this directory if you need to, making it world-readable but writeable only by admins.
 {{< /note >}}
 


### PR DESCRIPTION
# TL & DR

_The changes here impacts the documents in _english_ version._

I just updated the part of the documentation instructs the installation for Linux Ubuntu via `apt add repository` method, where actually is to Xenial Ubuntu release: [3. Add the Kubernetes apt repository](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management).

I've include a new `3.1` passing the instructions for Ubuntu Jammy 22.04 LTS. 

### And how I found this solution?

Simple I just browse through the [Packages Cloud Google](https://packages.cloud.google.com). until [/apt/dists/ubuntu-jammy-mirror/main](https://packages.cloud.google.com/apt/dists/ubuntu-jammy-mirror/main).

# Results

**APT Update**

![image](https://user-images.githubusercontent.com/1542315/221445692-961021c5-3e0f-4e0c-8fb3-ffe53e065105.png)

**Kubernetes List file**

```shell
$ cat /etc/apt/sources.list.d/kubernetes.list 
deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ ubuntu-jammy-mirror main
```
