### PR TITLE
update the avoid collision link

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -462,7 +462,7 @@ The IP address that you choose must be a valid IPv4 or IPv6 address from within 
 If you try to create a Service with an invalid `clusterIP` address value, the API
 server will return a 422 HTTP status code to indicate that there's a problem.
 
-Read [avoiding collisions](#avoiding-collisions)
+Read [avoiding collisions](/blog/2022/05/23/service-ip-dynamic-and-static-allocation/)
 to learn how Kubernetes helps reduce the risk and impact of two different Services
 both trying to use the same IP address.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -698,7 +698,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   ClusterIP range is subdivided. Dynamic allocated ClusterIP addresses will be allocated preferently
   from the upper range allowing users to assign static ClusterIPs from the lower range with a low
   risk of collision. See
-  [Avoiding collisions](/docs/concepts/services-networking/service/#avoiding-collisions)
+  [Avoiding collisions](/blog/2022/05/23/service-ip-dynamic-and-static-allocation/)
   for more details.
 - `SizeMemoryBackedVolumes`: Enable kubelets to determine the size limit for
   memory-backed volumes (mainly `emptyDir` volumes).


### PR DESCRIPTION




 Links for Avoiding collisions are broken in:

https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates (at ServiceIPStaticSubrange point)

issue number #41809 

