### PR TITLE
docs: Update kustomize examples to use non-deprecated resources key (English)

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -893,14 +893,14 @@ in different overlays. Here are two overlays using the same base.
 ```shell
 mkdir dev
 cat <<EOF > dev/kustomization.yaml
-bases:
+resources:
 - ../base
 namePrefix: dev-
 EOF
 
 mkdir prod
 cat <<EOF > prod/kustomization.yaml
-bases:
+resources:
 - ../base
 namePrefix: prod-
 EOF
@@ -1011,4 +1011,3 @@ deployment.apps "dev-my-nginx" deleted
 * [Kubectl Book](https://kubectl.docs.kubernetes.io)
 * [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/)
 * [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
-


### PR DESCRIPTION
Kustomize has deprecated the use of `bases` in `kustomization.yaml` files. This PR updates all references to `bases` in the docs to use the newer `resources`, which is [the suggested alternative](https://github.com/kubernetes-sigs/kustomize/issues/2243).