### PR TITLE
Fix quoting in JSONPath example

### DIFF
--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -76,7 +76,7 @@ Function            | Description               | Example                       
 `[,]`               | union operator            | `{.items[*]['metadata.name', 'status.capacity']}`               | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`
 `?()`               | filter                    | `{.users[?(@.name=="e2e")].user.password}`                      | `secret`
 `range`, `end`      | iterate list              | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]`
-`''`                | quote interpreted string  | `{range .items[*]}{.metadata.name}{'\t'}{end}`                  | `127.0.0.1      127.0.0.2`
+`''`                | quote interpreted string  | `{range .items[*]}{.metadata.name}{"\t"}{end}`                  | `127.0.0.1      127.0.0.2`
 
 Examples using `kubectl` and JSONPath expressions:
 


### PR DESCRIPTION
this matches the example found below this table and probably works better in most cases. the single quote didn't work for me on linux
