### PR TITLE
[pt-br] Fixed "Show the app in the terminal" URL

### DIFF
--- a/content/pt-br/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -267,7 +267,7 @@ description: |-
             Para ver a saída da aplicação, execute uma requisição com o comando
             <code>curl</code>:
           </p>
-          <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/proxy/</b></code></p>
+          <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME:8080/proxy/</b></code></p>
           <p>A URL é a rota para a API do Pod.</p>
         </div>
       </div>


### PR DESCRIPTION
The app is listening on port 8080 so that must be included otherwise port 80 (default) is used and the curl request will fail.

Issue: 41259

