### PR TITLE
Fix inappropriate word in sentence

### DIFF
--- a/content/en/docs/concepts/storage/ephemeral-volumes.md
+++ b/content/en/docs/concepts/storage/ephemeral-volumes.md
@@ -127,7 +127,7 @@ instructions.
 CSI ephemeral volumes allow users to provide `volumeAttributes`
 directly to the CSI driver as part of the Pod spec. A CSI driver
 allowing `volumeAttributes` that are typically restricted to
-administrators is NOT suitable for use in an inline ephemeral volume.
+administrators is not suitable for use in an inline ephemeral volume.
 For example, parameters that are normally defined in the StorageClass
 should not be exposed to users through the use of inline ephemeral volumes.
 


### PR DESCRIPTION
The sentence A CSI driver allowing volumeAttributes that are typically restricted to administrators is NOT suitable for use in an inline ephemeral volume. in the page https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#csi-driver-restrictions has used word "NOT" which looks like the abbreviation of something.

I replaced the word "NOT" with "not"