### PR TITLE
[zh] sync /tutorials/security/seccomp.md

### DIFF
--- a/content/zh-cn/docs/tutorials/security/seccomp.md
+++ b/content/zh-cn/docs/tutorials/security/seccomp.md
@@ -33,7 +33,7 @@ profiles that give only the necessary privileges to your container processes.
 -->
 Seccomp 代表安全计算（Secure Computing）模式，自 2.6.12 版本以来，一直是 Linux 内核的一个特性。
 它可以用来沙箱化进程的权限，限制进程从用户态到内核态的调用。
-Kubernetes 能使你自动将加载到 {{< glossary_tooltip text="节点" term_id="node" >}}上的
+Kubernetes 能使你自动将加载到{{< glossary_tooltip text="节点" term_id="node" >}}上的
 seccomp 配置文件应用到你的 Pod 和容器。
 
 识别你的工作负载所需要的权限是很困难的。在本篇教程中，
@@ -137,6 +137,7 @@ ls profiles
 You should see three profiles listed at the end of the final step:
 -->
 你应该看到在最后一步的末尾列出有三个配置文件：
+
 ```
 audit.json  fine-grained.json  violation.json
 ```
@@ -150,7 +151,6 @@ so each node of the cluster is a container. This allows for files
 to be mounted in the filesystem of each container similar to loading files
 onto a node.
 -->
