### PR TITLE
Remove duplicate paragraph

### DIFF
--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -19,8 +19,7 @@ graceful connection draining.
 
 There are often cases when you need to terminate a Pod - be it for upgrade or scale down.
 In order to improve application availability, it may be important to implement
-a proper active connections draining. This tutorial explains the flow of
-Pod termination in connection with the corresponding endpoint state and removal.
+a proper active connections draining.
 
 This tutorial explains the flow of Pod termination in connection with the
 corresponding endpoint state and removal by using


### PR DESCRIPTION
Duplicate paragraphs in tutorials/services/pods-and-endpoint-termination-flow

Under the "**Termination process for Pods and their endpoints**"  section of the page https://kubernetes.io/docs/tutorials/services/pods-and-endpoint-termination-flow/ .This tutorial explains the flow of Pod termination in connection with the corresponding endpoint state and removal._" repeats in the end of the first and the beginning of the second paragraph. This was raised in #40127. This PR is intended to close the issue #40127