### PR TITLE
Fix broken link in “Kubernetes 1.26: We're now signing our binary release artifacts!”

### DIFF
--- a/content/en/blog/_posts/2022-12-12-kubernetes-release-artifact-signing.md
+++ b/content/en/blog/_posts/2022-12-12-kubernetes-release-artifact-signing.md
@@ -32,7 +32,7 @@ files side by side to the artifacts for verifying their integrity.
 [tarballs]: https://github.com/kubernetes/kubernetes/blob/release-1.26/CHANGELOG/CHANGELOG-1.26.md#downloads-for-v1260
 [binaries]: https://gcsweb.k8s.io/gcs/kubernetes-release/release/v1.26.0/bin
 [sboms]: https://dl.k8s.io/release/v1.26.0/kubernetes-release.spdx
-[provenance]: https://dl.k8s.io/kubernetes-release/release/v1.26.0/provenance.json
+[provenance]: https://dl.k8s.io/release/v1.26.0/provenance.json
 [cosign]: https://github.com/sigstore/cosign
 
 To verify an artifact, for example `kubectl`, you can download the


### PR DESCRIPTION
Fixed provenance url to match the correct bucket.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
/kind cleanup