### PR TITLE
Fix incorrect translation[de] for word ''Architekur'' to  "Architektur"

### DIFF
--- a/content/de/docs/concepts/architecture/_index.md
+++ b/content/de/docs/concepts/architecture/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Kubernetes Architekur"
+title: "Kubernetes Architektur"
 weight: 30
 description: >
     Hier werden die architektonischen Konzepte von Kubernetes beschrieben.


### PR DESCRIPTION
Fix the translation[de] error for word  "Architekur" to "Architektur"
On path  /de/docs/concepts/architecture.
