### PR TITLE
Revise details for control plane taints / labels

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1114,7 +1114,7 @@ used to determine if the user has applied settings different from the kubeadm de
 
 Used on: Node
 
-Label that kubeadm applies on the control plane nodes that it manages.
+Label that kubeadm applies on the control plane nodes that it manages. If this label set, [EndpointSlice controller](/docs/concepts/services-networking/topology-aware-routing/#implementation-control-plane) ignores that node.
 
 ### node-role.kubernetes.io/control-plane {#node-role-kubernetes-io-control-plane-taint}
 
@@ -1122,7 +1122,7 @@ Used on: Node
 
 Example: `node-role.kubernetes.io/control-plane:NoSchedule`
 
-Taint that kubeadm applies on control plane nodes to allow only critical workloads to schedule on them.
+Taint that kubeadm applies on control plane nodes to allow only critical workloads to schedule on them. If this taint set, EndpointSlice controller ignores that node.
 
 ### node-role.kubernetes.io/master (deprecated) {#node-role-kubernetes-io-master-taint}
 
@@ -1133,3 +1133,6 @@ Example: `node-role.kubernetes.io/master:NoSchedule`
 Taint that kubeadm previously applied on control plane nodes to allow only critical workloads to schedule on them.
 Replaced by [`node-role.kubernetes.io/control-plane`](#node-role-kubernetes-io-control-plane-taint); kubeadm
 no longer sets or uses this deprecated taint.
+{{< note >}}
+The EndpointSlice controller ignores nodes with the `node-role.kubernetes.io/control-plane` or `node-role.kubernetes.io/master` label set.
+{{< /note >}}

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1116,7 +1116,7 @@ Used on: Node
 
 A marker label to indicate that the node is used to run {{< glossary_tooltip text="control plane" term_id="control-plane" >}} components. The kubeadm tool applies this label to the control plane nodes that it manages. Other cluster management tools typically also set this taint.
 
-You can label control plane nodes with this label to make it easier to schedule Pods only onto these nodes, or to avoid running Pods on the control plane. If this label set, [EndpointSlice controller](/docs/concepts/services-networking/topology-aware-routing/#implementation-control-plane) ignores that node.
+You can label control plane nodes with this label to make it easier to schedule Pods only onto these nodes, or to avoid running Pods on the control plane. If this label is set, [EndpointSlice controller](/docs/concepts/services-networking/topology-aware-routing/#implementation-control-plane) ignores that node while calculating Topology Aware Hints.
 
 ### node-role.kubernetes.io/control-plane {#node-role-kubernetes-io-control-plane-taint}
 
@@ -1126,7 +1126,10 @@ Taint that kubeadm applies on control plane nodes to restrict placing pods and a
 
 Example: `node-role.kubernetes.io/control-plane:NoSchedule`
 
-If this Taint applied, control plane nodes allow only critical workloads to schedule on them. You can manually remove this taint with `node-role.kubernetes.io/control-plane:NoSchedule-`
+If this Taint is applied, control plane nodes allow only critical workloads to schedule on them. You can manually remove this taint with the following command on a specific node.
+```shell
+kubectl taint nodes <node-name> node-role.kubernetes.io/control-plane:NoSchedule-
+```
 
 ### node-role.kubernetes.io/master (deprecated) {#node-role-kubernetes-io-master-taint}
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1114,15 +1114,19 @@ used to determine if the user has applied settings different from the kubeadm de
 
 Used on: Node
 
-Label that kubeadm applies on the control plane nodes that it manages. If this label set, [EndpointSlice controller](/docs/concepts/services-networking/topology-aware-routing/#implementation-control-plane) ignores that node.
+A marker label to indicate that the node is used to run {{< glossary_tooltip text="control plane" term_id="control-plane" >}} components. The kubeadm tool applies this label to the control plane nodes that it manages. Other cluster management tools typically also set this taint.
+
+You can label control plane nodes with this label to make it easier to schedule Pods only onto these nodes, or to avoid running Pods on the control plane. If this label set, [EndpointSlice controller](/docs/concepts/services-networking/topology-aware-routing/#implementation-control-plane) ignores that node.
 
 ### node-role.kubernetes.io/control-plane {#node-role-kubernetes-io-control-plane-taint}
 
 Used on: Node
 
+Taint that kubeadm applies on control plane nodes to restrict placing pods and allow only specific pods to schedule on them.
+
 Example: `node-role.kubernetes.io/control-plane:NoSchedule`
 
-Taint that kubeadm applies on control plane nodes to allow only critical workloads to schedule on them. If this taint set, EndpointSlice controller ignores that node.
+If this Taint applied, control plane nodes allow only critical workloads to schedule on them. You can manually remove this taint with `node-role.kubernetes.io/control-plane:NoSchedule-`
 
 ### node-role.kubernetes.io/master (deprecated) {#node-role-kubernetes-io-master-taint}
 
@@ -1133,6 +1137,3 @@ Example: `node-role.kubernetes.io/master:NoSchedule`
 Taint that kubeadm previously applied on control plane nodes to allow only critical workloads to schedule on them.
 Replaced by [`node-role.kubernetes.io/control-plane`](#node-role-kubernetes-io-control-plane-taint); kubeadm
 no longer sets or uses this deprecated taint.
-{{< note >}}
-The EndpointSlice controller ignores nodes with the `node-role.kubernetes.io/control-plane` or `node-role.kubernetes.io/master` label set.
-{{< /note >}}


### PR DESCRIPTION
Documented the EndpointSlice controller ignores nodes with the following labels node-role.kubernetes.io/control-plane or node-role.kubernetes.io/master
Fixes #40602 

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
