### PR TITLE
Use release data to calculate latest patch version

### DIFF
--- a/content/en/docs/concepts/containers/container-environment.md
+++ b/content/en/docs/concepts/containers/container-environment.md
@@ -51,7 +51,7 @@ FOO_SERVICE_PORT=<the port the service is running on>
 ```
 
 Services have dedicated IP addresses and are available to the Container via DNS,
-if [DNS addon](https://releases.k8s.io/{{< param "fullversion" >}}/cluster/addons/dns/) is enabled. 
+if [DNS addon](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/) is enabled. 
 
 
 

--- a/content/en/docs/reference/access-authn-authz/abac.md
+++ b/content/en/docs/reference/access-authn-authz/abac.md
@@ -126,7 +126,7 @@ up the verbosity:
     {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group": "system:unauthenticated", "readonly": true, "nonResourcePath": "*"}}
     ```
 
-[Complete file example](https://releases.k8s.io/{{< param "fullversion" >}}/pkg/auth/authorizer/abac/example_policy_file.jsonl)
+[Complete file example](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/pkg/auth/authorizer/abac/example_policy_file.jsonl)
 
 ## A quick note on service accounts
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -27,8 +27,8 @@ upgrade the control plane nodes before upgrading your Windows nodes.
 1.  From the Windows node, upgrade kubeadm:
 
     ```powershell
-    # replace {{< param "fullversion" >}} with your desired version
-    curl.exe -Lo <path-to-kubeadm.exe>  "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubeadm.exe"
+    # replace {{< skew currentPatchVersion >}} with your desired version
+    curl.exe -Lo <path-to-kubeadm.exe>  "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubeadm.exe"
     ```
 
 ### Drain the node
@@ -62,7 +62,7 @@ upgrade the control plane nodes before upgrading your Windows nodes.
 
     ```powershell
     stop-service kubelet
-    curl.exe -Lo <path-to-kubelet.exe> "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubelet.exe"
+    curl.exe -Lo <path-to-kubelet.exe> "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubelet.exe"
     restart-service kubelet
     ```
 
@@ -70,7 +70,7 @@ upgrade the control plane nodes before upgrading your Windows nodes.
 
     ```powershell
     stop-service kube-proxy
-    curl.exe -Lo <path-to-kube-proxy.exe> "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kube-proxy.exe"
+    curl.exe -Lo <path-to-kube-proxy.exe> "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kube-proxy.exe"
     restart-service kube-proxy
     ```
 

--- a/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-artifacts.md
@@ -27,7 +27,7 @@ standalone binaries) by using cosign's keyless signing. To verify a particular
 binary, retrieve it together with its signature and certificate:
 
 ```bash
-URL=https://dl.k8s.io/release/v{{< skew currentVersion >}}.0/bin/linux/amd64
+URL=https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/amd64
 BINARY=kubectl
 
 FILES=(
@@ -64,7 +64,7 @@ Let's pick one image from this list and verify its signature using
 the `cosign verify` command:
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/kube-apiserver-amd64:v{{< skew currentVersion >}}.0
+COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/kube-apiserver-amd64:v{{< skew currentPatchVersion >}}
 ```
 
 {{< note >}}

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -43,10 +43,10 @@ The following methods exist for installing kubectl on Linux:
    To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
    portion of the command with the specific version.
 
-   For example, to download version {{< param "fullversion" >}} on Linux x86-64, type:
+   For example, to download version {{< skew currentPatchVersion >}} on Linux x86-64, type:
 
    ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
+   curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/amd64/kubectl
    ```
 
    And for Linux ARM64, type:

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -48,16 +48,16 @@ The following methods exist for installing kubectl on macOS:
    To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
    portion of the command with the specific version.
 
-   For example, to download version {{< param "fullversion" >}} on Intel macOS, type:
+   For example, to download version {{< skew currentPatchVersion >}} on Intel macOS, type:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl"
+   curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/amd64/kubectl"
    ```
 
    And for macOS on Apple Silicon, type:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/arm64/kubectl"
+   curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/arm64/kubectl"
    ```
 
    {{< /note >}}

--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -27,12 +27,13 @@ The following methods exist for installing kubectl on Windows:
 
 ### Install kubectl binary with curl on Windows
 
-1. Download the [latest release {{< param "fullversion" >}}](https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
+1. Download the latest {{< skew currentVersion >}} patch release:
+   [kubectl {{< skew currentPatchVersion >}}](https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe).
 
    Or if you have `curl` installed, use this command:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe"
+   curl.exe -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe"
    ```
 
    {{< note >}}
@@ -45,7 +46,7 @@ The following methods exist for installing kubectl on Windows:
    Download the `kubectl` checksum file:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe.sha256"
