### PR TITLE
Add section “Maintaining etcd clusters” into “Operating etcd clusters for Kubernetes”

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -394,3 +394,16 @@ For more details on etcd upgrade, please refer to the [etcd upgrades](https://et
 {{< note >}}
 Before you start an upgrade, please back up your etcd cluster first.
 {{< /note >}}
+
+## Maintaining etcd clusters
+
+Fore more details on etcd maintenance, please refer to the [etcd maintenance](https://etcd.io/docs/latest/op-guide/maintenance/) documentation.
+
+{{% thirdparty-content single="true" %}}
+
+{{< note >}}
+Defragmentation is an expensive operation, so it should be executed as infrequent
+as possible. On the other hand, it's also necessary to make sure any etcd member
+will not run out of the storage quota. The Kubernetes project recommends that when
+you perform defragmentation, you use a tool such as [etcd-defrag](https://github.com/ahrtr/etcd-defrag).
+{{< /note >}}


### PR DESCRIPTION
An etcd cluster needs periodic maintenance to remain reliable, so added one more section `Maintaining etcd clusters`.

Note etcd defragmentation is an expensive operation, so it should be executed as infrequent as possible. On the other hand, it's also necessary to make sure any etcd member will not run out of the storage quota. It's recommended to run defragmentation using [etcd-defrag](https://github.com/ahrtr/etcd-defrag), which is an easier to use and smarter etcd defragmentation tool.