### PR TITLE
Remove reference to interactive tutorial in expose-intro.html

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -97,7 +97,7 @@ description: |-
 				<h3>Create a new Service</h3>
 				<p>Let’s verify that our application is running. We’ll use the <code>kubectl get</code> command and look for existing Pods:</p>
 				<p><code><b>kubectl get pods</b></code></p>
-				<p>If no pods are running then it means the interactive environment is still reloading its previous state. Please wait a couple of seconds and list the Pods again. You can continue once you see the one Pod running.</p>
+				<p>If no Pods are running then it means the objects from the previous tutorials were cleaned up. In this case, go back and recreate the tutorial Deployment. Please wait a couple of seconds and list the Pods again. You can continue once you see the one Pod running.</p>
 				<p>Next, let’s list the current Services from our cluster:</p>
 				<p><code><b>kubectl get services</b></code></p>
 				<p>We have a Service called <tt>kubernetes</tt> that is created by default when minikube starts the cluster.


### PR DESCRIPTION
### Changes

Remove reference to interactive tutorial in expose-intro.html as this is not going to be run from an interactive platform such as Katacoda anymore, but in the user's local workstation.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
