### PR TITLE
Fix apt-key is deprecated in Docs

### DIFF
--- a/content/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -180,7 +180,7 @@ Pour plus d'informations sur les compatibilités de version, voir:
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 ```bash
 sudo apt-get update && sudo apt-get install -y apt-transport-https curl
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF

--- a/content/fr/docs/tasks/tools/install-kubectl.md
+++ b/content/fr/docs/tasks/tools/install-kubectl.md
@@ -63,7 +63,7 @@ Vous devez utiliser une version de kubectl qui différe seulement d'une version 
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
 sudo apt-get update && sudo apt-get install -y apt-transport-https
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/content/id/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -180,7 +180,7 @@ Untuk informasi lebih lanjut mengenai _version skew_, lihat:
 {{% tab name="Ubuntu, Debian atau HypriotOS" %}}
 ```bash
 sudo apt-get update && sudo apt-get install -y apt-transport-https curl
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF

--- a/content/id/docs/tasks/tools/install-kubectl.md
+++ b/content/id/docs/tasks/tools/install-kubectl.md
@@ -59,7 +59,7 @@ Kamu harus menggunakan kubectl dengan perbedaan maksimal satu versi minor dengan
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
 sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/content/ja/docs/tasks/tools/install-kubectl.md
+++ b/content/ja/docs/tasks/tools/install-kubectl.md
@@ -60,7 +60,7 @@ kubectlのバージョンは、クラスターのマイナーバージョンと�
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu、DebianまたはHypriotOS" codelang="bash" >}}
 sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/content/ru/docs/tasks/tools/install-kubectl.md
+++ b/content/ru/docs/tasks/tools/install-kubectl.md
@@ -60,7 +60,7 @@ card:
 
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu, Debian или HypriotOS" codelang="bash" >}}sudo apt-get update && sudo apt-get install -y apt-transport-https
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/content/vi/docs/tasks/tools/install-kubectl.md
+++ b/content/vi/docs/tasks/tools/install-kubectl.md
@@ -61,7 +61,7 @@ Bạn cần phải sử dụng phiên bản kubectl sai lệch không quá một
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
 sudo apt-get update && sudo apt-get install -y apt-transport-https
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl


### PR DESCRIPTION
Fix docs in case of apt-key deprecated

In Ubuntu 22.04 apt-key is deprecated throwing a warning and `apt update` does not work.

```bash
$ sudo apt-key add apt-key.gpg 
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
$
```

```bash
$ sudo apt update
Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease
Hit:2 https://linux.teamviewer.com/deb stable InRelease
...
Reading package lists... Done
W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
$
```

To fix we must use `gpg --dearmor` like the following:

```bash
$ sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -orm /etc/apt/keyrings/kubernetes.gpg
$ sudo apt-get update
``` 

This new PR is following up the message: https://github.com/kubernetes/website/pull/41336/files/8780e9f0e6c0832d1ac9ae2a90d8e9698378d8df#r1206844288