### PR TITLE
Add `/proxy/` to URL in deploy-intro.html

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -145,7 +145,7 @@ description: |-
                 <p><b><code>export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')</code></b><br />
                    <b><code>echo Name of the Pod: $POD_NAME</code></b></p>
                 <p>You can access the Pod through the proxied API, by running:</p>
-                <p><b><code>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/</code></b></p>
+                <p><b><code>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/proxy/</code></b></p>
                 <p>In order for the new Deployment to be accessible without using the proxy, a Service is required which will be explained in the next modules.</p>
             </div>
 


### PR DESCRIPTION
This confused me until the next section (`explore-intro.html`) had the full URL with `/proxy/` in it. To me, it makes sense to give that URL here too, since the text is describing how to access the Pod itself through the proxy.
