### PR TITLE
a warning on liveness probes about cascading failures, added

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -25,7 +25,12 @@ it succeeds, making sure those probes don't interfere with the application start
 This can be used to adopt liveness checks on slow starting containers, avoiding them
 getting killed by the kubelet before they are up and running.
 
-
+{{< note >}}
+Please note that liveness probes can lead to cascading failures,
+e.g. causing excessive downtime due to container restarts in high-load situations.
+Understand the difference between readiness and liveness probes
+and when to apply them for your app.
+{{< /note >}}
 
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
#### Title of the Commit

A warning on liveness probes about cascading failures, added

#### Which issue(s) this PR fixes

Part of #16607 

#### Description

A simple note that liveness probes can lead to cascading failures is added. This note is added because many new inexperienced app developers can make mistakes because it does not say anything about the danger of using Liveness Probes.