### PR TITLE
Added kubectl completion command for fish shell in kubect cheatsheet docmentation

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -42,8 +42,10 @@ echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc 
 
 ### FISH
 
+Require kubectl version 1.23 or more.
+
 ```bash
-kubectl completion fish | source  # add it to your fish configuration file to setup autocomplete in your fish shell 
+echo 'kubectl completion fish | source' >> ~/.config/fish/config.fish  # add autocomplete permanently to your fish shell 
 ```
 
 ### A note on `--all-namespaces`

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -39,6 +39,13 @@ complete -o default -F __start_kubectl k
 source <(kubectl completion zsh)  # set up autocomplete in zsh into the current shell
 echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc # add autocomplete permanently to your zsh shell
 ```
+
+### FISH
+
+```bash
+kubectl completion fish | source  # add it to your fish configuration file to setup autocomplete in your fish shell 
+```
+
 ### A note on `--all-namespaces`
 
 Appending `--all-namespaces` happens frequently enough that you should be aware of the shorthand for `--all-namespaces`:

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -42,7 +42,7 @@ echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc 
 
 ### FISH
 
-Require kubectl version 1.23 or more.
+Require kubectl version 1.23 or above.
 
 ```bash
 echo 'kubectl completion fish | source' >> ~/.config/fish/config.fish  # add autocomplete permanently to your fish shell 

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -45,7 +45,7 @@ echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc 
 Require kubectl version 1.23 or above.
 
 ```bash
-echo 'kubectl completion fish | source' >> ~/.config/fish/config.fish  # add autocomplete permanently to your fish shell 
+echo 'kubectl completion fish | source' >> ~/.config/fish/config.fish  # add kubectl autocompletion permanently to your fish shell 
 ```
 
 ### A note on `--all-namespaces`


### PR DESCRIPTION
Description:
Added kubectl completion for fish shell

Page to Update:
https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration
