### PR TITLE
Include `initContainers` in list-all-running-container-images.md

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -23,7 +23,7 @@ of Containers for each.
 
 - Fetch all Pods in all namespaces using `kubectl get pods --all-namespaces`
 - Format the output to include only the list of Container image names
-  using `-o jsonpath={.items[*].spec.containers[*].image}`.  This will recursively parse out the
+  using `-o jsonpath={.items[*].spec['initContainers', 'containers'][*].image}`.  This will recursively parse out the
   `image` field from the returned json.
   - See the [jsonpath reference](/docs/reference/kubectl/jsonpath/)
     for further information on how to use jsonpath.
@@ -33,7 +33,7 @@ of Containers for each.
   - Use `uniq` to aggregate image counts
 
 ```shell
-kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" |\
+kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec['initContainers', 'containers'][*].image}" |\
 tr -s '[[:space:]]' '\n' |\
 sort |\
 uniq -c
@@ -42,7 +42,7 @@ The jsonpath is interpreted as follows:
 
 - `.items[*]`: for each returned value
 - `.spec`: get the spec
-- `.containers[*]`: for each container
+- `['initContainers', 'containers'][*]`: for each container
 - `.image`: get the image
 
 {{< note >}}


### PR DESCRIPTION
Hi all,

I found altering this script to include initContainers gave a more thorough picture of what images are actually being used throughout the cluster.

I see there is more doc below around gotemplate etc, I have not included the changes for those.