### PR TITLE
Add authz library details to CEL documentation

### DIFF
--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -164,8 +164,8 @@ API resource checks are performed as follows:
 Non-resource authorization performed are used as follows:
 
 1. specify only a path: `Authorizer.path(string) PathCheck`
-2. Call `PathCheck.check(httpVerb string) Decision` to perform the authorization check.
-3. Call `allowed() bool` or `reason() string` to inspect the result of the authorization check.
+1. Call `PathCheck.check(httpVerb string) Decision` to perform the authorization check.
+1. Call `allowed() bool` or `reason() string` to inspect the result of the authorization check.
 
 To perform an authorization check for a service account:
 

--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -181,7 +181,6 @@ To perform an authorization check for a service account:
 See the [Kubernetes Authz library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz)
 godoc for more information.
 
-
 ## Type checking
 
 CEL is a [gradually typed language](https://github.com/google/cel-spec/blob/master/doc/langdef.md#gradual-type-checking).

--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -144,6 +144,44 @@ Examples:
 See the [Kubernetes URL library](https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/library#URLs)
 godoc for more information.
 
+### Kubernetes authorizer library
+
+For CEL expressions in the API where a variable of type `Authorizer` is available,
+the authorizer may be used to perform authorization checks for the principal
+(authenticated user) of the request.
+
+API resource checks are performed as follows:
+
+1. Specify the group and resource to check: `Authorizer.group(string).resource(string) ResourceCheck`
+2. Optionally call any combination of the following to further narrow the authorization check:
+  - `ResourceCheck.subresource(string) ResourceCheck`
+  - `ResourceCheck.namespace(string) ResourceCheck`
+  - `ResourceCheck.name(string) ResourceCheck` 
+3. Call `ResourceCheck.check(verb string) Decision` to perform the authorization check.
+4. Call `allowed() bool` or `reason() string` to inspect the result of the authorization check.
+
+Non-resource authorization performed are used as follows:
+
+1. specify only a path: `Authorizer.path(string) PathCheck`
+2. Call `PathCheck.check(httpVerb string) Decision` to perform the authorization check.
+3. Call `allowed() bool` or `reason() string` to inspect the result of the authorization check.
+
+To perform an authorization check for a service account:
+
+- `Authorizer.serviceAccount(namespace string, name string) Authorizer`
+
+{{< table caption="Examples of CEL expressions using URL library functions" >}}
+| CEL Expression                                                                                               | Purpose                                        |
+|--------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| `authorizer.group('').resource('pods').namespace('default').check('create').allowed()`                       | Returns true if the principal (user or service account) is allowed create pods in the 'default' namespace. |
+| `authorizer.path('/healthz').check('get').allowed()`                                                         | Checks if the principal (user or service account) is authorized to make HTTP GET requests to the /healthz API path. |
+| `authorizer.serviceAccount('default', 'myserviceaccount').resource('deployments').check('delete').allowed()` | Checks if the service account is authorized to delete deployments. |
+{{< /table >}}
+
+See the [Kubernetes Authz library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz)
+godoc for more information.
+
+
 ## Type checking
 
 CEL is a [gradually typed language](https://github.com/google/cel-spec/blob/master/doc/langdef.md#gradual-type-checking).

--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -153,7 +153,8 @@ the authorizer may be used to perform authorization checks for the principal
 API resource checks are performed as follows:
 
 1. Specify the group and resource to check: `Authorizer.group(string).resource(string) ResourceCheck`
-2. Optionally call any combination of the following to further narrow the authorization check:
+2. Optionally call any combination of the following builder functions to further narrow the authorization check.
+   Note that these functions return the receiver type and can be chained:
   - `ResourceCheck.subresource(string) ResourceCheck`
   - `ResourceCheck.namespace(string) ResourceCheck`
   - `ResourceCheck.name(string) ResourceCheck` 


### PR DESCRIPTION
Per https://github.com/kubernetes/website/pull/39642#issuecomment-1451598146 we waited till after 1.27 was released to add this documentation.