### PR TITLE
[zh] sync /kubernetes-api/cluster-resources/lease-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
@@ -8,59 +8,56 @@ description: "Lease 定义了租约的概念。"
 title: "Lease"
 weight: 5
 ---
-
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+api_metadata:
+  apiVersion: "coordination.k8s.io/v1"
+  import: "k8s.io/api/coordination/v1"
+  kind: "Lease"
+content_type: "api_reference"
+description: "Lease defines a lease concept."
+title: "Lease"
+weight: 5
+auto_generated: true
 -->
 
 `apiVersion: coordination.k8s.io/v1`
 
 `import "k8s.io/api/coordination/v1"`
 
-
 ## Lease {#Lease}
+
 <!--
 Lease defines a lease concept.
 -->
 Lease 定义了租约的概念。
+
 <hr>
 
 - **apiVersion**: coordination.k8s.io/v1
 
-
 - **kind**: Lease
-
 
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
-<!--
+  <!--
   More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
--->
+  -->
   更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../cluster-resources/lease-v1#LeaseSpec" >}}">LeaseSpec</a>)
 
-<!--
-  Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
--->
-  Lease 规范。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-
-
-
+  <!--
+  spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  -->
+  spec 包含 Lease 的规约。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 ## LeaseSpec {#LeaseSpec}
 
 <!--
 LeaseSpec is a specification of a Lease.
 -->
-LeaseSpec 是一个 Lease 的规范。
+LeaseSpec 是一个 Lease 的规约。
 
 <hr>
 
@@ -75,21 +72,6 @@ LeaseSpec 是一个 Lease 的规范。
 - **holderIdentity** (string)
 
   holderIdentity contains the identity of the holder of a current lease.
-
-- **leaseDurationSeconds** (int32)
-
-  leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.
-
-- **leaseTransitions** (int32)
-
-  leaseTransitions is the number of transitions of a lease between holders.
-
-- **renewTime** (MicroTime)
-
-  renewTime is a time when the current holder of a lease has last updated the lease.
-
-  <a name="MicroTime"></a>
-  *MicroTime is version of Time with microsecond level precision.*
 -->
 - **acquireTime** (MicroTime)
 
@@ -102,13 +84,29 @@ LeaseSpec 是一个 Lease 的规范。
 
   holderIdentity 包含当前租约持有人的身份。
 
+<!--
 - **leaseDurationSeconds** (int32)
 
-  leaseDurationSeconds 是租约候选人需要等待强制获取租约的持续时间。这是相对于上次观察到的更新时间的度量。
+  leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.
 
 - **leaseTransitions** (int32)
 
-  LeasetTransitions 是租约持有人之间的转换次数。
+  leaseTransitions is the number of transitions of a lease between holders.
+
+- **renewTime** (MicroTime)
+
+  renewTime is a time when the current holder of a lease has last updated the lease.
+
+  <a name="MicroTime"></a>
+  *MicroTime is version of Time with microsecond level precision.*
+-->
+- **leaseDurationSeconds** (int32)
+
+  leaseDurationSeconds 是租约候选人需要等待强制获取租约的持续时间。这是相对于上次观察到的 renewTime 的度量。
+
+- **leaseTransitions** (int32)
+
+  leaseTransitions 是租约持有人之间的转换次数。
 
 - **renewTime** (MicroTime)
 
@@ -116,9 +114,6 @@ LeaseSpec 是一个 Lease 的规范。
 
   <a name="MicroTime"></a>
   **MicroTime 是具有微秒级精度的时间版本。**
-
-
-
 
 ## LeaseList {#LeaseList}
 
@@ -131,37 +126,29 @@ LeaseList 是 Lease 对象的列表。
 
 - **apiVersion**: coordination.k8s.io/v1
 
-
 - **kind**: LeaseList
-
 
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
 
-<!--
+  <!--
   Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
--->
-   标准列表元数据。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  -->
+  标准的列表元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **items** ([]<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>), required
 
-<!--
-  Items is a list of schema objects.
--->
-  Items 是架构对象的列表。
-
-
+  <!--
+  items is a list of schema objects.
+  -->
+  items 是架构对象的列表。
 
 <!--
 ## Operations {#Operations}
 -->
 ## 操作   {#operations}
 
-
 <hr>
-
-
-
-
 
 <!--
 ### `get` read the specified Lease
@@ -172,7 +159,7 @@ GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 
 #### Parameters
 -->
-### `get` 读取指定的租赁
+### `get` 读取指定的 Lease
 
 #### HTTP 请求
 
@@ -185,11 +172,9 @@ GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 
   name of the Lease
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **pretty** (*in query*): string
 
@@ -197,7 +182,7 @@ GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 - **name** (**路径参数**): string, 必需
 
-  Lease 名称
+  Lease 名称。
 
 - **namespace** (**路径参数**): string, 必需
 
@@ -232,56 +217,49 @@ GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 <!--
 #### Parameters
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **allowWatchBookmarks** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
-
 
 - **fieldSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
-
 
 - **limit** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **resourceVersion** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
-
 
 - **watch** (*in query*): boolean
 
@@ -289,41 +267,33 @@ GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 -->
 #### 参数
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
-
 
 - **allowWatchBookmarks** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
-
 
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
-
 
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **resourceVersion** (**查询参数**): string
 
@@ -333,11 +303,13 @@ GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
-
 
 - **watch** (**查询参数**): boolean
 
@@ -366,83 +338,72 @@ GET /apis/coordination.k8s.io/v1/leases
 <!--
 #### Parameters
 
-
 - **allowWatchBookmarks** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
-
 
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
 
-
 - **fieldSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
-
 
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
 
