### PR TITLE
[ja] update Slack channel link to #kubernetes-contributors

### DIFF
--- a/content/ja/docs/tasks/debug/_index.md
+++ b/content/ja/docs/tasks/debug/_index.md
@@ -48,7 +48,7 @@ Slackは登録が必要です。[招待をリクエストする](https://slack.k
 
 登録が完了したら、増え続けるチャンネルリストを見て、興味のある様々なテーマについて調べてみましょう。
 たとえば、Kubernetesの初心者は、[`#kubernetes-novice`](https://kubernetes.slack.com/messages/kubernetes-novice)に参加してみるのもよいでしょう。
-別の例として、開発者は[`#kubernetes-dev`](https://kubernetes.slack.com/messages/kubernetes-dev)チャンネルに参加するとよいでしょう。
+別の例として、開発者は[`#kubernetes-contributors`](https://kubernetes.slack.com/messages/kubernetes-contributors)チャンネルに参加するとよいでしょう。
 
 また、多くの国別/言語別チャンネルがあります。これらのチャンネルに参加すれば、地域特有のサポートや情報を得ることができます。
 


### PR DESCRIPTION
The Slack channel #kubernetes-dev has been moved/renamed to the #kubernetes-contributors channel for ja language.
This PR changes reference and link from #kubernetes-dev to #kubernetes-contributors.