### PR TITLE
Clarify IBM Java and IBM Semeru Runtimes cgroupsV2 support

### DIFF
--- a/content/en/blog/_posts/2022-08-31-cgroupv2-ga.md
+++ b/content/en/blog/_posts/2022-08-31-cgroupv2-ga.md
@@ -118,8 +118,8 @@ Scenarios in which you might need to update to cgroup v2 include the following:
   DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
 * If you deploy Java applications, prefer to use versions which fully support cgroup v2:
     * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
-    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
-    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
+    * [IBM Semeru Runtimes](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.382.0, 11.0.20.0, 17.0.8.0, and later
+    * [IBM Java](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.8.6 and later
 
 ## Learn more
 

--- a/content/en/docs/concepts/architecture/cgroups.md
+++ b/content/en/docs/concepts/architecture/cgroups.md
@@ -104,8 +104,8 @@ updated to newer versions that support cgroup v2. For example:
  DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
 * If you deploy Java applications, prefer to use versions which fully support cgroup v2:
     * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
-    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
-    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
+    * [IBM Semeru Runtimes](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.382.0, 11.0.20.0, 17.0.8.0, and later
+    * [IBM Java](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.8.6 and later
 * If you are using the [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) package, make sure
   the version you use is v1.5.1 or higher.
 


### PR DESCRIPTION
This is a follow-on to PR #40189. Since then, we've found an issue in the J9 JVM in the case that a user mixes cgroupsV1 and cgroupsV2. This was fixed in [APAR IJ46681](https://www.ibm.com/support/pages/apar/IJ46681) and this PR updates the versions of IBM Java and IBM Semeru Runtimes to match builds that have this APAR.