### PR TITLE
Migrated to use the v1beta3 API version of FlowSchema

### DIFF
--- a/content/en/examples/priority-and-fairness/health-for-strangers.yaml
+++ b/content/en/examples/priority-and-fairness/health-for-strangers.yaml
@@ -1,4 +1,4 @@
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 kind: FlowSchema
 metadata:
   name: health-for-strangers


### PR DESCRIPTION
Title: Migrated to use the v1beta3 API version of FlowSchema.

As per the Kubernetes API deprecation-guide, the flowcontrol.apiserver.k8s.io/v1beta2 API version of FlowSchema will no longer be served in v1.29.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/

I'm issuing this PR so that the example in the official Kubernetes documentation refers to the flowcontrol.apiserver.k8s.io/v1beta3 API version, available since v1.26