### PR TITLE
Changed the instructed master/slave to primary/seconday

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -191,14 +191,14 @@ labels:
    tier: frontend
 ```
 
-while the Redis master and slave would have different `tier` labels, and perhaps even an
+while the Redis primary and secondary would have different `tier` labels, and perhaps even an
 additional `role` label:
 
 ```yaml
 labels:
    app: guestbook
    tier: backend
-   role: master
+   role: primary
 ```
 
 and
@@ -207,7 +207,7 @@ and
 labels:
    app: guestbook
    tier: backend
-   role: slave
+   role: secondary
 ```
 
 The labels allow us to slice and dice our resources along any dimension specified by a label:


### PR DESCRIPTION
Fixed issue #41284 
Replaced 
`labels: app: guestbook tier: backend role: master` and `labels: app: guestbook tier: backend role: slave` 
with
`labels: app: guestbook tier: backend role: primary` and `labels: app: guestbook tier: backend role: secondary`
