### PR TITLE
[de] Make meaning of "you" on the main page consistent

### DIFF
--- a/data/i18n/de/de.toml
+++ b/data/i18n/de/de.toml
@@ -79,7 +79,7 @@ other = "Kubernetes Features"
 other = """Wir sind ein <a href="https://cncf.io/">CNCF</a> Abschlussprojekt</p>"""
 
 [main_kubeweekly_baseline]
-other = "Möchten Sie die neuesten Nachrichten von Kubernetes erhalten? Melden Sie sich für KubeWeekly an."
+other = "Möchtest du die neuesten Nachrichten von Kubernetes erhalten? Melde dich für KubeWeekly an."
 
 [main_kubernetes_past_link]
 other = "Frühere Newsletter anzeigen"


### PR DESCRIPTION
On the main page, the word **you** is translated in two ways.

In the feature blocks, **du** is used. 

In the registration section for the KubeWeekly newsletter, **Sie** is used.

This PR changes the registration section, so that **du** is used.