### PR TITLE
fix: replace hardcoded GCS URIs with dl.k8s.io

### DIFF
--- a/content/en/blog/_posts/2015-12-00-Creating-Raspberry-Pi-Cluster-Running.md
+++ b/content/en/blog/_posts/2015-12-00-Creating-Raspberry-Pi-Cluster-Running.md
@@ -85,7 +85,7 @@ f017f405ff4b        gcr.io/google\_containers/hyperkube-arm:v1.1.2   "/hyperkube
 
 When that’s looking good we’re able to access the master node of the Kubernetes cluster with kubectl. Kubectl for ARM can be downloaded from googleapis storage. kubectl get nodes shows which cluster nodes are registered with its status. The master node is named 127.0.0.1.
 ```
-$ curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.1.2/bin/linux/arm/kubectl
+$ curl -fsSL -o /usr/bin/kubectl https://dl.k8s.io/release/v1.1.2/bin/linux/arm/kubectl
 
 $ kubectl get nodes
 

--- a/content/en/blog/_posts/2019-03-28-running-kubernetes-locally-on-linux-with-minikube.md
+++ b/content/en/blog/_posts/2019-03-28-running-kubernetes-locally-on-linux-with-minikube.md
@@ -80,7 +80,7 @@ In order to manage the Kubernetes cluster, we need to install [kubectl](https://
 The recommended way to install it on Linux is to download the pre-built binary and move it to a directory under the `$PATH`.
 
 ```shell
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+curl -LO https://dl.k8s.io/release/$(curl -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl \
     && sudo install kubectl /usr/local/bin && rm kubectl
 ```
 

--- a/content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -245,7 +245,7 @@ curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL
 RELEASE="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
 ARCH="amd64"
 cd $DOWNLOAD_DIR
-sudo curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${ARCH}/{kubeadm,kubelet,kubectl}
+sudo curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/{kubeadm,kubelet,kubectl}
 sudo chmod +x {kubeadm,kubelet,kubectl}
 
 RELEASE_VERSION="v0.4.0"

--- a/content/ko/docs/tasks/administer-cluster/certificates.md
+++ b/content/ko/docs/tasks/administer-cluster/certificates.md
@@ -18,7 +18,7 @@ weight: 20
 1. `easyrsa3`의 패치 버전을 다운로드하여 압축을 풀고, 초기화한다.
 
    ```shell
-   curl -LO https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
+   curl -LO https://dl.k8s.io/easy-rsa/easy-rsa.tar.gz
    tar xzf easy-rsa.tar.gz
    cd easy-rsa-master/easyrsa3
    ./easyrsa init-pki


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

As per the initiative https://github.com/kubernetes/k8s.io/issues/1571  to move away from the use of GCP project google-containers, this PR fixes https://github.com/kubernetes/k8s.io/issues/2396

The existent references to https://storage.googleapis.com/kubernetes-release in the repo are replaced appropriately with https://dl.k8s.io/