### PR TITLE
CVE Feed: Make the switch from alpha -> beta

### DIFF
--- a/content/en/docs/reference/issues-security/official-cve-feed.md
+++ b/content/en/docs/reference/issues-security/official-cve-feed.md
@@ -9,7 +9,7 @@ outputs:
 layout: cve-feed
 ---
 
-{{< feature-state for_k8s_version="v1.25" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.27" state="beta" >}}
 
 This is a community maintained list of official CVEs announced by
 the Kubernetes Security Response Committee. See


### PR DESCRIPTION
With #39644 merged and set to be published April 25, lets officially switch the feature state from `alpha` to `beta`.

Happy for this to be merged after v1.27 is GA

/sig security docs release
/area cleanup security