### PR TITLE
Update ExpandedDNSConfig docs for GA

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -292,7 +292,7 @@ Below are the properties a user can specify in the `dnsConfig` field:
   This property is optional. When specified, the provided list will be merged
   into the base search domain names generated from the chosen DNS policy.
   Duplicate domain names are removed.
-  Kubernetes allows for at most 6 search domains.
+  Kubernetes allows up to 32 search domains.
 - `options`: an optional list of objects where each object may have a `name`
   property (required) and a `value` property (optional). The contents in this
   property will be merged to the options generated from the specified DNS policy.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -99,8 +99,6 @@ For a reference to old feature gates that are removed, please refer to
 | `ElasticIndexedJob` | `true` | Beta` | 1.27 | |
 | `EventedPLEG` | `false` | Alpha | 1.26 | 1.26 |
 | `EventedPLEG` | `false` | Beta | 1.27 | - |
-| `ExpandedDNSConfig` | `false` | Alpha | 1.22 | 1.25 |
-| `ExpandedDNSConfig` | `true` | Beta | 1.26 | |
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | |
 | `GracefulNodeShutdown` | `false` | Alpha | 1.20 | 1.20 |
 | `GracefulNodeShutdown` | `true` | Beta | 1.21 | |
@@ -276,6 +274,9 @@ For a reference to old feature gates that are removed, please refer to
 | `EndpointSliceTerminatingCondition` | `true` | Beta | 1.22 | 1.25 |
 | `EndpointSliceTerminatingCondition` | `true` | GA | 1.26 | |
 | `ExecProbeTimeout` | `true` | GA | 1.20 | - |
+| `ExpandedDNSConfig` | `false` | Alpha | 1.22 | 1.25 |
+| `ExpandedDNSConfig` | `true` | Beta | 1.26 | 1.27 |
+| `ExpandedDNSConfig` | `true` | GA | 1.28 | - |
 | `GRPCContainerProbe` | `false` | Alpha | 1.23 | 1.23 |
 | `GRPCContainerProbe` | `true` | Beta | 1.24 | 1.26 |
 | `GRPCContainerProbe` | `true` | GA | 1.27 | |


### PR DESCRIPTION
/sig network
This updates ExpandedDNSConfig docs for GA.

KEP: https://github.com/kubernetes/enhancements/issues/2595

/hold
this should be merged after [k/k PR](https://github.com/kubernetes/kubernetes/pull/116741)