### PR TITLE
[zh] fix markdown lint error in website/content/zh-cn/docs/concepts/o…

### DIFF
--- a/content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md
@@ -18,7 +18,7 @@ weight: 45
 <!--
 In Kubernetes, _namespaces_ provides a mechanism for isolating groups of resources within a single cluster. Names of resources need to be unique within a namespace, but not across namespaces. Namespace-based scoping is applicable only for namespaced {{< glossary_tooltip text="objects" term_id="object" >}} _(e.g. Deployments, Services, etc)_ and not for cluster-wide objects _(e.g. StorageClass, Nodes, PersistentVolumes, etc)_.
 -->
-在 Kubernetes 中，**名字空间（Namespace）**提供一种机制，将同一集群中的资源划分为相互隔离的组。
+在 Kubernetes 中，**名字空间（Namespace）** 提供一种机制，将同一集群中的资源划分为相互隔离的组。
 同一名字空间内的资源名称要唯一，但跨名字空间时没有这个要求。
 名字空间作用域仅针对带有名字空间的{{< glossary_tooltip text="对象" term_id="object" >}}，
 （例如 Deployment、Service 等），这种作用域对集群范围的对象


### PR DESCRIPTION
## PR Summary

Fixed and Markdown typo error in page [(zh-cn) Namespaces](https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/namespaces/).

The current `zh-cn` Namespaces page looks like this:

![](https://f005.backblazeb2.com/file/kivinsae-dev-pub/github.com/KKtheGhost/kubernetes/website/k8s_website_namespaces_md_zh-cn_master.png)

The current `en` Namespaces page looks like this:

![](https://f005.backblazeb2.com/file/kivinsae-dev-pub/github.com/KKtheGhost/kubernetes/website/k8s_website_namespaces_md_en_master.png)

In short, at the beginning of this document page, the term "Namespace" should be presented in italic font, without bold formatting.

Furthermore, there is currently a missing half-width space character after the asterisk symbol in the current page, which is actually causing the display issue.
<br>
<br>
Best Regards,
Kivinsae Fang
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
