### PR TITLE
[ja] update the link from kubectl tooltip

### DIFF
--- a/content/ja/docs/reference/glossary/kubectl.md
+++ b/content/ja/docs/reference/glossary/kubectl.md
@@ -2,7 +2,7 @@
 title: Kubectl
 id: kubectl
 date: 2018-04-12
-full_link: /docs/reference/kubectl/
+full_link: /ja/docs/reference/kubectl/
 short_description: >
   Kubernetesクラスターと通信するためのコマンドラインツールです。
 


### PR DESCRIPTION
This PR fixed the link of kubectl tooltip from en to ja.
In currently, link to https://kubernetes.io/docs/reference/kubectl/.
After fix, link to https://kubernetes.io/ja/docs/reference/kubectl/.

Example:
- Click "kubectl" at the following page:
  https://deploy-preview-39991--kubernetes-io-main-staging.netlify.app/ja/docs/concepts/architecture/nodes/#manual-node-administration
- Jump to Japanese page:
  https://deploy-preview-39991--kubernetes-io-main-staging.netlify.app/ja/docs/reference/kubectl/



Fixes: #39990