### PR TITLE
Fix typo in "Configure a Pod to Use a ConfigMap"

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -68,7 +68,7 @@ symlinks, devices, pipes, and more).
 
 {{< note >}}
 Each filename being used for ConfigMap creation must consist of only acceptable characters,
-which are: letters (`A` to `Z` and `a` to z`), digits (`0` to `9`), '-', '_', or '.'.
+which are: letters (`A` to `Z` and `a` to `z`), digits (`0` to `9`), '-', '_', or '.'.
 If you use `kubectl create configmap` with a directory where any of the file names contains
 an unacceptable character, the `kubectl` command may fail.
 


### PR DESCRIPTION
Add missing backtick