### PR TITLE
The description of Pod anti-affinity using preferredDuringSchedulingI…

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -508,12 +508,17 @@ For example, you could use
 co-locate Pods of two services in the same cloud provider zone because they
 communicate with each other a lot. Similarly, you could use
 `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity to spread Pods
-from a service across multiple cloud provider zones. However, it is important to note that for preferredDuringSchedulingIgnoredDuringExecution affinity, while the scheduler will make every effort to follow this rule, it may violate it as necessary to ensure that Pods are placed on appropriate nodes within the cluster.
+from a service across multiple cloud provider zones. 
+However, it is important to note that for `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity, 
+while the scheduler will make every effort to follow this rule, 
+it may violate it as necessary to ensure that Pods are placed on appropriate nodes within the cluster.
 -->
 例如，你可以使用 `requiredDuringSchedulingIgnoredDuringExecution` 亲和性来告诉调度器，
 将两个服务的 Pod 放到同一个云提供商可用区内，因为它们彼此之间通信非常频繁。
 类似地，你可以使用 `preferredDuringSchedulingIgnoredDuringExecution`
-反亲和性来将同一服务的多个 Pod 分布到多个云提供商可用区中。但是需要注意的是`preferredDuringSchedulingIgnoredDuringExecution`亲和性，调度器会尽力遵循这个规则，但在必要时可能会违反它，以确保Pod能够在集群中合适的节点上运行。
+反亲和性来将同一服务的多个 Pod 分布到多个云提供商可用区中。
+但是需要注意的是 `preferredDuringSchedulingIgnoredDuringExecution` 反亲和性，
+调度器会尽力遵循这个规则，但在必要时可能会违反它，以确保Pod能够在集群中合适的节点上运行。
 
 <!--
 To use inter-pod affinity, use the `affinity.podAffinity` field in the Pod spec.

--- a/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -508,12 +508,12 @@ For example, you could use
 co-locate Pods of two services in the same cloud provider zone because they
 communicate with each other a lot. Similarly, you could use
 `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity to spread Pods
-from a service across multiple cloud provider zones.
+from a service across multiple cloud provider zones. However, it is important to note that for preferredDuringSchedulingIgnoredDuringExecution affinity, while the scheduler will make every effort to follow this rule, it may violate it as necessary to ensure that Pods are placed on appropriate nodes within the cluster.
 -->
 例如，你可以使用 `requiredDuringSchedulingIgnoredDuringExecution` 亲和性来告诉调度器，
 将两个服务的 Pod 放到同一个云提供商可用区内，因为它们彼此之间通信非常频繁。
 类似地，你可以使用 `preferredDuringSchedulingIgnoredDuringExecution`
-反亲和性来将同一服务的多个 Pod 分布到多个云提供商可用区中。
+反亲和性来将同一服务的多个 Pod 分布到多个云提供商可用区中。但是需要注意的是`preferredDuringSchedulingIgnoredDuringExecution`亲和性，调度器会尽力遵循这个规则，但在必要时可能会违反它，以确保Pod能够在集群中合适的节点上运行。
 
 <!--
 To use inter-pod affinity, use the `affinity.podAffinity` field in the Pod spec.


### PR DESCRIPTION
…gnoredDuringExecution is not rigorous enough.

When using podAntiAffinity with a rule configuration of preferredDuringSchedulingIgnoredDuringExecution, the anti-affinity is not a strict requirement. Although it can distribute Pods from the same service across different regions, it may not necessarily deploy them in different regions compared to requiredDuringSchedulingIgnoredDuringExecution. It should be noted that while the scheduler will make every effort to follow the preferredDuringSchedulingIgnoredDuringExecution rule, it may violate it as necessary to ensure that Pods are placed on appropriate nodes within the cluster.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
