### PR TITLE
[zh] resync page horizontal-pod-autoscaler-v2

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2.md
@@ -44,7 +44,7 @@ HorizontalPodAutoscaler 是水平 Pod 自动扩缩器的配置，
   <!--
   metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   -->
-  
+
   metadata 是标准的对象元数据。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
@@ -52,15 +52,15 @@ HorizontalPodAutoscaler 是水平 Pod 自动扩缩器的配置，
   <!--
   spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   -->
-  
+
   spec 是自动扩缩器行为的规约。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 
 - **status** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
-  
+
   <!--
   status is the current information about the autoscaler.
   -->
-  
+
   status 是自动扩缩器的当前信息。
 
 ## HorizontalPodAutoscalerSpec {#HorizontalPodAutoscalerSpec}
@@ -99,34 +99,35 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
   - **scaleTargetRef.kind** (string), required
 
-    Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+    kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   -->
-  
+
   **CrossVersionObjectReference 包含足够的信息来让你识别出所引用的资源。**
 
   - **scaleTargetRef.kind** (string)，必需
 
-    被引用对象的类别；更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+    `kind` 是被引用对象的类别；更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
   <!--
   - **scaleTargetRef.name** (string), required
 
-    Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+    name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
   -->
 
   - **scaleTargetRef.name** (string)，必需
 
-    被引用对象的名称；更多信息： https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/names/#names
+    `name` 是被引用对象的名称；更多信息：https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/names/#names
 
   <!--
   - **scaleTargetRef.apiVersion** (string)
 
-    API version of the referent
+    apiVersion is the API version of the referent
+
   -->
-  
+
   - **scaleTargetRef.apiVersion** (string)
 
-    被引用对象的 API 版本。
+    `apiVersion` 是被引用对象的 API 版本。
 
 <!--
 - **minReplicas** (int32)
@@ -160,7 +161,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
     scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
   -->
-  
+
   **HorizontalPodAutoscalerBehavior 配置目标在扩容（Up）和缩容（Down）两个方向的扩缩行为
   （分别用 scaleUp 和 scaleDown 字段）。**
 
@@ -170,27 +171,27 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
     具有 300 秒的稳定窗口（使用最近 300 秒的最高推荐值）。
 
     <a name="HPAScalingRules"></a>
-  
+
     <!--
     *HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.*
 
     - **behavior.scaleDown.policies** ([]HPAScalingPolicy)
 
       *Atomic: will be replaced during a merge*
-      
+
       policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
     -->
-    
+
     HPAScalingRules 为一个方向配置扩缩行为。在根据 HPA 的指标计算 desiredReplicas 后应用这些规则。
     可以通过指定扩缩策略来限制扩缩速度。可以通过指定稳定窗口来防止抖动，
-    因此不会立即设置副本数，而是选择稳定窗口中最安全的值。 
+    因此不会立即设置副本数，而是选择稳定窗口中最安全的值。
 
     - **behavior.scaleDown.policies** ([]HPAScalingPolicy)
-    
+
       **原子性：将在合并时被替换**
 
       policies 是可在扩缩容过程中使用的潜在扩缩策略的列表。必须至少指定一个策略，否则 HPAScalingRules 将被视为无效而丢弃。
-  
+
       <a name="HPAScalingPolicy"></a>
 
       <!--
@@ -198,52 +199,53 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       - **behavior.scaleDown.policies.type** (string), required
 
-        Type is used to specify the scaling policy.
+        type is used to specify the scaling policy.
       -->
-      
+
       **HPAScalingPolicy 是一个单一的策略，它必须在指定的过去时间间隔内保持为 true。**
 
       - **behavior.scaleDown.policies.type** (string)，必需
 
         type 用于指定扩缩策略。
-      
+
       <!--
       - **behavior.scaleDown.policies.value** (int32), required
 
-        Value contains the amount of change which is permitted by the policy. It must be greater than zero
+        value contains the amount of change which is permitted by the policy. It must be greater than zero
       -->
-      
+
       - **behavior.scaleDown.policies.value** (int32)，必需
 
         value 包含策略允许的更改量。它必须大于零。
-  
+
       <!--
       - **behavior.scaleDown.policies.periodSeconds** (int32), required
 
-        PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+        periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
       -->
-      
+
       - **behavior.scaleDown.policies.periodSeconds** (int32)，必需
 
         periodSeconds 表示策略应该保持为 true 的时间窗口长度。
         periodSeconds 必须大于零且小于或等于 1800（30 分钟）。
-  
+
     <!--
     - **behavior.scaleDown.selectPolicy** (string)
 
       selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.
     -->
-    
+
     - **behavior.scaleDown.selectPolicy** (string)
 
       selectPolicy 用于指定应该使用哪个策略。如果未设置，则使用默认值 Max。
 
-    <!--  
+    <!--
     - **behavior.scaleDown.stabilizationWindowSeconds** (int32)
 
-      StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+      stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+
     -->
-    
+
     - **behavior.scaleDown.stabilizationWindowSeconds** (int32)
 
       stabilizationWindowSeconds 是在扩缩容时应考虑的之前建议的秒数。stabilizationWindowSeconds
@@ -251,7 +253,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       - 扩容：0（不设置稳定窗口）。
       - 缩容：300（即稳定窗口为 300 秒）。
-  
+
   <!--
   - **behavior.scaleUp** (HPAScalingRules)
 
