### PR TITLE
node: integration with topology manager is stable

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -397,7 +397,7 @@ ensure your kubelet services are started with the following flags:
 
 ## Device plugin integration with the Topology Manager
 
-{{< feature-state for_k8s_version="v1.18" state="beta" >}}
+{{< feature-state for_k8s_version="v1.27" state="stable" >}}
 
 The Topology Manager is a Kubelet component that allows resources to be co-ordinated in a Topology
 aligned manner. In order to do this, the Device Plugin API was extended to include a


### PR DESCRIPTION
Retroactively fix the feature state:
- device manager GA'd in 1.26
- topology manager GA'd in 1.27 thus we can safely call the integration between topology and device managers GA in 1.27

Extracted from https://github.com/kubernetes/website/pull/41804#discussion_r1247406374