### PR TITLE
Fix container-serve on SELinux systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ CONTAINER_ENGINE ?= docker
 IMAGE_REGISTRY ?= gcr.io/k8s-staging-sig-docs
 IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile | cut -c 1-12)
 CONTAINER_IMAGE   = $(IMAGE_REGISTRY)/k8s-website-hugo:v$(HUGO_VERSION)-$(IMAGE_VERSION)
-CONTAINER_RUN     = "$(CONTAINER_ENGINE)" run --rm --interactive --tty --volume "$(CURDIR):/src"
+# Mount read-only to allow use with tools like Podman in SELinux mode
+# Container targets don't need to write into /src
+CONTAINER_RUN     = "$(CONTAINER_ENGINE)" run --rm --interactive --tty --volume "$(CURDIR):/src:ro,Z"
 
 CCRED=\033[0;31m
 CCEND=\033[0m


### PR DESCRIPTION
`make container-serve` fails with `Error: open : no such file or directory` on SELinux enabled systems. Fix this by adding the `ro,Z` suffix to the volume mount to label the content with a read only private unshared label.