### PR TITLE
[ko] Update outdated files in dev-1.27-ko.1 (M244-M253)

### DIFF
--- a/content/ko/examples/admin/konnectivity/konnectivity-agent.yaml
+++ b/content/ko/examples/admin/konnectivity/konnectivity-agent.yaml
@@ -22,7 +22,7 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       containers:
-        - image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.16
+        - image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.37
           name: konnectivity-agent
           command: ["/proxy-agent"]
           args: [

--- a/content/ko/examples/admin/konnectivity/konnectivity-server.yaml
+++ b/content/ko/examples/admin/konnectivity/konnectivity-server.yaml
@@ -8,12 +8,13 @@ spec:
   hostNetwork: true
   containers:
   - name: konnectivity-server-container
-    image: registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32
+    image: registry.k8s.io/kas-network-proxy/proxy-server:v0.0.37
     command: ["/proxy-server"]
     args: [
             "--logtostderr=true",
             # 이것은 egressSelectorConfiguration에 설정된 값과 일치해야 한다.
             "--uds-name=/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+            "--delete-existing-uds-file",
             # 다음 두 줄은 Konnectivity 서버가 apiserver와 
             # 동일한 시스템에 배포되고 API 서버의 인증서와 
             # 키가 지정된 위치에 있다고 가정한다.

--- a/content/ko/examples/admin/sched/my-scheduler.yaml
+++ b/content/ko/examples/admin/sched/my-scheduler.yaml
@@ -30,6 +30,20 @@ roleRef:
   name: system:volume-scheduler
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-scheduler-extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: extension-apiserver-authentication-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: my-scheduler
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/content/ko/examples/application/php-apache.yaml
+++ b/content/ko/examples/application/php-apache.yaml
@@ -6,7 +6,6 @@ spec:
   selector:
     matchLabels:
       run: php-apache
-  replicas: 1
   template:
     metadata:
       labels:

--- a/content/ko/examples/concepts/policy/limit-range/problematic-limit-range.yaml
+++ b/content/ko/examples/concepts/policy/limit-range/problematic-limit-range.yaml
@@ -12,3 +12,4 @@ spec:
       cpu: "1"
     min:
       cpu: 100m
+    type: Container

--- a/content/ko/examples/pods/inject/secret-pod.yaml
+++ b/content/ko/examples/pods/inject/secret-pod.yaml
@@ -10,6 +10,7 @@ spec:
         # name must match the volume name below
         - name: secret-volume
           mountPath: /etc/secret-volume
+          readOnly: true
   # The secret data is exposed to Containers in the Pod through a Volume.
   volumes:
     - name: secret-volume

--- a/content/ko/examples/pods/pod-with-scheduling-gates.yaml
+++ b/content/ko/examples/pods/pod-with-scheduling-gates.yaml
@@ -4,8 +4,8 @@ metadata:
   name: test-pod
 spec:
   schedulingGates:
-  - name: foo
-  - name: bar
+  - name: example.com/foo
+  - name: example.com/bar
   containers:
   - name: pause
     image: registry.k8s.io/pause:3.6

--- a/content/ko/examples/security/kind-with-namespace-level-baseline-pod-security.sh
+++ b/content/ko/examples/security/kind-with-namespace-level-baseline-pod-security.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-# v1.23 출시 전까지, 노드 이미지 종류는 k/k 마스터 브랜치로부터 빌드 되어야 한다
-# Ref: https://kind.sigs.k8s.io/docs/user/quick-start/#building-images
-kind create cluster --name psa-ns-level --image kindest/node:v1.23.0
+kind create cluster --name psa-ns-level
 kubectl cluster-info --context kind-psa-ns-level
 # (임의의) 서비스 어카운트 어드미션 컨트롤러가 사용 가능할 때까지 15초 간 대기
 sleep 15
-kubectl create ns example
+
+# 네임스페이스 생성 및 레이블 지정
+kubectl create ns example || exit 1 # 네임스페이스가 존재하면, 다음 단계를 수행하지 않는다
 kubectl label --overwrite ns example \
   pod-security.kubernetes.io/enforce=baseline \
   pod-security.kubernetes.io/enforce-version=latest \
@@ -13,7 +13,9 @@ kubectl label --overwrite ns example \
   pod-security.kubernetes.io/warn-version=latest \
   pod-security.kubernetes.io/audit=restricted \
   pod-security.kubernetes.io/audit-version=latest
-cat <<EOF > /tmp/pss/nginx-pod.yaml
+
+# 파드 실행해 보기
+cat <<EOF |
 apiVersion: v1
 kind: Pod
 metadata:
@@ -25,4 +27,16 @@ spec:
       ports:
         - containerPort: 80
 EOF
-kubectl apply -n example -f /tmp/pss/nginx-pod.yaml
+kubectl apply -n example -f -
+
+# 입력 대기
+sleep 1
+( bash -c 'true' 2>/dev/null && bash -c 'read -p "Press any key to continue... " -n1 -s' ) || \
+    ( printf "Press Enter to continue... " && read ) 1>&2
+
+# 정리
+printf "\n\nCleaning up:\n" 1>&2
+set -e
+kubectl delete pod --all -n example --now
+kubectl delete ns example
+kind delete cluster --name psa-ns-level

--- a/content/ko/examples/service/networking/custom-dns.yaml
+++ b/content/ko/examples/service/networking/custom-dns.yaml
@@ -10,7 +10,7 @@ spec:
   dnsPolicy: "None"
   dnsConfig:
     nameservers:
-      - 1.2.3.4
+      - 192.0.2.1 # 다음은 예시이다
     searches:
       - ns1.svc.cluster-domain.example
       - my.dns.search.suffix


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Related Issue: #41631

Updated outdated files in `content/ko/examples/`.

**10 files to be modified**

- [x] M244.  `content/en/examples/admin/konnectivity/konnectivity-agent.yaml` | 1(+XS) 1(-)
- [x] M245.  `content/en/examples/admin/konnectivity/konnectivity-server.yaml` | 2(+XS) 1(-)
- [x] M246.  `content/en/examples/admin/sched/my-scheduler.yaml` | 14(+S) 0(-)
- [x] M247.  `content/en/examples/application/php-apache.yaml` | 1(+XS) 0(-)
- [x] M248.  `content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml` | 1(+XS) 0(-)
- [x] M249.  `content/en/examples/pods/inject/secret-pod.yaml` | 1(+XS) 0(-)
- [x] M250.  `content/en/examples/pods/pod-with-scheduling-gates.yaml` | 2(+XS) 2(-)
- [x] M251.  `content/en/examples/security/kind-with-cluster-level-baseline-pod-security.sh` | 17(+S) 3(-)
- [x] M252.  `content/en/examples/security/kind-with-namespace-level-baseline-pod-security.sh` | 21(+S) 7(-)
- [x] M253.  `content/en/examples/service/networking/custom-dns.yaml` | 1(+XS) 1(-)