### PR TITLE
replace `currentVersion` with `currentPatchVersion` in concepts

### DIFF
--- a/content/en/docs/concepts/windows/intro.md
+++ b/content/en/docs/concepts/windows/intro.md
@@ -291,7 +291,7 @@ network port spaces). Kubernetes uses pause containers to allow for worker conta
 crashing or restarting without losing any of the networking configuration.
 
 Kubernetes maintains a multi-architecture image that includes support for Windows.
-For Kubernetes v{{< skew currentVersion >}} the recommended pause image is `registry.k8s.io/pause:3.6`.
+For Kubernetes v{{< skew currentPatchVersion >}} the recommended pause image is `registry.k8s.io/pause:3.6`.
 The [source code](https://github.com/kubernetes/kubernetes/tree/master/build/pause)
 is available on GitHub.
 

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -55,7 +55,7 @@ to use this feature with Kubernetes stateless pods:
 * CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
 Please note that containerd v1.7 supports user namespaces for containers,
-compatible with Kubernetes {{< skew currentVersion >}}. It should not be used
+compatible with Kubernetes {{< skew currentPatchVersion >}}. It should not be used
 with Kubernetes 1.27 (and later).
 
 Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.


### PR DESCRIPTION
Have attempted to pick and replace `{{< skew currentVersion >}}` with `{{< skew currentPatchVersion >}}` in the concepts folder.