### PR TITLE
[zh] sync concepts/cluster-administration/flow-control.md

### DIFF
--- a/content/zh-cn/docs/concepts/cluster-administration/flow-control.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/flow-control.md
@@ -343,7 +343,7 @@ requests, and limitations on the number of queued requests.
 对未完成的请求数有各自的限制，对排队中的请求数也有限制。
 
 <!--
-The nominal oncurrency limit for a PriorityLevelConfiguration is not
+The nominal concurrency limit for a PriorityLevelConfiguration is not
 specified in an absolute number of seats, but rather in "nominal
 concurrency shares." The total concurrency limit for the API Server is
 distributed among the existing PriorityLevelConfigurations in


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/cluster-administration/flow-control.md`
- **Sync to**: `content/zh-cn/docs/concepts/cluster-administration/flow-control.md`
- **Updates**:
  - Sync'ed a spelling error fix from EN upstream

Sync check by`scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/cluster-administration/flow-control.md
diff --git a/content/en/docs/concepts/cluster-administration/flow-control.md b/content/en/docs/concepts/cluster-administration/flow-control.md
index 1a1438c5c0..9e61c95d8b 100644
--- a/content/en/docs/concepts/cluster-administration/flow-control.md
+++ b/content/en/docs/concepts/cluster-administration/flow-control.md
@@ -193,7 +193,7 @@ A PriorityLevelConfiguration represents a single priority level. Each
 PriorityLevelConfiguration has an independent limit on the number of outstanding
 requests, and limitations on the number of queued requests.

-The nominal oncurrency limit for a PriorityLevelConfiguration is not
+The nominal concurrency limit for a PriorityLevelConfiguration is not
 specified in an absolute number of seats, but rather in "nominal
 concurrency shares." The total concurrency limit for the API Server is
 distributed among the existing PriorityLevelConfigurations in
```
Sync check by`scripts/lsync.sh` on `sync/cluster_administration/flow-control` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/cluster-administration/flow-control.md
content/zh-cn/docs/concepts/cluster-administration/flow-control.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
