### PR TITLE
Fix broken link in Secret concept

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -143,7 +143,7 @@ method creates a new `Secret` object with the edited data.
 
 Depending on how you created the Secret, as well as how the Secret is used in
 your Pods, updates to existing `Secret` objects are propagated automatically to
-Pods that use the data. For more information, refer to [Mounted Secrets are updated automatically](#mounted-secrets-are-updated-automatically).
+Pods that use the data. For more information, refer to [Mounted Secrets are updated automatically](#using-secrets-as-files-from-a-pod).
 
 ### Using a Secret
 


### PR DESCRIPTION
<!--

 Hello!
There was a broken link in https://kubernetes.io/docs/concepts/configuration/secret/#mounted-secrets-are-updated-automatically in editing secret section. I have added the link and made the link active. 
-->