### PR TITLE
fixup to kube-proxy/kubelet skew requirement fix

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -177,5 +177,4 @@ Example:
 
 If `kube-proxy` version is **{{< skew currentVersionAddMinor -2 >}}**:
 
-* `kubelet` version must be at the same minor version as **{{< skew currentVersionAddMinor -2 >}}**.
 * `kube-apiserver` version must be between **{{< skew currentVersionAddMinor -2 >}}** and **{{< skew currentVersion >}}**, inclusive.


### PR DESCRIPTION
followup to https://github.com/kubernetes/website/pull/40672/files; I removed the _rule_ about kube-proxy/kubelet versioning, but missed that there was an example of that rule as well