### PR TITLE
fix: eliminate extra lines when copying to clipboard

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -10,36 +10,17 @@
 <script type="text/javascript">
 function copyCode(elem){
   if (document.getElementById(elem)) {
-    // create hidden text element, if it doesn't already exist
-    var targetId = "_hiddenCopyText_";
-    // must use a temporary form element for the selection and copy
-    target = document.getElementById(targetId);
-    if (!target) {
-      var target = document.createElement("textarea");
-      target.style.position = "absolute";
-      target.style.left = "-9999px";
-      target.style.top = "0";
-      target.id = targetId;
-      document.body.appendChild(target);
-    }
-    target.value = document.getElementById(elem).innerText;
-    // select the content
-    target.select();
-
-    // copy the selection
-    var succeed;
-    try {
-        succeed = document.execCommand("copy");
-    } catch(e) {
-        swal("Oh, no…","Sorry, your browser doesn't support copying this example to your clipboard.");
-        succeed = false;
-    }
-    if (succeed) {
-      swal("Copied to clipboard: ",elem);
-      return succeed;
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(document.getElementById(elem).textContent).then(
+        function () {
+          swal("Copied to clipboard: ",elem);
+        },
+        function () {
+          swal("Oh, no…","Failed to copy to clipboard: ",elem);
+        },
+      );
     } else {
-      swal("Oops!", elem + " not found when trying to copy code");
-      return false;
+      swal("Oh, no…","Sorry, your browser doesn't support copying this example to your clipboard.");
     }
   }
 }

--- a/layouts/shortcodes/codenew.html
+++ b/layouts/shortcodes/codenew.html
@@ -26,7 +26,7 @@
     </img>
     </div>
     <div class="includecode" id="{{ $file | anchorize }}">
-    {{ highlight . $codelang "" }}
+    {{- highlight . $codelang "" -}}
     </div>
 </div>
 {{ end }}


### PR DESCRIPTION
fixes: #37206
also closes: #34736

The key change is to use `textContent` instead of `innerText` of the element we want to copy text from. The reason is that `innerText` will take CSS styles into account, according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext). While `textContent` only considers text. The side effect is that spaces and newlines inside the element `<div class="includecode"...>` matters. So we need to eliminate them when rendering the template.

Another change is that `document.execCommand("copy")` API is deprecated, so I changed it to a more [modern API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText).