### PR TITLE
[ja] update link of go package text/template

### DIFF
--- a/content/ja/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/ja/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -84,7 +84,7 @@ kubectl get pods --namespace kube-system -o jsonpath="{..image}"
 
 ## jsonpathの代わりにgo-templateを使用してコンテナイメージを一覧表示する {#list-container-images-using-a-go-template-instead-of-jsonpath}
 
-jsonpathの代わりに、kubectlは[go-templates](https://golang.org/pkg/text/template/)を使用した出力のフォーマットをサポートしています:
+jsonpathの代わりに、kubectlは[go-templates](https://pkg.go.dev/text/template)を使用した出力のフォーマットをサポートしています:
 
 
 ```shell
@@ -105,7 +105,7 @@ kubectl get pods --all-namespaces -o go-template --template="{{range .items}}{{r
 ### 参照
 
 * [jsonpath](/docs/reference/kubectl/jsonpath/)参照ガイド
-* [Go template](https://golang.org/pkg/text/template/)参照ガイド
+* [Go template](https://pkg.go.dev/text/template)参照ガイド
 
 
 

--- a/content/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
+++ b/content/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
@@ -92,7 +92,7 @@ spec:
 
 * [コンテナ](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)の`terminationMessagePath`フィールド参照
 * [ログ取得](/docs/concepts/cluster-administration/logging/)について
-* [Goテンプレート](https://golang.org/pkg/text/template/)について
+* [Goテンプレート](https://pkg.go.dev/text/template)について
 
 
 


### PR DESCRIPTION
The old link cannot be accessed, so I update the link.

`https://golang.org/pkg/text/template` =>  `https://pkg.go.dev/text/template`