### PR TITLE
Fix v1.26 docs incorrectly not marked as stale

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -144,7 +144,7 @@ fullversion = "v1.26.3"
 version = "v1.26"
 githubbranch = "v1.26.3"
 docsbranch = "release-1.26"
-deprecated = false
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 


### PR DESCRIPTION
Resolves #41399

This PR modifies the `hugo.toml` file in the **release-1.26** branch to update the `deprecated` field from false to true. This change will activate a deprecation banner in the 1.26 documentation, informing users that the 1.26 version is no longer supported. 

Please note that the current latest release is version 1.27.