### PR TITLE
[zh-cn] sync cluster-role-binding stateful-set priority-class-v1 pod-emplate-v1 deploy

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
@@ -227,6 +227,8 @@ GET /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 - **resourceVersionMatch** (*in query*): string
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+- **sendInitialEvents** (*in query*): boolean
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 - **timeoutSeconds** (*in query*): integer
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 - **watch** (*in query*): boolean
@@ -265,6 +267,10 @@ GET /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
 - **resourceVersionMatch** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
 
@@ -557,6 +563,8 @@ DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
 - **resourceVersionMatch** (*in query*): string
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+- **sendInitialEvents** (*in query*): boolean
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 - **timeoutSeconds** (*in query*): integer
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
 -->
@@ -603,6 +611,10 @@ DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
 - **resourceVersionMatch** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
 

--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
@@ -79,7 +79,7 @@ DeploymentSpec 定义 Deployment 预期行为的规约。
 
 - **template** (<a href="{{< ref "../workload-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
 
-  Template describes the pods that will be created.
+  Template describes the pods that will be created. The only allowed template.spec.restartPolicy value is "Always".
 -->
 - **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)，必需
   
@@ -88,7 +88,8 @@ DeploymentSpec 定义 Deployment 预期行为的规约。
 
 - **template** (<a href="{{< ref "../workload-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>)，必需
   
-  template 描述将要创建的 Pod。
+  template 描述将要创建的 Pod。`template.spec.restartPolicy`
+  唯一被允许的值是 `Always`。
 
 <!--
 - **replicas** (int32)
@@ -521,6 +522,7 @@ GET /apis/apps/v1/namespaces/{namespace}/deployments
 - **pretty** (*in query*): string
 - **resourceVersion** (*in query*): string
 - **resourceVersionMatch** (*in query*): string
+- **sendInitialEvents** (*in query*): boolean
 - **timeoutSeconds** (*in query*): integer
 - **watch** (*in query*): boolean
 -->
@@ -562,6 +564,10 @@ GET /apis/apps/v1/namespaces/{namespace}/deployments
   
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 - **timeoutSeconds** (**查询参数**): integer
   
   <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
@@ -599,6 +605,7 @@ GET /apis/apps/v1/deployments
 - **pretty** (*in query*): string
 - **resourceVersion** (*in query*): string
 - **resourceVersionMatch** (*in query*): string
+- **sendInitialEvents** (*in query*): boolean
 - **timeoutSeconds** (*in query*): integer
 - **watch** (*in query*): boolean
 -->
@@ -635,6 +642,10 @@ GET /apis/apps/v1/deployments
 - **resourceVersionMatch** (**查询参数**): string
   
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
   
@@ -1043,6 +1054,7 @@ DELETE /apis/apps/v1/namespaces/{namespace}/deployments
 - **propagationPolicy** (*in query*): string
 - **resourceVersion** (*in query*): string
 - **resourceVersionMatch** (*in query*): string
+- **sendInitialEvents** (*in query*): boolean
 - **timeoutSeconds** (*in query*): integer
 -->
 #### 参数
@@ -1092,6 +1104,10 @@ DELETE /apis/apps/v1/namespaces/{namespace}/deployments
 - **resourceVersionMatch** (**查询参数**): string
   
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 - **timeoutSeconds** (**查询参数**): integer
   

--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-template-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-template-v1.md
@@ -247,6 +247,15 @@ GET /api/v1/namespaces/{namespace}/podtemplates
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
 
 <!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
+<!--
 - **timeoutSeconds** (*in query*): integer
 -->
 - **timeoutSeconds** （**查询参数**）：integer
@@ -340,6 +349,15 @@ GET /api/v1/podtemplates
 - **resourceVersionMatch** （**查询参数**）：string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!--
 - **timeoutSeconds** (*in query*): integer
@@ -760,6 +778,15 @@ DELETE /api/v1/namespaces/{namespace}/podtemplates
 - **resourceVersionMatch** （**查询参数**）：string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!--
 - **timeoutSeconds** (*in query*): integer

--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
@@ -65,11 +65,11 @@ PriorityClass 定义了从优先级类名到优先级数值的映射。
 <!--
 - **value** (int32), required
 
