### PR TITLE
[zh] Fix bold symbol in pod-security-admission.md

### DIFF
--- a/content/zh-cn/docs/concepts/security/pod-security-admission.md
+++ b/content/zh-cn/docs/concepts/security/pod-security-admission.md
@@ -182,7 +182,7 @@ Exemptions can be statically configured in the
 -->
 ## 豁免   {#exemptions}
 
-你可以为 Pod 安全性的实施设置**豁免（Exemptions）**规则，
+你可以为 Pod 安全性的实施设置**豁免（Exemptions）** 规则，
 从而允许创建一些本来会被与给定名字空间相关的策略所禁止的 Pod。
 豁免规则可以在[准入控制器配置](/zh-cn/docs/tasks/configure-pod-container/enforce-standards-admission-controller/#configure-the-admission-controller)
 中静态配置。


### PR DESCRIPTION
Bold symbols need to add an extra space when encountering Chinese symbols

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
