### PR TITLE
Add details for kubectl.kubernetes.io/restartedAt annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -126,6 +126,18 @@ For Kubernetes version {{< skew currentVersion >}}, you can use this label on Se
 
 Part of the specification used to implement [ApplySet-based pruning in kubectl](/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune). This label is what makes an object an ApplySet parent object. Its value is the unique ID of the ApplySet, which is derived from the identity of the parent object itself. This ID **must** be the base64 encoding (using the URL safe encoding of RFC4648) of the hash of the group-kind-name-namespace of the object it is on, in the form: `<base64(sha256(<name>.<namespace>.<kind>.<group>))>`. There is no relation between the value of this label and object UIDs.
 
+### kubectl.kubernetes.io/restartedAt
+
+Example: `kubectl.kubernetes.io/restartedAt: '2023-03-05T15:30:00Z`
+
+Used on: Pod
+
+This annotation indicates the time when a Kubernetes resource was last restarted using the kubectl command-line tool. It records the time of the most recent workload restart as a Unix timestamp.
+
+In the above example, the annotation indicates that the Pod was recently restarted at 3:30 PM UTC on March 31, 2023.
+
+The `"kubectl.kubernetes.io/restartedAt"` annotation is used by Kubernetes to keep track of the timestamp of the most recent container restart for a particular pod. This information can be useful for troubleshooting and auditing purposes, allowing administrators to track when a resource was last restarted and correlate it with other events or changes in the cluster.
+
 ### applyset.kubernetes.io/is-parent-type (alpha) {#applyset-kubernetes-io-is-parent-type}
 
 Example: `applyset.kubernetes.io/is-parent-type: "true"`

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -132,7 +132,12 @@ Example: `kubectl.kubernetes.io/restartedAt: '2023-03-05T15:30:00Z`
 
 Used on: Pod
 
-This annotation indicates the time when a Kubernetes resource was last restarted using the kubectl command-line tool. It records the time of the most recent workload restart as a Unix timestamp.
+This annotation indicates the time when a workload restart was triggered, using 
+the kubectl command-line tool.
+The kubelet tool updates the Pod template in a Deployment, ReplicaSet, StatefulSet
+or DaemonSet, making a change to the metadata of Pods defined by that template.
+By either setting this annotation or changing the value to a new date, the kubectl tool
+triggers a rollout and indirectly causes the launch of fresh, replacement Pods.
 
 In the above example, the annotation indicates that the Pod was recently restarted at 3:30 PM UTC on March 31, 2023.
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -128,7 +128,7 @@ Part of the specification used to implement [ApplySet-based pruning in kubectl](
 
 ### kubectl.kubernetes.io/restartedAt
 
-Example: `kubectl.kubernetes.io/restartedAt: '2023-03-05T15:30:00Z`
+Example: `kubectl.kubernetes.io/restartedAt: "2023-03-05T15:30:00Z"`
 
 Used on: Pod
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -139,7 +139,12 @@ or DaemonSet, making a change to the metadata of Pods defined by that template.
 By either setting this annotation or changing the value to a new date, the kubectl tool
 triggers a rollout and indirectly causes the launch of fresh, replacement Pods.
 
-In the above example, the annotation indicates that the Pod was recently restarted at 3:30 PM UTC on March 31, 2023. The `"kubectl.kubernetes.io/restartedAt"` annotation is used by Kubernetes to keep track of the timestamp of the most recent container restart for a particular pod. This information can be useful for troubleshooting and auditing purposes, allowing administrators to track when a resource was last restarted and correlate it with other events or changes in the cluster.
+In the above example, the annotation indicates that the Pod is part of a workload that was
+most recently restarted at 3:30 PM UTC on March 31, 2023.
+
+This information can be useful for troubleshooting and auditing purposes, but is mainly used
+to trigger the rollout. Recording that date is a side effect of the mechanism to trigger those
+changes.
 
 ### applyset.kubernetes.io/is-parent-type (alpha) {#applyset-kubernetes-io-is-parent-type}
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -139,10 +139,7 @@ or DaemonSet, making a change to the metadata of Pods defined by that template.
 By either setting this annotation or changing the value to a new date, the kubectl tool
 triggers a rollout and indirectly causes the launch of fresh, replacement Pods.
 
-In the above example, the annotation indicates that the Pod is part of a workload that was
-restarted at 3:30 PM UTC on March 31, 2023.
-
-The `"kubectl.kubernetes.io/restartedAt"` annotation is used by Kubernetes to keep track of the timestamp of the most recent container restart for a particular pod. This information can be useful for troubleshooting and auditing purposes, allowing administrators to track when a resource was last restarted and correlate it with other events or changes in the cluster.
+In the above example, the annotation indicates that the Pod was recently restarted at 3:30 PM UTC on March 31, 2023. The `"kubectl.kubernetes.io/restartedAt"` annotation is used by Kubernetes to keep track of the timestamp of the most recent container restart for a particular pod. This information can be useful for troubleshooting and auditing purposes, allowing administrators to track when a resource was last restarted and correlate it with other events or changes in the cluster.
 
 ### applyset.kubernetes.io/is-parent-type (alpha) {#applyset-kubernetes-io-is-parent-type}
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -139,7 +139,8 @@ or DaemonSet, making a change to the metadata of Pods defined by that template.
 By either setting this annotation or changing the value to a new date, the kubectl tool
 triggers a rollout and indirectly causes the launch of fresh, replacement Pods.
 
-In the above example, the annotation indicates that the Pod was recently restarted at 3:30 PM UTC on March 31, 2023.
+In the above example, the annotation indicates that the Pod is part of a workload that was
+restarted at 3:30 PM UTC on March 31, 2023.
 
 The `"kubectl.kubernetes.io/restartedAt"` annotation is used by Kubernetes to keep track of the timestamp of the most recent container restart for a particular pod. This information can be useful for troubleshooting and auditing purposes, allowing administrators to track when a resource was last restarted and correlate it with other events or changes in the cluster.
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -134,7 +134,7 @@ Used on: Pod
 
 This annotation indicates the time when a workload restart was triggered, using 
 the kubectl command-line tool.
-The kubelet tool updates the Pod template in a Deployment, ReplicaSet, StatefulSet
+The kubectl tool updates the Pod template in a Deployment, ReplicaSet, StatefulSet
 or DaemonSet, making a change to the metadata of Pods defined by that template.
 By either setting this annotation or changing the value to a new date, the kubectl tool
 triggers a rollout and indirectly causes the launch of fresh, replacement Pods.


### PR DESCRIPTION
fixed: #40067

Adding `kubectl.kubernetes.io/restartedAt` annotation to kubernetes documentation with proper description.

Changes made at: https://kubernetes.io/docs/reference/labels-annotations-taints/