### PR TITLE
Clarifying number of examples of controllers

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -48,13 +48,15 @@ for an example control plane setup that runs across multiple machines.
 
 {{< glossary_definition term_id="kube-controller-manager" length="all" >}}
 
-Some types of these controllers are:
+There are many different types of controllers. Some examples of them are:
 
   * Node controller: Responsible for noticing and responding when nodes go down.
   * Job controller: Watches for Job objects that represent one-off tasks, then creates
     Pods to run those tasks to completion.
   * EndpointSlice controller: Populates EndpointSlice objects (to provide a link between Services and Pods).
   * ServiceAccount controller: Create default ServiceAccounts for new namespaces.
+
+The above is not an exhaustive list
 
 ### cloud-controller-manager
 

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -56,7 +56,7 @@ There are many different types of controllers. Some examples of them are:
   * EndpointSlice controller: Populates EndpointSlice objects (to provide a link between Services and Pods).
   * ServiceAccount controller: Create default ServiceAccounts for new namespaces.
 
-The above is not an exhaustive list
+The above is not an exhaustive list.
 
 ### cloud-controller-manager
 


### PR DESCRIPTION
This PR is intended to fix [Issue 41864](https://github.com/kubernetes/website/issues/41864)

Clarified that the number of examples of controllers provided in [https://kubernetes.io/docs/concepts/overview/components/#kube-controller-manager](https://kubernetes.io/docs/concepts/overview/components/#kube-controller-manager) is not exhaustive. 