### PR TITLE
[ja] add garbage-collection in glossary.

### DIFF
--- a/content/ja/docs/concepts/architecture/garbage-collection.md
+++ b/content/ja/docs/concepts/architecture/garbage-collection.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 <!-- overview -->
-ガベージコレクションは、Kubernetesがクラスターリソースをクリーンアップするために使用するさまざまなメカニズムの総称です。これにより、次のようなリソースのクリーンアップが可能になります:
+{{<glossary_definition term_id="garbage-collection" length="short">}}これにより、次のようなリソースのクリーンアップが可能になります:
 
   * [終了したPod](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
   * [完了したJob](/ja/docs/concepts/workloads/controllers/ttlafterfinished/)

--- a/content/ja/docs/reference/glossary/garbage-collection.md
+++ b/content/ja/docs/reference/glossary/garbage-collection.md
@@ -1,0 +1,20 @@
+---
+title: ガベージコレクション
+id: garbage-collection
+date: 2021-07-07
+full_link: /ja/docs/concepts/architecture/garbage-collection/
+short_description: >
+  Kubernetesがクラスターリソースをクリーンアップするために使用するさまざまなメカニズムの総称です。
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+
+ガベージコレクションは、Kubernetesがクラスターリソースをクリーンアップするために使用するさまざまなメカニズムの総称です。
+
+<!--more-->
+
+Kubernetesはガベージコレクションを使用して、[未使用のコンテナとイメージ](/ja/docs/concepts/architecture/garbage-collection/#containers-images)、[失敗したPod](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)、[対象リソースが所有するオブジェクト](/ja/docs/concepts/overview/working-with-objects/owners-dependents/)、[完了したJob](/ja/docs/concepts/workloads/controllers/ttlafterfinished/)、期限切れまたは失敗したリソースなどのリソースをクリーンアップします。
+


### PR DESCRIPTION
This PR adds the garbage-collection in glossary of ja.
It is also used in content/ja/docs/concepts/architecture/garbage-collection.md.

Target pages
- https://deploy-preview-39948--kubernetes-io-main-staging.netlify.app/ja/docs/concepts/architecture/garbage-collection/
- https://deploy-preview-39948--kubernetes-io-main-staging.netlify.app/ja/docs/reference/glossary/?fundamental=true#term-garbage-collection
