### PR TITLE
修复{#manually-create-a-long-lived-api-token-for-a-serviceaccount}在页面显示的bug

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
@@ -338,7 +338,7 @@ subresource to obtain a token to access the API is recommended instead.
 If you want to obtain an API token for a ServiceAccount, you create a new Secret
 with a special annotation, `kubernetes.io/service-account.name`.
 -->
-### 手动为 ServiceAccount 创建长期有效的 API 令牌 {#manually-create-a-long-lived-api-token-for-a-serviceaccount}」
+### 手动为 ServiceAccount 创建长期有效的 API 令牌 {#manually-create-a-long-lived-api-token-for-a-serviceaccount}
 
 如果你需要为 ServiceAccount 获得一个 API 令牌，你可以创建一个新的、带有特殊注解
 `kubernetes.io/service-account.name` 的 Secret 对象。


### PR DESCRIPTION
修复{#manually-create-a-long-lived-api-token-for-a-serviceaccount}在页面显示的bug
preview in  https://deploy-preview-41387--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
