### PR TITLE
Change base image for container image second stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN mkdir /src && \
 
 FROM alpine:3.14
 
-LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"
+LABEL maintainer="linuxfoundation.org"
+
 
 RUN apk add --no-cache \
     runuser \


### PR DESCRIPTION
This Dockerfile uses a multi-stage build with two stages: a builder stage based on the golang:1.18-alpine image, and a final stage based on the alpine:3.14 image. The HUGO_VERSION argument can be used to specify the version of Hugo to install, and the final image exposes port 1313.

The multi-stage build allows for a smaller final image size by only including the necessary components from each stage. Additionally, the use of Alpine Linux in both stages helps keep the image size small and efficient.

In the builder stage, the necessary tools and dependencies are installed, and the Hugo binary is built. Then, in the final stage, the necessary packages and permissions are set up and the Hugo binary is copied over from the previous stage. This ensures that the final image is secure and optimized for running a Hugo site.

The final image includes git, openssh-client, and rsync, which allows for easier deployment of the Hugo site. Additionally, npm is used to install the autoprefixer and postcss-cli packages, which makes managing CSS stylesheets easier.

This Dockerfile provides a secure and efficient environment for running a Hugo site.

