### PR TITLE
Fix FQDN for pod in document dns-pod-service.md

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -126,7 +126,7 @@ The Pod spec also has an optional `subdomain` field which can be used to indicat
 that the pod is part of sub-group of the namespace. For example, a Pod with `spec.hostname`
 set to `"foo"`, and `spec.subdomain` set to `"bar"`, in namespace `"my-namespace"`, will
 have its hostname set to `"foo"` and its fully qualified domain name (FQDN) set to
-`"foo.bar.my-namespace.svc.cluster.local"` (once more, as observed from within
+`"foo.bar.my-namespace.pod.cluster.local"` (once more, as observed from within
 the Pod).
 
 If there exists a headless Service in the same namespace as the Pod, with


### PR DESCRIPTION
In the doc talking about pod subdomain, there is a mistake of the FQDN of the pod
![image](https://github.com/kubernetes/website/assets/4927154/9c107f47-9e09-4a96-a82e-beb96664e7c5)

The FQDN for a **pod** should be `***.namespace.pod.cluster.local` instead of `***.namespace.svc.cluster.local`
