### PR TITLE
Note on caBundle encoding in extensible-admission-controllers.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -116,7 +116,7 @@ webhooks:
 
 {{< note >}}
 You must replace the `<CA_BUNDLE>` in the above example by a valid CA bundle
-which is a PEM-encoded CA bundle for validating the webhook's server certificate.
+which is a PEM-encoded (field value is Base64 encoded) CA bundle for validating the webhook's server certificate.
 {{< /note >}}
 
 The `scope` field specifies if only cluster-scoped resources ("Cluster") or namespace-scoped


### PR DESCRIPTION
This is a small clarification suggestion.

The note on caBundle field description mentions it is PEM encoded, but the actual field value is then encoded into Base64, which is worth mentioning.

