### PR TITLE
Update server-side-apply.md

### DIFF
--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -313,8 +313,7 @@ read-modify-write and/or patch are the following:
 * the applied object must contain all the fields that the controller cares about.
 * there is no way to remove fields that haven't been applied by the controller
   before (controller can still send a PATCH/UPDATE for these use-cases).
-* the object doesn't have to be read beforehand, `resourceVersion` doesn't have
-  to be specified.
+* the object doesn't have to be read beforehand, `resourceVersion` must not be specified.
 
 It is strongly recommended for controllers to always "force" conflicts, since they
 might not be able to resolve or act on these conflicts.


### PR DESCRIPTION
Current documentation says that when controllers use sever-side apply `resourceVersion` "_doesn't have to be specified_" which kinda suggests that it's not a big deal even if `resourceVersion` is specified, however specifying `resourceVersion` usually results in version conflict, namely this error:
```
the object has been modified; please apply your changes to the latest version and try again
```
This is especially true for controllers which usually have to update status of resources frequently. 
Maybe it would be better to use some stronger language?  I propose to replace `doesn't have to` to `must not be`.