### PR TITLE
Update 1.23 job documentation for JobTrackingWithFinalizers

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -627,7 +627,7 @@ In order to use this behavior, you must enable the `JobTrackingWithFinalizers`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 on the [API server](/docs/reference/command-line-tools-reference/kube-apiserver/)
 and the [controller manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
-It is enabled by default.
+It is disabled by default.
 
 When enabled, the control plane tracks new Jobs using the behavior described
 below. Jobs created before the feature was enabled are unaffected. As a user,


### PR DESCRIPTION
This feature gate is actually disabled  by default in v1.23. Please see https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/ for confirmation.
