### PR TITLE
[ja] Update page weights under 5 sections of concepts

### DIFF
--- a/content/ja/docs/concepts/architecture/cri.md
+++ b/content/ja/docs/concepts/architecture/cri.md
@@ -1,7 +1,7 @@
 ---
 title: コンテナランタイムインターフェイス(CRI)
 content_type: concept
-weight: 50
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/architecture/garbage-collection.md
+++ b/content/ja/docs/concepts/architecture/garbage-collection.md
@@ -1,7 +1,7 @@
 ---
 title: ガベージコレクション
 content_type: concept
-weight: 50
+weight: 70
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/cluster-administration/addons.md
+++ b/content/ja/docs/concepts/cluster-administration/addons.md
@@ -1,6 +1,7 @@
 ---
 title: アドオンのインストール
 content_type: concept
+weight: 120
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/cluster-administration/proxies.md
+++ b/content/ja/docs/concepts/cluster-administration/proxies.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetesのプロキシー
 content_type: concept
-weight: 90
+weight: 100
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/cluster-administration/system-logs.md
+++ b/content/ja/docs/concepts/cluster-administration/system-logs.md
@@ -1,7 +1,7 @@
 ---
 title: システムログ
 content_type: concept
-weight: 60
+weight: 80
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/ja/docs/concepts/containers/container-lifecycle-hooks.md
@@ -1,7 +1,7 @@
 ---
 title: コンテナライフサイクルフック
 content_type: concept
-weight: 30
+weight: 40
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/containers/runtime-class.md
+++ b/content/ja/docs/concepts/containers/runtime-class.md
@@ -2,7 +2,7 @@
 reviewers:
 title: ランタイムクラス(Runtime Class)
 content_type: concept
-weight: 20
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/ja/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/ja/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Kubernetes APIの拡張
-weight: 20
+weight: 30
 ---

--- a/content/ja/docs/concepts/policy/resource-quotas.md
+++ b/content/ja/docs/concepts/policy/resource-quotas.md
@@ -2,7 +2,7 @@
 reviewers:
 title: リソースクォータ
 content_type: concept
-weight: 10
+weight: 20
 ---
 
 <!-- overview -->


### PR DESCRIPTION
This PR updates the page weights under the 5 sections in concepts.
This pr will be the last for the update of page weights under the ja/docs/concepts.

- content/ja/docs/concepts/extend-kubernetes
- content/ja/docs/concepts/containers
- content/ja/docs/concepts/architecture
- content/ja/docs/concepts/cluster-administration
- content/ja/docs/concepts/policy

This updates the page order.

Related: #37470 #37471 #37473 #37484 #23929

The files under policy were updated long ago in en.
