### PR TITLE
Add the blog post for the beta graduation of HPA ContainerResource type metric

### DIFF
--- a/content/en/blog/_posts/2023-04-13-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-04-13-hpa-container-resource-metric.md
@@ -1,0 +1,78 @@
+---
+layout: blog
+title: "HPA ContainerResource type metric moves to beta"
+date: 2023-04-11
+slug: hpa-container-resource-metric
+---
+
+**Author: [Kensei Nakada](https://github.com/sanposhiho) (Mercari)**
+
+Kubernetes 1.20 introduced [the ContainerResource type metric](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics) in HPA.
+
+In Kubernetes 1.27, this feature moves to beta and the corresponding feature gate (`HPAContainerMetrics`) gets enabled by default. 
+
+## What is the ContainerResource type metric
+
+The ContainerResource type metric allows us to configure the autoscaling based on resource usage of individual containers.
+
+In the following example, the HPA controller scales the target 
+so that the average utilization of the cpu in the application container of all the pods is 60%.
+
+```yaml
+type: ContainerResource
+containerResource:
+  name: cpu
+  container: application
+  target:
+    type: Utilization
+    averageUtilization: 60
+```
+
+## The difference from the Resource type metric
+
+HPA already has [the Resource type metric](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics). 
+
+We can define the target resource utilization like the following,
+and then HPA will scale up/down the replicas based on the current utilization.
+
+```yaml
+type: Resource
+resource:
+  name: cpu
+  target:
+    type: Utilization
+    averageUtilization: 60
+```
+
+But, this Resource type metric refers to the average utilization of the **Pods**.
+
+In case a Pod has multiple containers, the utilization calculation would be:
+
+```
+sum{the resource usages of each container} / sum{the resource request of each container}
+```
+
+So, even if one container's resource utilization goes high, the Resource type metric may not suggest scaling up.
+
+If your Pod has multiple containers, you may want to use the ContainerResource type metric instead for the accurate autoscaling.
+
+## What's new for the beta?
+
+For Kubernetes v1.27, the ContainerResource type metric will be available by default as described at the beginning.
+(You can still disable it by the `HPAContainerMetrics` feature gate.)
+
+On the instrumentation side, the kube-controller-manager reports the following new metrics([ref1](https://github.com/kubernetes/kubernetes/pull/116326), [ref2](https://github.com/kubernetes/kubernetes/pull/116010)):
+- `metric_computation_duration_seconds`: Number of metric computations. 
+- `metric_computation_total`: The time that the HPA controller takes to calculate one metric.
+- `reconciliations_total`: Number of reconciliation of HPA controller. 
+- `reconciliation_duration_seconds`: The time that the HPA controller takes to reconcile a HPA object once.
+
+## Getting involved 
+
+This feature is managed by the [SIG/Autoscaling](https://github.com/kubernetes/community/tree/master/sig-autoscaling). 
+Please join us and share your feedback. We look forward to hearing from you!
+
+## How can I learn more?
+
+- [The official document of the ContainerResource type metric](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics)
+- [KEP-1610: Container Resource based Autoscaling](https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling/1610-container-resource-autoscaling)

--- a/content/en/blog/_posts/2023-04-13-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-04-13-hpa-container-resource-metric.md
@@ -57,9 +57,16 @@ sum{the resource usage of each container} / sum{the resource request of each con
 The resource utiliaztion of each container may not have a direct correlation or may grow at different rates as the load changes. 
 
 For example:
-- A sidecar container is only providing an auxiliary service such as log shipping. If the application does not log very frequently or does not produce logs in its hotpath then the usage of the log shipper will not grow.
-- A sidecar container which provides authentication. Due to heavy caching the usage will only increase slightly when the load on the main container increases. In the current blended usage calculation approach this usually results in the the HPA not scaling up the deployment because the blended usage is still low.
-- A sidecar may be injected without resources set which prevents scaling based on utilization. In the current logic the HPA controller can only scale on absolute resource usage of the pod when the resource requests are not set.
+- A sidecar container is only providing an auxiliary service such as log shipping.
+  If the application does not log very frequently or does not produce logs in its hotpath
+  then the usage of the log shipper will not grow.
+- A sidecar container which provides authentication. Due to heavy caching
+  the usage will only increase slightly when the load on the main container increases.
+  In the current blended usage calculation approach this usually results in
+  the HPA not scaling up the deployment because the blended usage is still low.
+- A sidecar may be injected without resources set which prevents scaling
+  based on utilization. In the current logic the HPA controller can only scale
+  on absolute resource usage of the pod when the resource requests are not set.
 
 And, in such case, if only one container's resource utilization goes high, 
 the Resource type metric may not suggest scaling up.
@@ -85,7 +92,8 @@ All metrics are useful for general monitoring of HPA controller,
 you can get deeper insight like which part has a problem, where takes time, how many scaling tends to happen at which time on your cluster etc.
 
 Another minor stuff, we've changed the SuccessfulRescale event's messages 
-so that everyone can whether the events came from the resource metric or the container resource metric. ([ref](https://github.com/kubernetes/kubernetes/pull/116045))
+so that everyone can check whether the events came from the resource metric or
+the container resource metric (See [the related PR](https://github.com/kubernetes/kubernetes/pull/116045)).
 
 ## Getting involved 
 

--- a/content/en/blog/_posts/2023-04-13-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-04-13-hpa-container-resource-metric.md
@@ -7,7 +7,7 @@ slug: hpa-container-resource-metric
 
 **Author: [Kensei Nakada](https://github.com/sanposhiho) (Mercari)**
 
-Kubernetes 1.20 introduced [the ContainerResource type metric](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics) in HPA.
+Kubernetes 1.20 introduced [the ContainerResource type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics) in HPA.
 
 In Kubernetes 1.27, this feature moves to beta and the corresponding feature gate (`HPAContainerMetrics`) gets enabled by default. 
 
@@ -17,7 +17,8 @@ The ContainerResource type metric allows us to configure the autoscaling based o
 
 In the following example, the HPA controller scales the target 
 so that the average utilization of the cpu in the application container of all the pods is around 60%.
-(See [here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) to know how the desired replica number is calculated exactly)
+(See [the algorithm details](/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details)
+to know how the desired replica number is calculated exactly)
 
 ```yaml
 type: ContainerResource
@@ -31,7 +32,7 @@ containerResource:
 
 ## The difference from the Resource type metric
 
-HPA already has [the Resource type metric](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics). 
+HPA already has [the Resource type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics). 
 
 We can define the target resource utilization like the following,
 and then HPA will scale up/down the replicas based on the current utilization.
@@ -70,9 +71,9 @@ So, for the accurate autoscaling, you may want to use the ContainerResource type
 For Kubernetes v1.27, the ContainerResource type metric will be available by default as described at the beginning.
 (You can still disable it by the `HPAContainerMetrics` feature gate.)
 
-Also, we've improve the observability of HPA controller by exposing some metrics from the kube-controller-manager:
-- `metric_computation_duration_seconds`: Number of metric computations. 
-- `metric_computation_total`: The time that the HPA controller takes to calculate one metric.
+Also, we've improved the observability of HPA controller by exposing some metrics from the kube-controller-manager:
+- `metric_computation_total`: Number of metric computations. 
+- `metric_computation_duration_seconds`: The time that the HPA controller takes to calculate one metric.
 - `reconciliations_total`: Number of reconciliation of HPA controller. 
 - `reconciliation_duration_seconds`: The time that the HPA controller takes to reconcile a HPA object once.
 
@@ -93,5 +94,5 @@ Please join us and share your feedback. We look forward to hearing from you!
 
 ## How can I learn more?
 
-- [The official document of the ContainerResource type metric](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics)
+- [The official document of the ContainerResource type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics)
 - [KEP-1610: Container Resource based Autoscaling](https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling/1610-container-resource-autoscaling)

--- a/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes 1.27: HorizontalPodAutoscaler ContainerResource type metric moves to beta"
-date: 2023-05-02
+date: 2023-05-02T12:00:00+0800
 slug: hpa-container-resource-metric
 ---
 

--- a/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
@@ -1,13 +1,14 @@
 ---
 layout: blog
-title: "HPA ContainerResource type metric moves to beta"
+title: "Kubernetes 1.27: HorizontalPodAutoscaler ContainerResource type metric moves to beta"
 date: 2023-05-02
 slug: hpa-container-resource-metric
 ---
 
-**Author: [Kensei Nakada](https://github.com/sanposhiho) (Mercari)**
+**Author:** [Kensei Nakada](https://github.com/sanposhiho) (Mercari)
 
-Kubernetes 1.20 introduced [the ContainerResource type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics) in HPA.
+Kubernetes 1.20 introduced the [`ContainerResource` type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics)
+in HorizontalPodAutoscaler (HPA).
 
 In Kubernetes 1.27, this feature moves to beta and the corresponding feature gate (`HPAContainerMetrics`) gets enabled by default. 
 
@@ -32,9 +33,9 @@ containerResource:
 
 ## The difference from the Resource type metric
 
-HPA already has [the Resource type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics). 
+HPA already had a [Resource type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics).
 
-We can define the target resource utilization like the following,
+You can define the target resource utilization like the following,
 and then HPA will scale up/down the replicas based on the current utilization.
 
 ```yaml
@@ -54,7 +55,7 @@ In case a Pod has multiple containers, the utilization calculation would be:
 sum{the resource usage of each container} / sum{the resource request of each container}
 ```
 
-The resource utiliaztion of each container may not have a direct correlation or may grow at different rates as the load changes. 
+The resource utilization of each container may not have a direct correlation or may grow at different rates as the load changes.
 
 For example:
 - A sidecar container is only providing an auxiliary service such as log shipping.
@@ -75,7 +76,8 @@ So, for the accurate autoscaling, you may want to use the ContainerResource type
 
 ## What's new for the beta?
 
-For Kubernetes v1.27, the ContainerResource type metric will be available by default as described at the beginning.
+For Kubernetes v1.27, the ContainerResource type metric is available by default as described at the beginning
+of this article.
 (You can still disable it by the `HPAContainerMetrics` feature gate.)
 
 Also, we've improved the observability of HPA controller by exposing some metrics from the kube-controller-manager:
@@ -86,18 +88,18 @@ Also, we've improved the observability of HPA controller by exposing some metric
 
 These metrics have labels `action` (`scale_up`, `scale_down`, `none`) and `error` (`spec`, `internal`, `none`).
 And, in addition to them, the first two metrics have the `metric_type` label
-which corresponds to `HPA.spec.metrics[*].type`.
+which corresponds to `.spec.metrics[*].type` for a HorizontalPodAutoscaler.
 
 All metrics are useful for general monitoring of HPA controller,
-you can get deeper insight like which part has a problem, where takes time, how many scaling tends to happen at which time on your cluster etc.
+you can get deeper insight into which part has a problem, where it takes time, how much scaling tends to happen at which time on your cluster etc.
 
-Another minor stuff, we've changed the SuccessfulRescale event's messages 
+Another minor stuff, we've changed the `SuccessfulRescale` event's messages
 so that everyone can check whether the events came from the resource metric or
 the container resource metric (See [the related PR](https://github.com/kubernetes/kubernetes/pull/116045)).
 
 ## Getting involved 
 
-This feature is managed by the [SIG/Autoscaling](https://github.com/kubernetes/community/tree/master/sig-autoscaling). 
+This feature is managed by [SIG Autoscaling](https://github.com/kubernetes/community/tree/master/sig-autoscaling). 
 Please join us and share your feedback. We look forward to hearing from you!
 
 ## How can I learn more?

--- a/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "HPA ContainerResource type metric moves to beta"
-date: 2023-04-11
+date: 2023-05-02
 slug: hpa-container-resource-metric
 ---
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

The container resource metrics is planning to get graduated to beta in v1.27. So, the feature will be available for many people by default. 
 It’s worth sharing this feature and the motivation for people since this feature is very important to configure safe HPAs for Pod with multiple containers.

---


ref: https://github.com/kubernetes/enhancements/issues/1610