### PR TITLE
[ja] update page weights in /tasks/administer-cluster

### DIFF
--- a/content/ja/docs/tasks/administer-cluster/certificates.md
+++ b/content/ja/docs/tasks/administer-cluster/certificates.md
@@ -1,7 +1,7 @@
 ---
 title: 証明書を手動で生成する
 content_type: task
-weight: 20
+weight: 30
 ---
 
 

--- a/content/ja/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/ja/docs/tasks/administer-cluster/declare-network-policy.md
@@ -2,6 +2,7 @@
 title: ネットワークポリシーを宣言する
 min-kubernetes-server-version: v1.8
 content_type: task
+weight: 180
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/extended-resource-node.md
+++ b/content/ja/docs/tasks/administer-cluster/extended-resource-node.md
@@ -1,6 +1,7 @@
 ---
 title: 拡張リソースをNodeにアドバタイズする
 content_type: task
+weight: 70
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/ja/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -1,7 +1,7 @@
 ---
 title: cgroupドライバーの設定
 content_type: task
-weight: 10
+weight: 20
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/ja/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -2,7 +2,7 @@
 title: Windowsノードのアップグレード
 min-kubernetes-server-version: 1.17
 content_type: task
-weight: 40
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/manage-resources/_index.md
+++ b/content/ja/docs/tasks/administer-cluster/manage-resources/_index.md
@@ -1,4 +1,4 @@
 ---
 title: メモリー、CPU、APIリソースの管理
-weight: 20
+weight: 40
 ---

--- a/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
+++ b/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
@@ -1,6 +1,6 @@
 ---
 title: dockershimからの移行
-weight: 10
+weight: 20
 content_type: task
 ---
 

--- a/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-removal-affects-you.md
+++ b/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-removal-affects-you.md
@@ -1,7 +1,7 @@
 ---
 title: dockershim削除の影響範囲を確認する
 content_type: task
-weight: 20
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -1,7 +1,7 @@
 ---
 title: ノードで使用されているコンテナランタイムの確認
 content_type: task
-weight: 10
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents.md
+++ b/content/ja/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents.md
@@ -1,7 +1,7 @@
 ---
 title: dockershimからテレメトリーやセキュリティエージェントを移行する
 content_type: task
-weight: 70
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/ja/docs/tasks/administer-cluster/nodelocaldns.md
@@ -2,6 +2,7 @@
 reviewers:
 title: KubernetesクラスターでNodeLocal DNSキャッシュを使用する
 content_type: task
+weight: 390
 ---
  
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/content/ja/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -1,6 +1,7 @@
 ---
 title: クラウドコントローラーマネージャーの運用管理
 content_type: concept
+weight: 110
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/ja/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -1,6 +1,7 @@
 ---
 title: クラスターのセキュリティ
 content_type: task
+weight: 320
 ---
 
 <!-- overview -->

--- a/content/ja/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/ja/docs/tasks/administer-cluster/topology-manager.md
@@ -2,6 +2,7 @@
 title: ノードのトポロジー管理ポリシーを制御する
 content_type: task
 min-kubernetes-server-version: v1.18
+weight: 150
 ---
 
 <!-- overview -->


### PR DESCRIPTION
This updates the page weights under content/ja/docs/tasks/administer-cluster and the pages are shown with new order.
The weight values are same as the weight values in en.

Related: #38887
