### PR TITLE
Doc update for userns in 1.28

### DIFF
--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -48,7 +48,7 @@ ext4, xfs, fat, tmpfs, overlayfs.
 
 In addition, support is needed in the 
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
-to use this feature with Kubernetes stateless pods:
+to use this feature with Kubernetes pods:
 
 * CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
@@ -75,7 +75,7 @@ A pod can opt-in to use user namespaces by setting the `pod.spec.hostUsers` fiel
 to `false`.
 
 The kubelet will pick host UIDs/GIDs a pod is mapped to, and will do so in a way
-to guarantee that no two stateless pods on the same node use the same mapping.
+to guarantee that no two pods on the same node use the same mapping.
 
 The `runAsUser`, `runAsGroup`, `fsGroup`, etc. fields in the `pod.spec` always
 refer to the user inside the container.
@@ -92,7 +92,7 @@ Most applications that need to run as root but don't access other host
 namespaces or resources, should continue to run fine without any changes needed
 if user namespaces is activated.
 
-## Understanding user namespaces for stateless pods
+## Understanding user namespaces for pods {#pods-and-userns}
 
 Several container runtimes with their default configuration (like Docker Engine,
 containerd, CRI-O) use Linux namespaces for isolation. Other technologies exist
@@ -161,15 +161,6 @@ allowed to set any of:
  * `hostNetwork: true`
  * `hostIPC: true`
  * `hostPID: true`
-
-The pod is allowed to use no volumes at all or, if using volumes, only these
-volume types are allowed:
-
- * configmap
- * secret
- * projected
- * downwardAPI
- * emptyDir
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -54,9 +54,13 @@ to use this feature with Kubernetes stateless pods:
 
 * CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
-Please note that containerd v1.7 supports user namespaces for containers,
-compatible with Kubernetes {{< skew currentPatchVersion >}}. It should not be used
-with Kubernetes 1.27 (and later).
+containerd v1.7 is not compatible with the userns support in Kubernetes v{{< skew currentVersion >}}.
+Kubernetes v1.25 and v1.26 used an earlier implementation that **is** compatible with containerd v1.7,
+in terms of userns support.
+If you are using a version of Kubernetes other than {{< skew currentVersion >}},
+check the documentation for that version of Kubernetes for the most relevant information.
+If there is a newer release of containerd than v1.7 available for use, also check the containerd
+documentation for compatibility information.
 
 Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.
 

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -46,8 +46,6 @@ tmpfs, Secrets use a tmpfs, etc.)
 Some popular filesystems that support idmap mounts in Linux 6.3 are: btrfs,
 ext4, xfs, fat, tmpfs, overlayfs.
 
-<!-- When merging this with the dev-1.27 branch conflicts will arise. The text
-as it is in the dev-1.27 branch should be used. -->
 In addition, support is needed in the 
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
 to use this feature with Kubernetes stateless pods:

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -52,7 +52,7 @@ to use this feature with Kubernetes pods:
 
 * CRI-O: version 1.25 (and later) supports user namespaces for containers.
 
-containerd v1.7 is not compatible with the userns support in Kubernetes v{{< skew currentVersion >}}.
+containerd v1.7 is not compatible with the userns support in Kubernetes v1.27 to v{{< skew latestVersion >}}.
 Kubernetes v1.25 and v1.26 used an earlier implementation that **is** compatible with containerd v1.7,
 in terms of userns support.
 If you are using a version of Kubernetes other than {{< skew currentVersion >}},

--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -60,7 +60,8 @@ check the documentation for that version of Kubernetes for the most relevant inf
 If there is a newer release of containerd than v1.7 available for use, also check the containerd
 documentation for compatibility information.
 
-Support for this in [cri-dockerd is not planned][CRI-dockerd-issue] yet.
+You can see the status of user namespaces support in cri-dockerd tracked in an [issue][CRI-dockerd-issue]
+on GitHub.
 
 [CRI-dockerd-issue]: https://github.com/Mirantis/cri-dockerd/issues/74
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -203,7 +203,8 @@ For a reference to old feature gates that are removed, please refer to
 | `TopologyManagerPolicyOptions` | `false` | Alpha | 1.26 | 1.27 |
 | `TopologyManagerPolicyOptions` | `true` | Beta | 1.28 | |
 | `UnknownVersionInteroperabilityProxy` | `false` | Alpha | 1.28 | |
