### PR TITLE
[zh] sync logging.md, system-logs.md, and test.md

### DIFF
--- a/content/zh-cn/docs/concepts/cluster-administration/logging.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/logging.md
@@ -118,12 +118,13 @@ appending a container name to the command, with a `-c` flag, like so:
 如果你的 Pod 有多个容器，请如下通过将容器名称追加到该命令并使用 `-c`
 标志来指定要访问哪个容器的日志：
 
-```console
+```shell
 kubectl logs counter -c count
 ```
 
 <!--
-See the [`kubectl logs` documentation](/docs/reference/generated/kubectl/kubectl-commands#logs) for more details.
+See the [`kubectl logs` documentation](/docs/reference/generated/kubectl/kubectl-commands#logs)
+for more details.
 -->
 详见 [`kubectl logs` 文档](/docs/reference/generated/kubectl/kubectl-commands#logs)。
 
@@ -167,7 +168,8 @@ kubelet 通过 Kubernetes API 的特殊功能将日志提供给客户端访问�
 <!--
 You can configure the kubelet to rotate logs automatically.
 
-If you configure rotation, the kubelet is responsible for rotating container logs and managing the logging directory structure.
+If you configure rotation, the kubelet is responsible for rotating container logs and managing the
+logging directory structure.
 The kubelet sends this information to the container runtime (using CRI),
 and the runtime writes the container logs to the given location.
 -->
@@ -180,7 +182,8 @@ kubelet（使用 CRI）将此信息发送到容器运行时，而运行时则将
 You can configure two kubelet [configuration settings](/docs/reference/config-api/kubelet-config.v1beta1/),
 `containerLogMaxSize` and `containerLogMaxFiles`,
 using the [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/).
-These settings let you configure the maximum size for each log file and the maximum number of files allowed for each container respectively.
+These settings let you configure the maximum size for each log file and the maximum number of
+files allowed for each container respectively.
 
 When you run [`kubectl logs`](/docs/reference/generated/kubectl/kubectl-commands#logs) as in
 the basic logging example, the kubelet on the node handles the request and
@@ -196,8 +199,7 @@ kubelet [配置选项](/zh-cn/docs/reference/config-api/kubelet-config.v1beta1/#
 
 {{< note >}}
 <!--
-Only the contents of the latest log file are available through
-`kubectl logs`.
+Only the contents of the latest log file are available through `kubectl logs`.
 
 For example, if a Pod writes 40 MiB of logs and the kubelet rotates logs
 after 10 MiB, running `kubectl logs` returns at most 10MiB of data.
@@ -264,14 +266,12 @@ kubelet logs to a directory that you choose.
 并使用该工具将 kubelet 日志重定向到你所选择的目录。
 
 <!--
-You can also set a logging directory using the deprecated kubelet command line
-argument `--log-dir`. However, the kubelet always directs your container runtime to
-write logs into directories within `/var/log/pods`.
+The kubelet always directs your container runtime to write logs into directories within
+`/var/log/pods`.
 
 For more information on `kube-log-runner`, read [System Logs](/docs/concepts/cluster-administration/system-logs/#klog).
 -->
-你还可以使用已弃用的 kubelet 命令行参数 `--log-dir` 设置日志目录。
-但是，kubelet 始终指示你的容器运行时将日志写入 `/var/log/pods` 中的目录。
+kubelet 始终指示你的容器运行时将日志写入 `/var/log/pods` 中的目录。
 
 有关 `kube-log-runner` 的更多信息，请阅读[系统日志](/zh-cn/docs/concepts/cluster-administration/system-logs/#klog)。
 
@@ -393,7 +393,8 @@ application containers on that node.
 Because the logging agent must run on every node, it is recommended to run the agent
 as a `DaemonSet`.
 
-Node-level logging creates only one agent per node and doesn't require any changes to the applications running on the node. 
+Node-level logging creates only one agent per node and doesn't require any changes to the
+applications running on the node.
 -->
 由于日志记录代理必须在每个节点上运行，推荐以 `DaemonSet` 的形式运行该代理。
 
@@ -417,7 +418,8 @@ You can use a sidecar container in one of the following ways:
 
 <!--
 * The sidecar container streams application logs to its own `stdout`.
-* The sidecar container runs a logging agent, which is configured to pick up logs from an application container.
+* The sidecar container runs a logging agent, which is configured to pick up logs
+  from an application container.
 -->
 * 边车容器将应用程序日志传送到自己的标准输出。
 * 边车容器运行一个日志代理，配置该日志代理以便从应用容器收集日志。
@@ -646,7 +648,8 @@ The pod mounts a volume where fluentd can pick up its configuration data.
 ![直接从应用程序暴露日志](/images/docs/user-guide/logging/logging-from-application.png)
 
 <!--
-Cluster-logging that exposes or pushes logs directly from every application is outside the scope of Kubernetes.
+Cluster-logging that exposes or pushes logs directly from every application is outside the scope
+of Kubernetes.
 -->
 从各个应用中直接暴露和推送日志数据的集群日志机制已超出 Kubernetes 的范围。
 
@@ -655,7 +658,8 @@ Cluster-logging that exposes or pushes logs directly from every application is o
 <!--
 * Read about [Kubernetes system logs](/docs/concepts/cluster-administration/system-logs/)
 * Learn about [Traces For Kubernetes System Components](/docs/concepts/cluster-administration/system-traces/)
-* Learn how to [customise the termination message](/docs/tasks/debug/debug-application/determine-reason-pod-failure/#customizing-the-termination-message) that Kubernetes records when a Pod fails
+* Learn how to [customise the termination message](/docs/tasks/debug/debug-application/determine-reason-pod-failure/#customizing-the-termination-message)
+  that Kubernetes records when a Pod fails
 -->
 * 阅读有关 [Kubernetes 系统日志](/zh-cn/docs/concepts/cluster-administration/system-logs/)的信息
 * 进一步了解[追踪 Kubernetes 系统组件](/zh-cn/docs/concepts/cluster-administration/system-traces/)

--- a/content/zh-cn/docs/concepts/cluster-administration/system-logs.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/system-logs.md
@@ -33,24 +33,20 @@ scheduler decisions).
 <!--
 klog is the Kubernetes logging library. [klog](https://github.com/kubernetes/klog)
 generates log messages for the Kubernetes system components.
-
-For more information about klog configuration, see the [Command line tool reference](/docs/reference/command-line-tools-reference/).
 -->
 klog 是 Kubernetes 的日志库。
 [klog](https://github.com/kubernetes/klog)
 为 Kubernetes 系统组件生成日志消息。
 
-有关 klog 配置的更多信息，请参见[命令行工具参考](/zh-cn/docs/reference/command-line-tools-reference/)。
-
 <!--
 Kubernetes is in the process of simplifying logging in its components.
 The following klog command line flags
 [are deprecated](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components)
-starting with Kubernetes 1.23 and will be removed in a future release:
+starting with Kubernetes v1.23 and removed in Kubernetes v1.26:
 -->
-Kubernetes 正在进行简化其组件日志的努力。下面的 klog 命令行参数从 Kubernetes 1.23
+Kubernetes 正在进行简化其组件日志的努力。下面的 klog 命令行参数从 Kubernetes v1.23
 开始[已被废弃](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components)，
-会在未来版本中移除：
+在 Kubernetes v1.26 中被移除：
 
 - `--add-dir-header`
 - `--alsologtostderr`
@@ -168,7 +164,7 @@ compatible with traditional klog:
 -->
 默认的结构化日志消息是以文本形式呈现的，其格式与传统的 klog 保持向后兼容：
 
-```ini
+```
 <klog header> "<message>" <key1>="<value1>" <key2>="<value2>" ...
 ```
 
