### PR TITLE
[zh-cn] fix Equinix Metal url 404

### DIFF
--- a/content/zh-cn/docs/setup/production-environment/tools/kubespray.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubespray.md
@@ -114,14 +114,14 @@ Kubespray provides the following utilities to help provision your environment:
 * [Terraform](https://www.terraform.io/) scripts for the following cloud providers:
   * [AWS](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/aws)
   * [OpenStack](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/openstack)
-  * [Equinix Metal](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/metal)
+  * [Equinix Metal](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/equinix)
 -->
 Kubespray 提供以下实用程序来帮助你设置环境：
 
 * 为以下云驱动提供的 [Terraform](https://www.terraform.io/) 脚本：
   * [AWS](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/aws)
   * [OpenStack](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/openstack)
-  * [Equinix Metal](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/metal)
+  * [Equinix Metal](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/equinix)
 
 <!--
 ### (2/5) Compose an inventory file


### PR DESCRIPTION
fix url 404
https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/metal
to
https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/equinix

under this page
https://kubernetes.io/zh-cn/docs/setup/production-environment/tools/kubespray/