### PR TITLE
[pt-br] Replace k8s.gcr.io with registry.k8s.io in reference doc

### DIFF
--- a/content/pt-br/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
+++ b/content/pt-br/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
@@ -59,7 +59,7 @@ kubeadm config images pull [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Padrão: "k8s.gcr.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Padrão: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Escolha um registro de contêineres para baixar imagens da camada de gerenciamento</p></td>


### PR DESCRIPTION
This PR replaces k8s.gcr.io with registry.k8s.io in a reference document related to kubeadm.

/assign @sftim 
xref https://github.com/kubernetes/website/issues/39353
xref https://github.com/kubernetes/k8s.io/issues/4738