### PR TITLE
re-link from beta1 to stable documentation of kubelet-config.v1

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -20,7 +20,7 @@ You should be familiar with the Kubernetes
 
 The [Container runtimes](/docs/setup/production-environment/container-runtimes) page
 explains that the `systemd` driver is recommended for kubeadm based setups instead
-of the kubelet's [default](/docs/reference/config-api/kubelet-config.v1beta1) `cgroupfs` driver,
+of the kubelet's [default](/docs/reference/config-api/kubelet-config.v1) `cgroupfs` driver,
 because kubeadm manages the kubelet as a
 [systemd service](/docs/setup/production-environment/tools/kubeadm/kubelet-integration).
 


### PR DESCRIPTION
The introductory paragraph of the english documentation for "Configuring a cgroup driver" discusses differences between kubelet's systemd and cgroupfs driver usage in the context of kubeadm. Here is an outdated reference to an older beta version of the "Kubelet Configuration" documentation (kubelet-config.v1beta1). Shouldn't we point to the current documentation for the stable v1 release (kubelet-config.v1)? This PR fixes #41587 