### PR TITLE
Kubeadm without a package manager: Update cni, crictl and systemd versions

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -217,7 +217,7 @@ sudo systemctl enable --now kubelet
 Install CNI plugins (required for most pod network):
 
 ```bash
-CNI_PLUGINS_VERSION="v1.2.0"
+CNI_PLUGINS_VERSION="v1.3.0"
 ARCH="amd64"
 DEST="/opt/cni/bin"
 sudo mkdir -p "$DEST"
@@ -239,7 +239,7 @@ sudo mkdir -p "$DOWNLOAD_DIR"
 Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI))
 
 ```bash
-CRICTL_VERSION="v1.26.0"
+CRICTL_VERSION="v1.27.0"
 ARCH="amd64"
 curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | sudo tar -C $DOWNLOAD_DIR -xz
 ```
@@ -253,7 +253,7 @@ cd $DOWNLOAD_DIR
 sudo curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/{kubeadm,kubelet}
 sudo chmod +x {kubeadm,kubelet}
 
-RELEASE_VERSION="v0.4.0"
+RELEASE_VERSION="v0.15.1"
 curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /etc/systemd/system/kubelet.service
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
The section [_Installing kubeadm, kubelet and kubectl : Without a package manager_ ](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl) in the _Installing Kubeadm_ doc contains outdated versions. The following has been edited:

- [containernetworking/plugins](https://github.com/containernetworking/plugins/releases) updated to `v1.3.0` from `v1.2.0`
- [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/releases) updated to `v1.27.0` from `v1.26.0`
- [kubernetes/release](https://github.com/kubernetes/release/releases) (Kubelet systemd) to `v0.15.1` from `v0.4.0` (from Aug 10, 2020 - almost 3 years old!)

Other than that, the new changes have been tested multiple times inside Debian 11 and Ubuntu 22.04 based kvm virtual machines. All the components successfully install with the current instructions concerning the installation of kubeadm without a package manager. 
