### PR TITLE
Delay July 2023 patch releases for July 19

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,7 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| July 2023             | 2023-07-07           | 2023-07-12  |
+| July 2023             | 2023-07-14           | 2023-07-19  |
 | August 2023           | 2023-08-04           | 2023-08-09  |
 | September 2023        | 2023-09-08           | 2023-09-13  |
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -8,8 +8,8 @@ schedules:
   endOfLifeDate: 2024-06-28
   next:
     release: 1.27.4
-    cherryPickDeadline: 2023-07-07
-    targetDate: 2023-07-12
+    cherryPickDeadline: 2023-07-14
+    targetDate: 2023-07-19
   previousPatches:
     - release: 1.27.3
       cherryPickDeadline: 2023-06-09
@@ -31,8 +31,8 @@ schedules:
   endOfLifeDate: 2024-02-28
   next:
     release: 1.26.7
-    cherryPickDeadline: 2023-07-07
-    targetDate: 2023-07-12
+    cherryPickDeadline: 2023-07-14
+    targetDate: 2023-07-19
   previousPatches:
     - release: 1.26.6
       cherryPickDeadline: 2023-06-09
@@ -63,8 +63,8 @@ schedules:
   endOfLifeDate: 2023-10-28
   next:
     release: 1.25.12
-    cherryPickDeadline: 2023-07-07
-    targetDate: 2023-07-12
+    cherryPickDeadline: 2023-07-14
+    targetDate: 2023-07-19
   previousPatches:
     - release: 1.25.11
       cherryPickDeadline: 2023-06-09
@@ -114,8 +114,8 @@ schedules:
   endOfLifeDate: 2023-07-28
   next:
     release: 1.24.16
-    cherryPickDeadline: 2023-07-07
-    targetDate: 2023-07-07
+    cherryPickDeadline: 2023-07-14
+    targetDate: 2023-07-19
   previousPatches:
     - release: 1.24.15
       cherryPickDeadline: 2023-06-09


### PR DESCRIPTION
We discussed it on Slack that we want to delay July 2023 patch release for a week (to July 19) as we still have some important PRs to merge (such as bump to Go 1.20) and we want to give enough time for tests results to soak in.

I also postponed the cherry-pick deadline as we plan on merging additional PRs.

Reference: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1689013512945219

/assign @cpanato @Verolop @jeremyrickard 
cc @kubernetes/release-engineering 
/hold
we're still waiting a confirmation from Google Build Admins