### PR TITLE
Update the go download address

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -7,7 +7,7 @@
 
   - [Python](https://www.python.org/downloads/) v3.7.x
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Golang](https://golang.org/doc/install) version 1.13+
+  - [Golang](https://go.dev/doc/install) version 1.13+
   - [Pip](https://pypi.org/project/pip/) used to install PyYAML
   - [PyYAML](https://pyyaml.org/) v5.1.2
   - [make](https://www.gnu.org/software/make/)


### PR DESCRIPTION
The old link cannot be accessed. The update is as follows:
https://golang.org/doc/install -->  https://go.dev/doc/install