+   curl.exe -LO "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe.sha256"
    ```
 
    Validate the `kubectl` binary against the checksum file:
@@ -179,7 +180,7 @@ Below are the procedures to set up autocompletion for PowerShell.
 1. Download the latest release with the command:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe"
+   curl.exe -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl-convert.exe"
    ```
 
 1. Validate the binary (optional).
@@ -187,7 +188,7 @@ Below are the procedures to set up autocompletion for PowerShell.
    Download the `kubectl-convert` checksum file:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe.sha256"
+   curl.exe -LO "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl-convert.exe.sha256"
    ```
 
    Validate the `kubectl-convert` binary against the checksum file:

--- a/content/en/docs/tutorials/security/cluster-level-pss.md
+++ b/content/en/docs/tutorials/security/cluster-level-pss.md
@@ -52,7 +52,7 @@ that are most appropriate for your configuration, do the following:
    The output is similar to:
    ```
    Creating cluster "psa-wo-cluster-pss" ...
-   ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
+   ✓ Ensuring node image (kindest/node:v{{< skew currentPatchVersion >}}) 🖼
    ✓ Preparing nodes 📦
    ✓ Writing configuration 📜
    ✓ Starting control-plane 🕹️
@@ -268,7 +268,7 @@ following:
    The output is similar to this:
    ```
    Creating cluster "psa-with-cluster-pss" ...
-    ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
+    ✓ Ensuring node image (kindest/node:v{{< skew currentPatchVersion >}}) 🖼
     ✓ Preparing nodes 📦
     ✓ Writing configuration 📜
     ✓ Starting control-plane 🕹️

--- a/content/en/docs/tutorials/security/ns-level-pss.md
+++ b/content/en/docs/tutorials/security/ns-level-pss.md
@@ -38,7 +38,7 @@ Install the following on your workstation:
 
    ```
    Creating cluster "psa-ns-level" ...
-    ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼 
+    ✓ Ensuring node image (kindest/node:v{{< skew currentPatchVersion >}}) 🖼 
     ✓ Preparing nodes 📦  
     ✓ Writing configuration 📜 
     ✓ Starting control-plane 🕹️ 

