### PR TITLE
[ko] Update outdated files in dev-1.27-ko.1 [M16-21]

### DIFF
--- a/content/ko/docs/concepts/configuration/configmap.md
+++ b/content/ko/docs/concepts/configuration/configmap.md
@@ -37,7 +37,7 @@ weight: 20
 ## 컨피그맵 오브젝트
 
 컨피그맵은 다른 오브젝트가 사용할 구성을 저장할 수 있는
-API [오브젝트](/ko/docs/concepts/overview/working-with-objects/kubernetes-objects/)이다.
+{{< glossary_tooltip text="API 오브젝트" term_id="object" >}}이다.
 `spec` 이 있는 대부분의 쿠버네티스 오브젝트와 달리, 컨피그맵에는 `data` 및 `binaryData`
 필드가 있다. 이러한 필드는 키-값 쌍을 값으로 허용한다. `data` 필드와
 `binaryData` 는 모두 선택 사항이다. `data` 필드는
@@ -189,7 +189,7 @@ spec:
 kubelet은 모든 주기적인 동기화에서 마운트된 컨피그맵이 최신 상태인지 확인한다.
 그러나, kubelet은 로컬 캐시를 사용해서 컨피그맵의 현재 값을 가져온다.
 캐시 유형은 [KubeletConfiguration 구조체](/docs/reference/config-api/kubelet-config.v1beta1/)의
-`ConfigMapAndSecretChangeDetectionStrategy` 필드를 사용해서 구성할 수 있다.
+`configMapAndSecretChangeDetectionStrategy` 필드를 사용해서 구성할 수 있다.
 컨피그맵은 watch(기본값), ttl 기반 또는 API 서버로 직접
 모든 요청을 리디렉션할 수 있다.
 따라서 컨피그맵이 업데이트되는 순간부터 새 키가 파드에 업데이트되는 순간까지의

--- a/content/ko/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/ko/docs/concepts/configuration/manage-resources-containers.md
@@ -12,16 +12,15 @@ feature:
 <!-- overview -->
 
 {{< glossary_tooltip text="파드" term_id="pod" >}}를 지정할 때,
-{{< glossary_tooltip text="컨테이너" term_id="container" >}}에 필요한 각 리소스의 양을 선택적으로 지정할 수 있다.
-지정할 가장 일반적인 리소스는 CPU와 메모리(RAM) 그리고 다른 것들이 있다.
+{{< glossary_tooltip text="컨테이너" term_id="container" >}}에 필요한 각 리소스의 양을 선택적으로 지정할 수 있다. 지정할 수 있는 가장 일반적인 리소스는 CPU와 메모리
+(RAM)이다. 그 외에 다른 리소스들도 지정할 수 있다.
 
 파드에서 컨테이너에 대한 리소스 _요청(request)_ 을 지정하면, 
-{{< glossary_tooltip text="kube-scheduler" term_id="kube-scheduler" >}}는 이 정보를
-사용하여 파드가 배치될 노드를 결정한다. 컨테이너에 대한 리소스 _제한(limit)_ 을
-지정하면, kubelet은 실행 중인 컨테이너가 설정한 제한보다 많은 리소스를
-사용할 수 없도록 해당 제한을 적용한다. 또한 kubelet은
-컨테이너가 사용할 수 있도록 해당 시스템 리소스의 최소 _요청_ 량을
-예약한다.
+{{< glossary_tooltip text="kube-scheduler" term_id="kube-scheduler" >}}는 이 정보를 사용하여 파드가 배치될 노드를 결정한다. 
+컨테이너에 대한 리소스 _제한(limit)_ 을 지정하면, {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}은 해당 제한을 강제하여
+실행 중인 컨테이너가 설정된 제한보다 많은 리소스를
+사용할 수 없도록 한다. 또한 kubelet은 구체적으로 컨테이너가 사용할 
+시스템 리소스의 최소 _요청_ 량을 예약한다.
 
 <!-- body -->
 
