### PR TITLE
Change selection color to work for blue backgrounds

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -112,6 +112,26 @@ main {
   color: white;
 }
 
+// elements with blue backgrounds get different selection color
+.button::selection {
+  background: #7DA1FF;
+}
+.call-to-action,
+.community-cta-button {
+  ::selection  {
+    background: #7DA1FF;
+  }
+}
+.button::-moz-selection {
+  background: #7DA1FF;
+}
+.call-to-action,
+.community-cta-button {
+  ::-moz-selection  {
+    background: #7DA1FF;
+  }
+}
+
 // HEADER
 
 #hamburger {


### PR DESCRIPTION
Fixes #40797
Changes the selection color on elements with blue backgrounds to a lighter shade of the same blue (#7DA1FF) to maintain palette / aesthetics