### PR TITLE
correct YAML under examples and remove duplicate inline YAML

### DIFF
--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -38,6 +38,10 @@ Let's say you have a Deployment containing of a single `nginx` replica
 
 {{< codenew file="service/pod-with-graceful-termination.yaml" >}}
 
+```shell
+kubectl apply -f https://k8s.io/examples/service/pod-with-graceful-termination.yaml
+```
+
 Once the Pod and Service are running, you can get the name of any associated EndpointSlices:
 
 ```shell
@@ -72,6 +76,19 @@ The output is similar to this:
                 "ready": true,
                 "serving": true,
                 "terminating": false
+```
+
+You can get the name of any associated Pods:
+
+```shell
+kubectl get pods
+```
+
+The output is similar to this:
+
+```none
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-deployment-7768647bf9-b4b9s   1/1     Running   0          3m2s
 ```
 
 Now let's terminate the Pod and validate that the Pod is being terminated

--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -38,55 +38,6 @@ Let's say you have a Deployment containing of a single `nginx` replica
 
 {{< codenew file="service/pod-with-graceful-termination.yaml" >}}
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-  labels:
-    app: nginx
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      terminationGracePeriodSeconds: 120 # extra long grace period
-      containers:
-      - name: nginx
-        image: nginx:latest
-        ports:
-        - containerPort: 80
-        lifecycle:
-          preStop:
-            exec:
-              # Real life termination may take any time up to terminationGracePeriodSeconds.
-              # In this example - just hang around for at least the duration of terminationGracePeriodSeconds,
-              # at 120 seconds container will be forcibly terminated.
-              # Note, all this time nginx will keep processing requests.
-              command: [
-                "/bin/sh", "-c", "sleep 180"
-              ]
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: nginx-service
-spec:
-  selector:
-    app: nginx
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 80
-```
-
 Once the Pod and Service are running, you can get the name of any associated EndpointSlices:
 
 ```shell

--- a/content/en/examples/service/pod-with-graceful-termination.yaml
+++ b/content/en/examples/service/pod-with-graceful-termination.yaml
@@ -30,3 +30,17 @@ spec:
               command: [
                 "/bin/sh", "-c", "sleep 180"
               ]
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
* correct YAML under examples, using the inline YAML
* remove duplicate inline YAML
* double confirm that pod-with-graceful-termination.yaml is not referenced anywhere else

What it looks like now:

![image](https://user-images.githubusercontent.com/52395211/226825507-cbd622f5-7d59-4e6c-b42c-8767d6774eb6.png)