### PR TITLE
fix translations in mutating-webhook-configuration-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
@@ -374,9 +374,9 @@ MutatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可接
   - **webhooks.rules** ([]RuleWithOperations)
 
     rules 描述了 Webhook 关心的资源/子资源上有哪些操作。Webhook 关心操作是否匹配**任何**rules。
-    但是，为了防止 ValidatingAdmissionWebhooks 和 ValidatingAdmissionWebhooks 将集群置于只能完全禁用插件才能恢复的状态，
-    ValidatingAdmissionWebhooks 和 ValidatingAdmissionWebhooks 永远不会在处理 ValidatingWebhookConfiguration
-    和 ValidatingWebhookConfiguration 对象的准入请求被调用。
+    但是，为了防止 ValidatingAdmissionWebhooks 和 MutatingAdmissionWebhooks 将集群置于只能完全禁用插件才能恢复的状态，
+    ValidatingAdmissionWebhooks 和 MutatingAdmissionWebhooks 永远不会在处理 ValidatingWebhookConfiguration
+    和 MutatingWebhookConfiguration 对象的准入请求时被调用。
 
     <a name="RuleWithOperations"></a>
     **RuleWithOperations 是操作和资源的元组。建议确保所有元组组合都是有效的。**


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
In the English version, we have the following:
```
ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks
```

but in the Chinese version, it is translated to:
```
ValidatingAdmissionWebhooks 和 ValidatingAdmissionWebhooks
```

the PR will fix this.