### PR TITLE
[en] Replace k8s.gcr.io with registry.k8s.io in blogs

### DIFF
--- a/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
+++ b/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
@@ -119,8 +119,8 @@ Here are some of the images we built：
 - `gcr.io/kubernetes-e2e-test-images/volume/iscsi:2.0`
 - `gcr.io/kubernetes-e2e-test-images/volume/nfs:1.0`
 - `gcr.io/kubernetes-e2e-test-images/volume/rbd:1.0.1`
-- `k8s.gcr.io/etcd:3.3.15`
-- `k8s.gcr.io/pause:3.1`
+- `registry.k8s.io/etcd:3.3.15` (image changed since publication - previously used registry "k8s.gcr.io")
+- `registry.k8s.io/pause:3.1` (image changed since publication - previously used registry "k8s.gcr.io")
 
 Finally, we ran the tests and got the test result, include `e2e.log`, which showed that all test cases passed. Additionally, we submitted our test result to [k8s-conformance](https://github.com/cncf/k8s-conformance) as a [pull request](https://github.com/cncf/k8s-conformance/pull/779).
 

--- a/content/en/blog/_posts/2022-12-22-kubelet-credential-providers/index.md
+++ b/content/en/blog/_posts/2022-12-22-kubelet-credential-providers/index.md
@@ -69,7 +69,7 @@ in `CredentialProviderResponse`. When the value is `Image`, the kubelet will onl
 match the image of the first request. When the value is `Registry`, the kubelet will use cached credentials for any subsequent image pulls
 destined for the same registry host but using different paths (for example, `gcr.io/foo/bar` and `gcr.io/bar/foo` refer to different images
 from the same registry). Lastly, when the value is `Global`, the kubelet will use returned credentials for all images that match against
-the plugin, including images that can map to different registry hosts (for example, gcr.io vs k8s.gcr.io). The `cacheKeyType` field is required by plugin
+the plugin, including images that can map to different registry hosts (for example, gcr.io vs registry.k8s.io (previously k8s.gcr.io)). The `cacheKeyType` field is required by plugin
 implementations.
 
 ```json


### PR DESCRIPTION
This PR replaces k8s.gcr.io with registry.k8s.io in two blog posts where I think it kinda makes sense to do so:

- 2020-01-15-Kubernetes-on-MIPS.md: this blog post talks about what images they built, but both k8s.gcr.io images are available in the registry, so I think updating makes sense
- 2022-12-22-kubelet-credential-providers/index.md: was referencing k8s.gcr.io, I added registry.k8s.io as well

/assign @sftim 
xref https://github.com/kubernetes/website/issues/39353
xref https://github.com/kubernetes/k8s.io/issues/4738