### PR TITLE
Clarify cgroupsV2 Java statements

### DIFF
--- a/content/en/blog/_posts/2022-08-31-cgroupv2-ga.md
+++ b/content/en/blog/_posts/2022-08-31-cgroupv2-ga.md
@@ -116,8 +116,10 @@ Scenarios in which you might need to update to cgroup v2 include the following:
   agents to versions that support cgroup v2.
 * If you run [cAdvisor](https://github.com/google/cadvisor) as a stand-alone
   DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
-* If you deploy Java applications with the JDK, prefer to use JDK 11.0.16 and
-  later or JDK 15 and later, which [fully support cgroup v2](https://bugs.openjdk.org/browse/JDK-8230305).
+* If you deploy Java applications, prefer to use versions which fully support cgroup v2:
+    * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
+    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
+    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
 
 ## Learn more
 

--- a/content/en/docs/concepts/architecture/cgroups.md
+++ b/content/en/docs/concepts/architecture/cgroups.md
@@ -102,7 +102,10 @@ updated to newer versions that support cgroup v2. For example:
  Update these agents to versions that support cgroup v2.
 * If you run [cAdvisor](https://github.com/google/cadvisor) as a stand-alone
  DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
-* If you use JDK, prefer to use JDK 11.0.16 and later or JDK 15 and later, which [fully support cgroup v2](https://bugs.openjdk.org/browse/JDK-8230305).
+* If you deploy Java applications, prefer to use versions which fully support cgroup v2:
+    * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
+    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
+    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
 * If you are using the [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) package, make sure
   the version you use is v1.5.1 or higher.
 


### PR DESCRIPTION
* The previous statement was missing HotSpot 8 which had cgroupsV2 support [backported](https://bugs.openjdk.org/browse/JDK-8230305).
* The previous statement was ambiguous as different JVM implementations added and backported cgroupsV2 at different times. The [linked](https://bugs.openjdk.org/browse/JDK-8230305) bug report was specifically for the HotSpot JVM.
* This PR adds additional JVM vendors (specifically IBM/Eclipse OpenJ9, and others can be added by other vendors).
* Note that there is a translation at `content/zh-cn/blog/_posts/2022-08-31-cgroupv2-ga.md` which would be nice to update as well.

Although this is an older blog post, people still use and reference it.