### PR TITLE
Fix docs around nf_conntrack sysctl

### DIFF
--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -120,7 +120,7 @@ in future versions of the Linux kernel.
 - `kernel.sem`,
 - `fs.mqueue.*`,
 - The parameters under `net.*` that can be set in container networking
-  namespace. However, there are exceptions (e.g.,
+  namespace. However, there are exceptions (e.g., before Linux 5.12.2,
   `net.netfilter.nf_conntrack_max` and `net.netfilter.nf_conntrack_expect_max`
   can be set in container networking namespace but they are unnamespaced).
 


### PR DESCRIPTION
Non-init net namespaces are no longer allowed to change `net.netfilter.nf_conntrack_max` and `net.netfilter.nf_conntrack_expect_max`, as addressed in this [patch](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2671fa4). Fix the doc to reflect this.