### PR TITLE
Update scale-intro.html - fixed indentation 

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -114,7 +114,7 @@ description: |-
                <code><b>kubectl get deployments</b></code></p>
                <p>The output should be similar to:</p>
                <pre>NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
-               kubernetes-bootcamp   1/1     1            1           11m
+               kubernetes-bootcamp        1/1     1            1           11m
                </pre>
                <p>We should have 1 Pod. If not, run the command again. This shows:</p>
                <ul>

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -144,7 +144,7 @@ description: |-
                <p>First, check that the app is running. To find the exposed IP address and port, run the <code>describe service</code> command:</p>
                <p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
                <p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
-               <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')</b></code><br />
+               <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')"</b></code><br />
                   <code><b>echo "NODE_PORT=$NODE_PORT"</b></code></p>
                <p>Next, do a <code>curl</code> to the the exposed IP and port:</p>
                <p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -144,7 +144,7 @@ description: |-
                <p>First, check that the app is running. To find the exposed IP address and port, run the <code>describe service</code> command:</p>
                <p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
                <p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
-               <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')"</b></code><br />
+               <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')</b></code><br />
                   <code><b>echo "NODE_PORT=$NODE_PORT"</b></code></p>
                <p>Next, do a <code>curl</code> to the the exposed IP and port:</p>
                <p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>


### PR DESCRIPTION
Fixed indentation for the output of the command: kubectl get deployments in scale-intro.html
