### PR TITLE
[ja] sync concepts/architecture/control-plane-node-communication.md

### DIFF
--- a/content/ja/docs/concepts/architecture/control-plane-node-communication.md
+++ b/content/ja/docs/concepts/architecture/control-plane-node-communication.md
@@ -8,7 +8,7 @@ aliases:
 
 <!-- overview -->
 
-本ドキュメントは、APIサーバーとKubernetesクラスター間の通信経路をまとめたものです。
+本ドキュメントは、{{< glossary_tooltip term_id="kube-apiserver" text="APIサーバー" >}}とKubernetes{{< glossary_tooltip text="クラスター" term_id="cluster" length="all" >}}間の通信経路をまとめたものです。
 その目的は、信頼できないネットワーク上(またはクラウドプロバイダー上の完全なパブリックIP)でクラスターが実行できるよう、ユーザーがインストールをカスタマイズしてネットワーク構成を強固にできるようにすることです。
 
 <!-- body -->
@@ -18,10 +18,10 @@ aliases:
 Kubernetesには「ハブアンドスポーク」というAPIパターンがあります。ノード(またはノードが実行するPod)からのすべてのAPIの使用は、APIサーバーで終了します。他のコントロールプレーンコンポーネントは、どれもリモートサービスを公開するようには設計されていません。APIサーバーは、1つ以上の形式のクライアント[認証](/ja/docs/reference/access-authn-authz/authentication/)が有効になっている状態で、セキュアなHTTPSポート(通常は443)でリモート接続をリッスンするように設定されています。
 特に[匿名リクエスト](/ja/docs/reference/access-authn-authz/authentication/#anonymous-requests)や[サービスアカウントトークン](/ja/docs/reference/access-authn-authz/authentication/#service-account-token)が許可されている場合は、1つ以上の[認可](/docs/reference/access-authn-authz/authorization/)形式を有効にする必要があります。
 
-ノードは、有効なクライアント認証情報とともに、APIサーバーに安全に接続できるように、クラスターのパブリックルート証明書でプロビジョニングされる必要があります。適切なやり方は、kubeletに提供されるクライアント認証情報が、クライアント証明書の形式であることです。kubeletクライアント証明書の自動プロビジョニングについては、[kubelet TLSブートストラップ](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)を参照してください。
+ノードは、有効なクライアント認証情報とともに、APIサーバーに安全に接続できるように、クラスターのパブリックルート{{< glossary_tooltip text="証明書" term_id="certificate" >}}でプロビジョニングされる必要があります。適切なやり方は、kubeletに提供されるクライアント認証情報が、クライアント証明書の形式であることです。kubeletクライアント証明書の自動プロビジョニングについては、[kubelet TLSブートストラップ](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)を参照してください。
 
-APIサーバーに接続したいPodは、サービスアカウントを利用することで、安全に接続することができます。これにより、Podのインスタンス化時に、Kubernetesはパブリックルート証明書と有効なBearerトークンを自動的にPodに挿入します。
-`kubernetes`サービス(`デフォルト`の名前空間)は、APIサーバー上のHTTPSエンドポイントに(`kube-proxy`経由で)リダイレクトされる仮想IPアドレスで構成されます。
+APIサーバーに接続したい{{< glossary_tooltip text="Pod" term_id="pod" >}}は、サービスアカウントを利用することで、安全に接続することができます。これにより、Podのインスタンス化時に、Kubernetesはパブリックルート証明書と有効なBearerトークンを自動的にPodに挿入します。
+`kubernetes`サービス(`デフォルト`の名前空間)は、APIサーバー上のHTTPSエンドポイントに(`{{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}`経由で)リダイレクトされる仮想IPアドレスで構成されます。
 
 また、コントロールプレーンのコンポーネントは、セキュアなポートを介してAPIサーバーとも通信します。
 
@@ -30,7 +30,7 @@ APIサーバーに接続したいPodは、サービスアカウントを利用�
 ## コントロールプレーンからノードへの通信 {#control-plane-to-node}
 
 コントロールプレーン(APIサーバー)からノードへの主要な通信経路は2つあります。
-1つ目は、APIサーバーからクラスター内の各ノードで実行されるkubeletプロセスへの通信経路です。
+1つ目は、APIサーバーからクラスター内の各ノードで実行される{{< glossary_tooltip text="kubelet" term_id="kubelet" >}}プロセスへの通信経路です。
 2つ目は、APIサーバーの _プロキシー_ 機能を介した、APIサーバーから任意のノード、Pod、またはサービスへの通信経路です。
 
 ### APIサーバーからkubeletへの通信 {#api-server-to-kubelet}
@@ -56,7 +56,7 @@ APIサーバーからノード、Pod、またはサービスへの接続は、�
 
 ### SSHトンネル {#ssh-tunnels}
 
-Kubernetesは、コントロールプレーンからノードへの通信経路を保護するために、SSHトンネルをサポートしています。この構成では、APIサーバーがクラスター内の各ノードへのSSHトンネルを開始(ポート22でリッスンしているSSHサーバーに接続)し、kubelet、ノード、Pod、またはサービス宛てのすべてのトラフィックをトンネル経由で渡します。
+Kubernetesは、コントロールプレーンからノードへの通信経路を保護するために、[SSHトンネル](https://www.ssh.com/academy/ssh/tunneling)をサポートしています。この構成では、APIサーバーがクラスター内の各ノードへのSSHトンネルを開始(ポート22でリッスンしているSSHサーバーに接続)し、kubelet、ノード、Pod、またはサービス宛てのすべてのトラフィックをトンネル経由で渡します。
 このトンネルにより、ノードが稼働するネットワークの外部にトラフィックが公開されないようになります。
 
 {{< note >}}
@@ -73,3 +73,12 @@ Konnectivityサービスを有効にすると、コントロールプレーン�
 
 [Konnectivityサービスのセットアップ](/docs/tasks/extend-kubernetes/setup-konnectivity/)に従って、クラスターにKonnectivityサービスをセットアップしてください。
 
+## {{% heading "whatsnext" %}}
+
+* [Kubernetesコントロールプレーンコンポーネント](/ja/docs/concepts/overview/components/#control-plane-components)について読む。
+* [HubsとSpokeモデル](https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts.html#hubs-spokes-and-other-wheel-metaphors)について学習する。
+* [クラスターのセキュリティ](/ja/docs/tasks/administer-cluster/securing-a-cluster/)について学習する。
+* [Kubernetes API](/ja/docs/concepts/overview/kubernetes-api/)について学習する。
+* [Konnectivityサービスを設定する](/docs/tasks/extend-kubernetes/setup-konnectivity/)
+* [Port Forwardingを使用してクラスター内のアプリケーションにアクセスする](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+* [Podログを調べます](/ja/docs/tasks/debug/debug-application/debug-running-pod/#examine-pod-logs)と[kubectl port-forwardを使用します](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/#forward-a-local-port-to-a-port-on-the-pod)について学習する。


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/architecture/control-plane-node-communication.md`
- **Sync to**: `content/ja/docs/concepts/architecture/control-plane-node-communication.md`
- **Updates**:
  - Sync'ed upstream `glossary_tooltip`s.
  - Sync'ed upstream `What Next`.

Sync check by`scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/ja/docs/concepts/architecture/control-plane-node-communication.md
diff --git a/content/en/docs/concepts/architecture/control-plane-node-communication.md b/content/en/docs/concepts/architecture/control-plane-node-communication.md
index 785040cda3..2cfa37d5c5 100644
--- a/content/en/docs/concepts/architecture/control-plane-node-communication.md
+++ b/content/en/docs/concepts/architecture/control-plane-node-communication.md
@@ -11,7 +11,8 @@ aliases:

 <!-- overview -->

-This document catalogs the communication paths between the API server and the Kubernetes cluster.
+This document catalogs the communication paths between the {{< glossary_tooltip term_id="kube-apiserver" text="API server" >}}
+and the Kubernetes {{< glossary_tooltip text="cluster" term_id="cluster" length="all" >}}.
 The intent is to allow users to customize their installation to harden the network configuration
 such that the cluster can be run on an untrusted network (or on fully public IPs on a cloud
 provider).
@@ -30,28 +31,28 @@ enabled, especially if [anonymous requests](/docs/reference/access-authn-authz/a
 or [service account tokens](/docs/reference/access-authn-authz/authentication/#service-account-tokens)
 are allowed.

-Nodes should be provisioned with the public root certificate for the cluster such that they can
+Nodes should be provisioned with the public root {{< glossary_tooltip text="certificate" term_id="certificate" >}} for the cluster such that they can
 connect securely to the API server along with valid client credentials. A good approach is that the
 client credentials provided to the kubelet are in the form of a client certificate. See
 [kubelet TLS bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
 for automated provisioning of kubelet client certificates.

-Pods that wish to connect to the API server can do so securely by leveraging a service account so
+{{< glossary_tooltip text="Pods" term_id="pod" >}} that wish to connect to the API server can do so securely by leveraging a service account so
 that Kubernetes will automatically inject the public root certificate and a valid bearer token
 into the pod when it is instantiated.
 The `kubernetes` service (in `default` namespace) is configured with a virtual IP address that is
-redirected (via `kube-proxy`) to the HTTPS endpoint on the API server.
+redirected (via `{{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}`) to the HTTPS endpoint on the API server.

 The control plane components also communicate with the API server over the secure port.

-As a result, the default operating mode for connections from the nodes and pods running on the
+As a result, the default operating mode for connections from the nodes and pod running on the
 nodes to the control plane is secured by default and can run over untrusted and/or public
 networks.

 ## Control plane to node

 There are two primary communication paths from the control plane (the API server) to the nodes.
-The first is from the API server to the kubelet process which runs on each node in the cluster.
+The first is from the API server to the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} process which runs on each node in the cluster.
 The second is from the API server to any node, pod, or service through the API server's _proxy_
 functionality.

@@ -89,7 +90,7 @@ connections **are not currently safe** to run over untrusted or public networks.

 ### SSH tunnels

-Kubernetes supports SSH tunnels to protect the control plane to nodes communication paths. In this
+Kubernetes supports [SSH tunnels](https://www.ssh.com/academy/ssh/tunneling) to protect the control plane to nodes communication paths. In this
 configuration, the API server initiates an SSH tunnel to each node in the cluster (connecting to
 the SSH server listening on port 22) and passes all traffic destined for a kubelet, node, pod, or
 service through the tunnel.
@@ -117,3 +118,12 @@ connections.
 Follow the [Konnectivity service task](/docs/tasks/extend-kubernetes/setup-konnectivity/) to set
 up the Konnectivity service in your cluster.

+## {{% heading "whatsnext" %}}
+
+* Read about the [Kubernetes control plane components](/docs/concepts/overview/components/#control-plane-components)
+* Learn more about [Hubs and Spoke model](https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts.html#hubs-spokes-and-other-wheel-metaphors)
+* Learn how to [Secure a Cluster](/docs/tasks/administer-cluster/securing-a-cluster/)
+* Learn more about the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
+* [Set up Konnectivity service](/docs/tasks/extend-kubernetes/setup-konnectivity/)
+* [Use Port Forwarding to Access Applications in a Cluster](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+* Learn how to [Fetch logs for Pods](/docs/tasks/debug/debug-application/debug-running-pod/#examine-pod-logs), [use kubectl port-forward](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/#forward-a-local-port-to-a-port-on-the-pod)
\ No newline at end of file
```
Sync check by`scripts/lsync.sh` on `sync/ja_control-plane-node-communication` branch:
```diff
$ scripts/lsync.sh content/ja/docs/concepts/architecture/control-plane-node-communication.md
content/ja/docs/concepts/architecture/control-plane-node-communication.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
