### PR TITLE
[ja] update Japanese translation /docs/home/supported-doc-versions

### DIFF
--- a/content/ja/docs/home/supported-doc-versions.md
+++ b/content/ja/docs/home/supported-doc-versions.md
@@ -1,7 +1,7 @@
 ---
 title: 利用可能なドキュメントバージョン
 content_type: custom
-layout: supported-versions 
+layout: supported-versions
 card:
   name: about
   weight: 10
@@ -9,3 +9,6 @@ card:
 ---
 
 本ウェブサイトには、現行版とその直前4バージョンのKubernetesドキュメントがあります。
+
+Kubernetesバージョンのドキュメントの入手性は、そのリリースが現在サポートされているかどうかで分かれます。
+どのKubernetesバージョンが公式にどのくらいの期間サポートされるかについて知るには、[サポート期間](/releases/patch-releases/#support-period)を参照してください。


### PR DESCRIPTION
This PR updates Japanese translation of https://kubernetes.io/ja/docs/home/supported-doc-versions/

Fixes #41580 

I would prefer Japanese language for suggestions and discussion of revisions to this translation.
(表現に関わるため、この翻訳についてのデイスカッションは日本語を希望します。)
