### PR TITLE
[es] Replace use of deprecated fullversion param

### DIFF
--- a/content/es/docs/tasks/tools/included/install-kubectl-linux.md
+++ b/content/es/docs/tasks/tools/included/install-kubectl-linux.md
@@ -33,10 +33,10 @@ Existen los siguientes métodos para instalar kubectl en Linux:
    {{< note >}}
 Para descargar una versión específica, reemplace la parte de `$(curl -L -s https://dl.k8s.io/release/stable.txt)` del comando con la versión específica.
 
-Por ejemplo, para descargar la versión {{< param "fullversion" >}} en Linux, escriba:
+Por ejemplo, para descargar la versión {{< skew currentPatchVersion >}} en Linux, escriba:
 
    ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
+   curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/amd64/kubectl
    ```
    {{< /note >}}
 

--- a/content/es/docs/tasks/tools/included/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/included/install-kubectl-macos.md
@@ -38,16 +38,16 @@ Existen los siguientes métodos para instalar kubectl en macOS:
    {{< note >}}
    Para descargar una versión específica, reemplace el `$(curl -L -s https://dl.k8s.io/release/stable.txt)` parte del comando con la versión específica.
 
-   Por ejemplo, para descargar la versión {{< param "fullversion" >}} en Intel macOS, escriba:
+   Por ejemplo, para descargar la versión {{< skew currentPatchVersion >}} en Intel macOS, escriba:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl"
+   curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/amd64/kubectl"
    ```
 
    Y para macOS en Apple Silicon, escriba:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/arm64/kubectl"
+   curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/arm64/kubectl"
    ```
 
    {{< /note >}}

--- a/content/es/docs/tasks/tools/included/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/included/install-kubectl-windows.md
@@ -25,12 +25,12 @@ Existen los siguientes métodos para instalar kubectl en Windows:
 
 ### Instalar el binario de kubectl con curl en Windows
 
-1. Descarga la [última versión {{< param "fullversion" >}}](https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
+1. Descarga la [última versión {{< skew currentPatchVersion >}}](https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe).
 
    O si tiene `curl` instalado, use este comando:
 
    ```powershell
-   curl -LO https://dl.k8s.io/release/{{% param "fullversion" %}}/bin/windows/amd64/kubectl.exe
+   curl -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe
    ```
 
    {{< note >}}
@@ -42,7 +42,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
    Descargue el archivo de comprobación de kubectl:
 
    ```powershell
-   curl -LO https://dl.k8s.io/{{% param "fullversion" %}}/bin/windows/amd64/kubectl.exe.sha256
+   curl -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe.sha256
    ```
 
    Valide el binario kubectl con el archivo de comprobación:
@@ -148,7 +148,7 @@ A continuación se muestran los procedimientos para configurar el autocompletado
 1. Descargue la última versión con el comando:
 
    ```powershell
-   curl -LO https://dl.k8s.io/release/{{% param "fullversion" %}}/bin/windows/amd64/kubectl-convert.exe
+   curl -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe
    ```
 
 1. Validar el binario (opcional)
@@ -156,7 +156,7 @@ A continuación se muestran los procedimientos para configurar el autocompletado
    Descargue el archivo de comprobación kubectl-convert:
 
    ```powershell
-   curl -LO https://dl.k8s.io/{{% param "fullversion" %}}/bin/windows/amd64/kubectl-convert.exe.sha256
+   curl -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe.sha256
    ```
 
    Valide el binario kubectl-convert con el archivo de comprobación:


### PR DESCRIPTION
Use `{{% skew currentPatchVersion %}}` shortcode instead.

Fixes #41063