### PR TITLE
[zh] fix contenst for zh-cn/2023-01-05-retroactive-default-storage-class.md

### DIFF
--- a/content/zh-cn/blog/_posts/2023-01-05-retroactive-default-storage-class.md
+++ b/content/zh-cn/blog/_posts/2023-01-05-retroactive-default-storage-class.md
@@ -131,7 +131,7 @@ Any PersistentVolumeClaim with the storageClassName set to <code>null</code> or 
 would bind to an existing PersistentVolume resource with storageClassName also set to
 <code>null</code> or <code>""</code>.
 -->
-### Null `storageClassName` 与 `storageClassName: ""` - 有什么影响？ {#null-vs-empty-string}
+### Null `storageClassName` 与 `storageClassName: ""`
 
 此特性被引入之前，这两种赋值就其行为而言是相同的。storageClassName 设置为 `null` 或 `""`
 的所有 PersistentVolumeClaim 都会被绑定到 storageClassName 也设置为 `null` 或


### PR DESCRIPTION
Like [en fix docs](https://github.com/kubernetes/website/pull/40469).
raise a separate PR for the 'cn'..