### PR TITLE
Suggest alternative download source for package signing key

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -161,8 +161,8 @@ For more information on version skews, see:
    ```
    Note: If the command fails use below command  
    ```shell
-  sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-  ```
+   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
+   ```
 
 3. Add the Kubernetes `apt` repository:
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -159,6 +159,10 @@ For more information on version skews, see:
    ```shell
    sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
    ```
+   Note: If the command fails use below command  
+   ```shell
+  sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
+  ```
 
 3. Add the Kubernetes `apt` repository:
 


### PR DESCRIPTION
Currently gpg key errors out while installing kubeadm. More information about the issue can be found on here: kubernetes/k8s.io#4837

Currently when we try to install the update on Ubuntu 20.04 it fails using existing gpg key

![image](https://github.com/kubernetes/website/assets/7992615/7ad5818b-9802-41a7-a089-63a2cb7b0a4e)

![image](https://github.com/kubernetes/website/assets/7992615/82338949-a680-461a-aaed-323fd90aeccb)


After switching url

![image](https://github.com/kubernetes/website/assets/7992615/d9916a5e-bf0d-4a78-a9d4-a18d87202b60)

![image](https://github.com/kubernetes/website/assets/7992615/c11df37c-832d-4443-b8a0-a793d77395f6)


Fixes #41246
Fixes #41235

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
