### PR TITLE
Added the Paragraph: Use of Custom kubelet credentials with the kubeadm join.

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -175,6 +175,20 @@ In case the discovery file does not contain credentials, the TLS discovery token
   you must keep it secret and transfer it over a secure channel. This might be possible with your
   cloud provider or provisioning tool.
 
+{{< note >}}
+To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap
+and CSR approval for a new node, by the following way:
+1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
+execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
+2. `$NODE` must be set to the name of the new node. Modify the resulted `kubelet.conf` manually
+to adjust the cluster name and server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
+If your cluster does not have the `ca.key`then you must sign the embedded certificates in the
+`kubelet.conf` externally and after that:
+1. Copy the resulting `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the new node.
+2. Execute `kubeadm join` with the flag
+`--ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf` on the new node.
+{{< /note >}}
+
 ### Securing your installation even more {#securing-more}
 
 The defaults for kubeadm may not work for everyone. This section documents how to tighten up a kubeadm installation

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -184,7 +184,7 @@ and CSR approval for a new node:
   `$NODE` must be set to the name of the new node.
 2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
 
-  If your cluster does not have the `ca.key`file, you must sign the embedded certificates in 
+  If your cluster does not have the `ca.key` file, you must sign the embedded certificates in 
   the `kubelet.conf` externally.
 1. Copy the resulting `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the new node.
 2. Execute `kubeadm join` with the flag

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -180,7 +180,7 @@ In case the discovery file does not contain credentials, the TLS discovery token
   you must keep it secret and transfer it over a secure channel. This might be possible with your
   cloud provider or provisioning tool.
 
-#### Use of Custom kubelet credentials with the kubeadm join
+#### Use of custom kubelet credentials with `kubeadm join`
 
 To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap 
 and CSR approval for a new node:
@@ -189,7 +189,7 @@ and CSR approval for a new node:
    execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
    `$NODE` must be set to the name of the new node.
 2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the server endpoint,
-   or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
+   or pass `kubeadm kubeconfig user --config` (it accepts `InitConfiguration`).
 
 If your cluster does not have the `ca.key` file, you must sign the embedded certificates in 
 the `kubelet.conf` externally.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -81,7 +81,12 @@ the cluster configuration (including root CA) and validates it using the token
 as well as validating that the root CA public key matches the provided hash and
 that the API server certificate is valid under the root CA.
 
