### PR TITLE
[ko] Update outdated korean contents in dev-1.26-ko.1 (M156-157)

### DIFF
--- a/content/ko/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/ko/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -1,11 +1,15 @@
 ---
-title: kubectl을 사용한 시크릿 관리
+title: kubectl을 사용한 시크릿(Secret) 관리
 content_type: task
 weight: 10
 description: kubectl 커맨드를 사용하여 시크릿 오브젝트를 생성.
 ---
 
 <!-- overview -->
+
+이 페이지는 `kubectl` 커맨드라인 툴을 이용하여 쿠버네티스
+{{<glossary_tooltip text="시크릿" term_id="secret">}}을
+생성, 편집, 관리, 삭제하는 방법을 보여준다.
 
 ## {{% heading "prerequisites" %}}
 
@@ -15,64 +19,64 @@ description: kubectl 커맨드를 사용하여 시크릿 오브젝트를 생성.
 
 ## 시크릿 생성
 
-`시크릿`에는 파드가 데이터베이스에 접근하는 데 필요한 사용자 자격 증명이 포함될 수 있다.
-예를 들어 데이터베이스 연결 문자열은 사용자 이름과 암호로 구성된다.
-사용자 이름은 로컬 컴퓨터의 `./username.txt` 파일에, 비밀번호는
-`./password.txt` 파일에 저장할 수 있다.
+`시크릿` 오브젝트는 파드가 서비스에 접근하기 위해 사용하는 자격 증명과 같은
+민감한 데이터를 저장한다. 예를 들어 데이터베이스에 접근하는데 필요한 사용자 이름과 비밀번호를
+저장하기 위해서 시크릿이 필요할 수 있다.
 
-```shell
-echo -n 'admin' > ./username.txt
-echo -n '1f2d1e2e67df' > ./password.txt
-```
-이 명령에서 `-n` 플래그는 생성된 파일의
-텍스트 끝에 추가 개행 문자가 포함되지 않도록 해 준다. 이는 `kubectl`이 파일을 읽고
-내용을 base64 문자열로 인코딩할 때 개행 문자도 함께 인코딩될 수 있기 때문에 
-중요하다.
+명령어를 통해 원시 데이터를 바로 보내거나, 파일에 자격 증명을 저장하고 명령어로 전달하는 방식으로
+시크릿을 생성할 수 있다. 다음 명령어는 사용자 이름을 `admin`으로
+비밀번호는 `S!B\*d$zDsb=`으로 저장하는 시크릿을 생성한다.
 
-`kubectl create secret` 명령은 이러한 파일들을 시크릿으로 패키징하고
-API 서버에 오브젝트를 생성한다.
+### 원시 데이터 사용
+
+다음 명령어를 실행한다.
 
 ```shell
 kubectl create secret generic db-user-pass \
-  --from-file=./username.txt \
-  --from-file=./password.txt
+    --from-literal=username=admin \
+    --from-literal=password='S!B\*d$zDsb='
 ```
