### PR TITLE
[zh] fix Autoscaling external metrics

### DIFF
--- a/content/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -641,7 +641,7 @@ as when you use the `Object` type.
 -->
 使用外部度量指标时，需要了解你所使用的监控系统，相关的设置与使用自定义指标时类似。
 外部度量指标使得你可以使用你的监控系统的任何指标来自动扩缩你的集群。
-你需要在 `metric` 块中提供 `name` 和 `selector`，同时将类型由 `Object` 改为 `External`。
+你需要在 `metric` 块中提供 `name` 和 `selector`，同时将类型由 `Pods` 改为 `External`。
 如果 `metricSelector` 匹配到多个度量指标，HorizontalPodAutoscaler 将会把它们加和。
 外部度量指标同时支持 `Value` 和 `AverageValue` 类型，这与 `Object` 类型的度量指标相同。
 


### PR DESCRIPTION
"use the External metric type instead of Object" is ambiguous, Should `Object` be changed to `Pods`.

The `Object` type describes object information, but `External` does not support it. It should be modified from the `Pods` type that defines the same as `External`.

This problem is also described in other language versions.

```golang
type ObjectMetricSource struct {
	DescribedObject CrossVersionObjectReference struct {
		Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
		Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
		APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
	} `json:"describedObject" protobuf:"bytes,1,name=describedObject"`
	Metric MetricIdentifier `json:"metric" protobuf:"bytes,3,name=metric"`
	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
}
type PodsMetricSource struct {
	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
}
type ExternalMetricSource struct {
	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
}
```

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
