### PR TITLE
Add and use glossary entry for “replica”

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -24,7 +24,10 @@ a complete and working Kubernetes cluster.
 <!-- body -->
 ## Control Plane Components
 
-The control plane's components make global decisions about the cluster (for example, scheduling), as well as detecting and responding to cluster events (for example, starting up a new {{< glossary_tooltip text="pod" term_id="pod">}} when a deployment's `replicas` field is unsatisfied).
+The control plane's components make global decisions about the cluster (for example, scheduling),
+as well as detecting and responding to cluster events (for example, starting up a new
+{{< glossary_tooltip text="pod" term_id="pod">}} when a Deployment's
+`{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
 
 Control plane components can be run on any machine in the cluster. However,
 for simplicity, set up scripts typically start all control plane components on
@@ -102,19 +105,24 @@ see [Addons](/docs/concepts/cluster-administration/addons/).
 
 ### DNS
 
-While the other addons are not strictly required, all Kubernetes clusters should have [cluster DNS](/docs/concepts/services-networking/dns-pod-service/), as many examples rely on it.
+While the other addons are not strictly required, all Kubernetes clusters should have
+[cluster DNS](/docs/concepts/services-networking/dns-pod-service/), as many examples rely on it.
 
-Cluster DNS is a DNS server, in addition to the other DNS server(s) in your environment, which serves DNS records for Kubernetes services.
+Cluster DNS is a DNS server, in addition to the other DNS server(s) in your environment,
+which serves DNS records for Kubernetes services.
 
 Containers started by Kubernetes automatically include this DNS server in their DNS searches.
 
 ### Web UI (Dashboard)
 
-[Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in the cluster, as well as the cluster itself.
+[Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose,
+web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications
+running in the cluster, as well as the cluster itself.
 
 ### Container Resource Monitoring
 
-[Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/) records generic time-series metrics
+[Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)
+records generic time-series metrics
 about containers in a central database, and provides a UI for browsing that data.
 
 ### Cluster-level Logging
@@ -132,7 +140,8 @@ allocating IP addresses to pods and enabling them to communicate with each other
 ## {{% heading "whatsnext" %}}
 
 Learn more about the following:
-   * [Nodes](/docs/concepts/architecture/nodes/) and [their communication](/docs/concepts/architecture/control-plane-node-communication/) with the control plane.
+   * [Nodes](/docs/concepts/architecture/nodes/) and [their communication](/docs/concepts/architecture/control-plane-node-communication/)
+     with the control plane.
    * Kubernetes [controllers](/docs/concepts/architecture/controller/).
    * [kube-scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) which is the default scheduler for Kubernetes.
    * Etcd's official [documentation](https://etcd.io/docs/).

--- a/content/en/docs/reference/glossary/replica.md
+++ b/content/en/docs/reference/glossary/replica.md
@@ -1,0 +1,26 @@
+---
+title: Replica
+id: replica
+date: 2023-06-11
+full_link: 
+short_description: >
+  Replicas are copies of pods, ensuring availability, scalability, and fault tolerance by maintaining identical instances.
+aka: 
+tags:
+- fundamental
+- workload
+---
+A copy or duplicate of a {{< glossary_tooltip text="Pod" term_id="pod" >}} or
+a set of pods. Replicas ensure high availability, scalability, and fault tolerance
+by maintaining multiple identical instances of a pod.
+
+<!--more-->
+Replicas are commonly used in Kubernetes to achieve the desired application state and reliability.
+They enable workload scaling and distribution across multiple nodes in a cluster.
+
+By defining the number of replicas in a Deployment or ReplicaSet, Kubernetes ensures that
+the specified number of instances are running, automatically adjusting the count as needed.
+
+Replica management allows for efficient load balancing, rolling updates, and
+self-healing capabilities in a Kubernetes cluster.
+


### PR DESCRIPTION
This PR updates https://kubernetes.io/docs/concepts/overview/components/

Fixes: #41576

This adds a tooltip for replicas text and includes replicas in the glossary.
