### PR TITLE
[zh] sync page user-namespaces, sysctl-cluster

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -44,6 +44,15 @@ the Linux man-pages project.
 
 ## {{% heading "prerequisites" %}}
 
+{{< note >}}
+<!--
+`sysctl` is a Linux-specific command-line tool used to configure various kernel parameters
+and it is not available on non-Linux operating systems.
+-->
+`sysctl` 是一个 Linux 特有的命令行工具，用于配置各种内核参数，
+它在非 Linux 操作系统上无法使用。
+{{< /note >}}
+
 {{< include "task-tutorial-prereqs.md" >}}
 
 <!--
@@ -119,17 +128,17 @@ The following sysctls are supported in the _safe_ set:
 至今为止，大多数 **有命名空间的** sysctl 参数不一定被认为是 **安全** 的。
 以下几种 sysctl 参数是 **安全的**：
 
-- `kernel.shm_rmid_forced`
-- `net.ipv4.ip_local_port_range`
-- `net.ipv4.tcp_syncookies`
-- `net.ipv4.ping_group_range`（从 Kubernetes 1.18 开始）
+- `kernel.shm_rmid_forced`,
+- `net.ipv4.ip_local_port_range`,
+- `net.ipv4.tcp_syncookies`,
+- `net.ipv4.ping_group_range`（从 Kubernetes 1.18 开始）,
 - `net.ipv4.ip_unprivileged_port_start`（从 Kubernetes 1.22 开始）。
 
 {{< note >}}
 <!--
 The example `net.ipv4.tcp_syncookies` is not namespaced on Linux kernel version 4.4 or lower.
 -->
-示例中的 `net.ipv4.tcp_syncookies` 在Linux 内核 4.4 或更低的版本中是无命名空间的。
+示例中的 `net.ipv4.tcp_syncookies` 在 Linux 内核 4.4 或更低的版本中是无命名空间的。
 {{< /note >}}
 
 <!--
@@ -236,7 +245,7 @@ securityContext 应用于同一个 Pod 中的所有容器。
 <!--
 This example uses the pod securityContext to set a safe sysctl
 `kernel.shm_rmid_forced` and two unsafe sysctls `net.core.somaxconn` and
-`kernel.msgmax` There is no distinction between _safe_ and _unsafe_ sysctls in
+`kernel.msgmax`. There is no distinction between _safe_ and _unsafe_ sysctls in
 the specification.
 -->
 此示例中，使用 Pod SecurityContext 来对一个安全的 sysctl 参数

--- a/content/zh-cn/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/user-namespaces.md
@@ -75,16 +75,23 @@ this is true when user namespaces are used.
 * 特性 `UserNamespacesStatelessPodsSupport` 需要被启用。
 
 <!--
-In addition, support is needed in the
-{{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
-to use this feature with Kubernetes stateless pods:
+The cluster that you're using **must** include at least one node that meets the
+[requirements](/docs/concepts/workloads/pods/user-namespaces/#before-you-begin)
+for using user namespaces with Pods.
 -->
-此外, 需要{{< glossary_tooltip text="容器运行时" term_id="container-runtime" >}}提供相应的支持，
-才能将此特性与 Kubernetes 无状态 Pod 一起使用：
+你所使用的集群**必须**包括至少一个符合
+[要求](/zh-cn/docs/concepts/workloads/pods/user-namespaces/#before-you-begin)
+的节点，以便为 Pod 配置用户名字空间。
 
 <!--
-* CRI-O: v1.25 has support for user namespaces.
+If you have a mixture of nodes and only some of the nodes provide user namespace support for
+Pods, you also need to ensure that the user namespace Pods are
+[scheduled](/docs/concepts/scheduling-eviction/assign-pod-node/) to suitable nodes.
 -->
+如果你有混合节点，并且只有部分节点支持为 Pod 配置用户名字空间，
+你还需要确保配置了用户名字空间的 Pod
+被[调度](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/)到合适的节点。
+
 * CRI-O: v1.25 支持用户名字空间。
 
 <!--


### PR DESCRIPTION
This PR resyncs the following pages:

`content/zh-cn/docs/concepts/workloads/pods/user-namespaces.md`

`content/zh-cn/docs/tasks/configure-pod-container/user-namespaces.md`

`content/zh-cn/docs/tasks/administer-cluster/sysctl-cluster.md`