### PR TITLE
Fix spelling error in “Migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller”

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
+++ b/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
@@ -201,7 +201,7 @@ For each updated PodSecurityPolicy:
 3. Create the new PodSecurityPolicies. If any Roles or ClusterRoles are granting `use` on all PSPs
    this could cause the new PSPs to be used instead of their mutating counter-parts.
 4. Update your authorization to grant access to the new PSPs. In RBAC this means updating any Roles
-   or ClusterRoles that grant the `use` permision on the original PSP to also grant it to the
+   or ClusterRoles that grant the `use` permission on the original PSP to also grant it to the
    updated PSP.
 5. Verify: after some soak time, rerun the command from step 1 to see if any pods are still using
    the original PSPs. Note that pods need to be recreated after the new policies have been rolled


### PR DESCRIPTION
fix typo permision -> permission