### PR TITLE
Update statefulset pod name docs stating its a label

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -689,7 +689,7 @@ When this annotation is set, the Kubernetes components will "stand-down" and the
 
 ### statefulset.kubernetes.io/pod-name {#statefulsetkubernetesiopod-name}
 
-Type: Annotation
+Type: Label
 
 Example: `statefulset.kubernetes.io/pod-name: "mystatefulset-7"`
 


### PR DESCRIPTION
This well known value is a label, and has always been so. This fixes a typo where it was defined as an annotation

See; https://github.com/kubernetes/kubernetes/blob/v1.27.0/pkg/controller/statefulset/stateful_set_utils.go#L137

