### PR TITLE
Add missing index on pt-br tasks

### DIFF
--- a/content/pt-br/docs/tasks/configure-pod-container/_index.md
+++ b/content/pt-br/docs/tasks/configure-pod-container/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Configurar Pods e Contêineres"
+description: Realizar tarefas comuns de configuração de Pods e contêineres 
+weight: 30
+---


### PR DESCRIPTION
index.md is missing on a task page, making it kind of messy on pt-br translation.
