### PR TITLE
Remove duplicated yaml from pods-and-endpoint-termination-flow

### DIFF
--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -39,41 +39,6 @@ Let's say you have a Deployment containing of a single `nginx` replica
 {{< codenew file="service/pod-with-graceful-termination.yaml" >}}
 
 ```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-  labels:
-    app: nginx
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      terminationGracePeriodSeconds: 120 # extra long grace period
-      containers:
-      - name: nginx
-        image: nginx:latest
-        ports:
-        - containerPort: 80
-        lifecycle:
-          preStop:
-            exec:
-              # Real life termination may take any time up to terminationGracePeriodSeconds.
-              # In this example - just hang around for at least the duration of terminationGracePeriodSeconds,
-              # at 120 seconds container will be forcibly terminated.
-              # Note, all this time nginx will keep processing requests.
-              command: [
-                "/bin/sh", "-c", "sleep 180"
-              ]
-
----
-
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Seems this [Example flow with endpoint termination](https://kubernetes.io/docs/tutorials/services/pods-and-endpoint-termination-flow/#example-flow-with-endpoint-termination) section has duplicated Deployment YAMLs. See [preview](https://deploy-preview-40340--kubernetes-io-main-staging.netlify.app/docs/tutorials/services/pods-and-endpoint-termination-flow/).

![image](https://user-images.githubusercontent.com/79828097/227963057-68edb765-e9d5-43be-816d-3e2797289ab8.png)
