### PR TITLE
Fix references to exclude-from-external-load-balancer (add s)

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -339,9 +339,9 @@ Used on: ServiceAccount
 
 The value for this annotation must be **true** to take effect. This annotation indicates that pods running as this service account may only reference Secret API objects specified in the service account's `secrets` field.
 
-### node.kubernetes.io/exclude-from-external-load-balancer
+### node.kubernetes.io/exclude-from-external-load-balancers
 
-Example: `node.kubernetes.io/exclude-from-external-load-balancer`
+Example: `node.kubernetes.io/exclude-from-external-load-balancers`
 
 Used on: Node
 


### PR DESCRIPTION
The annotation is `node.kubernetes.io/exclude-from-external-load-balancers`, but the docs refer to it twice as `node.kubernetes.io/exclude-from-external-load-balancer` (without the s at the end). This change fixes those references by adding the `s` at the end. The final spelling of this annotation in the doc correctly includes the trailing s.