### PR TITLE
Add Hugo layout to hide release information on outdated k8s.io versions

### DIFF
--- a/content/en/releases/_index.md
+++ b/content/en/releases/_index.md
@@ -2,6 +2,7 @@
 linktitle: Release History
 title: Releases
 type: docs
+layout: release-info
 ---
 
 

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -65,7 +65,7 @@ other = "(last updated: %s)"
 other = "You are viewing documentation for Kubernetes version:"
 
 [deprecation_warning]
-other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see the "
+other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date information, see the "
 
 [deprecation_file_warning]
 other = "Deprecated"

--- a/layouts/docs/release-info.html
+++ b/layouts/docs/release-info.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+{{ if not .Site.Params.deprecated }}
+  {{ .Content }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Resolves https://github.com/kubernetes/website/issues/29428

#### High level summary of changes:

- Create a Hugo layout `release-info.html`, which will display the page's contents only if the value of `deprecated` in [hugo.toml](https://github.com/kubernetes/website/blob/main/hugo.toml#L149) is set to false.

- The new layout is assigned to a Markdown file by specifying the `layout` parameter in the Markdown front matter.

- Made small adjustment to the warning message text, displayed in yellow, for deprecation warnings, to ensure it is suitable  for documentation and releases.




