### PR TITLE
Fixed the Pods access url via proxy

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -154,7 +154,7 @@ description: |-
                 <p><code><b>export POD_NAME="$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"</b></code><br />
                 <code><b>echo Name of the Pod: $POD_NAME</b></code></p>
                 <p>To see the output of our application, run a <code>curl</code> request:</p>
-                <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/proxy/</b></code></p>
+                <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/</b></code></p>
                 <p>The URL is the route to the API of the Pod.</p>
            </div>
         </div>


### PR DESCRIPTION
The url to access Pods information via proxy is incorrect. It is `curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/proxy/` while it should be `curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/`