### PR TITLE
Housekeeping inactive Hindi reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -85,8 +85,6 @@ aliases:
     - Babapool
     - bishal7679
     - divya-mohan0209
-    - Garima-Negi
-    - verma-kunal
   sig-docs-id-owners: # Admins for Indonesian content
     - ariscahyadi
     - danninov


### PR DESCRIPTION
Per #41598 , we're housekeeping the Hindi reviewers to ensure better management of the Hindi localization. These are the members that have been housekept since they have not voiced any opposition to their inactivity:

- Kunal Verma
- Garima Negi