### PR TITLE
[zh] sync migrating-from-dockershim/find-out-runtime-you-use.md

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -69,9 +69,9 @@ node-3       Ready    v1.16.15   docker://19.3.1
 ```
 <!--
 If your runtime shows as Docker Engine, you still might not be affected by the
-removal of dockershim in Kubernetes v1.24. [Check the runtime
-endpoint](#which-endpoint) to see if you use dockershim. If you don't use
-dockershim, you aren't affected. 
+removal of dockershim in Kubernetes v1.24.
+[Check the runtime endpoint](#which-endpoint) to see if you use dockershim.
+If you don't use dockershim, you aren't affected. 
 
 For containerd, the output is similar to this:
 -->
@@ -154,17 +154,18 @@ nodes.
 
     *   If your nodes use Kubernetes v1.23 and earlier and these flags aren't
         present or if the `--container-runtime` flag is not `remote`,
-        you use the dockershim socket with Docker Engine.
+        you use the dockershim socket with Docker Engine. The `--container-runtime` command line
+        argument is not available in Kubernetes v1.27 and later.
     *   If the `--container-runtime-endpoint` flag is present, check the socket
         name to find out which runtime you use. For example,
         `unix:///run/containerd/containerd.sock` is the containerd endpoint.
 -->
 2. 在命令的输出中，查找 `--container-runtime` 和 `--container-runtime-endpoint` 标志。
 
-   * 如果 Kubernetes 集群版本是 v1.23 或者更早的版本，并且这两个参数不存在，
-      或者 `container-runtime` 标志值不是 `remote`，则你在通过 dockershim 套接字使用
-      Docker Engine。
-     或者如果集群使用的 Docker engine 和 dockershim socket，则输出结果中 `--container-runtime` 不是 `remote`,
+   * 如果你的节点使用 Kubernetes v1.23 或更早的版本，这两个参数不存在，
+     或者 `--container-runtime` 标志值不是 `remote`，则你在通过 dockershim 套接字使用
+     Docker Engine。
+     在 Kubernetes v1.27 及以后的版本中，`--container-runtime` 命令行参数不再可用。
    * 如果设置了 `--container-runtime-endpoint` 参数，查看套接字名称即可得知当前使用的运行时。
      如若套接字 `unix:///run/containerd/containerd.sock` 是 containerd 的端点。
 


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md`
- **Sync to**: `content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md`

Sync check by`scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
diff --git a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
index 8e04dd7a6c..f6f3db70dd 100644
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -41,9 +41,9 @@ node-2       Ready    v1.16.15   docker://19.3.1
 node-3       Ready    v1.16.15   docker://19.3.1
 \`\`\`
 If your runtime shows as Docker Engine, you still might not be affected by the
-removal of dockershim in Kubernetes v1.24. [Check the runtime
-endpoint](#which-endpoint) to see if you use dockershim. If you don't use
-dockershim, you aren't affected.
+removal of dockershim in Kubernetes v1.24.
+[Check the runtime endpoint](#which-endpoint) to see if you use dockershim.
+If you don't use dockershim, you aren't affected.

 For containerd, the output is similar to this:

@@ -88,7 +88,8 @@ nodes.

     *   If your nodes use Kubernetes v1.23 and earlier and these flags aren't
         present or if the `--container-runtime` flag is not `remote`,
-        you use the dockershim socket with Docker Engine.
+        you use the dockershim socket with Docker Engine. The `--container-runtime` command line
+        argument is not available in Kubernetes v1.27 and later.
     *   If the `--container-runtime-endpoint` flag is present, check the socket
         name to find out which runtime you use. For example,
         `unix:///run/containerd/containerd.sock` is the containerd endpoint.
@@ -96,4 +97,4 @@ nodes.
 If you want to change the Container Runtime on a Node from Docker Engine to containerd,
 you can find out more information on [migrating from Docker Engine to  containerd](/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd/),
 or, if you want to continue using Docker Engine in Kubernetes v1.24 and later, migrate to a
-CRI-compatible adapter like [`cri-dockerd`](https://github.com/Mirantis/cri-dockerd).
\ No newline at end of file
+CRI-compatible adapter like [`cri-dockerd`](https://github.com/Mirantis/cri-dockerd).
```
Sync check by`scripts/lsync.sh` on `sync/tasks_find-out-runtime-you-use` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
