### PR TITLE
[zh] sync pull-image-private-registry.md and kops.md

### DIFF
--- a/content/zh-cn/docs/setup/production-environment/tools/kops.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kops.md
@@ -3,7 +3,6 @@ title: 使用 kOps 安装 Kubernetes
 content_type: task
 weight: 20
 ---
-
 <!--
 title: Installing Kubernetes with kOps
 content_type: task
@@ -28,17 +27,22 @@ It uses a tool called [`kOps`](https://github.com/kubernetes/kops).
 * Fully automated installation
 * Uses DNS to identify clusters
 * Self-healing: everything runs in Auto-Scaling Groups
-* Multiple OS support (Amazon Linux, Debian, Flatcar, RHEL, Rocky and Ubuntu) - see the [images.md](https://github.com/kubernetes/kops/blob/master/docs/operations/images.md)
-* High-Availability support - see the [high_availability.md](https://github.com/kubernetes/kops/blob/master/docs/operations/high_availability.md)
-* Can directly provision, or generate terraform manifests - see the [terraform.md](https://github.com/kubernetes/kops/blob/master/docs/terraform.md)
+* Multiple OS support (Amazon Linux, Debian, Flatcar, RHEL, Rocky and Ubuntu) - see the
+  [images.md](https://github.com/kubernetes/kops/blob/master/docs/operations/images.md)
+* High-Availability support - see the
+  [high_availability.md](https://github.com/kubernetes/kops/blob/master/docs/operations/high_availability.md)
+* Can directly provision, or generate terraform manifests - see the
+  [terraform.md](https://github.com/kubernetes/kops/blob/master/docs/terraform.md)
 -->
 * 全自动安装流程
 * 使用 DNS 识别集群
 * 自我修复：一切都在自动扩缩组中运行
 * 支持多种操作系统（Amazon Linux、Debian、Flatcar、RHEL、Rocky 和 Ubuntu），
   参考 [images.md](https://github.com/kubernetes/kops/blob/master/docs/operations/images.md)。
-* 支持高可用，参考 [high_availability.md](https://github.com/kubernetes/kops/blob/master/docs/operations/high_availability.md)。
-* 可以直接提供或者生成 terraform 清单，参考 [terraform.md](https://github.com/kubernetes/kops/blob/master/docs/terraform.md)。
+* 支持高可用，参考
+  [high_availability.md](https://github.com/kubernetes/kops/blob/master/docs/operations/high_availability.md)。
+* 可以直接提供或者生成 terraform 清单，参考
+  [terraform.md](https://github.com/kubernetes/kops/blob/master/docs/terraform.md)。
 
 ## {{% heading "prerequisites" %}}
 
@@ -47,7 +51,10 @@ It uses a tool called [`kOps`](https://github.com/kubernetes/kops).
 
 * You must [install](https://github.com/kubernetes/kops#installing) `kops` on a 64-bit (AMD64 and Intel 64) device architecture.
 
-* You must have an [AWS account](https://docs.aws.amazon.com/polly/latest/dg/setting-up.html), generate [IAM keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) and [configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-quick-configuration) them. The IAM user will need [adequate permissions](https://github.com/kubernetes/kops/blob/master/docs/getting_started/aws.md#setup-iam-user).
+* You must have an [AWS account](https://docs.aws.amazon.com/polly/latest/dg/setting-up.html),
+  generate [IAM keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+  and [configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-quick-configuration) them.
+  The IAM user will need [adequate permissions](https://github.com/kubernetes/kops/blob/master/docs/getting_started/aws.md#setup-iam-user).
 -->
 * 你必须安装 [kubectl](/zh-cn/docs/tasks/tools/)。
 * 你必须安装[安装](https://github.com/kubernetes/kops#installing) `kops`
@@ -66,7 +73,8 @@ It uses a tool called [`kOps`](https://github.com/kubernetes/kops).
 
 #### Installation
 
-Download kops from the [releases page](https://github.com/kubernetes/kops/releases) (it is also convenient to build from source):
+Download kops from the [releases page](https://github.com/kubernetes/kops/releases)
+(it is also convenient to build from source):
 -->
 ## 创建集群 {#creating-a-cluster}
 
@@ -202,7 +210,7 @@ from clients.
 ### (2/5) 为你的集群创建一个 route53 域名
 
 kops 在集群内部和外部都使用 DNS 进行发现操作，这样你可以从客户端访问
-kubernetes API 服务器。
+Kubernetes API 服务器。
 
 <!--
 kops has a strong opinion on the cluster name: it should be a valid DNS name.  By doing so you will
@@ -225,7 +233,8 @@ but also `dev.example.com` or even `example.com`.  kops works with any of these,
 you choose for organization reasons (e.g. you are allowed to create records under `dev.example.com`,
 but not under `example.com`).
 -->
-Route53 托管区域可以服务子域名。你的托管区域可能是 `useast1.dev.example.com`，还有 `dev.example.com` 甚至 `example.com`。
+Route53 托管区域可以服务子域名。你的托管区域可能是 `useast1.dev.example.com`，
+还有 `dev.example.com` 甚至 `example.com`。
 kops 可以与以上任何一种配合使用，因此通常你出于组织原因选择不同的托管区域。
 例如，允许你在 `dev.example.com` 下创建记录，但不能在 `example.com` 下创建记录。
 
@@ -393,7 +402,8 @@ for production clusters!
 <!--
 ### Explore other add-ons
 
-See the [list of add-ons](/docs/concepts/cluster-administration/addons/) to explore other add-ons, including tools for logging, monitoring, network policy, visualization, and control of your Kubernetes cluster.
+See the [list of add-ons](/docs/concepts/cluster-administration/addons/) to explore other add-ons,
+including tools for logging, monitoring, network policy, visualization, and control of your Kubernetes cluster.
 -->
 ### 探索其他附加组件
 
@@ -413,8 +423,10 @@ See the [list of add-ons](/docs/concepts/cluster-administration/addons/) to expl
 
 <!--
 * Learn more about Kubernetes [concepts](/docs/concepts/) and [`kubectl`](/docs/reference/kubectl/).
-* Learn more about `kOps` [advanced usage](https://kops.sigs.k8s.io/) for tutorials, best practices and advanced configuration options.
-* Follow `kOps` community discussions on Slack: [community discussions](https://github.com/kubernetes/kops#other-ways-to-communicate-with-the-contributors).
+* Learn more about `kOps` [advanced usage](https://kops.sigs.k8s.io/) for tutorials,
+  best practices and advanced configuration options.
+* Follow `kOps` community discussions on Slack:
+  [community discussions](https://github.com/kubernetes/kops#other-ways-to-communicate-with-the-contributors).
 * Contribute to `kOps` by addressing or raising an issue [GitHub Issues](https://github.com/kubernetes/kops/issues).
 -->
 * 了解有关 Kubernetes 的[概念](/zh-cn/docs/concepts/)和

--- a/content/zh-cn/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -3,7 +3,6 @@ title: 从私有仓库拉取镜像
 content_type: task
 weight: 130
 ---
-
 <!--
 title: Pull an Image from a Private Registry
 content_type: task
@@ -19,7 +18,7 @@ from a private container image registry or repository. There are many private
 registries in use. This task uses [Docker Hub](https://www.docker.com/products/docker-hub)
 as an example registry.
 -->
-本文介绍如何使用 {{< glossary_tooltip text="Secret" term_id="secret" >}} 
+本文介绍如何使用 {{< glossary_tooltip text="Secret" term_id="secret" >}}
 从私有的镜像仓库或代码仓库拉取镜像来创建 Pod。
 有很多私有镜像仓库正在使用中。这个任务使用的镜像仓库是
 [Docker Hub](https://www.docker.com/products/docker-hub)。
@@ -36,9 +35,8 @@ as an example registry.
 * If you are using a different private container registry, you need the command 
   line tool for that registry and any login information for the registry. 
 -->
-
-* 要进行此练习，你需要 `docker` 命令行工具和一个知道密码的 
-[Docker ID](https://docs.docker.com/docker-id/)。
+* 要进行此练习，你需要 `docker` 命令行工具和一个知道密码的
+  [Docker ID](https://docs.docker.com/docker-id/)。
 * 如果你要使用不同的私有的镜像仓库，你需要有对应镜像仓库的命令行工具和登录信息。
 
 <!-- steps -->
@@ -72,11 +70,10 @@ The login process creates or updates a `config.json` file that holds an authoriz
 
 View the `config.json` file:
 -->
-当出现提示时，输入你的 Docker ID 和登录凭证（访问令牌、
-或 Docker ID 的密码）。
+当出现提示时，输入你的 Docker ID 和登录凭据（访问令牌或 Docker ID 的密码）。
 
 登录过程会创建或更新保存有授权令牌的 `config.json` 文件。
-查看 [Kubernetes 中如何解析这个文件](/zh-cn/docs/concepts/containers/images#config-json)。
+查看 [Kubernetes 如何解析这个文件](/zh-cn/docs/concepts/containers/images#config-json)。
 
 查看 `config.json` 文件：
 
@@ -104,8 +101,9 @@ The output contains a section similar to this:
 If you use a Docker credentials store, you won't see that `auth` entry but a `credsStore` entry with the name of the store as value.
 In that case, you can create a secret directly. See [Create a Secret by providing credentials on the command line](#create-a-secret-by-providing-credentials-on-the-command-line).
 -->
-如果使用 Docker 凭证仓库，则不会看到 `auth` 条目，看到的将是以仓库名称作为值的 `credsStore` 条目。
-在这种情况下，你可以直接创建一个 Secret。请参阅[在命令行上提供凭证来创建 Secret](#create-a-secret-by-providing-credentials-on-the-command-line)。
+如果使用 Docker 凭据仓库，则不会看到 `auth` 条目，看到的将是以仓库名称作为值的 `credsStore` 条目。
+在这种情况下，你可以直接创建一个 Secret。
+请参阅[在命令行上提供凭据来创建 Secret](#create-a-secret-by-providing-credentials-on-the-command-line)。
 {{< /note >}}
 
 <!--
@@ -117,12 +115,12 @@ a container registry to pull a private image.
 If you already ran `docker login`, you can copy
 that credential into Kubernetes:
 -->
-## 创建一个基于现有凭证的 Secret  {#registry-secret-existing-credentials}
+## 创建一个基于现有凭据的 Secret  {#registry-secret-existing-credentials}
 
 Kubernetes 集群使用 `kubernetes.io/dockerconfigjson` 类型的
 Secret 来通过镜像仓库的身份验证，进而提取私有镜像。
 
-如果你已经运行了 `docker login` 命令，你可以复制该镜像仓库的凭证到 Kubernetes:
+如果你已经运行了 `docker login` 命令，你可以复制该镜像仓库的凭据到 Kubernetes:
 
 ```shell
 kubectl create secret generic regcred \
@@ -180,7 +178,7 @@ the base64 encoded string in the data was successfully decoded, but could not be
 
 Create this Secret, naming it `regcred`:
 -->
-## 在命令行上提供凭证来创建 Secret  {#create-a-secret-by-providing-credentials-on-the-command-line}
+## 在命令行上提供凭据来创建 Secret  {#create-a-secret-by-providing-credentials-on-the-command-line}
 
 创建 Secret，命名为 `regcred`：
 
@@ -214,15 +212,15 @@ You have successfully set your Docker credentials in the cluster as a Secret cal
 * `<your-pword>` 是你的 Docker 密码。
 * `<your-email>` 是你的 Docker 邮箱。
 
-这样你就成功地将集群中的 Docker 凭证设置为名为 `regcred` 的 Secret。
+这样你就成功地将集群中的 Docker 凭据设置为名为 `regcred` 的 Secret。
 
+{{< note >}}
 <!--
 Typing secrets on the command line may store them in your shell history unprotected, and
 those secrets might also be visible to other users on your PC during the time that
 `kubectl` is running.
 -->
-{{< note >}}
-在命令行上键入 Secret 可能会将它们存储在你的 shell 历史记录中而不受保护，
+在命令行上键入 Secret 可能会将它们存储在你的 Shell 历史记录中而不受保护，
 并且这些 Secret 信息也可能在 `kubectl` 运行期间对你 PC 上的其他用户可见。
 {{< /note >}}
 
@@ -246,8 +244,6 @@ The output is similar to this:
 
 ```yaml
 apiVersion: v1
-data:
-  .dockerconfigjson: eyJodHRwczovL2luZGV4L ... J0QUl6RTIifX0=
 kind: Secret
 metadata:
   ...
@@ -264,7 +260,7 @@ The value of the `.dockerconfigjson` field is a base64 representation of your Do
 To understand what is in the `.dockerconfigjson` field, convert the secret data to a
 readable format:
 -->
-`.dockerconfigjson` 字段的值是 Docker 凭证的 base64 表示。
+`.dockerconfigjson` 字段的值是 Docker 凭据的 base64 表示。
 
 要了解 `dockerconfigjson` 字段中的内容，请将 Secret 数据转换为可读格式：
 
@@ -306,7 +302,7 @@ You have successfully set your Docker credentials as a Secret called `regcred` i
 -->
 注意，Secret 数据包含与本地 `~/.docker/config.json` 文件类似的授权令牌。
 
-这样你就已经成功地将 Docker 凭证设置为集群中的名为 `regcred` 的 Secret。
+这样你就已经成功地将 Docker 凭据设置为集群中的名为 `regcred` 的 Secret。
 
 <!--
 ## Create a Pod that uses your Secret
@@ -315,7 +311,7 @@ Here is a manifest for an example Pod that needs access to your Docker credentia
 -->
 ## 创建一个使用你的 Secret 的 Pod  {#create-a-pod-that-uses-your-secret}
 
-下面是一个 Pod 配置清单示例，该示例中 Pod 需要访问你的 Docker 凭证 `regcred`：
+下面是一个 Pod 配置清单示例，该示例中 Pod 需要访问你的 Docker 凭据 `regcred`：
 
 {{< codenew file="pods/private-reg-pod.yaml" >}}
 
@@ -345,8 +341,8 @@ Kubernetes should get the credentials from a Secret named `regcred`.
 
 Create a Pod that uses your Secret, and verify that the Pod is running:
 -->
-要从私有仓库拉取镜像，Kubernetes 需要凭证。
-配置文件中的 `imagePullSecrets` 字段表明 Kubernetes 应该通过名为 `regcred` 的 Secret 获取凭证。
+要从私有仓库拉取镜像，Kubernetes 需要凭据。
+配置文件中的 `imagePullSecrets` 字段表明 Kubernetes 应该通过名为 `regcred` 的 Secret 获取凭据。
 
 创建使用了你的 Secret 的 Pod，并检查它是否正常运行：
 
@@ -354,6 +350,40 @@ Create a Pod that uses your Secret, and verify that the Pod is running:
 kubectl apply -f my-private-reg-pod.yaml
 kubectl get pod private-reg
 ```
+
+{{< note >}}
+<!--
+In case the Pod fails to start with the status `ImagePullBackOff`, view the Pod events:
+-->
+如果 Pod 以状态 `ImagePullBackOff` 启动失败，查看 Pod 事件：
+
+```shell
+kubectl describe pod private-reg
+```
+
+<!--
+If you then see an event with the reason set to `FailedToRetrieveImagePullSecret`,
+Kubernetes can't find a Secret with name (`regcred`, in this example).
+If you specify that a Pod needs image pull credentials, the kubelet checks that it can
+access that Secret before attempting to pull the image.
+-->
+如果你看到一个原因设为 `FailedToRetrieveImagePullSecret` 的事件，
+那么 Kubernetes 找不到指定名称（此例中为 `regcred`）的 Secret。
+如果你指定 Pod 需要拉取镜像凭据，kubelet 在尝试拉取镜像之前会检查是否可以访问该 Secret。
+
+<!--
+Make sure that the Secret you have specified exists, and that its name is spelled properly.
+-->
+确保你指定的 Secret 存在，并且其名称拼写正确。
+
+```shell
+Events:
+  ...  Reason                           ...  Message
+       ------                                -------
+  ...  FailedToRetrieveImagePullSecret  ...  Unable to retrieve some image pull secrets (<regcred>); attempting to pull the image may not succeed.
+```
+
+{{< /note >}}
 
 ## {{% heading "whatsnext" %}}
 
@@ -365,10 +395,9 @@ kubectl get pod private-reg
 * See [kubectl create secret docker-registry](/docs/reference/generated/kubectl/kubectl-commands/#-em-secret-docker-registry-em-).
 * See the `imagePullSecrets` field within the [container definitions](/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers) of a Pod
 -->
-
 * 进一步了解 [Secret](/zh-cn/docs/concepts/configuration/secret/)
   * 或阅读 {{< api-reference page="config-and-storage-resources/secret-v1" >}} 的 API 参考
 * 进一步了解[使用私有仓库](/zh-cn/docs/concepts/containers/images/#using-a-private-registry)
-* 进一步了解[为服务账户添加拉取镜像凭证](/zh-cn/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
-* 查看 [kubectl 创建 docker-registry 凭证](/docs/reference/generated/kubectl/kubectl-commands/#-em-secret-docker-registry-em-)
-* 查看 Pod [容器定义](/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers)中的 `imagePullSecrets` 字段。
+* 进一步了解[为服务账户添加拉取镜像凭据](/zh-cn/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
+* 查看 [kubectl 创建 docker-registry 凭据](/docs/reference/generated/kubectl/kubectl-commands/#-em-secret-docker-registry-em-)
+* 查看 Pod [容器定义](/zh-cn/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers)中的 `imagePullSecrets` 字段


### PR DESCRIPTION
Sync 2 files with en:

```
content/zh-cn/docs/setup/production-environment/tools/kops.md
content/zh-cn/docs/tasks/configure-pod-container/pull-image-private-registry.md
```
Also replaced `凭证` with `凭据` by following [glossary](https://kubernetes.io/zh-cn/docs/contribute/localization_zh/#glossary).

See [preview kops](https://deploy-preview-42006--kubernetes-io-main-staging.netlify.app/zh-cn/docs/setup/production-environment/tools/kops/) and [preview pull-image-private-registry](https://deploy-preview-42006--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/configure-pod-container/pull-image-private-registry/) please.