### PR TITLE
[zh] sync network-policy-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
@@ -46,15 +46,15 @@ NetworkPolicy 描述针对一组 Pod 所允许的网络流量。
 
 - **spec** (<a href="{{< ref "../policy-resources/network-policy-v1#NetworkPolicySpec" >}}">NetworkPolicySpec</a>)
   <!--
-  Specification of the desired behavior for this NetworkPolicy.
+  spec represents the specification of the desired behavior for this NetworkPolicy.
   -->
-  spec 定义特定网络策略所需的所有信息.
+  spec 表示 NetworkPolicy 预期行为的规约。
 
 - **status** (<a href="{{< ref "../policy-resources/network-policy-v1#NetworkPolicyStatus" >}}">NetworkPolicyStatus</a>)
   <!--
-  Status is the current state of the NetworkPolicy. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  status represents the current state of the NetworkPolicy. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   -->
-  status 是 NetworkPolicy 的当前状态。更多信息：
+  status 表示 NetworkPolicy 的当前状态。更多信息：
   https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 ## NetworkPolicySpec {#NetworkPolicySpec}
@@ -69,7 +69,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 <!--
 - **podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), required
 
-  Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+  podSelector selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
 -->
 - **podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)，必需
   
@@ -81,11 +81,11 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 <!--
 - **policyTypes** ([]string)
 
-  List of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+  policyTypes is a list of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of ingress or egress rules; policies that contain an egress section are assumed to affect egress, and all policies (whether or not they contain an ingress section) are assumed to affect ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
 -->
 - **policyTypes** ([]string)
 
-  NetworkPolicy 相关的规则类型列表。有效选项为 `[“Ingress”]`、`[“Egress”]` 或 `[“Ingress”， “Egress”]`。
+  policyTypes 是 NetworkPolicy 相关的规则类型列表。有效选项为 `[“Ingress”]`、`[“Egress”]` 或 `[“Ingress”， “Egress”]`。
   如果不指定此字段，则默认值取决是否存在 Ingress 或 Egress 规则；规则里包含 Egress 部分的策略将会影响出站流量，
   并且所有策略（无论它们是否包含 Ingress 部分）都将会影响 入站流量。
   如果要仅定义出站流量策略，则必须明确指定 `[ "Egress" ]`。
@@ -95,26 +95,26 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 <!--
 - **ingress** ([]NetworkPolicyIngressRule)
 
-  List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+  ingress is a list of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
 
   <a name="NetworkPolicyIngressRule"></a>
   *NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.*
 -->
 - **ingress** ([]NetworkPolicyIngressRule)
 
-  定义所选 Pod 的入站规则列表。在没有被任何 NetworkPolicy 选择到 Pod 的情况下（同时假定集群策略允许对应流量），
+  ingress 是应用到所选 Pod 的入站规则列表。在没有被任何 NetworkPolicy 选择到 Pod 的情况下（同时假定集群策略允许对应流量），
   或者如果流量源是 Pod 的本地节点，或者流量与所有 NetworkPolicy 中的至少一个入站规则（Ingress) 匹配，
   则进入 Pod 的流量是被允许的。如果此字段为空，则此 NetworkPolicy 不允许任何入站流量
   （这种设置用来确保它所选择的 Pod 在默认情况下是被隔离的）。
 
   <a name="NetworkPolicyIngressRule"></a>
   **NetworkPolicyIngressRule 定义 NetworkPolicySpec 的 podSelector 所选 Pod 的入站规则的白名单列表，
-  流量必须同时匹配 ports 和 from 。**
+  流量必须同时匹配 ports 和 from。**
   
   <!--
   - **ingress.from** ([]NetworkPolicyPeer)
 
-    List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+    from is a list of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
 
     <a name="NetworkPolicyPeer"></a>
     *NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed*
@@ -122,7 +122,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
   - **ingress.from** ([]NetworkPolicyPeer)
 
