### PR TITLE
[ja] sync concepts/architecture/cgroups.md

### DIFF
--- a/content/ja/docs/concepts/architecture/cgroups.md
+++ b/content/ja/docs/concepts/architecture/cgroups.md
@@ -84,7 +84,11 @@ cgroup v2はcgroup v1とは違うAPIを利用しているため、cgroupファ�
 * サードパーティーの監視またはセキュリティエージェントはcgroupファイルシステムに依存していることがあります。
  エージェントをcgroup v2をサポートしているバージョンに更新してください。
 * Podやコンテナを監視するために[cAdvisor](https://github.com/google/cadvisor)をスタンドアローンのDaemonSetとして起動している場合、v0.43.0以上に更新してください。
-* JDKを利用している場合、[cgroup v2を完全にサポートしている](https://bugs.openjdk.org/browse/JDK-8230305)JDK 11.0.16以降、またはJDK15以降を利用することが望ましいです。
+* Javaアプリケーションをデプロイする場合は、完全にcgroup v2をサポートしているバージョンを利用してください：
+    * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372、11.0.16、15以降
+    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01、11.0.16.0、17.0.4.0、18.0.2.0以降
+    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15以降
+* [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs)パッケージを利用している場合は、利用するバージョンがv1.5.1以上であることを確認してください。
 
 ## Linux Nodeのcgroupバージョンを特定する {#check-cgroup-version}
 


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/architecture/cgroups.md`
- **Sync to**: `content/ja/docs/concepts/architecture/cgroups.md`
- **Updates**:
  - Sync'ed upstream cases for `JDKを利用している場合`

Sync check by`scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/ja/docs/concepts/architecture/cgroups.md
diff --git a/content/en/docs/concepts/architecture/cgroups.md b/content/en/docs/concepts/architecture/cgroups.md
index 377c073b42..b0a98af660 100644
--- a/content/en/docs/concepts/architecture/cgroups.md
+++ b/content/en/docs/concepts/architecture/cgroups.md
@@ -102,7 +102,12 @@ updated to newer versions that support cgroup v2. For example:
  Update these agents to versions that support cgroup v2.
 * If you run [cAdvisor](https://github.com/google/cadvisor) as a stand-alone
  DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
-* If you use JDK, prefer to use JDK 11.0.16 and later or JDK 15 and later, which [fully support cgroup v2](https://bugs.openjdk.org/browse/JDK-8230305).
+* If you deploy Java applications, prefer to use versions which fully support cgroup v2:
+    * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
+    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
+    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
+* If you are using the [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) package, make sure
+  the version you use is v1.5.1 or higher.

 ## Identify the cgroup version on Linux Nodes  {#check-cgroup-version}

content/ja/docs/concepts/architecture/cloud-controller.md is still in sync
```
Sync check by`scripts/lsync.sh` on `update/architecture-cgroups` branch:
```diff
$ scripts/lsync.sh content/ja/docs/concepts/architecture/cgroups.md
content/ja/docs/concepts/architecture/cgroups.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
