### PR TITLE
Update configure-aggregation-layer.md

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
@@ -44,7 +44,7 @@ The rest of this section describes these steps in detail.
 
 The flow can be seen in the following diagram.
 
-![aggregation auth flows](/images/docs/aggregation-api-auth-flow.png).
+![aggregation auth flows](/images/docs/aggregation-api-auth-flow.png)
 
 The source for the above swimlanes can be found in the source of this document.
 


### PR DESCRIPTION
This update removes a period after the swimlane graph. This period (IMO) is unnecessary, and it takes an extra line by itself thus create surprise for readers.

Screenshot:
<img width="586" alt="image" src="https://github.com/kubernetes/website/assets/8633434/236644ce-509f-41a6-a0a2-36a12d205564">

