### PR TITLE
removed hyperlink in restrict a container

### DIFF
--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -122,8 +122,7 @@ gke-test-default-pool-239f5d02-xwux: kubelet is posting ready status. AppArmor e
 
 {{< note >}}
 AppArmor is currently in beta, so options are specified as annotations. Once support graduates to
-general availability, the annotations will be replaced with first-class fields (more details in
-[Upgrade path to GA](#upgrade-path-to-general-availability)).
+general availability, the annotations will be replaced with first-class fields.
 {{< /note >}}
 
 AppArmor profiles are specified *per-container*. To specify the AppArmor profile to run a Pod


### PR DESCRIPTION
Removed invalid link in Restrict a container 

**Under** 
**Securing a Pod**  in `note` [Upgrade path to GA](https://kubernetes.io/docs/tutorials/security/apparmor/#upgrade-path-to-general-availability)

There is no valid link that can be replaced with it 