### PR TITLE
kubeadm: add the "config validate" command as placeholder

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_validate.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_validate.md
@@ -1,0 +1,77 @@
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+PLACEHOLDER
+
+### Synopsis
+
+PLACEHOLDER
+
+```
+kubeadm config validate [flags]
+```
+
+### Options
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>help for validate</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>PLACEHOLDER</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### Options inherited from parent commands
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -31,6 +31,8 @@ For more information on using the kubeadm configuration API navigate to
 You can use `kubeadm config migrate` to convert your old configuration files that contain a deprecated
 API version to a newer, supported API version.
 
+`kubeadm config validate` can be used for validating a configuration file.
+
 `kubeadm config images list` and `kubeadm config images pull` can be used to list and pull the images
 that kubeadm requires.
 
@@ -50,6 +52,10 @@ that kubeadm requires.
 ## kubeadm config migrate {#cmd-config-migrate}
 
 {{< include "generated/kubeadm_config_migrate.md" >}}
+
+## kubeadm config validate {#cmd-config-validate}
+
+{{< include "generated/kubeadm_config_validate.md" >}}
 
 ## kubeadm config images list {#cmd-config-images-list}
 


### PR DESCRIPTION
Include the command in kubeadm-config.md.
The generated file is a placeholder and will be updated before 1.28 releases.

PR is targeting the 1.28 branch.

xref https://github.com/kubernetes/kubeadm/issues/2871