### PR TITLE
Add server side field validation section

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -120,6 +120,22 @@ satisfy the StatefulSet specification.
 Different kinds of object can also have different `.status`; again, the API reference pages
 detail the structure of that `.status` field, and its content for each different type of object.
 
+### Server Side Field Validation
+
+Starting with Kubernetes v1.25, the API server offers server side
+[field validation](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/using-api/api-concepts.md#field-validation)
+that detects unrecognized or duplicate fields in an object. It provides all the functionality of `kubectl --validate` on the server side.
+
+The `kubectl` tool uses the `--validate` flag to set the level of field validation. It accepts the values `ignore`, `warn`, and `strict` while also
+accepting the values `true` (equivalent to `strict`) and `false` (equivalent to `ignore`). The default validation setting for kubectl is `--validate=true`,
+which means strict server-side field validation.
+
+- Strict: Strict field validation, errors on validation failure
+- Warn: Field validation is performed, but errors are exposed as warnings rather than failing the request
+- Ignore: No server side field validation is performed
+
+When `kubectl` cannot connect to an API server with field validation (API servers prior to Kubernetes 1.27), it will fall back to using client-side validation. Client-side validation will be removed entirely in a future version of `kubectl`.
+
 ## {{% heading "whatsnext" %}}
 
 If you're new to Kubernetes, read more about the following:

--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -123,7 +123,7 @@ detail the structure of that `.status` field, and its content for each different
 ### Server Side Field Validation
 
 Starting with Kubernetes v1.25, the API server offers server side
-[field validation](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/using-api/api-concepts.md#field-validation)
+[field validation](/docs/reference/using-api/api-concepts/#field-validation)
 that detects unrecognized or duplicate fields in an object. It provides all the functionality of `kubectl --validate` on the server side.
 
 The `kubectl` tool uses the `--validate` flag to set the level of field validation. It accepts the values `ignore`, `warn`, and `strict` while also

--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -141,8 +141,10 @@ which means strict server-side field validation.
 `Ignore`
 : No server side field validation is performed
 
-When `kubectl` cannot connect to an API server with field validation (API servers prior to Kubernetes 1.27),
-it will fall back to using client-side validation.
+When `kubectl` cannot connect to an API server that supports field validation it will fall back
+to using client-side validation. Kubernetes 1.27 and later versions always offer field validation;
+older Kubernetes releases might not. If your cluster is older than v1.27, check the documentation
+for your version of Kubernetes.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -129,8 +129,7 @@ of `kubectl --validate` on the server side.
 
 The `kubectl` tool uses the `--validate` flag to set the level of field validation. It accepts the
 values `ignore`, `warn`, and `strict` while also accepting the values `true` (equivalent to `strict`)
-and `false` (equivalent to `ignore`). The default validation setting for kubectl is `--validate=true`,
-which means strict server-side field validation.
+and `false` (equivalent to `ignore`). The default validation setting for `kubectl` is `--validate=true`.
 
 `Strict`
 : Strict field validation, errors on validation failure

--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -120,21 +120,29 @@ satisfy the StatefulSet specification.
 Different kinds of object can also have different `.status`; again, the API reference pages
 detail the structure of that `.status` field, and its content for each different type of object.
 
-### Server Side Field Validation
+## Server side field validation
 
 Starting with Kubernetes v1.25, the API server offers server side
 [field validation](/docs/reference/using-api/api-concepts/#field-validation)
-that detects unrecognized or duplicate fields in an object. It provides all the functionality of `kubectl --validate` on the server side.
+that detects unrecognized or duplicate fields in an object. It provides all the functionality
+of `kubectl --validate` on the server side.
 
-The `kubectl` tool uses the `--validate` flag to set the level of field validation. It accepts the values `ignore`, `warn`, and `strict` while also
-accepting the values `true` (equivalent to `strict`) and `false` (equivalent to `ignore`). The default validation setting for kubectl is `--validate=true`,
+The `kubectl` tool uses the `--validate` flag to set the level of field validation. It accepts the
+values `ignore`, `warn`, and `strict` while also accepting the values `true` (equivalent to `strict`)
+and `false` (equivalent to `ignore`). The default validation setting for kubectl is `--validate=true`,
 which means strict server-side field validation.
 
-- Strict: Strict field validation, errors on validation failure
-- Warn: Field validation is performed, but errors are exposed as warnings rather than failing the request
-- Ignore: No server side field validation is performed
+`Strict`
+: Strict field validation, errors on validation failure
 
-When `kubectl` cannot connect to an API server with field validation (API servers prior to Kubernetes 1.27), it will fall back to using client-side validation. Client-side validation will be removed entirely in a future version of `kubectl`.
+`Warn`
+: Field validation is performed, but errors are exposed as warnings rather than failing the request
+
+`Ignore`
+: No server side field validation is performed
+
+When `kubectl` cannot connect to an API server with field validation (API servers prior to Kubernetes 1.27),
+it will fall back to using client-side validation.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Adds Server Side Field Validation section to [Objects In Kubernetes](/docs/concepts/overview/working-with-objects/). Fixes #39212 