### PR TITLE
[zh] sync /using-api/deprecation-guide.md

### DIFF
--- a/content/zh-cn/docs/reference/using-api/deprecation-guide.md
+++ b/content/zh-cn/docs/reference/using-api/deprecation-guide.md
@@ -3,7 +3,6 @@ title: 已弃用 API 的迁移指南
 weight: 45
 content_type: reference
 ---
-
 <!--
 reviewers:
 - liggitt
@@ -62,7 +61,7 @@ The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and Prior
 * 所有的已保存的对象都可以通过新的 API 来访问；
 * **flowcontrol.apiserver.k8s.io/v1beta3** 中需要额外注意的变更：
   * PriorityLevelConfiguration 的 `spec.limited.assuredConcurrencyShares`
-  字段已被更名为 `spec.limited.nominalConcurrencyShares`
+    字段已被更名为 `spec.limited.nominalConcurrencyShares`
 
 ### v1.27
 
@@ -158,9 +157,9 @@ The **discovery.k8s.io/v1beta1** API version of EndpointSlice is no longer serve
 * Migrate manifests and API clients to use the **discovery.k8s.io/v1** API version, available since v1.21.
 * All existing persisted objects are accessible via the new API
 * Notable changes in **discovery.k8s.io/v1**:
-    * use per Endpoint `nodeName` field instead of deprecated `topology["kubernetes.io/hostname"]` field
-    * use per Endpoint `zone` field instead of deprecated `topology["topology.kubernetes.io/zone"]` field
-    * `topology` is replaced with the `deprecatedTopology` field which is not writable in v1
+  * use per Endpoint `nodeName` field instead of deprecated `topology["kubernetes.io/hostname"]` field
+  * use per Endpoint `zone` field instead of deprecated `topology["topology.kubernetes.io/zone"]` field
+  * `topology` is replaced with the `deprecatedTopology` field which is not writable in v1
 -->
 从 v1.25 版本开始不再提供 **discovery.k8s.io/v1beta1** API 版本的 EndpointSlice。
 
@@ -188,14 +187,20 @@ The **events.k8s.io/v1beta1** API version of Event is no longer served as of v1.
 
 <!--
 * Notable changes in **events.k8s.io/v1**:
-    * `type` is limited to `Normal` and `Warning`
-    * `involvedObject` is renamed to `regarding`
-    * `action`, `reason`, `reportingController`, and `reportingInstance` are required when creating new **events.k8s.io/v1** Events
-    * use `eventTime` instead of the deprecated `firstTimestamp` field (which is renamed to `deprecatedFirstTimestamp` and not permitted in new **events.k8s.io/v1** Events)
-    * use `series.lastObservedTime` instead of the deprecated `lastTimestamp` field (which is renamed to `deprecatedLastTimestamp` and not permitted in new **events.k8s.io/v1** Events)
-    * use `series.count` instead of the deprecated `count` field (which is renamed to `deprecatedCount` and not permitted in new **events.k8s.io/v1** Events)
-    * use `reportingController` instead of the deprecated `source.component` field (which is renamed to `deprecatedSource.component` and not permitted in new **events.k8s.io/v1** Events)
-    * use `reportingInstance` instead of the deprecated `source.host` field (which is renamed to `deprecatedSource.host` and not permitted in new **events.k8s.io/v1** Events)
+  * `type` is limited to `Normal` and `Warning`
+  * `involvedObject` is renamed to `regarding`
+  * `action`, `reason`, `reportingController`, and `reportingInstance` are required
+    when creating new **events.k8s.io/v1** Events
+  * use `eventTime` instead of the deprecated `firstTimestamp` field (which is renamed
+    to `deprecatedFirstTimestamp` and not permitted in new **events.k8s.io/v1** Events)
+  * use `series.lastObservedTime` instead of the deprecated `lastTimestamp` field
+    (which is renamed to `deprecatedLastTimestamp` and not permitted in new **events.k8s.io/v1** Events)
+  * use `series.count` instead of the deprecated `count` field
+    (which is renamed to `deprecatedCount` and not permitted in new **events.k8s.io/v1** Events)
+  * use `reportingController` instead of the deprecated `source.component` field
+    (which is renamed to `deprecatedSource.component` and not permitted in new **events.k8s.io/v1** Events)
+  * use `reportingInstance` instead of the deprecated `source.host` field
+    (which is renamed to `deprecatedSource.host` and not permitted in new **events.k8s.io/v1** Events)
 -->
 * **events.k8s.io/v1** 中值得注意的变更有：
   * `type` 字段只能设置为 `Normal` 和 `Warning` 之一；
