### PR TITLE
Add gpg to required apt packages

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -151,7 +151,7 @@ For more information on version skews, see:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y apt-transport-https ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gpg
    ```
 
 2. Download the Google Cloud public signing key:


### PR DESCRIPTION
I think `gpg` is one of the packages "needed to use the Kubernetes apt repository".