### PR TITLE
Add links between Securing a Cluster and Security Checklist for alignment

### DIFF
--- a/content/en/docs/concepts/security/security-checklist.md
+++ b/content/en/docs/concepts/security/security-checklist.md
@@ -423,6 +423,8 @@ alpha state but could be considered for certain use cases:
 
 - [RBAC Good Practices](/docs/concepts/security/rbac-good-practices/) for
   further information on authorization.
+- [Securing a Cluster](/docs/tasks/administer-cluster/securing-a-cluster/) for
+  information on protecting a cluster from accidental or malicious access.
 - [Cluster Multi-tenancy guide](/docs/concepts/security/multi-tenancy/) for
   configuration options recommendations and best practices on multi-tenancy.
 - [Blog post "A Closer Look at NSA/CISA Kubernetes Hardening Guidance"](/blog/2021/10/05/nsa-cisa-kubernetes-hardening-guidance/#building-secure-container-images)

--- a/content/en/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -224,7 +224,7 @@ The shorter the lifetime of a secret or credential the harder it is for an attac
 use of that credential. Set short lifetimes on certificates and automate their rotation. Use
 an authentication provider that can control how long issued tokens are available and use short
 lifetimes where possible. If you use service-account tokens in external integrations, plan to
-rotate those tokens frequently. For example, once the bootstrap phase is complete, a bootstrap 
+rotate those tokens frequently. For example, once the bootstrap phase is complete, a bootstrap
 token used for setting up nodes should be revoked or its authorization removed.
 
 ### Review third party integrations before enabling them
@@ -255,7 +255,7 @@ and may grant an attacker significant visibility into the state of your cluster.
 your backups using a well reviewed backup and encryption solution, and consider using full disk
 encryption where possible.
 
-Kubernetes supports optional [encryption at rest](/docs/tasks/administer-cluster/encrypt-data/) for information in the Kubernetes API. 
+Kubernetes supports optional [encryption at rest](/docs/tasks/administer-cluster/encrypt-data/) for information in the Kubernetes API.
 This lets you ensure that when Kubernetes stores data for objects (for example, `Secret` or
 `ConfigMap` objects), the API server writes an encrypted representation of the object.
 That encryption means that even someone who has access to etcd backup data is unable
@@ -272,3 +272,6 @@ group for emails about security announcements. See the
 page for more on how to report vulnerabilities.
 
 
+## What's next
+
+- [Security Checklist](/docs/concepts/security/security-checklist/) for additional information on Kubernetes security guidance.


### PR DESCRIPTION
Link documents [Securing a Cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/) (task) with [Security Checklist](https://kubernetes.io/docs/concepts/security/security-checklist/) (concept) for alignment. Fixes #37738 