### PR TITLE
[pt-br] Update apt keyring installation

### DIFF
--- a/content/pt-br/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/pt-br/docs/tasks/tools/install-kubectl-linux.md
@@ -120,7 +120,7 @@ Por exemplo, para fazer download da versão {{< skew currentPatchVersion >}} no 
 2. Faça download da chave de assinatura pública do Google Cloud:
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
    ```
 
 3. Adicione o repositório `apt` do Kubernetes:


### PR DESCRIPTION
Part of:
#41373
#41374
#41375
#41376

See #41307
> The plain google signing key for apt does not work anymore. It needs to be "deamord" using gpg.

Replaces #41349