### PR TITLE
add the known issue section for the scheduler bug on the release blog

### DIFF
--- a/content/en/blog/_posts/2023-04-11-kubernetes-1.27-blog.md
+++ b/content/en/blog/_posts/2023-04-11-kubernetes-1.27-blog.md
@@ -171,6 +171,16 @@ This release saw several removals:
 * [Removal of `IdentifyPodOS` feature gate](https://github.com/kubernetes/kubernetes/pull/111229)
 * [Removal of `DaemonSetUpdateSurge` feature gate](https://github.com/kubernetes/kubernetes/pull/111194)
 
+## The known issue
+
+### The PreEnqueue extension point doesn't work for Pods going to activeQ through backoffQ
+
+In v1.26.0, we've found the bug that the PreEnqueue extension point in the scheduler, 
+which it doesn't work for Pods going to activeQ through backoffQ. 
+It doesn't affect any of the vanilla Kubernetes scheduler's behavior, but may break custom PreEnqueue plugins.
+
+The cause PR is [reverted](https://github.com/kubernetes/kubernetes/pull/117194) by v1.26.1.
+
 ## Release notes
 
 The complete details of the Kubernetes v1.27 release are available in our [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md).

--- a/content/en/blog/_posts/2023-04-11-kubernetes-1.27-blog.md
+++ b/content/en/blog/_posts/2023-04-11-kubernetes-1.27-blog.md
@@ -171,15 +171,17 @@ This release saw several removals:
 * [Removal of `IdentifyPodOS` feature gate](https://github.com/kubernetes/kubernetes/pull/111229)
 * [Removal of `DaemonSetUpdateSurge` feature gate](https://github.com/kubernetes/kubernetes/pull/111194)
 
-## The known issue
+## Known issues
 
-### The PreEnqueue extension point doesn't work for Pods going to activeQ through backoffQ
+### The `PreEnqueue` scheduling extension point doesn't work for some customizations
 
-In v1.26.0, we've found the bug that the PreEnqueue extension point in the scheduler, 
-which it doesn't work for Pods going to activeQ through backoffQ. 
-It doesn't affect any of the vanilla Kubernetes scheduler's behavior, but may break custom PreEnqueue plugins.
+Kubernetes v1.27.0 includes a bug affecting the `PreEnqueue` extension point in the scheduler, 
+which it doesn't work for Pods going to `activeQ` through `backoffQ`. 
+The bug doesn't affect any of the compiled-in behaviour for the kube-scheduler, but may break
+custom `PreEnqueue` plugins.
 
-The cause PR is [reverted](https://github.com/kubernetes/kubernetes/pull/117194) by v1.26.1.
+The upcoming Kubernetes v1.27.1 patch release is likely to include a fix for this. See
+[Releases](/releases/#release-v1-27) for more detail.
 
 ## Release notes
 


### PR DESCRIPTION
suggested: https://kubernetes.slack.com/archives/C2C40FMNF/p1681218289441409?thread_ts=1681189516.035079&cid=C2C40FMNF

Add the known issue section for the scheduler's bug on the release blog.
https://github.com/kubernetes/kubernetes/pull/117194

We didn't include the change for reverting the cause PR because that bug doesn't break the vanilla Kubernetes scheduler (+ was found on the release day 😓 ).
It'll be reverted by v1.26.1. (cherry-pick)
