### PR TITLE
[ko] Update outdated korean contents in dev-1.26-ko.1 (M158-162)

### DIFF
--- a/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -88,7 +88,7 @@ Google Compute Engine 영구 디스크, NFS 공유 또는 Amazone Elastic
 Block Store 볼륨과 같은 네트워크 자원을 프로비저닝한다. 클러스터 관리자는 
 [스토리지클래스(StorageClasses)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageclass-v1-storage-k8s-io)를 
 사용하여 
-[동적 프로비저닝](/docs/concepts/storage/dynamic-provisioning/)을 설정할 수도 있다. 
+[동적 프로비저닝](/ko/docs/concepts/storage/dynamic-provisioning/)을 설정할 수도 있다. 
 
 hostPath 퍼시스턴트볼륨의 설정 파일은 아래와 같다.
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -86,9 +86,9 @@ Hello from Kubernetes storage
 운영 클러스터에서, 사용자가 hostPath를 사용하지는 않는다. 대신, 클러스터 관리자는 
 Google Compute Engine 영구 디스크, NFS 공유 또는 Amazone Elastic 
 Block Store 볼륨과 같은 네트워크 자원을 프로비저닝한다. 클러스터 관리자는 
-[스토리지클래스(StorageClasses)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageclass-v1-storage)를 
+[스토리지클래스(StorageClasses)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageclass-v1-storage-k8s-io)를 
 사용하여 
-[동적 프로비저닝](/blog/2016/10/dynamic-provisioning-and-storage-in-kubernetes)을 설정할 수도 있다. 
+[동적 프로비저닝](/docs/concepts/storage/dynamic-provisioning/)을 설정할 수도 있다. 
 
 hostPath 퍼시스턴트볼륨의 설정 파일은 아래와 같다.
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -14,14 +14,9 @@ weight: 50
 사용할 수 있다. 이것은 레디스(Redis)와 같은 키-값 저장소나
 데이터베이스와 같은 스테이트풀 애플리케이션에 매우 중요하다.
 
-
-
 ## {{% heading "prerequisites" %}}
 
-
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-
 
 <!-- steps -->
 
