### PR TITLE
[ja] add Japanese translation for /docs/tutorials/security/cluster-level-pss

### DIFF
--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -148,7 +148,7 @@ v{{< skew currentVersion >}}以外のKubernetesバージョンを実行してい
 このセクションでは、`latest`バージョンに以下のPodセキュリティの標準を適用します:
 
 * `enforce`モードで`baseline`標準。
-* `awrn`および`audit`モードで`restricted`標準。
+* `warn`および`audit`モードで`restricted`標準。
 
 `baseline` Podセキュリティの標準は、免除リストを短く保てて、かつ既知の特権昇格を防ぐような、利便性のある中庸を提供します。
 

--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -24,7 +24,6 @@ v{{< skew currentVersion >}}以外のKubernetesバージョンを実行してい
 - [kubectl](/ja/docs/tasks/tools/)
 
 このチュートリアルでは、完全な制御下にあるKubernetesクラスターの何を設定できるかをデモンストレーションします。
-
 コントロールプレーンを設定できない管理されたクラスターのPodセキュリティアドミッションに対しての設定方法を知りたいのであれば、[名前空間レベルでのPodセキュリティの標準の適用](/ja/docs/tutorials/security/ns-level-pss/)を参照してください。
 
 ## 適用する正しいPodセキュリティの標準の選択

--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -301,4 +301,4 @@ kind delete cluster --name psa-wo-cluster-pss
   6. 新しいクラスター内でPodを作成するために、このファイルを適用します。
 - [Podのセキュリティアドミッション](/ja/docs/concepts/security/pod-security-admission/)
 - [Podセキュリティの標準](/ja/docs/concepts/security/pod-security-standards/)
-- [名前空間レベルでのPodセキュリティの標準の適用](/docs/tutorials/security/ns-level-pss/)
+- [名前空間レベルでのPodセキュリティの標準の適用](/ja/docs/tutorials/security/ns-level-pss/)

