### PR TITLE
Change source for signing key to validate Debian packages

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -157,7 +157,7 @@ For more information on version skews, see:
 2. Download the Google Cloud public signing key:
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
    ```
 
 3. Add the Kubernetes `apt` repository:


### PR DESCRIPTION
Updated the signing key in **Debian-based distribution** section under **Installing kubeadm, kubelet and kubectl** subtitle