+문자열에서 `$`, `\`, `*`, `=` 및 `!`과 같은 특수 문자를 이스케이프(escape)하기
+위해서는 작은따옴표 `''`를 사용해야 한다. 그렇지 않으면 셸은 이런 문자들을
+해석한다.
 
-출력은 다음과 유사하다.
+### 소스 파일 사용
+
+1. base64로 인코딩된 자격 증명의 값들을 파일에 저장한다.
+
+   ```shell
+   echo -n 'admin' | base64 > ./username.txt
+   echo -n 'S!B\*d$zDsb=' | base64 > ./password.txt
+   ```
+   `-n` 플래그는 생성된 파일이 텍스트 끝에 추가적인 개행 문자를 갖지
+   않도록 보장한다. 이는 `kubectl`이 파일을 읽고 내용을 base64
+   문자열로 인코딩할 때 개행 문자도 함께 인코딩될 수 있기 때문에
+   중요하다. 파일에 포함된 문자열에서 특수 문자를 이스케이프 할
+   필요는 없다.
+
+1. `kubectl` 명령어에 파일 경로를 전달한다.
+
+   ```shell
+   kubectl create secret generic db-user-pass \
+       --from-file=./username.txt \
+       --from-file=./password.txt
+   ```
+   기본 키 이름은 파일 이름이다. 선택적으로 `--from-file=[key=]source`를 사용하여
+   키 이름을 설정할 수 있다. 예제:
+
+   ```shell
+   kubectl create secret generic db-user-pass \
+       --from-file=username=./username.txt \
+       --from-file=password=./password.txt
+   ```
+
+두 방법 모두 출력은 다음과 유사하다.
 
 ```
 secret/db-user-pass created
 ```
 
-기본 키 이름은 파일 이름이다. 선택적으로 `--from-file=[key=]source`를 사용하여 키 이름을 설정할 수 있다.
-예제:
-
-```shell
-kubectl create secret generic db-user-pass \
-  --from-file=username=./username.txt \
-  --from-file=password=./password.txt
-```
-
-파일에 포함하는 암호 문자열에서
-특수 문자를 이스케이프하지 않아도 된다.
-
-`--from-literal=<key>=<value>` 태그를 사용하여 시크릿 데이터를 제공할 수도 있다.
-이 태그는 여러 키-값 쌍을 제공하기 위해 두 번 이상 지정할 수 있다.
-`$`, `\`, `*`, `=` 및 `!`와 같은 특수 문자는
-[shell](https://en.wikipedia.org/wiki/Shell_(computing))에 해석하고 처리하기 때문에
-이스케이프할 필요가 있다.
-
-대부분의 셸에서 암호를 이스케이프하는 가장 쉬운 방법은 암호를 작은따옴표(`'`)로 둘러싸는 것이다.
-예를 들어, 비밀번호가 `S!B\*d$zDsb=`인 경우,
-다음 커맨드를 실행한다.
-
-```shell
-kubectl create secret generic db-user-pass \
-  --from-literal=username=devuser \
-  --from-literal=password='S!B\*d$zDsb='
-```
-
-## 시크릿 확인
+### 시크릿 확인 {#verify-the-secret}
 
 시크릿이 생성되었는지 확인한다.
 
@@ -83,14 +87,14 @@ kubectl get secrets
 출력은 다음과 유사하다.
 
 ```
-NAME                  TYPE                                  DATA      AGE
-db-user-pass          Opaque                                2         51s
+NAME              TYPE       DATA      AGE
+db-user-pass      Opaque     2         51s
 ```
 
-다음 명령을 실행하여 `시크릿`에 대한 상세 사항을 볼 수 있다.
+시크릿의 상세 사항을 보자.
 
 ```shell
-kubectl describe secrets/db-user-pass
+kubectl describe secret db-user-pass
 ```
 
 출력은 다음과 유사하다.
@@ -113,59 +117,83 @@ username:    5 bytes
 기본적으로 `시크릿`의 내용을 표시하지 않는다. 이는 `시크릿`이 실수로 노출되거나
 터미널 로그에 저장되는 것을 방지하기 위한 것이다.
 
+### 시크릿 디코딩 {#decoding-secret}
 
