### PR TITLE
[en] Remove dangling </div> from interactive tutorials pages

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -30,7 +30,5 @@ _build:
 
     </main>
 
-</div>
-
 </body>
 </html>

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -29,7 +29,5 @@ _build:
 
     </main>
 
-</div>
-
 </body>
 </html>

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -29,7 +29,5 @@ _build:
 
     </main>
 
-</div>
-
 </body>
 </html>

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -29,8 +29,6 @@ _build:
 
     </main>
 
-</div>
-
 </body>
 </html>
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -29,8 +29,6 @@ _build:
 
     </main>
 
-</div>
-
 </body>
 </html>
 

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -29,8 +29,6 @@ _build:
 
     </main>
 
-</div>
-
 </body>
 </html>
 


### PR DESCRIPTION
### Changes
Remove a dangling </div> element that is causing the following pages to break rendering:
* `tutorials/kubernetes-basics/create-cluster/cluster-interactive.html`
* `tutorials/kubernetes-basics/deploy-app/deploy-interactive.html`
* `tutorials/kubernetes-basics/explore/explore-interactive.html`
* `tutorials/kubernetes-basics/expose/expose-interactive.html`
* `tutorials/kubernetes-basics/scale/scale-interactive.html`
* `tutorials/kubernetes-basics/update/update-interactive.html`

/cc @sftim
