### PR TITLE
[id] Replace deprecated fullversion shortcode #41485

### DIFF
--- a/content/id/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/id/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -28,7 +28,7 @@ Kubelet memiliki _plugin_ jaringan bawaan tunggal, dan jaringan bawaan umum untu
 
 ## Persyaratan _Plugin_ Jaringan
 
-Selain menyediakan [antarmuka `NetworkPlugin`](https://github.com/kubernetes/kubernetes/tree/{{< param "fullversion" >}}/pkg/kubelet/dockershim/network/plugins.go) untuk mengonfigurasi dan membersihkan jaringan Pod, _plugin_ ini mungkin juga memerlukan dukungan khusus untuk kube-proxy. Proksi _iptables_ jelas tergantung pada _iptables_, dan _plugin_ ini mungkin perlu memastikan bahwa lalu lintas kontainer tersedia untuk _iptables_. Misalnya, jika plugin menghubungkan kontainer ke _bridge_ Linux, _plugin_ harus mengatur nilai sysctl `net/bridge/bridge-nf-call-iptables` menjadi `1` untuk memastikan bahwa proksi _iptables_ berfungsi dengan benar. Jika _plugin_ ini tidak menggunakan _bridge_ Linux (melainkan sesuatu seperti Open vSwitch atau mekanisme lainnya), _plugin_ ini harus memastikan lalu lintas kontainer dialihkan secara tepat untuk proksi.
+Selain menyediakan [antarmuka `NetworkPlugin`](https://github.com/kubernetes/kubernetes/tree/v{{< skew currentPatchVersion >}}/pkg/kubelet/dockershim/network/plugins.go) untuk mengonfigurasi dan membersihkan jaringan Pod, _plugin_ ini mungkin juga memerlukan dukungan khusus untuk kube-proxy. Proksi _iptables_ jelas tergantung pada _iptables_, dan _plugin_ ini mungkin perlu memastikan bahwa lalu lintas kontainer tersedia untuk _iptables_. Misalnya, jika plugin menghubungkan kontainer ke _bridge_ Linux, _plugin_ harus mengatur nilai sysctl `net/bridge/bridge-nf-call-iptables` menjadi `1` untuk memastikan bahwa proksi _iptables_ berfungsi dengan benar. Jika _plugin_ ini tidak menggunakan _bridge_ Linux (melainkan sesuatu seperti Open vSwitch atau mekanisme lainnya), _plugin_ ini harus memastikan lalu lintas kontainer dialihkan secara tepat untuk proksi.
 
 Secara bawaan jika tidak ada _plugin_ jaringan Kubelet yang ditentukan, _plugin_ `noop` digunakan, yang menetapkan `net/bridge/bridge-nf-call-iptables=1` untuk memastikan konfigurasi sederhana (seperti Docker dengan sebuah _bridge_) bekerja dengan benar dengan proksi _iptables_.
 
@@ -155,6 +155,3 @@ Opsi ini disediakan untuk _plugin_ jaringan; Saat ini **hanya kubenet yang mendu
 
 
 ## {{% heading "whatsnext" %}}
-
-
-

--- a/content/id/docs/tasks/tools/install-kubectl.md
+++ b/content/id/docs/tasks/tools/install-kubectl.md
@@ -31,10 +31,10 @@ Kamu harus menggunakan kubectl dengan perbedaan maksimal satu versi minor dengan
 
     Untuk mengunduh versi spesifik, ganti bagian `curl -LS https://dl.k8s.io/release/stable.txt` dengan versi yang diinginkan.
 
-    Misalnya, untuk mengunduh versi {{< param "fullversion" >}} di Linux, ketik:
+    Misalnya, untuk mengunduh versi {{< skew currentPatchVersion >}} di Linux, ketik:
     
     ```
-    curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
+    curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/amd64/kubectl
     ```
 
 2. Jadikan program `kubectl` dapat dieksekusi.
@@ -111,10 +111,10 @@ kubectl version --client
 
     Untuk mengunduh versi spesifik, ganti bagian `curl -LS https://dl.k8s.io/release/stable.txt` dengan versi yang diinginkan.
 
-    Misalnya, untuk mengunduh versi {{< param "fullversion" >}} pada macOS, ketik:
+    Misalnya, untuk mengunduh versi {{< skew currentPatchVersion >}} pada macOS, ketik:
 		  
     ```
-    curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
+    curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/amd64/kubectl
     ```
 
 2. Buat agar program `kubectl` dapat dijalankan.
@@ -176,12 +176,12 @@ Jika kamu menggunakan macOS dan manajer paket [Macports](https://macports.org/),
 
 ### Menginstal program kubectl dengan curl pada Windows
 
-1. Unduh versi terbarunya {{< param "fullversion" >}} dari [tautan ini](https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
+1. Unduh versi terbarunya {{< skew currentPatchVersion >}} dari [tautan ini](https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe).
 
     Atau jika sudah ada `curl` pada mesin kamu, jalankan perintah ini:
 
     ```
-    curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe
+    curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe
     ```
 
     Untuk mendapatkan versi stabil terakhir (misalnya untuk _scripting_), lihat di [https://dl.k8s.io/release/stable.txt](https://dl.k8s.io/release/stable.txt).


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/41485
There doesn't seem to be a localization branch for `in`, so I'm using `main` instead.
Related to https://github.com/kubernetes/website/issues/41005
