### PR TITLE
docs: Update kustomize examples to use non-deprecated resources key (ID lang)

### DIFF
--- a/content/id/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/id/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -118,7 +118,7 @@ metadata:
 #### secretGenerator
 
 Kamu dapat membangkitkan Secret dari berkas atau pasangan _key-value_ literal. Untuk membangkitkan dari berkas, tambahkan entri pada daftar `files` di `secretGenerator`.
-Contoh di bawah ini membangkitkan Secret dengan data dari berkas: 
+Contoh di bawah ini membangkitkan Secret dengan data dari berkas:
 
 ```shell
 # Membuat berkas password.txt
@@ -719,14 +719,14 @@ _field_ lainnya yang bersinggungan di dalam **overlay** berbeda. Di bawah ini me
 ```shell
 mkdir dev
 cat <<EOF > dev/kustomization.yaml
-bases:
+resources:
 - ../base
 namePrefix: dev-
 EOF
 
 mkdir prod
 cat <<EOF > prod/kustomization.yaml
-bases:
+resources:
 - ../base
 namePrefix: prod-
 EOF
@@ -837,5 +837,3 @@ deployment.apps "dev-my-nginx" deleted
 * [Buku Kubectl](https://kubectl.docs.kubernetes.io)
 * [Rujukan Perintah Kubectl](/docs/reference/generated/kubectl/kubectl-commands/)
 * [Rujukan API Kubernetes](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
-
-


### PR DESCRIPTION
Kustomize has deprecated the use of bases in kustomization.yaml files. This PR updates all references to bases in the id docs to use the newer resources, which is https://github.com/kubernetes-sigs/kustomize/issues/2243.

Original English PR: https://github.com/kubernetes/website/pull/40761
