### PR TITLE
Corrected the number of selectors in network-policies.md file

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -137,7 +137,7 @@ walkthrough for further examples.
 
 ## Behavior of `to` and `from` selectors
 
-There are four kinds of selectors that can be specified in an `ingress` `from` section or `egress`
+There are three kinds of selectors that can be specified in an `ingress` `from` section or `egress`
 `to` section:
 
 **podSelector**: This selects particular Pods in the same namespace as the NetworkPolicy which


### PR DESCRIPTION
fixes #41354 

This PR corrects Improper count of Ingress/Egress NetworkPolicy selectors on the Network Policies page