### PR TITLE
Deleted duplicate info in configure-pod-configmap

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -861,22 +861,7 @@ spec:
   restartPolicy: Never
 ```
 
-### Mounted ConfigMaps are updated automatically
 
-When a mounted ConfigMap is updated, the projected content is eventually updated too.
-This applies in the case where an optionally referenced ConfigMap comes into existence after
-a pod has started.
-
-The kubelet checks whether the mounted ConfigMap is fresh on every periodic sync. However, it
-uses its local TTL-based cache for getting the current value of the ConfigMap. As a result,
-the total delay from the moment when the ConfigMap is updated to the moment when new keys
-are projected to the pod can be as long as kubelet sync period (1 minute by default) + TTL of
-ConfigMaps cache (1 minute by default) in kubelet.
-
-{{< note >}}
-A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes/#using-subpath)
-volume will not receive ConfigMap updates.
-{{< /note >}}
 
 ## Restrictions
 


### PR DESCRIPTION
Info about  `Mounted ConfigMaps are updated automatically` is added twice at these two places

1. https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically
2. https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically-1

deleted the second occurrence.