@@ -210,7 +215,7 @@ The **events.k8s.io/v1beta1** API version of Event is no longer served as of v1.
     （该字段已被更名为 `deprecatedCount`，且不允许出现在新的 **events.k8s.io/v1** Event 对象中）；
   * 使用 `reportingController` 而不是已被弃用的 `source.component` 字段
     （该字段已被更名为 `deprecatedSource.component`，且不允许出现在新的 **events.k8s.io/v1** Event 对象中）；
-   * 使用 `reportingInstance` 而不是已被弃用的 `source.host` 字段
+  * 使用 `reportingInstance` 而不是已被弃用的 `source.host` 字段
     （该字段已被更名为 `deprecatedSource.host`，且不允许出现在新的 **events.k8s.io/v1** Event 对象中）。
 
 #### HorizontalPodAutoscaler {#horizontalpodautoscaler-v125}
@@ -235,7 +240,9 @@ The **policy/v1beta1** API version of PodDisruptionBudget is no longer served as
 * Migrate manifests and API clients to use the **policy/v1** API version, available since v1.21.
 * All existing persisted objects are accessible via the new API
 * Notable changes in **policy/v1**:
-  * an empty `spec.selector` (`{}`) written to a `policy/v1` PodDisruptionBudget selects all pods in the namespace (in `policy/v1beta1` an empty `spec.selector` selected no pods). An unset `spec.selector` selects no pods in either API version.
+  * an empty `spec.selector` (`{}`) written to a `policy/v1` PodDisruptionBudget selects all
+    pods in the namespace (in `policy/v1beta1` an empty `spec.selector` selected no pods).
+    An unset `spec.selector` selects no pods in either API version.
 -->
 从 v1.25 版本开始不再提供 **policy/v1beta1** API 版本的 PodDisruptionBudget。
 
@@ -250,7 +257,8 @@ The **policy/v1beta1** API version of PodDisruptionBudget is no longer served as
 #### PodSecurityPolicy {#psp-v125}
 
 <!--
