### PR TITLE
remove beta reference from LocalStorageCapacityIsolation GA promotion

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -257,7 +257,7 @@ Your applications cannot expect any performance SLAs (disk IOPS for example)
 from local ephemeral storage.
 {{< /caution >}}
 
-As a beta feature, Kubernetes lets you track, reserve and limit the amount
+Kubernetes lets you track, reserve and limit the amount
 of ephemeral local storage a Pod can consume.
 
 ### Configurations for local ephemeral storage


### PR DESCRIPTION
this seems to have been missed during the GA promotion in https://github.com/kubernetes/website/pull/35989 
