### PR TITLE
Add optional way to access ingress minikube host

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -193,6 +193,34 @@ The following manifest defines an Ingress that sends traffic to your Service via
 
      After you make this change, your web browser sends requests for
      `hello-world.info` URLs to Minikube.
+     
+     If you are still experiencing problems with routing to the miniube ip you
+     can expose the ingress instance by running: 
+     
+     To get the service name and namespace:
+     
+     ```shell
+     minikube service list
+     ```
+     
+     From the above output the service name was: `ingress-nginx-controller` and
+     the namespace was: `ingress-nginx`.
+     
+     To expose the port on localhost: 
+     
+     ```shell
+     minikube service ingress-nginx-controller --url -n ingress-nginx
+     ```
+     
+     You should now be able to navigate to the exposed ports on the local ip.
+     
+     {{< note >}}
+     There may be two ports exposed. You will utilize the first one.
+     Since you are navigating to the local IP you will get a 404 since the host does not match.
+     Follow the steps above to add `127.0.0.1 hello-world.info` to your `etc/hosts` file.
+     Then you should be able to access hello-world.info:PORT_NUMBER where `PORT_NUMBER` matches
+     the exposed port from the last minikube command to expose the web url to the ingress.
+     {{< /note >}}
 
 ## Create a second Deployment
 


### PR DESCRIPTION
This adds an additional option to access the ingress by creating a forward to it so it is exposed on the local IP instead.

Maybe I was doing something wrong, but the minikube IP was not working for me.

Edit: It seems like `minikube tunnel` might be a better route to take, since I just found that and it seems to work easily.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
