### PR TITLE
node: fix release state for podresources API

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -195,7 +195,7 @@ of the device allocations during the upgrade.
 
 ## Monitoring device plugin resources
 
-{{< feature-state for_k8s_version="v1.15" state="beta" >}}
+{{< feature-state for_k8s_version="v1.28" state="stable" >}}
 
 In order to monitor resources provided by device plugins, monitoring agents need to be able to
 discover the set of devices that are in-use on the node and obtain metadata to describe which


### PR DESCRIPTION
followup to https://github.com/kubernetes/website/pull/41506#pullrequestreview-1485713121
we fix the release state of the podresources API (related to device monitoring)


KEP: https://github.com/kubernetes/enhancements/issues/606
enhancement: https://github.com/kubernetes/enhancements/issues/3743