@@ -177,7 +173,7 @@ Example:
 -->
 示例：
 
-```ini
+```
 I1025 00:15:15.525108       1 controller_utils.go:116] "Pod status updated" pod="kube-system/kubedns" status="ready"
 ```
 
@@ -449,10 +445,9 @@ The complete list of options that can be used are:
 -->
 kubelet 使用启发方式来检索日志。
 如果你还未意识到给定的系统服务正将日志写入到操作系统的原生日志记录程序（例如 journald）
-或 `/var/log/` 中的日志文件，这会很有帮助。
-这种启发方式先检查原生的日志记录程序，如果不可用，则尝试从
-`/var/log/<servicename>`、`/var/log/<servicename>.log` 或 `/var/log/<servicename>/<servicename>.log`
-中检索第一批日志。
+或 `/var/log/` 中的日志文件，这会很有帮助。这种启发方式先检查原生的日志记录程序，
+如果不可用，则尝试从 `/var/log/<servicename>`、`/var/log/<servicename>.log`
+或 `/var/log/<servicename>/<servicename>.log` 中检索第一批日志。
 
 可用选项的完整列表如下：
 

--- a/content/zh-cn/docs/test.md
+++ b/content/zh-cn/docs/test.md
@@ -116,9 +116,9 @@ Markdown doesn't have strict rules about how to process lists. When we moved
 from Jekyll to Hugo, we broke some lists. To fix them, keep the following in
 mind:
 
-- Make sure you indent sub-list items **2 spaces**. 
+- Make sure you indent sub-list items **2 spaces**.
 
-- To end a list and start another, you need a HTML comment block on a new line
+- To end a list and start another, you need an HTML comment block on a new line
   between the lists, flush with the left-hand border. The first list won't end
   otherwise, no matter how many blank lines you put between it and the second.
 -->
@@ -133,18 +133,18 @@ Markdown 在如何处理列表方面没有严格的规则。在我们从 Jekyll 
 <!--
 ### Bullet lists
 
-- This is a list item
-* This is another list item in the same list
-- You can mix `-` and `*`
+- This is a list item.
+* This is another list item in the same list.
+- You can mix `-` and `*`.
   - To make a sub-item, indent two spaces.
     - This is a sub-sub-item. Indent two more spaces.
   - Another sub-item.
 -->
 ### 项目符号列表   {#bullet-lists}
 
-- 此为列表条目
-* 此为另一列表条目，位于同一列表中
-- 你可以将 `-` 和 `*` 混合使用
+- 此为列表条目。
+* 此为另一列表条目，位于同一列表中。
+- 你可以将 `-` 和 `*` 混合使用。
   - 要开始子列表，缩进两个空格。
     - 这是另一个子子条目。进一步多缩进两个空格。
   - 另一个子条目。
@@ -178,8 +178,8 @@ Markdown 在如何处理列表方面没有严格的规则。在我们从 Jekyll 
 
 <!--
 - A bullet list item can contain a numbered list.
-    1.  Numbered sub-list item 1
-    2.  Numbered sub-list item 2
+  1. Numbered sub-list item 1
+  1. Numbered sub-list item 2
 -->
 - 项目符号列表条目中还可以包含编号列表。
   1. 编号子列表条目一
@@ -194,44 +194,41 @@ Markdown 在如何处理列表方面没有严格的规则。在我们从 Jekyll 
 <!--
 ### Numbered lists
 
-1.  This is a list item
-2.  This is another list item in the same list. The number you use in Markdown
-    does not necessarily correlate to the number in the final output. By
-    convention, we keep them in sync.
-3.  {{<note>}}
-    For single-digit numbered lists, using two spaces after the period makes
-    interior block-level content line up better along tab-stops.
-    {{</note>}}
+1. This is a list item
+1. This is another list item in the same list. The number you use in Markdown
+   does not necessarily correlate to the number in the final output. By
+   convention, we keep them in sync.
 -->
 ### 编号列表  {#numbered-lists}
 
 1. 此为列表条目
-2. 此为列表中的第二个条目。在 Markdown 源码中所给的编号数字与最终输出的数字
+1. 此为列表中的第二个条目。在 Markdown 源码中所给的编号数字与最终输出的数字
    可能不同。建议在紧凑列表中编号都使用 1。如果条目之间有其他内容（比如注释
    掉的英文）存在，则需要显式给出编号。
-3. {{<note>}}
-   <!--
-   For single-digit numbered lists, using two spaces after the period makes
-   interior block-level content line up better along tab-stops.
-   -->
-   对于单个数字的编号列表，在句点（`.`）后面加两个空格。这样有助于将列表的
-   内容更好地对齐。
-   {{</note>}}
+
+{{<note>}}
+<!--
+For single-digit numbered lists, using two spaces after the period makes
+interior block-level content line up better along tab-stops.
+-->
+对于单个数字的编号列表，在句点（`.`）后面加两个空格。这样有助于将列表的
+内容更好地对齐。
+{{</note>}}
 
 <!-- separate lists -->
 
 <!--
-1.  This is a new list. With Hugo, you need to use a HTML comment to separate
-    two consecutive lists. **The HTML comment needs to be at the left margin.**
-2.  Numbered lists can have paragraphs or block elements within them.
+1. This is a new list. With Hugo, you need to use an HTML comment to separate
+   two consecutive lists. **The HTML comment needs to be at the left margin.**
+1. Numbered lists can have paragraphs or block elements within them.
 
-    Indent the content to be the same as the first line of the bullet
-    point. **This paragraph and the code block line up with the `N` in
-    `Numbered` above.**
+   Indent the content to be the same as the first line of the bullet
+   point. **This paragraph and the code block line up with the `N` in
+   `Numbered` above.**
 -->
 1. 这是一个新的列表。 使用 Hugo 时，你需要用 HTML 注释将两个紧挨着的列表分开。
    **HTML 注释需要按左边顶边对齐。**
-2. 编号列表条目中也可以包含额外的段落或者块元素。
+1. 编号列表条目中也可以包含额外的段落或者块元素。
 
    后续段落应该按编号列表文字的第一行左侧对齐。
    **此段落及下面的代码段都与本条目中的第一个字“编”对齐。**
@@ -242,8 +239,8 @@ Markdown 在如何处理列表方面没有严格的规则。在我们从 Jekyll 
 
    <!--
    - And a sub-list after some block-level content. This is at the same
-      "level" as the paragraph and code block above, despite being indented
-      more.
+     "level" as the paragraph and code block above, despite being indented
+     more.
    -->
    - 编号列表条目中可以在块级内容之后有子列表。子列表的符号项要与上层列表条目文字左侧对齐。
 
@@ -477,20 +474,23 @@ source for this page).
 ## Links
 
 To format a link, put the link text inside square brackets, followed by the
-link target in parentheses. [Link to Kubernetes.io](https://kubernetes.io/) or
-[Relative link to Kubernetes.io](/)
+link target in parentheses.
+
+- `[Link to Kubernetes.io](https://kubernetes.io/)` or
+- `[Relative link to Kubernetes.io](/)`
 
 You can also use HTML, but it is not preferred.
-<a href="https://kubernetes.io/">Link to Kubernetes.io</a>
+For example, `<a href="https://kubernetes.io/">Link to Kubernetes.io</a>`.
 -->
 ## 链接   {#links}
 
 要格式化链接，将链接显示文本放在方括号中，后接用圆括号括起来的链接目标。
-[指向 Kubernetes.io 的链接](https://kubernetes.io/)或
-[到 Kubernetes.io 的相对链接](/)。
+
+- `[指向 Kubernetes.io 的链接](https://kubernetes.io/)`或
+- `[到 Kubernetes.io 的相对链接](/)`
 
 你也可以使用 HTML，但这种方式不是推荐的方式。
-<a href="https://kubernetes.io/">到 Kubernetes.io 的链接</a>。
+例如，`<a href="https://kubernetes.io/">到 Kubernetes.io 的链接</a>`。
 
 ### 中文链接
 
@@ -595,7 +595,7 @@ You can also use HTML for images, but it is not preferred.
 即使你不想使用 figure 短代码，图片也可以展示为链接。这里，铅笔图标指向
 Kubernetes 网站。外层的方括号将整个 image 标签封装起来，链接目标在末尾的圆括号之间给出。
 
-[![pencil icon](/images/pencil.png)](https://kubernetes.io)
+[![铅笔图标](/images/pencil.png)](https://kubernetes.io)
 
 你也可以使用 HTML 来嵌入图片，不过这种方式是不推荐的。
 
@@ -690,7 +690,7 @@ graph TD;
 ```
 
 <!--
-Produces: 
+Produces:
 -->
 会产生：
 
@@ -742,7 +742,7 @@ sequenceDiagram
 ```
 
 <!--
-Produces: 
+Produces:
 -->
 会产生：
 
@@ -772,9 +772,9 @@ sequenceDiagram
 {{</ mermaid >}}
 
 <!--
-<br>More [examples](https://mermaid-js.github.io/mermaid/#/examples) from the official docs.
+You can check more [examples](https://mermaid-js.github.io/mermaid/#/examples) from the official docs.
 -->
-<br>在官方网站上有更多的[示例](https://mermaid-js.github.io/mermaid/#/examples)。
+你可以查阅官方网站上的更多[示例](https://mermaid-js.github.io/mermaid/#/examples)。
 
 <!--
 ## Sidebars and Admonitions
@@ -813,6 +813,7 @@ A sidebar offsets text visually, but without the visual prominence of
 > ```bash
 > sudo dmesg
 > ```
+
 <!--
 ### Admonitions
 
@@ -822,8 +823,8 @@ Admonitions (notes, warnings, etc) use Hugo shortcodes.
 
 提醒框（说明、警告等等）都是用 Hugo 短代码的形式展现。
 
-<!--
 {{< note >}}
+<!--
 Notes catch the reader's attention without a sense of urgency.
 
 You can have multiple paragraphs and block-level elements inside an admonition.


### PR DESCRIPTION
Sync 3 files with en #41395 and #41863

```
content/zh-cn/docs/concepts/cluster-administration/logging.md
content/zh-cn/docs/concepts/cluster-administration/system-logs.md
content/zh-cn/docs/test.md
```
See previews:
- [logging.md](https://deploy-preview-41900--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/cluster-administration/logging/)
- [system-logs.md](https://deploy-preview-41900--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/cluster-administration/system-logs/)
- [test.md](https://deploy-preview-41900--kubernetes-io-main-staging.netlify.app/zh-cn/docs/test/)