--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -255,7 +255,7 @@ v{{< skew currentVersion >}}以外のKubernetesバージョンを実行してい
    Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
    ```
 
-1. kubectlをクラスターに向けます:
+1. kubectlをこのクラスターに向けます:
    ```shell
    kubectl cluster-info --context kind-psa-with-cluster-pss
    ```

--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -29,8 +29,6 @@ v{{< skew currentVersion >}}以外のKubernetesバージョンを実行してい
 ## 適用する正しいPodセキュリティの標準の選択
 
 [Podのセキュリティアドミッション](/ja/docs/concepts/security/pod-security-admission/)は、以下のモードでビルトインの[Podセキュリティの標準](/ja/docs/concepts/security/pod-security-standards/)の適用を促します: `enforce`、`audit`、`warn`。
-
-
 設定に最適なPodセキュリティの標準を選択するにあたって助けになる情報を収集するために、以下を行ってください:
 
 1. Podセキュリティの標準を適用していないクラスターを作成します:

--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -1,0 +1,333 @@
+---
+title: Apply Pod Security Standards at the Cluster Level
+content_type: tutorial
+weight: 10
+---
+
+{{% alert title="Note" %}}
+This tutorial applies only for new clusters.
+{{% /alert %}}
+
+Pod Security admission (PSA) is enabled by default in v1.23 and later, as it has
+[graduated to beta](/blog/2021/12/09/pod-security-admission-beta/).
+Pod Security
+is an admission controller that carries out checks against the Kubernetes
+[Pod Security Standards](/docs/concepts/security/pod-security-standards/) when new pods are
+created. This tutorial shows you how to enforce the `baseline` Pod Security
+Standard at the cluster level which applies a standard configuration
+to all namespaces in a cluster.
+
+To apply Pod Security Standards to specific namespaces, refer to
+[Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss).
+
+If you are running a version of Kubernetes other than v{{< skew currentVersion >}},
+check the documentation for that version.
+
+## {{% heading "prerequisites" %}}
+
+Install the following on your workstation:
+
+- [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [kubectl](/docs/tasks/tools/)
+
+This tutorial demonstrates what you can configure for a Kubernetes cluster that you fully
+control. If you are learning how to configure Pod Security Admission for a managed cluster
+where you are not able to configure the control plane, read
+[Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss).
+
+## Choose the right Pod Security Standard to apply
+
+[Pod Security Admission](/docs/concepts/security/pod-security-admission/)
+lets you apply built-in [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
+with the following modes: `enforce`, `audit`, and `warn`.
+
+To gather information that helps you to choose the Pod Security Standards
+that are most appropriate for your configuration, do the following:
+
+1. Create a cluster with no Pod Security Standards applied:
+
+   ```shell
+   kind create cluster --name psa-wo-cluster-pss
+   ```
+   The output is similar to:
+   ```
+   Creating cluster "psa-wo-cluster-pss" ...
+   ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
+   ✓ Preparing nodes 📦
+   ✓ Writing configuration 📜
+   ✓ Starting control-plane 🕹️
+   ✓ Installing CNI 🔌
+   ✓ Installing StorageClass 💾
+   Set kubectl context to "kind-psa-wo-cluster-pss"
+   You can now use your cluster with:
+
+   kubectl cluster-info --context kind-psa-wo-cluster-pss
+
+   Thanks for using kind! 😊
+   ```
+
+1. Set the kubectl context to the new cluster:
+
+   ```shell
+   kubectl cluster-info --context kind-psa-wo-cluster-pss
+   ```
+   The output is similar to this:
+
+   ```
+   Kubernetes control plane is running at https://127.0.0.1:61350
+
+   CoreDNS is running at https://127.0.0.1:61350/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+
+   To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+   ```
+
+1. Get a list of namespaces in the cluster:
+
+   ```shell
+   kubectl get ns
+   ```
+   The output is similar to this:
+   ```
+   NAME                 STATUS   AGE
+   default              Active   9m30s
+   kube-node-lease      Active   9m32s
+   kube-public          Active   9m32s
+   kube-system          Active   9m32s
+   local-path-storage   Active   9m26s
+   ```
+
+1. Use `--dry-run=server` to understand what happens when different Pod Security Standards
+   are applied:
+
+   1. Privileged
+      ```shell
+      kubectl label --dry-run=server --overwrite ns --all \
+      pod-security.kubernetes.io/enforce=privileged
+      ```
+
+      The output is similar to:
+      ```
+      namespace/default labeled
+      namespace/kube-node-lease labeled
+      namespace/kube-public labeled
+      namespace/kube-system labeled
+      namespace/local-path-storage labeled
+      ```
+   2. Baseline
+      ```shell
+      kubectl label --dry-run=server --overwrite ns --all \
+      pod-security.kubernetes.io/enforce=baseline
+      ```
+
+      The output is similar to:
+      ```
+      namespace/default labeled
+      namespace/kube-node-lease labeled
+      namespace/kube-public labeled
+      Warning: existing pods in namespace "kube-system" violate the new PodSecurity enforce level "baseline:latest"
+      Warning: etcd-psa-wo-cluster-pss-control-plane (and 3 other pods): host namespaces, hostPath volumes
+      Warning: kindnet-vzj42: non-default capabilities, host namespaces, hostPath volumes
+      Warning: kube-proxy-m6hwf: host namespaces, hostPath volumes, privileged
+      namespace/kube-system labeled
+      namespace/local-path-storage labeled
+      ```
+
+   3. Restricted
+      ```shell
+      kubectl label --dry-run=server --overwrite ns --all \
+      pod-security.kubernetes.io/enforce=restricted
+      ```
+
+      The output is similar to:
+      ```
+      namespace/default labeled
+      namespace/kube-node-lease labeled
+      namespace/kube-public labeled
+      Warning: existing pods in namespace "kube-system" violate the new PodSecurity enforce level "restricted:latest"
+      Warning: coredns-7bb9c7b568-hsptc (and 1 other pod): unrestricted capabilities, runAsNonRoot != true, seccompProfile
+      Warning: etcd-psa-wo-cluster-pss-control-plane (and 3 other pods): host namespaces, hostPath volumes, allowPrivilegeEscalation != false, unrestricted capabilities, restricted volume types, runAsNonRoot != true
+      Warning: kindnet-vzj42: non-default capabilities, host namespaces, hostPath volumes, allowPrivilegeEscalation != false, unrestricted capabilities, restricted volume types, runAsNonRoot != true, seccompProfile
+      Warning: kube-proxy-m6hwf: host namespaces, hostPath volumes, privileged, allowPrivilegeEscalation != false, unrestricted capabilities, restricted volume types, runAsNonRoot != true, seccompProfile
+      namespace/kube-system labeled
+      Warning: existing pods in namespace "local-path-storage" violate the new PodSecurity enforce level "restricted:latest"
+      Warning: local-path-provisioner-d6d9f7ffc-lw9lh: allowPrivilegeEscalation != false, unrestricted capabilities, runAsNonRoot != true, seccompProfile
+      namespace/local-path-storage labeled
+      ```
+
+From the previous output, you'll notice that applying the `privileged` Pod Security Standard shows no warnings
+for any namespaces. However, `baseline` and `restricted` standards both have
+warnings, specifically in the `kube-system` namespace.
+
+## Set modes, versions and standards
+
+In this section, you apply the following Pod Security Standards to the `latest` version:
+
+* `baseline` standard in `enforce` mode.
+* `restricted` standard in `warn` and `audit` mode.
+
+The `baseline` Pod Security Standard provides a convenient
+middle ground that allows keeping the exemption list short and prevents known
+privilege escalations.
+
+Additionally, to prevent pods from failing in `kube-system`, you'll exempt the namespace
+from having Pod Security Standards applied.
+
+When you implement Pod Security Admission in your own environment, consider the
+following:
+
+1. Based on the risk posture applied to a cluster, a stricter Pod Security
+   Standard like `restricted` might be a better choice.
+1. Exempting the `kube-system` namespace allows pods to run as
+   `privileged` in this namespace. For real world use, the Kubernetes project
+   strongly recommends that you apply strict RBAC
+   policies that limit access to `kube-system`, following the principle of least
+   privilege.
+   To implement the preceding standards, do the following:
+1. Create a configuration file that can be consumed by the Pod Security
+   Admission Controller to implement these Pod Security Standards:
+
+   ```
+   mkdir -p /tmp/pss
+   cat <<EOF > /tmp/pss/cluster-level-pss.yaml
+   apiVersion: apiserver.config.k8s.io/v1
+   kind: AdmissionConfiguration
+   plugins:
+   - name: PodSecurity
+     configuration:
+       apiVersion: pod-security.admission.config.k8s.io/v1
+       kind: PodSecurityConfiguration
+       defaults:
+         enforce: "baseline"
+         enforce-version: "latest"
+         audit: "restricted"
+         audit-version: "latest"
+         warn: "restricted"
+         warn-version: "latest"
+       exemptions:
+         usernames: []
+         runtimeClasses: []
+         namespaces: [kube-system]
+   EOF
+   ```
+
+   {{< note >}}
+   `pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
+   For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+   For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+   {{< /note >}}
+
+
+1. Configure the API server to consume this file during cluster creation:
+
+   ```
+   cat <<EOF > /tmp/pss/cluster-config.yaml
+   kind: Cluster
+   apiVersion: kind.x-k8s.io/v1alpha4
+   nodes:
+   - role: control-plane
+     kubeadmConfigPatches:
+     - |
+       kind: ClusterConfiguration
+       apiServer:
+           extraArgs:
+             admission-control-config-file: /etc/config/cluster-level-pss.yaml
+           extraVolumes:
+             - name: accf
+               hostPath: /etc/config
+               mountPath: /etc/config
+               readOnly: false
+               pathType: "DirectoryOrCreate"
+     extraMounts:
+     - hostPath: /tmp/pss
+       containerPath: /etc/config
+       # optional: if set, the mount is read-only.
+       # default false
+       readOnly: false
+       # optional: if set, the mount needs SELinux relabeling.
+       # default false
+       selinuxRelabel: false
+       # optional: set propagation mode (None, HostToContainer or Bidirectional)
+       # see https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+       # default None
+       propagation: None
+   EOF
+   ```
+
+   {{<note>}}
+   If you use Docker Desktop with KinD on macOS, you can
+   add `/tmp` as a Shared Directory under the menu item
+   **Preferences > Resources > File Sharing**.
+   {{</note>}}
+
+1. Create a cluster that uses Pod Security Admission to apply
+   these Pod Security Standards:
+
+   ```shell
+   kind create cluster --name psa-with-cluster-pss --config /tmp/pss/cluster-config.yaml
+   ```
+   The output is similar to this:
+   ```
+   Creating cluster "psa-with-cluster-pss" ...
+    ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
+    ✓ Preparing nodes 📦
+    ✓ Writing configuration 📜
+    ✓ Starting control-plane 🕹️
+    ✓ Installing CNI 🔌
+    ✓ Installing StorageClass 💾
+   Set kubectl context to "kind-psa-with-cluster-pss"
+   You can now use your cluster with:
+
+   kubectl cluster-info --context kind-psa-with-cluster-pss
+
+   Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
+   ```
+
+1. Point kubectl to the cluster:
+   ```shell
+   kubectl cluster-info --context kind-psa-with-cluster-pss
+   ```
+   The output is similar to this:
+   ```
+   Kubernetes control plane is running at https://127.0.0.1:63855
+   CoreDNS is running at https://127.0.0.1:63855/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+
+   To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+   ```
+
+1. Create a Pod in the default namespace:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/security/example-baseline-pod.yaml
+   ```
+
+   The pod is started normally, but the output includes a warning:
+   ```
+   Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "nginx" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "nginx" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "nginx" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "nginx" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
+   pod/nginx created
+   ```
+
+## Clean up
+
+Now delete the clusters which you created above by running the following command:
+
+```shell
+kind delete cluster --name psa-with-cluster-pss
+```
+```shell
+kind delete cluster --name psa-wo-cluster-pss
+```
+
+## {{% heading "whatsnext" %}}
+
+- Run a
+  [shell script](/examples/security/kind-with-cluster-level-baseline-pod-security.sh)
+  to perform all the preceding steps at once:
+  1. Create a Pod Security Standards based cluster level Configuration
+  2. Create a file to let API server consume this configuration
+  3. Create a cluster that creates an API server with this configuration
+  4. Set kubectl context to this new cluster
+  5. Create a minimal pod yaml file
+  6. Apply this file to create a Pod in the new cluster
+- [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
+- [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
+- [Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss/)

--- a/content/ja/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ja/docs/tutorials/security/cluster-level-pss.md
@@ -1,55 +1,45 @@
 ---
-title: Apply Pod Security Standards at the Cluster Level
+title: クラスターレベルでのPodセキュリティの標準の適用
 content_type: tutorial
 weight: 10
 ---
 
 {{% alert title="Note" %}}
-This tutorial applies only for new clusters.
+このチュートリアルは、新しいクラスターにのみ適用されます。
 {{% /alert %}}
 
-Pod Security admission (PSA) is enabled by default in v1.23 and later, as it has
-[graduated to beta](/blog/2021/12/09/pod-security-admission-beta/).
-Pod Security
-is an admission controller that carries out checks against the Kubernetes
-[Pod Security Standards](/docs/concepts/security/pod-security-standards/) when new pods are
-created. This tutorial shows you how to enforce the `baseline` Pod Security
-Standard at the cluster level which applies a standard configuration
-to all namespaces in a cluster.
+Podセキュリティアドミッション(PSA)は、[ベータへ進み](/blog/2021/12/09/pod-security-admission-beta/)、v1.23以降でデフォルトで有効になっています。
+Podセキュリティアドミッションは、Podが作成される際に、[Podセキュリティの標準](/ja/docs/concepts/security/pod-security-standards/)の適用の認可を制御するものです。
+このチュートリアルでは、クラスター内の全ての名前空間に標準設定を適用することで、クラスターレベルで`baseline` Podセキュリティの標準を強制する方法を示します。
 
-To apply Pod Security Standards to specific namespaces, refer to
-[Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss).
+Podセキュリティの標準を特定の名前空間に適用するには、[名前空間レベルでのPodセキュリティの標準の適用](/ja/docs/tutorials/security/ns-level-pss/)を参照してください。
 
-If you are running a version of Kubernetes other than v{{< skew currentVersion >}},
-check the documentation for that version.
+v{{< skew currentVersion >}}以外のKubernetesバージョンを実行している場合は、そのバージョンのドキュメントを確認してください。
 
 ## {{% heading "prerequisites" %}}
 
-Install the following on your workstation:
+ワークステーションに以下をインストールしてください:
 
 - [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
-- [kubectl](/docs/tasks/tools/)
+- [kubectl](/ja/docs/tasks/tools/)
 
-This tutorial demonstrates what you can configure for a Kubernetes cluster that you fully
-control. If you are learning how to configure Pod Security Admission for a managed cluster
-where you are not able to configure the control plane, read
-[Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss).
+このチュートリアルでは、完全な制御下にあるKubernetesクラスターの何を設定できるかをデモンストレーションします。
 
-## Choose the right Pod Security Standard to apply
+コントロールプレーンを設定できない管理されたクラスターのPodセキュリティアドミッションに対しての設定方法を知りたいのであれば、[名前空間レベルでのPodセキュリティの標準の適用](/ja/docs/tutorials/security/ns-level-pss/)を参照してください。
 
-[Pod Security Admission](/docs/concepts/security/pod-security-admission/)
-lets you apply built-in [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
-with the following modes: `enforce`, `audit`, and `warn`.
+## 適用する正しいPodセキュリティの標準の選択
 
-To gather information that helps you to choose the Pod Security Standards
-that are most appropriate for your configuration, do the following:
+[Podのセキュリティアドミッション](/ja/docs/concepts/security/pod-security-admission/)は、以下のモードでビルトインの[Podセキュリティの標準](/ja/docs/concepts/security/pod-security-standards/)の適用を促します: `enforce`、`audit`、`warn`。
 
-1. Create a cluster with no Pod Security Standards applied:
+
+設定に最適なPodセキュリティの標準を選択するにあたって助けになる情報を収集するために、以下を行ってください:
+
+1. Podセキュリティの標準を適用していないクラスターを作成します:
 
    ```shell
    kind create cluster --name psa-wo-cluster-pss
    ```
-   The output is similar to:
+   出力は次のようになります:
    ```
    Creating cluster "psa-wo-cluster-pss" ...
    ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