-    流量来源列表，列表中的来源可以访问被此规则选中的 Pod。此列表中的流量来源使用逻辑或操作进行组合。
+    from 是流量来源列表，列表中的来源可以访问被此规则选中的 Pod。此列表中的流量来源使用逻辑或操作进行组合。
     如果此字段为空值或缺失（未设置），
     则此规则匹配所有流量来源（也即允许所有入站流量）。如果此字段存在并且至少包含一项来源，则仅当流量与来自列表中的至少一项匹配时，
     此规则才允许流量访问被选中的 Pod 集合。
@@ -133,7 +133,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **ingress.from.ipBlock** (IPBlock)
 
-      IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+      ipBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
 
       <a name="IPBlock"></a>
       *IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.*
@@ -141,26 +141,26 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
     - **ingress.from.ipBlock** (IPBlock)
 
-      IPBlock 针对特定的 IP CIDR 范围设置策略。如果设置了此字段，则不可以设置其他字段。
+      ipBlock 针对特定 IPBlock 定义策略。如果设置了此字段，则不可以设置其他字段。
 
       <a name="IPBlock"></a>
-      IPBlock 定义一个特定的 CIDR 范围（例如 `192.168.1.0/24`、`2001:db8::/64`），
+      **IPBlock 定义一个特定的 CIDR 范围（例如 `192.168.1.0/24`、`2001:db8::/64`），
       来自这个 IP 范围的流量来源将会被允许访问与 NetworkPolicySpec 的 podSelector 匹配的 Pod 集合。
-      except 字段则设置应排除在此规则之外的 CIDR 范围。
+      except 字段则设置应排除在此规则之外的 CIDR 范围。**
 
       <!--
       - **ingress.from.ipBlock.cidr** (string), required
 
-        CIDR is a string representing the IP Block Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+        cidr is a string representing the IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 
       - **ingress.from.ipBlock.except** ([]string)
 
-        Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.0/24" or "2001:db8::/64" Except values will be rejected if they are outside the CIDR range
+        except is a slice of CIDRs that should not be included within an IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64" Except values will be rejected if they are outside the cidr range
       -->
       
       - **ingress.from.ipBlock.cidr** (string)，必需
 
-        CIDR 是指定 IP 组块的字符串，例如 `"192.168.1.0/24"` 或 `"2001:db8::/64"`。
+        cidr 是表示 IP 组块的字符串，例如 `"192.168.1.0/24"` 或 `"2001:db8::/64"`。
 
       - **ingress.from.ipBlock.except** ([]string)
 
@@ -171,14 +171,14 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **ingress.from.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+      namespaceSelector selects namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
       
-      If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+      If podSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the namespaces selected by namespaceSelector. Otherwise it selects all pods in the namespaces selected by namespaceSelector.
     -->
 
     - **ingress.from.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      此选择器使用集群范围标签来选择特定的 Namespace。此字段遵循标准标签选择算符语义；
+      namespaceSelector 使用集群范围标签来选择特定的 Namespace。此字段遵循标准标签选择算符语义；
       如果此字段存在但为空值，则会选择所有名字空间。
       
       如果 podSelector 也被定义了, 那么 NetworkPolicyPeer 将选择那些同时满足 namespaceSelector
@@ -188,14 +188,14 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **ingress.from.podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+      podSelector is a label selector which selects pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
       
-      If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+      If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace.
     -->
 
     - **ingress.from.podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      这个标签选择算符负责选择 Pod。该字段遵循标准标签选择算符语义；如果字段存在但为空值，则选择所有 Pod。
+      podSelector 是负责选择 Pod 的标签选择算符。该字段遵循标准标签选择算符语义；如果字段存在但为空值，则选择所有 Pod。
 
       如果 namespaceSelector 也被定义，那么 NetworkPolicyPeer 将选择那些同时满足 namespaceSelector
       定义的名字空间下和 podSelector 规则匹配的 Pod。
@@ -204,7 +204,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
   <!--
   - **ingress.ports** ([]NetworkPolicyPort)
 
-    List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+    ports is a list of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
 
     <a name="NetworkPolicyPort"></a>
     *NetworkPolicyPort describes a port to allow traffic on*
@@ -212,7 +212,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
   - **ingress.ports** ([]NetworkPolicyPort)
 
