### PR TITLE
KEP-3453 to GA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -147,8 +147,6 @@ For a reference to old feature gates that are removed, please refer to
 | `MinDomainsInPodTopologySpread` | `false` | Alpha | 1.24 | 1.24 |
 | `MinDomainsInPodTopologySpread` | `false` | Beta | 1.25 | 1.26 |
 | `MinDomainsInPodTopologySpread` | `true` | Beta | 1.27 | |
-| `MinimizeIPTablesRestore` | `false` | Alpha | 1.26 | 1.26 |
-| `MinimizeIPTablesRestore` | `true` | Beta | 1.27 | |
 | `MultiCIDRRangeAllocator` | `false` | Alpha | 1.25 | |
 | `MultiCIDRServiceAllocator` | `false` | Alpha | 1.27 | |
 | `NetworkPolicyStatus` | `false` | Alpha | 1.24 |  |
@@ -295,6 +293,9 @@ For a reference to old feature gates that are removed, please refer to
 | `LegacyServiceAccountTokenTracking` | `false` | Alpha | 1.26 | 1.26 |
 | `LegacyServiceAccountTokenTracking` | `true` | Beta | 1.27 | 1.27 |
 | `LegacyServiceAccountTokenTracking` | `true` | GA | 1.28 | - |
+| `MinimizeIPTablesRestore` | `false` | Alpha | 1.26 | 1.26 |
+| `MinimizeIPTablesRestore` | `true` | Beta | 1.27 | 1.27 |
+| `MinimizeIPTablesRestore` | `true` | GA | 1.28 | - |
 | `MixedProtocolLBService` | `false` | Alpha | 1.20 | 1.23 |
 | `MixedProtocolLBService` | `true` | Beta | 1.24 | 1.25 |
 | `MixedProtocolLBService` | `true` | GA | 1.26 | - |

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -138,26 +138,6 @@ iptables:
 ...
 ```
 
-##### Performance optimization for `iptables` mode {#minimize-iptables-restore}
-
-{{< feature-state for_k8s_version="v1.27" state="beta" >}}
-
-In Kubernetes {{< skew currentVersion >}} the kube-proxy defaults to a minimal approach
-to `iptables-restore` operations, only making updates where Services or EndpointSlices have
-actually changed. This is a performance optimization.
-The original implementation updated all the rules for all Services on every sync; this
-sometimes led to performance issues (update lag) in large clusters.
-
-If you are not running kube-proxy from Kubernetes {{< skew currentVersion >}}, check
-the behavior and associated advice for the version that you are actually running.
-
-If you were previously overriding `minSyncPeriod`, you should try
-removing that override and letting kube-proxy use the default value
-(`1s`) or at least a smaller value than you were using before upgrading.
-You can select the legacy behavior by disabling the `MinimizeIPTablesRestore`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-(you should not need to).
-
 ##### `minSyncPeriod`
 
 The `minSyncPeriod` parameter sets the minimum duration between
@@ -188,6 +168,22 @@ large clusters it may be necessary to set it to a larger value.
 Especially, if kube-proxy's `sync_proxy_rules_duration_seconds` metric
 indicates an average time much larger than 1 second, then bumping up
 `minSyncPeriod` may make updates more efficient.
+
+##### Updating legacy `minSyncPeriod` configuration {#minimize-iptables-restore}
+
+Older versions of kube-proxy updated all the rules for all Services on
+every sync; this led to performance issues (update lag) in large
+clusters, and the recommended solution was to set a larger
+`minSyncPeriod`. Since Kubernetes v1.28, the iptables mode of
+kube-proxy uses a more minimal approach, only making updates where
+Services or EndpointSlices have actually changed.
+
+If you were previously overriding `minSyncPeriod`, you should try
+removing that override and letting kube-proxy use the default value
+(`1s`) or at least a smaller value than you were using before upgrading.
+
+If you are not running kube-proxy from Kubernetes {{< skew currentVersion >}}, check
+the behavior and associated advice for the version that you are actually running.
 
 ##### `syncPeriod`
 


### PR DESCRIPTION
(The fact that it looks like we missed adding a Beta feature-gates line for 1.27 is an artifact of the current state of the `dev-1.28` branch. The line exists in `main`.)