### PR TITLE
Fixed "Show the app in the terminal" URL (zh-cn)

### DIFF
--- a/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -279,7 +279,7 @@ description: |-
                 -->
                 <p>要查看应用的输出，运行 <code>curl</code> 请求：</p>
 
-                <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/proxy/</b></code></p>
+                <p><code><b>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME:8080/proxy/</b></code></p>
 
                 <!--
                 <p>The URL is the route to the API of the Pod.</p>


### PR DESCRIPTION
The app is listening on port 8080 so that must be included otherwise port 80 (default) is used and the curl request will fail.

Issue: 41259
