### PR TITLE
[zh] resync page horizontal-pod-autoscaler-v1

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1.md
@@ -61,21 +61,21 @@ configuration of a horizontal pod autoscaler.
 <!--
 - **spec** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
 
-  behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+  spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 -->
 - **spec** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
 
-  自动缩放器的规约。
+  `spec` 定义自动缩放器的规约。
   更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 
 <!--
 - **status** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
 
-  current information about the autoscaler.
+  status is the current information about the autoscaler.
 -->
 - **status** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
 
-  自动缩放器的当前信息。
+  `status` 是自动缩放器的当前信息。
 
 <!--
 ## HorizontalPodAutoscalerSpec {#HorizontalPodAutoscalerSpec}
@@ -93,11 +93,11 @@ specification of a horizontal pod autoscaler.
 <!--
 - **maxReplicas** (int32), required
 
-  upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+  maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 -->
 - **maxReplicas** (int32)，必填
 
-  自动扩缩器可以设置的 Pod 数量上限；
+  `maxReplicas` 是自动扩缩器可以设置的 Pod 数量上限；
   不能小于 minReplicas。
 
 <!--
@@ -109,7 +109,7 @@ specification of a horizontal pod autoscaler.
 
   对被扩缩资源的引用；
   水平 Pod 自动缩放器将了解当前的资源消耗，并使用其 scale 子资源设置所需的 Pod 数量。
-  
+
   <!--
   <a name="CrossVersionObjectReference"></a>
   *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
@@ -120,41 +120,39 @@ specification of a horizontal pod autoscaler.
   <!--
   - **scaleTargetRef.kind** (string), required
 
-    Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+    kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   -->
-  
+
   - **scaleTargetRef.kind** (string)，必填
 
-    被引用对象的类别；
+    `kind` 是被引用对象的类别；
     更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
   <!--
   - **scaleTargetRef.name** (string), required
 
-    Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names  
+    name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
   -->
-  
+
   - **scaleTargetRef.name** (string)，必填
 
-    被引用对象的名称；
-    更多信息： http://kubernetes.io/docs/user-guide/identifiers#names
+    `name` 是被引用对象的名称；
+    更多信息： https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 
   <!--
-    - **scaleTargetRef.apiVersion** (string)
-  
-      API version of the referent
-  -->
-  
   - **scaleTargetRef.apiVersion** (string)
 
-    被引用对象的 API 版本。
+    apiVersion is the API version of the referent
+  -->
+
+  - **scaleTargetRef.apiVersion** (string)
+
+    `apiVersion` 是被引用对象的 API 版本。
 
 <!--
 - **minReplicas** (int32)
 
-  minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod. 
-  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  
-  Scaling is active as long as at least one metric value is available.
+  minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
 -->
 - **minReplicas** (int32)
 
@@ -167,12 +165,11 @@ specification of a horizontal pod autoscaler.
 <!--
 - **targetCPUUtilizationPercentage** (int32)
 
-  target average CPU utilization (represented as a percentage of requested CPU) over all the pods; 
-  if not specified the default autoscaling policy will be used.
+  targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
 -->
 - **targetCPUUtilizationPercentage** (int32)
 
-  所有 Pod 的目标平均 CPU 利用率（以请求 CPU 的百分比表示）；
+  `targetCPUUtilizationPercentage` 是所有 Pod 的目标平均 CPU 利用率（以请求 CPU 的百分比表示）；
   如果未指定，将使用默认的自动缩放策略。
 
 <!--
@@ -191,45 +188,45 @@ current status of a horizontal pod autoscaler
 <!--
 - **currentReplicas** (int32), required
 
-  current number of replicas of pods managed by this autoscaler.
+  currentReplicas is the current number of replicas of pods managed by this autoscaler.
 -->
 - **currentReplicas** (int32)，必填
 
-  此自动缩放器管理的 Pod 的当前副本数。
+  `currentReplicas` 是此自动缩放器管理的 Pod 的当前副本数。
 
 <!--
 - **desiredReplicas** (int32), required
 
-  desired number of replicas of pods managed by this autoscaler.
+  desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.
 -->
 - **desiredReplicas** (int32)，必填
 
