### PR TITLE
update content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md

### DIFF
--- a/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -994,7 +994,8 @@ This merges the list as though it was a map where each element is keyed
 by `name`.
 -->
 此合并策略会使用每个字段上的一个名为 `patchMergeKey` 的特殊标签。
-Kubernetes 源代码 [types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747) 中为每个字段定义了 `patchMergeKey`.
+Kubernetes 源代码 [types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747)
+中为每个字段定义了 `patchMergeKey`.
 当合并由 map 组成的 list 时，给定元素中被设置为 `patchMergeKey` 的字段会被
 当做该元素的 map 键值来使用。
 

--- a/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -995,7 +995,7 @@ by `name`.
 -->
 此合并策略会使用每个字段上的一个名为 `patchMergeKey` 的特殊标签。
 Kubernetes 源代码 [types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747)
-中为每个字段定义了 `patchMergeKey`.
+中为每个字段定义了 `patchMergeKey`。
 当合并由 map 组成的 list 时，给定元素中被设置为 `patchMergeKey` 的字段会被
 当做该元素的 map 键值来使用。
 

--- a/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -994,8 +994,8 @@ This merges the list as though it was a map where each element is keyed
 by `name`.
 -->
 此合并策略会使用每个字段上的一个名为 `patchMergeKey` 的特殊标签。
-Kubernetes 源代码 [types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747)
-中为每个字段定义了 `patchMergeKey`。
+Kubernetes 源代码文件 [types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747)
+为每个字段定义了 `patchMergeKey`。
 当合并由 map 组成的 list 时，给定元素中被设置为 `patchMergeKey` 的字段会被
 当做该元素的 map 键值来使用。
 

--- a/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -994,8 +994,7 @@ This merges the list as though it was a map where each element is keyed
 by `name`.
 -->
 此合并策略会使用每个字段上的一个名为 `patchMergeKey` 的特殊标签。
-Kubernetes 源代码中为每个字段定义了 `patchMergeKey`：
-[types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747)
+Kubernetes 源代码 [types.go](https://github.com/kubernetes/api/blob/d04500c8c3dda9c980b668c57abc2ca61efcf5c4/core/v1/types.go#L2747) 中为每个字段定义了 `patchMergeKey`.
 当合并由 map 组成的 list 时，给定元素中被设置为 `patchMergeKey` 的字段会被
 当做该元素的 map 键值来使用。
 


### PR DESCRIPTION
Optimize the location of "types.go" to avoid misunderstanding
in content/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config.md
preview in https://deploy-preview-41359--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/manage-kubernetes-objects/declarative-config/#apply-%E6%93%8D%E4%BD%9C%E6%98%AF%E5%A6%82%E4%BD%95%E8%AE%A1%E7%AE%97%E9%85%8D%E7%BD%AE%E5%B7%AE%E5%BC%82%E5%B9%B6%E5%90%88%E5%B9%B6%E5%8F%98%E6%9B%B4%E7%9A%84:~:text=%E6%AD%A4%E5%90%88%E5%B9%B6%E7%AD%96%E7%95%A5%E4%BC%9A%E4%BD%BF%E7%94%A8%E6%AF%8F%E4%B8%AA%E5%AD%97%E6%AE%B5%E4%B8%8A%E7%9A%84%E4%B8%80%E4%B8%AA%E5%90%8D%E4%B8%BA%20patchMergeKey%20%E7%9A%84%E7%89%B9%E6%AE%8A%E6%A0%87%E7%AD%BE%E3%80%82%20Kubernetes%20%E6%BA%90%E4%BB%A3%E7%A0%81%20types.go%20%E4%B8%AD%E4%B8%BA%E6%AF%8F%E4%B8%AA%E5%AD%97%E6%AE%B5%E5%AE%9A%E4%B9%89%E4%BA%86%20patchMergeKey.%20%E5%BD%93%E5%90%88%E5%B9%B6%E7%94%B1%20map%20%E7%BB%84%E6%88%90%E7%9A%84%20list%20%E6%97%B6%EF%BC%8C%E7%BB%99%E5%AE%9A%E5%85%83%E7%B4%A0%E4%B8%AD%E8%A2%AB%E8%AE%BE%E7%BD%AE%E4%B8%BA%20patchMergeKey%20%E7%9A%84%E5%AD%97%E6%AE%B5%E4%BC%9A%E8%A2%AB%20%E5%BD%93%E5%81%9A%E8%AF%A5%E5%85%83%E7%B4%A0%E7%9A%84%20map%20%E9%94%AE%E5%80%BC%E6%9D%A5%E4%BD%BF%E7%94%A8%E3%80%82
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
