### PR TITLE
Fix data type of the kubelet `--seccomp-default` flag

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -959,7 +959,7 @@ WindowsHostNetwork=true|false (ALPHA - default=true)<br/>
 </tr>
 
 <tr>
-<td colspan="2">--seccomp-default string</td>
+<td colspan="2">--seccomp-default&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: <code>false</code></td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">&lt;Warning: Beta feature&gt; Enable the use of <code>RuntimeDefault</code> as the default seccomp profile for all workloads. The <code>SeccompDefault</code> feature gate must be enabled to allow this flag.</td>

--- a/content/zh-cn/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/kubelet.md
@@ -1980,7 +1980,7 @@ Timeout of all runtime requests except long running request - <code>pull</code>,
 </tr>
 
 <tr>
-<td colspan="2">--seccomp-default string</td>
+<td colspan="2">--seccomp-default&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default: <code>false</code>-->默认值：<code>false</code></td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">


### PR DESCRIPTION
I fixed data type of the kubelet `--seccomp-default` flag.