### PR TITLE
[zh-cn] Fix redundant picture text display of components.md

### DIFF
--- a/content/zh-cn/docs/concepts/overview/components.md
+++ b/content/zh-cn/docs/concepts/overview/components.md
@@ -25,12 +25,12 @@ card:
 <!-- overview -->
 <!--
 When you deploy Kubernetes, you get a cluster.
-{{< glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
+{{ < glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
 
 This document outlines the various components you need to have for
 a complete and working Kubernetes cluster.
 
-{{< figure src="/images/docs/components-of-kubernetes.svg" alt="Components of Kubernetes" caption="The components of a Kubernetes cluster" class="diagram-large" >}}
+{{ < figure src="/images/docs/components-of-kubernetes.svg" alt="Components of Kubernetes" caption="The components of a Kubernetes cluster" class="diagram-large" >}}
 -->
 当你部署完 Kubernetes，便拥有了一个完整的集群。
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
I just added a space here to prevent shortcode parsing.
Fixes: https://github.com/kubernetes/website/issues/40984

Introduced PR: https://github.com/kubernetes/website/pull/39516

See the [preview](https://deploy-preview-41051--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/overview/components/) page.