### PR TITLE
"具有"更改为“需要”

### DIFF
--- a/content/zh-cn/docs/concepts/services-networking/service.md
+++ b/content/zh-cn/docs/concepts/services-networking/service.md
@@ -1868,7 +1868,7 @@ Otherwise, those client Pods won't have their environment variables populated.
 If you only use DNS to discover the cluster IP for a Service, you don't need to
 worry about this ordering issue.
 -->
-当你的 Pod 具有访问某 Service，并且你在使用环境变量方法将端口和集群 IP 发布到客户端
+当你的 Pod 需要访问某 Service，并且你在使用环境变量方法将端口和集群 IP 发布到客户端
 Pod 时，必须在客户端 Pod 出现**之前**创建该 Service。
 否则，这些客户端 Pod 中将不会出现对应的环境变量。
 


### PR DESCRIPTION
当你的 Pod **具有**访问某 Service，并且你在使用环境变量方法将端口和集群 IP 发布到客户端 Pod 时，必须在客户端 Pod 出现之前创建该 Service。
更改为:
当你的 Pod **需要**访问某 Service，并且你在使用环境变量方法将端口和集群 IP 发布到客户端 Pod 时，必须在客户端 Pod 出现之前创建该 Service。
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
