### PR TITLE
Update apt keyring installation (Japanese)

### DIFF
--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -132,7 +132,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
 2. Google Cloudの公開鍵をダウンロードします:
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
    ```
 
 3. Kubernetesの`apt`リポジトリを追加します:


### PR DESCRIPTION
Part of:
#41373
#41374
#41375
#41376

See #41307
> The plain google signing key for apt does not work anymore. It needs to be "deamord" using gpg.

Replaces #41349