### PR TITLE
Documentation for messageExpression update to KEP-2876

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1049,6 +1049,10 @@ x-kubernetes-validations:
   messageExpression: '"x exceeded max limit of " + string(self.maxLimit)'
 ```
 
+Keep in mind that CEL is strict about using `+` to build strings; it only works on two strings. If
+you have a non-string data type that should be part of `messageExpression`, cast it to a string like
+in the example first.
+
 `messageExpression` must evaluate to a string, and this is checked while the CRD is being written. Note that it is possible
 to set `message` and `messageExpression` on the same rule, and if both are present, `messageExpression`
 will be used. However, if `messageExpression` fails while being evaluated, the string defined in `message` 

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1035,6 +1035,32 @@ xref: [CEL types](https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#
 [OpenAPI types](https://swagger.io/specification/#data-types),
 [Kubernetes Structural Schemas](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema).
 
+#### The messageExpression field
+
+As an alternative to the `message` field that is used to report rule validation failures, there is the
+`messageExpression` field, which is a CEL expression that evaluates to a string. All the same variables
+that are available to the rule are available when writing `messageExpression`, so this makes it easy
+to insert more descriptive information into the validation failure message. For example:
+
+```yaml
+x-kubernetes-validations:
+- rule: "self.x <= self.maxLimit"
+  messageExpression: '"x exceeded max limit of " + string(self.maxLimit)'
+```
+
+`messageExpression` must evaluate to a string, and this is checked at write time. Note that it is possible
+to set `message` and `messageExpression` on the same rule, and if both are present, `messageExpression`
+will be used. However, if `messageExpression` fails at runtime, the string defined in `message` will be
+used instead, and the `messageExpression` error will be logged. This fallback will also occur if
+the CEL expression defined in `messageExpression` generates an empty string, a string with only spaces,
+or a string containing line breaks.
+
+If one of the above conditions are met and no `message` has been set, then the default validation failure
+message will be used instead.
+
+`messageExpression` is a CEL expression, so the restrictions listed in [Resource use by validation functions](#resource-use-by-validation-functions) apply. If the resource system halts during 
+`messageExpression` execution, then no further validation rules will be executed.
+
 #### Validation functions {#available-validation-functions}
 
 Functions available include:

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1037,10 +1037,11 @@ xref: [CEL types](https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#
 
 #### The messageExpression field
 
-As an alternative to the `message` field that is used to report rule validation failures, there is the
-`messageExpression` field, which is a CEL expression that evaluates to a string. All the same variables
-that are available to the rule are available when writing `messageExpression`, so this makes it easy
-to insert more descriptive information into the validation failure message. For example:
+Similar to the `message` field, which defines the string reported for a validation rule failure, 
+`messageExpression` allows you to use a CEL expression to construct the message string.
+This allows you to insert more descriptive information into the validation failure message. 
+`messageExpression` must evaluate a string and may use the same variables that are available to the `rule` 
+field. For example:
 
 ```yaml
 x-kubernetes-validations:
@@ -1048,18 +1049,18 @@ x-kubernetes-validations:
   messageExpression: '"x exceeded max limit of " + string(self.maxLimit)'
 ```
 
-`messageExpression` must evaluate to a string, and this is checked at write time. Note that it is possible
+`messageExpression` must evaluate to a string, and this is checked while the CRD is being written. Note that it is possible
 to set `message` and `messageExpression` on the same rule, and if both are present, `messageExpression`
-will be used. However, if `messageExpression` fails at runtime, the string defined in `message` will be
-used instead, and the `messageExpression` error will be logged. This fallback will also occur if
-the CEL expression defined in `messageExpression` generates an empty string, a string with only spaces,
-or a string containing line breaks.
+will be used. However, if `messageExpression` fails while being evaluated, the string defined in `message` 
+will be used instead, and the `messageExpression` error will be logged. This fallback will also occur if
+the CEL expression defined in `messageExpression` generates an empty string, or a string containing line 
+breaks.
 
 If one of the above conditions are met and no `message` has been set, then the default validation failure
 message will be used instead.
 
-`messageExpression` is a CEL expression, so the restrictions listed in [Resource use by validation functions](#resource-use-by-validation-functions) apply. If the resource system halts during 
-`messageExpression` execution, then no further validation rules will be executed.
+`messageExpression` is a CEL expression, so the restrictions listed in [Resource use by validation functions](#resource-use-by-validation-functions) apply. If evaluation halts due to resource constraints 
+during `messageExpression` execution, then no further validation rules will be executed.
 
 #### Validation functions {#available-validation-functions}
 

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1049,9 +1049,9 @@ x-kubernetes-validations:
   messageExpression: '"x exceeded max limit of " + string(self.maxLimit)'
 ```
 
-Keep in mind that CEL is strict about using `+` to build strings; it only works on two strings. If
-you have a non-string data type that should be part of `messageExpression`, cast it to a string like
-in the example first.
+Keep in mind that CEL string concatenation (`+` operator) does not auto-cast to string. If
+you have a non-string scalar, use the `string(<value>)` function to cast the scalar to a string
+like shown in the above example.
 
 `messageExpression` must evaluate to a string, and this is checked while the CRD is being written. Note that it is possible
 to set `message` and `messageExpression` on the same rule, and if both are present, `messageExpression`

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1055,7 +1055,7 @@ in the example first.
 
 `messageExpression` must evaluate to a string, and this is checked while the CRD is being written. Note that it is possible
 to set `message` and `messageExpression` on the same rule, and if both are present, `messageExpression`
-will be used. However, if `messageExpression` fails while being evaluated, the string defined in `message` 
+will be used. However, if `messageExpression` evaluates to an error, the string defined in `message` 
 will be used instead, and the `messageExpression` error will be logged. This fallback will also occur if
 the CEL expression defined in `messageExpression` generates an empty string, or a string containing line 
 breaks.


### PR DESCRIPTION
This is the docs PR for the `messageExpression` [update](https://github.com/kubernetes/enhancements/pull/3747) to [KEP-2876](https://github.com/kubernetes/enhancements/issues/2876) that was implemented by https://github.com/kubernetes/kubernetes/pull/115969.