-    定义在此规则选中的 Pod 上应可访问的端口列表。此列表中的个项目使用逻辑或操作组合。如果此字段为空或缺失，
+    ports 是在此规则选中的 Pod 上应可访问的端口列表。此列表中的个项目使用逻辑或操作组合。如果此字段为空或缺失，
     则此规则匹配所有端口（进入流量可访问任何端口）。
     如果此字段存在并且包含至少一个有效值，则此规则仅在流量至少匹配列表中的一个端口时才允许访问。
 
@@ -222,7 +222,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **ingress.ports.port** (IntOrString)
 
-      The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+      port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 
       <a name="IntOrString"></a>
       *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
@@ -230,58 +230,57 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
     - **ingress.ports.port** (IntOrString)
 
-      给定协议上的端口。字段值可以是 Pod 上的数字或命名端口。如果未提供此字段，则匹配所有端口名和端口号。
+      port 表示符合给定协议的端口。字段值可以是 Pod 上的数字或命名端口。如果未提供此字段，则匹配所有端口名和端口号。
       如果定义了，则仅允许对给定的协议和端口的入口流量。
 
       <a name="IntOrString"></a>
-      IntOrString 是一种可以包含 int32 或字符串值的类型。在 JSON 或 YAML 编组和解组中使用时，它会生成或使用内部类型。
-      例如，这允许你拥有一个可以接受名称或数字的 JSON 字段。
+      **IntOrString 是一种可以包含 int32 或字符串值的类型。在 JSON 或 YAML 编组和解组中使用时，它会生成或使用内部类型。
+      例如，这允许你拥有一个可以接受名称或数字的 JSON 字段。**
 
     <!--
     - **ingress.ports.endPort** (int32)
 
-      If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
+      endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
 
     - **ingress.ports.protocol** (string)
 
-      The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+      protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
     -->
 
     - **ingress.ports.endPort** (int32)
 
-      如果设置了此字段，则表明策略应该允许 port 与 endPort 之间（包含二者）的所有端口。
+      endPort 表示如果设置了此字段，则策略应该允许 port 与 endPort 之间（包含二者）的所有端口。
       如果未定义 port 或将 port 字段值为命名端口（字符串），则不可以使用 endPort。
       endPort 必须等于或大于 port 值。
 
     - **ingress.ports.protocol** (string)
 
-      流量必须匹配的网络协议（TCP、UDP 或 SCTP）。如果未指定，此字段默认为 TCP。
+      protocol 表示流量必须匹配的网络协议（TCP、UDP 或 SCTP）。如果未指定，此字段默认为 TCP。
 
 <!--
 - **egress** ([]NetworkPolicyEgressRule)
 
-  List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+  egress is a list of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
 
   <a name="NetworkPolicyEgressRule"></a>
   *NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8*
 -->
-
 - **egress** ([]NetworkPolicyEgressRule)
 
-  egress 定义所选 Pod 的出站规则的列表。如果没有 NetworkPolicy 选中指定 Pod（并且其他集群策略也允许出口流量），
+  egress 是应用到所选 Pod 的出站规则的列表。如果没有 NetworkPolicy 选中指定 Pod（并且其他集群策略也允许出口流量），
   或者在所有通过 podSelector 选中了某 Pod 的 NetworkPolicy 中，至少有一条出站规则与出站流量匹配，
   则该 Pod 的出站流量是被允许的。
   如果此字段为空，则此 NetworkPolicy 拒绝所有出站流量（这策略可以确保它所选中的 Pod 在默认情况下是被隔离的）。
   egress 字段在 1.8 中为 Beta 级别。
 
   <a name="NetworkPolicyEgressRule"></a>
-  NetworkPolicyEgressRule 针对被 NetworkPolicySpec 的 podSelector 所选中 Pod，描述其被允许的出站流量。
-  流量必须同时匹配 ports 和 to 设置。此类型在 1.8 中为 Beta 级别。
+  **NetworkPolicyEgressRule 针对被 NetworkPolicySpec 的 podSelector 所选中 Pod，描述其被允许的出站流量。
+  流量必须同时匹配 ports 和 to 设置。此类型在 1.8 中为 Beta 级别。**
 
   <!--
   - **egress.to** ([]NetworkPolicyPeer)
 
