### PR TITLE
content: Clarify version requirements for userns and other minor fixes

### DIFF
--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -54,9 +54,13 @@ to use this feature with Kubernetes stateless pods:
 
 * CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
-Please note that containerd v1.7 supports user namespaces for containers,
-compatible with Kubernetes {{< skew currentPatchVersion >}}. It should not be used
-with Kubernetes 1.27 (and later).
+containerd v1.7 is not compatible with the userns support in Kubernetes v{{< skew currentVersion >}}.
+Kubernetes v1.25 and v1.26 used an earlier implementation that **is** compatible with containerd v1.7,
+in terms of userns support.
+If you are using a version of Kubernetes other than {{< skew currentVersion >}},
+check the documentation for that version of Kubernetes for the most relevant information.
+If there is a newer release of containerd than v1.7 available for use, also check the containerd
+documentation for compatibility information.
 
 Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.
 

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -46,8 +46,6 @@ tmpfs, Secrets use a tmpfs, etc.)
 Some popular filesystems that support idmap mounts in Linux 6.3 are: btrfs,
 ext4, xfs, fat, tmpfs, overlayfs.
 
-<!-- When merging this with the dev-1.27 branch conflicts will arise. The text
-as it is in the dev-1.27 branch should be used. -->
 In addition, support is needed in the 
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
 to use this feature with Kubernetes stateless pods:

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -60,7 +60,8 @@ check the documentation for that version of Kubernetes for the most relevant inf
 If there is a newer release of containerd than v1.7 available for use, also check the containerd
 documentation for compatibility information.
 
-Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.
+You can see the status of user namespaces support in cri-dockerd tracked in an [issue][CRI-dockerd-issue]
+on GitHub.
 
 [CRI-dockerd-issue]: https://github.com/Mirantis/cri-dockerd/issues/74
 


### PR DESCRIPTION
The variable expansion is wrong: it currently expands to 1.27.3 on the rendered website. Furthermore, we don't want this to be expanded to other versions when the current k8s release is 1.30.

So, let's just use the plain versions, as that is what we really want.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
