### PR TITLE
[ja] fixed the outdated link 

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/ja/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -157,7 +157,7 @@ profiles:
 `addedAffinity`はエンドユーザーには見えないので、その動作はエンドユーザーにとって予期しないものになる可能性があります。スケジューラープロファイル名と明確な相関関係のあるNodeラベルを使用すべきです。
 
 {{< note >}}
-[DaemonSetのPodを作成する](/ja/docs/concepts/workloads/controllers/daemonset/#scheduled-by-default-scheduler)DaemonSetコントローラーは、スケジューリングプロファイルをサポートしていません。DaemonSetコントローラーがPodを作成すると、デフォルトのKubernetesスケジューラーがそれらのPodを配置し、DaemonSetコントローラーの`nodeAffinity`ルールに優先して従います。
+[DaemonSetのPodを作成する](/ja/docs/concepts/workloads/controllers/daemonset/#how-daemon-pods-are-scheduled)DaemonSetコントローラーは、スケジューリングプロファイルをサポートしていません。DaemonSetコントローラーがPodを作成すると、デフォルトのKubernetesスケジューラーがそれらのPodを配置し、DaemonSetコントローラーの`nodeAffinity`ルールに優先して従います。
 {{< /note >}}
 
 ### Pod間のアフィニティとアンチアフィニティ {#inter-pod-affinity-and-anti-affinity}


### PR DESCRIPTION
Fix for the following commit :
- [fixed the outdated link](https://github.com/kubernetes/website/pull/39936/commits/64af02f2817d5103fb3d2a35d032781af2548889)

Deploy preview:

- https://deploy-preview-40124--kubernetes-io-main-staging.netlify.app/ja/docs/concepts/scheduling-eviction/assign-pod-node/