### PR TITLE
Container runtime cleanup

### DIFF
--- a/content/en/docs/concepts/architecture/cri.md
+++ b/content/en/docs/concepts/architecture/cri.md
@@ -26,7 +26,7 @@ each Node in your cluster, so that the
 The kubelet acts as a client when connecting to the container runtime via gRPC.
 The runtime and image service endpoints have to be available in the container
 runtime, which can be configured separately within the kubelet by using the
-`--image-service-endpoint` [command line flags](/docs/reference/command-line-tools-reference/kubelet)
+`--image-service-endpoint` [command line flags](/docs/reference/command-line-tools-reference/kubelet).
 
 For Kubernetes v{{< skew currentVersion >}}, the kubelet prefers to use CRI `v1`.
 If a container runtime does not support `v1` of the CRI, then the kubelet tries to

--- a/content/en/docs/concepts/architecture/cri.md
+++ b/content/en/docs/concepts/architecture/cri.md
@@ -26,8 +26,7 @@ each Node in your cluster, so that the
 The kubelet acts as a client when connecting to the container runtime via gRPC.
 The runtime and image service endpoints have to be available in the container
 runtime, which can be configured separately within the kubelet by using the
-`--image-service-endpoint` and `--container-runtime-endpoint` [command line
-flags](/docs/reference/command-line-tools-reference/kubelet)
+`--image-service-endpoint` [command line flags](/docs/reference/command-line-tools-reference/kubelet)
 
 For Kubernetes v{{< skew currentVersion >}}, the kubelet prefers to use CRI `v1`.
 If a container runtime does not support `v1` of the CRI, then the kubelet tries to

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -182,14 +182,14 @@ kubelet [flags]
 <td colspan="2">--container-log-max-files int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">&lt;Warning: Beta feature&gt; Set the maximum number of container log files that can be present for a container. The number must be &gt;= 2. This flag can only be used with <code>--container-runtime=remote</code>. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">&lt;Warning: Beta feature&gt; Set the maximum number of container log files that can be present for a container. The number must be &gt;= 2. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
 </tr>
 
 <tr>
 <td colspan="2">--container-log-max-size string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: <code>10Mi</code></td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">&lt;Warning: Beta feature&gt; Set the maximum size (e.g. <code>10Mi</code>) of container log file before it is rotated. This flag can only be used with <code>--container-runtime=remote</code>.  (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">&lt;Warning: Beta feature&gt; Set the maximum size (e.g. <code>10Mi</code>) of container log file before it is rotated.  (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
 </tr>
 
 <tr>

--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -68,7 +68,8 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
    ExecStart=
    # Replace "systemd" with the cgroup driver of your container runtime. The default value in the kubelet is "cgroupfs".
    # Replace the value of "--container-runtime-endpoint" for a different container runtime if needed.
-   ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --cgroup-driver=systemd --container-runtime=remote --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+   ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --cgroup-driver=systemd 
+   --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
    Restart=always
    EOF
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -68,8 +68,7 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
    ExecStart=
    # Replace "systemd" with the cgroup driver of your container runtime. The default value in the kubelet is "cgroupfs".
    # Replace the value of "--container-runtime-endpoint" for a different container runtime if needed.
-   ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --cgroup-driver=systemd 
-   --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+   ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --cgroup-driver=systemd --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
    Restart=always
    EOF
 

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
@@ -98,7 +98,7 @@ then run the following commands:
 
 ## Configure the kubelet to use containerd as its container runtime
 
-Edit the file `/var/lib/kubelet/kubeadm-flags.env` and add the containerd runtime to the flags.
+Edit the file `/var/lib/kubelet/kubeadm-flags.env` and add the containerd runtime to the flags;
 `--container-runtime-endpoint=unix:///run/containerd/containerd.sock`.
 
 Users using kubeadm should be aware that the `kubeadm` tool stores the CRI socket for each host as

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
@@ -99,7 +99,6 @@ then run the following commands:
 ## Configure the kubelet to use containerd as its container runtime
 
 Edit the file `/var/lib/kubelet/kubeadm-flags.env` and add the containerd runtime to the flags.
-`--container-runtime=remote` and
 `--container-runtime-endpoint=unix:///run/containerd/containerd.sock`.
 
 Users using kubeadm should be aware that the `kubeadm` tool stores the CRI socket for each host as

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -41,9 +41,9 @@ node-2       Ready    v1.16.15   docker://19.3.1
 node-3       Ready    v1.16.15   docker://19.3.1
 ```
 If your runtime shows as Docker Engine, you still might not be affected by the
-removal of dockershim in Kubernetes v1.24. [Check the runtime
-endpoint](#which-endpoint) to see if you use dockershim. If you don't use
-dockershim, you aren't affected. 
+removal of dockershim in Kubernetes v1.24.
+[Check the runtime endpoint](#which-endpoint) to see if you use dockershim.
+If you don't use dockershim, you aren't affected. 
 
 For containerd, the output is similar to this:
 

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -88,8 +88,8 @@ nodes.
 
     *   If your nodes use Kubernetes v1.23 and earlier and these flags aren't
         present or if the `--container-runtime` flag is not `remote`,
-        you use the dockershim socket with Docker Engine. `--container-runtime`
-        is removed since v1.27.
+        you use the dockershim socket with Docker Engine. The `--container-runtime` command line
+        argument is not available in Kubernetes v1.27 and later.
     *   If the `--container-runtime-endpoint` flag is present, check the socket
         name to find out which runtime you use. For example,
         `unix:///run/containerd/containerd.sock` is the containerd endpoint.

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -88,7 +88,8 @@ nodes.
 
     *   If your nodes use Kubernetes v1.23 and earlier and these flags aren't
         present or if the `--container-runtime` flag is not `remote`,
-        you use the dockershim socket with Docker Engine.
+        you use the dockershim socket with Docker Engine. `--container-runtime`
+        is removed since v1.27.
     *   If the `--container-runtime-endpoint` flag is present, check the socket
         name to find out which runtime you use. For example,
         `unix:///run/containerd/containerd.sock` is the containerd endpoint.


### PR DESCRIPTION
Fixes #41401

https://github.com/kubernetes/kubernetes/pull/114017 removed the comment in v1.27.

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ is not re-generated. This is a little confusing to me.
