### PR TITLE
Update taint-and-toleration.md

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -129,8 +129,8 @@ toleration matching the third taint. But it will be able to continue running if 
 already running on the node when the taint is added, because the third taint is the only
 one of the three that is not tolerated by the pod.
 
-Normally, if a taint with effect `NoExecute` is added to a node, then any pods that do
-not tolerate the taint will be evicted immediately, and pods that do tolerate the
+Normally, if a taint with effect `NoExecute` is added to a node, then any pods that 
+do not tolerate the taint will be _deleted_ immediately, and pods that do tolerate the
 taint will never be evicted. However, a toleration with `NoExecute` effect can specify
 an optional `tolerationSeconds` field that dictates how long the pod will stay bound
 to the node after the taint is added. For example,


### PR DESCRIPTION
Solved issue :- #40839
Problem:

This is in regards to this page: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

There, one can read Normally, if a taint with effect NoExecute is added to a node, then any pods that do not tolerate the taint will be evicted immediately [...]

Proposed Solution:

Reword the passage to then any pods that do not tolerate the taint will be _deleted_ immediately as it doesn't seem that any kind of eviction is happening.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
