### PR TITLE
Re-add v1.24 schedule to patch releases

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -76,3 +76,57 @@ schedules:
     - release: 1.25.0
       cherryPickDeadline: ""
       targetDate: 2022-08-23
+- release: 1.24
+  releaseDate: 2022-05-03
+  maintenanceModeStartDate: 2023-05-28
+  endOfLifeDate: 2023-07-28
+  next:
+    release: 1.24.13
+    cherryPickDeadline: 2023-04-07
+    targetDate: 2023-04-12
+  previousPatches:
+    - release: 1.24.12
+      cherryPickDeadline: 2023-03-10
+      targetDate: 2023-03-15
+    - release: 1.24.11
+      cherryPickDeadline: 2023-02-10
+      targetDate: 2023-02-15
+      note: >-
+        [Some container images might be **unsigned** due to a temporary issue with the promotion process](https://groups.google.com/a/kubernetes.io/g/dev/c/MwSx761slM0/m/4ajkeUl0AQAJ)
+    - release: 1.24.10
+      cherryPickDeadline: 2023-01-13
+      targetDate: 2023-01-18
+    - release: 1.24.9
+      cherryPickDeadline: 2022-12-02
+      targetDate: 2022-12-08
+    - release: 1.24.8
+      cherryPickDeadline: 2022-11-04
+      targetDate: 2022-11-09
+    - release: 1.24.7
+      cherryPickDeadline: 2022-10-07
+      targetDate: 2022-10-12
+    - release: 1.24.6
+      cherryPickDeadline: 2022-09-20
+      targetDate: 2022-09-21
+      note: >-
+        [Out-of-Band release to fix the regression introduced in 1.24.5](https://groups.google.com/a/kubernetes.io/g/dev/c/tA6LNOQTR4Q/m/zL73maPTAQAJ)
+    - release: 1.24.5
+      cherryPickDeadline: 2022-09-09
+      targetDate: 2022-09-14
+      note: >-
+        [Regression](https://groups.google.com/a/kubernetes.io/g/dev/c/tA6LNOQTR4Q/m/zL73maPTAQAJ)
+    - release: 1.24.4
+      cherryPickDeadline: 2022-08-12
+      targetDate: 2022-08-17
+    - release: 1.24.3
+      cherryPickDeadline: 2022-07-08
+      targetDate: 2022-07-13
+    - release: 1.24.2
+      cherryPickDeadline: 2022-06-10
+      targetDate: 2022-06-15
+    - release: 1.24.1
+      cherryPickDeadline: 2022-05-20
+      targetDate: 2022-05-24
+    - release: 1.24.0
+      cherryPickDeadline: ""
+      targetDate: 2022-05-03


### PR DESCRIPTION
We removed them as part of https://github.com/kubernetes/website/pull/40551, but v1.24 is not EOL yet.

See https://github.com/kubernetes/website/pull/40551/files#r1163739853

@kubernetes/release-managers  PTAL