### PR TITLE
Remove typo in documentation

### DIFF
--- a/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
@@ -36,7 +36,7 @@ A node selector requirement is a selector that contains values, a key, and an op
 
 - **operator** (string), required
 
-  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist, Gt, and Lt.
   
   
 


### PR DESCRIPTION
Remove typo (i.e., replace full stop `.` with a comma `,`) in [document](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeselectorrequirement-v1-core).

 