-
 - **limit** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **resourceVersion** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
-
 
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 
-
 - **watch** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
 -->
 #### 参数
-
 
 - **allowWatchBookmarks** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
 
-
 - **continue** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
-
 
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **labelSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
 
-
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -456,11 +417,13 @@ GET /apis/coordination.k8s.io/v1/leases
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
-
 
 - **watch** (**查询参数**): boolean
 
@@ -468,14 +431,8 @@ GET /apis/coordination.k8s.io/v1/leases
 
 <!--
 #### Response
-
-
-200 (<a href="{{< ref "../cluster-resources/lease-v1#LeaseList" >}}">LeaseList</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../cluster-resources/lease-v1#LeaseList" >}}">LeaseList</a>): OK
 
@@ -485,8 +442,6 @@ GET /apis/coordination.k8s.io/v1/leases
 ### `create` create a Lease
 
 #### HTTP Request
-
-POST /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 -->
 ### `create` 创建 Lease
 
@@ -497,31 +452,23 @@ POST /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 <!--
 #### Parameters
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>, required
-
-  
-
 
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
 
-
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -529,31 +476,23 @@ POST /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 -->
 #### 参数
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>, 必需
-
-  
-
 
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
 
-
 - **fieldValidation** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -561,18 +500,8 @@ POST /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 
 <!--
 #### Response
-
-
-200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
-
-201 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Created
-
-202 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Accepted
-
-401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
 
@@ -586,47 +515,37 @@ POST /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 ### `update` replace the specified Lease
 
 #### HTTP Request
-
-PUT /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 ### `update` 替换指定的 Lease
 
 #### HTTP 请求
 
 PUT /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
 <!--
 #### Parameters
-
 
 - **name** (*in path*): string, required
 
   name of the Lease
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>, required
-
-  
-
 
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
 
-
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
-
 
 - **pretty** (*in query*): string
 
@@ -634,31 +553,23 @@ PUT /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 #### 参数
 
-
 - **name** (**路径参数**): string, 必需
 
-  租贷名称
-
+  Lease 的名称。
 
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>, 必需
-
-  
-
 
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
-
 
 - **fieldValidation** (**查询参数**): string
 
@@ -670,16 +581,8 @@ PUT /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 
 <!--
 #### Response
-
-
-200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
-
-201 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Created
-
-401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
 
@@ -691,52 +594,41 @@ PUT /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 ### `patch` partially update the specified Lease
 
 #### HTTP Request
-
-PATCH /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 ### `patch` 部分更新指定的 Lease
 
 #### HTTP 请求
 
 PATCH /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
 <!--
 #### Parameters
-
 
 - **name** (*in path*): string, required
 
   name of the Lease
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
-
-  
-
 
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
-
 
 - **fieldValidation** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **force** (*in query*): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
-
 
 - **pretty** (*in query*): string
 
@@ -744,41 +636,31 @@ PATCH /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 #### 参数
 
-
 - **name** (**路径参数**): string, 必需
 
-  租贷名称
-
+  Lease 的名称。
 
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, 必需
-
-  
-
 
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **fieldManager** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
-
 
 - **fieldValidation** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldValidation" >}}">fieldValidation</a>
 
-
 - **force** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
-
 
 - **pretty** (**查询参数**): string
 
@@ -786,16 +668,8 @@ PATCH /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 
 <!--
 #### Response
-
-
-200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
-
-201 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Created
-
-401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
 
@@ -807,47 +681,37 @@ PATCH /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 ### `delete` delete a Lease
 
 #### HTTP Request
-
-DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 ### `delete` 删除一个 Lease
 
 #### HTTP 请求
 
 DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
 <!--
 #### Parameters
-
 
 - **name** (*in path*): string, required
 
   name of the Lease
 
-
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
-
-  
-
 
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **gracePeriodSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
 
-
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **propagationPolicy** (*in query*): string
 
@@ -855,36 +719,27 @@ DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 -->
 #### 参数
 
-
 - **name** (**路径参数**): string, 必需
 
-  租贷的名称
-
+  Lease 的名称。
 
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
-
-  
-
 
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
 
-
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
 
-
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
-
 
 - **propagationPolicy** (**查询参数**): string
 
@@ -892,16 +747,8 @@ DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 
 <!--
 #### Response
-
-
-200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
-
-202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
-
-401: Unauthorized
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
@@ -913,77 +760,65 @@ DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
 ### `deletecollection` delete collection of Lease
 
 #### HTTP Request
-
-DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 -->
 ### `deletecollection` 删除 Lease 收款
 
 #### HTTP 请求
 
 DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
+
 <!--
 #### Parameters
-
 
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
-
-  
-
 
 - **continue** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
 
-
 - **dryRun** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **gracePeriodSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
-
 
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
 
-
 - **limit** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **propagationPolicy** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
-
 
 - **resourceVersion** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (*in query*): integer
 
@@ -991,66 +826,55 @@ DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 -->
 #### 参数
 
-
 - **namespace** (**路径参数**): string, 必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
-
-  
-
 
 - **continue** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
 
-
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
-
 
 - **fieldSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
-
 
 - **labelSelector** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
 
-
 - **limit** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
-
 
 - **pretty** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
 
-
 - **propagationPolicy** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
-
 
 - **resourceVersion** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 
-
 - **resourceVersionMatch** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
 
@@ -1058,16 +882,9 @@ DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
 
 <!--
 #### Response
-
-
-200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
 
-
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
 401: Unauthorized
-


### PR DESCRIPTION
- Sync with en text
- Remove redundant blank lines

```
content/zh-cn/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
```
See [preview](https://deploy-preview-40743--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/cluster-resources/lease-v1/) please.