### PR TITLE
docs(storage-classes): add section on default `StorageClass`

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -664,3 +664,7 @@ specified by the `WaitForFirstConsumer` volume binding mode.
 Delaying volume binding allows the scheduler to consider all of a Pod's
 scheduling constraints when choosing an appropriate PersistentVolume for a
 PersistentVolumeClaim.
+
+### Note
+
+You should only have one default storage class in your cluster at any given time. Kubernetes does not technically prevent you from having more than one, but it will behave as if there is no default storage class at all.

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -57,14 +57,13 @@ mountOptions:
 volumeBindingMode: Immediate
 ```
 
-### Default Storage Class
+### Default StorageClass
 
-Typically, each Kubernetes cluster should have a default storage class defined, which would be used by the user who make a storage request without implicitly specifying a StorageClass in his/her PersistentVolumeClaim.  Kubernetes clusters on different cloud providers may already have default storageclasses defined.  By having a default storage classs defined, this allows users to request storage through a PersistentVolumeClaim without explicitly setting a StorageClassName.
+Typically, each Kubernetes cluster should have a default StorageClass defined, which allows users to request storage through a PersistentVolumeClaim without explicitly setting a `storageClassName`. Kubernetes clusters on different cloud providers may already have a default StorageClass defined.
 
-There can only be one default storage class in the cluster.  Dynamic provisioning will fail if there are multiple default storage classes set.
+There can only be one default StorageClass in the cluster. Dynamic provisioning will fail if there are multiple default storage classes set.
 
-Refer to [Change Default Storage Class](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) on how to set the default storage class.
-
+Refer to [Change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) on how to set the default StorageClass.
 
 ### Provisioner
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -59,11 +59,14 @@ volumeBindingMode: Immediate
 
 ### Default StorageClass
 
-Typically, each Kubernetes cluster should have a default StorageClass defined, which allows users to request storage through a PersistentVolumeClaim without explicitly setting a `storageClassName`. Kubernetes clusters on different cloud providers may already have a default StorageClass defined.
+When a PVC does not specify a `storageClassName`, the default StorageClass will
+be used. The cluster can only have one default StorageClass. If more than one
+default StorageClass is set, dynamic provisioning of a PVC without a
+`storageClassName` will fail.
 
-There can only be one default StorageClass in the cluster. Dynamic provisioning will fail if there are multiple default storage classes set.
-
-Refer to [Change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) on how to set the default StorageClass.
+For instructions on setting the default StorageClass, see
+[Change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/).
+Note that certain cloud providers may already define a default StorageClass.
 
 ### Provisioner
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -59,10 +59,10 @@ volumeBindingMode: Immediate
 
 ### Default StorageClass
 
-When a PVC does not specify a `storageClassName`, the default StorageClass will
-be used. The cluster can only have one default StorageClass. If more than one
-default StorageClass is accidentally set, the newest default will be used when
-dynamically provisioning a PVC without a `storageClassName`.
+When a PVC does not specify a `storageClassName`, the default StorageClass is
+used. The cluster can only have one default StorageClass. If more than one
+default StorageClass is accidentally set, the newest default is used when the
+PVC is dynamically provisioned.
 
 For instructions on setting the default StorageClass, see
 [Change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/).

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -65,7 +65,7 @@ default StorageClass is accidentally set, the newest default is used when the
 PVC is dynamically provisioned.
 
 For instructions on setting the default StorageClass, see
-[Change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/).
+[Change the default StorageClass](/docs/tasks/administer-cluster/change-default-storage-class/).
 Note that certain cloud providers may already define a default StorageClass.
 
 ### Provisioner

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -57,6 +57,13 @@ mountOptions:
 volumeBindingMode: Immediate
 ```
 
+### Default Storage Class
+
+Typically, each Kubernetes cluster should have a default storage class defined, which would be used by the user who make a storage request without implicitly specifying a StorageClass in his/her PersistentVolumeClaim.  This is useful for Administrators to provide easy management of a storage volume without having to set up or communicate specialized storage classes across the cluster.
+
+Refer to [Change Default Storage Class](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) on how to set the default storage class.
+
+
 ### Provisioner
 
 Each StorageClass has a provisioner that determines what volume plugin is used
