### PR TITLE
Integrate downloadkubernetes.com into docs website 

### DIFF
--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -10,6 +10,24 @@ cluster. Those components are also shipped in container images as part of the
 official release process. All binaries as well as container images are available
 for multiple operating systems as well as hardware architectures.
 
+### kubectl
+
+<!-- overview -->
+
+The Kubernetes command-line tool, [kubectl](/docs/reference/kubectl/kubectl/), allows
+you to run commands against Kubernetes clusters.
+
+You can use kubectl to deploy applications, inspect and manage cluster resources,
+and view logs. For more information including a complete list of kubectl operations, see the
+[`kubectl` reference documentation](/docs/reference/kubectl/).
+
+kubectl is installable on a variety of Linux platforms, macOS and Windows.
+Find your preferred operating system below.
+
+- [Install kubectl on Linux](/docs/tasks/tools/install-kubectl-linux)
+- [Install kubectl on macOS](/docs/tasks/tools/install-kubectl-macos)
+- [Install kubectl on Windows](/docs/tasks/tools/install-kubectl-windows)
+
 ## Container Images
 
 All Kubernetes container images are deployed to the
@@ -53,25 +71,4 @@ To manually verify signed container images of Kubernetes core components, refer 
 
 ## Binaries
 
-Find links to download Kubernetes components (and their checksums) in the
-[CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files.
-
-Alternately, use [downloadkubernetes.com](https://www.downloadkubernetes.com/) to filter by version and architecture.
-
-### kubectl
-
-<!-- overview -->
-
-The Kubernetes command-line tool, [kubectl](/docs/reference/kubectl/kubectl/), allows
-you to run commands against Kubernetes clusters.
-
-You can use kubectl to deploy applications, inspect and manage cluster resources,
-and view logs. For more information including a complete list of kubectl operations, see the
-[`kubectl` reference documentation](/docs/reference/kubectl/).
-
-kubectl is installable on a variety of Linux platforms, macOS and Windows.
-Find your preferred operating system below.
-
-- [Install kubectl on Linux](/docs/tasks/tools/install-kubectl-linux)
-- [Install kubectl on macOS](/docs/tasks/tools/install-kubectl-macos)
-- [Install kubectl on Windows](/docs/tasks/tools/install-kubectl-windows)
+{{< release-binaries >}}

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -366,6 +366,78 @@ other = "Before you begin"
 [previous_patches]
 other = "Patch Releases:"
 
+# The following text is displayed when JavaScript isn't available.
+[release_binary_alternate_links]
+other  = """You can find links to download Kubernetes components (and their checksums) in the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files.
+Alternately, use [downloadkubernetes.com](https://www.downloadkubernetes.com/) to filter by version and architecture."""
+
+[release_binary_arch]
+other  = "Architecture"
+
+[release_binary_arch_option]
+other = "Architectures"
+
+[release_binary_copy_link]
+other = "Copy Link"
+
+[release_binary_copy_link_certifcate]
+other = "cert"
+
+[release_binary_copy_link_checksum]
+other = "checksum"
+
+[release_binary_copy_link_signature]
+other = "signature"
+
+[release_binary_copy_link_tooltip]
+other = "copy to clipboard"
+
+[release_binary_download]
+other  = "Download Binary"
+
+[release_binary_download_tooltip]
+other = "download binary file"
+
+[release_binary_options]
+other  = "Download Options"
+
+[release_binary_os]
+other = "Operating System"
+
+[release_binary_os_option]
+other = "Operating Systems"
+
+[release_binary_os_darwin]
+other = "darwin"
+
+[release_binary_os_linux]
+other = "linux"
+
+[release_binary_os_windows]
+other = "windows"
+
+[release_binary_table_caption]
+other = "Download Kubernetes component binaries"
+
+# NOTE: <current-version> is a placeholder for the actual version number set by 'release-binaries' shortcode.
+# Please do not localize or modify <current-version> placeholder.
+[release_binary_section]
+other = """You can find the links to download <current-version> Kubernetes components (along with their checksums) below.
+To access downloads for older supported versions, visit the respective documentation 
+link for [older versions](https://kubernetes.io/docs/home/supported-doc-versions/#versions-older) or use [downloadkubernetes.com](https://www.downloadkubernetes.com/).""" 
+
+# NOTE: <current-version> and <current-changelog-url> are placeholders set by 'release-binaries' shortcode.
+# Please do not localize or modify <current-version> and <current-changelog-url>  placeholders.
+[release_binary_section_note]
+other = """To download older patch versions of <current-version> Kubernetes components (and their checksums), 
+please refer to the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG/CHANGELOG-<current-changelog-url>.md) file.""" 
+
+[release_binary_version]
+other  = "Version"
+
+[release_binary_version_option]
+other = "Latest Version"
+
 [release_date_after]
 other = ")"
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -87,6 +87,10 @@
 <script defer src="{{ "js/sortable-table.js" | relURL }}"></script>
 {{- end -}}
 
+{{- if .HasShortcode "release-binaries" -}}
+<script defer src="{{ "js/release_binaries.js" | relURL }}"></script>
+{{- end -}}
+
 {{- if eq (lower .Params.cid) "community" -}}
 {{- if eq .Params.community_styles_migrated true -}}
 <link href="/css/community.css" rel="stylesheet"><!-- legacy styles -->

--- a/layouts/shortcodes/release-binaries.html
+++ b/layouts/shortcodes/release-binaries.html
@@ -1,0 +1,130 @@
+<!-- Fetch release_binaries.json from kubernetes-sigs/downloadkubernetes to render in table -->
+{{ $response := getJSON "https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/dist/release_binaries.json" }}
+
+{{ $currentVersion := site.Params.version }}
+
+{{ $Binaries := slice }}
+{{ $AllOSes := slice }}
+{{ $AllArch := slice }}
+{{ $AllVersions := slice }}
+
+{{ range $key, $value := $response }}
+    {{ if eq $key "Binaries" }}
+        {{ $Binaries = $value }}
+    {{ else if eq $key "AllOSes" }}
+        {{ $AllOSes = $value }}
+    {{ else if eq $key "AllArch" }}
+        {{ $AllArch = $value }}
+    {{ else if eq $key "AllVersions" }}
+        {{ $AllVersions = $value }}
+    {{ end }}
+{{ end }}
+
+
+<!-- The below <div> defines an alternate content to be displayed only 
+     when Javascript is disabled or when user's browser doesn't support Javascript -->
+<div class="downloadbinaries-nojs">
+        <p>{{ T "release_binary_alternate_links" | markdownify }}</p>
+</div>
+
+<!-- The below section containing the release binary details
+    is enabled by the script "release_binaries.js"  -->
+<div id="download-kubernetes-data" style="display: none;">
+    <p>
+        {{ $releaseBinarySection := T "release_binary_section" }}
+        {{ $releaseBinarySection = replace $releaseBinarySection "<current-version>" $currentVersion }}
+        {{ $releaseBinarySection | markdownify }}
+    </p>
+    <div class="alert alert-info note callout" role="alert">
+        <strong>{{ T "note" }}</strong>
+        {{ $releaseBinarySectionNote := T "release_binary_section_note" }}
+        {{ $releaseBinarySectionNote = replace $releaseBinarySectionNote "<current-changelog-url>" (replace $currentVersion "v" "") }}    
+        {{ $releaseBinarySectionNote = replace $releaseBinarySectionNote "<current-version>" $currentVersion }}
+        {{ $releaseBinarySectionNote | markdownify }}
+    </div>    
+    <details>
+        <summary>{{ T "release_binary_options" }}</summary>
+        <div class="text-center w-100">
+            <div class="d-inline-block text-center pr-4">
+                <div>
+                    <b>{{ T "release_binary_os_option" }}</b>
+                    <div class="buttons" id="os-filter">
+                        {{- range $AllOSes }}
+                        <button class="btn btn-outline-primary m-1" data-os="{{.}}-data">{{ T (printf "release_binary_os_%s" .) }}</button>
+                        {{- end }}
+                    </div>
+                </div>
+            </div>
+            <div class="d-inline-block text-center pr-4">
+                <div>
+                    <b>{{ T "release_binary_version_option" }}</b>
+                    <div class="buttons" id="version-filter">
+                        {{- range $AllVersions }}
+                        {{- $releaseBinaryData := printf "%s.%s" (index (split . ".") 0) (index (split . ".") 1) -}}
+                        {{- if eq $releaseBinaryData $currentVersion }}
+                        <button class="btn btn-primary m-1" data-version="{{.}}-data">{{ $currentVersion }} ({{ T "patch_release" }} {{ . }})</button>
+                        {{- end }}
+                        {{- end }}
+                    </div>
+                </div>
+            </div>
+
+            <div class="text-center w-100 p-4">
+                <div>
+                    <b>{{ T "release_binary_arch_option" }}</b>
+                    <div class="buttons" id="arch-filter">
+                        {{- range $AllArch }}
+                        <button class="btn btn-outline-primary m-1" data-arch="{{.}}-data">{{.}}</button>
+                        {{- end }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </details>
+
+    <div class="table-responsive">
+        <table class="table" id="release-binary-table">
+            <caption style="display:none">{{ T "release_binary_table_caption" }}</caption>
+            <thead>
+                <tr>
+                    <th>{{ T "release_binary_version" }}</th>
+                    <th>{{ T "release_binary_os" }}</th>
+                    <th>{{ T "release_binary_arch" }}</th>
+                    <th>{{ T "release_binary_download" }}</th>
+                    <th>{{ T "release_binary_copy_link" }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range $index, $binary := $Binaries -}}
+                {{- $releaseBinaryData := printf "%s.%s" (index (split $binary.Version ".") 0) (index (split $binary.Version ".") 1) -}}
+                {{- if eq $releaseBinaryData $currentVersion }}
+                {{ $LinkText := printf "dl.k8s.io/%s/bin/%s/%s/%s" $binary.Version $binary.OperatingSystem $binary.Architecture $binary.Name }}
+                {{ $BinaryLink := printf "https://dl.k8s.io/%s/bin/%s/%s/%s" $binary.Version $binary.OperatingSystem $binary.Architecture $binary.Name }}
+                {{ $ChecksumLink := printf "https://dl.k8s.io/%s/bin/%s/%s/%s.sha256" $binary.Version $binary.OperatingSystem $binary.Architecture $binary.Name }}
+                {{ $SignatureLink := printf "https://dl.k8s.io/%s/bin/%s/%s/%s.sig" $binary.Version $binary.OperatingSystem $binary.Architecture $binary.Name }}
+                {{ $CertificateLink := printf "https://dl.k8s.io/%s/bin/%s/%s/%s.cert" $binary.Version $binary.OperatingSystem $binary.Architecture $binary.Name }}
+                <tr class="{{ $binary.Version }}-data {{ $binary.OperatingSystem }}-data {{ $binary.Architecture }}-data {{ $binary.Name }}-data">
+                    <td>{{ $binary.Version }}</td>
+                    <td>{{ T (printf "release_binary_os_%s" $binary.OperatingSystem) }}</td>
+                    <td>{{ $binary.Architecture }}</td>
+                    <td>
+                        <span title="{{ T "release_binary_download_tooltip" }}">
+                            <a href="{{$BinaryLink}}">{{ $binary.Name }}</a>
+                        </span>
+                    </td>
+                    <td>
+                        <span class="icon">
+                            <i class="fa fa-copy"></i>
+                        </span>
+                        <span title="{{ T "release_binary_copy_link_tooltip" }}">
+                            <a class="release-binary-copy" href="{{$BinaryLink}}">{{$LinkText}}</a>
+                            (<a class="release-binary-copy" href="{{$ChecksumLink}}">{{T "release_binary_copy_link_checksum"}}</a> | <a class="release-binary-copy" href="{{$SignatureLink}}">{{T "release_binary_copy_link_signature"}}</a> | <a class="release-binary-copy" href="{{$CertificateLink}}">{{T "release_binary_copy_link_certifcate"}}</a>)
+                        </span>
+                    </td>
+                </tr>
+                {{- end }}
+                {{- end }}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/static/js/release_binaries.js
+++ b/static/js/release_binaries.js
@@ -1,0 +1,75 @@
+const filterCriteria = {
+    os: "",
+    arch: ""
+};
+
+["os", "arch"].forEach(kind => {
+    eventListener(kind);
+});
+
+function eventListener(kind) {
+    let buttonGroupQuery = '#' + kind + '-filter' + ' > button';
+    let buttonGroup = document.querySelectorAll(buttonGroupQuery);
+
+    buttonGroup.forEach(button => {
+        button.addEventListener('click', (evt) => {
+            let buttonData = button.dataset[kind];
+
+            if (filterCriteria[kind] === buttonData) {
+                filterCriteria[kind] = "";
+                button.classList.add('btn-outline-primary');
+                button.classList.remove('btn-primary');
+            } else {
+                filterCriteria[kind] = buttonData;
+                buttonGroup.forEach(b => {
+                    b.classList.remove('btn-primary');
+                    b.classList.add('btn-outline-primary');
+                });
+                button.classList.remove('btn-outline-primary');
+                button.classList.add('btn-primary');
+            }
+            
+            filterRows();
+        });
+    });
+}
+
+function filterRows() {
+    const rows = document.querySelectorAll('#release-binary-table tbody tr');
+    
+    rows.forEach(row => {
+        const os = row.classList.contains(filterCriteria.os) || filterCriteria.os === "";
+        const arch = row.classList.contains(filterCriteria.arch) || filterCriteria.arch === "";
+        
+        if (os && arch) {
+            row.classList.remove('hide');
+        } else {
+            row.classList.add('hide');
+        }
+    });
+}
+
+document.querySelectorAll("#release-binary-table .release-binary-copy").forEach(link => {
+    link.addEventListener('click', (evt) => {
+        evt.preventDefault();
+
+        const hrefValue = link.getAttribute('href');
+        const tempTextArea = document.createElement('textarea');
+        tempTextArea.value = hrefValue;
+        document.body.appendChild(tempTextArea);
+        tempTextArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(tempTextArea);
+        return false;
+    });
+});
+
+// The page and script is loaded successfully
+$( document ).ready(function() {
+
+    // Remove the non-js content
+    $('.downloadbinaries-nojs').hide();
+
+    // Display the release binary content
+    $('#download-kubernetes-data').show();
+})


### PR DESCRIPTION
### Description:
This PR incorporates changes that involve to integrate [downloadkubernetes.com ](https://www.downloadkubernetes.com/)into k/website.
Related to feature request: #30579

### Summary of changes:

- **Pre-req:** Will need `release_binaries.json` from `kubernetes-sigs/downloadkubernetes`. The logic to generate the json file is added as part of PR https://github.com/kubernetes-sigs/downloadkubernetes/pull/472

- Added a Hugo shortcode to render the details of release binaries from a JSON file generated by  `kubernetes-sigs/downloadkubernetes` The table structure, CSS, and scripts are mostly reused from 'downloadkubernetes' repository wherever it was appropriate and did not cause any issues.


### Preview after Integration with k/website: [deploy-preview-k8s.io/releases/download/](https://deploy-preview-41687--kubernetes-io-main-staging.netlify.app/releases/download/)