### PR TITLE
[ja] update Japanese translation for /docs/tutorials/_index

### DIFF
--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -51,7 +51,7 @@ content_type: concept
 
 ## セキュリティ
 
-* [Apply Pod Security Standards at Cluster level](/docs/tutorials/security/cluster-level-pss/)
+* [クラスターレベルのPod Securityの標準の適用](/docs/tutorials/security/cluster-level-pss/)
 * [NamespaceレベルのPod Securityの標準の適用](/docs/tutorials/security/ns-level-pss/)
 * [AppArmor](/docs/tutorials/security/apparmor/)
 * [seccomp](/docs/tutorials/security/seccomp/)

--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -52,7 +52,7 @@ content_type: concept
 ## セキュリティ
 
 * [Apply Pod Security Standards at Cluster level](/docs/tutorials/security/cluster-level-pss/)
-* [Apply Pod Security Standards at Namespace level](/ja/docs/tutorials/security/ns-level-pss/)
+* [NamespaceレベルのPod Securityの標準の適用](/docs/tutorials/security/ns-level-pss/)
 * [AppArmor](/docs/tutorials/security/apparmor/)
 * [seccomp](/docs/tutorials/security/seccomp/)
 

--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -24,6 +24,8 @@ content_type: concept
 
 ## 設定
 
+* [Example: Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
+
 * [ConfigMapを用いたRedisの設定](/ja/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## ステートレスアプリケーション
@@ -34,29 +36,26 @@ content_type: concept
 
 ## ステートフルアプリケーション
 
-* [StatefulSetの基本](/docs/tutorials/stateful-application/basic-stateful-set/)
+* [StatefulSetの基本](/ja/docs/tutorials/stateful-application/basic-stateful-set/)
 
-* [例: 永続ボリュームを使ったWordPressとMySQLのデプロイ](/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+* [例: Persistent Volumeを使用したWordpressとMySQLをデプロイする](/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
 
-* [例: Stateful Setsを使ったCassandraのデプロイ](/docs/tutorials/stateful-application/cassandra/)
+* [例: Stateful Setを使用したCassandraのデプロイ](/ja/docs/tutorials/stateful-application/cassandra/)
 
 * [CP(一貫性＋分断耐性)分散システムZooKeeperの実行](/docs/tutorials/stateful-application/zookeeper/)
 
-## クラスター
-
-* [AppArmor](/docs/tutorials/clusters/apparmor/)
-
-* [seccomp](/docs/tutorials/clusters/seccomp/)
-
 ## サービス
 
+* [Connecting Applications with Services](/docs/tutorials/services/connect-applications-service/)
 * [Source IPを使う](/ja/docs/tutorials/services/source-ip/)
 
+## セキュリティ
 
+* [Apply Pod Security Standards at Cluster level](/docs/tutorials/security/cluster-level-pss/)
+* [Apply Pod Security Standards at Namespace level](/ja/docs/tutorials/security/ns-level-pss/)
+* [AppArmor](/docs/tutorials/security/apparmor/)
+* [seccomp](/docs/tutorials/security/seccomp/)
 
 ## {{% heading "whatsnext" %}}
 
-
 チュートリアルのページタイプについての情報は、[Content Page Types](/docs/contribute/style/page-content-types/)を参照してください。
-
-

--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -24,7 +24,7 @@ content_type: concept
 
 ## 設定
 
-* [Example: Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
+* [例: Javaのマイクロサービスの設定](/docs/tutorials/configuration/configure-java-microservice/)
 
 * [ConfigMapを用いたRedisの設定](/ja/docs/tutorials/configuration/configure-redis-using-configmap/)
 


### PR DESCRIPTION
This PR updates Japanese translation of https://kubernetes.io/docs/tutorials/_index

Fixes #40543

I would prefer Japanese language for suggestions and discussion of revisions to this translation.
(表現に関わるため、この翻訳についてのデイスカッションは日本語を希望します。
英語の更新に同期し、各リンクの見出しは日本語記事の見出しに合わせました)