-    List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+    to is a list of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
 
     <a name="NetworkPolicyPeer"></a>
     *NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed*
@@ -289,7 +288,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
   - **egress.to** ([]NetworkPolicyPeer)
 
-    针对此规则所选择的 Pod 的出口流量的目的地列表。此列表中的目的地使用逻辑或操作进行组合。如果此字段为空或缺失，
+    to 是针对此规则所选择的 Pod 的出口流量的目的地列表。此列表中的目的地使用逻辑或操作进行组合。如果此字段为空或缺失，
     则此规则匹配所有目的地（流量不受目的地限制）。如果此字段存在且至少包含一项目的地，则仅当流量与目标列表中的至少一个匹配时，
     此规则才允许出口流量。
 
@@ -299,7 +298,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **egress.to.ipBlock** (IPBlock)
 
-      IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+      ipBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
 
       <a name="IPBlock"></a>
       *IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.*
@@ -317,16 +316,16 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
       <!--
       - **egress.to.ipBlock.cidr** (string), required
 
-        CIDR is a string representing the IP Block Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+        cidr is a string representing the IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 
       - **egress.to.ipBlock.except** ([]string)
 
-        Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.0/24" or "2001:db8::/64" Except values will be rejected if they are outside the CIDR range
+        except is a slice of CIDRs that should not be included within an IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64" Except values will be rejected if they are outside the cidr range
       -->
 
       - **egress.to.ipBlock.cidr** (string)，必需
 
-        CIDR 是用来表达 IP 组块的字符串，例如 `"192.168.1.0/24"` 或 `"2001:db8::/64"`。
+        cidr 是用来表达 IP 组块的字符串，例如 `"192.168.1.0/24"` 或 `"2001:db8::/64"`。
 
       - **egress.to.ipBlock.except** ([]string)
 
@@ -336,31 +335,31 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **egress.to.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+      namespaceSelector selects namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
       
-      If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+      If podSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the namespaces selected by namespaceSelector. Otherwise it selects all pods in the namespaces selected by namespaceSelector.
     -->
 
     - **egress.to.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      此选择算符使用集群范围标签来选择特定的名字空间。该字段遵循标准标签选择算符语义；
+      namespaceSelector 使用集群范围标签来选择特定的名字空间。该字段遵循标准标签选择算符语义；
       如果字段存在但为空值，那会选择所有名字空间。
       
-      如果 egress.to.podSelector 也被定义了, 那么 NetworkPolicyPeer 将选择那些同时满足 namespaceSelector
+      如果 podSelector 也被定义了, 那么 NetworkPolicyPeer 将选择那些同时满足 namespaceSelector
       指定的名字空间下和 podSelector 规则匹配的 Pod。
       反之选择 namespaceSelector 指定的名字空间下所有的 Pod。
 
     <!--
     - **egress.to.podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+      podSelector is a label selector which selects pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
       
-      If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+      If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace.
     -->
 
     - **egress.to.podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
-      这个标签选择器负责选择一组 Pod。该字段遵循标准标签选择算符语义；
+      podSelector 是负责选择一组 Pod 的标签选择算符。该字段遵循标准标签选择算符语义；
       如果字段存在但为空值，则选择所有 Pod。
 
       如果 egress.to.namespaceSelector 也被定义，则 NetworkPolicyPeer 将选择 namespaceSelector
@@ -370,7 +369,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
   <!--
   - **egress.ports** ([]NetworkPolicyPort)
 
-    List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+    ports is a list of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
 
     <a name="NetworkPolicyPort"></a>
     *NetworkPolicyPort describes a port to allow traffic on*
@@ -378,7 +377,7 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
   - **egress.ports** ([]NetworkPolicyPort)
 
-    出站流量目的地的端口列表。此列表中的各个项目使用逻辑或操作进行组合。如果此字段为空或缺失，
+    ports 是出站流量目的地的端口列表。此列表中的各个项目使用逻辑或操作进行组合。如果此字段为空或缺失，
     则此规则匹配所有端口（可访问出口流量目的地的任何端口）。如果此字段存在并且包含至少一个有效值，
     则此规则仅在流量与列表中的至少一个端口匹配时才允许访问。
 
