### PR TITLE
Fix broken link to kube-proxy details page

### DIFF
--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -154,7 +154,7 @@ my-nginx-7vzhx   IPv4          80      10.244.2.5,10.244.3.4   21s
 You should now be able to curl the nginx Service on `<CLUSTER-IP>:<PORT>` from
 any node in your cluster. Note that the Service IP is completely virtual, it
 never hits the wire. If you're curious about how this works you can read more
-about the [service proxy](/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies).
+about the [service proxy](/docs/reference/networking/virtual-ips/).
 
 ## Accessing the Service
 


### PR DESCRIPTION
This PR fixed the link for the `service proxy` under the [Connecting Applications with Services](https://kubernetes.io/docs/tutorials/services/connect-applications-service/) docs.

Fixes #41891