### PR TITLE
[zh] resync page cloud-controller

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/cloud-controller.md
+++ b/content/zh-cn/docs/concepts/architecture/cloud-controller.md
@@ -83,17 +83,17 @@ hosts running inside your tenancy with the cloud provider. The node controller p
 
 <!--
 1. Update a Node object with the corresponding server's unique identifier obtained from the cloud provider API.
-2. Annotating and labelling the Node object with cloud-specific information, such as the region the node
+1. Annotating and labelling the Node object with cloud-specific information, such as the region the node
    is deployed into and the resources (CPU, memory, etc) that it has available.
-3. Obtain the node's hostname and network addresses.
-4. Verifying the node's health. In case a node becomes unresponsive, this controller checks with
+1. Obtain the node's hostname and network addresses.
+1. Verifying the node's health. In case a node becomes unresponsive, this controller checks with
    your cloud provider's API to see if the server has been deactivated / deleted / terminated.
    If the node has been deleted from the cloud, the controller deletes the Node object from your Kubernetes
    cluster.
 -->
 1. 使用从云平台 API 获取的对应服务器的唯一标识符更新 Node 对象；
 2. 利用特定云平台的信息为 Node 对象添加注解和标签，例如节点所在的区域
-  （Region）和所具有的资源（CPU、内存等等）；
+   （Region）和所具有的资源（CPU、内存等等）；
 3. 获取节点的网络地址和主机名；
 4. 检查节点的健康状况。如果节点无响应，控制器通过云平台 API
    查看该节点是否已从云中禁用、删除或终止。如果节点已从云中删除，
@@ -159,13 +159,13 @@ to read and modify Node objects.
 
 `v1/Node`：
 
-- Get
-- List
-- Create
-- Update
-- Patch
-- Watch
-- Delete
+- get
+- list
+- create
+- update
+- patch
+- watch
+- delete
 
 <!--
 ### Route controller {#authorization-route-controller}
@@ -180,69 +180,66 @@ routes appropriately. It requires Get access to Node objects.
 
 `v1/Node`：
 
-- Get
+- get
 
 <!--
 ### Service controller {#authorization-service-controller}
 
-The service controller listens to Service object Create, Update and Delete events and then configures Endpoints for those Services appropriately (for EndpointSlices, the kube-controller-manager manages these on demand).
+The service controller watches for Service object **create**, **update** and **delete** events and then
+configures Endpoints for those Services appropriately (for EndpointSlices, the
+kube-controller-manager manages these on demand).
 
-To access Services, it requires List, and Watch access. To update Services, it requires Patch and Update access.
+To access Services, it requires **list**, and **watch** access. To update Services, it requires
+**patch** and **update** access.
 
-To set up Endpoints resources for the Services, it requires access to Create, List, Get, Watch, and Update.
+To set up Endpoints resources for the Services, it requires access to **create**, **list**,
+**get**, **watch**, and **update**.
 -->
 ### 服务控制器 {#authorization-service-controller}
 
-服务控制器监测 Service 对象的 Create、Update 和 Delete 事件，并配置对应服务的 Endpoints 对象
+服务控制器监测 Service 对象的 **create**、**update** 和 **delete** 事件，
+并配置对应服务的 Endpoints 对象
 （对于 EndpointSlices，kube-controller-manager 按需对其进行管理）。
 
-为了访问 Service 对象，它需要 List 和 Watch 访问权限。
-为了更新 Service 对象，它需要 Patch 和 Update 访问权限。
+为了访问 Service 对象，它需要 **list** 和 **watch** 访问权限。
+为了更新 Service 对象，它需要 **patch** 和 **update** 访问权限。
 
 为了能够配置 Service 对应的 Endpoints 资源，
-它需要 Create、List、Get、Watch 和 Update 等访问权限。
+它需要 **create**、**list**、**get**、**watch** 和 **update** 等访问权限。
 
 `v1/Service`：
 
-- List
-- Get
-- Watch
-- Patch
-- Update
+- list
+- get
+- watch
+- patch
+- update
 
 <!--
 ### Others {#authorization-miscellaneous}
 
