### PR TITLE
docs(fr): fix curl option for kubectl installation on macOS

### DIFF
--- a/content/fr/docs/tasks/tools/install-kubectl.md
+++ b/content/fr/docs/tasks/tools/install-kubectl.md
@@ -110,10 +110,10 @@ kubectl version --client
 1. Téléchargez la dernière version:
 
     ```		
-    curl -LO https://dl.k8s.io/release/$(curl -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl
+    curl -LO https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl
     ```
 
-    Pour télécharger une version spécifique, remplacez `$(curl -s https://dl.k8s.io/release/stable.txt)` avec la version spécifique.
+    Pour télécharger une version spécifique, remplacez `$(curl -Ls https://dl.k8s.io/release/stable.txt)` avec la version spécifique.
 
     Par exemple, pour télécharger la version {{< param "fullversion" >}} sur macOS, tapez :
 		


### PR DESCRIPTION
On [this page ](https://kubernetes.io/fr/docs/tasks/tools/install-kubectl/#installer-le-binaire-kubectl-avec-curl-sur-macos) (in French), the `curl` command does not follow HTTP redirection, which causes the download to fail (because `https://dl.k8s.io` redirects to `https://storage.googleapis.com/kubernetes-release`).

This PR adds the `-L` option to curl in order to follow redirection.