### PR TITLE
When building for deploy, limit GOMAXPROCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ check-headers-file:
 	scripts/check-headers-file.sh
 
 production-build: module-check ## Build the production site and ensure that noindex headers aren't added
-	hugo --cleanDestinationDir --minify --environment production
+	GOMAXPROCS=1 hugo --cleanDestinationDir --minify --environment production
 	HUGO_ENV=production $(MAKE) check-headers-file
 
 non-production-build: module-check ## Build the non-production site, which adds noindex headers to prevent indexing
-	hugo --cleanDestinationDir --enableGitInfo --environment nonprod
+	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --environment nonprod
 
 serve: module-check ## Boot the development server.
 	hugo server --buildFuture --environment development


### PR DESCRIPTION
Copy the approach that we already use for Netlify deploy previews (added in PR https://github.com/kubernetes/website/pull/41142).

It would be OK to drop this once Golang is better able to work with CFS, or if Hugo includes detection for the cgroup CPU limit.