@@ -260,7 +262,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
       * double the number of pods per 60 seconds
     No stabilization is used.
   -->
-  
+
   - **behavior.scaleUp** (HPAScalingRules)
 
     scaleUp 是用于扩容的扩缩策略。如果未设置，则默认值为以下值中的较高者：
@@ -271,17 +273,17 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
     不使用稳定窗口。
 
     <a name="HPAScalingRules"></a>
-  
+
     <!--
     *HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.*
 
     - **behavior.scaleUp.policies** ([]HPAScalingPolicy)
 
       *Atomic: will be replaced during a merge*
-      
+
       policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
     -->
-    
+
     HPAScalingRules 为一个方向配置扩缩行为。在根据 HPA 的指标计算 desiredReplicas 后应用这些规则。
     可以通过指定扩缩策略来限制扩缩速度。可以通过指定稳定窗口来防止抖动，
     因此不会立即设置副本数，而是选择稳定窗口中最安全的值。
@@ -293,37 +295,36 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
       policies 是可在扩缩容过程中使用的潜在扩缩策略的列表。必须至少指定一个策略，否则 HPAScalingRules 将被视为无效而丢弃。
 
       <a name="HPAScalingPolicy"></a>
-    
+
       <!--
       *HPAScalingPolicy is a single policy which must hold true for a specified past interval.*
 
       - **behavior.scaleUp.policies.type** (string), required
 
-        Type is used to specify the scaling policy.
+        type is used to specify the scaling policy.
       -->
-      
+
       **HPAScalingPolicy 是一个单一的策略，它必须在指定的过去时间间隔内保持为 true。**
 
       - **behavior.scaleUp.policies.type** (string)，必需
 
         type 用于指定扩缩策略。
-      
+
       <!--
       - **behavior.scaleUp.policies.value** (int32), required
 
-        Value contains the amount of change which is permitted by the policy. It must be greater than zero
+        value contains the amount of change which is permitted by the policy. It must be greater than zero
       -->
-      
       - **behavior.scaleUp.policies.value** (int32)，必需
 
         value 包含策略允许的更改量。它必须大于零。
-      
+
       <!--
       - **behavior.scaleUp.policies.periodSeconds** (int32), required
 
-        PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+        periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
       -->
-      
+
       - **behavior.scaleUp.policies.periodSeconds** (int32)，必需
 
         periodSeconds 表示策略应该保持为 true 的时间窗口长度。
@@ -334,17 +335,18 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.
     -->
-    
+
     - **behavior.scaleUp.selectPolicy** (string)
 
       selectPolicy 用于指定应该使用哪个策略。如果未设置，则使用默认值 Max。
-    
+
     <!--
     - **behavior.scaleUp.stabilizationWindowSeconds** (int32)
 
-      StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+      stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+
     -->
-    
+
     - **behavior.scaleUp.stabilizationWindowSeconds** (int32)
 
       stabilizationWindowSeconds 是在扩缩容时应考虑的之前建议的秒数。stabilizationWindowSeconds
@@ -357,7 +359,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 - **metrics** ([]MetricSpec)
 
   *Atomic: will be replaced during a merge*
-  
+
   metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
 -->
 
@@ -375,13 +377,13 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
   <!--
   *MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).*
-
+  
   - **metrics.type** (string), required
-
+  
     type is the type of metric source.  It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
   -->
-  
-  **MetricSpec 指定如何基于单个指标进行扩缩容（一次只能设置 `type` 和一个其他匹配字段）** 
+
+  **MetricSpec 指定如何基于单个指标进行扩缩容（一次只能设置 `type` 和一个其他匹配字段）**
 
   - **metrics.type** (string)，必需
 
@@ -393,8 +395,8 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
     containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
   -->
-  
-  - **metrics.containerResource** (ContainerResourceMetricSource)  
+
+  - **metrics.containerResource** (ContainerResourceMetricSource)
 
     containerResource 是指 Kubernetes 已知的资源指标（例如在请求和限制中指定的那些），
     描述当前扩缩目标中每个 Pod 中的单个容器（例如 CPU 或内存）。
@@ -402,7 +404,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
     这是一个 Alpha 特性，可以通过 HPAContainerMetrics 特性标志启用。
 
     <a name="ContainerResourceMetricSource"></a>
-  
+
     <!--
     *ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.*
 
@@ -410,11 +412,11 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       container is the name of the container in the pods of the scaling target
     -->
-    
+
     ContainerResourceMetricSource 指示如何根据请求和限制中指定的 Kubernetes 已知的资源指标进行扩缩容，
     此结构描述当前扩缩目标中的每个 Pod（例如 CPU 或内存）。在与目标值比较之前，这些值先计算平均值。
     此类指标内置于 Kubernetes 中，并且在使用 “Pods” 源的、按 Pod 统计的普通指标之外支持一些特殊的扩缩选项。
-    只应设置一种 “target” 类别。 
+    只应设置一种 “target” 类别。
 
     - **metrics.containerResource.container** (string)，必需
 
@@ -425,23 +427,22 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       name is the name of the resource in question.
     -->
-    
     - **metrics.containerResource.name** (string)，必需
 
       name 是相关资源的名称。
-  
+
     <!--
     - **metrics.containerResource.target** (MetricTarget), required
 
       target specifies the target value for the given metric
     -->
