### PR TITLE
[zh-cn] Shortcode fixes

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -207,6 +207,7 @@ change will have no or little effect, for a similar reason.
 If your cluster has several hundred Nodes or fewer, leave this configuration option
 at its default value. Making changes is unlikely to improve the
 scheduler's performance significantly.
+{{< /note >}}
 -->
 {{< note >}}
 当集群中的可调度节点少于 50 个时，调度器仍然会去检查所有的 Node，

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates-removed.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates-removed.md
@@ -360,6 +360,7 @@ In the following table:
 | `WindowsRunAsUserName` | `false` | Alpha | 1.16 | 1.16 |
 | `WindowsRunAsUserName` | `true` | Beta | 1.17 | 1.17 |
 | `WindowsRunAsUserName` | `true` | GA | 1.18 | 1.20 |
+{{< /table >}}
 
 <!--
 ## Descriptions for removed feature gates

--- a/content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
@@ -169,6 +169,7 @@ is the first provider, the first key is used for encryption.
 `aesgcm` | 带有随机数的 AES-GCM | 必须每 200k 写入一次 | 最快 | 16、24 或者 32字节 | 建议不要使用，除非实施了自动密钥循环方案。
 `aescbc` | 填充 [PKCS#7](https://datatracker.ietf.org/doc/html/rfc2315) 的 AES-CBC | 弱 | 快 | 32 字节 | 由于 CBC 容易受到密文填塞攻击（Padding Oracle Attack），不推荐使用。
 `kms` | 使用信封加密方案：数据使用带有 [PKCS#7](https://datatracker.ietf.org/doc/html/rfc2315) 填充的 AES-CBC（v1.25 之前），从 v1.25 开始使用 AES-GCM 通过数据加密密钥（DEK）加密，DEK 根据 Key Management Service（KMS）中的配置通过密钥加密密钥（Key Encryption Keys，KEK）加密 | 最强 | 快 | 32 字节 | 建议使用第三方工具进行密钥管理。为每个加密生成新的 DEK，并由用户控制 KEK 轮换来简化密钥轮换。[配置 KMS 提供程序](/zh-cn/docs/tasks/administer-cluster/kms-provider/)
+{{< /table >}}
 
 每个 provider 都支持多个密钥 - 在解密时会按顺序使用密钥，如果是第一个 provider，则第一个密钥用于加密。
 

--- a/content/zh-cn/docs/tutorials/stateful-application/cassandra.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/cassandra.md
@@ -91,6 +91,7 @@ To complete this tutorial, you should already have a basic familiarity with
 [Minikube](https://minikube.sigs.k8s.io/docs/) defaults to 2048MB of memory and 2 CPU.
 Running Minikube with the default resource configuration results in insufficient resource
 errors during this tutorial. To avoid these errors, start Minikube with the following settings:
+{{< /caution >}}
 -->
 ### 额外的 Minikube 设置说明
 


### PR DESCRIPTION
Hugo v0.111.x will throw an error if shortcodes are not correctly closed. (https://github.com/gohugoio/hugo/issues/10675)
This PR brings fixes this issue for the zh-ch locale.