### PR TITLE
Updating documentation for Topology Aware Routing in 1.27

### DIFF
--- a/content/en/docs/concepts/services-networking/service-topology.md
+++ b/content/en/docs/concepts/services-networking/service-topology.md
@@ -16,8 +16,8 @@ weight: 150
 
 This feature, specifically the alpha `topologyKeys` API, is deprecated since
 Kubernetes v1.21.
-[Topology Aware Hints](/docs/concepts/services-networking/topology-aware-hints/),
-introduced in Kubernetes v1.21, provide similar functionality.
+[Topology Aware Routing](/docs/concepts/services-networking/topology-aware-routing/),
+introduced in Kubernetes v1.21, provides similar functionality.
 {{</ note >}}
 
 _Service Topology_ enables a service to route traffic based upon the Node

--- a/static/_redirects
+++ b/static/_redirects
@@ -94,6 +94,7 @@
 /docs/concepts/service-catalog/     /docs/concepts/extend-kubernetes/service-catalog/ 301
 /docs/concepts/services-networking/networkpolicies/     /docs/concepts/services-networking/network-policies/ 301
 /docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/     /docs/tasks/network/customize-hosts-file-for-pods/ 301
+/docs/concepts/services-networking/topology-aware-hints/     /docs/concepts/services-networking/topology-aware-routing/ 302
 /docs/concepts/storage/etcd-store-api-object/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
 /docs/concepts/storage/volumes/emptyDirapiVersion/     /docs/concepts/storage/volumes/#emptydir/ 301
 /docs/concepts/tools/kubectl/object-management-overview/     /docs/concepts/overview/object-management-kubectl/overview/ 301


### PR DESCRIPTION
This updates documentation for the Topology Aware Hints KEP https://github.com/kubernetes/enhancements/issues/2433. Notably, as the updates in 1.27 have made "Hints" an optional implementation detail of Topology Aware Routing Heuristics, I'm working on a broader overall of the documentation. 

/sig network