### PR TITLE
Fix referenced paths in Service page

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -1239,7 +1239,7 @@ for that Service.
 When you define a Service, you can specify `externalIPs` for any
 [service type](#publishing-services-service-types).
 In the example below, the Service named `"my-service"` can be accessed by clients using TCP,
-on `"198.51.100.32:80"` (calculated from `.spec.externalIP` and `.spec.port`).
+on `"198.51.100.32:80"` (calculated from `.spec.externalIPs[]` and `.spec.ports[].port`).
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
In the External IPs section, the text mentions a couple of paths from the Service manifest that determine how clients can access the service. Those paths are misspelled, and this PR fixes that.