### PR TITLE
Added 'command' block for some busybox pod's scripts

### DIFF
--- a/content/en/examples/admin/resource/limit-range-pod-3.yaml
+++ b/content/en/examples/admin/resource/limit-range-pod-3.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
   - name: busybox-cnt01
     image: busybox:1.28
+    command: ["sleep", "3600"]
     resources:
       limits:
         memory: "300Mi"

--- a/content/en/examples/pods/share-process-namespace.yaml
+++ b/content/en/examples/pods/share-process-namespace.yaml
@@ -9,6 +9,7 @@ spec:
     image: nginx
   - name: shell
     image: busybox:1.28
+    command: ["sleep", "3600"]
     securityContext:
       capabilities:
         add:

--- a/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
+++ b/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
   - name: container-test
     image: busybox:1.28
+    command: ["sleep", "3600"]
     volumeMounts:
     - name: all-in-one
       mountPath: "/projected-volume"

--- a/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
+++ b/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
   - name: container-test
     image: busybox:1.28
+    command: ["sleep", "3600"]
     volumeMounts:
     - name: all-in-one
       mountPath: "/projected-volume"

--- a/content/en/examples/pods/storage/projected-service-account-token.yaml
+++ b/content/en/examples/pods/storage/projected-service-account-token.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
   - name: container-test
     image: busybox:1.28
+    command: ["sleep", "3600"]
     volumeMounts:
     - name: token-vol
       mountPath: "/service-account"


### PR DESCRIPTION
Some example scripts have `busybox:1.28` as their image, but no `command` or `arg` values were declared in them that will keep the container alive. Because of which if someone copies the code and try to run it, the pod it will create will complete/crash continuously creating `CrashLoopBackoff` state.  