### PR TITLE
[de] changed misspelled german translation in i18n file

### DIFF
--- a/data/i18n/de/de.toml
+++ b/data/i18n/de/de.toml
@@ -200,4 +200,4 @@ other = "Veranstaltungskalender"
 other = "Suchen"
 
 [input_placeholder_email_address]
-other = "E-Mail-Addresse"
+other = "E-Mail-Adresse"


### PR DESCRIPTION
This pull request corrects a misspelling in the german i18n file. Small change but while reading across it popped out.