### PR TITLE
content: Mention containerd 1.7 supports user namespaces

### DIFF
--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -29,22 +29,22 @@ mitigate some future vulnerabilities too.
 <!-- body -->
 ## {{% heading "prerequisites" %}}
 
-{{% thirdparty-content single="true" %}}
-<!-- if adding another runtime in the future, omit the single setting -->
+{{% thirdparty-content %}}
 
 This is a Linux only feature. In addition, support is needed in the 
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
 to use this feature with Kubernetes stateless pods:
 
-* CRI-O: v1.25 has support for user namespaces.
+* CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
-* containerd: support is planned for the 1.7 release. See containerd
-  issue [#7063][containerd-userns-issue] for more details.
+* containerd: version 1.7 supports user namespaces for containers, compatible
+  with Kubernetes v1.25 and v1.26 (those two minor versions only). If you are
+  running a different version of Kubernetes, check the documentation for that
+  Kubernetes release.
 
 Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.
 
 [CRI-dockerd-issue]: https://github.com/Mirantis/cri-dockerd/issues/74
-[containerd-userns-issue]: https://github.com/containerd/containerd/issues/7063
 
 ## Introduction
 

--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -43,11 +43,13 @@ this is true when user namespaces are used.
 * You need to be able to exec into pods
 * Feature gate `UserNamespacesStatelessPodsSupport` need to be enabled.
 
-In addition, support is needed in the
-{{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
-to use this feature with Kubernetes stateless pods:
+The cluster that you're using **must** include at least one node that meets the
+[requirements](/docs/concepts/workloads/pods/user-namespaces/#before-you-begin)
+for using user namespaces with Pods.
 
-* CRI-O: v1.25 has support for user namespaces.
+If you have a mixture of nodes and only some of the nodes provide user namespace support for
+Pods, you also need to ensure that the user namespace Pods are
+[scheduled](/docs/concepts/scheduling-eviction/assign-pod-node/) to suitable nodes.
 
 Please note that **if your container runtime doesn't support user namespaces, the
 new `pod.spec` field will be silently ignored and the pod will be created without


### PR DESCRIPTION
This is a backport of https://github.com/kubernetes/website/pull/40264 to 1.25 docs. It applies without conflicts.

---

containerd 1.7 was just released with user namespaces support. Let's mention this.

Also, let's emphasize in the task page that only supported runtimes work with user namespaces.

cc @SergeyKanzhelev