### PR TITLE
Drop kube-proxy/kubelet skew requirement

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -170,7 +170,6 @@ Running a cluster with `kubelet` instances that are persistently two minor versi
 
 ### kube-proxy
 
-* `kube-proxy` must be the same minor version as `kubelet` on the node.
 * `kube-proxy` must not be newer than `kube-apiserver`.
 * `kube-proxy` must be at most two minor versions older than `kube-apiserver.`
 


### PR DESCRIPTION
Discussed in SIG Network today; the docs claim that kubelet and kube-proxy must be the same version, but we had actually forgotten that, and the last time this was actually even theoretically true was 1.19. SIG Network will be making sure there are no "kubelet and kube-proxy must be the same version" problems in the future. (https://github.com/kubernetes/kubernetes/pull/117307 adds some clarification about that.)

(KEP-3178 involves an n-2 skew constraint between kube-proxy and kubelet, but that already exists transitively via apiserver skew constraints without needing a specific kube-proxy/kubelet skew rule: kube-proxy 1.27 doesn't work with kubelet 1.24, but (a) kube-proxy 1.27 requires kube-apiserver >= 1.27, and (b) kubelet 1.24 only supports kube-apiserver <= 1.26.)

cc @thockin @aojea 