### PR TITLE
add redirect for user guide, fix https://github.com/kubernetes/kubern…

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -428,3 +428,8 @@
 
 /docs/concepts/overview/what-is-kubernetes/      /docs/concepts/overview/ 301
 /docs/tasks/administer-cluster/verify-signed-images/     /docs/tasks/administer-cluster/verify-signed-artifacts/   301
+
+/docs/user-guide/identifiers/      /docs/concepts/overview/working-with-objects/names/  301
+/docs/user-guide/namespaces/       /docs/concepts/overview/working-with-objects/namespaces/  301
+/docs/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/  301
+/docs/user-guide/annotations/      /docs/concepts/overview/working-with-objects/annotations/  301


### PR DESCRIPTION
Some of the document links in typemeta are no longer accessible, I redirect these links like the follwing:

/docs/user-guide/identifiers/    ->     /docs/concepts/overview/working-with-objects/names/  301
/docs/user-guide/namespaces/      ->   /docs/concepts/overview/working-with-objects/namespaces/  301
/docs/user-guide/labels/    ->   /docs/concepts/overview/working-with-objects/labels/  301
/docs/user-guide/annotations/     ->    /docs/concepts/overview/working-with-objects/annotations/  301

This change is to keep some links active:
https://github.com/kubernetes/kubernetes/blob/33d9543ceb09a9aff54940d639da23c6102d2fcc/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L115-L120