-    
+
     - **metrics.containerResource.target** (MetricTarget)，必需
 
       target 指定给定指标的目标值。
-  
+
       <a name="MetricTarget"></a>
-    
+
       <!--
       *MetricTarget defines the target value, average value, or average utilization of a specific metric*
 
@@ -449,57 +450,57 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         type represents whether the metric type is Utilization, Value, or AverageValue
       -->
-      
+
       **MetricTarget 定义特定指标的目标值、平均值或平均利用率**
 
       - **metrics.containerResource.target.type** (string)，必需
 
         type 表示指标类别是 `Utilization`、`Value` 或 `AverageValue`。
-  
+
       <!--
       - **metrics.containerResource.target.averageUtilization** (int32)
 
         averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
       -->
-      
+
       - **metrics.containerResource.target.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 的资源指标均值的目标值，
         表示为 Pod 资源请求值的百分比。目前仅对 “Resource” 指标源类别有效。
-      
+
       <!--
       - **metrics.containerResource.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **metrics.containerResource.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         是跨所有相关 Pod 的指标均值的目标值（以数量形式给出）。
-  
+
       <!--
       - **metrics.containerResource.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value is the target value of the metric (as a quantity).
       -->
-      
+
       - **metrics.containerResource.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的目标值（以数量形式给出）。
-  
+
   <!--
   - **metrics.external** (ExternalMetricSource)
 
     external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
   -->
-  
+
   - **metrics.external** (ExternalMetricSource)
 
     external 指的是不与任何 Kubernetes 对象关联的全局指标。
     这一字段允许基于来自集群外部运行的组件（例如云消息服务中的队列长度，或来自运行在集群外部的负载均衡器的 QPS）的信息进行自动扩缩容。
 
     <a name="ExternalMetricSource"></a>
-  
+
     <!--
     *ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).*
 
@@ -507,16 +508,16 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       metric identifies the target metric by name and selector
     -->
-    
+
     ExternalMetricSource 指示如何基于 Kubernetes 对象无关的指标
     （例如云消息传递服务中的队列长度，或来自集群外部运行的负载均衡器的 QPS）执行扩缩操作。
 
     - **metrics.external.metric** (MetricIdentifier)，必需
 
       metric 通过名称和选择算符识别目标指标。
-  
+
       <a name="MetricIdentifier"></a>
-    
+
       <!--
       *MetricIdentifier defines the name and optionally selector for a metric*
 
@@ -524,37 +525,37 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         name is the name of the given metric
       -->
-      
+
       **MetricIdentifier 定义指标的名称和可选的选择算符**
 
       - **metrics.external.metric.name** (string)，必需
 
         name 是给定指标的名称。
-      
+
       <!--
       - **metrics.external.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
       -->
-      
+
       - **metrics.external.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector 是给定指标的标准 Kubernetes 标签选择算符的字符串编码形式。
         设置后，它作为附加参数传递给指标服务器，以获取更具体的指标范围。
         未设置时，仅 metricName 参数将用于收集指标。
-  
+
     <!--
     - **metrics.external.target** (MetricTarget), required
 
       target specifies the target value for the given metric
     -->
-    
+
     - **metrics.external.target** (MetricTarget)，必需
 
       target 指定给定指标的目标值。
-  
+
       <a name="MetricTarget"></a>
-    
+
       <!--
       *MetricTarget defines the target value, average value, or average utilization of a specific metric*
 
@@ -562,30 +563,30 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         type represents whether the metric type is Utilization, Value, or AverageValue
       -->
-      
+
       **MetricTarget 定义特定指标的目标值、平均值或平均利用率**
 
       - **metrics.external.target.type** (string)，必需
 
         type 表示指标类别是 `Utilization`、`Value` 或 `AverageValue`。
-  
+
       <!--
       - **metrics.external.target.averageUtilization** (int32)
 
         averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
       -->
-      
+
       - **metrics.external.target.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得到的资源指标均值的目标值，
         表示为 Pod 资源请求值的百分比。目前仅对 “Resource” 指标源类别有效。
-  
+
       <!--
       - **metrics.external.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **metrics.external.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有相关 Pod 得到的指标均值的目标值（以数量形式给出）。
@@ -595,7 +596,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         value is the target value of the metric (as a quantity).
       -->
-      
+
       - **metrics.external.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的目标值（以数量形式给出）。
@@ -605,13 +606,13 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
     object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
   -->
-  
+
   - **metrics.object** (ObjectMetricSource)
 
     object 是指描述单个 Kubernetes 对象的指标（例如，Ingress 对象上的 `hits-per-second`）。
 
     <a name="ObjectMetricSource"></a>
-  
+
     <!--
     *ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).*
 
@@ -619,61 +620,61 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       describedObject specifies the descriptions of a object,such as kind,name apiVersion
     -->
-    
+
     **ObjectMetricSource 表示如何根据描述 Kubernetes 对象的指标进行扩缩容（例如，Ingress 对象的 `hits-per-second`）**
 
     - **metrics.object.describedObject** (CrossVersionObjectReference)，必需
 
       describeObject 表示对象的描述，如对象的 `kind`、`name`、`apiVersion`。
-  
+
       <a name="CrossVersionObjectReference"></a>
-    
+
       <!--
       *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
 
       - **metrics.object.describedObject.kind** (string), required
 
-        Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
       -->
