### PR TITLE
linkchecker: detect absolute links with missing leading slash

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -113,7 +113,7 @@ There are two cgroup drivers available:
 
 ### cgroupfs driver {#cgroupfs-cgroup-driver}
 
-The `cgroupfs` driver is the [default cgroup driver in the kubelet](docs/reference/config-api/kubelet-config.v1beta1).
+The `cgroupfs` driver is the [default cgroup driver in the kubelet](/docs/reference/config-api/kubelet-config.v1beta1).
  When the `cgroupfs` driver is used, the kubelet and the container runtime directly interface with
  the cgroup filesystem to configure cgroups.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -140,6 +140,10 @@ Cases handled:
   + /docs/bar                : is a redirect entry, or
   + /docs/bar                : is something we don't understand
 
++ [foo](<lang>/docs/bar/...) : leading slash missing for absolute path
+
++ [foo](docs/bar/...)        : leading slash missing for absolute path
+
 ```
 ## lsync.sh
 

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -34,6 +34,10 @@
 #   + /docs/bar                : is a redirect entry, or
 #   + /docs/bar                : is something we don't understand
 #
+# + [foo](<lang>/docs/bar/...) : leading slash missing for absolute path
+#
+# + [foo](docs/bar/...)        : leading slash missing for absolute path
+#
 # + {{ < api-reference page="" anchor="" ... > }}
 # + {{ < api-reference page="" > }}
 
@@ -333,6 +337,11 @@ def check_target(page, anchor, target):
                    real_target)
             return new_record("WARNING", msg, target)
         return new_record("ERROR", "Missing link for [%s]" % anchor, target)
+
+    # absolute link missing leading slash
+    if (target.startswith("docs/") or target.startswith(LANG + "/docs/")):
+        return new_record("ERROR", "Missing leading slash. Try \"/%s\"" %
+                                   target, target)
 
     msg = "Link may be wrong for the anchor [%s]" % anchor
     return new_record("WARNING", msg, target)


### PR DESCRIPTION
When an absolute link is missing the leading slash (it starts with "docs/foo" instead of "/docs/foo/), print a more specific error instead of the generic catch-all warning.

Without the leading slash, these are treated as relative paths and so lead to non-existing pages.

Also, while we're at it, fix all the instances it detects.

--

For one example, see the `default cgroup driver in the kubelet` here:
https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroupfs-cgroup-driver

It leads to a page that doesn't exist:
https://kubernetes.io/docs/setup/production-environment/container-runtimes/docs/reference/config-api/kubelet-config.v1beta1

Instead of the intended target:
https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/