### PR TITLE
[fr] add french translation for task inject-data-application/environment-variable-expose-pod-information.md

### DIFF
--- a/content/fr/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/fr/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -1,0 +1,164 @@
+---
+title: Exposer les informations du Pod aux containers via les variables d'environnement 
+content_type: task
+weight: 30
+---
+
+<!-- overview -->
+
+Cette page montre comment un Pod peut utiliser des variables d'environnement pour
+exposer ses propres informations aux containers qu'il exécute via la  
+_downward API_.
+Vous pouvez utiliser des variables d'environnement pour exposer des champs 
+de configuration du Pod, des containers ou les deux.
+Dans Kubernetes, il y a deux façons distinctes d'exposer les champs de
+configuration de Pod et de container à l'intérieur d'un container:
+
+* _Via les variables d'environnement_, comme expliqué ci-dessous
+* Via un [volume](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)
+
+Ensemble, ces deux façons d'exposer des informations du Pod et du container sont appelées la _downward API_.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+## Utiliser les champs du Pod comme variables d'environnement
+
+Dans cette partie de l'exercice, vous allez créer un Pod qui a un container,
+et vous allez projeter les champs d'informations du Pod à l'intérieur du
+container comme variables d'environnement.
+
+{{< codenew file="pods/inject/dapi-envars-pod.yaml" >}}
+
+Dans ce fichier de configuration, on trouve cinq variables d'environnement. Le champ `env` est une liste de variables d'environnement. 
+Le premier élément de la liste spécifie que la variable d'environnement
+`MY_NODE_NAME` aura sa valeur à partir du champ `spec.nodeName` du Pod.
+Il en va de même pour les autres variables d'environnement, qui héritent
+des champs du Pod.
+{{< note >}}
+Les champs de configuration présents dans cet exemple sont des champs du Pod. Ce ne sont pas les champs du container à l'intérieur du Pod.
+{{< /note >}}
+
+Créez le Pod:
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/inject/dapi-envars-pod.yaml
+```
+
+Vérifiez que le container dans le Pod fonctionne:
+
+```shell
+# If the new Pod isn't yet healthy, rerun this command a few times.
+kubectl get pods
+```
+
+Affichez les logs du container:
+
+```shell
+kubectl logs dapi-envars-fieldref
+```
+
+Le résultat doit afficher les valeurs des variables d'environnement choisies:
+
+```
+minikube
+dapi-envars-fieldref
+default
+172.17.0.4
+default
+```
+
+Pour comprendre pourquoi ces valeurs apparaissent dans les logs, regardez les champs `command` et `args` du fichier de configuration. Lorsque le container s'exécute, il écrit les valeurs de 5 variables d'environnement vers stdout, avec un interval de 10 secondes.
+
+Ensuite, exécutez un shell à l'intérieur du container:
+
+```shell
+kubectl exec -it dapi-envars-fieldref -- sh
+```
+
+Dans ce shell, listez les variables d'environnement:
+
+```shell
+# À exécuter à l'intérieur du container
+printenv
+```
+
+Le résultat doit montrer que certaines variables d'environnement contiennent 
+les informations du Pod:
+
+```
+MY_POD_SERVICE_ACCOUNT=default
+...
+MY_POD_NAMESPACE=default
+MY_POD_IP=172.17.0.4
+...
+MY_NODE_NAME=minikube
+...
+MY_POD_NAME=dapi-envars-fieldref
+```
+
+## Utiliser des informations du container comme variables d'environnement
+
+Dans l'exercice précédent, vous avez utilisé les informations du Pod à
+travers des variables d'environnement.
+Dans cet exercice, vous allez faire passer des champs appartenant 
+au [container](/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container) 
+qui est exécuté à l'intérieur du Pod. 
+
+Voici un fichier de configuration pour un autre Pod qui ne contient qu'un seul 
+container:
+
+{{< codenew file="pods/inject/dapi-envars-container.yaml" >}}
+
+Dans ce fichier, vous pouvez voir 4 variables d'environnement.
+Le champ `env` est une liste de variables d'environnement.
+Le premier élément de la liste spécifie que la variable d'environnement `MY_CPU_REQUEST` aura sa valeur à partir du champ `requests.cpu` du container avec le nom `test-container`. Il en va de même pour les autres variables d'environnement, qui hériteront des champs du container qui sera exécuté.
+
+Créez le Pod:
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/inject/dapi-envars-container.yaml
+```
+
+Vérifiez que le container dans le Pod fonctionne:
+
+```shell
+# Si le nouveau Pod n'est pas fonctionnel, re-exécutez cette commande plusieurs fois
+kubectl get pods
+```
+
+Affichez les logs du container:
+
+```shell
+kubectl logs dapi-envars-resourcefieldref
+```
+
+Le résultat doit afficher les valeurs des variables selectionnées:
+
+```
+1
+1
+33554432
+67108864
+```
+
+## {{% heading "whatsnext" %}}
+
+
+* Lire [Defining Environment Variables for a Container](/docs/tasks/inject-data-application/define-environment-variable-container/)
+* Read the [`spec`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
+  API definition for Pod. This includes the definition of Container (part of Pod).
+* Read the list of [available fields](/docs/concepts/workloads/pods/downward-api/#available-fields) that you
+  can expose using the downward API.
+
+Read about Pods, containers and environment variables in the legacy API reference:
+
+* [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core)
+* [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)
+* [EnvVar](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#envvar-v1-core)
+* [EnvVarSource](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#envvarsource-v1-core)
+* [ObjectFieldSelector](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#objectfieldselector-v1-core)
+* [ResourceFieldSelector](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#resourcefieldselector-v1-core)

--- a/content/fr/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/fr/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -53,7 +53,7 @@ kubectl apply -f https://k8s.io/examples/pods/inject/dapi-envars-pod.yaml
 Vérifiez que le container dans le Pod fonctionne:
 
 ```shell
-# If the new Pod isn't yet healthy, rerun this command a few times.
+# Si le nouveau Pod n'est pas fonctionnel, re-exécutez cette commande plusieurs fois
 kubectl get pods
 ```
 

--- a/content/fr/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/fr/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -11,10 +11,11 @@ exposer ses propres informations aux containers qu'il exécute via la
 _downward API_.
 Vous pouvez utiliser des variables d'environnement pour exposer des champs 
 de configuration du Pod, des containers ou les deux.
+
 Dans Kubernetes, il y a deux façons distinctes d'exposer les champs de
 configuration de Pod et de container à l'intérieur d'un container:
 
-* _Via les variables d'environnement_, comme expliqué ci-dessous
+* _Via les variables d'environnement_, comme expliqué dans cette tâche,
 * Via un [volume](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)
 
 Ensemble, ces deux façons d'exposer des informations du Pod et du container sont appelées la _downward API_.
@@ -33,11 +34,12 @@ container comme variables d'environnement.
 
 {{< codenew file="pods/inject/dapi-envars-pod.yaml" >}}
 
-Dans ce fichier de configuration, on trouve cinq variables d'environnement. Le champ `env` est une liste de variables d'environnement. 
-Le premier élément de la liste spécifie que la variable d'environnement
-`MY_NODE_NAME` aura sa valeur à partir du champ `spec.nodeName` du Pod.
+Dans ce fichier de configuration, on trouve cinq variables d'environnement.
+Le champ `env` est une liste de variables d'environnement.
+Le premier élément de la liste spécifie que la valeur de la variable d'environnement
+`MY_NODE_NAME` hérite du champ `spec.nodeName` du Pod.
 Il en va de même pour les autres variables d'environnement, qui héritent
-des champs du Pod.
+des autres champs du Pod.
 {{< note >}}
 Les champs de configuration présents dans cet exemple sont des champs du Pod. Ce ne sont pas les champs du container à l'intérieur du Pod.
 {{< /note >}}
@@ -148,13 +150,13 @@ Le résultat doit afficher les valeurs des variables selectionnées:
 ## {{% heading "whatsnext" %}}
 
 
-* Lire [Defining Environment Variables for a Container](/docs/tasks/inject-data-application/define-environment-variable-container/)
-* Read the [`spec`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
-  API definition for Pod. This includes the definition of Container (part of Pod).
-* Read the list of [available fields](/docs/concepts/workloads/pods/downward-api/#available-fields) that you
-  can expose using the downward API.
+* Lire [Définir des variables d'environnement pour un Container](/docs/tasks/inject-data-application/define-environment-variable-container/)
+* Lire la [`documentation de référence des Pod`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec).
+  Elle inclut la documentation pour les containers.
+* Lire la liste des [champs de configuration disponibles](/docs/concepts/workloads/pods/downward-api/#available-fields)
+  qui peuvent être exposés via la downward API.
 
-Read about Pods, containers and environment variables in the legacy API reference:
+En savoir plus sur les pods, les containers et les variables d'environnement avec les documentations de référence:
 
 * [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core)
 * [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)

--- a/content/fr/examples/pods/inject/dapi-envars-container.yaml
+++ b/content/fr/examples/pods/inject/dapi-envars-container.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-envars-resourcefieldref
+spec:
+  containers:
+    - name: test-container
+      image: registry.k8s.io/busybox:1.24
+      command: [ "sh", "-c"]
+      args:
+      - while true; do
+          echo -en '\n';
+          printenv MY_CPU_REQUEST MY_CPU_LIMIT;
+          printenv MY_MEM_REQUEST MY_MEM_LIMIT;
+          sleep 10;
+        done;
+      resources:
+        requests:
+          memory: "32Mi"
+          cpu: "125m"
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+      env:
+        - name: MY_CPU_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              containerName: test-container
+              resource: requests.cpu
+        - name: MY_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: test-container
+              resource: limits.cpu
+        - name: MY_MEM_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              containerName: test-container
+              resource: requests.memory
+        - name: MY_MEM_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: test-container
+              resource: limits.memory
+  restartPolicy: Never

--- a/content/fr/examples/pods/inject/dapi-envars-pod.yaml
+++ b/content/fr/examples/pods/inject/dapi-envars-pod.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-envars-fieldref
+spec:
+  containers:
+    - name: test-container
+      image: registry.k8s.io/busybox
+      command: [ "sh", "-c"]
+      args:
+      - while true; do
+          echo -en '\n';
+          printenv MY_NODE_NAME MY_POD_NAME MY_POD_NAMESPACE;
+          printenv MY_POD_IP MY_POD_SERVICE_ACCOUNT;
+          sleep 10;
+        done;
+      env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: MY_POD_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+  restartPolicy: Never


### PR DESCRIPTION
Hi,

This adds the French translation for the task "Expose Pod Information to Containers Through Environment Variables", from the "Inject Data Into Applications" section, including the example yaml files.

This is the [reference document](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).

Thx 😄 