### PR TITLE
change host file entry for Mac

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -208,6 +208,15 @@ The following manifest defines an Ingress that sends traffic to your Service via
    If you are running Minikube locally, use `minikube ip` to get the external IP.
    The IP address displayed within the ingress list will be the internal IP.
    {{< /note >}}
+   
+   {{< note >}}
+   For Mac, if you are running Minikube locally, point to localhost in the hosts file instead of the minikube ip
+   
+    ```none
+    127.0.0.1 hello-world.info
+    ```
+   And then use `minikube tunnel`
+   {{< /note >}}
 
    After you make this change, your web browser sends requests for
    `hello-world.info` URLs to Minikube.


### PR DESCRIPTION
For mac, the following parts of the documentation did not work for me:
> 1. Add the following line to the bottom of the `/etc/hosts` file on
>   your computer (you will need administrator access):

>    ```none
>   172.17.0.15 hello-world.info
>  ```

Instead, my host file needed to point to 127.0.0.1 (localhost), and Mac users need to run `minikube tunnel`

This works on Mac with minikube running on a Docker back-end:

>    ```none
>   127.0.0.1 hello-world.info
>  ```

followed by running the command `minikube tunnel`

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

See this comment: https://github.com/kubernetes/minikube/issues/13510#issuecomment-1130152467
