### PR TITLE
Remove "new" word in userns documentation

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -50,8 +50,8 @@ to use this feature with Kubernetes stateless pods:
 * CRI-O: v1.25 has support for user namespaces.
 
 Please note that **if your container runtime doesn't support user namespaces, the
-new `pod.spec` field will be silently ignored and the pod will be created without
-user namespaces.**
+`hostUsers` field in the pod spec will be silently ignored and the pod will be
+created without user namespaces.**
 
 <!-- steps -->
 


### PR DESCRIPTION
This PR fixes the issue noticed by @sftim here: https://github.com/kubernetes/website/pull/40264#discussion_r1147974619.

While we are there, we also change pod.spec to pod spec.

Opening in a new PR as @sftim seems to prefer that, let's see if these PRs not create conflicts with each other... :crossed_fingers: 

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