-      
+
       **CrossVersionObjectReference 包含足够的信息来让你识别所引用的资源。**
 
       - **metrics.object.describedObject.kind** (string)，必需
 
         被引用对象的类别；更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  
+
       <!--
       - **metrics.object.describedObject.name** (string), required
 
-        Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
       -->
-      
+
       - **metrics.object.describedObject.name** (string)，必需
-      
+
         被引用对象的名称；更多信息： https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/names/#names
-  
+
       <!--
       - **metrics.object.describedObject.apiVersion** (string)
 
-        API version of the referent
+        apiVersion is the API version of the referent
       -->
-      
+
       - **metrics.object.describedObject.apiVersion** (string)
-      
+
         被引用对象的 API 版本。
-      
+
     <!--
     - **metrics.object.metric** (MetricIdentifier), required
 
       metric identifies the target metric by name and selector
     -->
-    
+
     - **metrics.object.metric** (MetricIdentifier)，必需
 
       metric 通过名称和选择算符识别目标指标。
-  
+
       <a name="MetricIdentifier"></a>
-    
+
       <!--
       *MetricIdentifier defines the name and optionally selector for a metric*
 
@@ -681,19 +682,19 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         name is the name of the given metric
       -->
-      
+
       **MetricIdentifier 定义指标的名称和可选的选择算符**
 
       - **metrics.object.metric.name** (string)，必需
 
-        name 是给定指标的名称。 
-  
+        name 是给定指标的名称。
+
       <!--
       - **metrics.object.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
       -->
-      
+
       - **metrics.object.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector 是给定指标的标准 Kubernetes 标签选择算符的字符串编码形式。
@@ -705,13 +706,13 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       target specifies the target value for the given metric
     -->
-    
+
     - **metrics.object.target** (MetricTarget)，必需
 
       target 表示给定指标的目标值。
-  
+
       <a name="MetricTarget"></a>
-    
+
       <!--
       *MetricTarget defines the target value, average value, or average utilization of a specific metric*
 
@@ -719,30 +720,30 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         type represents whether the metric type is Utilization, Value, or AverageValue
       -->
-      
+
       **MetricTarget 定义特定指标的目标值、平均值或平均利用率**
 
       - **metrics.object.target.type** (string)，必需
 
         type 表示指标类别是 `Utilization`、`Value` 或 `AverageValue`。
-  
+
       <!--
       - **metrics.object.target.averageUtilization** (int32)
 
         averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
       -->
-      
+
       - **metrics.object.target.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的目标值，
         表示为 Pod 资源请求值的百分比。目前仅对 “Resource” 指标源类别有效。
-  
+
       <!--
       - **metrics.object.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **metrics.object.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有 Pod 得出的指标均值的目标值（以数量形式给出）。
@@ -752,7 +753,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         value is the target value of the metric (as a quantity).
       -->
-      
+
       - **metrics.object.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的目标值（以数量形式给出）。
@@ -762,14 +763,14 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
     pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
   -->
-  
+
   - **metrics.pods** (PodsMetricSource)
 
     pods 是指描述当前扩缩目标中每个 Pod 的指标（例如，`transactions-processed-per-second`）。
     在与目标值进行比较之前，这些指标值将被平均。
 
     <a name="PodsMetricSource"></a>
-  
+
     <!--
     *PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.*
 
@@ -777,16 +778,16 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       metric identifies the target metric by name and selector
     -->
-    
+
     PodsMetricSource 表示如何根据描述当前扩缩目标中每个 Pod 的指标进行扩缩容（例如，`transactions-processed-per-second`）。
-    在与目标值进行比较之前，这些指标值将被平均。 
+    在与目标值进行比较之前，这些指标值将被平均。
 
     - **metrics.pods.metric** (MetricIdentifier)，必需
 
       metric 通过名称和选择算符识别目标指标。
 
       <a name="MetricIdentifier"></a>
-    
+
       <!--
       *MetricIdentifier defines the name and optionally selector for a metric*
 
@@ -794,19 +795,19 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         name is the name of the given metric
       -->
-      
+
       **MetricIdentifier 定义指标的名称和可选的选择算符**
 
       - **metrics.pods.metric.name** (string)，必需
 
         name 是给定指标的名称。
-   
+
       <!--
       - **metrics.pods.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
       -->
-      
+
       - **metrics.pods.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector 是给定指标的标准 Kubernetes 标签选择算符的字符串编码形式。
@@ -818,13 +819,13 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       target specifies the target value for the given metric
     -->
-    
+
     - **metrics.pods.target** (MetricTarget)，必需
 
       target 表示给定指标的目标值。
-  
+
       <a name="MetricTarget"></a>
-    
+
       <!--
       *MetricTarget defines the target value, average value, or average utilization of a specific metric*
 
@@ -832,30 +833,30 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         type represents whether the metric type is Utilization, Value, or AverageValue
       -->
-      
+
       **MetricTarget 定义特定指标的目标值、平均值或平均利用率**
 
       - **metrics.pods.target.type** (string)，必需
 
         type 表示指标类别是 `Utilization`、`Value` 或 `AverageValue`。
-  
+
       <!--
       - **metrics.pods.target.averageUtilization** (int32)
 
         averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
       -->
-      
+
       - **metrics.pods.target.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的目标值，
         表示为 Pod 资源请求值的百分比。目前仅对 “Resource” 指标源类别有效。
