### PR TITLE
Remove Bundle Bar registry link

### DIFF
--- a/content/en/blog/_posts/2023-05-24-oci-security-profiles.md
+++ b/content/en/blog/_posts/2023-05-24-oci-security-profiles.md
@@ -116,7 +116,6 @@ are a bunch of registries that already supports OCI artifacts:
 - [Amazon Elastic Container Registry](https://aws.amazon.com/ecr)
 - [Google Artifact Registry](https://cloud.google.com/artifact-registry)
 - [GitHub Packages container registry](https://docs.github.com/en/packages/guides/about-github-container-registry)
-- [Bundle Bar](https://bundle.bar/docs/supported-clients/oras)
 - [Docker Hub](https://hub.docker.com)
 - [Zot Registry](https://zotregistry.io)
 


### PR DESCRIPTION
Removed **Bundle Bar**  registry from blog 2023 oci-security-profiles
As the **Bundle Bar** registry is not working
Remove link : [Bundle Bar](https://bundle.bar/docs/supported-clients/oras)