### PR TITLE
Adding katacoda removal notices on pages with interactive tutorials

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive.html
+++ b/content/en/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive.html
@@ -3,6 +3,8 @@ title: "Interactive Tutorial - Configuring a Java Microservice"
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -3,6 +3,8 @@ title: Interactive Tutorial - Creating a Cluster
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -3,6 +3,8 @@ title: Interactive Tutorial - Deploying an App
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -3,6 +3,8 @@ title: Interactive Tutorial - Exploring Your App
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -3,6 +3,8 @@ title: Interactive Tutorial - Exposing Your App
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -3,6 +3,8 @@ title: Interactive Tutorial - Scaling Your App
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -3,6 +3,8 @@ title: Interactive Tutorial - Updating Your App
 weight: 20
 ---
 
+{{% katacoda-removal %}}
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -133,6 +133,20 @@ other = "email address"
 [javascript_required]
 other = "JavaScript must be [enabled](https://www.enable-javascript.com/) to view this content"
 
+[katacoda_message]
+other = """Shutdown of interactive tutorials.
+<p>The interactive tutorials on this website are being shut down. The
+Kubernetes
+project hopes to reinstate a similar interactive learning option in the long
+term future.</p>
+<p>The shutdown follows O'Reilly Media's 2019 <a
+href="https://www.oreilly.com/content/oreilly-acquires-katacoda-and-a-new-way-for-2-5m-customers-to-learn/">acquisition</a>
+of Katacoda.</p>
+<p>Kubernetes is grateful to O'Reilly and Katacoda for many years of helping
+people take their first steps in learning Kubernetes.</p>
+<p>The tutorials will cease to function after the 31<sup>st</sup> of March
+2023.</p>"""
+
 [latest_release]
 other = "Latest Release:"
 

--- a/layouts/shortcodes/katacoda-removal.html
+++ b/layouts/shortcodes/katacoda-removal.html
@@ -1,0 +1,3 @@
+<div class="alert alert-secondary callout note" role="alert">
+  <strong>{{ T "note" | safeHTML }}</strong> {{ T "katacoda_message" | safeHTML }}
+</div>


### PR DESCRIPTION
Since we [aren't having a sitewide banner](https://github.com/kubernetes/website/pull/39257#issuecomment-1441430171), I've added a note on pages with interactive tutorials on them. Based on [this list](https://github.com/kubernetes/website/issues/33936) @reylejano put together.

The copy is from @sftim's PR https://github.com/kubernetes/website/pull/39257.