### PR TITLE
Added section on operators for `nodeAffinity` and `podAffinity`

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -135,6 +135,9 @@ You can use the `operator` field to specify a logical operator for Kubernetes to
 interpreting the rules. You can use `In`, `NotIn`, `Exists`, `DoesNotExist`,
 `Gt` and `Lt`.
 
+Read [Operators](/docs/concepts/scheduling-eviction/assign-pod-node/#operators)
+to learn more about how these work.
+
 `NotIn` and `DoesNotExist` allow you to define node anti-affinity behavior.
 Alternatively, you can use [node taints](/docs/concepts/scheduling-eviction/taint-and-toleration/)
 to repel Pods from specific nodes.
@@ -309,6 +312,9 @@ refer to the [design proposal](https://git.k8s.io/design-proposals-archive/sched
 
 You can use the `In`, `NotIn`, `Exists` and `DoesNotExist` values in the
 `operator` field for Pod affinity and anti-affinity.
+
+Read [Operators](/docs/concepts/scheduling-eviction/assign-pod-node/#operators)
+to learn more about how these work.
 
 In principle, the `topologyKey` can be any allowed label key with the following
 exceptions for performance and security reasons:
@@ -491,6 +497,24 @@ overall utilization.
 
 Read [Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 to learn more about how these work.
+
+## Operators
+
+The following are all the logical operators that you can use with the `operator` field for `nodeAffinity` and `podAffinity` as mentioned above.
+
+|    <div style="width:150px">Operator</div>    |    Behaviour    |
+| :------------: | :-------------: |
+| In | The label value is contained in the supplied set of strings |
+|   NotIn   | The label value is not contained in the supplied set of strings |
+| Exists | A label with this key is applied to the object |
+| DoesNotExist | No such label with this key is applied to the object |
+| Gt | The supplied value will be parsed as an integer, and that integer is less than or equal to the integer that results from parsing the value of a label named by this selector | 
+| Lt | The supplied value will be parsed as an integer, and that integer is greater than or equal to the integer that results from parsing the value of a label named by this selector | 
+
+
+{{<note>}}
+`Gt` and `Lt` are not available for `nodeAffinity` as of now.
+{{</note>}}
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -513,7 +513,7 @@ The following are all the logical operators that you can use with the `operator`
 
 
 {{<note>}}
-`Gt` and `Lt` operators will not work with non integer values. Also, `Gt` and `Lt` are not available for `podAffinity` as of now. 
+`Gt` and `Lt` operators will not work with non integer values. If the given value doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt` are not available for `podAffinity` as of now. 
 {{</note>}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -135,7 +135,7 @@ You can use the `operator` field to specify a logical operator for Kubernetes to
 interpreting the rules. You can use `In`, `NotIn`, `Exists`, `DoesNotExist`,
 `Gt` and `Lt`.
 
-Read [Operators](/docs/concepts/scheduling-eviction/assign-pod-node/#operators)
+Read [Operators](#operators)
 to learn more about how these work.
 
 `NotIn` and `DoesNotExist` allow you to define node anti-affinity behavior.
@@ -313,7 +313,7 @@ refer to the [design proposal](https://git.k8s.io/design-proposals-archive/sched
 You can use the `In`, `NotIn`, `Exists` and `DoesNotExist` values in the
 `operator` field for Pod affinity and anti-affinity.
 
-Read [Operators](/docs/concepts/scheduling-eviction/assign-pod-node/#operators)
+Read [Operators](#operators)
 to learn more about how these work.
 
 In principle, the `topologyKey` can be any allowed label key with the following
@@ -500,14 +500,14 @@ to learn more about how these work.
 
 ## Operators
 
-The following are all the logical operators that you can use with the `operator` field for `nodeAffinity` and `podAffinity` as mentioned above.
+The following are all the logical operators that you can use with the `operator` field for `nodeAffinity` and `podAffinity` mentioned above.
 
-|    <div style="width:150px">Operator</div>    |    Behaviour    |
+|    Operator    |    Behaviour    |
 | :------------: | :-------------: |
 | In | The label value is contained in the supplied set of strings |
 |   NotIn   | The label value is not contained in the supplied set of strings |
-| Exists | A label with this key is applied to the object |
-| DoesNotExist | No such label with this key is applied to the object |
+| Exists | A label with this key exists on the object |
+| DoesNotExist | No such label with this key exists on the object |
 | Gt | The supplied value will be parsed as an integer, and that integer is less than or equal to the integer that results from parsing the value of a label named by this selector | 
 | Lt | The supplied value will be parsed as an integer, and that integer is greater than or equal to the integer that results from parsing the value of a label named by this selector | 
 

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -513,7 +513,7 @@ The following are all the logical operators that you can use with the `operator`
 
 
 {{<note>}}
-`Gt` and `Lt` are not available for `nodeAffinity` as of now.
+`Gt` and `Lt` operators will not work with non integer values. Also, `Gt` and `Lt` are not available for `podAffinity` as of now. 
 {{</note>}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -502,7 +502,7 @@ to learn more about how these work.
 
 The following are all the logical operators that you can use in the `operator` field for `nodeAffinity` and `podAffinity` mentioned above.
 
-|    Operator    |    Behaviour    |
+|    Operator    |    Behavior     |
 | :------------: | :-------------: |
 | `In` | The label value is present in the supplied set of strings |
 |   `NotIn`   | The label value is not contained in the supplied set of strings |
@@ -518,7 +518,9 @@ The following operators can only be used with `nodeAffinity`.
 
 
 {{<note>}}
-`Gt` and `Lt` operators will not work with non integer values. If the given value doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt` are not available for `podAffinity`.
+`Gt` and `Lt` operators will not work with non-integer values. If the given value 
+doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt` 
+are not available for `podAffinity`.
 {{</note>}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -500,20 +500,25 @@ to learn more about how these work.
 
 ## Operators
 
-The following are all the logical operators that you can use with the `operator` field for `nodeAffinity` and `podAffinity` mentioned above.
+The following are all the logical operators that you can use in the `operator` field for `nodeAffinity` and `podAffinity` mentioned above.
 
 |    Operator    |    Behaviour    |
 | :------------: | :-------------: |
-| In | The label value is contained in the supplied set of strings |
-|   NotIn   | The label value is not contained in the supplied set of strings |
-| Exists | A label with this key exists on the object |
-| DoesNotExist | No such label with this key exists on the object |
-| Gt | The supplied value will be parsed as an integer, and that integer is less than or equal to the integer that results from parsing the value of a label named by this selector | 
-| Lt | The supplied value will be parsed as an integer, and that integer is greater than or equal to the integer that results from parsing the value of a label named by this selector | 
+| `In` | The label value is present in the supplied set of strings |
+|   `NotIn`   | The label value is not contained in the supplied set of strings |
+| `Exists` | A label with this key exists on the object |
+| `DoesNotExist` | No label with this key exists on the object |
+
+The following operators can only be used with `nodeAffinity`.
+
+|    Operator    |    Behaviour    |
+| :------------: | :-------------: |
+| `Gt` | The supplied value will be parsed as an integer, and that integer is less than or equal to the integer that results from parsing the value of a label named by this selector | 
+| `Lt` | The supplied value will be parsed as an integer, and that integer is greater than or equal to the integer that results from parsing the value of a label named by this selector | 
 
 
 {{<note>}}
-`Gt` and `Lt` operators will not work with non integer values. If the given value doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt` are not available for `podAffinity` as of now. 
+`Gt` and `Lt` operators will not work with non integer values. If the given value doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt` are not available for `podAffinity`.
 {{</note>}}
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
This PR adds a section in the [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) page in the docs explaining the different operators. I have added a common section in the bottom and mentioned this in both the `nodeAffinity` and `podAffinity` section where the operators are mentioned.

Closes #33323 and #39256

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