@@ -226,7 +225,7 @@ kubelet은 해당 컨테이너의 메모리/CPU 요청 및 제한을 컨테이�
 ### 컴퓨트 및 메모리 리소스 사용량 모니터링
 
 kubelet은 파드의 리소스 사용량을 파드 
-[`status`](/ko/docs/concepts/overview/working-with-objects/kubernetes-objects/#오브젝트-명세-spec-와-상태-status)에 포함하여 보고한다.
+[`status`](/ko/docs/concepts/overview/working-with-objects/#오브젝트-명세-spec-와-상태-status)에 포함하여 보고한다.
 
 클러스터에서 선택적인 [모니터링 도구](/ko/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)를
 사용할 수 있다면, [메트릭 API](/ko/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-api)에서
@@ -257,7 +256,19 @@ kubelet은 이러한 종류의 스토리지를 사용하여
 기대할 수 없다.
 {{< /caution >}}
 
-베타 기능에서, 쿠버네티스는 파드가 사용할 수 있는 임시 로컬 스토리지의 양을
+
+{{< note >}}
+임시 스토리지에 리소스를 할당하기 위해서, 다음 두 가지 작업을 수행한다.
+
+* 관리자는 네임스페이스에서 임시 스토리지를 위한 리소스 할당량을 설정한다.
+* 사용자는 파드 스펙에서 임시 스토리지 리소스 제한을 지정한다.
+
+만약 사용자가 파드 스펙에 임시 스토리지 리소스 제한을 지정하지 않으면,
+임시 스토리지의 리소스 할당량이 제한되지 않는다.
+
+{{< /note >}}
+
+쿠버네티스는 파드가 사용할 수 있는 임시 로컬 스토리지의 양을
 추적, 예약 및 제한할 수 있도록 해준다.
 
 ### 로컬 임시 스토리지 구성
@@ -323,7 +334,7 @@ kubelet은 임시 스토리지을 위해 오직 루트 파일시스템만을 추
 
 ### 로컬 임시 스토리지에 대한 요청 및 제한 설정
 
-`ephemeral-storage`를 명시하여 로컬 임시 저장소를 관리할 수 있다. 
+`ephemeral-storage`를 명시하여 로컬 임시 스토리지를 관리할 수 있다. 
 파드의 각 컨테이너는 다음 중 하나 또는 모두를 명시할 수 있다.
 
 * `spec.containers[].resources.limits.ephemeral-storage`
@@ -805,5 +816,6 @@ Events:
 * [컨테이너와 파드에 CPU 리소스를 할당](/ko/docs/tasks/configure-pod-container/assign-cpu-resource/)하는 핸즈온 경험을 해보자.
 * API 레퍼런스에 [컨테이너](/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)와 
   [컨테이너 리소스 요구사항](/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)이 어떻게 정의되어 있는지 확인한다.
-* XFS의 [프로젝트 쿼터](https://xfs.org/index.php/XFS_FAQ#Q:_Quota:_Do_quotas_work_on_XFS.3F)에 대해 읽어보기
+* XFS의 [프로젝트 쿼터](https://www.linux.org/docs/man8/xfs_quota.html)에 대해 읽어보기
 * [kube-scheduler 정책 레퍼런스 (v1beta3)](/docs/reference/config-api/kube-scheduler-config.v1beta3/)에 대해 더 읽어보기
+* [파드의 QoS(Quality of Service) 클래스](/docs/concepts/workloads/pods/pod-qos/)에 대해 더 읽어보기

--- a/content/ko/docs/concepts/configuration/overview.md
+++ b/content/ko/docs/concepts/configuration/overview.md
@@ -102,13 +102,13 @@ weight: 10
   모든 `phase: test` 컴포넌트를 선택하는 서비스를 생각해 볼 수 있다.
   이 접근 방법의 예시는 [방명록](https://github.com/kubernetes/examples/tree/master/guestbook/) 앱을 참고한다.
 
-릴리스에 특정되는 레이블을 서비스의 셀렉터에서 생략함으로써 여러 개의 디플로이먼트에 걸치는 서비스를
-생성할 수 있다. 동작 중인 서비스를 다운타임 없이 갱신하려면,
-[디플로이먼트](/ko/docs/concepts/workloads/controllers/deployment/)를 사용한다.
+  릴리스에 특정되는 레이블을 서비스의 셀렉터에서 생략함으로써 여러 개의 디플로이먼트에 걸치는 서비스를
+  생성할 수 있다. 동작 중인 서비스를 다운타임 없이 갱신하려면,
+  [디플로이먼트](/ko/docs/concepts/workloads/controllers/deployment/)를 사용한다.
 
-오브젝트의 의도한 상태는 디플로이먼트에 의해 기술되며, 만약 그 스펙에 대한 변화가
-_적용될_ 경우, 디플로이먼트 컨트롤러는
-일정한 비율로 실제 상태를 의도한 상태로 변화시킨다.
+  오브젝트의 의도한 상태는 디플로이먼트에 의해 기술되며, 만약 그 스펙에 대한 변화가
+  _적용될_ 경우, 디플로이먼트 컨트롤러는
+  일정한 비율로 실제 상태를 의도한 상태로 변화시킨다.
 
 - 일반적인 활용 사례인 경우 [쿠버네티스 공통 레이블](/ko/docs/concepts/overview/working-with-objects/common-labels/)을 
   사용한다. 이 표준화된 레이블은 `kubectl` 및

--- a/content/ko/docs/concepts/containers/container-environment.md
+++ b/content/ko/docs/concepts/containers/container-environment.md
@@ -39,8 +39,7 @@ weight: 20
 
 ### 클러스터 정보
 
-컨테이너가 생성될 때 실행 중이던 모든 서비스의 목록은 환경 변수로 해당 컨테이너에서 사용할 수
-있다.
+컨테이너가 생성될 때 실행 중이던 모든 서비스의 목록은 환경 변수로 해당 컨테이너에서 사용할 수 있다.
 이 목록은 새로운 컨테이너의 파드 및 쿠버네티스 컨트롤 플레인 서비스와 동일한 네임스페이스 내에 있는 서비스로 한정된다.
 
 *bar* 라는 이름의 컨테이너에 매핑되는 *foo* 라는 이름의 서비스에 대해서는,
@@ -51,7 +50,8 @@ FOO_SERVICE_HOST=<서비스가 동작 중인 호스트>
 FOO_SERVICE_PORT=<서비스가 동작 중인 포트>
 ```
 
-서비스에 지정된 IP 주소가 있고 [DNS 애드온](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/)이 활성화된 경우, DNS를 통해서 컨테이너가 서비스를 사용할 수 있다.
+서비스에 지정된 IP 주소가 있고 [DNS 애드온](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/)이 활성화된 경우, 
+DNS를 통해서 컨테이너가 서비스를 사용할 수 있다.
 
 
 


### PR DESCRIPTION
Related Issue : https://github.com/kubernetes/website/issues/41631

### Files Checked & Modified
- [ ]  M16. `content/en/docs/concepts/configuration/configmap.md` | 2(+XS) 2(-)
- [ ]  M17. `content/en/docs/concepts/configuration/manage-resources-containers.md` | 24(+S) 12(-)
- [ ]  M18. `content/en/docs/concepts/configuration/overview.md` | 6(+XS) 6(-)
- [ ]  M19. `content/en/docs/concepts/configuration/secret.md` | 55(+M) 299(-)
- [ ]  M20. `content/en/docs/concepts/containers/_index.md` | 2(+XS) 2(-)
- [ ]  M21. `content/en/docs/concepts/containers/container-environment.md` | 1(+XS) 1(-)

### Comments
M20 : 문서의 변동사항이 없어 수정하지 않았습니다.