### PR TITLE
modify text decoration about plugins in concepts/storage/windows-storage

### DIFF
--- a/content/en/docs/concepts/storage/windows-storage.md
+++ b/content/en/docs/concepts/storage/windows-storage.md
@@ -57,9 +57,9 @@ Volume management components are shipped as Kubernetes volume
 [plugin](/docs/concepts/storage/volumes/#types-of-volumes).
 The following broad classes of Kubernetes volume plugins are supported on Windows:
 
-* [`FlexVolume plugins`](/docs/concepts/storage/volumes/#flexvolume)
+* [`FlexVolume` plugins](/docs/concepts/storage/volumes/#flexvolume)
   * Please note that FlexVolumes have been deprecated as of 1.23
-* [`CSI Plugins`](/docs/concepts/storage/volumes/#csi)
+* [`CSI` plugins](/docs/concepts/storage/volumes/#csi)
 
 ##### In-tree volume plugins
 


### PR DESCRIPTION
- Inspired from https://github.com/kubernetes/website/pull/39662#discussion_r1119141901
- The linked pages are about `FlexVolume` and `CSI` plugins, but the texts were also decorating word `plugins`
  → modify to decorate names only