### PR TITLE
docs: Update kustomize examples to use non-deprecated resources key (ko lang)

### DIFF
--- a/content/ko/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/ko/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -893,14 +893,14 @@ EOF
 ```shell
 mkdir dev
 cat <<EOF > dev/kustomization.yaml
-bases:
+resources:
 - ../base
 namePrefix: dev-
 EOF
 
 mkdir prod
 cat <<EOF > prod/kustomization.yaml
-bases:
+resources:
 - ../base
 namePrefix: prod-
 EOF
@@ -1011,4 +1011,3 @@ deployment.apps "dev-my-nginx" deleted
 * [Kubectl 문서](https://kubectl.docs.kubernetes.io)
 * [Kubectl 커맨드 참조](/docs/reference/generated/kubectl/kubectl-commands/)
 * [쿠버네티스 API 참조](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
-


### PR DESCRIPTION
Kustomize has deprecated the use of bases in kustomization.yaml files. This PR updates all references to bases in the ko docs to use the newer resources, which is https://github.com/kubernetes-sigs/kustomize/issues/2243.

Original English PR: https://github.com/kubernetes/website/pull/40761