### PR TITLE
Provide a per-page outdated notification for localized content

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -70,6 +70,12 @@ other = " documentation is no longer actively maintained. The version you are cu
 [deprecation_file_warning]
 other = "Deprecated"
 
+[outdated_content_title]
+other = "Information in this document may be out of date"
+
+[outdated_content_message]
+other = "This document has an older update date than the original, so the information it contains may be out of date. If you're able to read English, see the English version for the most up-to-date information: "
+
 [dockershim_message]
 other = """Dockershim has been removed from the Kubernetes project as of release 1.24. Read the <a href="/dockershim">Dockershim Removal FAQ</a> for further details."""
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -25,6 +25,9 @@
             {{ block "deprecated" . }}
               {{ partial "deprecation-warning.html" . }}
             {{ end }}
+            {{ block "outdated_content" . }}
+              {{ partial "docs/outdated_content.html" . }}
+            {{ end }}
               {{ block "main" . }}{{ end }}
               {{- if .HasShortcode "thirdparty-content" -}}
                 {{ block "thirdparty-disclaimer" . }}

--- a/layouts/partials/docs/outdated_content.html
+++ b/layouts/partials/docs/outdated_content.html
@@ -1,0 +1,22 @@
+{{ if not (.Site.Param "deprecated") }}
+  {{ if ne .Site.Language.Lang "en" }}
+    {{ $currentLastmodUnixtime := .Lastmod.Unix }}
+    {{ $originCurrentLastmodUnixtime := 0 }}
+    {{ $originPageURL := "" }}
+    {{ $originPageTitle := "" }}
+    {{ range .Translations }}
+      {{ if eq .Lang "en" }}
+        {{ $originCurrentLastmodUnixtime = .Lastmod.Unix }}
+        {{ $originPageURL = .RelPermalink  }}
+        {{ $originPageTitle = .Title }}
+        {{ break }}
+      {{ end }}
+    {{ end }}
+    {{ if lt $currentLastmodUnixtime $originCurrentLastmodUnixtime }}
+    <div class="pageinfo pageinfo-primary outdated-localization-notice">
+      <p><strong>{{ T "outdated_content_title" }}</strong></p>
+      <p><span class="outdated-localization-notice-text">{{ T "outdated_content_message" }} <a href="{{ $originPageURL }}">{{ $originPageTitle }}</a></span></p>
+    </div>
+    {{ end }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
I have implemented a notification on the localization page to alert users that information may be out of date.
issue: https://github.com/kubernetes/website/issues/41519

This function is implemented with the following logic

1. get the `Lastmod` of the currently opened page.
2. get the `Lastmod` of the English version of the page.
3. compare 1 and 2 and display a notification if 1 is older.

I am a Japanese speaker and could not configure non-English i18n settings.
If this implementation details are ok, I would appreciate it if you could work with me to come up with messages in other languages :)

https://github.com/kubernetes/website/assets/24271557/6d2fc27a-64af-4e16-881d-d9ccf85bbb8f


