### PR TITLE
[zh] sync kubeadm_init_phase_show-join-command.md

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_all.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_all.md
@@ -63,6 +63,21 @@ kubeadm init phase kubelet-finalize all --config
 </tr>
 
 <tr>
+<td colspan="2">--dry-run</td>
+</tr>
+<tr>
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<!--
+Don't apply any changes; just output what would be done.
+-->
+<p>
+不做任何更改；只输出将要执行的操作。
+</p></td>
+</tr>
+
+<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_show-join-command.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_show-join-command.md
@@ -1,0 +1,94 @@
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+<!--
+Show the join command for control-plane and worker node
+-->
+显示针对控制平面和工作节点的 join 命令。
+
+<!--
+### Synopsis
+-->
+### 概要
+
+<!--
+Show the join command for control-plane and worker node
+-->
+显示针对控制平面和工作节点的 join 命令。
+
+```
+kubeadm init phase show-join-command [flags]
+```
+
+<!--
+### Options
+-->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<!--
+help for show-join-command
+-->
+<p>
+show-join-command 操作的帮助命令
+</p>
+</td>
+</tr>
+
+</tbody>
+</table>
+
+<!--
+### Options inherited from parent commands
+-->
+### 从父命令继承的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<!--
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
+-->
+<p>
+[实验] 到 '真实' 主机根文件系统的路径。
+</p>
+</td>
+</tr>
+
+</tbody>
+</table>
+
+
+


### PR DESCRIPTION
Sync two files:

- One is the first file listed in `task-16` of issue #39987, 
  which is missing in PR #40244
  ```
  content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_all.md
  ```
- The other is a new zh page:
  ```
  content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_show-join-command.md
  ```