### PR TITLE
Remove a confusing table header

### DIFF
--- a/content/en/docs/concepts/security/service-accounts.md
+++ b/content/en/docs/concepts/security/service-accounts.md
@@ -48,7 +48,7 @@ accounts in the API server.
 
 {{< table caption="Comparison between service accounts and users" >}}
 
-| Description | ServiceAccount | User or group |
+|  | ServiceAccount | User or group |
 | --- | --- | --- |
 | Location | Kubernetes API (ServiceAccount object) | External |
 | Access control | Kubernetes RBAC or other [authorization mechanisms](/docs/reference/access-authn-authz/authorization/#authorization-modules) | Kubernetes RBAC or other identity and access management mechanisms |


### PR DESCRIPTION
Remove the "Description" label for the table captioned "Comparison between service accounts and users" to make it immediately obvious that the table has two, not three, data columns.