### PR TITLE
Fix feature state for MixedProtocolLBService

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -618,7 +618,7 @@ can define your own (provider specific) annotations on the Service that specify 
 
 #### Load balancers with mixed protocol types
 
-{{< feature-state for_k8s_version="v1.24" state="beta" >}}
+{{< feature-state for_k8s_version="v1.26" state="stable" >}}
 
 By default, for LoadBalancer type of Services, when there is more than one port defined, all
 ports must have the same protocol, and the protocol must be one which is supported


### PR DESCRIPTION
This PR updated the FEATURE STATE of `MixedProtocolLBService` under the [Service](https://kubernetes.io/docs/concepts/services-networking/service/) docs.

Fixes #41965