### PR TITLE
Add note for when multiple pods are started for the same job index

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -293,10 +293,9 @@ Jobs with _fixed completion count_ - that is, jobs that have non null
 
 {{< note >}}
 Although rare, more than one Pod could be started for the same index (due to various reasons such as node failures,
-kubelet restarts, or Pod evictions), but only one of them will count towards the completion count.
-In this case, only the first Pod that completes successfully will count towards the completion count and
-update the status of the Job. The other Pods that are running or completed for the same index will be
-deleted by the Job controller once they are detected.
+kubelet restarts, or Pod evictions). In this case, only the first Pod that completes successfully will
+count towards the completion count and update the status of the Job. The other Pods that are running
+or completed for the same index will be deleted by the Job controller once they are detected.
 {{< /note >}}
 
 

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -290,8 +290,14 @@ Jobs with _fixed completion count_ - that is, jobs that have non null
   The Job is considered complete when there is one successfully completed Pod
   for each index. For more information about how to use this mode, see
   [Indexed Job for Parallel Processing with Static Work Assignment](/docs/tasks/job/indexed-parallel-processing-static/).
-  Note that, although rare, more than one Pod could be started for the same
-  index, but only one of them will count towards the completion count.
+
+{{< note >}}
+Although rare, more than one Pod could be started for the same index (due to various reasons such as node failures,
+kubelet restarts, or Pod evictions), but only one of them will count towards the completion count.
+In this case, only the first Pod that completes successfully will count towards the completion count and
+update the status of the Job. The other Pods that are running or completed for the same index will be
+deleted by the Job controller once they are detected.
+{{< /note >}}
 
 
 ## Handling Pod and container failures


### PR DESCRIPTION
Add note to clarify what happens when multiple pods are started for the same index. Ref #31719 