### PR TITLE
[zh] sync /kubernetes-api/other-resources/

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/other-resources/_index.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/other-resources/_index.md
@@ -1,0 +1,21 @@
+---
+title: "其他资源"
+weight: 10
+---
+<!--
+title: "Other Resources"
+weight: 10
+auto_generated: true
+-->
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/zh-cn/docs/reference/kubernetes-api/other-resources/validating-admission-policy-binding-list-v1alpha1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/other-resources/validating-admission-policy-binding-list-v1alpha1.md
@@ -1,0 +1,38 @@
+---
+api_metadata:
+  apiVersion: "admissionregistration.k8s.io/v1alpha1"
+  import: "k8s.io/api/admissionregistration/v1alpha1"
+  kind: "ValidatingAdmissionPolicyBindingList"
+content_type: "api_reference"
+description: ""
+title: "ValidatingAdmissionPolicyBindingList v1alpha1"
+weight: 1
+---
+<!--
+api_metadata:
+  apiVersion: "admissionregistration.k8s.io/v1alpha1"
+  import: "k8s.io/api/admissionregistration/v1alpha1"
+  kind: "ValidatingAdmissionPolicyBindingList"
+content_type: "api_reference"
+description: ""
+title: "ValidatingAdmissionPolicyBindingList v1alpha1"
+weight: 1
+auto_generated: true
+-->
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+`apiVersion: admissionregistration.k8s.io/v1alpha1`
+
+`import "k8s.io/api/admissionregistration/v1alpha1"`
+
+


### PR DESCRIPTION
Add two zh pages by syncing with en version:

```
content/zh-cn/docs/reference/kubernetes-api/other-resources/_index.md
content/zh-cn/docs/reference/kubernetes-api/other-resources/validating-admission-policy-binding-list-v1alpha1.md
```
See [preview](https://deploy-preview-40322--kubernetes-io-main-staging.netlify.app//zh-cn/docs/reference/kubernetes-api/other-resources/).