### PR TITLE
kubectl/jsonpath: add example of escaping termination character

### DIFF
--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -34,7 +34,12 @@ Given the JSON input:
   "items":[
     {
       "kind":"None",
-      "metadata":{"name":"127.0.0.1"},
+      "metadata":{
+        "name":"127.0.0.1",
+        "labels":{
+          "kubernetes.io/hostname":"127.0.0.1"
+        }
+      },
       "status":{
         "capacity":{"cpu":"4"},
         "addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}]
@@ -65,18 +70,19 @@ Given the JSON input:
 }
 ```
 
-Function            | Description               | Example                                                         | Result
---------------------|---------------------------|-----------------------------------------------------------------|------------------
-`text`              | the plain text            | `kind is {.kind}`                                               | `kind is List`
-`@`                 | the current object        | `{@}`                                                           | the same as input
-`.` or `[]`         | child operator            | `{.kind}`, `{['kind']}` or `{['name\.type']}`                   | `List`
-`..`                | recursive descent         | `{..name}`                                                      | `127.0.0.1 127.0.0.2 myself e2e`
-`*`                 | wildcard. Get all objects | `{.items[*].metadata.name}`                                     | `[127.0.0.1 127.0.0.2]`
-`[start:end:step]` | subscript operator        | `{.users[0].name}`                                              | `myself`
-`[,]`               | union operator            | `{.items[*]['metadata.name', 'status.capacity']}`               | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`
-`?()`               | filter                    | `{.users[?(@.name=="e2e")].user.password}`                      | `secret`
-`range`, `end`      | iterate list              | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]`
-`''`                | quote interpreted string  | `{range .items[*]}{.metadata.name}{'\t'}{end}`                  | `127.0.0.1      127.0.0.2`
+Function            | Description                  | Example                                                         | Result
+--------------------|------------------------------|-----------------------------------------------------------------|------------------
+`text`              | the plain text               | `kind is {.kind}`                                               | `kind is List`
+`@`                 | the current object           | `{@}`                                                           | the same as input
+`.` or `[]`         | child operator               | `{.kind}`, `{['kind']}` or `{['name\.type']}`                   | `List`
+`..`                | recursive descent            | `{..name}`                                                      | `127.0.0.1 127.0.0.2 myself e2e`
+`*`                 | wildcard. Get all objects    | `{.items[*].metadata.name}`                                     | `[127.0.0.1 127.0.0.2]`
+`[start:end:step]` | subscript operator           | `{.users[0].name}`                                              | `myself`
+`[,]`               | union operator               | `{.items[*]['metadata.name', 'status.capacity']}`               | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`
+`?()`               | filter                       | `{.users[?(@.name=="e2e")].user.password}`                      | `secret`
+`range`, `end`      | iterate list                 | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]`
+`''`                | quote interpreted string     | `{range .items[*]}{.metadata.name}{'\t'}{end}`                  | `127.0.0.1      127.0.0.2`
+`\`                 | escape termination character | `{.items[0].metadata.labels.kubernetes\.io/hostname}`           | `127.0.0.1`
 
 Examples using `kubectl` and JSONPath expressions:
 
@@ -87,6 +93,7 @@ kubectl get pods -o=jsonpath='{.items[0]}'
 kubectl get pods -o=jsonpath='{.items[0].metadata.name}'
 kubectl get pods -o=jsonpath="{.items[*]['metadata.name', 'status.capacity']}"
 kubectl get pods -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.startTime}{"\n"}{end}'
+kubectl get pods -o=jsonpath='{.items[0].metadata.labels.kubernetes\.io/hostname}'
 ```
 
 {{< note >}}


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

The jsonpath implementation of kubernetes differs from some online executors, especially for escaping. Many users don't know how to get value from keys that contains dot(or other char). I think it is necessary to add an example of how to get it.

Related issues:
- https://github.com/kubernetes/kubernetes/issues/117579
- https://github.com/kubernetes/kubernetes/issues/23386

Example ref:

https://github.com/kubernetes/kubernetes/blob/551790729f1d26d75c1d3fa1411e341eb367f9f3/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go#L319-L329

Exec result:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/61452000/234285113-526e6b7b-f971-45be-b93f-a1b3aaf81047.png">