-  
+
       <!--
       - **metrics.pods.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **metrics.pods.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有 Pod 得出的指标均值的目标值（以数量形式给出）。
@@ -865,7 +866,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         value is the target value of the metric (as a quantity).
       -->
-      
+
       - **metrics.pods.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的目标值（以数量形式给出）。
@@ -875,7 +876,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
     resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
   -->
-  
+
   - **metrics.resource** (ResourceMetricSource)
 
     resource 是指 Kubernetes 已知的资源指标（例如在请求和限制中指定的那些），
@@ -883,7 +884,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
     并且在使用 “Pods” 源的、按 Pod 统计的普通指标之外支持一些特殊的扩缩选项。
 
     <a name="ResourceMetricSource"></a>
-  
+
     <!--
     *ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.*
 
@@ -891,7 +892,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
       name is the name of the resource in question.
     -->
-    
+
     ResourceMetricSource 指示如何根据请求和限制中指定的 Kubernetes 已知的资源指标进行扩缩容，
     此结构描述当前扩缩目标中的每个 Pod（例如 CPU 或内存）。在与目标值比较之前，这些指标值将被平均。
     此类指标内置于 Kubernetes 中，并且在使用 “Pods” 源的、按 Pod 统计的普通指标之外支持一些特殊的扩缩选项。
@@ -900,19 +901,19 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
     - **metrics.resource.name** (string)，必需
 
       name 是相关资源的名称。
-    
+
     <!--
     - **metrics.resource.target** (MetricTarget), required
 
       target specifies the target value for the given metric
     -->
-    
+
     - **metrics.resource.target** (MetricTarget)，必需
 
       target 指定给定指标的目标值。
-  
+
       <a name="MetricTarget"></a>
-    
+
       <!--
       *MetricTarget defines the target value, average value, or average utilization of a specific metric*
 
@@ -920,30 +921,30 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         type represents whether the metric type is Utilization, Value, or AverageValue
       -->
-      
+
       **MetricTarget 定义特定指标的目标值、平均值或平均利用率**
 
       - **metrics.resource.target.type** (string)，必需
 
         type 表示指标类别是 `Utilization`、`Value` 或 `AverageValue`。
-  
+
       <!--
       - **metrics.resource.target.averageUtilization** (int32)
 
         averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
       -->
-      
+
       - **metrics.resource.target.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的目标值，
         表示为 Pod 资源请求值的百分比。目前仅对 “Resource” 指标源类别有效。
-  
+
       <!--
       - **metrics.resource.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **metrics.resource.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有 Pod 得出的指标均值的目标值（以数量形式给出）。
@@ -953,7 +954,7 @@ HorizontalPodAutoscalerSpec 描述了 HorizontalPodAutoscaler 预期的功能。
 
         value is the target value of the metric (as a quantity).
       -->
-      
+
       - **metrics.resource.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的目标值（以数量形式给出）。
@@ -981,9 +982,9 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 - **conditions** ([]HorizontalPodAutoscalerCondition)
 
   *Patch strategy: merge on key `type`*
-  
+
   *Map: unique values on key type will be kept during a merge*
-  
+
   conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
 -->
 
@@ -1004,19 +1005,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     status is the status of the condition (True, False, Unknown)
   -->
-  
+
   **HorizontalPodAutoscalerCondition 描述 HorizontalPodAutoscaler 在某一时间点的状态。**
 
   - **conditions.status** (string)，必需
 
     status 是状况的状态（True、False、Unknown）。
-  
+
   <!--
   - **conditions.type** (string), required
 
     type describes the current condition
   -->
-  
+
   - **conditions.type** (string)，必需
 
     type 描述当前状况。
@@ -1026,7 +1027,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     lastTransitionTime is the last time the condition transitioned from one status to another
   -->
-  
+
   - **conditions.lastTransitionTime** (Time)
 
     lastTransitionTime 是状况最近一次从一种状态转换到另一种状态的时间。
@@ -1035,15 +1036,15 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     <!--
     *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
     -->
-    
-    **Time 是对 time.Time 的封装。Time 支持对 YAML 和 JSON 进行正确封包。为 time 包的许多函数方法提供了封装器。**  
-  
+
+    **Time 是对 time.Time 的封装。Time 支持对 YAML 和 JSON 进行正确封包。为 time 包的许多函数方法提供了封装器。**
+
   <!--
   - **conditions.message** (string)
 
     message is a human-readable explanation containing details about the transition
   -->
-  
+
   - **conditions.message** (string)
 
     message 是一个包含有关转换的可读的详细信息。
@@ -1053,7 +1054,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     reason is the reason for the condition's last transition.
   -->
-  
+
   - **conditions.reason** (string)
 
     reason 是状况最后一次转换的原因。
@@ -1062,12 +1063,12 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 - **currentMetrics** ([]MetricStatus)
 
   *Atomic: will be replaced during a merge*
-  
+
   currentMetrics is the last read state of the metrics used by this autoscaler.
 -->
 
 - **currentMetrics** ([]MetricStatus)
-  
+
   **原子性：将在合并期间被替换**
 
   currentMetrics 是此自动扩缩器使用的指标的最后读取状态。
@@ -1081,7 +1082,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     type is the type of metric source.  It will be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each corresponds to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
   -->
