### PR TITLE
Update install-kubectl-linux.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -178,6 +178,16 @@ In releases older than Debian 12 and Ubuntu 22.04, `/etc/apt/keyrings` does not 
 You can create this directory if you need to, making it world-readable but writeable only by admins.
 {{< /note >}}
 
+{{< note >}}
+In case of deprecated apt-key warning like `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).` please use `gpg --dearmor` instead of `apt-key add`:
+```shel
+sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes.gpg
+```
+{{< /note >}}
+
+
+
+
 {{% /tab %}}
 
 {{% tab name="Red Hat-based distributions" %}}


### PR DESCRIPTION
Fix docs in case of apt-key deprecated

In Ubuntu 22.04 apt-key is deprecated throwing a warning and `apt update` does not work.

```bash
$ sudo apt-key add apt-key.gpg 
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
$
```

```bash
$ sudo apt update
Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease
Hit:2 https://linux.teamviewer.com/deb stable InRelease
...
Reading package lists... Done
W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
$
```

To fix we must use `gpg --dearmor` like the following:

```bash
$ sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -orm /etc/apt/keyrings/kubernetes.gpg
$ sudo apt-get update
```