### PR TITLE
improve/correcting wording in User Namespaces page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -54,8 +54,8 @@ to use this feature with Kubernetes stateless pods:
 
 * CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
-Please note that containerd v1.7 supports user namespaces for containers,
-compatible with Kubernetes {{< skew currentPatchVersion >}}. It should not be used
+Please note that containerd v1.7 (and later) supports user namespaces for containers,
+Kubernetes {{< skew currentPatchVersion >}} introduced support for user namespaces in container runtimes. It should be used
 with Kubernetes 1.27 (and later).
 
 Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.


### PR DESCRIPTION
fixed: #41445 

Updated Page: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/

issue: containerd v1.7 supports user namespaces for containers, compatible with Kubernetes 1.27.2. It should not be used with Kubernetes 1.27 (and later).

Solution: fix the issue in user-namespace page that containerd v1.7 (and later) supports user namespaces for containers. user namespaces should be used with Kubernetes 1.27 (and later).

/language en