### PR TITLE
[zh] sync concepts/overview/working-with-objects/namespaces.md

### DIFF
--- a/content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md
@@ -273,13 +273,11 @@ kubectl api-resources --namespaced=false
 
 <!--
 The Kubernetes control plane sets an immutable {{< glossary_tooltip text="label" term_id="label" >}}
-`kubernetes.io/metadata.name` on all namespaces, provided that the `NamespaceDefaultLabelName`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled.
+`kubernetes.io/metadata.name` on all namespaces.
 The value of the label is the namespace name.
 -->
 Kubernetes 控制面会为所有名字空间设置一个不可变更的{{< glossary_tooltip text="标签" term_id="label" >}}
-`kubernetes.io/metadata.name`，只要 `NamespaceDefaultLabelName`
-这一[特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)被启用。
+`kubernetes.io/metadata.name`。
 标签的值是名字空间的名称。
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/overview/working-with-objects/namespaces.md`
- **Sync to**: `content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md`

Sync check by`scripts/lsync.sh` on `main` branch:
```diff
$ ./scripts/lsync.sh content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md
diff --git a/content/en/docs/concepts/overview/working-with-objects/namespaces.md b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
index a1865b5ced..29d9ff857c 100644
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -150,8 +150,7 @@ kubectl api-resources --namespaced=false
 {{< feature-state for_k8s_version="1.22" state="stable" >}}

 The Kubernetes control plane sets an immutable {{< glossary_tooltip text="label" term_id="label" >}}
-`kubernetes.io/metadata.name` on all namespaces, provided that the `NamespaceDefaultLabelName`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled.
+`kubernetes.io/metadata.name` on all namespaces.
 The value of the label is the namespace name.


```
Sync check by`scripts/lsync.sh` on `sync/overview-wwo-namespaces` branch:
```diff
$ ./scripts/lsync.sh content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md
content/zh-cn/docs/concepts/overview/working-with-objects/namespaces.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
