### PR TITLE
Add docs for VolumeManager reconstruction after kubelet restart

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -149,6 +149,7 @@ For a reference to old feature gates that are removed, please refer to
 | `MinimizeIPTablesRestore` | `false` | Alpha | 1.26 | - |
 | `MultiCIDRRangeAllocator` | `false` | Alpha | 1.25 | |
 | `NetworkPolicyStatus` | `false` | Alpha | 1.24 |  |
+| `NewVolumeManagerReconstruction` | `true` | Beta | 1.27 |  |
 | `NodeInclusionPolicyInPodTopologySpread` | `false` | Alpha | 1.25 | 1.25 |
 | `NodeInclusionPolicyInPodTopologySpread` | `true` | Beta | 1.26 | |
 | `NodeOutOfServiceVolumeDetach` | `false` | Alpha | 1.24 | 1.25 |
@@ -626,6 +627,19 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `NetworkPolicyEndPort`: Enable use of the field `endPort` in NetworkPolicy objects,
   allowing the selection of a port range instead of a single port.
 - `NetworkPolicyStatus`: Enable the `status` subresource for NetworkPolicy objects.
+- `NewVolumeManagerReconstruction`: Enable improved discovery of mounted volumes during kubelet
+  startup.
+  <!-- remove next 2 paragraphs when feature graduates to GA -->
+  Before Kubernetes v1.25, the kubelet used different default behavior for discovering mounted
+  volumes during the kubelet startup. If you disable this feature gate (it's enabled by default), you select
+  the legacy discovery behavior.
+
+  In Kubernetes v1.25 and v1.26, this behavior toggle was part of the `SELinuxMountReadWriteOncePod`
+  feature gate.
+- `NewVolumeManagerReconstruction`: Enables improved discovery of mounted volumes during kubelet
+  startup. Since this code has been significantly refactored, we allow to opt-out in case kubelet
+  gets stuck at the startup or is not unmounting volumes from terminated Pods. Note that this
+  refactoring was behind `SELinuxMountReadWriteOncePod` alpha feature gate in Kubernetes 1.25.
 - `NodeInclusionPolicyInPodTopologySpread`: Enable using `nodeAffinityPolicy` and `nodeTaintsPolicy` in
   [Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
   when calculating pod topology spread skew.


### PR DESCRIPTION
Add docs for `NewVolumeManagerReconstruction` feature gate. This feature *should* be invisible to users - kubelet does the same thing as before, only in a different order at the startup. It's behind a feature gate to allow opt-out in case it's buggy.

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3756-volume-reconstruction
Enhancement issue: https://github.com/kubernetes/enhancements/issues/3756