### PR TITLE
fixed buggy example note shortcode

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -422,7 +422,7 @@ For example:
     1. Preheat oven to 350˚F
 
     1. Prepare the batter, and pour into springform pan.
-       `{{</* note */>}}Grease the pan for best results.{{</* /note */>}}`
+       {{</* note */>}}Grease the pan for best results.{{</* /note */>}}
 
     1. Bake for 20-25 minutes or until set.
 


### PR DESCRIPTION
fixed Buggy example for note shortcode. by removing **Backticks** from the example.

> {{< note >}}Grease the pan for best results.{{< /note >}}

**Page**: https://kubernetes.io/docs/contribute/style/style-guide/#common-shortcode-issues