-
 ## 使用 kind 创建本地 Kubernetes 集群 {#create-a-local-kubernetes-cluster-with-kind}
 
 为简单起见，[kind](https://kind.sigs.k8s.io/) 可用来创建加载了 seccomp 配置文件的单节点集群。
@@ -163,6 +163,7 @@ Kind 在 Docker 中运行 Kubernetes，因此集群的每个节点都是一个�
 Download that example kind configuration, and save it to a file named `kind.yaml`:
 -->
 下载该示例 kind 配置，并将其保存到名为 `kind.yaml` 的文件中：
+
 ```shell
 curl -L -O https://k8s.io/examples/pods/security/seccomp/kind.yaml
 ```
@@ -233,6 +234,12 @@ of the kubelet. Use `docker exec` to run a command in the Pod:
 你应该会看到 `profiles/` 目录已成功加载到 kubelet 的默认 seccomp 路径中。
 使用 `docker exec` 在 Pod 中运行命令：
 
+<!--
+```shell
+# Change 6a96207fed4b to the container ID you saw from "docker ps"
+docker exec -it 6a96207fed4b ls /var/lib/kubelet/seccomp/profiles
+```
+-->
 ```shell
 # 将 6a96207fed4b 更改为你从 “docker ps” 看到的容器 ID
 docker exec -it 6a96207fed4b ls /var/lib/kubelet/seccomp/profiles
@@ -253,21 +260,17 @@ running within kind.
 -->
 ## 启用使用 `RuntimeDefault` 作为所有工作负载的默认 seccomp 配置文件 {#enable-runtimedefault-as-default}
 
-{{< feature-state state="beta" for_k8s_version="v1.25" >}}
+{{< feature-state state="stable" for_k8s_version="v1.27" >}}
 
 <!-- 
-To use seccomp profile defaulting, you must run the kubelet with the `SeccompDefault`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) enabled
-(this is the default). You must also explicitly enable the defaulting behavior for each
-node where you want to use this with the corresponding `--seccomp-default`
-[command line flag](/docs/reference/command-line-tools-reference/kubelet).
-Both have to be enabled simultaneously to use the feature.
+To use seccomp profile defaulting, you must run the kubelet with the
+`--seccomp-default`
+[command line flag](/docs/reference/command-line-tools-reference/kubelet)
+enabled for each node where you want to use it. 
 -->
-要使用 Seccomp（安全计算模式）配置文件来设定默认值，你必须要在启用 `SeccompDefault`
-[特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)的情况下运行 kubelet
-（这是默认值）。
-你还必须显式地启用每个节点的默认行为，以及相应的
-`--seccomp-default` [命令行标志](/zh-cn/docs/reference/command-line-tools-reference/kubelet)。两者必须同时启用才能使用该特性。
+要使用 Seccomp（安全计算模式）配置文件采用默认设置这一行为，你必须使用在想要启用此行为的每个节点上启用
+`--seccomp-default`
+[命令行标志](/zh-cn/docs/reference/command-line-tools-reference/kubelet)来运行 kubelet。
 
 <!-- 
 If enabled, the kubelet will use the `RuntimeDefault` seccomp profile by default, which is
@@ -337,14 +340,11 @@ Kubernetes 项目建议你在部分节点上启用此特性门控，
 <!--
 Kubernetes {{< skew currentVersion >}} lets you configure the seccomp profile
 that applies when the spec for a Pod doesn't define a specific seccomp profile.
-This is a beta feature and the corresponding `SeccompDefault` [feature
-gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled by
-default. However, you still need to enable this defaulting for each node where
-you would like to use it.
+However, you still need to enable this defaulting for each node where you would
+like to use it.
 -->
 Kubernetes {{< skew currentVersion >}} 允许你配置 Seccomp 配置文件，
 当 Pod 的规约未定义特定的 Seccomp 配置文件时应用该配置文件。
-这是一个 Beta 特性，默认启用相应的 `SeccompDefault` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)。
 但是，你仍然需要为要使用它的每个节点启用此默认设置。
 
 <!--
@@ -368,8 +368,6 @@ the minimum required Kubernetes version and enables the `SeccompDefault` feature
 ```yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  SeccompDefault: true
 nodes:
   - role: control-plane
     image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
@@ -386,7 +384,6 @@ nodes:
         kind: JoinConfiguration
         nodeRegistration:
           kubeletExtraArgs:
-            feature-gates: SeccompDefault=true
             seccomp-default: "true"
 ```
 
@@ -439,11 +436,11 @@ type in the security context of a pod or container to `RuntimeDefault`.
 
 {{< note >}}
 <!-- 
-If you have the `SeccompDefault` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+If you have the `seccompDefault` [configuration](/docs/reference/config-api/kubelet-config.v1beta1/)
 enabled, then Pods use the `RuntimeDefault` seccomp profile whenever
 no other seccomp profile is specified. Otherwise, the default is `Unconfined`.
 -->
-如果你已经启用了 `SeccompDefault` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)，
+如果你已经启用了 `seccompDefault` [配置](/zh-cn/docs/reference/config-api/kubelet-config.v1beta1/)，
 只要没有指定其他 seccomp 配置文件，那么 Pod 就会使用 `RuntimeDefault` seccomp 配置文件。
 否则，默认值为 `Unconfined`。
 {{< /note >}}
@@ -506,26 +503,15 @@ Here's a manifest for that Pod:
 
 {{< note >}}
 <!-- 
-The functional support for the already deprecated seccomp annotations
-`seccomp.security.alpha.kubernetes.io/pod` (for the whole pod) and
-`container.seccomp.security.alpha.kubernetes.io/[name]` (for a single container)
-is going to be removed with a future release of Kubernetes. Please always use
-the native API fields in favor of the annotations.
-
-Since Kubernetes v1.25, kubelets no longer support the annotations, use of the
-annotations in static pods is no longer supported, and the seccomp annotations
-are no longer auto-populated when pods with seccomp fields are created.
-Auto-population of the seccomp fields from the annotations is planned to be
-removed in a future release.
+Older versions of Kubernetes allowed you to configure seccomp
+behavior using {{< glossary_tooltip text="annotations" term_id="annotation" >}}.
+Kubernetes {{< skew currentVersion >}} only supports using fields within
+`.spec.securityContext` to configure seccomp, and this tutorial explains that
+approach.
 -->
-已弃用的 seccomp 注解 `seccomp.security.alpha.kubernetes.io/pod`（针对整个 Pod）和
-`container.seccomp.security.alpha.kubernetes.io/[name]`（针对单个容器）
-将随着未来 Kubernetes 的发布而被删除。
-请在可能的情况下使用原生 API 字段而不是注解。
-
-从 Kubernetes v1.25 开始，kubelet 不再支持这些注解，
-也不再支持在静态 Pod 中使用注解，并且当创建带有 seccomp 字段的 Pod 时不再自动填充 seccomp 注解。
-从注释中自动填充 seccomp 字段的特性，将计划在未来的版本中删除。
+旧版本的 Kubernetes 允许你使用{{< glossary_tooltip text="注解" term_id="annotation" >}}配置
+seccomp 行为。Kubernetes {{< skew currentVersion >}} 仅支持使用位于 `.spec.securityContext`
+内的字段来配置 seccomp。本教程将阐述这个方法。
 {{< /note >}}
 
 <!--
@@ -592,6 +578,12 @@ container belonging to that control plane container:
 现在，你可以使用 `curl` 从 kind 控制平面容器内部访问该端点，位于该服务所公开的端口上。
 使用 `docker exec` 在属于该控制平面容器的容器中运行 `curl` 命令：
 
+<!--
+```shell
+# Change 6a96207fed4b to the control plane container ID you saw from "docker ps"
+docker exec -it 6a96207fed4b curl localhost:32373
+```
+-->
 ```shell
 # 将 6a96207fed4b 更改为你从 “docker ps” 看到的控制平面容器 ID
 docker exec -it 6a96207fed4b curl localhost:32373
@@ -625,6 +617,7 @@ For example:
 如果你在控制平面容器中 `curl` 端点，你会看到更多的写入。
 
 例如：
+
 ```
 Jul  6 15:37:40 my-machine kernel: [369128.669452] audit: type=1326 audit(1594067860.484:14536): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=29064 comm="http-echo" exe="/http-echo" sig=0 arch=c000003e syscall=51 compat=0 ip=0x46fe1f code=0x7ffc0000
 Jul  6 15:37:40 my-machine kernel: [369128.669453] audit: type=1326 audit(1594067860.484:14537): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=29064 comm="http-echo" exe="/http-echo" sig=0 arch=c000003e syscall=54 compat=0 ip=0x46fdba code=0x7ffc0000
@@ -683,7 +676,7 @@ kubectl apply -f https://k8s.io/examples/pods/security/seccomp/ga/violation-pod.
 The Pod creates, but there is an issue.
 If you check the status of the Pod, you should see that it failed to start.
 -->
-Pod 创建，但存在问题。
+Pod 已创建，但存在问题。
 如果你检查 Pod 状态，你应该看到它没有启动。
 
 ```shell
@@ -732,7 +725,7 @@ The manifest for this example is:
 如果你看一看 `fine-grained.json` 配置文件，
 你会注意到第一个示例的 syslog 中看到的一些系统调用，
 其中配置文件设置为 `"defaultAction": "SCMP_ACT_LOG"`。
-现在的配置文件设置 `"defaultAction": "SCMP_ACT_ERRNO"`,
+现在的配置文件设置 `"defaultAction": "SCMP_ACT_ERRNO"`，
 但在 `"action": "SCMP_ACT_ALLOW"` 块中明确允许一组系统调用。
 理想情况下，容器将成功运行，并且你看到没有消息发送到 `syslog`。
 
@@ -769,6 +762,12 @@ mention calls from `http-echo`:
 -->
 打开一个新的终端窗口并使用 `tail` 来监视提到来自 `http-echo` 的调用的日志条目：
 
+<!--
+```shell
+# The log path on your computer might be different from "/var/log/syslog"
+tail -f /var/log/syslog | grep 'http-echo'
+```
+-->
 ```shell
 # 你计算机上的日志路径可能与 “/var/log/syslog” 不同
 tail -f /var/log/syslog | grep 'http-echo'
@@ -796,6 +795,7 @@ kubectl get service fine-pod
 The output is similar to:
 -->
 输出类似于：
+
 ```
 NAME        TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
 fine-pod    NodePort   10.111.36.142   <none>        5678:32373/TCP   72s
@@ -806,6 +806,12 @@ Use `curl` to access that endpoint from inside the kind control plane container:
 -->
 使用 `curl` 从 kind 控制平面容器内部访问端点：
 
+<!--
+```shell
+# Change 6a96207fed4b to the control plane container ID you saw from "docker ps"
+docker exec -it 6a96207fed4b curl localhost:32373
+```
+-->
 ```shell
 # 将 6a96207fed4b 更改为你从 “docker ps” 看到的控制平面容器 ID
 docker exec -it 6a96207fed4b curl localhost:32373


### PR DESCRIPTION
Sync with en text:

```
content/zh-cn/docs/tutorials/security/seccomp.md
```
See [preview](https://deploy-preview-40748--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tutorials/security/seccomp/) please.