-  
+
   **MetricStatus 描述了单个指标的最后读取状态。**
 
   - **currentMetrics.type** (string)，必需
@@ -1094,7 +1095,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
   -->
-  
+
   - **currentMetrics.containerResource** (ContainerResourceMetricStatus)
 
     containerResource 是指 Kubernetes 已知的一种资源指标（例如在请求和限制中指定的那些），
@@ -1102,13 +1103,13 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     此类指标内置于 Kubernetes 中，并且在使用 "Pods" 源的、按 Pod 统计的普通指标之外支持一些特殊的扩缩选项。
 
     <a name="ContainerResourceMetricStatus"></a>
-  
+
     <!--
     *ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.*
 
     - **currentMetrics.containerResource.container** (string), required
 
-      Container is the name of the container in the pods of the scaling target
+      container is the name of the container in the pods of the scaling target
     -->
 
     ContainerResourceMetricStatus 指示如何根据请求和限制中指定的 Kubernetes 已知的资源指标进行扩缩容，
@@ -1118,19 +1119,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     - **currentMetrics.containerResource.container** (string)，必需
 
       container 是扩缩目标的 Pod 中的容器名称。
-  
+
     <!--
     - **currentMetrics.containerResource.current** (MetricValueStatus), required
 
       current contains the current value for the given metric
     -->
-    
+
     - **currentMetrics.containerResource.current** (MetricValueStatus)，必需
 
       current 包含给定指标的当前值。
-  
+
       <a name="MetricValueStatus"></a>
-    
+
       <!--
       *MetricValueStatus holds the current value for a metric*
 
@@ -1138,19 +1139,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
       -->
-      
+
       **MetricValueStatus 保存指标的当前值**
 
       - **currentMetrics.containerResource.current.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的当前值，表示为 Pod 资源请求值的百分比。
-  
+
       <!--
       - **currentMetrics.containerResource.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **currentMetrics.containerResource.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有相关 Pod 的指标均值的当前值（以数量形式给出）。
@@ -1160,7 +1161,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         value is the current value of the metric (as a quantity).
       -->
-      
+
       - **currentMetrics.containerResource.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的当前值（以数量形式给出）。
@@ -1168,26 +1169,26 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     <!--
     - **currentMetrics.containerResource.name** (string), required
 
-      Name is the name of the resource in question.
+      name is the name of the resource in question.
     -->
-    
+
     - **currentMetrics.containerResource.name** (string)，必需
 
       name 是相关资源的名称。
-  
+
   <!--
   - **currentMetrics.external** (ExternalMetricStatus)
 
     external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
   -->
-  
+
   - **currentMetrics.external** (ExternalMetricStatus)
 
     external 指的是不与任何 Kubernetes 对象关联的全局指标。这一字段允许基于来自集群外部运行的组件
     （例如云消息服务中的队列长度，或来自集群外部运行的负载均衡器的 QPS）的信息进行自动扩缩。
 
     <a name="ExternalMetricStatus"></a>
-  
+
     <!--
     *ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.*
 
@@ -1195,15 +1196,15 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
       current contains the current value for the given metric
     -->
-    
+
     **ExternalMetricStatus 表示与任何 Kubernetes 对象无关的全局指标的当前值。**
 
     - **currentMetrics.external.current** (MetricValueStatus)，必需
 
       current 包含给定指标的当前值。
-  
+
       <a name="MetricValueStatus"></a>
-    
+
       <!--
       *MetricValueStatus holds the current value for a metric*
 
@@ -1211,19 +1212,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
       -->
-      
+
       **MetricValueStatus 保存指标的当前值**
 
       - **currentMetrics.external.current.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的当前值，表示为 Pod 资源请求值的百分比。
-      
+
       <!--
       - **currentMetrics.external.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **currentMetrics.external.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有相关 Pod 的指标均值的当前值（以数量形式给出）。
@@ -1233,7 +1234,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         value is the current value of the metric (as a quantity).
       -->
-      
+
       - **currentMetrics.external.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的当前值（以数量形式给出）。
@@ -1243,13 +1244,13 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
       metric identifies the target metric by name and selector
     -->
-    
+
     - **currentMetrics.external.metric** (MetricIdentifier)，必需
 
       metric 通过名称和选择算符识别目标指标。
-  
+
       <a name="MetricIdentifier"></a>
-    
+
       <!--
       *MetricIdentifier defines the name and optionally selector for a metric*
 
@@ -1257,19 +1258,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         name is the name of the given metric
       -->
-      
+
       **MetricIdentifier 定义指标的名称和可选的选择算符**
 
       - **currentMetrics.external.metric.name** (string)，必需
 
         name 是给定指标的名称。
-  
+
       <!--
       - **currentMetrics.external.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
       -->
-      
+
       - **currentMetrics.external.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector 是给定指标的标准 Kubernetes 标签选择算符的字符串编码形式。
@@ -1281,13 +1282,13 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
   -->
-  
+
   - **currentMetrics.object** (ObjectMetricStatus)
 
     object 是指描述单个 Kubernetes 对象的指标（例如，Ingress 对象的 `hits-per-second`）。
 
     <a name="ObjectMetricStatus"></a>
-  
+
     <!--
     *ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).*
 
@@ -1295,15 +1296,15 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
       current contains the current value for the given metric
     -->
