### PR TITLE
Update apt keyring installation (Chinese)

### DIFF
--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -288,7 +288,7 @@ For more information on version skews, see:
 2. 下载 Google Cloud 公开签名秘钥：
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
    ```
 
 <!--

--- a/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
@@ -244,7 +244,7 @@ Or use this for detailed view of version:
 2. 下载 Google Cloud 公开签名秘钥：
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
    ```
 
 <!--


### PR DESCRIPTION
Part of:
#41373
#41374
#41375
#41376

See #41307
> The plain google signing key for apt does not work anymore. It needs to be "deamord" using gpg.

Replaces #41349