### PR TITLE
Fix a shell command in examples of "Init Containers" page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -83,7 +83,7 @@ Here are some ideas for how to use init containers:
 * Wait for a {{< glossary_tooltip text="Service" term_id="service">}} to
   be created, using a shell one-line command like:
   ```shell
-  for i in {1..100}; do sleep 1; if dig myservice; then exit 0; fi; done; exit 1
+  for i in {1..100}; do sleep 1; if nslookup myservice; then exit 0; fi; done; exit 1
   ```
 
 * Register this Pod with a remote server from the downward API with a command like:


### PR DESCRIPTION
Fix https://github.com/kubernetes/website/issues/41144 

Ref Link: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#examples

Because `dig myservice` always returns true "0" regardless of whether the name resolves.
To wait for the service to be created, we can replace dig with `nslookup` since "nslookup returns with an exit status of 1 if any query failed, and 0 otherwise."