### PR TITLE
add doc for ServiceNodePortStaticSubrange

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -586,6 +586,20 @@ spec:
       nodePort: 30007
 ```
 
+#### Reserve Nodeport Ranges to avoid collisions when port assigning 
+
+{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+
+The policy for assigning ports to NodePort services applies to both the auto-assignment and
+the manual assignment scenarios. When a user wants to create a NodePort service that
+uses a specific port, the target port may conflict with another port that has already been assigned.
+In this case, you can enable the feature gate `ServiceNodePortStaticSubrange`, which allows you
+to use a different port allocation strategy for NodePort Services. The port range for NodePort services
+is divided into two bands. Dynamic port assignment uses the upper band by default, and it may use
+the lower band once the upper band has been exhausted. Users can then allocate from the lower band
+with a lower risk of port collision.
+
+
 #### Custom IP address configuration for `type: NodePort` Services {#service-nodeport-custom-listen-address}
 
 You can set up nodes in your cluster to use a particular IP address for serving node port

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -186,6 +186,7 @@ For a reference to old feature gates that are removed, please refer to
 | `SeccompDefault` | `true` | Beta | 1.25 | |
 | `ServerSideFieldValidation` | `false` | Alpha | 1.23 | 1.24 |
 | `ServerSideFieldValidation` | `true` | Beta | 1.25 | |
+| `ServiceNodePortStaticSubrange` | `false` | Alpha | 1.27 | |
 | `SizeMemoryBackedVolumes` | `false` | Alpha | 1.20 | 1.21 |
 | `SizeMemoryBackedVolumes` | `true` | Beta | 1.22 | |
 | `StatefulSetAutoDeletePVC` | `false` | Alpha | 1.22 | |


### PR DESCRIPTION
add doc for KEP 3668 https://github.com/kubernetes/enhancements/issues/3668

add doc in service concepts page to describes the behavior of the new Feature ServiceNodePortStaticSubrange, and the problems it solves