### PR TITLE
[ja] Update page weights under content/ja/docs/contribute

### DIFF
--- a/content/ja/docs/contribute/localization.md
+++ b/content/ja/docs/contribute/localization.md
@@ -1,6 +1,7 @@
 ---
 title: Kubernetesのドキュメントを翻訳する
 content_type: concept
+weight: 50
 card:
   name: contribute
   weight: 30

--- a/content/ja/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/ja/docs/contribute/style/hugo-shortcodes/index.md
@@ -1,6 +1,7 @@
 ---
 title: カスタムHugoショートコード
 content_type: concept
+weight: 120
 ---
 
 <!-- overview -->


### PR DESCRIPTION
This updates the page weights under content/ja/docs/contribute and the pages are shown with new order.

Related: #37480, #19576

The localization.md was updated long ago in en.
Though the page is made for Japanese translation and it is different from en, I thought that the weight should be the same as en.