-The implementation of the core of the cloud controller manager requires access to create Event objects, and to ensure secure operation, it requires access to create ServiceAccounts.
-
-`v1/Event`:
-
-- Create
-- Patch
-- Update
-
-`v1/ServiceAccount`:
-
-- Create
-
-The {{< glossary_tooltip term_id="rbac" text="RBAC" >}} ClusterRole for the cloud
-controller manager looks like:
+The implementation of the core of the cloud controller manager requires access to create Event
+objects, and to ensure secure operation, it requires access to create ServiceAccounts.
 -->
 ### 其他  {#authorization-miscellaneous}
 
 在云控制器管理器的实现中，其核心部分需要创建 Event 对象的访问权限，
 并创建 ServiceAccount 资源以保证操作安全性的权限。
 
-`v1/Event`：
+`v1/Event`:
 
-- Create
-- Patch
-- Update
+- create
+- patch
+- update
 
-`v1/ServiceAccount`：
+`v1/ServiceAccount`:
 
-- Create
+- create
 
+<!--
+The {{< glossary_tooltip term_id="rbac" text="RBAC" >}} ClusterRole for the cloud
+controller manager looks like:
+-->
 用于云控制器管理器 {{< glossary_tooltip term_id="rbac" text="RBAC" >}}
 的 ClusterRole 如下例所示：
 
@@ -314,7 +311,8 @@ rules:
 [Cloud Controller Manager Administration](/docs/tasks/administer-cluster/running-cloud-controller/#cloud-controller-manager)
 has instructions on running and managing the cloud controller manager.
 
-To upgrade a HA control plane to use the cloud controller manager, see [Migrate Replicated Control Plane To Use Cloud Controller Manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/).
+To upgrade a HA control plane to use the cloud controller manager, see
+[Migrate Replicated Control Plane To Use Cloud Controller Manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/).
 
 Want to know how to implement your own cloud controller manager, or extend an existing project?
 -->
@@ -327,17 +325,24 @@ Want to know how to implement your own cloud controller manager, or extend an ex
 想要了解如何实现自己的云控制器管理器，或者对现有项目进行扩展么？
 
 <!--
-The cloud controller manager uses Go interfaces to allow implementations from any cloud to be plugged in. Specifically, it uses the `CloudProvider` interface defined in [`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.21/cloud.go#L42-L69) from [kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider).
+The cloud controller manager uses Go interfaces to allow implementations from any cloud to be plugged in.
+Specifically, it uses the `CloudProvider` interface defined in
+[`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.26/cloud.go#L43-L69) from
+[kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider).
 -->
 云控制器管理器使用 Go 语言的接口，从而使得针对各种云平台的具体实现都可以接入。
 其中使用了在 [kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider)
-项目中 [`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.21/cloud.go#L42-L69)
+项目中 [`cloud.go`](https://github.com/kubernetes/cloud-provider/blob/release-1.26/cloud.go#L43-L69)
 文件所定义的 `CloudProvider` 接口。
 
 <!--
-The implementation of the shared controllers highlighted in this document (Node, Route, and Service), and some scaffolding along with the shared cloudprovider interface, is part of the Kubernetes core. Implementations specific to cloud providers are outside the core of Kubernetes and implement the `CloudProvider` interface.
+The implementation of the shared controllers highlighted in this document (Node, Route, and Service),
+and some scaffolding along with the shared cloudprovider interface, is part of the Kubernetes core.
+Implementations specific to cloud providers are outside the core of Kubernetes and implement the
+`CloudProvider` interface.
 
-For more information about developing plugins, see [Developing Cloud Controller Manager](/docs/tasks/administer-cluster/developing-cloud-controller-manager/).
+For more information about developing plugins, see
+[Developing Cloud Controller Manager](/docs/tasks/administer-cluster/developing-cloud-controller-manager/).
 -->
 本文中列举的共享控制器（节点控制器、路由控制器和服务控制器等）的实现以及其他一些生成具有
 CloudProvider 接口的框架的代码，都是 Kubernetes 的核心代码。


### PR DESCRIPTION
This PR resynced page `content/zh-cn/docs/concepts/architecture/cloud-controller.md` according to the upstream page.