-The CA key hash has the format `sha256:<hex_encoded_hash>`. By default, the hash value is returned in the `kubeadm join` command printed at the end of `kubeadm init` or in the output of `kubeadm token create --print-join-command`. It is in a standard format (see [RFC7469](https://tools.ietf.org/html/rfc7469#section-2.4)) and can also be calculated by 3rd party tools or provisioning systems. For example, using the OpenSSL CLI:
+The CA key hash has the format `sha256:<hex_encoded_hash>`.
+By default, the hash value is returned in the `kubeadm join` command printed
+at the end of `kubeadm init` or in the output of `kubeadm token create --print-join-command`.
+It is in a standard format (see [RFC7469](https://tools.ietf.org/html/rfc7469#section-2.4))
+and can also be calculated by 3rd party tools or provisioning systems.
+For example, using the OpenSSL CLI:
 
 ```shell
 openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
@@ -179,13 +184,16 @@ In case the discovery file does not contain credentials, the TLS discovery token
 
 To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap 
 and CSR approval for a new node:
-1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
-  execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
-  `$NODE` must be set to the name of the new node.
-2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
 
-  If your cluster does not have the `ca.key` file, you must sign the embedded certificates in 
-  the `kubelet.conf` externally.
+1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
+   execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
+   `$NODE` must be set to the name of the new node.
+2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the server endpoint,
+   or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
+
+If your cluster does not have the `ca.key` file, you must sign the embedded certificates in 
+the `kubelet.conf` externally.
+
 1. Copy the resulting `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the new node.
 2. Execute `kubeadm join` with the flag
    `--ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf` on the new node.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -189,7 +189,7 @@ and CSR approval for a new node:
    execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
    `$NODE` must be set to the name of the new node.
 2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the server endpoint,
-   or pass `kubeadm kubeconfig user --config` (it accepts `InitConfiguration`).
+   or run `kubeadm kubeconfig user --config` (it accepts `InitConfiguration`).
 
 If your cluster does not have the `ca.key` file, you must sign the embedded certificates in 
 the `kubelet.conf` externally.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -180,13 +180,14 @@ To allow `kubeadm join` to use predefined kubelet credentials and skip client TL
 and CSR approval for a new node:
 1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
 execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
-2. `$NODE` must be set to the name of the new node. Modify the resulted `kubelet.conf` manually
-to adjust the cluster name and server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
-If your cluster does not have the `ca.key`then you must sign the embedded certificates in the
+  `$NODE` must be set to the name of the new node.
+2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the
+server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
+If your cluster does not have the `ca.key`file, you must sign the embedded certificates in the
 `kubelet.conf` externally.
 1. Copy the resulting `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the new node.
 2. Execute `kubeadm join` with the flag
-`--ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf` on the new node.
+   `--ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf` on the new node.
 {{< /note >}}
 
 ### Securing your installation even more {#securing-more}

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -177,13 +177,13 @@ In case the discovery file does not contain credentials, the TLS discovery token
 
 {{< note >}}
 To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap
-and CSR approval for a new node, by the following way:
+and CSR approval for a new node:
 1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
 execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
 2. `$NODE` must be set to the name of the new node. Modify the resulted `kubelet.conf` manually
 to adjust the cluster name and server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
 If your cluster does not have the `ca.key`then you must sign the embedded certificates in the
-`kubelet.conf` externally and after that:
+`kubelet.conf` externally.
 1. Copy the resulting `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the new node.
 2. Execute `kubeadm join` with the flag
 `--ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf` on the new node.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -175,20 +175,20 @@ In case the discovery file does not contain credentials, the TLS discovery token
   you must keep it secret and transfer it over a secure channel. This might be possible with your
   cloud provider or provisioning tool.
 
-{{< note >}}
-To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap
+#### Use of Custom kubelet credentials with the kubeadm join
+
+To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap 
 and CSR approval for a new node:
 1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
-execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
+  execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
   `$NODE` must be set to the name of the new node.
-2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the
-server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
-If your cluster does not have the `ca.key`file, you must sign the embedded certificates in the
-`kubelet.conf` externally.
+2. Modify the resulted `kubelet.conf` manually to adjust the cluster name and the server endpoint, or pass `kubeconfig user --config` (it accepts `InitConfiguration`).
+
+  If your cluster does not have the `ca.key`file, you must sign the embedded certificates in 
+  the `kubelet.conf` externally.
 1. Copy the resulting `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the new node.
 2. Execute `kubeadm join` with the flag
    `--ignore-preflight-errors=FileAvailable--etc-kubernetes-kubelet.conf` on the new node.
-{{< /note >}}
 
 ### Securing your installation even more {#securing-more}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -82,8 +82,8 @@ as well as validating that the root CA public key matches the provided hash and
 that the API server certificate is valid under the root CA.
 
 The CA key hash has the format `sha256:<hex_encoded_hash>`.
-By default, the hash value is returned in the `kubeadm join` command printed
-at the end of `kubeadm init` or in the output of `kubeadm token create --print-join-command`.
+By default, the hash value is printed at the end of the `kubeadm init` command or
+in the output from the `kubeadm token create --print-join-command` command.
 It is in a standard format (see [RFC7469](https://tools.ietf.org/html/rfc7469#section-2.4))
 and can also be calculated by 3rd party tools or provisioning systems.
 For example, using the OpenSSL CLI:


### PR DESCRIPTION
This PR added the note in the kubeadm join [docs](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-join/#file-or-https-based-discovery)  about the use of `Custom kubelet credentials` and `skipping client TLS bootstrap with CSRs`.

Fixes #40874