@@ -66,12 +56,12 @@ that are most appropriate for your configuration, do the following:
    Thanks for using kind! 😊
    ```
 
-1. Set the kubectl context to the new cluster:
+1. kubectl contextを新しいクラスターにセットします:
 
    ```shell
    kubectl cluster-info --context kind-psa-wo-cluster-pss
    ```
-   The output is similar to this:
+   出力は次のようになります:
 
    ```
    Kubernetes control plane is running at https://127.0.0.1:61350
@@ -81,12 +71,12 @@ that are most appropriate for your configuration, do the following:
    To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
    ```
 
-1. Get a list of namespaces in the cluster:
+1. クラスター内の名前空間の一覧を取得します:
 
    ```shell
    kubectl get ns
    ```
-   The output is similar to this:
+   出力は次のようになります:
    ```
    NAME                 STATUS   AGE
    default              Active   9m30s
@@ -96,16 +86,15 @@ that are most appropriate for your configuration, do the following:
    local-path-storage   Active   9m26s
    ```
 
-1. Use `--dry-run=server` to understand what happens when different Pod Security Standards
-   are applied:
+1. 異なるPodセキュリティの標準が適用されたときに何が起きるかを理解するために、`-dry-run=server`を使います:
 
-   1. Privileged
+   1. privileged
       ```shell
       kubectl label --dry-run=server --overwrite ns --all \
       pod-security.kubernetes.io/enforce=privileged
       ```
 
-      The output is similar to:
+      出力は次のようになります:
       ```
       namespace/default labeled
       namespace/kube-node-lease labeled
