### PR TITLE
Add note about `nodeName` ignoring a drained node

### DIFF
--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -62,6 +62,11 @@ and respecting the PodDisruptionBudget you have defined). It is then safe to
 bring down the node by powering down its physical machine or, if running on a
 cloud platform, deleting its virtual machine.
 
+{{< note >}}
+[nodeName](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename) bypasses the scheduler, 
+thus evicted Pods will still run on a drained node.
+{{< /note >}}
+
 First, identify the name of the node you wish to drain. You can list all of the nodes in your cluster with
 
 ```shell

--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -63,8 +63,13 @@ bring down the node by powering down its physical machine or, if running on a
 cloud platform, deleting its virtual machine.
 
 {{< note >}}
-[nodeName](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename) bypasses the scheduler, 
-thus evicted Pods will still run on a drained node.
+If any new Pods tolerate the `node.kubernetes.io/unschedulable` taint, then those Pods
+might be scheduled to the node you have drained. Avoid tolerating that taint other than
+for DaemonSets.
+
+If you or another API user directly set the [`nodeName`](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename)
+field for a Pod (bypassing the scheduler), then the Pod is bound to the specified node
+and will run there, even though you have drained that node and marked it unschedulable.
 {{< /note >}}
 
 First, identify the name of the node you wish to drain. You can list all of the nodes in your cluster with


### PR DESCRIPTION
Clarify that `nodeName` still places Pods on nodes with `SchedulingDisabled` status. Please check issue [117843](https://github.com/kubernetes/kubernetes/issues/117843) for more info.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
