### PR TITLE
update link of go package text/template

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -81,7 +81,7 @@ kubectl get pods --namespace kube-system -o jsonpath="{.items[*].spec.containers
 
 ## List Container images using a go-template instead of jsonpath
 
-As an alternative to jsonpath, Kubectl supports using [go-templates](https://golang.org/pkg/text/template/)
+As an alternative to jsonpath, Kubectl supports using [go-templates](https://pkg.go.dev/text/template)
 for formatting the output:
 
 ```shell
@@ -93,5 +93,4 @@ kubectl get pods --all-namespaces -o go-template --template="{{range .items}}{{r
 ### Reference
 
 * [Jsonpath](/docs/reference/kubectl/jsonpath/) reference guide
-* [Go template](https://golang.org/pkg/text/template/) reference guide
-
+* [Go template](https://pkg.go.dev/text/template) reference guide

--- a/content/en/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
@@ -128,4 +128,4 @@ is empty and the container exited with an error. The log output is limited to
 * See the `terminationMessagePath` field in
   [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core).
 * Learn about [retrieving logs](/docs/concepts/cluster-administration/logging/).
-* Learn about [Go templates](https://golang.org/pkg/text/template/).
+* Learn about [Go templates](https://pkg.go.dev/text/template).


### PR DESCRIPTION
The old link cannot be accessed, so I update the link.

`https://golang.org/pkg/text/template` =>  `https://pkg.go.dev/text/template`