### PR TITLE
Add tenative July and August patch release dates

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -80,6 +80,8 @@ releases may also occur in between these.
 | --------------------- | -------------------- | ----------- |
 | May 2023              | 2023-05-12           | 2023-05-17  |
 | June 2023             | 2023-06-09           | 2023-06-14  |
+| July 2023             | 2023-07-07           | 2023-07-12  |
+| August 2023           | 2023-08-04           | 2023-08-09  |
 
 ## Detailed Release History for Active Branches
 


### PR DESCRIPTION
Add tentative patch release dates for July and August patch releases

Some notes:
* August patch date is the week before Kubernetes 1.28 release
* Cherry Pick Deadline falls the week of 4th July for US folks
* Dates otherwise seem _mostly_ (but not entirely) to clear holidays otherwise 

/assign @saschagrunert @Verolop @xmudrii 
cc https://github.com/orgs/kubernetes/teams/release-engineering