-  The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
+  value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
 -->
 - **value** （int32），必需
 
-  此优先级的值。这是 Pod 在其 Pod 规约中有此类名称时收到的实际优先级。
+  value 表示此优先级的整数值。这是 Pod 在其 Pod 规约中有此类名称时收到的实际优先级。
 
 <!--
 - **description** (string)
@@ -95,7 +95,7 @@ PriorityClass 定义了从优先级类名到优先级数值的映射。
 <!--
 - **preemptionPolicy** (string)
 
-  PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+  preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
 -->  
 - **preemptionPolicy** (string)
 
@@ -293,6 +293,15 @@ GET /apis/scheduling.k8s.io/v1/priorityclasses
 - **resourceVersionMatch** （**查询参数**）：string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!--
 - **timeoutSeconds** (*in query*): integer
@@ -786,6 +795,15 @@ DELETE /apis/scheduling.k8s.io/v1/priorityclasses
 - **resourceVersionMatch** （**查询参数**）：string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!--
 - **timeoutSeconds** (*in query*): integer

--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
@@ -101,7 +101,7 @@ StatefulSetSpec 是 StatefulSet 的规约。
 <!-- 
 - **template** (<a href="{{< ref "../workload-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
 
-  template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet. Each pod will be named with the format \<statefulsetname>-\<podindex>. For example, a pod in a StatefulSet named "web" with index number "3" would be named "web-3".  
+  template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet. Each pod will be named with the format \<statefulsetname>-\<podindex>. For example, a pod in a StatefulSet named "web" with index number "3" would be named "web-3". The only allowed template.spec.restartPolicy value is "Always".
 -->
 - **template** (<a href="{{< ref "../workload-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), 必需
 
@@ -109,6 +109,7 @@ StatefulSetSpec 是 StatefulSet 的规约。
   经由 StatefulSet 创建的每个 Pod 都将满足这个模板，但与 StatefulSet 的其余 Pod 相比，每个 Pod 具有唯一的标识。
   每个 Pod 将以 \<statefulsetname>-\<podindex> 格式命名。
   例如，名为 "web" 且索引号为 "3" 的 StatefulSet 中的 Pod 将被命名为 "web-3"。
+  `template.spec.restartPolicy` 唯一被允许的值是 `Always`。
 
 <!-- 
 - **replicas** (int32)
@@ -273,11 +274,11 @@ StatefulSetSpec 是 StatefulSet 的规约。
 - **ordinals** (StatefulSetOrdinals)
 
   <!--
-  ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a "0" index to the first replica and increments the index by one for each additional replica requested. Using the ordinals field requires the StatefulSetStartOrdinal feature gate to be enabled, which is alpha.
+  ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a "0" index to the first replica and increments the index by one for each additional replica requested. Using the ordinals field requires the StatefulSetStartOrdinal feature gate to be enabled, which is beta.
   -->
   ordinals 控制 StatefulSet 中副本索引的编号。
   默认序数行为是将索引 "0" 设置给第一个副本，对于每个额外请求的副本，该索引加一。
-  使用 ordinals 字段需要启用 Alpha 级别的 StatefulSetStartOrdinal 特性门控。
+  使用 ordinals 字段需要启用 Beta 级别的 StatefulSetStartOrdinal 特性门控。
 
   <!--
   <a name="StatefulSetOrdinals"></a>
@@ -681,6 +682,15 @@ GET /apis/apps/v1/namespaces/{namespace}/statefulsets
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a> 
 
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+
 <!-- 
 - **timeoutSeconds** (*in query*): integer
 
@@ -793,6 +803,15 @@ GET /apis/apps/v1/statefulsets
 - **resourceVersionMatch** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a> 
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!-- 
 - **timeoutSeconds** (*in query*): integer
@@ -1447,6 +1466,15 @@ DELETE /apis/apps/v1/namespaces/{namespace}/statefulsets
 - **resourceVersionMatch** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+<!--
+- **sendInitialEvents** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+-->
+- **sendInitialEvents** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!-- 
 - **timeoutSeconds** (*in query*): integer


### PR DESCRIPTION
```
#       modified:   content/zh-cn/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-template-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md

```