### PR TITLE
Drop or adapt tutorials that rely on Katacoda

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -385,29 +385,6 @@ The output is:
 Beware.
 {{< /warning >}}
 
-### Katacoda Embedded Live Environment
-
-This button lets users run Minikube in their browser using the Katacoda Terminal.
-It lowers the barrier of entry by allowing users to use Minikube with one click instead of going through the complete
-Minikube and Kubectl installation process locally.
-
-The Embedded Live Environment is configured to run `minikube start` and lets users complete tutorials in the same window
-as the documentation.
-
-{{< caution >}}
-The session is limited to 15 minutes.
-{{< /caution >}}
-
-For example:
-
-```
-{{</* kat-button */>}}
-```
-
-The output is:
-
-{{< kat-button >}}
-
 ## Common Shortcode Issues
 
 ### Ordered Lists

--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -17,17 +17,16 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 
 ## {{% heading "prerequisites" %}}
 
+This tutorial assumes that you are using `minikube` to run a local Kubernetes cluster.
+Visit [Install tools](/docs/tasks/tools/#minikube) to learn how to install `minikube`.
+
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 If you are using an older Kubernetes version, switch to the documentation for that version.
 
-### Create a Minikube cluster
+### Create a minikube cluster
 
-Using Katacoda
-: {{< kat-button >}}
+If you haven't already set up a cluster locally, run `minikube start` to create a cluster.
 
-Locally
-: If you already [installed Minikube](/docs/tasks/tools/#minikube)
-  locally, run `minikube start` to create a cluster.
 
 <!-- steps -->
 
@@ -40,10 +39,6 @@ Locally
    ```
 
 1. Verify that the NGINX Ingress controller is running
-
-
-   {{< tabs name="tab_with_md" >}}
-   {{% tab name="minikube v1.19 or later" %}}
 
    ```shell
    kubectl get pods -n ingress-nginx
@@ -61,35 +56,6 @@ Locally
    ingress-nginx-admission-patch-rqp78         0/1     Completed   1          11m
    ingress-nginx-controller-59b45fb494-26npt   1/1     Running     0          11m
    ```
-   {{% /tab %}}
-
-   {{% tab name="minikube v1.18.1 or earlier" %}}
-
-   ```shell
-   kubectl get pods -n kube-system
-   ```
-
-   {{< note >}}
-   It can take up to a minute before you see these pods running OK.
-   {{< /note >}}
-
-   The output is similar to:
-
-   ```none
-   NAME                                        READY     STATUS    RESTARTS   AGE
-   default-http-backend-59868b7dd6-xb8tq       1/1       Running   0          1m
-   kube-addon-manager-minikube                 1/1       Running   0          3m
-   kube-dns-6dcb57bcc8-n4xd4                   3/3       Running   0          2m
-   kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
-   nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
-   storage-provisioner                         1/1       Running   0          2m
-   ```
-
-   Make sure that you see a Pod with a name that starts with `nginx-ingress-controller-`.
-
-   {{% /tab %}}
-
-   {{< /tabs >}}
 
 ## Deploy a hello, world app
 
@@ -142,12 +108,6 @@ Locally
    http://172.17.0.15:31637
    ```
 
-   {{< note >}}
-   Katacoda environment only: at the top of the terminal panel, click the plus sign,
-   and then click **Select port to view on Host 1**. Enter the NodePort value,
-   in this case `31637`, and then click **Display Port**.
-   {{< /note >}}
-
    The output is similar to:
 
    ```none
@@ -197,25 +157,11 @@ The following manifest defines an Ingress that sends traffic to your Service via
    example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
    ```
 
-1. Add the following line to the bottom of the `/etc/hosts` file on
-   your computer (you will need administrator access):
-
-    ```none
-    172.17.0.15 hello-world.info
-    ```
-
-   {{< note >}}
-   If you are running Minikube locally, use `minikube ip` to get the external IP.
-   The IP address displayed within the ingress list will be the internal IP.
-   {{< /note >}}
-
-   After you make this change, your web browser sends requests for
-   `hello-world.info` URLs to Minikube.
 
 1. Verify that the Ingress controller is directing traffic:
 
    ```shell
-   curl hello-world.info
+   curl --resolve "hello-world.info:80:$( minikube ip )" -i http://hello-world.info
    ```
 
    You should see:
@@ -226,9 +172,27 @@ The following manifest defines an Ingress that sends traffic to your Service via
    Hostname: web-55b8c6998d-8k564
    ```
 
-   {{< note >}}
-   If you are running Minikube locally, you can visit `hello-world.info` from your browser.
-   {{< /note >}}
+   You can also visit `hello-world.info` from your browser.
+
+   * **Optionally**
+     Look up the external IP address as reported by minikube:
+     ```shell
+     minikube ip
+     ```
+
+     Add line similar to the following one to the bottom of the `/etc/hosts` file on
+     your computer (you will need administrator access):
+
+     ```none
+     172.17.0.15 hello-world.info
+     ```
+
+     {{< note >}}
+     Change the IP address to match the output from `minikube ip`.
+     {{< /note >}}
+
+     After you make this change, your web browser sends requests for
+     `hello-world.info` URLs to Minikube.
 
 ## Create a second Deployment
 
@@ -288,7 +252,7 @@ The following manifest defines an Ingress that sends traffic to your Service via
 1. Access the 1st version of the Hello World app.
 
    ```shell
-   curl hello-world.info
+   curl --resolve "hello-world.info:80:$( minikube ip )" -i http://hello-world.info
    ```
 
    The output is similar to:
@@ -302,7 +266,7 @@ The following manifest defines an Ingress that sends traffic to your Service via
 1. Access the 2nd version of the Hello World app.
 
    ```shell
-   curl hello-world.info/v2
+   curl --resolve "hello-world.info:80:$( minikube ip )" -i http://hello-world.info/v2
    ```
 
    The output is similar to:
@@ -314,7 +278,7 @@ The following manifest defines an Ingress that sends traffic to your Service via
    ```
 
    {{< note >}}
-   If you are running Minikube locally, you can visit `hello-world.info` and
+   If you did the optional step to update `/etc/hosts`, you can also visit `hello-world.info` and
    `hello-world.info/v2` from your browser.
    {{< /note >}}
 

--- a/content/en/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive.html
+++ b/content/en/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive.html
@@ -1,9 +1,12 @@
 ---
-title: "Interactive Tutorial - Configuring a Java Microservice"
+title: "Tutorial - Configuring a Java Microservice"
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
 
 <!DOCTYPE html>
 
@@ -11,16 +14,21 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
-{{< katacoda-tutorial >}}
-
 <div class="layout" id="top">
 
     <main class="content katacoda-content">
-        <div class="katacoda">
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/9" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;"></div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for creating a cluster is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
+
     </main>
 
 </div>

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -17,14 +17,8 @@ card:
 
 <!-- overview -->
 
-This tutorial shows you how to run a sample app
-on Kubernetes using minikube and Katacoda.
-Katacoda provides a free, in-browser Kubernetes environment.
-
-{{< note >}}
-You can also follow this tutorial if you've installed minikube locally.
-See [minikube start](https://minikube.sigs.k8s.io/docs/start/) for installation instructions.
-{{< /note >}}
+This tutorial shows you how to run a sample app on Kubernetes using minikube.
+The tutorial provides a container image that uses NGINX to echo back all the requests.
 
 ## {{% heading "objectives" %}}
 
@@ -35,31 +29,34 @@ See [minikube start](https://minikube.sigs.k8s.io/docs/start/) for installation 
 ## {{% heading "prerequisites" %}}
 
 
-This tutorial provides a container image that uses NGINX to echo back all the requests.
+This tutorial assumes that you have already set up `minikube`.
+See [minikube start](https://minikube.sigs.k8s.io/docs/start/) for installation instructions.
 
+You also need to install `kubectl`.
+See [Install tools](/docs/tasks/tools/#kubectl) for installation instructions.
 
 
 <!-- lessoncontent -->
 
 ## Create a minikube cluster
 
-1. Click **Launch Terminal**.
+```shell
+minikube start
+```
 
-    {{< kat-button >}}
+## Open the Dashboard
 
-{{< note >}}
-If you installed minikube locally, run `minikube start`. Before you run `minikube dashboard`, you should open a new terminal, start `minikube dashboard` there, and then switch back to the main terminal.
-{{< /note >}}
+Open the Kubernetes dashboard. You can do this two different ways:
 
-2. Open the Kubernetes dashboard in a browser:
+{{< tabs name="dashboard" >}}
+{{% tab name="Launch a browser" %}}
+Open a **new** terminal, and run:
+```shell
+# Start a new terminal, and leave this running.
+minikube dashboard
+```
 
-    ```shell
-    minikube dashboard
-    ```
-
-3. Katacoda environment only: At the top of the terminal pane, click the plus sign, and then click **Select port to view on Host 1**.
-
-4. Katacoda environment only: Type `30000`, and then click **Display Port**.
+Now, switch back to the terminal where you ran `minikube start`.
 
 {{< note >}}
 The `dashboard` command enables the dashboard add-on and opens the proxy in the default web browser.
@@ -75,13 +72,23 @@ After the command exits, the dashboard remains running in the Kubernetes cluster
 You can run the `dashboard` command again to create another proxy to access the dashboard.
 {{< /note >}}
 
-## Open Dashboard with URL
+{{% /tab %}}
+{{% tab name="URL copy and paste" %}}
 
-If you don't want to open a web browser, run the dashboard command with the `--url` flag to emit a URL:
+If you don't want minikube to open a web browser fr you, run the dashboard command with the
+`--url` flag. `minikube` outputs a URL that you can open in the browser you prefer:
 
+```
+Open a **new** terminal, and run:
 ```shell
+# Start a new terminal, and leave this running.
 minikube dashboard --url
 ```
+
+Now, switch back to the terminal where you ran `minikube start`.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Create a Deployment
 
@@ -91,8 +98,6 @@ tutorial has only one Container. A Kubernetes
 [*Deployment*](/docs/concepts/workloads/controllers/deployment/) checks on the health of your
 Pod and restarts the Pod's Container if it terminates. Deployments are the
 recommended way to manage the creation and scaling of Pods.
-
-1. Katacoda environment only: At the top of the terminal pane, click the plus sign, and then click **Open New Terminal**.
 
 1. Use the `kubectl create` command to create a Deployment that manages a Pod. The
 Pod runs a Container based on the provided Docker image.
@@ -186,10 +191,6 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
     ```shell
     minikube service hello-node
     ```
-
-4. Katacoda environment only: Click the plus sign, and then click **Select port to view on Host 1**.
-
-5. Katacoda environment only: Note the 5-digit port number displayed opposite to `8080` in services output. This port number is randomly generated and it can be different for you. Type your number in the port number text box, then click Display Port. Using the example from earlier, you would type `30369`.
 
     This opens up a browser window that serves your app and shows the app's response.
 
@@ -287,7 +288,7 @@ kubectl delete service hello-node
 kubectl delete deployment hello-node
 ```
 
-Optionally, stop the Minikube virtual machine (VM):
+Stop the minikube cluster:
 
 ```shell
 minikube stop
@@ -296,10 +297,11 @@ minikube stop
 Optionally, delete the Minikube VM:
 
 ```shell
+# Optional
 minikube delete
 ```
 
-
+If you want to use minikube again to learn more about Kubernetes, you don't need to delete it.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -98,9 +98,10 @@ Pod and restarts the Pod's Container if it terminates. Deployments are the
 recommended way to manage the creation and scaling of Pods.
 
 1. Use the `kubectl create` command to create a Deployment that manages a Pod. The
-Pod runs a Container based on the provided Docker image.
+   Pod runs a Container based on the provided Docker image.
 
     ```shell
+    # Run a test container image that includes a webserver
     kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.39 -- /agnhost netexec --http-port=8080
     ```
 
@@ -162,7 +163,7 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
     The `--type=LoadBalancer` flag indicates that you want to expose your Service
     outside of the cluster.
     
-    The application code inside the image `registry.k8s.io/echoserver` only listens on TCP port 8080. If you used
+    The application code inside the test image only listens on TCP port 8080. If you used
     `kubectl expose` to expose a different port, clients could not connect to that other port.
 
 2. View the Service you created:
@@ -236,7 +237,7 @@ The minikube tool includes a set of built-in {{< glossary_tooltip text="addons" 
     The 'metrics-server' addon is enabled
     ```
 
-3. View the Pod and Service you created:
+3. View the Pod and Service you created by installing that addon:
 
     ```shell
     kubectl get pod,svc -n kube-system
@@ -286,7 +287,7 @@ kubectl delete service hello-node
 kubectl delete deployment hello-node
 ```
 
-Stop the minikube cluster:
+Stop the Minikube cluster
 
 ```shell
 minikube stop

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -13,8 +13,6 @@ card:
   weight: 10
 ---
 
-{{% katacoda-removal %}}
-
 <!-- overview -->
 
 This tutorial shows you how to run a sample app on Kubernetes using minikube.

--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -1,9 +1,12 @@
 ---
 title: Interactive Tutorial - Creating a Cluster
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
 
 <!DOCTYPE html>
 
@@ -11,20 +14,18 @@ weight: 20
 
 <body>
 
-{{< katacoda-tutorial >}}
+    <main class="content">
 
-<div class="layout" id="top">
-
-    <main class="content katacoda-content">
-
-        <div class="katacoda">
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/1" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;"></div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continue to Module 2 &gt;<span class=""></span></a>
-            </div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for creating a cluster is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
 
     </main>

--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -1,6 +1,10 @@
 ---
 title: Using Minikube to Create a Cluster
 weight: 10
+description: |-
+  Learn what a Kubernetes cluster is.
+  Learn what Minikube is.
+  Start a Kubernetes cluster.
 ---
 
 <!DOCTYPE html>
@@ -20,7 +24,7 @@ weight: 10
                 <ul>
                     <li>Learn what a Kubernetes cluster is.</li>
                     <li>Learn what Minikube is.</li>
-                    <li>Start a Kubernetes cluster using an online terminal.</li>
+                    <li>Start a Kubernetes cluster on your computer.</li>
                 </ul>
             </div>
 
@@ -84,18 +88,16 @@ weight: 10
             <div class="col-md-8">
                 <p>When you deploy applications on Kubernetes, you tell the control plane to start the application containers. The control plane schedules the containers to run on the cluster's nodes. <b>The nodes communicate with the control plane using the <a href="/docs/concepts/overview/kubernetes-api/">Kubernetes API</a></b>, which the control plane exposes. End users can also use the Kubernetes API directly to interact with the cluster.</p>
 
-                <p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use Minikube. Minikube is a lightweight Kubernetes implementation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, macOS, and Windows systems. The Minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete. For this tutorial, however, you'll use a provided online terminal with Minikube pre-installed.</p>
+                <p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use Minikube. Minikube is a lightweight Kubernetes implementation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, macOS, and Windows systems. The Minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete.</p>
 
-                <p>Now that you know what Kubernetes is, let's go to the online tutorial and start our first cluster!</p>
+                <p>Now that you know more about what Kubernetes is, visit <a href="/docs/tutorials/hello-minikube/">Hello Minikube</a>
+                   to try this out on your computer.</p>
+
 
             </div>
         </div>
-        <br>
-
         <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
-            </div>
+            <p>Once you've done that, move on to <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">Using <tt>kubectl</tt> to create a Deployment</a>.</p>
         </div>
 
     </main>

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -1,42 +1,30 @@
 ---
 title: Interactive Tutorial - Deploying an App
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
-
 <!DOCTYPE html>
 
 <html lang="en">
 
 <body>
 
-{{< katacoda-tutorial >}}
+    <main class="content">
 
-<div class="layout" id="top">
-
-    <main class="content katacoda-content">
-
-        <div class="row">
-            <div class="col-md-12">
-                <p>
-                    A Pod is the basic execution unit of a Kubernetes application. Each Pod represents a part of a workload that is running on your cluster. <a href="/docs/concepts/workloads/pods/">Learn more about Pods</a>.
-                </p>
-            </div>
-        </div>
-
-        <br>
-        <div class="katacoda">
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/7" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
-
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button"> &lt; Return to Module 1<span class=""></span></a>
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continue to Module 3 &gt;<span class=""></span></a>
-            </div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for deploying an application to your cluster is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
 
     </main>

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -1,6 +1,9 @@
 ---
 title: Using kubectl to Create a Deployment
 weight: 10
+description: |-
+  Learn about application Deployments.
+  Deploy your first app on Kubernetes with kubectl.
 ---
 
 <!DOCTYPE html>
@@ -14,26 +17,25 @@ weight: 10
     <main class="content">
 
         <div class="row">
-
          <div class="col-md-8">
           <h3>Objectives</h3>
-                <ul>
-                    <li>Learn about application Deployments.</li>
-                    <li>Deploy your first app on Kubernetes with kubectl.</li>
-                </ul>
-            </div>
+          <ul>
+             <li>Learn about application Deployments.</li>
+             <li>Deploy your first app on Kubernetes with kubectl.</li>
+          </ul>
+         </div>
 
             <div class="col-md-8">
                 <h3>Kubernetes Deployments</h3>
                 <p>
-                Once you have a running Kubernetes cluster, you can deploy your containerized applications on top of it.
-                To do so, you create a Kubernetes <b>Deployment</b> configuration. The Deployment instructs Kubernetes
+                Once you have a <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/">running Kubernetes cluster</a>, you can deploy your containerized applications on top of it.
+                To do so, you create a Kubernetes <b>Deployment</b>. The Deployment instructs Kubernetes
                 how to create and update instances of your application. Once you've created a Deployment, the Kubernetes
                 control plane schedules the application instances included in that Deployment to run on individual Nodes in the
                 cluster.
                 </p>
 
-                <p>Once the application instances are created, a Kubernetes Deployment Controller continuously monitors those instances. If the Node hosting an instance goes down or is deleted, the Deployment controller replaces the instance with an instance on another Node in the cluster. <b>This provides a self-healing mechanism to address machine failure or maintenance.</b></p>
+                <p>Once the application instances are created, a Kubernetes Deployment controller continuously monitors those instances. If the Node hosting an instance goes down or is deleted, the Deployment controller replaces the instance with an instance on another Node in the cluster. <b>This provides a self-healing mechanism to address machine failure or maintenance.</b></p>
 
                 <p>In a pre-orchestration world, installation scripts would often be used to start applications, but they did not allow recovery from machine failure.  By both creating your application instances and keeping them running across Nodes, Kubernetes Deployments provide a fundamentally different approach to application management. </p>
 
@@ -72,7 +74,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
 
-                <p>You can create and manage a Deployment by using the Kubernetes command line interface, <b>Kubectl</b>. Kubectl uses the Kubernetes API to interact with the cluster. In this module, you'll learn the most common Kubectl commands needed to create Deployments that run your applications on a Kubernetes cluster.</p>
+                <p>You can create and manage a Deployment by using the Kubernetes command line interface, <b>kubectl</b>. Kubectl uses the Kubernetes API to interact with the cluster. In this module, you'll learn the most common Kubectl commands needed to create Deployments that run your applications on a Kubernetes cluster.</p>
 
                 <p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/">5</a> and <a href="/docs/tutorials/kubernetes-basics/update/update-intro/">6</a> of the bootcamp discuss how you can scale and update your Deployments.</p>
 
@@ -91,18 +93,69 @@ weight: 10
             <div class="col-md-8">
               <p>
                 For your first Deployment, you'll use a hello-node application packaged in a Docker container that uses NGINX to echo back all the requests. (If you didn't already try creating a hello-node application and deploying it using a container, you can do that first by following the instructions from the <a href="/docs/tutorials/hello-minikube/">Hello Minikube tutorial</a>).
-              <p>
-              
-               <p>Now that you know what Deployments are, let's go to the online tutorial and deploy our first app!</p>
+              <p>You will need to have installed kubectl as well. If you need to install it, visit <a href="/docs/tasks/tools/#kubectl">install tools</a>.</p>
+              <p>Now that you know what Deployments are, let's deploy our first app!</p>
             </div>
         </div>
         <br>
 
         <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
+            <div class="col-md-8">
+                <h3>kubectl basics</h3>
+                <p>The common format of a kubectl command is: <code>kubectl <i>action resource</i></code></p>
+                <p>This performs the specified <em>action</em> (like create, describe or delete) on the specified <em>resource</em> (like <tt>node</tt> or <tt>deployment</tt>). You can use <code>-<span />-help</code> after the subcommand to get additional info about possible parameters (for example: <code>kubectl get nodes --help</code>).</p>
+                <p>Check that kubectl is configured to talk to your cluster, by running the <b><code>kubectl version</code></b> command.</p>
+                <p>Check that kubectl is installed and you can see both the client and the server versions.</p>
+                <p>To view the nodes in the cluster, run the <b><code>kubectl get nodes</code></b> command.</p>
+                <p>You see the available nodes. Later, Kubernetes will choose where to deploy our application based on Node available resources.</p>
             </div>
         </div>
+        <div class="row">
+            <div class="col-md-12">
+                <h3>Deploy an app</h3>
+                <p>Let’s deploy our first app on Kubernetes with the <code>kubectl create deployment</code> command. We need to provide the deployment name and app image location (include the full repository url for images hosted outside Docker hub).</p>
+                <p><b><code>kubectl create deployment kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1</code></b></p>
+                <p>Great! You just deployed your first application by creating a deployment. This performed a few things for you:</p>
+                <ul>
+                <li>searched for a suitable node where an instance of the application could be run (we have only 1 available node)</li>
+                <li>scheduled the application to run on that Node</li>
+                <li>configured the cluster to reschedule the instance on a new Node when needed</li>
+                </ul>
+                <p>To list your deployments use the <code>kubectl get deployments</code> command:</p>
+                <p><b><code>kubectl get deployments</code></b></p>
+                <p>We see that there is 1 deployment running a single instance of your app. The instance is running inside a container on your node.</p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <h3>View the app</h3>
+                <p>Pods that are running inside Kubernetes are running on a private, isolated network.
+                By default they are visible from other pods and services within the same kubernetes cluster, but not outside that network.
+                When we use <code>kubectl</code>, we're interacting through an API endpoint to communicate with our application.</p>
+                <p>We will cover other options on how to expose your application outside the kubernetes cluster in Module 4.</p>
+                <p>The <code>kubectl</code> command can create a proxy that will forward communications into the cluster-wide, private network. The proxy can be terminated by pressing control-C and won't show any output while its running. </p>
+                <p><strong>You need to open a second terminal window to run the proxy.</strong></p>
+                <p><b><code>kubectl proxy</b></code>
+                <p>We now have a connection between our host (the online terminal) and the Kubernetes cluster. The  proxy enables direct access to the API from these terminals.</p>
+                <p>You can see all those APIs hosted through the proxy endpoint. For example, we can query the version directly through the API using the <code>curl</code> command:</p>
+                <p><b><code>curl http://localhost:8001/version</code></b></p>
+                <div class="alert alert-info note callout" role="alert"><strong>Note:</strong> If Port 8001 is not accessible, ensure that the <code>kubectl proxy</code> that you started above is running in the second terminal.</div>
+                <p>The API server will automatically create an endpoint for each pod, based on the pod name, that is also accessible through the proxy.</p>
+                <p>First we need to get the Pod name, and we'll store in the environment variable <tt>POD_NAME</tt>:</p>
+                <p><b><code>export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')</code></b><br />
+                   <b><code>echo Name of the Pod: $POD_NAME</code></b></p>
+                <p>You can access the Pod through the proxied API, by running:</p>
+                <p><b><code>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/</code></b></p>
+                <p>In order for the new Deployment to be accessible without using the proxy, a Service is required which will be explained in the next modules.</p>
+            </div>
+
+      </div>
+      <div class="row">
+          <p>
+            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" title="Viewing Pods and Nodes">Viewing Pods and Nodes</a>.</p>
+          </p>
+      </div>
+
 
     </main>
 

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -1,34 +1,30 @@
 ---
 title: Interactive Tutorial - Exploring Your App
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
-
 <!DOCTYPE html>
 
 <html lang="en">
 
 <body>
 
-{{< katacoda-tutorial >}}
+    <main class="content">
 
-<div class="layout" id="top">
-
-    <main class="content katacoda-content">
-
-        <br>
-        <div class="katacoda">
-
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/4" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">&lt; Return to Module 2<span class="btn"></span></a>
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-intro/" role="button">Continue to Module 4 &gt;<span class="btn"></span></a>
-            </div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for exploring your app is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
 
     </main>

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -1,6 +1,10 @@
 ---
 title: Viewing Pods and Nodes
 weight: 10
+description: |-
+  Learn how to troubleshoot Kubernetes applications using
+  kubectl get, kubectl describe, kubectl logs and
+  kubectl exec.
 ---
 
 <!DOCTYPE html>
@@ -105,12 +109,12 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <h2>Troubleshooting with kubectl</h2>
-                <p>In Module <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>, you used Kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl commands:</p>
+                <p>In Module <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>, you used the kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl subcommands:</p>
                 <ul>
-                    <li><b>kubectl get</b> - list resources</li>
-                    <li><b>kubectl describe</b> - show detailed information about a resource</li>
-                    <li><b>kubectl logs</b> - print the logs from a container in a pod</li>
-                    <li><b>kubectl exec</b> - execute a command on a container in a pod</li>
+                    <li><tt><b>kubectl get</b></tt> - list resources</li>
+                    <li><tt><b>kubectl describe</b></tt> - show detailed information about a resource</li>
+                    <li><tt><b>kubectl logs</b></tt> - print the logs from a container in a pod</li>
+                    <li><tt><b>kubectl exec</b></tt> - execute a command on a container in a pod</li>
                 </ul>
 
                 <p>You can use these commands to see when applications were deployed, what their current statuses are, where they are running and what their configurations are.</p>
@@ -124,13 +128,71 @@ weight: 10
                 </div>
             </div>
         </div>
-        <br>
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
+                <h3>Check application configuration</h3>
+                <p>Let's verify that the application we deployed in the previous scenario is running. We'll use the <code>kubectl get</code> command and look for existing Pods:</p>
+                <p><b><code>kubectl get pods</code></b></p>
+                <p>If no pods are running, please wait a couple of seconds and list the Pods again. You can continue once you see one Pod running.</p>
+                <p>Next, to view what containers are inside that Pod and what images are used to build those containers we run the <code>kubectl describe pods</code> command:</p>
+                <p><b><code>kubectl describe pods</code></b></p>
+                <p>We see here details about the Pod’s container: IP address, the ports used and a list of events related to the lifecycle of the Pod.</p>
+                <p>The output of the <tt>describe</tt> subcommand is extensive and covers some concepts that we didn’t explain yet, but don’t worry, they will become familiar by the end of this bootcamp.</p>
+                <p><em><strong>Note:</strong> the <tt>describe</tt> subcommand can be used to get detailed information about most of the Kubernetes primitives, including Nodes, Pods, and Deployments. The describe output is designed to be human readable, not to be scripted against.</em></p>
             </div>
         </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <h3>Show the app in the terminal</h3>
+                <p>Recall that Pods are running in an isolated, private network - so we need to proxy access
+                to them so we can debug and interact with them. To do this, we'll use the <code>kubectl proxy</code> command to run a proxy in a <strong>second terminal</strong>. Open a new terminal window, and in that new terminal, run:</p>
+                <p><code><b>kubectl proxy</b></code></p>
+                <p>Now again, we'll get the Pod name and query that pod directly through the proxy.
+                To get the Pod name and store it in the <tt>POD_NAME</tt> environment variable:</p>
+                <p><code><b>export POD_NAME="$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"</b></code><br />
+                <code><b>echo Name of the Pod: $POD_NAME</b></code></p>
+                <p>To see the output of our application, run a <code>curl</code> request:</p>
+                <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/proxy/</b></code></p>
+                <p>The URL is the route to the API of the Pod.</p>
+           </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <h3>View the container logs</h3>
+                <p>Anything that the application would normally send to standard output becomes logs for the container within the Pod. We can retrieve these logs using the <code>kubectl logs</code> command:</p>
+                <p><code><b>kubectl logs "$POD_NAME"</b></code></p>
+                <p><em><strong>Note:</strong> We don't need to specify the container name, because we only have one container inside the pod.</em></p>
+           </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <h3>Executing command on the container</h3>
+                <p>We can execute commands directly on the container once the Pod is up and running.
+                For this, we use the <code>exec</code> subcommand and use the name of the Pod as a parameter. Let’s list the environment variables:</p>
+                <p><code><b>kubectl exec "$POD_NAME" -- env</b></code></p>
+                <p>Again, it's worth mentioning that the name of the container itself can be omitted since we only have a single container in the Pod.</p>
+                <p>Next let’s start a bash session in the Pod’s container:</p>
+                <p><code><b>kubectl exec -ti $POD_NAME -- bash</b></code></p>
+                <p>We have now an open console on the container where we run our NodeJS application.  The source code of the app is in the <tt>server.js</tt> file:</p>
+                <p><code><b>cat server.js</b></code></p>
+                <p>You can check that the application is up by running a <tt>curl</tt> command:</p>
+                <p><code><b>curl http://localhost:8080</b></code></p>
+                <p><em><strong>Note:</strong> here we used <tt>localhost</tt> because we executed the command inside the NodeJS Pod. If you cannot connect to localhost:8080, check to make sure you have run the <code>kubectl exec</code> command and are launching the command from within the Pod</em></p>
+                <p>To close your container connection, type <code><b>exit</b></code>.</p>
+           </div>
+        </div>
+
+
+      <div class="row">
+          <p>
+            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/" title="Using A Service To Expose Your App">Using A Service To Expose Your App</a>.</p>
+          </p>
+      </div>
+
 
     </main>
 

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -1,32 +1,30 @@
 ---
 title: Interactive Tutorial - Exposing Your App
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
-
 <!DOCTYPE html>
 
 <html lang="en">
 
 <body>
 
-{{< katacoda-tutorial >}}
+    <main class="content">
 
-<div class="layout" id="top">
-
-    <main class="content katacoda-content">
-
-        <div class="katacoda">
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/8" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">&lt; Return to Module 3<span class=""></span></a>
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">Continue to Module 5 &gt;<span class=""></span></a>
-            </div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for exposing your app is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
 
     </main>
@@ -35,3 +33,4 @@ weight: 20
 
 </body>
 </html>
+

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -1,6 +1,10 @@
 ---
 title: Using a Service to Expose Your App
 weight: 10
+description: |-
+    Learn about a Service in Kubernetes.
+    Understand how labels and selectors relate to a Service.
+    Expose an application outside a Kubernetes cluster.
 ---
 
 <!DOCTYPE html>
@@ -18,7 +22,7 @@ weight: 10
     		<h3>Objectives</h3>
 				<ul>
 					<li>Learn about a Service in Kubernetes</li>
-					<li>Understand how labels and LabelSelector objects relate to a Service</li>
+					<li>Understand how labels and selectors relate to a Service</li>
 					<li>Expose an application outside a Kubernetes cluster using a Service</li>
 				</ul>
 			</div>
@@ -28,9 +32,9 @@ weight: 10
 
 			<p>Kubernetes <a href="/docs/concepts/workloads/pods/">Pods</a> are mortal. Pods have a <a href="/docs/concepts/workloads/pods/pod-lifecycle/">lifecycle</a>. When a worker node dies, the Pods running on the Node are also lost. A <a href="/docs/concepts/workloads/controllers/replicaset/">ReplicaSet</a> might then dynamically drive the cluster back to the desired state via the creation of new Pods to keep your application running. As another example, consider an image-processing backend with 3 replicas. Those replicas are exchangeable; the front-end system should not care about backend replicas or even if a Pod is lost and recreated. That said, each Pod in a Kubernetes cluster has a unique IP address, even Pods on the same Node, so there needs to be a way of automatically reconciling changes among Pods so that your applications continue to function.</p>
 
-			<p>A Service in Kubernetes is an abstraction which defines a logical set of Pods and a policy by which to access them. Services enable a loose coupling between dependent Pods. A Service is defined using YAML <a href="/docs/concepts/configuration/overview/#general-configuration-tips">(preferred)</a> or JSON, like all Kubernetes objects. The set of Pods targeted by a Service is usually determined by a <i>LabelSelector</i> (see below for why you might want a Service without including a <code>selector</code> in the spec).</p>
+			<p>A Service in Kubernetes is an abstraction which defines a logical set of Pods and a policy by which to access them. Services enable a loose coupling between dependent Pods. A Service is defined using YAML or JSON, like all Kubernetes object manifests. The set of Pods targeted by a Service is usually determined by a <i>label selector</i> (see below for why you might want a Service without including a <code>selector</code> in the spec).</p>
 
-			<p>Although each Pod has a unique IP address, those IPs are not exposed outside the cluster without a Service. Services allow your applications to receive traffic. Services can be exposed in different ways by specifying a <code>type</code> in the ServiceSpec:</p>
+                        <p>Although each Pod has a unique IP address, those IPs are not exposed outside the cluster without a Service. Services allow your applications to receive traffic. Services can be exposed in different ways by specifying a <code>type</code> in the <tt>spec</tt> of the Service:</p>
 			<ul>
 				<li><i>ClusterIP</i> (default) - Exposes the Service on an internal IP in the cluster. This type makes the Service only reachable from within the cluster.</li>
 				<li><i>NodePort</i> - Exposes the Service on the same port of each selected Node in the cluster using NAT. Makes a Service accessible from outside the cluster using <code>&lt;NodeIP&gt;:&lt;NodePort&gt;</code>. Superset of ClusterIP.</li>
@@ -88,11 +92,75 @@ weight: 10
 				<p>Labels can be attached to objects at creation time or later on. They can be modified at any time. Let's expose our application now using a Service and apply some labels.</p>
 			</div>
 		</div>
-		<br>
 		<div class="row">
 			<div class="col-md-12">
-				<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">Start Interactive Tutorial<span class="btn__next">›</span></a>
+				<h3>Create a new Service</h3>
+				<p>Let’s verify that our application is running. We’ll use the <code>kubectl get</code> command and look for existing Pods:</p>
+				<p><code><b>kubectl get pods</b></code></p>
+				<p>If no pods are running then it means the interactive environment is still reloading its previous state. Please wait a couple of seconds and list the Pods again. You can continue once you see the one Pod running.</p>
+				<p>Next, let’s list the current Services from our cluster:</p>
+				<p><code><b>kubectl get services</b></code></p>
+				<p>We have a Service called <tt>kubernetes</tt> that is created by default when minikube starts the cluster.
+				To create a new service and expose it to external traffic we'll use the expose command with NodePort as parameter.</p>
+				<p><code><b>kubectl expose deployment/kubernetes-bootcamp --type="NodePort" --port 8080</b></code></p>
+				<p>Let's run again the <code>get services</code> subcommand:</p>
+				<p><code><b>kubectl get services</b></code></p>
+				<p>We have now a running Service called kubernetes-bootcamp. Here we see that the Service received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).</p>
+				<p>To find out what port was opened externally (for the <tt>type: NodePort</tt> Service) we’ll run the <code>describe service</code> subcommand:</p>
+				<p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
+				<p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
+				<p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')"</b></code><br />
+				<code><b>echo "NODE_PORT=$NODE_PORT"</b></code></p>
+				<p>Now we can test that the app is exposed outside of the cluster using <code>curl</code>, the IP address of the Node and the externally exposed port:</p>
+				<p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>
+				<p>And we get a response from the server. The Service is exposed.</p>
 			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-md-12">
+				<h3>Step 2: Using labels</h3>
+				<div class="content">
+				<p>The Deployment created automatically a label for our Pod. With the <code>describe deployment</code> subcommand you can see the name (the <em>key</em>) of that label:</p>
+				<p><code><b>kubectl describe deployment</b></code></p>
+				<p>Let’s use this label to query our list of Pods. We’ll use the <code>kubectl get pods</code> command with <tt>-l</tt> as a parameter, followed by the label values:</p>
+				<p><code><b>kubectl get pods -l app=kubernetes-bootcamp</b></code></p>
+				<p>You can do the same to list the existing Services:</p>
+				<p><code><b>kubectl get services -l app=kubernetes-bootcamp</b></code></p>
+				<p>Get the name of the Pod and store it in the <tt>POD_NAME</tt> environment variable:</p>
+				<p><code><b>export POD_NAME="$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"</b></code><br />
+				   <code><b>echo "Name of the Pod: $POD_NAME"</b></code></p>
+				<p>To apply a new label we use the <code>label</code> subcommand followed by the object type, object name and the new label:</p>
+				<p><code><b>kubectl label pods "$POD_NAME" version=v1</b></code></p>
+				<p>This will apply a new label to our Pod (we pinned the application version to the Pod), and we can check it with the describe pod command:</p>
+				<p><code><b>kubectl describe pods "$POD_NAME"</b></code></p>
+				<p>We see here that the label is attached now to our Pod. And we can query now the list of pods using the new label:</p>
+				<p><code><b>kubectl get pods -l version=v1</b></code></p>
+				<p>And we see the Pod.</p>
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-md-12">
+				<h3>Deleting a service</h3>
+				<p>To delete Services you can use the <code>delete service</code> subcommand. Labels can be used also here:</p>
+				<p><code><b>kubectl delete service -l app=kubernetes-bootcamp</b></code></p>
+				<p>Confirm that the Service is gone:</p>
+				<p><code><b>kubectl get services</b></code></p>
+				<p>This confirms that our Service was removed. To confirm that route is not exposed anymore you can <tt>curl</tt> the previously exposed IP and port:</p>
+				<p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>
+				<p>This proves that the application is not reachable anymore from outside of the cluster.
+				You can confirm that the app is still running with a <tt>curl</tt> from inside the pod:</p>
+				<p><code><b>kubectl exec -ti $POD_NAME -- curl http://localhost:8080</b></code></p>
+				<p>We see here that the application is up. This is because the Deployment is managing the application. To shut down the application, you would need to delete the Deployment as well.</p>
+			</div>
+		</div>
+				<div class="row">
+				<p>
+					Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" title="Running Multiple Instances of Your App">Running Multiple Instances of Your App</a>.</p>
+				</p>
+				</div>
+
 		</div>
 	</main>
 </div>

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -1,39 +1,36 @@
 ---
 title: Interactive Tutorial - Scaling Your App
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
-
 <!DOCTYPE html>
 
 <html lang="en">
 
 <body>
 
-{{< katacoda-tutorial >}}
+    <main class="content">
 
-<div class="layout" id="top">
-
-    <main class="content katacoda-content">
-
-        <div class="katacoda">
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/5" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">&lt; Return to Module 4<span class=""></span></a>
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-intro/" role="button">Continue to Module 6 &gt;<span class=""></span></a>
-            </div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for scaling an application that's running in your cluster is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
 
     </main>
-
-<a class="scrolltop" href="#top"></a>
 
 </div>
 
 </body>
 </html>
+

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -1,6 +1,8 @@
 ---
 title: Running Multiple Instances of Your App
 weight: 10
+description: |-
+  Scale an existing app manually using kubectl.
 ---
 
 <!DOCTYPE html>
@@ -25,9 +27,10 @@ weight: 10
             <div class="col-md-8">
        <h3>Scaling an application</h3>
 
-            <p>In the previous modules we created a <a href="/docs/concepts/workloads/controllers/deployment/"> Deployment</a>, and then exposed it publicly via a <a href="/docs/concepts/services-networking/service/">Service</a>. The Deployment created only one Pod for running our application.  When traffic increases, we will need to scale the application to keep up with  user demand.</p>
+            <p>Previously we created a <a href="/docs/concepts/workloads/controllers/deployment/"> Deployment</a>, and then exposed it publicly via a <a href="/docs/concepts/services-networking/service/">Service</a>. The Deployment created only one Pod for running our application.  When traffic increases, we will need to scale the application to keep up with user demand.</p>
+            <p>If you haven't worked through the earlier sections, start from <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/">Using minikube to create a cluster</a>.</p>
 
-            <p><b>Scaling</b> is accomplished by changing the number of replicas in a Deployment</p>
+            <p><em>Scaling</em> is accomplished by changing the number of replicas in a Deployment</p>
 
             </div>
             <div class="col-md-4">
@@ -100,16 +103,79 @@ weight: 10
 
         <div class="row">
             <div class="col-md-8">
-                <p> Once you have multiple instances of an Application running, you would be able to do Rolling updates without downtime. We'll cover that in the next module. Now, let's go to the online terminal and scale our application.</p>
+                <p> Once you have multiple instances of an application running, you would be able to do Rolling updates without downtime. We'll cover that in the next section of the tutorial. Now, let's go to the online terminal and scale our application.</p>
             </div>
         </div>
-        <br>
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
+               <h3>Scaling a deployment</h3>
+               <p>To list your deployments use the <code>get deployments</code> subcommand:
+               <code><b>kubectl get deployments</b></code></p>
+               <p>The output should be similar to:</p>
+               <pre>NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+               kubernetes-bootcamp   1/1     1            1           11m
+               </pre>
+               <p>We should have 1 Pod. If not, run the command again. This shows:</p>
+               <ul>
+               <li><em>NAME</em> lists the names of the Deployments in the cluster.</li>
+               <li><em>READY</em> shows the ratio of CURRENT/DESIRED replicas</li>
+               <li><em>UP-TO-DATE</em> displays the number of replicas that have been updated to achieve the desired state.</li>
+               <li><em>AVAILABLE</em> displays how many replicas of the application are available to your users.</li>
+               <li><em>AGE</em> displays the amount of time that the application has been running.</li>
+               </ul>
+               <p>To see the ReplicaSet created by the Deployment, run
+               <code><b>kubectl get rs</b></code></p>
+               <p>Notice that the name of the ReplicaSet is always formatted as <tt>[DEPLOYMENT-NAME]-[RANDOM-STRING]</tt>. The random string is randomly generated and uses the <em>pod-template-hash</em> as a seed.</p>
+               <p>Two important columns of this output are:</p>
+               <ul>
+               <li><em>DESIRED</em> displays the desired number of replicas of the application, which you define when you create the Deployment. This is the desired state.</li>
+               <li><em>CURRENT</em> displays how many replicas are currently running.</li>
+               </ul>
+               <p>Next, let’s scale the Deployment to 4 replicas. We’ll use the <code>kubectl scale</code> command, followed by the deployment type, name and desired number of instances:</p>
+               <p><code><b>kubectl scale deployments/kubernetes-bootcamp --replicas=4</b></code></p>
+               <p>To list your Deployments once again, use <code>get deployments</code>:</p>
+               <p><code><b>kubectl get deployments</b></code></p>
+               <p>The change was applied, and we have 4 instances of the application available. Next, let’s check if the number of Pods changed:</p>
+               <p><code><b>kubectl get pods -o wide</b></code></p>
+               <p>There are 4 Pods now, with different IP addresses. The change was registered in the Deployment events log. To check that, use the describe subcommand:</p>
+               <p><code><b>kubectl describe deployments/kubernetes-bootcamp</b></code></p>
+               <p>You can also view in the output of this command that there are 4 replicas now.</p>
             </div>
         </div>
+
+        <div class="row">
+            <div class="col-md-12">
+               <h3>Load Balancing</h3>
+               <p>Let's check that the Service is load-balancing the traffic. To find out the exposed IP and Port we can use the describe service as we learned in the previous part of the tutorial:</p>
+               <p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
+               <p>Create an environment variable called <tt>NODE_PORT</tt> that has a value as the Node port:</p>
+               <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')"</b></code><br />
+               <p><code><b>echo NODE_PORT=$NODE_PORT</b></code></p>
+               <p>Next, we’ll do a <code>curl</code> to the exposed IP address and port. Execute the command multiple times:</p>
+               <p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></b></b></code></p>
+               <p>We hit a different Pod with every request. This demonstrates that the load-balancing is working.</p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+               <h3>Scale Down</h3>
+               <p>To scale down the Deployment to 2 replicas, run again the <code>scale</code> subcommand:</p>
+               <p><code><b>kubectl scale deployments/kubernetes-bootcamp --replicas=2</b></code></p>
+               <p>List the Deployments to check if the change was applied with the <code>get deployments</code> subcommand:</p>
+               <p><code><b>kubectl get deployments</b></code></p>
+               <p>The number of replicas decreased to 2. List the number of Pods, with <code>get pods</code>:</p>
+               <p><code><b>kubectl get pods -o wide</b></code></p>
+               <p>This confirms that 2 Pods were terminated.</p>
+            </div>
+        </div>
+
+      <div class="row">
+          <p>
+            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/update/update-intro/" title="Performing a Rolling Update">Performing a Rolling Update</a>.</p>
+          </p>
+      </div>
 
     </main>
 

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -1,39 +1,36 @@
 ---
 title: Interactive Tutorial - Updating Your App
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
-
-{{% katacoda-removal %}}
-
 <!DOCTYPE html>
 
 <html lang="en">
 
 <body>
 
-{{< katacoda-tutorial >}}
+    <main class="content">
 
-<div class="layout" id="top">
-
-    <main class="content katacoda-content">
-
-        <div class="katacoda">
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/6" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
+        <div>
+            <h2 class="katacoda-gone">
+              Content unavailable
+            </h2>
+            <p>
+              The interactive tutorial for updating an application in your cluster is not available.
+              For more information, see the
+              <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+                shutdown announcement</a>.
+            </p>
         </div>
-        <div class="row">
-            <div class="col-md-12">
-               <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">&lt; Return to Module 5<span class=""></span></a>
-               <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Return to Kubernetes Basics<span class=""></span></a>
-            </div>
-        </div>
+
     </main>
 
 </div>
 
 </body>
 </html>
-
-
-
 

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -1,6 +1,8 @@
 ---
 title: Performing a Rolling Update
 weight: 10
+description: |-
+  Perform a rolling update using kubectl.
 ---
 
 <!DOCTYPE html>
@@ -122,9 +124,69 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
+               <h3>Update the version of the app</h3>
+               <p>To list your Deployments, run the <code>get deployments</code> subcommand:
+               <code><b>kubectl get deployments</b></code></p>
+               <p>To list the running Pods, run the <code>get pods</code> subcommand:</p>
+               <p><code><b>kubectl get pods</b></code></p>
+               <p>To view the current image version of the app, run the <code>describe pods</code> subcommand
+               and look for the <code>Image</code> field:</p>
+               <p><code><b>kubectl describe pods</b></code></p>
+               <p>To update the image of the application to version 2, use the <code>set image</code> subcommand, followed by the deployment name and the new image version:</p>
+               <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=jocatalin/kubernetes-bootcamp:v2</b></code></p>
+               <p>The command notified the Deployment to use a different image for your app and initiated a rolling update. Check the status of the new Pods, and view the old one terminating with the <code>get pods</code> subcommand:</p>
+               <p><code><b>kubectl get pods</b></code></p>
             </div>
         </div>
+        <div class="row">
+            <div class="col-md-12">
+               <h3>Step 2: Verify an update</h3>
+               <p>First, check that the app is running. To find the exposed IP address and port, run the <code>describe service</code> command:</p>
+               <p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
+               <p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
+               <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')</b></code><br />
+                  <code><b>echo "NODE_PORT=$NODE_PORT"</b></code></p>
+               <p>Next, do a <code>curl</code> to the the exposed IP and port:</p>
+               <p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>
+               <p>Every time you run the <code>curl</code> command, you will hit a different Pod. Notice that all Pods are now running the latest version (v2).</p>
+               <p>You can also confirm the update by running the <code>rollout status</code> subcommand:</p>
+               <p><code><b>kubectl rollout status deployments/kubernetes-bootcamp</b></code></p>
+               <p>To view the current image version of the app, run the <code>describe pods</code> subcommand:</p>
+               <p><code><b>kubectl describe pods</b></code></p>
+               <p>In the <code>Image</code> field of the output, verify that you are running the latest image version (v2).</p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+               <h3>Roll back an update</h3>
+               <p>Let’s perform another update, and try to deploy an image tagged with <code>v10</code>:</p>
+               <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=gcr.io/google-samples/kubernetes-bootcamp:v10</b></code></p>
+               <p>Use <code>get deployments</code> to see the status of the deployment:</p>
+               <p><code><b>kubectl get deployments</b></code></p>
+               <p>Notice that the output doesn't list the desired number of available Pods. Run the <code>get pods</code> subcommand to list all Pods:</p>
+               <p><code><b>kubectl get pods</b></code></p>
+               <p>Notice that some of the Pods have a status of <tt>ImagePullBackOff</tt>.</p>
+               <p>To get more insight into the problem, run the <code>describe pods</code> subcommand:</p>
+               <p><code><b>kubectl describe pods</b></code></p>
+               <p>In the <code>Events</code> section of the output for the affected Pods, notice that the <code>v10</code> image version did not exist in the repository.</p>
+               <p>To roll back the deployment to your last working version, use the <code>rollout undo</code> subcommand:</p>
+               <p><code><b>kubectl rollout undo deployments/kubernetes-bootcamp</b></code></p>
+               <p>The <code>rollout undo</code> command reverts the deployment to the previous known state (v2 of the image). Updates are versioned and you can revert to any previously known state of a Deployment.</p>
+               <p>Use the <code>get pods</code> subcommand to list the Pods again:</p>
+               <p><code><b>kubectl get pods</b></code></p>
+               <p>Four Pods are running. To check the image deployed on these Pods, use the <code>describe pods</code> subcommand:</p>
+               <p><code><b>kubectl describe pods</b></code></p>
+               <p>The Deployment is once again using a stable version of the app (v2). The rollback was successful.</p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <p>Remember to clean up your local cluster</p>
+                <p><code><b>kubectl delete deployments/kubernetes-bootcamp services/kubernetes-bootcamp</b></code></p>
+            </div>
+        </div>
+
 
     </main>
 


### PR DESCRIPTION
Prompted by https://github.com/kubernetes/website/issues/33936

Follows https://github.com/kubernetes/website/pull/40292

Remove pages where we don't have a replacement online, interactive tutorial mechanism, changing them to an apology message
(aside: we don't have an _easy_ way to serve 410 Gone responses)

Update pages where we have an way to let people run the tutorial locally.

/hold
We should not make this change until the end of March 2023.


