### PR TITLE
KEP-3488 ValidatingAdmissionPolicy post-1.27 update

### DIFF
--- a/content/en/examples/access/deployment-replicas-policy.yaml
+++ b/content/en/examples/access/deployment-replicas-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "deploy-replica-policy.example.com"
+spec:
+  paramKind:
+    group: rules.example.com
+    kind: ReplicaLimit
+    version: v1
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments"]
+  validations:
+  - expression: "object.spec.replicas <= params.maxReplicas"
+    messageExpression: "'object.spec.replicas must be no greater than ' + string(params.maxReplicas)"
+    reason: Invalid
+


### PR DESCRIPTION
This PR covers the following new features of ValidatingAdmissionPolicy
- [x] messageExpression
- [x] type checking

This PR is ready for review.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3488-cel-admission-control