@@ -388,29 +387,30 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
     <!--
     - **egress.ports.port** (IntOrString)
 
-      The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+      port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 
       <a name="IntOrString"></a>
       *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
-
-    - **egress.ports.endPort** (int32)
-
-      If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
-
-    - **egress.ports.protocol** (string)
-
-      The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
     -->
 
     - **egress.ports.port** (IntOrString)
 
-      给定协议上的端口。字段值可以是 Pod 上的数字或命名端口。如果未提供此字段，则匹配所有端口名和端口号。
+      port 表示符合给定协议的端口。字段值可以是 Pod 上的数字或命名端口。如果未提供此字段，则匹配所有端口名和端口号。
       如果定义此字段，则仅允许针对给定的协议和端口的出站流量。
 
       <a name="IntOrString"></a>
-      IntOrString 是一种可以包含 int32 或字符串值的类型。在 JSON 或 YAML 编组和解组中使用时，它会生成或使用内部类型。
-      例如，这允许你拥有一个可以接受名称或数字的 JSON 字段。
+      **IntOrString 是一种可以包含 int32 或字符串值的类型。在 JSON 或 YAML 编组和解组中使用时，它会生成或使用内部类型。
+      例如，这允许你拥有一个可以接受名称或数字的 JSON 字段。**
 
+    <!--
+    - **egress.ports.endPort** (int32)
+
+      endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
+
+    - **egress.ports.protocol** (string)
+
+      protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+    -->
     - **egress.ports.endPort** (int32)
 
       如果设置了 endPort，则用来指定策略所允许的从 port 到 endPort 的端口范围（包含边界值）。
@@ -419,14 +419,13 @@ NetworkPolicySpec 定义特定 NetworkPolicy 所需的所有信息.
 
     - **egress.ports.protocol** (string)
 
-      流量必须匹配的网络协议（TCP、UDP 或 SCTP）。如果未指定，此字段默认为 TCP。
+      protocol 表示流量必须匹配的网络协议（TCP、UDP 或 SCTP）。如果未指定，此字段默认为 TCP。
 
 ## NetworkPolicyStatus {#NetworkPolicyStatus}
 
 <!--
-NetworkPolicyStatus describe the current state of the NetworkPolicy.
+NetworkPolicyStatus describes the current state of the NetworkPolicy.
 -->
-
 NetworkPolicyStatus 描述有关此 NetworkPolicy 的当前状态。
 
 <hr>
@@ -438,7 +437,7 @@ NetworkPolicyStatus 描述有关此 NetworkPolicy 的当前状态。
   
   *Map: unique values on key type will be kept during a merge*
   
-  Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state
+  conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state
 
   <a name="Condition"></a>
   *Condition contains details for one aspect of the current state of this API Resource.*
@@ -549,13 +548,13 @@ NetworkPolicyList 是 NetworkPolicy 的集合。
 
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
 
-  标准的对象元数据。
-  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata。
+  标准的对象元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata。
 
 <!--
 - **items** ([]<a href="{{< ref "../policy-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>), required
 
-  Items is a list of schema objects.
+  items is a list of schema objects.
 -->
 
 - **items** ([]<a href="{{< ref "../policy-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>)，必需
@@ -767,6 +766,15 @@ GET /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 <!-- 
 - **timeoutSeconds** (*in query*): integer
 
@@ -881,6 +889,15 @@ GET /apis/networking.k8s.io/v1/networkpolicies
 - **resourceVersionMatch** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!-- 
 - **timeoutSeconds** (*in query*): integer
@@ -1470,6 +1487,10 @@ s
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 - **timeoutSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -1520,6 +1541,10 @@ s
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 - **timeoutSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -1532,4 +1557,3 @@ s
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
 401: Unauthorized
-


### PR DESCRIPTION
Sync with en text:

```
content/zh-cn/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
```
See [preview](https://deploy-preview-40891--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) please.