### PR TITLE
setup-ha-etcd-with-kubeadm.md: add missing authn/authz fields

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -69,6 +69,13 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
    #
    apiVersion: kubelet.config.k8s.io/v1beta1
    kind: KubeletConfiguration
+   authentication:
+     anonymous:
+       enabled: false
+     webhook:
+       enabled: false
+   authorization:
+     mode: AlwaysAllow
    cgroupDriver: systemd
    address: 127.0.0.1
    containerRuntimeEndpoint: unix:///var/run/containerd/containerd.sock
@@ -298,7 +305,7 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
     https://[HOST1 IP]:2379 is healthy: successfully committed proposal: took = 19.44402ms
     https://[HOST2 IP]:2379 is healthy: successfully committed proposal: took = 35.926451ms
     ```
-    
+
     - Set `${HOST0}`to the IP address of the host you are testing.
 
 


### PR DESCRIPTION
The kubelet is run in standalone mode and these fields are required
so that the config is accepted. In this guide the kubelet
is only used as a service manager. Note that while the authz
mode is AlwaysAllow, anonymous and webhook authn are disabled.

/sig cluster-lifecycle
/kind cleanup