@@ -113,13 +102,13 @@ that are most appropriate for your configuration, do the following:
       namespace/kube-system labeled
       namespace/local-path-storage labeled
       ```
-   2. Baseline
+   2. baseline
       ```shell
       kubectl label --dry-run=server --overwrite ns --all \
       pod-security.kubernetes.io/enforce=baseline
       ```
 
-      The output is similar to:
+      出力は次のようになります:
       ```
       namespace/default labeled
       namespace/kube-node-lease labeled
@@ -132,13 +121,13 @@ that are most appropriate for your configuration, do the following:
       namespace/local-path-storage labeled
       ```
 
-   3. Restricted
+   3. restricted
       ```shell
       kubectl label --dry-run=server --overwrite ns --all \
       pod-security.kubernetes.io/enforce=restricted
       ```
 
-      The output is similar to:
+      出力は次のようになります:
       ```
       namespace/default labeled
       namespace/kube-node-lease labeled
@@ -154,37 +143,27 @@ that are most appropriate for your configuration, do the following:
       namespace/local-path-storage labeled
       ```
 
-From the previous output, you'll notice that applying the `privileged` Pod Security Standard shows no warnings
-for any namespaces. However, `baseline` and `restricted` standards both have
-warnings, specifically in the `kube-system` namespace.
+この出力から、`privileged` Podセキュリティの標準を適用すると、名前空間のどれにも警告が示されないことに気付くでしょう。
+これに対し、`baseline`と`restrict`の標準ではどちらも、とりわけ`kube-system`名前空間に対して警告が示されています。
 
-## Set modes, versions and standards
+## モード、バージョン、標準のセット
 
-In this section, you apply the following Pod Security Standards to the `latest` version:
+このセクションでは、`latest`バージョンに以下のPodセキュリティの標準を適用します:
 
-* `baseline` standard in `enforce` mode.
-* `restricted` standard in `warn` and `audit` mode.
+* `enforce`モードで`baseline`標準。
+* `awrn`および`audit`モードで`restricted`標準。
 
-The `baseline` Pod Security Standard provides a convenient
-middle ground that allows keeping the exemption list short and prevents known
-privilege escalations.
+`baseline` Podセキュリティの標準は、免除リストを短く保てて、かつ既知の特権昇格を防ぐような、利便性のある中庸を提供します。
 
-Additionally, to prevent pods from failing in `kube-system`, you'll exempt the namespace
-from having Pod Security Standards applied.
+加えて、`kube-system`内の失敗からPodを守るために、適用されるPodセキュリティの標準の対象から名前空間を免除します。
 
-When you implement Pod Security Admission in your own environment, consider the
-following:
+環境にPodセキュリティアドミッションを実装する際には、以下の点を考慮してください:
 
-1. Based on the risk posture applied to a cluster, a stricter Pod Security
-   Standard like `restricted` might be a better choice.
-1. Exempting the `kube-system` namespace allows pods to run as
-   `privileged` in this namespace. For real world use, the Kubernetes project
-   strongly recommends that you apply strict RBAC
-   policies that limit access to `kube-system`, following the principle of least
-   privilege.
-   To implement the preceding standards, do the following:
-1. Create a configuration file that can be consumed by the Pod Security
-   Admission Controller to implement these Pod Security Standards:
+1. クラスターに適用されるリスク状況に基づくと、`restricted`のようにより厳格なPodセキュリティの標準のほうが、より良い選択肢かもしれません。
+1. `kube-ssytem`名前空間の免除は、Podがその名前空間で`privileged`として実行するのを許容することになります。
+   実世界で使うにあたっては、以下の最小権限の原則に従って`kube-system`へのアクセスを制限する厳格なRBACポリシーを適用することを、Kubernetesプロジェクトは強く推奨します。
+   上記の標準を実装するには、次のようにします:
+1. 目的のPodセキュリティの標準を実装するために、Podセキュリティアドミッションコントローラーで利用可能な設定ファイルを作成します:
 
    ```
    mkdir -p /tmp/pss
