### PR TITLE
show redirect-after banner now

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -156,8 +156,8 @@ announcements:
   startTime: 2023-03-27T00:00:00 # This should run after the redirect begins
   endTime: 2023-05-31T00:00:00
   style: "background: #c70202"
-  title: Legacy k8s.gcr.io container image registry will be redirected to registry.k8s.io
+  title: Legacy k8s.gcr.io container image registry is being redirected to registry.k8s.io
   message: |
-    k8s.gcr.io image registry is being redirected to registry.k8s.io (since Monday March 20th).<br>
+    k8s.gcr.io image registry is gradually being redirected to registry.k8s.io (since Monday March 20th).<br>
     All images available in k8s.gcr.io are available at registry.k8s.io.</br>
     Please read our [announcement](/blog/2023/03/10/image-registry-redirect/) for more details.

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -143,7 +143,7 @@ announcements:
     Please read our [announcement](/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) for more details.
 
 - name: Redirecting k8s.gcr.io - Before
-  startTime: 2023-03-10T00:00:00 # This should run before and after Kubecon EU 2023
+  startTime: 2023-03-10T00:00:00 # This should run before the redirect
   endTime: 2023-03-26T00:00:00
   style: "background: #c70202"
   title: Legacy k8s.gcr.io container image registry will be redirected to registry.k8s.io
@@ -153,7 +153,7 @@ announcements:
     Please read our [announcement](/blog/2023/03/10/image-registry-redirect/) for more details.
 
 - name: Redirecting k8s.gcr.io - After
-  startTime: 2023-04-05T00:00:00 # This should run before and after Kubecon EU 2023
+  startTime: 2023-03-27T00:00:00 # This should run after the redirect begins
   endTime: 2023-05-31T00:00:00
   style: "background: #c70202"
   title: Legacy k8s.gcr.io container image registry will be redirected to registry.k8s.io


### PR DESCRIPTION
Really we probably should have shown this starting on the 20th or so, and there is no EU 2023 banner ...

And EU 2023 is sold out anyhow.

If we need to add an EU banner, we can, but in the meantime we should keep running a banner for the registry redirect.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
