### PR TITLE
Fix documentation for Job pod condition failure policy

### DIFF
--- a/content/en/examples/controllers/job-pod-failure-policy-config-issue.yaml
+++ b/content/en/examples/controllers/job-pod-failure-policy-config-issue.yaml
@@ -17,3 +17,4 @@ spec:
     - action: FailJob
       onPodConditions:
       - type: ConfigIssue
+        status: "True"

--- a/content/en/examples/controllers/job-pod-failure-policy-example.yaml
+++ b/content/en/examples/controllers/job-pod-failure-policy-example.yaml
@@ -26,3 +26,4 @@ spec:
     - action: Ignore             # one of: Ignore, FailJob, Count
       onPodConditions:
       - type: DisruptionTarget   # indicates Pod disruption
+        status: "True"           # one of: True, False or Unknown

--- a/content/en/examples/controllers/job-pod-failure-policy-ignore.yaml
+++ b/content/en/examples/controllers/job-pod-failure-policy-ignore.yaml
@@ -21,3 +21,4 @@ spec:
     - action: Ignore
       onPodConditions:
       - type: DisruptionTarget
+	status: "True"

--- a/content/en/examples/controllers/job-pod-failure-policy-ignore.yaml
+++ b/content/en/examples/controllers/job-pod-failure-policy-ignore.yaml
@@ -21,4 +21,4 @@ spec:
     - action: Ignore
       onPodConditions:
       - type: DisruptionTarget
-	status: "True"
+        status: "True"


### PR DESCRIPTION
PodFailurePolicy requires that the status field in onPodConditions to be specified.  If someone tried to run these examples you get a validation error.  

This PR corrects the examples so they are valid yaml for testing this feature.