### PR TITLE
add link for kubelet and cloud-controller-manager

### DIFF
--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -12,7 +12,7 @@ tags:
 - operation
 ---
  A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component
-that embeds cloud-specific control logic. The cloud controller manager lets you link your
+that embeds cloud-specific control logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your
 cluster into your cloud provider's API, and separates out the components that interact
 with that cloud platform from components that only interact with your cluster.
 

--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -12,8 +12,8 @@ tags:
 - operation
 ---
 A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that embeds cloud-specific control logic. 
-The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your cluster into your cloud provider's API, 
-and separates out the components that interact with that cloud platform from components that 
+The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your cluster into your cloud provider's API,
+and separates out the components that interact with that cloud platform from components that
 only interact with your cluster.
 
 <!--more-->

--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -11,10 +11,10 @@ tags:
 - architecture
 - operation
 ---
-A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that 
-embeds cloud-specific control logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your
-cluster into your cloud provider's API, and separates out the components that interact with that 
-cloud platform from components that only interact with your cluster.
+A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that embeds cloud-specific control logic. 
+The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your cluster into your cloud provider's API, 
+and separates out the components that interact with that cloud platform from components that 
+only interact with your cluster.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -11,10 +11,10 @@ tags:
 - architecture
 - operation
 ---
- A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component
-that embeds cloud-specific control logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your
-cluster into your cloud provider's API, and separates out the components that interact
-with that cloud platform from components that only interact with your cluster.
+A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that 
+embeds cloud-specific control logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your
+cluster into your cloud provider's API, and separates out the components that interact with that 
+cloud platform from components that only interact with your cluster.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -11,10 +11,10 @@ tags:
 - architecture
 - operation
 ---
-A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that embeds cloud-specific control logic. 
-The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your cluster into your cloud provider's API,
-and separates out the components that interact with that cloud platform from components that
-only interact with your cluster.
+A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that embeds cloud-specific control 
+logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your cluster into your cloud
+provider's API, and separates out the components that interact with that cloud 
+platform from components that only interact with your cluster.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -11,10 +11,10 @@ tags:
 - architecture
 - operation
 ---
-A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component that embeds cloud-specific control 
-logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your cluster into your cloud
-provider's API, and separates out the components that interact with that cloud 
-platform from components that only interact with your cluster.
+ A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component
+that embeds cloud-specific control logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/) lets you link your
+cluster into your cloud provider's API, and separates out the components that interact
+with that cloud platform from components that only interact with your cluster.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/kubelet.md
+++ b/content/en/docs/reference/glossary/kubelet.md
@@ -14,4 +14,4 @@ tags:
 
 <!--more-->
 
-The kubelet takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.
+The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.

--- a/content/en/docs/reference/glossary/kubelet.md
+++ b/content/en/docs/reference/glossary/kubelet.md
@@ -14,4 +14,8 @@ tags:
 
 <!--more-->
 
-The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.
+
+The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) takes a set of PodSpecs that 
+are provided through various mechanisms and ensures that the containers described in those 
+PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by 
+Kubernetes.


### PR DESCRIPTION
cloud-controller-manager and kubelet glossary files has been updated with corresponding links
Issue: https://github.com/kubernetes/website/issues/40820