### PR TITLE
Removed beta stage for TTLAfterFinished.

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -180,4 +180,4 @@ configure garbage collection:
 
 * Learn more about [ownership of Kubernetes objects](/docs/concepts/overview/working-with-objects/owners-dependents/).
 * Learn more about Kubernetes [finalizers](/docs/concepts/overview/working-with-objects/finalizers/).
-* Learn about the [TTL controller](/docs/concepts/workloads/controllers/ttlafterfinished/) (beta) that cleans up finished Jobs.
+* Learn about the [TTL controller](/docs/concepts/workloads/controllers/ttlafterfinished/) that cleans up finished Jobs.


### PR DESCRIPTION
This PR removed the `beta`  word for the TTLAfterFinished  in the [Garbage Collection](https://kubernetes.io/docs/concepts/architecture/garbage-collection/#what-s-next) docs

Fixes #40521