### PR TITLE
Fixed broken link

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -143,7 +143,7 @@ method creates a new `Secret` object with the edited data.
 
 Depending on how you created the Secret, as well as how the Secret is used in
 your Pods, updates to existing `Secret` objects are propagated automatically to
-Pods that use the data. For more information, refer to [Mounted Secrets are updated automatically](#mounted-secrets-are-updated-automatically).
+Pods that use the data. For more information, refer to [Using Secrets as files from a Pod](#using-secrets-as-files-from-a-pod).
 
 ### Using a Secret
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -143,7 +143,7 @@ method creates a new `Secret` object with the edited data.
 
 Depending on how you created the Secret, as well as how the Secret is used in
 your Pods, updates to existing `Secret` objects are propagated automatically to
-Pods that use the data. For more information, refer to [Using Secrets as files from a Pod](#using-secrets-as-files-from-a-pod).
+Pods that use the data. For more information, refer to [Mounted Secrets are updated automatically](#using-secrets-as-files-from-a-pod).
 
 ### Using a Secret
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -143,7 +143,7 @@ method creates a new `Secret` object with the edited data.
 
 Depending on how you created the Secret, as well as how the Secret is used in
 your Pods, updates to existing `Secret` objects are propagated automatically to
-Pods that use the data. For more information, refer to [Mounted Secrets are updated automatically](#using-secrets-as-files-from-a-pod).
+Pods that use the data. For more information, refer to [Using Secrets as files from a Pod](#using-secrets-as-files-from-a-pod) section.
 
 ### Using a Secret
 


### PR DESCRIPTION
This PR solves the issue https://github.com/kubernetes/website/issues/40042 , where [Mounted Secrets are updated automatically](https://kubernetes.io/docs/concepts/configuration/secret/#mounted-secrets-are-updated-automatically) link does not refer to this topic. it is referring to the whole Secret page again. I changed the link to route it towards the topic using secrets as files from a pod
<!--


-->
