### PR TITLE
Fix 2017 autoscaling blog article

### DIFF
--- a/content/en/blog/_posts/2017-11-00-Autoscaling-In-Kubernetes.md
+++ b/content/en/blog/_posts/2017-11-00-Autoscaling-In-Kubernetes.md
@@ -1,14 +1,20 @@
 ---
-title: " Autoscaling in Kubernetes "
+title: "Autoscaling in Kubernetes"
 date: 2017-11-17
 slug: autoscaling-in-kubernetes
 url: /blog/2017/11/Autoscaling-In-Kubernetes
 ---
 
+Kubernetes allows developers to automatically adjust cluster sizes and the number of
+pod replicas based on current traffic and load. These adjustments reduce the amount of
+unused nodes, saving money and resources. In this talk, Marcin Wielgus of Google walks
+you through the current state of pod and node autoscaling in Kubernetes: how it works,
+and how to use it, including best practices for deployments in production applications.
 
-Kubernetes allows developers to automatically adjust cluster sizes and the number of pod replicas based on current traffic and load. These adjustments reduce the amount of unused nodes, saving money and resources. In this talk, Marcin Wielgus of Google walks you through the current state of pod and node autoscaling in Kubernetes: .how it works, and how to use it, including best practices for deployments in production applications.  
-{{< youtube id="m3Ma3G14dJ0" title=" Autoscaling in Kubernetes [I] - Marcin Wielgus, Google" >}}
+{{< youtube id="m3Ma3G14dJ0" title=" Autoscaling in Kubernetes [I] - Marcin Wielgus, Google" >}}  
 
-Enjoyed this talk? Join us for more exciting sessions on scaling and automating your Kubernetes clusters at KubeCon in Austin on December 6-8. [Register Now](https://www.eventbrite.com/e/kubecon-cloudnativecon-north-america-registration-37824050754?_ga=2.9666039.317115486.1510003873-1623727562.1496428006)  
+Enjoyed this talk? Join us for more exciting sessions on scaling and automating your
+Kubernetes clusters at KubeCon in Austin on December 6-8.
+<del><a href="https://www.eventbrite.com/e/kubecon-cloudnativecon-north-america-registration-37824050754">Register now</a>.</del>
 
 Be sure to check out [Automating and Testing Production Ready Kubernetes Clusters in the Public Cloud](http://sched.co/CU64) by Ron Lipke, Senior Developer, Platform as a Service, Gannet/USA Today Network.

--- a/content/en/blog/_posts/2017-11-00-Autoscaling-In-Kubernetes.md
+++ b/content/en/blog/_posts/2017-11-00-Autoscaling-In-Kubernetes.md
@@ -7,6 +7,7 @@ url: /blog/2017/11/Autoscaling-In-Kubernetes
 
 
 Kubernetes allows developers to automatically adjust cluster sizes and the number of pod replicas based on current traffic and load. These adjustments reduce the amount of unused nodes, saving money and resources. In this talk, Marcin Wielgus of Google walks you through the current state of pod and node autoscaling in Kubernetes: .how it works, and how to use it, including best practices for deployments in production applications.  
+{{< youtube id="m3Ma3G14dJ0" title=" Autoscaling in Kubernetes [I] - Marcin Wielgus, Google" >}}
 
 Enjoyed this talk? Join us for more exciting sessions on scaling and automating your Kubernetes clusters at KubeCon in Austin on December 6-8. [Register Now](https://www.eventbrite.com/e/kubecon-cloudnativecon-north-america-registration-37824050754?_ga=2.9666039.317115486.1510003873-1623727562.1496428006)  
 


### PR DESCRIPTION
Since https://kubernetes.io/blog/2017/11/autoscaling-in-kubernetes/ was published, we've somehow lost the link to the YouTube video.

Put it back ([preview](https://deploy-preview-40975--kubernetes-io-main-staging.netlify.app/blog/2017/11/autoscaling-in-kubernetes))

/area blog