### PR TITLE
Fix misspelling on Pods page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -296,14 +296,14 @@ Your {{< glossary_tooltip text="container runtime" term_id="container-runtime" >
 Any container in a pod can run in privileged mode to use operating system administrative capabilities
 that would otherwise be inaccessible. This is available for both Windows and Linux.
 
-### Linux priviledged containers
+### Linux privileged containers
 
 In Linux, any container in a Pod can enable privileged mode using the `privileged` (Linux) flag
 on the [security context](/docs/tasks/configure-pod-container/security-context/) of the
 container spec. This is useful for containers that want to use operating system administrative
 capabilities such as manipulating the network stack or accessing hardware devices.
 
-### Windows priviledged containers
+### Windows privileged containers
 
 {{< feature-state for_k8s_version="v1.26" state="stable" >}}
 


### PR DESCRIPTION
Replaces `priviledged` with `privileged`.