### PR TITLE
[zh-cn] Replace k8s.gcr.io with registry.k8s.io in blog

### DIFF
--- a/content/zh-cn/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
+++ b/content/zh-cn/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
@@ -225,8 +225,8 @@ Here are some of the images we built
 - `gcr.io/kubernetes-e2e-test-images/volume/iscsi:2.0`
 - `gcr.io/kubernetes-e2e-test-images/volume/nfs:1.0`
 - `gcr.io/kubernetes-e2e-test-images/volume/rbd:1.0.1`
-- `k8s.gcr.io/etcd:3.3.15`
-- `k8s.gcr.io/pause:3.1`
+- `registry.k8s.io/etcd:3.3.15` (镜像自发布以来已更改（以前使用的仓库为 "k8s.gcr.io"))
+- `registry.k8s.io/pause:3.1` (镜像自发布以来已更改（以前使用的仓库为 "k8s.gcr.io"))
 
 <!--
 Finally, we ran the tests and got the test result, include `e2e.log`, which showed that all test cases passed. Additionally, we submitted our test result to [k8s-conformance](https://github.com/cncf/k8s-conformance) as a [pull request](https://github.com/cncf/k8s-conformance/pull/779).


### PR DESCRIPTION
This is a follow up on #40585 to replace k8s.gcr.io with registry.k8s.io in a Chinese translation of Kubernetes on MIPS blog post.

/assign @sftim 
xref https://github.com/kubernetes/website/issues/39353
xref https://github.com/kubernetes/k8s.io/issues/4738

/hold
for #40585 to get merged first