### PR TITLE
Fix issues in generated config API references

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-audit.v1.md
@@ -322,12 +322,14 @@ The empty string represents the core API group.</p>
 </td>
 <td>
    <p>Resources is a list of resources this rule applies to.</p>
-<p>For example:
-'pods' matches pods.
-'pods/log' matches the log subresource of pods.
-'<em>' matches all resources and their subresources.
-'pods/</em>' matches all subresources of pods.
-'*/scale' matches all scale subresources.</p>
+<p>For example:</p>
+<ul>
+<li><code>pods</code> matches pods.</li>
+<li><code>pods/log</code> matches the log subresource of pods.</li>
+<li><code>&ast;<code> matches all resources and their subresources.</li>
+<li><code>pods/&ast;</code> matches all subresources of pods.</li>
+<li><code>&ast;/scale</code> matches all scale subresources.</li>
+</ul>
 <p>If wildcard is present, the validation rule will ensure resources do not
 overlap with each other.</p>
 <p>An empty list implies all resources and subresources in this API groups apply.</p>
@@ -501,10 +503,12 @@ An empty list implies every namespace.</p>
 </td>
 <td>
    <p>NonResourceURLs is a set of URL paths that should be audited.
-<em>s are allowed, but only as the full, final step in the path.
-Examples:
-&quot;/metrics&quot; - Log requests for apiserver metrics
-&quot;/healthz</em>&quot; - Log all health checks</p>
+<code>&ast;<code>s are allowed, but only as the full, final step in the path.
+Examples:</p>
+<ul>
+<li>&quot;/metrics&quot; - Log requests for apiserver metrics</li>
+<li>&quot;/healthz&ast;&quot; - Log all health checks</li>
+</ul>
 </td>
 </tr>
 <tr><td><code>omitStages</code><br/>

--- a/content/en/docs/reference/config-api/kubelet-config.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1.md
@@ -81,9 +81,9 @@ to provide credentials. Images are expected to contain the registry domain
 and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '&#42;.k8s.io' or 'k8s.&#42;.io', and top-level-domains such as 'k8s.&#42;'.
-Matching partial subdomains like 'app&#42;.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so &#42;.io does not match &#42;.k8s.io.</p>
+as subdomains like <code>&ast;.k8s.io</code> or <code>k8s.&ast;.io</code>, and top-level-domains such as <code>k8s.&ast;</code>.
+Matching partial subdomains like <code>app&ast;.k8s.io<code> is also supported. Each glob can only match
+a single subdomain segment, so <code>&ast;.io</code> does not match <code>&ast;.k8s.io</code>.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -93,9 +93,9 @@ a single subdomain segment, so &#42;.io does not match &#42;.k8s.io.</p>
 <p>Example values of matchImages:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>&#42;.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li>&#42;.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -1303,9 +1303,9 @@ to provide credentials. Images are expected to contain the registry domain
 and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '&#42;.k8s.io' or 'k8s.&#42;.io', and top-level-domains such as 'k8s.&#42;'.
-Matching partial subdomains like 'app&#42;.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so &#42;.io does not match &#42;.k8s.io.</p>
+as subdomains like <code>&ast;.k8s.io</code> or <code>k8s.&ast;.io</code>, and top-level-domains such as <code>k8s.&ast;</code>.
+Matching partial subdomains like <code>app&ast;.k8s.io</code> is also supported. Each glob can only match
+a single subdomain segment, so <code>&ast;.io</code> does not match <code>&ast;.k8s.io</code>.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -1315,9 +1315,9 @@ a single subdomain segment, so &#42;.io does not match &#42;.k8s.io.</p>
 <p>Example values of matchImages:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>&#42;.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li>&#42;.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
@@ -89,9 +89,9 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like <code>&ast;.k8s.io</code> or <code>k8s.&ast;.io</code>, and top-level-domains such as <code>k8s.&ast;</code>.
+Matching partial subdomains like <code>app&ast;.k8s.io</code> is also supported. Each glob can only match
+a single subdomain segment, so <code>&ast;.io</code> does not match <code>&ast;.k8s.io</code>.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -108,9 +108,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1alpha1.md
@@ -89,9 +89,9 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like <code>&ast;.k8s.io</code> or <code>k8s.&ast;.io</code>, and top-level-domains such as <code>k8s.&ast;</code>.
+Matching partial subdomains like <code>app&ast;.k8s.io</code> is also supported. Each glob can only match
+a single subdomain segment, so <code>&ast;.io</code> does not match <code>&ast;.k8s.io</code>.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -108,9 +108,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1beta1.md
@@ -89,9 +89,9 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like <code>&ast;.k8s.io</code> or <code>k8s.&ast;.io</code>, and top-level-domains such as <code>k8s.&ast;</code>.
+Matching partial subdomains like <code>app&ast;.k8s.io</code> is also supported. Each glob can only match
+a single subdomain segment, so <code>&ast;.io</code> does not match <code>&ast;.k8s.io</code>.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -108,9 +108,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>


### PR DESCRIPTION
This PR fixes some issues caused by the bad format in source code comments that confuse the reference generator. Problems are related to the use of `*` in comment text as literal string rather than emphasis.

Related: #41035
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