@@ -211,13 +190,13 @@ following:
    ```
 
    {{< note >}}
-   `pod-security.admission.config.k8s.io/v1` configuration requires v1.25+.
-   For v1.23 and v1.24, use [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
-   For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).
+   `pod-security.admission.config.k8s.io/v1`設定はv1.25+での対応です。
+   v1.23とv1.24では[v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)を使用してください。
+   v1.22では[v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/)を使用してください。
    {{< /note >}}
 
 
-1. Configure the API server to consume this file during cluster creation:
+1. クラスターの作成中にこのファイルを取り込むAPIサーバーを設定します:
 
    ```
    cat <<EOF > /tmp/pss/cluster-config.yaml
@@ -254,18 +233,15 @@ following:
    ```
 
    {{<note>}}
-   If you use Docker Desktop with KinD on macOS, you can
-   add `/tmp` as a Shared Directory under the menu item
-   **Preferences > Resources > File Sharing**.
+   macOSでDocker DesktopとKinDを利用している場合は、**Preferences > Resources > File Sharing**のメニュー項目からShared Directoryとして`/tmp`を追加できます。
    {{</note>}}
 
-1. Create a cluster that uses Pod Security Admission to apply
-   these Pod Security Standards:
+1. 目的のPodセキュリティの標準を適用するために、Podセキュリティアドミッションを使うクラスターを作成します:
 
    ```shell
    kind create cluster --name psa-with-cluster-pss --config /tmp/pss/cluster-config.yaml
    ```
-   The output is similar to this:
+   出力は次のようになります:
    ```
    Creating cluster "psa-with-cluster-pss" ...
     ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
