### PR TITLE
Fix generated config API for API server encryption

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-encryption.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-encryption.v1.md
@@ -20,8 +20,8 @@ auto_generated: true
 
 <p>EncryptionConfiguration stores the complete configuration for encryption providers.
 It also allows the use of wildcards to specify the resources that should be encrypted.
-Use '<em>.<!-- raw HTML omitted -->' to encrypt all resources within a group or '</em>.<em>' to encrypt all resources.
-'</em>.' can be used to encrypt all resource in the core group.  '<em>.</em>' will encrypt all
+Use <code>&ast;.&lt;group&gt;</code> to encrypt all resources within a group or <code>&ast;.&ast;</code> to encrypt all resources.
+<code>&ast;.</code> can be used to encrypt all resource in the core group. <code>&ast;.&ast;</code> will encrypt all
 resources, even custom resources that are added after API server start.
 Use of wildcards that overlap within the same resource list or across multiple
 entries are not allowed since part of the configuration would be ineffective.
@@ -282,10 +282,10 @@ Set to a negative value to disable caching. This field is only allowed for KMS v
 </td>
 <td>
    <p>resources is a list of kubernetes resources which have to be encrypted. The resource names are derived from <code>resource</code> or <code>resource.group</code> of the group/version/resource.
-eg: pandas.awesome.bears.example is a custom resource with 'group': awesome.bears.example, 'resource': pandas.
-Use '<em>.</em>' to encrypt all resources and '<em>.<!-- raw HTML omitted -->' to encrypt all resources in a specific group.
-eg: '</em>.awesome.bears.example' will encrypt all resources in the group 'awesome.bears.example'.
-eg: '*.' will encrypt all resources in the core group (such as pods, configmaps, etc).</p>
+eg: <code>pandas.awesome.bears.example</code> is a custom resource with 'group': <code>awesome.bears.example</code>, 'resource': <code>pandas</code>.
+Use <code>&ast;.&ast;</code> to encrypt all resources and <code>&ast;.&lt;group&gt;</code>' to encrypt all resources in a specific group.
+eg: <code>&ast;.awesome.bears.example</code> will encrypt all resources in the group <code>awesome.bears.example</code>.
+eg: <code>&ast;.</code> will encrypt all resources in the core group (such as pods, configmaps, etc).</p>
 </td>
 </tr>
 <tr><td><code>providers</code> <B>[Required]</B><br/>


### PR DESCRIPTION
There are limitations in the generator when parsing ambiguous strings such as `*`, `<` etc. `*` is used in Markdown for emphasis, but some comments are using the literal '*' without properly escaping it. `<` and `>` are not allowed in Markdown parser. The generated content for this is at best some warning strings.

This PR fixes this issue manually.

An ideal fix would be proposed to the upstream source code wherever these happen.

Related: #41018

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
