### PR TITLE
Update Wordpress stateful example to use MySQL8 and Wordpress 6.2. Improved database setup.

### DIFF
--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -50,7 +50,7 @@ earlier versions of this tutorial.
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-The example shown on this page works with `kubectl` 1.14 and above.
+The example shown on this page works with `kubectl` 1.27 and above.
 
 Download the following configuration files:
 

--- a/content/en/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/en/examples/application/wordpress/mysql-deployment.yaml
@@ -54,9 +54,9 @@ spec:
               name: mysql-pass
               key: password
         - name: MYSQL_DATABASE
-          value: "wordpress"
+          value: wordpress
         - name: MYSQL_USER
-          value: "wordpress"
+          value: wordpress
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/content/en/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/en/examples/application/wordpress/mysql-deployment.yaml
@@ -45,10 +45,19 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.0
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        - name: MYSQL_DATABASE
+          value: "wordpress"
+        - name: MYSQL_USER
+          value: "wordpress"
+        - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: mysql-pass

--- a/content/en/examples/application/wordpress/wordpress-deployment.yaml
+++ b/content/en/examples/application/wordpress/wordpress-deployment.yaml
@@ -56,7 +56,7 @@ spec:
               name: mysql-pass
               key: password
         - name: WORDPRESS_DB_USER
-          value: "wordpress"
+          value: wordpress
         ports:
         - containerPort: 80
           name: wordpress

--- a/content/en/examples/application/wordpress/wordpress-deployment.yaml
+++ b/content/en/examples/application/wordpress/wordpress-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: wordpress:4.8-apache
+      - image: wordpress:6.2.1-apache
         name: wordpress
         env:
         - name: WORDPRESS_DB_HOST
@@ -55,6 +55,8 @@ spec:
             secretKeyRef:
               name: mysql-pass
               key: password
+        - name: WORDPRESS_DB_USER
+          value: "wordpress"
         ports:
         - containerPort: 80
           name: wordpress


### PR DESCRIPTION
Updated the Wordpress Stateful example to use MySQL 8. This change allows users on Arm architecture to use the example as there does not appear to be a MySQL 5.6 image for Arm chips. I upgraded Wordpress as well to be compatible with MySQL8. 

The new images support the creation of named users and databases, this allows us to use non-root users for the example.