-인코딩된 데이터의 실제 내용을 확인하려면 [시크릿 디코딩](#decoding-secret)을 확인하자.
+1.  생성한 시크릿을 보려면 다음 명령을 실행한다.
 
-## 시크릿 디코딩  {#decoding-secret}
+    ```shell
+    kubectl get secret db-user-pass -o jsonpath='{.data}'
+    ```
 
-생성한 시크릿을 보려면 다음 명령을 실행한다.
+    출력은 다음과 유사하다.
+
+    ```json
+    { "password": "UyFCXCpkJHpEc2I9", "username": "YWRtaW4=" }
+    ```
+
+1.  `password` 데이터를 디코딩한다.
+
+    ```shell
+    echo 'UyFCXCpkJHpEc2I9' | base64 --decode
+    ```
+
+    출력은 다음과 유사하다.
+
+    ```
+    S!B\*d$zDsb=
+    ```
+
+    {{< caution >}}
+    이 예시는 문서화를 위한 것이다. 실제로,
+    이 방법은 인코딩된 데이터가 포함된 명령어를 셸 히스토리에 남기게 되는 문제를 야기할 수 있다.
+    당신의 컴퓨터에 접근할 수 있는 사람은 누구나 그 명령어를 찾아 그 비밀 정보를
+    디코드할 수 있다. 더 나은 접근법은 시크릿을 보는 명령어와 디코드하는 명령어를
+    조합하여 사용하는 것이다.
+    {{< /caution >}}
+
+    ```shell
+    kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
+    ```
+
+## 시크릿 편집 {#edit-secret}
+
+존재하는 `시크릿` 오브젝트가 [수정 불가능한(immutable)](/ko/docs/concepts/configuration/secret/#secret-immutable)이
+아니라면 편집할 수 있다. 시크릿을 편집하기 위해서  
+다음 명령어를 실행한다.
 
 ```shell
-kubectl get secret db-user-pass -o jsonpath='{.data}'
+kubectl edit secrets <secret-name>
 ```
 
-출력은 다음과 유사하다.
+이 명령어는 기본 편집기를 열고 다음 예시와 같이 `data` 필드의 base64로 인코딩된
+시크릿의 값들을 업데이트할 수 있도록 허용한다.
 
-```json
-{"password":"MWYyZDFlMmU2N2Rm","username":"YWRtaW4="}
+```yaml
+# 아래 오브젝트를 편집하길 바란다. '#'로 시작하는 줄은 무시될 것이고,
+# 빈 파일은 편집을 중단시킬 것이다. 이 파일을 저장하는 동안 오류가 발생한다면
+# 이 파일은 관련된 오류와 함께 다시 열린다.
+#
+apiVersion: v1
+data:
+  password: UyFCXCpkJHpEc2I9
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  creationTimestamp: "2022-06-28T17:44:13Z"
+  name: db-user-pass
+  namespace: default
+  resourceVersion: "12708504"
+  uid: 91becd59-78fa-4c85-823f-6d44436242ac
+type: Opaque
 ```
-
-이제 `password` 데이터를 디코딩할 수 있다.
-
-```shell
-# 이 예시는 문서화를 위한 것이다. 
-# 아래와 같은 방법으로 이를 수행했다면, 
-# 'MWYyZDFlMmU2N2Rm' 데이터가 셸 히스토리에 저장될 수 있다. 
-# 당신의 컴퓨터에 접근할 수 있는 사람이 당신 몰래 저장된 명령을 찾아 
-# 시크릿을 base-64 디코드할 수도 있다. 
-# 따라서 이 페이지의 아래 부분에 나오는 다른 단계들과 조합하는 것이 좋다.
-echo 'MWYyZDFlMmU2N2Rm' | base64 --decode
-```
-
-출력은 다음과 유사하다.
-
-```
-1f2d1e2e67df
-```
-
-인코딩된 시크릿 값이 셸 히스토리에 저장되는 것을 피하려면, 
-다음의 명령을 실행할 수 있다.
-
-```shell
-kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
-```
-
-출력은 위의 경우와 유사할 것이다.
 
 ## 삭제
 
-생성한 시크릿을 삭제하려면 다음 명령을 실행한다.
+시크릿을 삭제하기 위해서 다음 명령어를 실행한다.
 
 ```shell
 kubectl delete secret db-user-pass
 ```
-
-<!-- discussion -->
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/ko/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/ko/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -1,5 +1,5 @@
 ---
-title: kustomize를 사용하여 시크릿 관리
+title: kustomize를 사용하여 시크릿(Secret) 관리
 content_type: task
 weight: 30
 description: kustomization.yaml 파일을 사용하여 시크릿 오브젝트 생성.
@@ -7,12 +7,9 @@ description: kustomization.yaml 파일을 사용하여 시크릿 오브젝트 �
 
 <!-- overview -->
 
-쿠버네티스 v1.14부터 `kubectl`은 
-[Kustomize를 이용한 쿠버네티스 오브젝트의 선언형 관리](/ko/docs/tasks/manage-kubernetes-objects/kustomization/)를 지원한다.
-Kustomize는 시크릿 및 컨피그맵을 생성하기 위한 리소스 생성기를 제공한다.
-Kustomize 생성기는 디렉토리 내의 `kustomization.yaml` 파일에 지정되어야 한다.
-시크릿 생성 후 `kubectl apply`를 통해 API
-서버에 시크릿을 생성할 수 있다.
+`kubectl`은 시크릿과 컨피그맵(ConfigMap)을 관리하기위해 [Kustomize를 이용한 쿠버네티스 오브젝트의 선언형 관리](/ko/docs/tasks/manage-kubernetes-objects/kustomization/)를
+지원한다. Kustomize를 이용하여 *리소스 생성기*를 생성한다. 이는 `kubectl`을
+사용하여 API 서버에 적용할 수 있는 시크릿을 생성한다.
 
 ## {{% heading "prerequisites" %}}
 
@@ -20,37 +17,46 @@ Kustomize 생성기는 디렉토리 내의 `kustomization.yaml` 파일에 지정
 
 <!-- steps -->
 
-## Kustomization 파일 생성
+## 시크릿 생성
 
-`kustomization.yaml` 파일에 다른 기존 파일을 참조하는 
-`secretGenerator`를 정의하여 시크릿을 생성할 수 있다.
-예를 들어 다음 kustomization 파일은
-`./username.txt` 및 `./password.txt` 파일을 참조한다.
+`kustomization.yaml` 파일에 다른 기존 파일, `.env` 파일 및
+리터럴(literal) 값들을 참조하는 `secretGenerator`를 정의하여 시크릿을 생성할 수 있다.
+예를 들어 다음 명령어는 사용자 이름 `admin`과 비밀번호 `1f2d1e2e67df`
+를 위해 Kustomization 파일을 생성한다.
 
-```yaml
+### Kustomization 파일 생성
+
+{{< tabs name="Secret data" >}}
+{{< tab name="Literals" codelang="yaml" >}}
 secretGenerator:
-- name: db-user-pass
-  files:
-  - username.txt
-  - password.txt
-```
-
-`kustomization.yaml` 파일에 리터럴을 명시하여 `secretGenerator`를
-정의할 수도 있다.
-예를 들어 다음 `kustomization.yaml` 파일에는
-각각 `username`과 `password`에 대한 두 개의 리터럴이 포함되어 있다.
-
-```yaml
-secretGenerator:
-- name: db-user-pass
+- name: database-creds
   literals:
   - username=admin
   - password=1f2d1e2e67df
-```
+{{< /tab >}}
+{{% tab name="Files" %}}
+1.  base64로 인코딩된 자격 증명의 값들을 파일에 저장한다.
 
-`kustomization.yaml` 파일에 `.env` 파일을 명시하여
-`secretGenerator`를 정의할 수도 있다.
-예를 들어 다음 `kustomization.yaml` 파일은
+    ```shell
+    echo -n 'admin' > ./username.txt
+    echo -n '1f2d1e2e67df' > ./password.txt
+    ```
+    `-n` 플래그는 파일의 끝에 개행 문자가 존재하지 않는 것을
+    보장한다.
+
+1.  `kustomization.yaml` 파일 생성:
+
+    ```yaml
+    secretGenerator:
+    - name: database-creds
+      files:
+      - username.txt
+      - password.txt
+    ```
+{{% /tab %}}}
+{{% tab name=".env files" %}}
+`kustomization.yaml` 파일에 `.env` 파일을 명시하여 시크릿 생성자를
+정의할 수도 있다. 예를 들어 다음 `kustomization.yaml` 파일은
 `.env.secret` 파일에서 데이터를 가져온다.
 
 ```yaml
@@ -59,81 +65,62 @@ secretGenerator:
   envs:
   - .env.secret
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
-모든 경우에 대해, 값을 base64로 인코딩하지 않아도 된다.
+모든 경우에 대해, 값을 base64로 인코딩하지 않아도 된다. YAML 파일의 이름은
+**무조건** `kustomization.yaml` 또는 `kustomization.yml` 이어야 한다.
 
-## 시크릿 생성
+### kustomization 파일 적용
 
-다음 명령을 실행하여 시크릿을 생성한다.
+시크릿을 생성하기 위해서 kustomization 파일을 포함하는 디렉토리에 적용한다.
 
 ```shell
-kubectl apply -k .
+kubectl apply -k <directory-path>
 ```
 
 출력은 다음과 유사하다.
 
 ```
-secret/db-user-pass-96mffmfh4k created
+secret/database-creds-5hdh7hhgfk created
 ```
 
 시크릿이 생성되면 시크릿 데이터를 해싱하고
 이름에 해시 값을 추가하여 시크릿 이름이 생성된다. 이렇게 함으로써
 데이터가 수정될 때마다 시크릿이 새롭게 생성된다.
 
-## 생성된 시크릿 확인
+시크릿이 생성되었는지 확인하고 시크릿 데이터를 디코딩하려면, 다음을 참조한다.
+[kubectl을 사용한 시크릿 관리](/ko/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
-시크릿이 생성된 것을 확인할 수 있다.
+## 시크릿 편집 {#edit-secret}
 
-```shell
-kubectl get secrets
-```
+1.  `kustomization.yaml` 파일에서 `password`와 같은 데이터를 수정한다.
+1.  kustomization 파일을 포함하는 디렉토리에 적용한다:
 
-출력은 다음과 유사하다.
+    ```shell
+    kubectl apply -k <directory-path>
+    ```
 
-```
-NAME                             TYPE                                  DATA      AGE
-db-user-pass-96mffmfh4k          Opaque                                2         51s
-```
+    출력은 다음과 유사하다.
 
-다음 명령을 실행하여 시크릿에 대한 상세 사항을 볼 수 있다.
+    ```
+    secret/db-user-pass-6f24b56cc8 created
+    ```
 
-```shell
-kubectl describe secrets/db-user-pass-96mffmfh4k
-```
-
-출력은 다음과 유사하다.
-
-```
-Name:            db-user-pass-96mffmfh4k
-Namespace:       default
-Labels:          <none>
-Annotations:     <none>
-
-Type:            Opaque
-
-Data
-====
-password.txt:    12 bytes
-username.txt:    5 bytes
-```
-
-`kubectl get` 및 `kubectl describe` 명령은 기본적으로 `시크릿`의 내용을 표시하지 않는다.
-이는 `시크릿`이 실수로 구경꾼에게 노출되는 것을 방지하기 위한 것으로,
-또는 터미널 로그에 저장되지 않는다.
-인코딩된 데이터의 실제 내용을 확인하려면 다음을 참조한다.
-[시크릿 디코딩](/ko/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
+편집된 시크릿은 존재하는 `Secret` 오브젝트를 업데이트하는 것이 아니라
+새로운 `Secret` 오브젝트로 생성된다. 따라서 파드에서 시크릿에 대한 참조를
+업데이트해야 한다.
 
 ## 삭제
 
-생성한 시크릿을 삭제하려면 다음 명령을 실행한다.
+시크릿을 삭제하려면 `kubectl`을 사용한다.
 
 ```shell
-kubectl delete secret db-user-pass-96mffmfh4k
+kubectl delete secret db-user-pass
 ```
 
-<!-- Optional section; add links to information related to this topic. -->
 ## {{% heading "whatsnext" %}}
 
 - [시크릿 개념](/ko/docs/concepts/configuration/secret/)에 대해 자세히 알아보기
-- [`kubectl` 커맨드을 사용하여 시크릿 관리](/ko/docs/tasks/configmap-secret/managing-secret-using-kubectl/) 방법 알아보기
-- [환경 설정 파일을 사용하여 시크릿을 관리](/ko/docs/tasks/configmap-secret/managing-secret-using-config-file/)하는 방법 알아보기
+- [kubectl을 사용한 시크릿 관리](/ko/docs/tasks/configmap-secret/managing-secret-using-kubectl/) 방법 알아보기
+- [환경 설정 파일을 사용한 시크릿 관리](/ko/docs/tasks/configmap-secret/managing-secret-using-config-file/) 방법 알아보기


### PR DESCRIPTION
Related Issue : https://github.com/kubernetes/website/issues/38458

I have updated some of the outdated contents in dev-1.26-ko.1 branch.

Full changes in the original english content can be checked with this [comparison](https://github.com/kubernetes/website/compare/dev-1.25-ko.1...dev-1.26-ko.1)

## Updated Files
- [ ]  M156. content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md | 109(+L) 80(-)
- [ ]  M157. content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md | 65(+M) 79(-)