### PR TITLE
Konnectivity example refresh.

### DIFF
--- a/content/en/examples/admin/konnectivity/konnectivity-agent.yaml
+++ b/content/en/examples/admin/konnectivity/konnectivity-agent.yaml
@@ -22,7 +22,7 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       containers:
-        - image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.16
+        - image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.37
           name: konnectivity-agent
           command: ["/proxy-agent"]
           args: [

--- a/content/en/examples/admin/konnectivity/konnectivity-server.yaml
+++ b/content/en/examples/admin/konnectivity/konnectivity-server.yaml
@@ -8,12 +8,13 @@ spec:
   hostNetwork: true
   containers:
   - name: konnectivity-server-container
-    image: registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32
+    image: registry.k8s.io/kas-network-proxy/proxy-server:v0.0.37
     command: ["/proxy-server"]
     args: [
             "--logtostderr=true",
             # This needs to be consistent with the value set in egressSelectorConfiguration.
             "--uds-name=/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+            "--delete-existing-uds-file",
             # The following two lines assume the Konnectivity server is
             # deployed on the same machine as the apiserver, and the certs and
             # key of the API Server are at the specified location.


### PR DESCRIPTION
- Delete UDS file if exists (common pain point).
- Make server and agent images consistent (and include latest memory leak fixes).

Relevant discussion: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/476