### PR TITLE
[ko] Replace k8s.gcr.io with registry.k8s.io in blog

### DIFF
--- a/content/ko/blog/_posts/2022-05-13-grpc-probes-in-beta.md
+++ b/content/ko/blog/_posts/2022-05-13-grpc-probes-in-beta.md
@@ -93,7 +93,8 @@ metadata:
 spec:
   containers:
   - name: agnhost
-    image: k8s.gcr.io/e2e-test-images/agnhost:2.35
+    # 이미지가 변경됨 (기존에는 "k8s.gcr.io" 레지스트리를 사용)
+    image: registry.k8s.io/e2e-test-images/agnhost:2.35
     command: ["/agnhost", "grpc-health-checking"]
     ports:
     - containerPort: 5000


### PR DESCRIPTION
This PR replaces a reference to k8s.gcr.io with registry.k8s.io in a Korean blog post translation.

/assign @sftim 
xref https://github.com/kubernetes/website/issues/39353
xref https://github.com/kubernetes/k8s.io/issues/4738