@@ -282,11 +258,11 @@ following:
    Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
    ```
 
-1. Point kubectl to the cluster:
+1. kubectlをクラスターに向けます:
    ```shell
    kubectl cluster-info --context kind-psa-with-cluster-pss
    ```
-   The output is similar to this:
+   出力は次のようになります:
    ```
    Kubernetes control plane is running at https://127.0.0.1:63855
    CoreDNS is running at https://127.0.0.1:63855/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
@@ -294,21 +270,21 @@ following:
    To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
    ```
 
-1. Create a Pod in the default namespace:
+1. デフォルトの名前空間にPodを作成します:
 
    ```shell
    kubectl apply -f https://k8s.io/examples/security/example-baseline-pod.yaml
    ```
 
-   The pod is started normally, but the output includes a warning:
+   Podは正常に開始されますが、出力には警告が含まれます:
    ```
    Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "nginx" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "nginx" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "nginx" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "nginx" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
    pod/nginx created
    ```
 
-## Clean up
+## 後片付け
 
-Now delete the clusters which you created above by running the following command:
+では、上記で作成したクラスターを、以下のコマンドを実行して削除します:
 
 ```shell
 kind delete cluster --name psa-with-cluster-pss
@@ -319,15 +295,13 @@ kind delete cluster --name psa-wo-cluster-pss
 
 ## {{% heading "whatsnext" %}}
 
