### PR TITLE
update kind install prereqs to include podman

### DIFF
--- a/content/en/docs/tasks/tools/_index.md
+++ b/content/en/docs/tasks/tools/_index.md
@@ -24,8 +24,8 @@ Find your preferred operating system below.
 ## kind
 
 [`kind`](https://kind.sigs.k8s.io/) lets you run Kubernetes on
-your local computer. This tool requires that you have
-[Docker](https://docs.docker.com/get-docker/) installed and configured.
+your local computer. This tool requires that you have either
+[Docker](https://www.docker.com/) or [Podman](https://podman.io/) installed.
 
 The kind [Quick Start](https://kind.sigs.k8s.io/docs/user/quick-start/) page
 shows you what you need to do to get up and running with kind.


### PR DESCRIPTION
Update Kind install prerequisites to include podman as an option, besides docker. Fixes #36159 
