### PR TITLE
Add the go-template output format in "kubectl Cheat Sheet" page

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -430,6 +430,8 @@ Output format | Description
 --------------| -----------
 `-o=custom-columns=<spec>` | Print a table using a comma separated list of custom columns
 `-o=custom-columns-file=<filename>` | Print a table using the custom columns template in the `<filename>` file
+`-o=go-template=<template>`     | Print the fields defined in a [golang template](https://pkg.go.dev/text/template)
+`-o=go-template-file=<filename>` | Print the fields defined by the [golang template](https://pkg.go.dev/text/template) in the `<filename>` file
 `-o=json`     | Output a JSON formatted API object
 `-o=jsonpath=<template>` | Print the fields defined in a [jsonpath](/docs/reference/kubectl/jsonpath) expression
 `-o=jsonpath-file=<filename>` | Print the fields defined by the [jsonpath](/docs/reference/kubectl/jsonpath) expression in the `<filename>` file


### PR DESCRIPTION
Adding  the `go-template` and `go-template-file` output formats to https://kubernetes.io/docs/reference/kubectl/cheatsheet/#formatting-output

Both output formats are supported in kubectl. See https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands.
