### PR TITLE
Add Kubernetes version information to the kubectl cheat sheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -18,7 +18,6 @@ This page contains a list of commonly used `kubectl` commands and flags.
 {{< note >}}
 These instructions are for Kubernetes v{{< skew currentVersion >}}. To check the version, use the `kubectl version` command.
 {{< /note >}}
-
 <!-- body -->
 
 ## Kubectl autocomplete

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -15,6 +15,7 @@ card:
 
 This page contains a list of commonly used `kubectl` commands and flags.
 
+These instructions are for Kubernetes {{< skew currentVersion >}}. To check the version, use the `kubectl version` command.
 <!-- body -->
 
 ## Kubectl autocomplete
@@ -85,7 +86,7 @@ kubectl config set-context gce --user=cluster-admin --namespace=foo \
 
 kubectl config unset users.foo                       # delete user foo
 
-# short alias to set/show context/namespace (only works for bash and bash-compatible shells, current context to be set before using kn to set namespace) 
+# short alias to set/show context/namespace (only works for bash and bash-compatible shells, current context to be set before using kn to set namespace)
 alias kx='f() { [ "$1" ] && kubectl config use-context $1 || kubectl config current-context ; } ; f'
 alias kn='f() { [ "$1" ] && kubectl config set-context --current --namespace $1 || kubectl config view --minify | grep namespace | cut -d" " -f6 ; } ; f'
 ```

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -15,7 +15,10 @@ card:
 
 This page contains a list of commonly used `kubectl` commands and flags.
 
-These instructions are for Kubernetes {{< skew currentVersion >}}. To check the version, use the `kubectl version` command.
+{{< note >}}
+These instructions are for Kubernetes v{{< skew currentVersion >}}. To check the version, use the `kubectl version` command.
+{{< /note >}}
+
 <!-- body -->
 
 ## Kubectl autocomplete


### PR DESCRIPTION
Adds a comment to the kubectl cheat sheet that indicates that this is relevant for the current version of Kubernetes. Fixes #40582 