### PR TITLE
fix contenst for 2023-01-05-retroactive-default-storage-class.md

### DIFF
--- a/content/en/blog/_posts/2023-01-05-retroactive-default-storage-class.md
+++ b/content/en/blog/_posts/2023-01-05-retroactive-default-storage-class.md
@@ -60,7 +60,7 @@ to any unbound PersistentVolumeClaim that has the storageClassName set to <code>
 We've also modified the PersistentVolumeClaim admission within the API server to allow
 the change of values from an unset value to an actual StorageClass name.
 
-### Null `storageClassName` versus `storageClassName: ""` - does it matter? { #null-vs-empty-string }
+### Null `storageClassName` versus `storageClassName: ""`
 
 Before this feature was introduced, those values were equal in terms of behavior.
 Any PersistentVolumeClaim with the storageClassName set to <code>null</code> or <code>""</code>


### PR DESCRIPTION
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/12080746/229561904-1f093dc1-0f80-4d2e-ae06-eda8cfbbf16e.png">


the ```- does it matter? { #null-vs-empty-string }``` may confusion the read.. 
Just delete it for better read.