### PR TITLE
terminationGracePeriodSeconds: stable in 1.27

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -511,7 +511,7 @@ to resolve it.
 
 ### Probe-level `terminationGracePeriodSeconds`
 
-{{< feature-state for_k8s_version="v1.25" state="beta" >}}
+{{< feature-state for_k8s_version="v1.27" state="stable" >}}
 
 Prior to release 1.21, the pod-level `terminationGracePeriodSeconds` was used
 for terminating a container that failed its liveness or startup probe. This


### PR DESCRIPTION
Bumps terminationGracePeriodSeconds to stable for 1.27.

Reference:  https://github.com/kubernetes/enhancements/issues/2238

cc @mickeyboxell 