### PR TITLE
FortiADC new ingress controller

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -61,6 +61,8 @@ Kubernetes as a project supports and maintains [AWS](https://github.com/kubernet
 * [Voyager](https://appscode.com/products/voyager) is an ingress controller for
   [HAProxy](https://www.haproxy.org/#desc).
 * [Wallarm Ingress Controller](https://www.wallarm.com/solutions/waf-for-kubernetes) is an Ingress Controller that provides WAAP (WAF) and API Security capabilities.
+* [Fortinet FortiADC](https://docs.fortinet.com/document/fortiadc/7.0.0/fortiadc-ingress-controller-1-0/518751/prerequisite-knowledge) supports an ingress controller to configure FortiADC as a reverse proxy (L4-L7 Load balancing) along with security features.![image](https://user-images.githubusercontent.com/101046255/228473991-daf711c0-f86b-4180-aee2-64a553c5d17e.png)
+
 
 ## Using multiple Ingress controllers
 


### PR DESCRIPTION
Hi,

I've added FortiADC to the list, as now FortiADC supports the K8s ingress controller.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