-| `UserNamespacesStatelessPodsSupport` | `false` | Alpha | 1.25 | |
+| `UserNamespacesStatelessPodsSupport` | `false` | Alpha | 1.25 | 1.27 |
+| `UserNamespacesSupport` | `false` | Alpha | 1.28 | |
 | `ValidatingAdmissionPolicy` | `false` | Alpha | 1.26 | |
 | `VolumeCapacityPriority` | `false` | Alpha | 1.21 | - |
 | `WatchList` | false | Alpha | 1.27 | |
@@ -764,7 +765,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `UnknownVersionInteroperabilityProxy`: Proxy resource requests to the correct peer kube-apiserver when
   multiple kube-apiservers exist at varied versions.
   See [Mixed version proxy](/docs/concepts/architecture/mixed-version-proxy/) for more information.
-- `UserNamespacesStatelessPodsSupport`: Enable user namespace support for stateless Pods.
+- `UserNamespacesStatelessPodsSupport`: Enable user namespace support for stateless Pods. This flag was renamed on newer releases to `UserNamespacesSupport`.
+- `UserNamespacesSupport`: Enable user namespace support for Pods.
 - `ValidatingAdmissionPolicy`: Enable [ValidatingAdmissionPolicy](/docs/reference/access-authn-authz/validating-admission-policy/) support for CEL validations be used in Admission Control.
 - `VolumeCapacityPriority`: Enable support for prioritizing nodes in different
   topologies based on available PV capacity.

--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -9,9 +9,8 @@ min-kubernetes-server-version: v1.25
 <!-- overview -->
 {{< feature-state for_k8s_version="v1.25" state="alpha" >}}
 
-This page shows how to configure a user namespace for stateless pods. This
-allows to isolate the user running inside the container from the one in the
-host.
+This page shows how to configure a user namespace for pods. This allows to
+isolate the user running inside the container from the one in the host.
 
 A process running as root in a container can run as a different (non-root) user
 in the host; in other words, the process has full privileges for operations
@@ -41,7 +40,14 @@ this is true when user namespaces are used.
 * The node OS needs to be Linux
 * You need to exec commands in the host
 * You need to be able to exec into pods
-* Feature gate `UserNamespacesStatelessPodsSupport` need to be enabled.
+* You need to enable the `UserNamespacesSupport`
+  [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+
+{{< note >}}
+The feature gate to enable user namespaces was previously named
+`UserNamespacesStatelessPodsSupport`, when only stateless pods were supported.
+Only Kubernetes v1.25 through to v1.27 recognise `UserNamespacesStatelessPodsSupport`.
+{{</ note >}}
 
 The cluster that you're using **must** include at least one node that meets the
 [requirements](/docs/concepts/workloads/pods/user-namespaces/#before-you-begin)
@@ -59,8 +65,8 @@ created without user namespaces.**
 
 ## Run a Pod that uses a user namespace {#create-pod}
 
-A user namespace for a stateless pod is enabled setting the `hostUsers` field of
-`.spec` to `false`. For example:
+A user namespace for a pod is enabled setting the `hostUsers` field of `.spec`
+to `false`. For example:
 
 {{< codenew file="pods/user-namespaces-stateless.yaml" >}}
 

--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -9,7 +9,7 @@ min-kubernetes-server-version: v1.25
 <!-- overview -->
 {{< feature-state for_k8s_version="v1.25" state="alpha" >}}
 
-This page shows how to configure a user namespace for pods. This allows to
+This page shows how to configure a user namespace for pods. This allows you to
 isolate the user running inside the container from the one in the host.
 
 A process running as root in a container can run as a different (non-root) user


### PR DESCRIPTION
Commits 1-3 are ports of what we just merged in main, for 1.27. They improve the wording, fix a typo and use a timeless way for some sentences.

On top of that is the new commit that just removes mentiones to stateless pods, as we support all pods (stateful and stateless) now.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
