### PR TITLE
docs: Update 'kind' definition

### DIFF
--- a/content/en/docs/tasks/tools/_index.md
+++ b/content/en/docs/tasks/tools/_index.md
@@ -23,9 +23,7 @@ Find your preferred operating system below.
 
 ## kind
 
-[`kind`](https://kind.sigs.k8s.io/) lets you run Kubernetes on
-your local computer. This tool requires that you have
-[Docker](https://docs.docker.com/get-docker/) installed and configured.
+[`kind`](https://kind.sigs.k8s.io/) short for Kubernetes in Docker, and as the name suggests, it creates a Kubernetes cluster using Docker to host the nodes. This tool requires that you have [Docker](https://docs.docker.com/get-docker/) installed and configured.
 
 The kind [Quick Start](https://kind.sigs.k8s.io/docs/user/quick-start/) page
 shows you what you need to do to get up and running with kind.


### PR DESCRIPTION
Definition of **kind** is insufficient. Added a more understandable explanation. Before it was written as`kind lets you run Kubernetes on your local computer` this is same as **minikube** then, because **minikube** definition also states that `minikube is a tool that lets you run Kubernetes locally`


