### PR TITLE
[ja] Remove stale information about pod selector

### DIFF
--- a/content/ja/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/ja/docs/concepts/workloads/controllers/daemonset.md
@@ -69,7 +69,7 @@ DaemonSet内のPodテンプレートでは、[`RestartPolicy`](/ja/docs/concepts
 
 上記の2つが指定された場合は、2つの条件をANDでどちらも満たすものを結果として返します。
 
-もし`spec.selector`が指定されたとき、`.spec.template.metadata.labels`とマッチしなければなりません。この2つの値がマッチしない設定をした場合、APIによってリジェクトされます。
+`spec.selector`は`.spec.template.metadata.labels`とマッチしなければなりません。この2つの値がマッチしない設定をした場合、APIによってリジェクトされます。
 
 ### 選択したNode上でPodを稼働させる {#running-pods-on-select-nodes}
 


### PR DESCRIPTION

[pod-selector](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector) is represented as follow:

> The .spec.selector must match the .spec.template.metadata.labels. Config with these two not matching will be rejected by the API.
