### PR TITLE
[zh] for fluent Chiness reading(content/zh-cn/docs/reference/kubernetes-api/extend-resources)

### DIFF
--- a/content/zh-cn/blog/_posts/2022-05-23-service-ip-dynamic-and-static-allocation.md
+++ b/content/zh-cn/blog/_posts/2022-05-23-service-ip-dynamic-and-static-allocation.md
@@ -43,7 +43,7 @@ _dynamically_
 : the cluster's control plane automatically picks a free IP address from within the configured IP range for `type: ClusterIP` Services.
 -->
 **动态**
-：群集的控制平面会自动从配置的 IP 范围内为 `type:ClusterIP` 的 Service 选择一个空闲 IP 地址。
+：集群的控制平面会自动从配置的 IP 范围内为 `type:ClusterIP` 的 Service 选择一个空闲 IP 地址。
 
 <!--
 _statically_
@@ -58,7 +58,7 @@ Trying to create a Service with a specific `ClusterIP` that has already
 been allocated will return an error.
 -->
 在整个集群中，每个 Service 的 `ClusterIP` 必须是唯一的。
-尝试创建一个已经被分配了的 `ClusterIP` 的 Service 将会返回错误。
+尝试创建一个已经被分配了 `ClusterIP` 的 Service 将会返回错误。
 
 <!--
 ## Why do you need to reserve Service Cluster IPs?
@@ -142,7 +142,7 @@ use the lower range. This will allow users to use static allocations on the lowe
 risk of collision.
 -->
 分配默认使用上半段地址，当上半段地址耗尽后，将使用下半段地址范围。
-这将允许用户使用下半段地址中静态分配的地址并且降低冲突的风险。
+这将允许用户在下半段地址中使用静态分配从而降低冲突的风险。
 
 <!--
 Examples:
@@ -264,5 +264,5 @@ The current SIG-Network [KEPs](https://github.com/orgs/kubernetes/projects/10) a
 [SIG Network meetings](https://github.com/kubernetes/community/tree/master/sig-network) are a friendly, welcoming venue for you to connect with the community and share your ideas.
 Looking forward to hearing from you!
 -->
-[SIG Network 会议](https://github.com/kubernetes/community/tree/master/sig-network)是一个友好、热情的场所，
+[SIG Network 会议](https://github.com/kubernetes/community/tree/master/sig-network)是一个友好、热情的地方，
 你可以与社区联系并分享你的想法。期待你的回音！

--- a/content/zh-cn/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -150,7 +150,7 @@ CustomResourceDefinitionSpec 描述了用户希望资源的呈现方式。
 
 - **scope** (string)，必需
   
-  scope 表示自定义资源是群集作用域还是命名空间作用域。允许的值为 `Cluster` 和 `Namespaced`。
+  scope 表示自定义资源是集群作用域还是命名空间作用域。允许的值为 `Cluster` 和 `Namespaced`。
 
 <!--
 - **versions** ([]CustomResourceDefinitionVersion), required
@@ -161,7 +161,7 @@ CustomResourceDefinitionSpec 描述了用户希望资源的呈现方式。
 - **versions** ([]CustomResourceDefinitionVersion)，必需
 
   versions 是自定义资源的所有 API 版本的列表。版本名称用于计算服务版本在 API 发现中列出的顺序。
-  如果版本字符串是与 Kubernetes 的版本号形式类似，则它将排序在非 Kubernetes 形式版本字符串之前。
+  如果版本字符串与 Kubernetes 的版本号形式类似，则它将被排序在非 Kubernetes 形式版本字符串之前。
   Kubernetes 的版本号字符串按字典顺序排列。Kubernetes 版本号以 “v” 字符开头，
   后面是一个数字（主版本），然后是可选字符串 “alpha” 或 “beta” 和另一个数字（次要版本）。
   它们首先按 GA > beta > alpha 排序（其中 GA 是没有 beta 或 alpha 等后缀的版本），然后比较主要版本，
@@ -200,7 +200,7 @@ CustomResourceDefinitionSpec 描述了用户希望资源的呈现方式。
 
   - **versions.storage** (boolean)，必需
 
-    storage 表示在将自定义资源持久保存到存储时应使用此版本。有且仅有一个版本的 storage=true。
+    storage 表示在将自定义资源持久保存到存储时，应使用此版本。有且仅有一个版本的 storage=true。
 
   - **versions.additionalPrinterColumns** ([]CustomResourceColumnDefinition)
 
@@ -388,8 +388,8 @@ CustomResourceDefinitionSpec 描述了用户希望资源的呈现方式。
 
       status 表示自定义资源应该为 `/status` 子资源服务。当启用时：
 
-      1. 对自定义资源主端点的请求会忽略对对象的 `status` 节的改变；
-      2. 对自定义资源 `/status` 子资源的请求忽略对对象的 `status` 节以外的任何变化。
+      1. 对自定义资源主端点的请求会忽略对对象 `status` 节的改变；
+      2. 对自定义资源 `/status` 子资源的请求忽略对对象 `status` 节以外的任何变化。
 
       <a name="CustomResourceSubresourceStatus"></a>
       <!--
@@ -1103,7 +1103,7 @@ CustomResourceDefinitionStatus 表示 CustomResourceDefinition 的状态。
 
   - **conditions.type** (string)，必需
 
-    type 是状况的类型。类型包括：Established、NamesAccepted 和 Terminating。
+    type 是条件的类型。类型包括：Established、NamesAccepted 和 Terminating。
 
   - **conditions.lastTransitionTime** (Time)
 


### PR DESCRIPTION
 For fluent Chiness reading
modified:   content/zh-cn/blog/_posts/2022-05-23-service-ip-dynamic-and-static-allocation.md
modified:   content/zh-cn/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md

Thanks