### PR TITLE
Fix the broken link for Kubernetes Volume Plugin

### DIFF
--- a/content/en/docs/concepts/storage/windows-storage.md
+++ b/content/en/docs/concepts/storage/windows-storage.md
@@ -54,7 +54,7 @@ mounting/dismounting a volume to/from individual containers in a pod that needs 
 persist data.
 
 Volume management components are shipped as Kubernetes volume
-[plugin](/docs/concepts/storage/volumes/#types-of-volumes).
+[plugin](/docs/concepts/storage/volumes/#volume-types).
 The following broad classes of Kubernetes volume plugins are supported on Windows:
 
 * [`FlexVolume plugins`](/docs/concepts/storage/volumes/#flexvolume)


### PR DESCRIPTION
This PR fix the link for `Kubernetes Volume Plugin ` in [Windows Storage](https://kubernetes.io/docs/concepts/storage/windows-storage/). 

Fixes #41990 