### PR TITLE
Clarify pod scheduling during node graceful termination

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -424,7 +424,7 @@ node shutdown has been detected, so that even Pods with a
 {{< glossary_tooltip text="toleration" term_id="toleration" >}} for
 `node.kubernetes.io/not-ready:NoSchedule` do not start there.
 
-At the same time when kubelet is setting that condition on its node via the API, the kubelet also begins
+At the same time when kubelet is setting that condition on its Node via the API, the kubelet also begins
 terminating any Pods that are running locally.
 
 During a graceful shutdown, kubelet terminates pods in two phases:


### PR DESCRIPTION
We never documented the Pod admission failures and Not Ready status. See https://github.com/kubernetes/enhancements/blob/80e76860ab0c9faa53fe833150091c15c5855ded/keps/sig-node/2000-graceful-node-shutdown/README.md?plain=1#L368-L371

/sig node
/assign @bobbypage 
/kind cleanup