-  此自动缩放器管理的 Pod 副本的所需数量。
+  `desiredReplicas` 是此自动缩放器管理的 Pod 副本的所需数量。
 
 <!--
 - **currentCPUUtilizationPercentage** (int32)
 
-  current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.
+  currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.
 -->
 - **currentCPUUtilizationPercentage** (int32)
 
-  当前所有 Pod 的平均 CPU 利用率，
+  `currentCPUUtilizationPercentage` 是当前所有 Pod 的平均 CPU 利用率，
   以请求 CPU 的百分比表示，
   例如：70 表示平均 Pod 现在正在使用其请求 CPU 的 70%。
 
 <!--
 - **lastScaleTime** (Time)
 
-  last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
+  lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
 -->
 - **lastScaleTime** (Time)
 
-  上次 HorizontalPodAutoscaler 缩放 Pod 的数量；
+  `lastScaleTime` 是上次 HorizontalPodAutoscaler 缩放 Pod 的数量；
   自动缩放器用它来控制 Pod 数量的更改频率。
-  
+
   <!--
   <a name="Time"></a>
-    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
   -->
   <a name="Time"></a>
   **Time 是 time.Time 的包装类，支持正确地序列化为 YAML 和 JSON。
@@ -238,11 +235,11 @@ current status of a horizontal pod autoscaler
 <!--
 - **observedGeneration** (int64)
 
-  most recent generation observed by this autoscaler.
+  observedGeneration is the most recent generation observed by this autoscaler.
 -->
 - **observedGeneration** (int64)
 
-  此自动缩放器观察到的最新一代。
+  `observedGeneration` 是此自动缩放器观察到的最新一代。
 
 <!--
 ## HorizontalPodAutoscalerList {#HorizontalPodAutoscalerList}
@@ -278,11 +275,11 @@ list of horizontal pod autoscaler objects.
 <!--
 - **items** ([]<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>), required
 
-  list of horizontal pod autoscaler objects.
+  items is the list of horizontal pod autoscaler objects.
 -->
 - **items** ([]<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>), required
 
-  水平 Pod 自动缩放器对象的列表。
+  `items` 是水平 Pod 自动缩放器对象的列表。
 
 <!--
 ## Operations {#Operations}
@@ -341,10 +338,6 @@ GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -399,10 +392,6 @@ GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -511,6 +500,15 @@ GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
 <!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** （**查询参数**）： boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
+<!--
 - **timeoutSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -530,10 +528,6 @@ GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerList" >}}">HorizontalPodAutoscalerList</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -632,6 +626,15 @@ GET /apis/autoscaling/v1/horizontalpodautoscalers
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
 <!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** （**查询参数**）： boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
+<!--
 - **timeoutSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -651,10 +654,6 @@ GET /apis/autoscaling/v1/horizontalpodautoscalers
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerList" >}}">HorizontalPodAutoscalerList</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -732,14 +731,6 @@ POST /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-201 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
-
-202 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Accepted
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -755,8 +746,6 @@ POST /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
 ### `update` replace the specified HorizontalPodAutoscaler
 
 #### HTTP Request
-
-PUT /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
 -->
 ### `update` 替换特定的 HorizontalPodAutoscaler
 
@@ -830,12 +819,6 @@ PUT /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-201 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -924,12 +907,6 @@ PUT /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-201 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -1027,12 +1004,6 @@ PATCH /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-201 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -1130,12 +1101,6 @@ PATCH /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
-
-201 (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -1224,12 +1189,6 @@ DELETE /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{nam
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
-
-202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
-
-401: Unauthorized
 -->
 #### 响应
 
@@ -1362,6 +1321,15 @@ DELETE /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
 <!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** （**查询参数**）： boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
+<!--
 - **timeoutSeconds** (*in query*): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -1372,10 +1340,6 @@ DELETE /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
 
 <!--
 #### Response
-
-200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
-
-401: Unauthorized
 -->
 #### 响应
 


### PR DESCRIPTION
This PR resyncs page `horizontal-pod-autoscaler-v1` referring to en upstram.

By the way, I removed some `response` sections which are not changed while translating.