### PR TITLE
add more clarification regarding priorityClassName use with DaemonSet

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -120,7 +120,9 @@ of the new Pod.
 
 {{< note >}}
 If it's important that the DaemonSet pod run on each node, it's often desirable
-to set the `.spec.template.spec.priorityClassName` of the DaemonSet to a [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) with a higher priority to ensure that this eviction occurs.
+to set the `.spec.template.spec.priorityClassName` of the DaemonSet to a
+[PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass)
+with a higher priority to ensure that this eviction occurs.
 {{< /note >}}
 
 The user can specify a different scheduler for the Pods of the DaemonSet, by

--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -108,8 +108,8 @@ If you do not specify either, then the DaemonSet controller will create Pods on 
 
 ## How Daemon Pods are scheduled
 
-A DaemonSet ensures that all eligible nodes run a copy of a Pod. The DaemonSet
-controller creates a Pod for each eligible node and adds the
+A DaemonSet can be used to ensure that all eligible nodes run a copy of a Pod.
+The DaemonSet controller creates a Pod for each eligible node and adds the
 `spec.affinity.nodeAffinity` field of the Pod to match the target host. After
 the Pod is created, the default scheduler typically takes over and then binds
 the Pod to the target host by setting the `.spec.nodeName` field.  If the new
@@ -117,6 +117,11 @@ Pod cannot fit on the node, the default scheduler may preempt (evict) some of
 the existing Pods based on the
 [priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority)
 of the new Pod.
+
+{{< note >}}
+If it's important that the DaemonSet pod run on each node, it's often desirable
+to set the `.spec.template.spec.priorityClassName` of the DaemonSet to a [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) with a higher priority to ensure that this eviction occurs.
+{{< /note >}}
 
 The user can specify a different scheduler for the Pods of the DaemonSet, by
 setting the `.spec.template.spec.schedulerName` field of the DaemonSet.

--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
         volumeMounts:
         - name: varlog
           mountPath: /var/log
+      # it may be desirable to set a high priority class to ensure that a DaemonSet Pod
+      # preempts running Pods
+      # priorityClassName: important
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Not using a priority class name can result in DaemonsetPods remaining pending.  This can occur with cluster-autoscaler where the new DS pod is created, but can't evict existing
scheduled pods due to not having a high priority class.  The DS pod then remains pending
indefinitely unless existing pods on the node happen to terminate to make room.
