### PR TITLE
Update install-kubectl-linux.md for spanish

### DIFF
--- a/content/es/docs/tasks/tools/included/install-kubectl-linux.md
+++ b/content/es/docs/tasks/tools/included/install-kubectl-linux.md
@@ -125,6 +125,17 @@ Por ejemplo, para descargar la versión {{< skew currentPatchVersion >}} en Linu
    sudo apt-get update
    sudo apt-get install -y kubectl
    ```
+{{< note >}}
+Em versões anteriores ao Debian 12 e Ubuntu 22.04, o `/etc/apt/keyrings` não existe por padrão. 
+Você pode criar este diretório se precisar, tornando-o visível para todos, mas com permissão de escrita apenas aos administradores.
+{{< /note >}}
+
+{{< note >}}
+Em caso de avisos de apt-key depreciado como `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).` por favor use `gpg --dearmor` ao invés de `apt-key add`:
+```shell
+sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes.gpg
+```
+{{< /note >}}
 
 {{% /tab %}}
 


### PR DESCRIPTION
Fix docs in case of apt-key deprecated for spanish docs

It relates to the pull request https://github.com/kubernetes/website/pull/41336


In Ubuntu 22.04 apt-key is deprecated throwing a warning and `apt update` does not work.

```bash
$ sudo apt-key add apt-key.gpg 
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
$
```

```bash
$ sudo apt update
Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease
Hit:2 https://linux.teamviewer.com/deb stable InRelease
...
Reading package lists... Done
W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
$
```

To fix we must use `gpg --dearmor` like the following:

```bash
$ sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -orm /etc/apt/keyrings/kubernetes.gpg
$ sudo apt-get update
```