@@ -667,4 +674,4 @@ PersistentVolumeClaim.
 
 ### Note
 
-You should only have one default storage class in your cluster at any given time. Kubernetes does not technically prevent you from having more than one, but it will behave as if there is no default storage class at all.
+You should only have one default storage class in your cluster at any given time. Kubernetes does not technically prevent you from having more than one storage class; however, requests for persistent volume claims will fail when there are multiple default storage classes.

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -59,7 +59,9 @@ volumeBindingMode: Immediate
 
 ### Default Storage Class
 
-Typically, each Kubernetes cluster should have a default storage class defined, which would be used by the user who make a storage request without implicitly specifying a StorageClass in his/her PersistentVolumeClaim.  This is useful for Administrators to provide easy management of a storage volume without having to set up or communicate specialized storage classes across the cluster.
+Typically, each Kubernetes cluster should have a default storage class defined, which would be used by the user who make a storage request without implicitly specifying a StorageClass in his/her PersistentVolumeClaim.  Kubernetes clusters on different cloud providers may already have default storageclasses defined.  By having a default storage classs defined, this allows users to request storage through a PersistentVolumeClaim without explicitly setting a StorageClassName.
+
+There can only be one default storage class in the cluster.  Dynamic provisioning will fail if there are multiple default storage classes set.
 
 Refer to [Change Default Storage Class](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) on how to set the default storage class.
 
@@ -671,7 +673,3 @@ specified by the `WaitForFirstConsumer` volume binding mode.
 Delaying volume binding allows the scheduler to consider all of a Pod's
 scheduling constraints when choosing an appropriate PersistentVolume for a
 PersistentVolumeClaim.
-
-### Note
-
-You should only have one default storage class in your cluster at any given time. Kubernetes does not technically prevent you from having more than one storage class; however, requests for persistent volume claims will fail when there are multiple default storage classes.

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -61,8 +61,8 @@ volumeBindingMode: Immediate
 
 When a PVC does not specify a `storageClassName`, the default StorageClass will
 be used. The cluster can only have one default StorageClass. If more than one
-default StorageClass is set, dynamic provisioning of a PVC without a
-`storageClassName` will fail.
+default StorageClass is accidentally set, the newest default will be used when
+dynamically provisioning a PVC without a `storageClassName`.
 
 For instructions on setting the default StorageClass, see
 [Change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/).


### PR DESCRIPTION
## Summary

Add a section to Storage Classes briefly describing the default StorageClass
- I was looking to add this to the docs myself, but then saw that #15575 had added this section and went through a few review cycles but was never completed and merged
  - So initially based it off that, rebasing and addressing all the feedback therein ([these](https://github.com/kubernetes/website/pull/15575#discussion_r317714805) [two](https://github.com/kubernetes/website/pull/15575#pullrequestreview-279732022) points specifically). I ended up rewriting significant chunks as part of the feedback as well as after generally reviewing the [style guide](https://kubernetes.io/docs/contribute/style/style-guide/) and style of the existing doc, trying to more closely match those.

## Details

- the PVC docs reference this and there is an administrator guide on how to change this, but no section within the central Storage Classes document
  - this has made it a bit difficult to explain how that a default StorageClass exists as the StorageClass docs themselves barely mention it
    - for new cluster admins I was teaching in particular, I wanted to make sure they were aware of the pitfall that I hit with kOps in https://github.com/kubernetes/kubernetes/issues/34549#issuecomment-643501992, so the note about more than one default was particularly relevant (as well as how the [implemented fix](https://github.com/kubernetes/kubernetes/pull/110559) [works](https://github.com/kubernetes/kubernetes/pull/110559/files#diff-77fd84defc818b9e6010794bf87e0eece0960dfeff196e19b7d84da8de15ddffR67))
  - with a new section, this makes it very clear and links out to other existing docs on the topic
