### PR TITLE
[ja] update Japanese translation for https://kubernetes.io/ja

### DIFF
--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -30,6 +30,8 @@ Googleが週に何十億ものコンテナを実行することを可能とし�
 
 Kubernetesはオープンソースなので、オンプレミスやパブリッククラウド、それらのハイブリッドなどの利点を自由に得ることができ、簡単に移行することができます。
 
+Kubernetesをダウンロードするには、[ダウンロード](/releases/download/)セクションを訪れてください。
+
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
@@ -41,12 +43,12 @@ Kubernetesはオープンソースなので、オンプレミスやパブリッ�
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">ビデオを見る</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu22" button id="desktopKCButton">2022年5月16日〜20日のKubeCon EUバーチャルに参加する</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">2023年4月18日〜21日のKubeCon + CloudNativeCon Europeに参加する</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna22" button id="desktopKCButton">2022年10月24日-28日のKubeCon NAバーチャルに参加する</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">2023年11月6日〜9日のKubeCon + CloudNativeCon North Americaに参加する</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
This PR updates Japanese translation of https://kubernetes.io/ja

Fixes #41130

I would prefer Japanese language for suggestions and discussion of revisions to this translation.
(表現に関わるため、この翻訳についてのデイスカッションは日本語を希望します)

- added download link
- updated events info