### PR TITLE
[zh] Update outdated version in `install-kubeadm` and `kubeadm-init`

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -228,7 +228,7 @@ Alternatively, you can use the `skipPhases` field under `InitConfiguration`.
 <!--
 The config file is still considered beta and may change in future versions.
 -->
-配置文件的功能仍然处于 alpha 状态并且在将来的版本中可能会改变。
+配置文件的功能仍然处于 beta 状态并且在将来的版本中可能会改变。
 {{< /caution >}}
 
 <!--

--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -377,7 +377,7 @@ Install CNI plugins (required for most pod network):
 安装 CNI 插件（大多数 Pod 网络都需要）：
 
 ```bash
-CNI_PLUGINS_VERSION="v1.2.0"
+CNI_PLUGINS_VERSION="v1.3.0"
 ARCH="amd64"
 DEST="/opt/cni/bin"
 sudo mkdir -p "$DEST"
@@ -409,7 +409,7 @@ Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI)
 安装 crictl（kubeadm/kubelet 容器运行时接口（CRI）所需）
 
 ```bash
-CRICTL_VERSION="v1.26.0"
+CRICTL_VERSION="v1.27.0"
 ARCH="amd64"
 curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | sudo tar -C $DOWNLOAD_DIR -xz
 ```
@@ -426,7 +426,7 @@ cd $DOWNLOAD_DIR
 sudo curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/{kubeadm,kubelet}
 sudo chmod +x {kubeadm,kubelet}
 
-RELEASE_VERSION="v0.4.0"
+RELEASE_VERSION="v0.15.1"
 curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /etc/systemd/system/kubelet.service
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
1. `CNI_PLUGINS_VERSION`, `CRICTL_VERSION` and `RELEASE_VERSION`

update tool version in install-kubeadm without package manager case (https://kubernetes.io/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)

comparison:

(outdated in Chinese)
![image](https://github.com/kubernetes/website/assets/53565118/0ab3800e-c138-453d-92ff-ee33f04e0fd2)

(latest changes in English)
![image](https://github.com/kubernetes/website/assets/53565118/6bc8fe73-25d8-4354-bd5f-3579d19172ef)

---

2. `alpha` -> `beta`

change statement, `alpha` -> `beta` in kubeadm-init config-file part (https://kubernetes.io/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file)

comparison:

(outdated in Chinese)
![image](https://github.com/kubernetes/website/assets/53565118/6f7e7e61-5804-42db-ab74-cb178d72f12b)

(latest changes in English)
![image](https://github.com/kubernetes/website/assets/53565118/e7ef3737-59e5-4551-9ece-b74089466ce9)



<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
