### PR TITLE
Adding script for cgroup v2 memory available.sh

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -69,7 +69,8 @@ like `free -m`. This is important because `free -m` does not work in a
 container, and if users use the [node allocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)
 feature, out of resource decisions
 are made local to the end user Pod part of the cgroup hierarchy as well as the
-root node. This [script](/examples/admin/resource/memory-available.sh)/ [cgroupv2 script] (/examples/admin/resource/memory-available-cgroupv2.sh)
+root node. This [script](/examples/admin/resource/memory-available.sh) or
+[cgroupv2 script](/examples/admin/resource/memory-available-cgroupv2.sh)
 reproduces the same set of steps that the kubelet performs to calculate
 `memory.available`. The kubelet excludes inactive_file (i.e. # of bytes of
 file-backed memory on inactive LRU list) from its calculation as it assumes that

--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -69,7 +69,7 @@ like `free -m`. This is important because `free -m` does not work in a
 container, and if users use the [node allocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)
 feature, out of resource decisions
 are made local to the end user Pod part of the cgroup hierarchy as well as the
-root node. This [script](/examples/admin/resource/memory-available.sh)
+root node. This [script](/examples/admin/resource/memory-available.sh)/ [cgroupv2 script] (/examples/admin/resource/memory-available-cgroupv2.sh)
 reproduces the same set of steps that the kubelet performs to calculate
 `memory.available`. The kubelet excludes inactive_file (i.e. # of bytes of
 file-backed memory on inactive LRU list) from its calculation as it assumes that

--- a/content/en/examples/admin/resource/memory-available-cgroupv2.sh
+++ b/content/en/examples/admin/resource/memory-available-cgroupv2.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#!/usr/bin/env bash
 
 # This script reproduces what the kubelet does
 # to calculate memory.available relative to kubepods cgroup.

--- a/content/en/examples/admin/resource/memory-available-cgroupv2.sh
+++ b/content/en/examples/admin/resource/memory-available-cgroupv2.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#!/usr/bin/env bash
+
+# This script reproduces what the kubelet does
+# to calculate memory.available relative to kubepods cgroup.
+
+# current memory usage
+memory_capacity_in_kb=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
+memory_capacity_in_bytes=$((memory_capacity_in_kb * 1024))
+memory_usage_in_bytes=$(cat /sys/fs/cgroup/kubepods.slice/memory.current)
+memory_total_inactive_file=$(cat /sys/fs/cgroup/kubepods.slice/memory.stat | grep inactive_file | awk '{print $2}')
+
+memory_working_set=${memory_usage_in_bytes}
+if [ "$memory_working_set" -lt "$memory_total_inactive_file" ];
+then
+    memory_working_set=0
+else
+    memory_working_set=$((memory_usage_in_bytes - memory_total_inactive_file))
+fi
+
+memory_available_in_bytes=$((memory_capacity_in_bytes - memory_working_set))
+memory_available_in_kb=$((memory_available_in_bytes / 1024))
+memory_available_in_mb=$((memory_available_in_kb / 1024))
+
+echo "memory.capacity_in_bytes $memory_capacity_in_bytes"
+echo "memory.usage_in_bytes $memory_usage_in_bytes"
+echo "memory.total_inactive_file $memory_total_inactive_file"
+echo "memory.working_set $memory_working_set"
+echo "memory.available_in_bytes $memory_available_in_bytes"
+echo "memory.available_in_kb $memory_available_in_kb"
+echo "memory.available_in_mb $memory_available_in_mb"


### PR DESCRIPTION
This request adds a script to calculate the memory available in cgroup v2 which is currently missing.  The current [script ](https://kubernetes.io/examples/admin/resource/memory-available.sh) only works for users using cgroup v1. For more details, please check [this](https://github.com/kubernetes/enhancements/issues/2254) issue 


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