@@ -37,71 +32,71 @@ weight: 50
 
 1. 파드 생성
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/pods/storage/redis.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/storage/redis.yaml
+   ```
 
 1. 파드의 컨테이너가 Running 중인지 확인하고, 파드의 변경사항을
 지켜본다.
 
-    ```shell
-    kubectl get pod redis --watch
-    ```
+   ```shell
+   kubectl get pod redis --watch
+   ```
 
-    출력은 이와 유사하다.
+   출력은 이와 유사하다.
 
-    ```shell
-    NAME      READY     STATUS    RESTARTS   AGE
-    redis     1/1       Running   0          13s
-    ```
+   ```shell
+   NAME      READY     STATUS    RESTARTS   AGE
+   redis     1/1       Running   0          13s
+   ```
 
 1. 다른 터미널에서 실행 중인 컨테이너의 셸을 획득한다.
 
-    ```shell
-    kubectl exec -it redis -- /bin/bash
-    ```
+   ```shell
+   kubectl exec -it redis -- /bin/bash
+   ```
 
 1. 셸에서 `/data/redis` 로 이동하고, 파일을 생성한다.
 
-    ```shell
-    root@redis:/data# cd /data/redis/
-    root@redis:/data/redis# echo Hello > test-file
-    ```
+   ```shell
+   root@redis:/data# cd /data/redis/
+   root@redis:/data/redis# echo Hello > test-file
+   ```
 
 1. 셸에서 실행 중인 프로세스 목록을 확인한다.
 
-    ```shell
-    root@redis:/data/redis# apt-get update
-    root@redis:/data/redis# apt-get install procps
-    root@redis:/data/redis# ps aux
-    ```
+   ```shell
+   root@redis:/data/redis# apt-get update
+   root@redis:/data/redis# apt-get install procps
+   root@redis:/data/redis# ps aux
+   ```
 
-    출력은 이와 유사하다.
+   출력은 이와 유사하다.
 
-    ```shell
-    USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-    redis        1  0.1  0.1  33308  3828 ?        Ssl  00:46   0:00 redis-server *:6379
-    root        12  0.0  0.0  20228  3020 ?        Ss   00:47   0:00 /bin/bash
-    root        15  0.0  0.0  17500  2072 ?        R+   00:48   0:00 ps aux
-    ```
+   ```shell
+   USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+   redis        1  0.1  0.1  33308  3828 ?        Ssl  00:46   0:00 redis-server *:6379
+   root        12  0.0  0.0  20228  3020 ?        Ss   00:47   0:00 /bin/bash
+   root        15  0.0  0.0  17500  2072 ?        R+   00:48   0:00 ps aux
+   ```
 
 1. 셸에서 Redis 프로세스를 강제종료(kill)한다.
 
-    ```shell
-    root@redis:/data/redis# kill <pid>
-    ```
+   ```shell
+   root@redis:/data/redis# kill <pid>
+   ```
 
-    여기서 `<pid>`는 Redis 프로세스 ID(PID) 이다.
+   여기서 `<pid>`는 Redis 프로세스 ID(PID) 이다.
 
 1. 원래 터미널에서, Redis 파드의 변경을 지켜본다. 결국,
-다음과 유사한 것을 보게 될 것이다.
+   다음과 유사한 것을 보게 될 것이다.
 
-    ```shell
-    NAME      READY     STATUS     RESTARTS   AGE
-    redis     1/1       Running    0          13s
-    redis     0/1       Completed  0         6m
-    redis     1/1       Running    1         6m
-    ```
+   ```shell
+   NAME      READY     STATUS     RESTARTS   AGE
+   redis     1/1       Running    0          13s
+   redis     0/1       Completed  0         6m
+   redis     1/1       Running    1         6m
+   ```
 
 이때, 컨테이너는 종료되고 재시작된다. 이는
 Redis 파드의
@@ -110,27 +105,25 @@ Redis 파드의
 
 1. 재시작된 컨테이너의 셸을 획득한다.
 
-    ```shell
-    kubectl exec -it redis -- /bin/bash
-    ```
+   ```shell
+   kubectl exec -it redis -- /bin/bash
+   ```
 
 1. 셸에서 `/data/redis` 로 이동하고, `test-file` 이 여전히 존재하는지 확인한다.
-    ```shell
-    root@redis:/data/redis# cd /data/redis/
-    root@redis:/data/redis# ls
-    test-file
-    ```
+
+   ```shell
+   root@redis:/data/redis# cd /data/redis/
+   root@redis:/data/redis# ls
+   test-file
+   ```
 
 1. 이 연습을 위해 생성한 파드를 삭제한다.
 
-    ```shell
-    kubectl delete pod redis
-    ```
-
-
+   ```shell
+   kubectl delete pod redis
+   ```
 
 ## {{% heading "whatsnext" %}}
-
 
 * [볼륨](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#volume-v1-core)을 참고한다.
 
@@ -141,7 +134,3 @@ Redis 파드의
 네트워크 연결 스토리지(NAS) 솔루션을 지원하며,
 노드의 디바이스 마운트, 언마운트와 같은 세부사항을 처리한다.
 자세한 내용은 [볼륨](/ko/docs/concepts/storage/volumes/)을 참고한다.
-
-
-
-

--- a/content/ko/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/ko/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -61,6 +61,7 @@ cat ~/.docker/config.json
 
 {{< note >}}
 도커 자격 증명 저장소를 사용하는 경우, `auth` 항목이 아닌, 저장소의 이름을 값으로 사용하는 `credsStore` 항목을 확인할 수 있다.
+이 경우, 시크릿을 직접 생성할 수 있다. [커맨드 라인에서 자격 증명을 통하여 시크릿 생성하기](#커맨드-라인에서-자격-증명을-통하여-시크릿-생성하기)를 보자.
 {{< /note >}}
 
 ## 기존의 자격 증명을 기반으로 시크릿 생성하기 {#registry-secret-existing-credentials}
@@ -190,7 +191,7 @@ janedoe:xxxxxxxxxxx
 위 파일을 컴퓨터에 다운로드한다.
 
 ```shell
-curl -L -O my-private-reg-pod.yaml https://k8s.io/examples/pods/private-reg-pod.yaml
+curl -L -o my-private-reg-pod.yaml https://k8s.io/examples/pods/private-reg-pod.yaml
 ```
 
 `my-private-reg-pod.yaml` 파일 안에서, `<your-private-image>` 값을 다음과 같은 프라이빗 저장소 안의 이미지 경로로 변경한다.

--- a/content/ko/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/ko/docs/tasks/configure-pod-container/static-pod.md
@@ -38,6 +38,10 @@ API 서버에서 제어될 수는 없다.
 {{< glossary_tooltip text="시크릿" term_id="secret" >}}, 등)가 참조할 수 없다.
 {{< /note >}}
 
+{{< note >}}
+스태틱 파드는 [임시 컨테이너](/ko/docs/concepts/workloads/pods/ephemeral-containers/)를 지원하지 않는다.
+{{< /note >}}
+
 ## {{% heading "prerequisites" %}}
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}


### PR DESCRIPTION
Related Issue : https://github.com/kubernetes/website/issues/38458

I have updated some of the outdated contents in dev-1.26-ko.1 branch.

Full changes in the original english content can be checked with this [comparison](https://github.com/kubernetes/website/compare/dev-1.25-ko.1...dev-1.26-ko.1)


## Updated Files
- [ ] M158. `content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md` | 2(+XS) 2(-)
- [ ]  M159. `content/en/docs/tasks/configure-pod-container/configure-volume-storage.md` | 63(+M) 74(-)
- [ ]  M160. `content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md` | 2(+XS) 1(-)
- [ ]  M161. `content/en/docs/tasks/configure-pod-container/static-pod.md` | 4(+XS) 0(-)

M162는 이미 변경 사항이 적용되어 있어서 따로 수정하지 않았습니다.