-PodSecurityPolicy in the **policy/v1beta1** API version is no longer served as of v1.25, and the PodSecurityPolicy admission controller will be removed.
+PodSecurityPolicy in the **policy/v1beta1** API version is no longer served as of v1.25,
+and the PodSecurityPolicy admission controller will be removed.
 
 Migrate to [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
 or a [3rd party admission webhook](/docs/reference/access-authn-authz/extensible-admission-controllers/).
@@ -260,7 +268,7 @@ For more information on the deprecation, see [PodSecurityPolicy Deprecation: Pas
 从 v1.25 版本开始不再提供 **policy/v1beta1** API 版本中的 PodSecurityPolicy，
 并且 PodSecurityPolicy 准入控制器也会被删除。
 
-迁移到 [Pod 安全准入](/zh-cn/docs/concepts/security/pod-security-admission/)或[第三方准入 webhook](/zh-cn/docs/reference/access-authn-authz/extensible-admission-controllers/)。
+迁移到 [Pod 安全准入](/zh-cn/docs/concepts/security/pod-security-admission/)或[第三方准入 Webhook](/zh-cn/docs/reference/access-authn-authz/extensible-admission-controllers/)。
 有关迁移指南，请参阅[从 PodSecurityPolicy 迁移到内置 PodSecurity 准入控制器](/zh-cn/docs/tasks/configure-pod-container/migrate-from-psp/)。
 有关弃用的更多信息，请参阅 [PodSecurityPolicy 弃用：过去、现在和未来](/zh-cn/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/)。
 
@@ -292,7 +300,8 @@ The **v1.22** release stopped serving the following deprecated API versions:
 #### Webhook 资源   {#webhook-resources-v122}
 
 <!--
-The **admissionregistration.k8s.io/v1beta1** API version of MutatingWebhookConfiguration and ValidatingWebhookConfiguration is no longer served as of v1.22.
+The **admissionregistration.k8s.io/v1beta1** API version of MutatingWebhookConfiguration
+and ValidatingWebhookConfiguration is no longer served as of v1.22.
 -->
 **admissionregistration.k8s.io/v1beta1** API 版本的 MutatingWebhookConfiguration
 和 ValidatingWebhookConfiguration 不在 v1.22 版本中继续提供。
@@ -307,23 +316,25 @@ The **admissionregistration.k8s.io/v1beta1** API version of MutatingWebhookConfi
 
 <!--
 * Notable changes:
-    * `webhooks[*].failurePolicy` default changed from `Ignore` to `Fail` for v1
-    * `webhooks[*].matchPolicy` default changed from `Exact` to `Equivalent` for v1
-    * `webhooks[*].timeoutSeconds` default changed from `30s` to `10s` for v1
-    * `webhooks[*].sideEffects` default value is removed, and the field made required, and only `None` and `NoneOnDryRun` are permitted for v1
-    * `webhooks[*].admissionReviewVersions` default value is removed and the field made required for v1 (supported versions for AdmissionReview are `v1` and `v1beta1`)
-    * `webhooks[*].name` must be unique in the list for objects created via `admissionregistration.k8s.io/v1`
+  * `webhooks[*].failurePolicy` default changed from `Ignore` to `Fail` for v1
+  * `webhooks[*].matchPolicy` default changed from `Exact` to `Equivalent` for v1
+  * `webhooks[*].timeoutSeconds` default changed from `30s` to `10s` for v1
+  * `webhooks[*].sideEffects` default value is removed, and the field made required,
+    and only `None` and `NoneOnDryRun` are permitted for v1
+  * `webhooks[*].admissionReviewVersions` default value is removed and the field made
+    required for v1 (supported versions for AdmissionReview are `v1` and `v1beta1`)
+  * `webhooks[*].name` must be unique in the list for objects created via `admissionregistration.k8s.io/v1`
 -->
 * 值得注意的变更：
-    * `webhooks[*].failurePolicy` 在 v1 版本中默认值从 `Ignore` 改为 `Fail`
-    * `webhooks[*].matchPolicy` 在 v1 版本中默认值从 `Exact` 改为 `Equivalent`
-    * `webhooks[*].timeoutSeconds` 在 v1 版本中默认值从 `30s` 改为 `10s`
-    * `webhooks[*].sideEffects` 的默认值被删除，并且该字段变为必须指定；
-      在 v1 版本中可选的值只能是 `None` 和 `NoneOnDryRun` 之一
-    * `webhooks[*].admissionReviewVersions` 的默认值被删除，在 v1
-      版本中此字段变为必须指定（AdmissionReview 的被支持版本包括 `v1` 和 `v1beta1`）
-    * `webhooks[*].name` 必须在通过 `admissionregistration.k8s.io/v1`
-      创建的对象列表中唯一
+  * `webhooks[*].failurePolicy` 在 v1 版本中默认值从 `Ignore` 改为 `Fail`
+  * `webhooks[*].matchPolicy` 在 v1 版本中默认值从 `Exact` 改为 `Equivalent`
+  * `webhooks[*].timeoutSeconds` 在 v1 版本中默认值从 `30s` 改为 `10s`
+  * `webhooks[*].sideEffects` 的默认值被删除，并且该字段变为必须指定；
+    在 v1 版本中可选的值只能是 `None` 和 `NoneOnDryRun` 之一
+  * `webhooks[*].admissionReviewVersions` 的默认值被删除，在 v1
+    版本中此字段变为必须指定（AdmissionReview 的被支持版本包括 `v1` 和 `v1beta1`）
+  * `webhooks[*].name` 必须在通过 `admissionregistration.k8s.io/v1`
+    创建的对象列表中唯一
 
 #### CustomResourceDefinition {#customresourcedefinition-v122}
 
@@ -340,38 +351,43 @@ The **apiextensions.k8s.io/v1beta1** API version of CustomResourceDefinition is 
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:
-    * `spec.scope` is no longer defaulted to `Namespaced` and must be explicitly specified
-    * `spec.version` is removed in v1; use `spec.versions` instead
-    * `spec.validation` is removed in v1; use `spec.versions[*].schema` instead
-    * `spec.subresources` is removed in v1; use `spec.versions[*].subresources` instead
-    * `spec.additionalPrinterColumns` is removed in v1; use `spec.versions[*].additionalPrinterColumns` instead
-    * `spec.conversion.webhookClientConfig` is moved to `spec.conversion.webhook.clientConfig` in v1
+  * `spec.scope` is no longer defaulted to `Namespaced` and must be explicitly specified
+  * `spec.version` is removed in v1; use `spec.versions` instead
+  * `spec.validation` is removed in v1; use `spec.versions[*].schema` instead
+  * `spec.subresources` is removed in v1; use `spec.versions[*].subresources` instead
+  * `spec.additionalPrinterColumns` is removed in v1; use `spec.versions[*].additionalPrinterColumns` instead
+  * `spec.conversion.webhookClientConfig` is moved to `spec.conversion.webhook.clientConfig` in v1
 -->
 * 值得注意的变更：
-    * `spec.scope` 的默认值不再是 `Namespaced`，该字段必须显式指定
-    * `spec.version` 在 v1 版本中被删除；应改用 `spec.versions`
-    * `spec.validation` 在 v1 版本中被删除；应改用 `spec.versions[*].schema`
-    * `spec.subresources` 在 v1 版本中被删除；应改用 `spec.versions[*].subresources`
-    * `spec.additionalPrinterColumns` 在 v1 版本中被删除；应改用
-      `spec.versions[*].additionalPrinterColumns`
-    * `spec.conversion.webhookClientConfig` 在 v1 版本中被移动到
-      `spec.conversion.webhook.clientConfig` 中
-    <!--
-    * `spec.conversion.conversionReviewVersions` is moved to `spec.conversion.webhook.conversionReviewVersions` in v1
-    * `spec.versions[*].schema.openAPIV3Schema` is now required when creating v1 CustomResourceDefinition objects, and must be a [structural schema](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)
-    * `spec.preserveUnknownFields: true` is disallowed when creating v1 CustomResourceDefinition objects; it must be specified within schema definitions as `x-kubernetes-preserve-unknown-fields: true`
-    * In `additionalPrinterColumns` items, the `JSONPath` field was renamed to `jsonPath` in v1 (fixes [#66531](https://github.com/kubernetes/kubernetes/issues/66531))
-    -->
-    * `spec.conversion.conversionReviewVersions` 在 v1 版本中被移动到
-      `spec.conversion.webhook.conversionReviewVersions`
-    * `spec.versions[*].schema.openAPIV3Schema` 在创建 v1 版本的
-      CustomResourceDefinition 对象时变成必需字段，并且其取值必须是一个
-      [结构化的 Schema](/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)
-    * `spec.preserveUnknownFields: true` 在创建 v1 版本的 CustomResourceDefinition
-      对象时不允许指定；该配置必须在 Schema 定义中使用
-      `x-kubernetes-preserve-unknown-fields: true` 来设置
-    * 在 v1 版本中，`additionalPrinterColumns` 的条目中的 `JSONPath` 字段被更名为
-      `jsonPath`（补丁 [#66531](https://github.com/kubernetes/kubernetes/issues/66531)）
+  * `spec.scope` 的默认值不再是 `Namespaced`，该字段必须显式指定
+  * `spec.version` 在 v1 版本中被删除；应改用 `spec.versions`
+  * `spec.validation` 在 v1 版本中被删除；应改用 `spec.versions[*].schema`
+  * `spec.subresources` 在 v1 版本中被删除；应改用 `spec.versions[*].subresources`
+  * `spec.additionalPrinterColumns` 在 v1 版本中被删除；应改用
+    `spec.versions[*].additionalPrinterColumns`
+  * `spec.conversion.webhookClientConfig` 在 v1 版本中被移动到
+    `spec.conversion.webhook.clientConfig` 中
+
+  <!--
+  * `spec.conversion.conversionReviewVersions` is moved to `spec.conversion.webhook.conversionReviewVersions` in v1
+  * `spec.versions[*].schema.openAPIV3Schema` is now required when creating v1 CustomResourceDefinition objects,
+    and must be a [structural schema](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)
+  * `spec.preserveUnknownFields: true` is disallowed when creating v1 CustomResourceDefinition objects;
+    it must be specified within schema definitions as `x-kubernetes-preserve-unknown-fields: true`
+  * In `additionalPrinterColumns` items, the `JSONPath` field was renamed to `jsonPath` in v1
+    (fixes [#66531](https://github.com/kubernetes/kubernetes/issues/66531))
+  -->
+
+  * `spec.conversion.conversionReviewVersions` 在 v1 版本中被移动到
+    `spec.conversion.webhook.conversionReviewVersions`
+  * `spec.versions[*].schema.openAPIV3Schema` 在创建 v1 版本的
+    CustomResourceDefinition 对象时变成必需字段，并且其取值必须是一个
+    [结构化的 Schema](/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)
+  * `spec.preserveUnknownFields: true` 在创建 v1 版本的 CustomResourceDefinition
+    对象时不允许指定；该配置必须在 Schema 定义中使用
+    `x-kubernetes-preserve-unknown-fields: true` 来设置
+  * 在 v1 版本中，`additionalPrinterColumns` 的条目中的 `JSONPath` 字段被更名为
+    `jsonPath`（补丁 [#66531](https://github.com/kubernetes/kubernetes/issues/66531)）
 
 #### APIService {#apiservice-v122}
 
@@ -407,11 +423,12 @@ The **authentication.k8s.io/v1beta1** API version of TokenReview is no longer se
 #### SubjectAccessReview resources {#subjectaccessreview-resources-v122}
 
 <!--
-The **authorization.k8s.io/v1beta1** API version of LocalSubjectAccessReview, SelfSubjectAccessReview, SubjectAccessReview, and SelfSubjectRulesReview is no longer served as of v1.22.
+The **authorization.k8s.io/v1beta1** API version of LocalSubjectAccessReview,
+SelfSubjectAccessReview, SubjectAccessReview, and SelfSubjectRulesReview is no longer served as of v1.22.
 
 * Migrate manifests and API clients to use the **authorization.k8s.io/v1** API version, available since v1.6.
 * Notable changes:
-    * `spec.group` was renamed to `spec.groups` in v1 (fixes [#32709](https://github.com/kubernetes/kubernetes/issues/32709))
+  * `spec.group` was renamed to `spec.groups` in v1 (fixes [#32709](https://github.com/kubernetes/kubernetes/issues/32709))
 -->
 **authorization.k8s.io/v1beta1** API 版本的 LocalSubjectAccessReview、
 SelfSubjectAccessReview、SubjectAccessReview、SelfSubjectRulesReview 不在 v1.22 版本中继续提供。
@@ -440,13 +457,15 @@ v1.22 版本中继续提供。
 
 <!--
 * Notable changes in `certificates.k8s.io/v1`:
-    * For API clients requesting certificates:
-        * `spec.signerName` is now required (see [known Kubernetes signers](/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers)), and requests for `kubernetes.io/legacy-unknown` are not allowed to be created via the `certificates.k8s.io/v1` API
-        * `spec.usages` is now required, may not contain duplicate values, and must only contain known usages
-    * For API clients approving or signing certificates:
-        * `status.conditions` may not contain duplicate types
-        * `status.conditions[*].status` is now required
-        * `status.certificate` must be PEM-encoded, and contain only `CERTIFICATE` blocks
+  * For API clients requesting certificates:
+    * `spec.signerName` is now required
+      (see [known Kubernetes signers](/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers)),
+      and requests for `kubernetes.io/legacy-unknown` are not allowed to be created via the `certificates.k8s.io/v1` API
+    * `spec.usages` is now required, may not contain duplicate values, and must only contain known usages
+  * For API clients approving or signing certificates:
+    * `status.conditions` may not contain duplicate types
+    * `status.conditions[*].status` is now required
+    * `status.certificate` must be PEM-encoded, and contain only `CERTIFICATE` blocks
 -->
 * `certificates.k8s.io/v1` 中需要额外注意的变更：
   * 对于请求证书的 API 客户端而言：
@@ -455,7 +474,7 @@ v1.22 版本中继续提供。
       并且通过 `certificates.k8s.io/v1` API 不可以创建签署者为
       `kubernetes.io/legacy-unknown` 的请求
     * `spec.usages` 现在变成必需字段，其中不可以包含重复的字符串值，
-       并且只能包含已知的用法字符串
+      并且只能包含已知的用法字符串
   * 对于要批准或者签署证书的 API 客户端而言：
     * `status.conditions` 中不可以包含重复的类型
     * `status.conditions[*].status` 字段现在变为必需字段
@@ -494,11 +513,12 @@ The **extensions/v1beta1** and **networking.k8s.io/v1beta1** API versions of Ing
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:
-    * `spec.backend` is renamed to `spec.defaultBackend`
-    * The backend `serviceName` field is renamed to `service.name`
-    * Numeric backend `servicePort` fields are renamed to `service.port.number`
-    * String backend `servicePort` fields are renamed to `service.port.name`
-    * `pathType` is now required for each specified path. Options are `Prefix`, `Exact`, and `ImplementationSpecific`. To match the undefined `v1beta1` behavior, use `ImplementationSpecific`.
+  * `spec.backend` is renamed to `spec.defaultBackend`
+  * The backend `serviceName` field is renamed to `service.name`
+  * Numeric backend `servicePort` fields are renamed to `service.port.number`
+  * String backend `servicePort` fields are renamed to `service.port.name`
+  * `pathType` is now required for each specified path. Options are `Prefix`,
+    `Exact`, and `ImplementationSpecific`. To match the undefined `v1beta1` behavior, use `ImplementationSpecific`.
 -->
 * 值得注意的变更：
   * `spec.backend` 字段被更名为 `spec.defaultBackend`
@@ -526,9 +546,10 @@ The **networking.k8s.io/v1beta1** API version of IngressClass is no longer serve
 * 没有需要额外注意的变更。
 
 <!--
-#### RBAC resources  {#rbac-resources-v122}
+#### RBAC resources {#rbac-resources-v122}
 
-The **rbac.authorization.k8s.io/v1beta1** API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.
+The **rbac.authorization.k8s.io/v1beta1** API version of ClusterRole, ClusterRoleBinding,
+Role, and RoleBinding is no longer served as of v1.22.
 
 * Migrate manifests and API clients to use the **rbac.authorization.k8s.io/v1** API version, available since v1.8.
 * All existing persisted objects are accessible via the new APIs
@@ -623,9 +644,11 @@ v1.16 版本中不再继续提供。
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:
-    * `spec.templateGeneration` is removed
-    * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
-    * `spec.updateStrategy.type` now defaults to `RollingUpdate` (the default in `extensions/v1beta1` was `OnDelete`)
+  * `spec.templateGeneration` is removed
+  * `spec.selector` is now required and immutable after creation; use the existing
+    template labels as the selector for seamless upgrades
+  * `spec.updateStrategy.type` now defaults to `RollingUpdate`
+    (the default in `extensions/v1beta1` was `OnDelete`)
 -->
 * 值得注意的变更：
   * `spec.templateGeneration` 字段被删除
@@ -649,11 +672,15 @@ Deployment 在 v1.16 版本中不再继续提供。
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:
-    * `spec.rollbackTo` is removed
-    * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
-    * `spec.progressDeadlineSeconds` now defaults to `600` seconds (the default in `extensions/v1beta1` was no deadline)
-    * `spec.revisionHistoryLimit` now defaults to `10` (the default in `apps/v1beta1` was `2`, the default in `extensions/v1beta1` was to retain all)
-    * `maxSurge` and `maxUnavailable` now default to `25%` (the default in `extensions/v1beta1` was `1`)
+  * `spec.rollbackTo` is removed
+  * `spec.selector` is now required and immutable after creation; use the existing
+    template labels as the selector for seamless upgrades
+  * `spec.progressDeadlineSeconds` now defaults to `600` seconds
+    (the default in `extensions/v1beta1` was no deadline)
+  * `spec.revisionHistoryLimit` now defaults to `10`
+    (the default in `apps/v1beta1` was `2`, the default in `extensions/v1beta1` was to retain all)
+  * `maxSurge` and `maxUnavailable` now default to `25%`
+    (the default in `extensions/v1beta1` was `1`)
 -->
 * 值得注意的变更：
   * `spec.rollbackTo` 字段被删除
@@ -681,8 +708,10 @@ The **apps/v1beta1** and **apps/v1beta2** API versions of StatefulSet are no lon
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:
-    * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
-    * `spec.updateStrategy.type` now defaults to `RollingUpdate` (the default in `apps/v1beta1` was `OnDelete`)
+  * `spec.selector` is now required and immutable after creation;
+    use the existing template labels as the selector for seamless upgrades
+  * `spec.updateStrategy.type` now defaults to `RollingUpdate`
+    (the default in `apps/v1beta1` was `OnDelete`)
 -->
 * 值得注意的变更：
   * `spec.selector` 字段现在变为必需字段，并且在 StatefulSet 创建之后不可变更；
@@ -705,7 +734,7 @@ ReplicaSet 在 v1.16 版本中不再继续提供。
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:
-    * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
+  * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
 -->
 * 值得注意的变更：
   * `spec.selector` 现在变成必需字段，并且在对象创建之后不可变更；


### PR DESCRIPTION
Sync with en #41758

```
content/zh-cn/docs/reference/using-api/deprecation-guide.md
```
See [preview](https://deploy-preview-41762--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/using-api/deprecation-guide/) please.