### PR TITLE
Add -subj Command Option.

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -488,7 +488,7 @@ O is the group that this user will belong to. You can refer to
 
 ```shell
 openssl genrsa -out myuser.key 2048
-openssl req -new -key myuser.key -out myuser.csr
+openssl req -new -key myuser.key -out myuser.csr -subj "/CN=myuser"
 ```
 
 ### Create a CertificateSigningRequest {#create-certificatessigningrequest}


### PR DESCRIPTION
This PR added the `-subj` command option for the `req` command of OpenSSL under the `Create private key` in [Certificates and Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) docs.

Fixes #39591
 