### PR TITLE
[pt-br] Remove Katacoda references and tutorials

### DIFF
--- a/content/pt-br/docs/contribute/style/style-guide.md
+++ b/content/pt-br/docs/contribute/style/style-guide.md
@@ -429,31 +429,6 @@ A saída é:
 Cuidado.
 {{< /warning >}}
 
-### Ambiente de teste embutido do Katacoda
-
-Este botão permite aos usuários executar o Minikube dentro dos seus navegadores
-utilizando o terminal do Katacoda. Ele diminui a barreira de entrada permitindo
-que as pessoas utilizem o Minikube com um único clique ao invés de precisar
-fazer todo o processo de instalação e configuração das ferramentas Minikube e
-Kubectl na máquina local.
-
-O ambiente de teste embutido está configurado para executar `minikube start` e
-permite aos usuários completar tutoriais na mesma janela que a documentação.
-
-{{< caution >}}
-Esta sessão é limitada a 15 minutos.
-{{< /caution >}}
-
-Por exemplo:
-
-```
-{{</* kat-button */>}}
-```
-
-The output is:
-
-{{< kat-button >}}
-
 ## Problemas comuns com _shortcodes_ {#common-shortcode-issues}
 
 ### Listas ordenadas

--- a/content/pt-br/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -1,11 +1,16 @@
 ---
 title: Tutorial interativo - Criando um cluster
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
 
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="pt-BR">
 
 <body>
 
@@ -15,20 +20,19 @@ weight: 20
 
 <div class="layout" id="top">
 
-    <main class="content katacoda-content">
+    <main class="content">
+      <div>
+        <h2 class="katacoda-gone">
+          Conteúdo indisponível
+        </h2>
+        <p>
+          O tutorial interativo de como criar um cluster não está disponível.
 
-        <div class="katacoda">
-            <div class="katacoda__alert">
-                Esta tela é muito estreita para interagir com o Terminal, use um desktop / tablet.
-            </div>
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/1" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;"></div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/pt/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continue para o Módulo 2<span class="btn__next">›</span></a>
-            </div>
-        </div>
-
+          Para mais informações, veja o
+            <a href="https://kubernetes.io/pt-br/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+            anúncio de encerramento do Katacoda</a>.
+        </p>
+      </div>
     </main>
 
 </div>

--- a/content/pt-br/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -1,11 +1,16 @@
 ---
 title: Tutorial interativo - implantando um aplicativo
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
 
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="pt-BR">
 
 <body>
 
@@ -15,32 +20,19 @@ weight: 20
 
 <div class="layout" id="top">
 
-    <main class="content katacoda-content">
+    <main class="content">
+      <div>
+        <h2 class="katacoda-gone">
+          Conteúdo indisponível
+        </h2>
+        <p>
+          O tutorial interativo de como implantar um aplicativo no seu cluster não está disponível.
 
-        <div class="row">
-            <div class="col-md-12">
-                <p>
-                    Um pod é a unidade de execução básica de um aplicativo Kubernetes. Cada pod representa uma parte de uma carga de trabalho em execução no cluster. <a href="/docs/concepts/workloads/pods/"> Saiba mais sobre pods</a>.
-                </p>
-            </div>
-        </div>
-
-        <br>
-        <div class="katacoda">
-            <div class="katacoda__alert">
-                Para interagir com o Terminal, use a versão desktop/tablet
-            </div>
-
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/7" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Terminal para treinamento do Kubernetes" style="height: 600px;">
-            </div>
-
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/pt/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continue para o Módulo 3<span class="btn__next">›</span></a>
-            </div>
-        </div>
-
+          Para mais informações, veja o
+          <a href="https://kubernetes.io/pt-br/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+            anúncio de encerramento do Katacoda</a>.
+        </p>
+      </div>
     </main>
 
 </div>

--- a/content/pt-br/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -1,6 +1,11 @@
 ---
 title: Tutorial Interativo - Explorando seu aplicativo
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
 
 <!DOCTYPE html>
@@ -15,24 +20,19 @@ weight: 20
 
 <div class="layout" id="top">
 
-    <main class="content katacoda-content">
+    <main class="content">
+      <div>
+        <h2 class="katacoda-gone">
+          Conteúdo indisponível
+        </h2>
+        <p>
+          O tutorial interativo de como explorar seu aplicativo não está disponível.
 
-        <br>
-        <div class="katacoda">
-
-            <div class="katacoda__alert">
-                Para interagir com o Terminal, por favor, use a versão para desktop ou table.
-            </div>
-
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/4" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/pt/docs/tutorials/kubernetes-basics/expose/expose-intro/" role="button">Continue para o Módulo 4<span class="btn__next">›</span></a>
-            </div>
-        </div>
-
+          Para mais informações, veja o
+          <a href="https://kubernetes.io/pt-br/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+            anúncio de encerramento do Katacoda</a>.
+        </p>
+      </div>
     </main>
 
 </div>

--- a/content/pt-br/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -1,6 +1,11 @@
 ---
 title: Tutorial Interativo - Expondo seu aplicativo
 weight: 20
+headless: true
+toc_hide: true
+_build:
+  list: never
+  publishResources: false
 ---
 
 <!DOCTYPE html>
@@ -16,20 +21,18 @@ weight: 20
 <div class="layout" id="top">
 
     <main class="content katacoda-content">
+      <div>
+        <h2 class="katacoda-gone">
+          Conteúdo indisponível
+        </h2>
+        <p>
+          O tutorial interativo de como expor seu aplicativo não está disponível.
 
-        <div class="katacoda">
-            <div class="katacoda__alert">
-                Para interagir com o terminal, favor utilizar a versão desktop/tablet
-            </div>
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/8" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Terminal Kubernetes Bootcamp" style="height: 600px;">
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/pt/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">Continue para o Módulo 5<span class="btn__next">›</span></a>
-            </div>
-        </div>
-
+          Para mais informações, veja o
+          <a href="https://kubernetes.io/pt-br/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+            anúncio de encerramento do Katacoda</a>.
+        </p>
+      </div>
     </main>
 
 </div>

--- a/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -16,23 +16,20 @@ weight: 20
 <div class="layout" id="top">
 
     <main class="content katacoda-content">
+      <div>
+        <h2 class="katacoda-gone">
+          Conteúdo indisponível
+        </h2>
+        <p>
+          O tutorial interativo de como escalonar um aplicativo que está rodando
+          no seu cluster não está disponível.
 
-        <div class="katacoda">
-            <div class="katacoda__alert">
-              Para interagir com o terminal, favor utilizar a versão desktop/tablet
-            </div>
-            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/5" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-intro/" role="button">Continue para o Módulo 6<span class="btn__next">›</span></a>
-            </div>
-        </div>
-
+          Para mais informações, veja o
+          <a href="https://kubernetes.io/pt-br/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
+            anúncio de encerramento do Katacoda</a>.
+        </p>
+      </div>
     </main>
-
-<a class="scrolltop" href="#top"></a>
 
 </div>
 


### PR DESCRIPTION
### Umbrella issue: #41496

### Changes
* Remove references to Katacoda from the style guide.
* Disable interactive tutorials that relied on Katacoda.

/cc @edsoncelio @devlware

Fixes #41456

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
