### PR TITLE
[ja] Update certificates.md

### DIFF
--- a/content/ja/docs/setup/best-practices/certificates.md
+++ b/content/ja/docs/setup/best-practices/certificates.md
@@ -20,6 +20,7 @@ Kubernetesでは、TLS認証のためにPKI証明書が必要です。
 Kubernetesは下記の用途でPKIを必要とします：
 
 * kubeletがAPIサーバーの認証をするためのクライアント証明書
+* API サーバーが kubelet と通信するための Kubelet [サーバー認証書](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#client-and-serving-certificates)
 * APIサーバーのエンドポイント用サーバー証明書
 * クラスターの管理者がAPIサーバーの認証を行うためのクライアント証明書
 * APIサーバーがkubeletと通信するためのクライアント証明書


### PR DESCRIPTION
Added link at "サーバー認証書" in the japanese version of the document like the english version.

<!--

 Hello! 
I Just Added the link at "[サーバー認証書](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#client-and-serving-certificates)" in the japanese version of the document like the english version.
As there was no link for server certificate in the japenese webpage .
Hope This Might Help As I am new to open source . It would be really nice if you leave feedback for me if any issues .
Thank You Kubernetes Team.

-->
