### PR TITLE
editorconfig: preserve final newline in YAML

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,8 @@ indent_size = 2
 indent_style = space
 indent_size = 4
 
+[*.{yaml}]
+insert_final_newline = true
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
I'm not sure why this is defaulted to `false` for all file types, so this just enables it for YAML for now.

(I couldn't figure out why my editor kept stripping this while working on #40780.)
