### PR TITLE
about apiGroups

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -285,8 +285,8 @@ If you restrict `list` or `watch` by resourceName, clients must include a `metad
 For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap`
 {{< /note >}}
 
-Rather than referring to individual `resources` and `verbs` you can use the wildcard `*` symbol to refer to all such objects.
-For `nonResourceURLs` you can use the wildcard `*` symbol as a suffix glob match and for `apiGroups` and `resourceNames` an empty set means that everything is allowed.
+Rather than referring to individual `resources` 、`apiGroups`and `verbs` you can use the wildcard `*` symbol to refer to all such objects.
+For `nonResourceURLs` you can use the wildcard `*` symbol as a suffix glob match and for `resourceNames` an empty set means that everything is allowed. `apiGroups` is accessible only to resources that do not have apiGroups if it is an empty set.
 Here is an example that allows access to perform any current and future action on all current and future resources (note, this is similar to the built-in `cluster-admin` role).
 
 ```yaml

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -287,7 +287,7 @@ For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap
 
 Rather than referring to individual `resources` 、`apiGroups`and `verbs` you can use the wildcard `*` symbol to refer to all such objects.
 For `nonResourceURLs` you can use the wildcard `*` symbol as a suffix glob match and for `resourceNames` an empty set means that everything is allowed. `apiGroups` is accessible only to resources that do not have apiGroups if it is an empty set.
-Here is an example that allows access to perform any current and future action on all current and future resources (note, this is similar to the built-in `cluster-admin` role).
+Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -285,8 +285,9 @@ If you restrict `list` or `watch` by resourceName, clients must include a `metad
 For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap`
 {{< /note >}}
 
-Rather than referring to individual `resources` 、`apiGroups`and `verbs` you can use the wildcard `*` symbol to refer to all such objects.
-For `nonResourceURLs` you can use the wildcard `*` symbol as a suffix glob match and for `resourceNames` an empty set means that everything is allowed. `apiGroups` is accessible only to resources that do not have apiGroups if it is an empty set.
+Rather than referring to individual `resources` 、`apiGroups`and `verbs` you can use the wildcard `*` symbol to refer to all such objects. 
+For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. In addition, if 'apiGroups' is an empty set, it can only access the resources of the core group. 
+For `resourceNames`, an empty set means that everything is allowed.
 Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 
 ```yaml

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -285,7 +285,8 @@ If you restrict `list` or `watch` by resourceName, clients must include a `metad
 For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap`
 {{< /note >}}
 
-Rather than referring to individual `resources`、`apiGroups`, and `verbs`, you can use the wildcard `*` symbol to refer to all such objects. 
+Rather than referring to individual `resources`、`apiGroups`, and `verbs`,
+you can use the wildcard `*` symbol to refer to all such objects. 
 For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. 
 Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -287,7 +287,8 @@ For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap
 
 Rather than referring to individual `resources`、`apiGroups`, and `verbs`,
 you can use the wildcard `*` symbol to refer to all such objects. 
-For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. 
+For `nonResourceURLs`, you can use the wildcard `*` as a suffix glob match.
+For `resourceNames`, an empty set means that everything is allowed.
 Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 
 ```yaml

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -285,7 +285,7 @@ If you restrict `list` or `watch` by resourceName, clients must include a `metad
 For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap`
 {{< /note >}}
 
-Rather than referring to individual `resources` 、`apiGroups`and `verbs` you can use the wildcard `*` symbol to refer to all such objects. 
+Rather than referring to individual `resources`、`apiGroups`, and `verbs`, you can use the wildcard `*` symbol to refer to all such objects. 
 For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. In addition, if 'apiGroups' is an empty set, it can only access the resources of the core group. 
 Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -287,7 +287,6 @@ For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap
 
 Rather than referring to individual `resources` 、`apiGroups`and `verbs` you can use the wildcard `*` symbol to refer to all such objects. 
 For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. In addition, if 'apiGroups' is an empty set, it can only access the resources of the core group. 
-For `resourceNames`, an empty set means that everything is allowed.
 Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 
 ```yaml

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -286,7 +286,7 @@ For example, `kubectl get configmaps --field-selector=metadata.name=my-configmap
 {{< /note >}}
 
 Rather than referring to individual `resources`、`apiGroups`, and `verbs`, you can use the wildcard `*` symbol to refer to all such objects. 
-For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. In addition, if 'apiGroups' is an empty set, it can only access the resources of the core group. 
+For `nonResourceURLs`, you can use the wildcard `*` symbol as a suffix glob match. For `resourceNames`, an empty set means that everything is allowed. 
 Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
 
 ```yaml

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -289,7 +289,9 @@ Rather than referring to individual `resources`、`apiGroups`, and `verbs`,
 you can use the wildcard `*` symbol to refer to all such objects. 
 For `nonResourceURLs`, you can use the wildcard `*` as a suffix glob match.
 For `resourceNames`, an empty set means that everything is allowed.
-Here is an example that allows access to perform any current and future action on all current and future resources in the `example.com` API group (note, this is similar to the built-in `cluster-admin` role).
+Here is an example that allows access to perform any current and future action on
+all current and future resources in the `example.com` API group.
+This is similar to the built-in `cluster-admin` role.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Look at the source code, apiGroups is an empty set and not all are allowed, you need to use * to be able to, if it is an empty set if the resource does not have apiGroups then it will not be accessible

Refer to：
https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/rbac/v1/evaluation_helpers.go#L85 https://github.com/kubernetes/api/blob/master/rbac/v1/types.go#L29

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