-    
+
     **ObjectMetricStatus 表示描述 Kubernetes 对象的指标的当前值（例如，Ingress 对象的 `hits-per-second`）。**
 
     - **currentMetrics.object.current** (MetricValueStatus)，必需
 
       current 包含给定指标的当前值。
-  
+
       <a name="MetricValueStatus"></a>
-    
+
       <!--
       *MetricValueStatus holds the current value for a metric*
 
@@ -1311,19 +1312,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
       -->
-      
+
       **MetricValueStatus 保存指标的当前值**
 
       - **currentMetrics.object.current.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的当前值，表示为 Pod 资源请求值的百分比。
-  
+
       <!--
       - **currentMetrics.object.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **currentMetrics.object.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有相关 Pod 的指标均值的当前值（以数量形式给出）。
@@ -1333,7 +1334,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         value is the current value of the metric (as a quantity).
       -->
-      
+
       - **currentMetrics.object.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的当前值（以数量形式给出）。
@@ -1343,59 +1344,59 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
       DescribedObject specifies the descriptions of a object,such as kind,name apiVersion
     -->
-    
+
     - **currentMetrics.object.describedObject** (CrossVersionObjectReference)，必需
 
       describeObject 表示对象的描述，如对象的 `kind`、`name`、`apiVersion`。
-  
+
       <a name="CrossVersionObjectReference"></a>
-    
+
       <!--
       *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
 
       - **currentMetrics.object.describedObject.kind** (string), required
 
-        Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
       -->
-      
+
       **CrossVersionObjectReference 包含足够的信息来让你识别所引用的资源。**
 
       - **currentMetrics.object.describedObject.kind** (string)，必需
 
-        被引用对象的类别；更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  
+        `kind` 是被引用对象的类别；更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
       <!--
       - **currentMetrics.object.describedObject.name** (string), required
 
-        Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
       -->
-      
+
       - **currentMetrics.object.describedObject.name** (string)，必需
 
         被引用对象的名称；更多信息： https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/names/#names
-  
+
       <!--
       - **currentMetrics.object.describedObject.apiVersion** (string)
 
-        API version of the referent
+        apiVersion is the API version of the referent
       -->
-      
+
       - **currentMetrics.object.describedObject.apiVersion** (string)
 
         被引用对象的 API 版本。
-  
+
     <!--
     - **currentMetrics.object.metric** (MetricIdentifier), required
 
       metric identifies the target metric by name and selector
     -->
-    
+
     - **currentMetrics.object.metric** (MetricIdentifier)，必需
 
       metric 通过名称和选择算符识别目标指标。
-  
+
       <a name="MetricIdentifier"></a>
-    
+
       <!--
       *MetricIdentifier defines the name and optionally selector for a metric*
 
@@ -1403,19 +1404,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         name is the name of the given metric
       -->
-      
+
       **MetricIdentifier 定义指标的名称和可选的选择算符**
 
       - **currentMetrics.object.metric.name** (string)，必需
 
         name 是给定指标的名称。
 
-      <!--  
+      <!--
       - **currentMetrics.object.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
       -->
-      
+
       - **currentMetrics.object.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector 是给定指标的标准 Kubernetes 标签选择算符的字符串编码形式。
@@ -1427,14 +1428,14 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
   -->
-  
+
   - **currentMetrics.pods** (PodsMetricStatus)
 
     pods 是指描述当前扩缩目标中每个 Pod 的指标（例如，`transactions-processed-per-second`）。
     在与目标值进行比较之前，这些指标值将被平均。
 
     <a name="PodsMetricStatus"></a>
-  
+
     <!--
     *PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).*
 
@@ -1442,15 +1443,15 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
       current contains the current value for the given metric
     -->
-    
+
     **PodsMetricStatus 表示描述当前扩缩目标中每个 Pod 的指标的当前值（例如，`transactions-processed-per-second`）。**
 
     - **currentMetrics.pods.current** (MetricValueStatus)，必需
 
       current 包含给定指标的当前值。
-  
+
       <a name="MetricValueStatus"></a>
-    
+
       <!--
       *MetricValueStatus holds the current value for a metric*
 
@@ -1458,19 +1459,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
       -->
-      
+
       **MetricValueStatus 保存指标的当前值**
 
       - **currentMetrics.pods.current.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的当前值，表示为 Pod 资源请求值的百分比。
-  
+
       <!--
       - **currentMetrics.pods.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **currentMetrics.pods.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有相关 Pod 的指标均值的当前值（以数量形式给出）。
@@ -1480,23 +1481,23 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         value is the current value of the metric (as a quantity).
       -->
-      
+
       - **currentMetrics.pods.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的当前值（以数量形式给出）。
-    
+
     <!--
     - **currentMetrics.pods.metric** (MetricIdentifier), required
 
       metric identifies the target metric by name and selector
     -->
-    
+
     - **currentMetrics.pods.metric** (MetricIdentifier)，必需
 
       metric 通过名称和选择算符识别目标指标。
-  
+
       <a name="MetricIdentifier"></a>
-    
+
       <!--
       *MetricIdentifier defines the name and optionally selector for a metric*
 
@@ -1504,19 +1505,19 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         name is the name of the given metric
       -->
-      
+
       **MetricIdentifier 定义指标的名称和可选的选择算符**
 
       - **currentMetrics.pods.metric.name** (string)，必需
 
         name 是给定指标的名称。
-  
+
       <!--
       - **currentMetrics.pods.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
       -->
