### PR TITLE
Cleanup page hello-minikube

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -26,13 +26,11 @@ The tutorial provides a container image that uses NGINX to echo back all the req
 
 ## {{% heading "prerequisites" %}}
 
-
 This tutorial assumes that you have already set up `minikube`.
 See [minikube start](https://minikube.sigs.k8s.io/docs/start/) for installation instructions.
 
 You also need to install `kubectl`.
 See [Install tools](/docs/tasks/tools/#kubectl) for installation instructions.
-
 
 <!-- lessoncontent -->
 
@@ -49,6 +47,7 @@ Open the Kubernetes dashboard. You can do this two different ways:
 {{< tabs name="dashboard" >}}
 {{% tab name="Launch a browser" %}}
 Open a **new** terminal, and run:
+
 ```shell
 # Start a new terminal, and leave this running.
 minikube dashboard
@@ -63,7 +62,8 @@ You can create Kubernetes resources on the dashboard such as Deployment and Serv
 If you are running in an environment as root, see [Open Dashboard with URL](#open-dashboard-with-url).
 
 By default, the dashboard is only accessible from within the internal Kubernetes virtual network.
-The `dashboard` command creates a temporary proxy to make the dashboard accessible from outside the Kubernetes virtual network.
+The `dashboard` command creates a temporary proxy to make the dashboard accessible from outside the
+Kubernetes virtual network.
 
 To stop the proxy, run `Ctrl+C` to exit the process.
 After the command exits, the dashboard remains running in the Kubernetes cluster.
@@ -77,6 +77,7 @@ If you don't want minikube to open a web browser for you, run the dashboard comm
 `--url` flag. `minikube` outputs a URL that you can open in the browser you prefer.
 
 Open a **new** terminal, and run:
+
 ```shell
 # Start a new terminal, and leave this running.
 minikube dashboard --url
@@ -99,48 +100,48 @@ recommended way to manage the creation and scaling of Pods.
 1. Use the `kubectl create` command to create a Deployment that manages a Pod. The
    Pod runs a Container based on the provided Docker image.
 
-    ```shell
-    # Run a test container image that includes a webserver
-    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.39 -- /agnhost netexec --http-port=8080
-    ```
+   ```shell
+   # Run a test container image that includes a webserver
+   kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.39 -- /agnhost netexec --http-port=8080
+   ```
 
 1. View the Deployment:
 
-    ```shell
-    kubectl get deployments
-    ```
+   ```shell
+   kubectl get deployments
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-    hello-node   1/1     1            1           1m
-    ```
+   ```
+   NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+   hello-node   1/1     1            1           1m
+   ```
 
 1. View the Pod:
 
-    ```shell
-    kubectl get pods
-    ```
+   ```shell
+   kubectl get pods
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    NAME                          READY     STATUS    RESTARTS   AGE
-    hello-node-5f76cf6ccf-br9b5   1/1       Running   0          1m
-    ```
+   ```
+   NAME                          READY     STATUS    RESTARTS   AGE
+   hello-node-5f76cf6ccf-br9b5   1/1       Running   0          1m
+   ```
 
 1. View cluster events:
 
-    ```shell
-    kubectl get events
-    ```
+   ```shell
+   kubectl get events
+   ```
 
 1. View the `kubectl` configuration:
 
-    ```shell
-    kubectl config view
-    ```
+   ```shell
+   kubectl config view
+   ```
 
 {{< note >}}
 For more information about `kubectl` commands, see the [kubectl overview](/docs/reference/kubectl/).
@@ -155,127 +156,128 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 
 1. Expose the Pod to the public internet using the `kubectl expose` command:
 
-    ```shell
-    kubectl expose deployment hello-node --type=LoadBalancer --port=8080
-    ```
+   ```shell
+   kubectl expose deployment hello-node --type=LoadBalancer --port=8080
+   ```
 
-    The `--type=LoadBalancer` flag indicates that you want to expose your Service
-    outside of the cluster.
-    
-    The application code inside the test image only listens on TCP port 8080. If you used
-    `kubectl expose` to expose a different port, clients could not connect to that other port.
+   The `--type=LoadBalancer` flag indicates that you want to expose your Service
+   outside of the cluster.
+
+   The application code inside the test image only listens on TCP port 8080. If you used
+   `kubectl expose` to expose a different port, clients could not connect to that other port.
 
 2. View the Service you created:
 
-    ```shell
-    kubectl get services
-    ```
+   ```shell
+   kubectl get services
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    NAME         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
-    hello-node   LoadBalancer   10.108.144.78   <pending>     8080:30369/TCP   21s
-    kubernetes   ClusterIP      10.96.0.1       <none>        443/TCP          23m
-    ```
+   ```
+   NAME         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+   hello-node   LoadBalancer   10.108.144.78   <pending>     8080:30369/TCP   21s
+   kubernetes   ClusterIP      10.96.0.1       <none>        443/TCP          23m
+   ```
 
-    On cloud providers that support load balancers,
-    an external IP address would be provisioned to access the Service. On minikube,
-    the `LoadBalancer` type makes the Service accessible through the `minikube service`
-    command.
+   On cloud providers that support load balancers,
+   an external IP address would be provisioned to access the Service. On minikube,
+   the `LoadBalancer` type makes the Service accessible through the `minikube service`
+   command.
 
 3. Run the following command:
 
-    ```shell
-    minikube service hello-node
-    ```
+   ```shell
+   minikube service hello-node
+   ```
 
-    This opens up a browser window that serves your app and shows the app's response.
+   This opens up a browser window that serves your app and shows the app's response.
 
 ## Enable addons
 
-The minikube tool includes a set of built-in {{< glossary_tooltip text="addons" term_id="addons" >}} that can be enabled, disabled and opened in the local Kubernetes environment.
+The minikube tool includes a set of built-in {{< glossary_tooltip text="addons" term_id="addons" >}}
+that can be enabled, disabled and opened in the local Kubernetes environment.
 
 1. List the currently supported addons:
 
-    ```shell
-    minikube addons list
-    ```
+   ```shell
+   minikube addons list
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    addon-manager: enabled
-    dashboard: enabled
-    default-storageclass: enabled
-    efk: disabled
-    freshpod: disabled
-    gvisor: disabled
-    helm-tiller: disabled
-    ingress: disabled
-    ingress-dns: disabled
-    logviewer: disabled
-    metrics-server: disabled
-    nvidia-driver-installer: disabled
-    nvidia-gpu-device-plugin: disabled
-    registry: disabled
-    registry-creds: disabled
-    storage-provisioner: enabled
-    storage-provisioner-gluster: disabled
-    ```
+   ```
+   addon-manager: enabled
+   dashboard: enabled
+   default-storageclass: enabled
+   efk: disabled
+   freshpod: disabled
+   gvisor: disabled
+   helm-tiller: disabled
+   ingress: disabled
+   ingress-dns: disabled
+   logviewer: disabled
+   metrics-server: disabled
+   nvidia-driver-installer: disabled
+   nvidia-gpu-device-plugin: disabled
+   registry: disabled
+   registry-creds: disabled
+   storage-provisioner: enabled
+   storage-provisioner-gluster: disabled
+   ```
 
 2. Enable an addon, for example, `metrics-server`:
 
-    ```shell
-    minikube addons enable metrics-server
-    ```
+   ```shell
+   minikube addons enable metrics-server
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    The 'metrics-server' addon is enabled
-    ```
+   ```
+   The 'metrics-server' addon is enabled
+   ```
 
 3. View the Pod and Service you created by installing that addon:
 
-    ```shell
-    kubectl get pod,svc -n kube-system
-    ```
+   ```shell
+   kubectl get pod,svc -n kube-system
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/coredns-5644d7b6d9-mh9ll                1/1       Running   0          34m
-    pod/coredns-5644d7b6d9-pqd2t                1/1       Running   0          34m
-    pod/metrics-server-67fb648c5                1/1       Running   0          26s
-    pod/etcd-minikube                           1/1       Running   0          34m
-    pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
-    pod/kube-addon-manager-minikube             1/1       Running   0          34m
-    pod/kube-apiserver-minikube                 1/1       Running   0          34m
-    pod/kube-controller-manager-minikube        1/1       Running   0          34m
-    pod/kube-proxy-rnlps                        1/1       Running   0          34m
-    pod/kube-scheduler-minikube                 1/1       Running   0          34m
-    pod/storage-provisioner                     1/1       Running   0          34m
+   ```
+   NAME                                        READY     STATUS    RESTARTS   AGE
+   pod/coredns-5644d7b6d9-mh9ll                1/1       Running   0          34m
+   pod/coredns-5644d7b6d9-pqd2t                1/1       Running   0          34m
+   pod/metrics-server-67fb648c5                1/1       Running   0          26s
+   pod/etcd-minikube                           1/1       Running   0          34m
+   pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
+   pod/kube-addon-manager-minikube             1/1       Running   0          34m
+   pod/kube-apiserver-minikube                 1/1       Running   0          34m
+   pod/kube-controller-manager-minikube        1/1       Running   0          34m
+   pod/kube-proxy-rnlps                        1/1       Running   0          34m
+   pod/kube-scheduler-minikube                 1/1       Running   0          34m
+   pod/storage-provisioner                     1/1       Running   0          34m
 
-    NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/metrics-server         ClusterIP   10.96.241.45    <none>        80/TCP              26s
-    service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
-    service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
-    service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
-    ```
+   NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
+   service/metrics-server         ClusterIP   10.96.241.45    <none>        80/TCP              26s
+   service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
+   service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
+   service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
+   ```
 
 4. Disable `metrics-server`:
 
-    ```shell
-    minikube addons disable metrics-server
-    ```
+   ```shell
+   minikube addons disable metrics-server
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    metrics-server was successfully disabled
-    ```
+   ```
+   metrics-server was successfully disabled
+   ```
 
 ## Clean up
 
@@ -303,8 +305,6 @@ If you want to use minikube again to learn more about Kubernetes, you don't need
 
 ## {{% heading "whatsnext" %}}
 
-
 * Learn more about [Deployment objects](/docs/concepts/workloads/controllers/deployment/).
 * Learn more about [Deploying applications](/docs/tasks/run-application/run-stateless-application-deployment/).
 * Learn more about [Service objects](/docs/concepts/services-networking/service/).
-


### PR DESCRIPTION
This PR cleanup page `hello-minikube`:

1. The indentation of list items should be 3 spaces for ordered lists. We should avoid using 4 spaces as indentation because 4-spaces indentation has special meaning in markdown.
2. Removed redundant blank lines