-- Run a
-  [shell script](/examples/security/kind-with-cluster-level-baseline-pod-security.sh)
-  to perform all the preceding steps at once:
-  1. Create a Pod Security Standards based cluster level Configuration
-  2. Create a file to let API server consume this configuration
-  3. Create a cluster that creates an API server with this configuration
-  4. Set kubectl context to this new cluster
-  5. Create a minimal pod yaml file
-  6. Apply this file to create a Pod in the new cluster
-- [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
-- [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
-- [Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss/)
+- 前出の一連の手順を一度に全て行うために[シェルスクリプト](/examples/security/kind-with-cluster-level-baseline-pod-security.sh)を実行します:
+  1. クラスターレベルの設定に基づきPodセキュリティの標準を作成します。
+  2. APIサーバーでこの設定を取り込むようにファイルを作成します。
+  3. この設定のAPIサーバーを立てるクラスターを作成します。
+  4. この新しいクラスターにkubectl contextをセットします。
+  5. 最小限のPod YAMLファイルを作成します。
+  6. 新しいクラスター内でPodを作成するために、このファイルを適用します。
+- [Podのセキュリティアドミッション](/ja/docs/concepts/security/pod-security-admission/)
+- [Podセキュリティの標準](/ja/docs/concepts/security/pod-security-standards/)
+- [名前空間レベルでのPodセキュリティの標準の適用](/docs/tutorials/security/ns-level-pss/)


### PR DESCRIPTION
This PR adds Japanese translation of https://kubernetes.io/docs/tutorials/security/cluster-level-pss

Fixes #40693

I would prefer Japanese language for suggestions and discussion of revisions to this translation.
(表現に関わるため、この翻訳についてのデイスカッションは日本語を希望します。)

- This translation depends on the translation terms of #40542
