### PR TITLE
Update the minimum recommended etcd versions to run in production to `3.4.22+` and `3.5.6+`

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -38,7 +38,7 @@ weight: 270
   clusters. Therefore, run etcd clusters on dedicated machines or isolated
   environments for [guaranteed resource requirements](https://etcd.io/docs/current/op-guide/hardware/).
 
-* The minimum recommended version of etcd to run in production is `3.2.10+`.
+* The minimum recommended etcd versions to run in production are `3.4.22+` and `3.5.6+`.
 
 ## Resource requirements
 


### PR DESCRIPTION
3.3 is end of life.

There is also a data inconsistency issue in 3.4.21 and 3.5.5, so 3.4.22+ and 3.5.6+ are the minimum recommended etcd versions. Please read
https://groups.google.com/g/etcd-dev/c/8S7u6NqW6C4

