### PR TITLE
Fix typos in labels-annotations-taints

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -43,7 +43,7 @@ Starting from v1.9, this label is deprecated.
 
 ### app.kubernetes.io/instance
 
-Type: Label 
+Type: Label
 
 Example: `app.kubernetes.io/instance: "mysql-abcxzy"`
 
@@ -180,6 +180,7 @@ There is no relation between the value of this label and object UID.
 ### applyset.kubernetes.io/is-parent-type (alpha) {#applyset-kubernetes-io-is-parent-type}
 
 Type: Label
+
 Example: `applyset.kubernetes.io/is-parent-type: "true"`
 
 Used on: Custom Resource Definition (CRD)
@@ -399,7 +400,7 @@ This label can have one of three values: `Reconcile`, `EnsureExists`, or `Ignore
 - `Ignore`: Addon resources will be ignored. This mode is useful for add-ons that are not
   compatible with the add-on manager or that are managed by another controller.
 
-For more details, see [Addon-manager](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/README.md)
+For more details, see [Addon-manager](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/README.md).
 
 ### beta.kubernetes.io/arch (deprecated)
 
@@ -758,7 +759,7 @@ Kubernetes makes a few assumptions about the structure of zones and regions:
 
 1. regions and zones are hierarchical: zones are strict subsets of regions and
    no zone can be in 2 regions
-2) zone names are unique across regions; for example region "africa-east-1" might be comprised
+2. zone names are unique across regions; for example region "africa-east-1" might be comprised
    of zones "africa-east-1a" and "africa-east-1b"
 
 It should be safe to assume that topology labels do not change.
@@ -796,7 +797,7 @@ Example: `volume.beta.kubernetes.io/storage-provisioner: "k8s.io/minikube-hostpa
 Used on: PersistentVolumeClaim
 
 This annotation has been deprecated since v1.23.
-See [volume.kubernetes.io/storage-provisioner](#volume-kubernetes-io-storage-provisioner)
+See [volume.kubernetes.io/storage-provisioner](#volume-kubernetes-io-storage-provisioner).
 
 ### volume.beta.kubernetes.io/storage-class (deprecated)
 
@@ -1009,6 +1010,7 @@ Starting in v1.18, this annotation is deprecated in favor of `spec.ingressClassN
 ### storageclass.kubernetes.io/is-default-class
 
 Type: Annotation
+
 Example: `storageclass.kubernetes.io/is-default-class: "true"`
 
 Used on: StorageClass
@@ -1065,8 +1067,7 @@ container.
 {{< note >}}
 This annotation is deprecated. You should use the
 [`kubectl.kubernetes.io/default-container`](#kubectl-kubernetes-io-default-container)
-annotation instead.
-Kubernetes versions 1.25 and newer ignore this annotation.
+annotation instead. Kubernetes versions 1.25 and newer ignore this annotation.
 {{< /note >}}
 
 ### endpoints.kubernetes.io/over-capacity
@@ -1324,7 +1325,7 @@ Type: Label
 
 Example: `feature.node.kubernetes.io/network-sriov.capable: "true"`
 
-Used on: Node 
+Used on: Node
 
 These labels are used by the Node Feature Discovery (NFD) component to advertise
 features on a node. All built-in labels use the `feature.node.kubernetes.io` label
@@ -1636,7 +1637,7 @@ the integration configures an internal load balancer.
 If you use the [AWS load balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/),
 see [`service.beta.kubernetes.io/aws-load-balancer-scheme`](#service-beta-kubernetes-io-aws-load-balancer-scheme).
 
-### service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules (beta) {#service-beta-kubernetes-io-aws-load-balancer-manage-backend-security-group-rules)
+### service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules (beta) {#service-beta-kubernetes-io-aws-load-balancer-manage-backend-security-group-rules}
 
 Example: `service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "true"`
 
@@ -1662,7 +1663,7 @@ balancer to the value you set for _this_ annotation.
 See [annotations](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/)
 in the AWS load balancer controller documentation.
 
-### service.beta.kubernetes.io/aws-load-balancer-nlb-target-type (beta) {#service-beta-kubernetes-io-aws-load-balancer-nlb-target-type)
+### service.beta.kubernetes.io/aws-load-balancer-nlb-target-type (beta) {#service-beta-kubernetes-io-aws-load-balancer-nlb-target-type}
 
 Example: `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "true"`
 
@@ -2044,9 +2045,9 @@ of the exposed advertise address/port endpoint for that API server instance.
 
 Type: Annotation
 
-Used on: ConfigMap
-
 Example: `kubeadm.kubernetes.io/component-config.hash: 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae`
+
+Used on: ConfigMap
 
 Annotation that kubeadm places on ConfigMaps that it manages for configuring components.
 It contains a hash (SHA-256) used to determine if the user has applied settings different
@@ -2098,4 +2099,3 @@ Taint that kubeadm previously applied on control plane nodes to allow only criti
 workloads to schedule on them. Replaced by the
 [`node-role.kubernetes.io/control-plane`](#node-role-kubernetes-io-control-plane-taint)
 taint. kubeadm no longer sets or uses this deprecated taint.
-


### PR DESCRIPTION
Performed actions below:
- fix typos
-  add necessary blank lines
- fix anchors

```
content/en/docs/reference/labels-annotations-taints/_index.md
```