### PR TITLE
Update install-kubectl-linux.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -160,7 +160,7 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 sudo yum install -y kubectl
 ```


### PR DESCRIPTION
gpg check did not work on RHEL8, seems to be missing an argument.

Document fix: The instructions for downloading RPMs on RHEL systems seems to be incomplete. I've added the complete arguments that worked on my machine.