### PR TITLE
Update install-kubeadm.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -157,7 +157,11 @@ For more information on version skews, see:
 2. Download the Google Cloud public signing key:
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+  sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   ```
+  Note: If the command fails use below command  
+   ```shell
+  sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
    ```
 
 3. Add the Kubernetes `apt` repository:


### PR DESCRIPTION
Currently gpg key errors out while installing kubeadm. 
More information about the issue can be found on here:  https://github.com/kubernetes/k8s.io/pull/4837

Currently when we try to install the update on Ubuntu 20.04 it fails when we update after adding the key.

![image](https://github.com/kubernetes/website/assets/122509001/61c1af4a-6ac4-4dc2-8faa-1141f96d6557)

After switching the url it works.

![image](https://github.com/kubernetes/website/assets/122509001/e39dced7-5524-4e3a-b148-4be9b26ca1da)

-->
