### PR TITLE
Add site search to home page

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -14,6 +14,9 @@
 {{- end }}
 
 <link rel="stylesheet" href="{{ "css/feature-states.css" | relURL }}">
+{{ if .IsHome }}
+<link rel="stylesheet" href="{{ "css/site-searchbar.css" | relURL }}">
+{{ end }}
 
 {{- if or (eq .Params.class "gridPage") (eq .Params.class "gridPage gridPageHome") }}
   <link rel="stylesheet" href="{{ "css/gridpage.css" | relURL }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -91,3 +91,7 @@
 {{- end -}}
 {{ with .Params.js }}{{ range (split . ",") }}<script src="{{ (trim . " ") | relURL }}"></script><!-- custom js added -->
 {{ end }}{{ else }}<!-- no custom js detected -->{{ end }}
+<!-- script for homepage search bar -->
+{{ if .IsHome }}
+<script src="{{ "js/site-searchbar.js" | relURL }}"></script>
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -24,7 +24,24 @@
 				{{ partial "navbar-lang-selector.html" . }}
 			</li>
 			{{ end }}
+			{{ if .IsHome }}
+			<li class="nav-item" >
+				<a href="#" class="nav-link site-searchbar-activate"aria-label="Search" title="Search">
+					<i class="fa fa-search fa-lg"></i>
+				</a>
+			</li>
+			{{ end }}
 		</ul>
 	</div>
+	{{ if .IsHome }}
+	<div class="site-searchbar">
+		{{ partial "search-input.html" . }}
+		<button type="button" class="search-close" aria-label="Close" title="Close">
+			<i class="fa fa-times-circle" aria-hidden="true"></i>
+		</button>
+	</div>
+
+	<div class="site-searchbar-sm"><a href="#" class="nav-link site-searchbar-activate" id="site-searchbar-navlink" aria-label="Search" title="Search"><i class="fa fa-search fa-lg"></i></a></div>
+	{{ end }}
 	<button id="hamburger" onclick="kub.toggleMenu()" data-auto-burger-exclude><div></div></button>
 </nav>

--- a/static/css/site-searchbar.css
+++ b/static/css/site-searchbar.css
@@ -1,0 +1,75 @@
+.site-searchbar {
+    position: absolute;
+    z-index: 100;
+    background-color: #fff;
+    border-radius: 10px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    padding: 10px;
+    display: none;
+  }
+  
+  .site-searchbar input {
+    width: 70vw;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 0, 0, 0.2) !important;
+    outline: none;
+    font-size: 16px;
+  }
+  
+  .site-searchbar input::placeholder {
+    color: black !important;
+  }
+  
+  .search-close {
+    position: absolute;
+    top: 15%;
+    right: 6%;
+    font-size: 1.6em;
+    color: #f20000;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    background: none;
+  }
+  
+  .site-searchbar-sm {
+    display: none;
+  }
+  
+  @media only screen and (max-width: 768px) {
+    .site-searchbar-sm {
+      display: block;
+    }
+  
+    #site-searchbar-navlink {
+      position: fixed;
+      top: 0;
+      left: 0;
+      margin-top: 2%;
+    }
+  
+    .site-searchbar {
+      position: fixed;
+      top: 1%;
+      left: 0;
+    }
+  
+    .site-searchbar input {
+      width: 70vw;
+      padding: 10px;
+      border-radius: 10px;
+      font-size: 16px;
+    }
+  
+    .search-close {
+      position: absolute;
+      top: 20%;
+      right: 2%;
+      font-size: 1.4em;
+      color: #f20000;
+      border: none;
+      outline: none;
+      cursor: pointer;
+    }
+  }

--- a/static/css/site-searchbar.css
+++ b/static/css/site-searchbar.css
@@ -53,9 +53,12 @@
       position: fixed;
       top: 1%;
       left: 0;
+      display: flex;
+      align-items: center;
     }
   
     .site-searchbar input {
+      flex: 1;
       width: 70vw;
       padding: 10px;
       border-radius: 10px;
@@ -65,7 +68,7 @@
     .search-close {
       position: absolute;
       top: 20%;
-      right: 2%;
+      right: 1%;
       font-size: 1.4em;
       color: #f20000;
       border: none;

--- a/static/css/site-searchbar.css
+++ b/static/css/site-searchbar.css
@@ -53,12 +53,9 @@
       position: fixed;
       top: 1%;
       left: 0;
-      display: flex;
-      align-items: center;
     }
   
     .site-searchbar input {
-      flex: 1;
       width: 70vw;
       padding: 10px;
       border-radius: 10px;

--- a/static/js/site-searchbar.js
+++ b/static/js/site-searchbar.js
@@ -1,0 +1,54 @@
+function toggleSearchBar() {
+    $('.site-searchbar-activate').click(function (evt) {
+      evt.preventDefault();
+  
+      if (window.matchMedia('(min-width: 768px)').matches) {
+        $('.site-searchbar').toggle().css('right', '-200px').animate({
+          right: '0',
+        }, 300);
+        $('.site-searchbar > input').focus();
+      }
+  
+      else {
+        $('.site-searchbar').toggle();
+        $('.site-searchbar > input').focus();
+      }
+    });
+  }
+  
+  $(document).ready(function () {
+    toggleSearchBar();
+  
+    if (window.matchMedia('(min-width: 768px)').matches) {
+      $('.search-close').click(function (evt) {
+        evt.preventDefault();
+  
+        $('.site-searchbar').animate({
+          right: '-400px',
+        }, 300, function () {
+          $('.site-searchbar').fadeOut(200);
+          $('.site-searchbar > input').val("");
+        });
+        $('.site-searchbar').css({ 'right': '' });
+      });
+  
+      $('.site-searchbar > input').blur(function () {
+        $('.site-searchbar').animate({
+          right: '-400px',
+        }, 300, function () {
+          $('.site-searchbar').fadeOut(100);
+          $('.site-searchbar > input').val("");
+        });
+        $('.site-searchbar').css({ 'right': '' });
+      });
+    }
+  
+    else {
+      $('.search-close').click(function (evt) {
+        evt.preventDefault();
+        $('.site-searchbar > input').val("");
+        $('.site-searchbar').toggle();
+      });
+    }
+  
+  });


### PR DESCRIPTION
Resolves #21867 

**_Brief summary of changes in this PR:_**

* A search bar has been added to the navigation bar on the home page.
* Corresponding CSS and script have also been added.
* Screenshots have been below to show how the search bar looks on desktop and mobile devices.

_Search on Desktop_

![K8s-desktop-nav](https://user-images.githubusercontent.com/13051389/232467295-e3402fe8-6c1f-4ab2-ac2a-ca0f1a3677d4.png)

<img width="1467" alt="K8s-desktop-searchbar" src="https://user-images.githubusercontent.com/13051389/232467242-716a186d-e2af-4159-8dcd-e153ea3c51aa.png">

_Search on Mobile_

![K8s-mobile-nav](https://user-images.githubusercontent.com/13051389/232467384-5ce27f08-da1c-4ad4-98de-0c46c68ce0de.png)

![K8s-mobile-searchbar](https://user-images.githubusercontent.com/13051389/232467425-9d7f605f-8df6-49a6-a1c6-79dd119a1599.png)
