### PR TITLE
Add ja redirect for learning environment

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -386,6 +386,7 @@
 /docs/setup/learning-environment/     /docs/tasks/tools/  302!
 /id/docs/setup/learning-environment/     /id/docs/tasks/tools/  302!
 /zh-cn/docs/setup/learning-environment/     /zh-cn/docs/tasks/tools/  302!
+/ja/docs/setup/learning-environment/     /ja/docs/tasks/tools/  302!
 /hi/docs/setup/learning-environment/     /hi/docs/tasks/tools/ 302!
 /docs/setup/learning-environment/kind/  /docs/tasks/tools/  302
 /id/docs/setup/learning-environment/kind/  /id/docs/tasks/tools/  302


### PR DESCRIPTION
Add redirection for https://kubernetes.io/ja/docs/setup/learning-environment/ to behave the same way as EN version

Fixes https://github.com/kubernetes/website/issues/41724

Before:
No redirect

After:
Redirection to https://kubernetes.io/ja/docs/tasks/tools/