--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -160,13 +160,13 @@ about the [service proxy](/docs/concepts/services-networking/service/#virtual-ip
 
 Kubernetes supports 2 primary modes of finding a Service - environment variables
 and DNS. The former works out of the box while the latter requires the
-[CoreDNS cluster addon](https://releases.k8s.io/{{< param "fullversion" >}}/cluster/addons/dns/coredns).
+[CoreDNS cluster addon](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/coredns).
 
 {{< note >}}
 If the service environment variables are not desired (because possible clashing
 with expected program ones, too many variables to process, only using DNS, etc)
 you can disable this mode by setting the `enableServiceLinks` flag to `false` on
-the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core).
+the [pod spec](/docs/reference/generated/kubernetes-api/v{{< skew latestVersion >}}/#pod-v1-core).
 {{< /note >}}
 
 

--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -21,19 +21,19 @@ For Kubernetes {{< param "version" >}}, the following
 container images are signed using [cosign](https://github.com/sigstore/cosign)
 signatures:
 
-| Container Image                                                     | Supported Architectures                                                                  |
-| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| registry.k8s.io/kube-apiserver:{{< param "fullversion" >}}          | amd64, arm, arm64, ppc64le, s390x |
-| registry.k8s.io/kube-controller-manager:{{< param "fullversion" >}} | amd64, arm, arm64, ppc64le, s390x |
-| registry.k8s.io/kube-proxy:{{< param "fullversion" >}}              | amd64, arm, arm64, ppc64le, s390x |
-| registry.k8s.io/kube-scheduler:{{< param "fullversion" >}}          | amd64, arm, arm64, ppc64le, s390x |
-| registry.k8s.io/conformance:{{< param "fullversion" >}}             | amd64, arm, arm64, ppc64le, s390x |
+| Container Image                                                           | Supported Architectures                                                                  |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| registry.k8s.io/kube-apiserver:v{{< skew currentPatchVersion >}}          | amd64, arm, arm64, ppc64le, s390x |
+| registry.k8s.io/kube-controller-manager:v{{< skew currentPatchVersion >}} | amd64, arm, arm64, ppc64le, s390x |
+| registry.k8s.io/kube-proxy:v{{< skew currentPatchVersion >}}              | amd64, arm, arm64, ppc64le, s390x |
+| registry.k8s.io/kube-scheduler:v{{< skew currentPatchVersion >}}          | amd64, arm, arm64, ppc64le, s390x |
+| registry.k8s.io/conformance:v{{< skew currentPatchVersion >}}             | amd64, arm, arm64, ppc64le, s390x |
 
 All container images are available for multiple architectures, whereas the
 container runtime should choose the correct one based on the underlying
 platform. It is also possible to pull a dedicated architecture by suffixing the
 container image name, for example
-`registry.k8s.io/kube-apiserver-arm64:{{< param "fullversion" >}}`. All
+`registry.k8s.io/kube-apiserver-arm64:v{{< skew currentPatchVersion >}}`. All
 those derivations are signed in the same way as the multi-architecture manifest lists.
 
 The Kubernetes project publishes a list of signed Kubernetes container images

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,3 +1,6 @@
+---
+# This file helps to populate the /releases page, and is also parsed to find out the
+# latest patch version for a minor release.
 schedules:
 - release: 1.27
   releaseDate: 2024-04-11

--- a/hugo.toml
+++ b/hugo.toml
@@ -140,7 +140,9 @@ showedit = true
 
 latest = "v1.27"
 
-fullversion = "v1.27.0"
+fullversion = "v1.27.0" # legacy; use {{< skew currentPatchVersion >}} instead
+                        # retain until all localizations have migrated
+
 version = "v1.27"
 githubbranch = "main"
 docsbranch = "main"
@@ -181,35 +183,40 @@ js = [
 ]
 
 [[params.versions]]
-fullversion = "v1.27.0"
+fullversion = "v1.27.0"  # legacy; use {{< skew currentPatchVersion >}} instead
+                         # retain until all localizations have migrated
 version = "v1.27"
 githubbranch = "v1.27.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.26.3"
+fullversion = "v1.26.3"  # legacy; use {{< skew currentPatchVersion >}} instead
+                         # retain until all localizations have migrated
 version = "v1.26"
 githubbranch = "v1.26.3"
 docsbranch = "release-1.26"
 url = "https://v1-26.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.25.8"
+fullversion = "v1.25.8"  # legacy; use {{< skew currentPatchVersion >}} instead
+                         # retain until all localizations have migrated
 version = "v1.25"
 githubbranch = "v1.25.8"
 docsbranch = "release-1.25"
 url = "https://v1-25.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.24.12"
+fullversion = "v1.24.12" # legacy; use {{< skew currentPatchVersion >}} instead
+                         # retain until all localizations have migrated
 version = "v1.24"
 githubbranch = "v1.24.12"
 docsbranch = "release-1.24"
 url = "https://v1-24.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.23.17"
+fullversion = "v1.23.17" # legacy; use {{< skew currentPatchVersion >}} instead
+                         # retain until all localizations have migrated
 version = "v1.23"
 githubbranch = "v1.23.17"
 docsbranch = "release-1.23"

--- a/layouts/shortcodes/skew.html
+++ b/layouts/shortcodes/skew.html
@@ -77,6 +77,25 @@
     {{- $currentVersionAddMinor -}}
 {{- end -}}
 
+<!-- output patch version for current release -->
+{{- if eq $version "currentPatchVersion" -}}
+    {{- $seenPatchVersionInfoCount := 0 }}
+    {{- range $releaseInfo := .Site.Data.releases.schedule.schedules -}}
+        {{- if eq $currentVersion ( printf "%.2f" $releaseInfo.release ) -}}
+            {{- range $patchReleaseInfo := $releaseInfo.previousPatches -}}
+                {{- if eq $seenPatchVersionInfoCount 0 -}}
+                  {{- $patchReleaseInfo.release -}}
+                {{- end -}}
+                {{- $seenPatchVersionInfoCount = add $seenPatchVersionInfoCount 1 -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if eq $seenPatchVersionInfoCount 0 -}}
+        <!-- fallback patch version to .0 -->
+        {{- printf "%.2f.0" $currentVersion -}}
+    {{- end -}}
+{{- end -}}
+
 <!--
 example shortcode use:
 - skew nextMinorVersion


### PR DESCRIPTION
Before this PR, the way we represented patch versions in docs was to hard code the `.0` patch release. The site actually had a facility to update the patch version, Hugo param `fullversion`, but access to update that is limited just to website maintainers, because access there also lets you reconfigure the Hugo static site generator.

_However_ we also have the patch information available in `data/releases/schedule.yaml`, and SIG Release do update that during the lifecycle of a release.

So: use it. Switch the English localization to use an updated `skew` shortcode, and deprecate the `fullversion` param.

~Note to reviewers: this does work, but to satisfy yourself that it's correct you might need to locally update `data/releases/schedule.yaml` with the actually information for the v1.27.1 release. Right now the data for _main_ still show v1.27.1 as an upcoming patch release.~

[Preview](https://deploy-preview-40692--kubernetes-io-main-staging.netlify.app/releases/download/) vs [existing](https://k8s.io/releases/download/) for page https://k8s.io/releases/download/

/area web-development