### PR TITLE
Remove redundant description of finalizers

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/finalizers.md
+++ b/content/en/docs/concepts/overview/working-with-objects/finalizers.md
@@ -8,10 +8,6 @@ weight: 80
 
 {{<glossary_definition term_id="finalizer" length="long">}}
 
-You can use finalizers to control {{<glossary_tooltip text="garbage collection" term_id="garbage-collection">}}
-of resources by alerting {{<glossary_tooltip text="controllers" term_id="controller">}} to perform specific cleanup tasks before
-deleting the target resource. 
-
 Finalizers don't usually specify the code to execute. Instead, they are
 typically lists of keys on a specific resource similar to annotations.
 Kubernetes specifies some finalizers automatically, but you can also specify

--- a/content/zh-cn/docs/concepts/overview/working-with-objects/finalizers.md
+++ b/content/zh-cn/docs/concepts/overview/working-with-objects/finalizers.md
@@ -9,15 +9,6 @@ weight: 80
 {{<glossary_definition term_id="finalizer" length="long">}}
 
 <!--
-You can use finalizers to control {{<glossary_tooltip text="garbage collection" term_id="garbage-collection">}}
-of resources by alerting {{<glossary_tooltip text="controllers" term_id="controller">}} to perform specific cleanup tasks before
-deleting the target resource. 
--->
-你可以通过使用 Finalizers 提醒{{<glossary_tooltip text="控制器" term_id="controller">}}
-在删除目标资源前执行特定的清理任务，
-来控制资源的{{<glossary_tooltip text="垃圾收集" term_id="garbage-collection">}}。
-
-<!--
 Finalizers don't usually specify the code to execute. Instead, they are
 typically lists of keys on a specific resource similar to annotations.
 Kubernetes specifies some finalizers automatically, but you can also specify


### PR DESCRIPTION
Remove redundant information about finalizers on the finalizers page within the "working with objects" section.

The same description of finalizers is imported directly from the glossary, so previous to this commit a nearly identical paragraph is repeated.

For reference, the text imported from the glossasry is

> You can use finalizers to control garbage collection of resources.
> For example, you can define a finalizer to clean up related resources
> or infrastructure before the controller deletes the target resource.

while the text being removed in this commit is:

> You can use finalizers to control garbage collection of resources
> by alerting controllers to perform specific cleanup tasks before
> deleting the target resource.

Note that this PR updates both the english and chinese versions.
