### PR TITLE
Add more owners and approvers to sig-docs-es aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -53,11 +53,17 @@ aliases:
     - shannonxtreme
     - tengqm
   sig-docs-es-owners: # Admins for Spanish content
+    - 92nqb
+    - krol3
     - electrocucaracha
     - raelga
+    - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
+    - 92nqb
+    - krol3
     - electrocucaracha
     - raelga
+    - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - awkif
     - feloy


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This PRs adds reviewers and approvers for the sig-docs-es aliases. All of new people are already added to the GitHub org.


/cc @92nqb @krol3 
/assign @electrocucaracha @raelga 