### PR TITLE
solve the issue StatefulSetAutoDeletePVC introduction version should be 1.23

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -201,7 +201,7 @@ For a reference to old feature gates that are removed, please refer to
 | `SizeMemoryBackedVolumes` | `false` | Alpha | 1.20 | 1.21 |
 | `SizeMemoryBackedVolumes` | `true` | Beta | 1.22 | |
 | `StableLoadBalancerNodeGet` | `true` | Beta | 1.27 | |
-| `StatefulSetAutoDeletePVC` | `false` | Alpha | 1.22 | 1.26 |
+| `StatefulSetAutoDeletePVC` | `false` | Alpha | 1.23 | 1.26 |
 | `StatefulSetAutoDeletePVC` | `false` | Beta | 1.27 | |
 | `StatefulSetStartOrdinal` | `false` | Alpha | 1.26 | 1.26 |
 | `StatefulSetStartOrdinal` | `true` | Beta | 1.27 | |


### PR DESCRIPTION
Problem:
On:
https://github.com/kubernetes/website/blob/main/content/en/docs/reference/command-line-tools-reference/feature-gates.md?plain=1#L204

StatefulSetAutoDeletePVC is listed as being introduced in 1.22, however it was introduced in 1.23: https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/

Proposed Solution:

Update it to 1.23

Page to Update:
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

