### PR TITLE
docs: update Slack link to #kubernetes-contributors

### DIFF
--- a/content/en/docs/tasks/debug/_index.md
+++ b/content/en/docs/tasks/debug/_index.md
@@ -81,7 +81,7 @@ via your web browser or via Slack's own dedicated app.
 Once you are registered, browse the growing list of channels for various subjects of
 interest. For example, people new to Kubernetes may also want to join the
 [`#kubernetes-novice`](https://kubernetes.slack.com/messages/kubernetes-novice) channel. As another example, developers should join the
-[`#kubernetes-dev`](https://kubernetes.slack.com/messages/kubernetes-dev) channel.
+[`#kubernetes-contributors`](https://kubernetes.slack.com/messages/kubernetes-contributors) channel.
 
 There are also many country specific / local language channels. Feel free to join
 these channels for localized support and info:


### PR DESCRIPTION
The Slack channel #kubernetes-dev has been moved/renamed to the #kubernetes-contributors channel.
This PR changes reference and link from #kubernetes-dev to #kubernetes-contributors.
