### PR TITLE
Add in-place substitution option for linkchecker.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,12 +7,12 @@
 | `test_examples.sh`      | This script tests whether a change affects example files bundled in the website.                                                      |
 | `check-headers-file.sh` | This script checks the headers if you are in a production environment.                                                                |
 | `diff_l10n_branches.py` | This script generates a report of outdated contents in `content/<l10n-lang>` directory by comparing two l10n team milestone branches. |
-| `hash-files.sh` | This script emits as hash for the files listed in $@ |
-| `linkchecker.py` | This a link checker for Kubernetes documentation website. |
-| `lsync.sh` | This script checks if the English version of a page has changed since a localized page has been committed. |
-| `replace-capture.sh` | This script sets K8S_WEBSITE in your env to your docs website root or rely on this script to determine it automatically |
-| `check-ctrlcode.py` | This script finds control-code(0x00-0x1f) in text files. |
-| `ja/verify-spelling.sh` | This script finds Japanese words that are against the guideline. |
+| `hash-files.sh`         | This script emits as hash for the files listed in $@                                                                                  |
+| `linkchecker.py`        | This a link checker for Kubernetes documentation website.                                                                             |
+| `lsync.sh`              | This script checks if the English version of a page has changed since a localized page has been committed.                            |
+| `replace-capture.sh`    | This script sets K8S_WEBSITE in your env to your docs website root or rely on this script to determine it automatically               |
+| `check-ctrlcode.py`     | This script finds control-code(0x00-0x1f) in text files.                                                                              |
+| `ja/verify-spelling.sh` | This script finds Japanese words that are against the guideline.                                                                      |
 
 
 
@@ -104,14 +104,17 @@ This script emits as hash for the files listed in $@.
 ## linkchecker.py
 
 This a link checker for Kubernetes documentation website.
-- We cover the following cases for the language you provide via `-l`, which
-  defaults to 'en'.
-- If the language specified is not English (`en`), we check if you are
-  actually using the localized links. For example, if you specify `zh` as
-  the language, and for link target `/docs/foo/bar`, we check if the English
-  version exists AND if the Chinese version exists as well. A checking record
-  is produced if the link can use the localized version.
-
+- If the language for the files scanned is not English (`en`), we check if you
+  are actually using the localized links. For example, if you specify a filter
+  similar to as `content/zh-cn/docs/**/*.md`, we check if the English version
+  exists AND if the Chinese version exists as well. A checking record is
+  produced if the link can use the localized version.
+- If the language specified is not English (`en`), a checking record is produced,
+  and the `-w` switch is used, the script will perform in-place substitutions
+  for links that have the format `/docs` and currently have a localized version
+  available. This is an experimental feature and aims to reduce the amount of
+  work required to update links to point to localized content. It currently
+  works for Markdown files only.
 ```
 
 Usage: linkchecker.py -h

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -427,9 +427,9 @@ def validate_links(page, in_place_edit):
             if any(rec in line for rec in target_records):
                 for rec in target_records:
                     line = line.replace(
-                        "(" + rec + ")",
+                        f"({rec})",
                         # assumes unlocalized links are in "/docs/..." format
-                        "(/" + LANG + rec + ")")
+                        f"(/{LANG}{rec})")
             updated_data.append(line)
 
         with open(page, "w") as f:

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -420,11 +420,11 @@ def validate_links(page, in_place_edit):
 
     # if multiple records are the same they need not be checked repeatedly
     # remove paths that are not relative too
-    target_records = set([item for item in target_records
+    target_records = {item for item in target_records
                          if not item.startswith("http") and
                           not item.startswith(f"/{LANG}")])
 
-    if in_place_edit and len(target_records) > 0:
+    if in_place_edit and target_records:
         updated_data = []
         for line in data:
             if any(rec in line for rec in target_records):

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -481,7 +481,8 @@ def parse_arguments():
                         help=("File pattern to scan. "
                               "(default='content/en/docs/**/*.md')"))
     PARSER.add_argument("-w", dest="in_place_edit", action="store_true",
-                        help="[EXPERIMENTAL] Turns on in-place replacement.")
+                        help="[EXPERIMENTAL] Turns on in-place replacement "
+                             "for localized content.")
 
     return PARSER.parse_args()
 

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -419,7 +419,10 @@ def validate_links(page, in_place_edit):
             target_records.append(m[1])
 
     # if multiple records are the same they need not be checked repeatedly
-    target_records = set(target_records)
+    # remove paths that are not relative too
+    target_records = set([item for item in target_records
+                         if not item.startswith("http") and
+                          not item.startswith(f"/{LANG}")])
 
     if in_place_edit and len(target_records) > 0:
         updated_data = []

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -424,7 +424,8 @@ def validate_links(page, in_place_edit):
                          if not item.startswith("http") and
                           not item.startswith(f"/{LANG}")])
 
-    if in_place_edit and target_records:
+    # English-language pages don't have "en" in their path
+    if in_place_edit and target_records and LANG != "en":
         updated_data = []
         for line in data:
             if any(rec in line for rec in target_records):

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -422,7 +422,7 @@ def validate_links(page, in_place_edit):
     # remove paths that are not relative too
     target_records = {item for item in target_records
                          if not item.startswith("http") and
-                          not item.startswith(f"/{LANG}")])
+                          not item.startswith(f"/{LANG}")}
 
     # English-language pages don't have "en" in their path
     if in_place_edit and target_records and LANG != "en":


### PR DESCRIPTION
### Changes

Add a new flag `-w` to enable experimental in-place substitutions for Markdown links only.

This is intended to reduce the amount of repetitive work required to update out-of-date links.
