### PR TITLE
Add `seokho-son` to sig-docs-localization-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
     - onlydole
     - reylejano
     - sftim
+    - seokho-son
     - tengqm
   sig-docs-de-owners: # Admins for German content
     - bene2k1


### PR DESCRIPTION

- Based on the consensus to appoint @seokho-son as co-lead for the Localization subproject of SIG Docs,
this PR update OWNERS_ALIASES by adding `seokho-son` to sig-docs-localization-owners
- https://groups.google.com/g/kubernetes-sig-docs/c/mx1fd_WizX4/m/P1tGHol4BAAJ

> Hello SIG Docs community,
> 
> After having formalized the [Localization subproject](https://kubernetes.io/docs/contribute/localization/) some time ago, we've been able to help several localization teams across SIG Docs with their translation work, alongside bootstrapping new languages and supporting new localization contributors. Brad Topol recently stepped down as a co-lead for the subproject, and we've had Seokho Son step up to support Abbie (Localization Lead) in continuing the localization mission for the SIG.
> 
> Seokho is the current Korean Docs Lead and has been regularly running our monthly Localization subproject community meetings. He has also been diligent in managing the community in [#sig-docs-localizations](https://kubernetes.slack.com/messages/sig-docs-localizations) and is involved in onboarding new localizations as they navigate their review and approval workflows. To ensure we have enough owners across our subprojects, we're excited that Seokho has chosen to step into a leadership role to continue this important and necessary work.
> 
> This email is seeking lazy consensus to confirm Seokho's appointment as co-lead for the Localization subproject. After two weeks of review (13 June, 2023), a PR reflecting this change can be merged.
> 
> I want to wish Seokho a mighty congratulations on behalf of the SIG Docs leads for the recognition he is receiving around his SIG contributions. Thank you for all you have done and will continue to do, Seokho!
> 
> Cheers,
> Natali Vlatko, on behalf of SIG Docs leads