### PR TITLE
fix: typo fix in daemonset.md

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -115,7 +115,7 @@ the existing Pods based on the
 [priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority)
 of the new Pod.
 
-The user can specify a different scheduler for the Pods of the DamonSet, by
+The user can specify a different scheduler for the Pods of the DaemonSet, by
 setting the `.spec.template.spec.schedulerName` field of the DaemonSet.
 
 The original node affinity specified at the


### PR DESCRIPTION
updates daemonset.md by fixing typo for the word `Daemonset`