### PR TITLE
Update data/releases/schedule.yaml for April 2023 patches

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,6 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| April 2023            | 2023-04-07           | 2023-04-12  |
 | May 2023              | 2023-05-12           | 2023-05-17  |
 | June 2023             | 2023-06-09           | 2023-06-14  |
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,10 +4,15 @@ schedules:
   maintenanceModeStartDate: 2024-04-28
   endOfLifeDate: 2024-06-28
   next:
-    release: 1.27.1
-    cherryPickDeadline: 2023-05-10
+    release: 1.27.2
+    cherryPickDeadline: 2023-05-12
     targetDate: 2023-05-17
   previousPatches:
+    - release: 1.27.1
+      cherryPickDeadline: ""
+      targetDate: 2023-04-14
+      note: >-
+        [Regression](https://groups.google.com/g/kubernetes-announce/c/9FTKjmIFOTw/m/TH6cJT64AAAJ)
     - release: 1.27.0
       cherryPickDeadline: ""
       targetDate: 2023-04-11
@@ -16,10 +21,13 @@ schedules:
   maintenanceModeStartDate: 2023-12-28
   endOfLifeDate: 2024-02-28
   next:
-    release: 1.26.4
-    cherryPickDeadline: 2023-04-07
-    targetDate: 2023-04-12
+    release: 1.26.5
+    cherryPickDeadline: 2023-05-12
+    targetDate: 2023-05-17
   previousPatches:
+    - release: 1.26.4
+      cherryPickDeadline: 2023-04-07
+      targetDate: 2023-04-12
     - release: 1.26.3
       cherryPickDeadline: 2023-03-10
       targetDate: 2023-03-15
@@ -39,10 +47,13 @@ schedules:
   maintenanceModeStartDate: 2023-08-28
   endOfLifeDate: 2023-10-28
   next:
-    release: 1.25.9
-    cherryPickDeadline: 2023-04-07
-    targetDate: 2023-04-12
+    release: 1.25.10
+    cherryPickDeadline: 2023-05-12
+    targetDate: 2023-05-17
   previousPatches:
+    - release: 1.25.9
+      cherryPickDeadline: 2023-04-07
+      targetDate: 2023-04-12
     - release: 1.25.8
       cherryPickDeadline: 2023-03-10
       targetDate: 2023-03-15
@@ -81,10 +92,13 @@ schedules:
   maintenanceModeStartDate: 2023-05-28
   endOfLifeDate: 2023-07-28
   next:
-    release: 1.24.13
-    cherryPickDeadline: 2023-04-07
-    targetDate: 2023-04-12
+    release: 1.24.14
+    cherryPickDeadline: 2023-05-12
+    targetDate: 2023-05-17
   previousPatches:
+    - release: 1.24.13
+      cherryPickDeadline: 2023-04-07
+      targetDate: 2023-04-12
     - release: 1.24.12
       cherryPickDeadline: 2023-03-10
       targetDate: 2023-03-15


### PR DESCRIPTION
Add release data for the April 2023 patches:
* v1.24.13
* v1.25.9
* v1.26.4

Additionally:
* v1.27.1

I also removed April 2023 from the upcoming patch calendar since it already happened.

Note that I left `cherryPickDeadline` blank on v1.27.1 because I wasn't sure what made sense for that (afaik it was an out-of-band release due to regression in v1.27.0)