### PR TITLE
Fix ServiceAccount admission controller link

### DIFF
--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -67,7 +67,7 @@ for a number of reasons:
 {{< feature-state for_k8s_version="v1.22" state="stable" >}}
 
 By default, the Kubernetes control plane (specifically, the
-[ServiceAccount admission controller](#serviceaccount-admission-controller))
+[ServiceAccount admission controller](#serviceaccount-admission-controller)) 
 adds a [projected volume](/docs/concepts/storage/projected-volumes/) to Pods,
 and this volume includes a token for Kubernetes API access.
 

--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -67,7 +67,7 @@ for a number of reasons:
 {{< feature-state for_k8s_version="v1.22" state="stable" >}}
 
 By default, the Kubernetes control plane (specifically, the
-[ServiceAccount admission controller](#service-account-admission-controller))
+[ServiceAccount admission controller](#serviceaccount-admission-controller))
 adds a [projected volume](/docs/concepts/storage/projected-volumes/) to Pods,
 and this volume includes a token for Kubernetes API access.
 


### PR DESCRIPTION
Fix ServiceAccount admission controller link

The existing link for ServiceAccount admission controller is broken and doesn't work. This commit will fix the link and redirect it correctly.