-      
+
       - **currentMetrics.pods.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
         selector 是给定指标的标准 Kubernetes 标签选择算符的字符串编码形式。
@@ -1528,7 +1529,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
     resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
   -->
-  
+
   - **currentMetrics.resource** (ResourceMetricStatus)
 
     resource 是指 Kubernetes 已知的资源指标（例如在请求和限制中指定的那些），
@@ -1536,7 +1537,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     并且在使用 “Pods” 源的、按 Pod 统计的普通指标之外支持一些特殊的扩缩选项。
 
     <a name="ResourceMetricStatus"></a>
-  
+
     <!--
     *ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.*
 
@@ -1544,7 +1545,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
       current contains the current value for the given metric
     -->
-    
+
     ResourceMetricSource 指示如何根据请求和限制中指定的 Kubernetes 已知的资源指标进行扩缩容，
     此结构描述当前扩缩目标中的每个 Pod（例如 CPU 或内存）。在与目标值比较之前，这些指标值将被平均。
     此类指标内置于 Kubernetes 中，并且在使用 “Pods” 源的、按 Pod 统计的普通指标之外支持一些特殊的扩缩选项。
@@ -1552,9 +1553,9 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     - **currentMetrics.resource.current** (MetricValueStatus)，必需
 
       current 包含给定指标的当前值。
-  
+
       <a name="MetricValueStatus"></a>
-    
+
       <!--
       *MetricValueStatus holds the current value for a metric*
 
@@ -1562,20 +1563,20 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
       -->
-      
+
       **MetricValueStatus 保存指标的当前值**
 
       - **currentMetrics.resource.current.averageUtilization** (int32)
 
         averageUtilization 是跨所有相关 Pod 得出的资源指标均值的当前值，
         表示为 Pod 资源请求值的百分比。
-  
+
       <!--
       - **currentMetrics.resource.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
       -->
-      
+
       - **currentMetrics.resource.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         averageValue 是跨所有相关 Pod 的指标均值的当前值（以数量形式给出）。
@@ -1585,7 +1586,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
 
         value is the current value of the metric (as a quantity).
       -->
-      
+
       - **currentMetrics.resource.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
         value 是指标的当前值（以数量形式给出）。
@@ -1593,9 +1594,9 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
     <!--
     - **currentMetrics.resource.name** (string), required
 
-      Name is the name of the resource in question.
+      name is the name of the resource in question.
     -->
-    
+
     - **currentMetrics.resource.name** (string)，必需
 
       name 是相关资源的名称。
@@ -1625,7 +1626,7 @@ HorizontalPodAutoscalerStatus 描述了水平 Pod 自动扩缩器的当前状态
   <!--
   *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
   -->
-  
+
   **Time 是对 time.Time 的封装。Time 支持对 YAML 和 JSON 进行正确封包。为 time 包的许多函数方法提供了封装器。**
 
 <!--
@@ -1823,6 +1824,10 @@ GET /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** <!--(*in query*)-->（**查询参数**）: boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 - **timeoutSeconds** <!--(*in query*)-->（**查询参数**）: integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -1888,6 +1893,10 @@ GET /apis/autoscaling/v2/horizontalpodautoscalers
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** <!--(*in query*)-->（**查询参数**）: boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 - **timeoutSeconds** <!--(*in query*)-->（**查询参数**）: integer
 
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -1922,6 +1931,9 @@ POST /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
 -->
 #### 参数
 
@@ -1929,7 +1941,7 @@ POST /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>，<!--required-->必需
+- **body**：<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>，必需
 
 - **dryRun** <!--(*in query*)-->（**查询参数**）: string
 
@@ -1988,12 +2000,15 @@ PUT /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers/{name}
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
 -->
 - **namespace** （**路径参数**）: string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>，<!--required-->必需
+- **body**：<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>，必需
 
 - **dryRun** <!--(*in query*)-->（**查询参数**）: string
 
@@ -2050,12 +2065,15 @@ PUT /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers/{name}/
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
 -->
 - **namespace** （**路径参数**）: string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>，<!--required-->必需
+- **body**：<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>，必需
 
 - **dryRun** <!--(*in query*)-->（**查询参数**）: string
 
@@ -2112,12 +2130,15 @@ PATCH /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers/{name
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 -->
 - **namespace** （**路径参数**）: string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，<!--required-->必需
+- **body**：<a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，必需
 
 - **dryRun** <!--(*in query*)-->（**查询参数**）: string
 
@@ -2178,12 +2199,15 @@ PATCH /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers/{name
 - **namespace** (*in path*): string, required
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 -->
 - **namespace** （**路径参数**）: string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，<!--required-->必需
+- **body**：<a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，必需
 
 - **dryRun** <!--(*in query*)-->（**查询参数**）: string
 
@@ -2343,6 +2367,10 @@ DELETE /apis/autoscaling/v2/namespaces/{namespace}/horizontalpodautoscalers
 - **resourceVersionMatch** <!--(*in query*)-->（**查询参数**）: string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+- **sendInitialEvents** <!--(*in query*)-->（**查询参数**）: boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** <!--(*in query*)-->（**查询参数**）: integer
 


### PR DESCRIPTION
This PR resync page `content/zh-cn/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2.md`.

1. Remove extra blanks.
2. Move section `body` to the comment section for future change tracking.
3. Sync 1.27.