### PR TITLE
Clarify horizontal pod autoscaler docs on scaling behavior

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -470,7 +470,7 @@ for scaling down which allows a 100% of the currently running replicas to be rem
 means the scaling target can be scaled down to the minimum allowed replicas.
 For scaling up there is no stabilization window. When the metrics indicate that the target should be
 scaled up the target is scaled up immediately. There are 2 policies where 4 pods or a 100% of the currently
-running replicas will be added every 15 seconds till the HPA reaches its steady state.
+running replicas may at most be added every 15 seconds till the HPA reaches its steady state.
 
 ### Example: change downscale stabilization window
 


### PR DESCRIPTION
Stresses that behavior controls define limits to scaling (what at most can happen) and not the size of scaling actions verbatim. This is currently being repeatedly misunderstood by users.