### PR TITLE
[ko] Update outdated contents (M32-M39)

### DIFF
--- a/content/ko/docs/concepts/overview/working-with-objects/annotations.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/annotations.md
@@ -6,8 +6,8 @@ weight: 60
 
 <!-- overview -->
 쿠버네티스 어노테이션을 사용하여 임의의 비-식별 메타데이터를
-오브젝트에 첨부할 수 있다. 도구 및 라이브러리와 같은 클라이언트는 이 메타데이터를 검색할 수 있다.
-
+{{< glossary_tooltip text="오브젝트" term_id="object" >}}에 첨부할 수 있다.
+도구 및 라이브러리와 같은 클라이언트는 이 메타데이터를 검색할 수 있다.
 
 <!-- body -->
 ## 오브젝트에 메타데이터 첨부
@@ -74,10 +74,9 @@ _어노테이션_ 은 키/값 쌍이다. 유효한 어노테이션 키에는 두
 
 `kubernetes.io/`와 `k8s.io/` 접두사는 쿠버네티스 핵심 구성 요소를 위해 예약되어 있다.
 
-다음은 `imageregistry: https://hub.docker.com/` 어노테이션이 있는 파드의 구성 파일 예시이다.
+다음은 `imageregistry: https://hub.docker.com/` 어노테이션이 있는 파드 매니페스트의 예시이다.
 
 ```yaml
-
 apiVersion: v1
 kind: Pod
 metadata:
@@ -90,14 +89,8 @@ spec:
     image: nginx:1.14.2
     ports:
     - containerPort: 80
-
 ```
-
-
 
 ## {{% heading "whatsnext" %}}
 
 [레이블과 셀렉터](/ko/docs/concepts/overview/working-with-objects/labels/)에 대해 알아본다.
-
-
-

--- a/content/ko/docs/concepts/overview/working-with-objects/common-labels.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/common-labels.md
@@ -37,7 +37,7 @@ kubectl과 대시보드와 같은 많은 도구들로 쿠버네티스 오브젝�
 | ----------------------------------- | --------------------- | -------- | ---- |
 | `app.kubernetes.io/name`            | 애플리케이션 이름 | `mysql` | 문자열 |
 | `app.kubernetes.io/instance`        | 애플리케이션의 인스턴스를 식별하는 고유한 이름 | `mysql-abcxzy` | 문자열 |
-| `app.kubernetes.io/version`         | 애플리케이션의 현재 버전 (예: a semantic version, revision hash 등.) | `5.7.21` | 문자열 |
+| `app.kubernetes.io/version`         | 애플리케이션의 현재 버전 (예: [SemVer 1.0](https://semver.org/spec/v1.0.0.html), revision hash 등.) | `5.7.21` | 문자열 |
 | `app.kubernetes.io/component`       | 아키텍처 내 구성요소 | `database` | 문자열 |
 | `app.kubernetes.io/part-of`         | 이 애플리케이션의 전체 이름 | `wordpress` | 문자열 |
 | `app.kubernetes.io/managed-by`      | 애플리케이션의 작동을 관리하는 데 사용되는 도구 | `helm` | 문자열 |

--- a/content/ko/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -4,7 +4,8 @@ content_type: concept
 weight: 70
 ---
 
-_필드 셀렉터_ 는 한 개 이상의 리소스 필드 값에 따라 [쿠버네티스 리소스를 선택](/ko/docs/concepts/overview/working-with-objects/kubernetes-objects/)하기 위해 사용된다. 필드 셀렉터 쿼리의 예시는 다음과 같다.
+_필드 셀렉터_ 는 한 개 이상의 리소스 필드 값에 따라 쿠버네티스 {{< glossary_tooltip text="오브젝트" term_id="object" >}}를 선택하기 위해 사용된다. 
+필드 셀렉터 쿼리의 예시는 다음과 같다.
 
 * `metadata.name=my-service`
 * `metadata.namespace!=default`

--- a/content/ko/docs/concepts/overview/working-with-objects/finalizers.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/finalizers.md
@@ -10,7 +10,7 @@ weight: 80
 
 파이널라이저(Finalizer)를 사용하면 리소스를 삭제하기 전 특정 정리 작업을 수행하도록
 {{<glossary_tooltip term_id="controller">}}에 경고하여
-리소스의 {{<glossary_tooltip term_id="garbage-collection">}}을 제어할 수 있다.
+{{< glossary_tooltip text="오브젝트" term_id="object" >}}의 {{<glossary_tooltip term_id="garbage-collection">}}을 제어할 수 있다.
 
 파이널라이저는 보통 실행할 코드를 지정하지 않는다.
 대신 파이널라이저는 일반적으로 어노테이션과 비슷하게 특정 리소스에 대한 키들의 목록이다.

--- a/content/ko/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/labels.md
@@ -8,10 +8,14 @@ weight: 40
 
 <!-- overview -->
 
-_레이블_ 은 파드와 같은 오브젝트에 첨부된 키와 값의 쌍이다.
-레이블은 오브젝트의 특성을 식별하는 데 사용되어 사용자에게 중요하지만, 코어 시스템에 직접적인 의미는 없다.
-레이블로 오브젝트의 하위 집합을 선택하고, 구성하는데 사용할 수 있다. 레이블은 오브젝트를 생성할 때에 붙이거나 생성 이후에 붙이거나 언제든지 수정이 가능하다.
-오브젝트마다 키와 값으로 레이블을 정의할 수 있다. 오브젝트의 키는 고유한 값이어야 한다.
+_레이블_ 은 파드와 같은 {{< glossary_tooltip text="오브젝트" term_id="object" >}}에 첨부된 
+키와 값의 쌍이다. 레이블은 오브젝트의 특성을 식별하는 데 사용되어 사용자에게 중요하지만, 
+코어 시스템에 직접적인 의미는 없다. 
+레이블로 오브젝트의 하위 집합을 선택하고, 구성하는데 사용할 수 있다. 
+레이블은 오브젝트를 생성할 때에 붙이거나 생성 이후에 붙이거나 
+언제든지 수정이 가능하다. 
+오브젝트마다 키와 값으로 레이블을 정의할 수 있다. 
+오브젝트의 키는 고유한 값이어야 한다.
 
 ```json
 "metadata": {
@@ -30,37 +34,56 @@ _레이블_ 은 파드와 같은 오브젝트에 첨부된 키와 값의 쌍이�
 
 ## 사용 동기
 
-레이블을 이용하면 사용자가 느슨하게 결합한 방식으로 조직 구조와 시스템 오브젝트를 매핑할 수 있으며, 클라이언트에 매핑 정보를 저장할 필요가 없다.
+레이블을 이용하면 사용자가 느슨하게 결합한 방식으로 조직 구조와 시스템 오브젝트를 매핑할 수 있으며, 
+클라이언트에 매핑 정보를 저장할 필요가 없다.
 
-서비스 배포와 배치 프로세싱 파이프라인은 흔히 다차원의 엔티티들이다(예: 다중 파티션 또는 배포, 다중 릴리스 트랙, 다중 계층, 계층 속 여러 마이크로 서비스들). 관리에는 크로스-커팅 작업이 필요한 경우가 많은데 이 작업은 사용자보다는 인프라에 의해 결정된 엄격한 계층 표현인 캡슐화를 깨트린다.
+서비스 배포와 배치 프로세싱 파이프라인은 
+흔히 다차원의 엔티티들이다(예: 다중 파티션 또는 배포, 다중 릴리스 트랙, 다중 계층, 계층 속 여러 마이크로 서비스들). 
+관리에는 크로스-커팅 작업이 필요한 경우가 많은데 
+이 작업은 사용자보다는 인프라에 의해 결정된 
+엄격한 계층 표현인 캡슐화를 깨트린다.
 
 레이블 예시:
 
-   * `"release" : "stable"`, `"release" : "canary"`
-   * `"environment" : "dev"`, `"environment" : "qa"`, `"environment" : "production"`
-   * `"tier" : "frontend"`, `"tier" : "backend"`, `"tier" : "cache"`
-   * `"partition" : "customerA"`, `"partition" : "customerB"`
-   * `"track" : "daily"`, `"track" : "weekly"`
+* `"release" : "stable"`, `"release" : "canary"`
+* `"environment" : "dev"`, `"environment" : "qa"`, `"environment" : "production"`
+* `"tier" : "frontend"`, `"tier" : "backend"`, `"tier" : "cache"`
+* `"partition" : "customerA"`, `"partition" : "customerB"`
+* `"track" : "daily"`, `"track" : "weekly"`
 
-이 예시는 [일반적으로 사용하는 레이블](/ko/docs/concepts/overview/working-with-objects/common-labels/)이며, 사용자는 자신만의 규칙(convention)에 따라 자유롭게 개발할 수 있다. 오브젝트에 붙여진 레이블 키는 고유해야 한다는 것을 기억해야 한다.
+이 예시는 
+[일반적으로 사용하는 레이블](/ko/docs/concepts/overview/working-with-objects/common-labels/)이며, 
+사용자는 자신만의 규칙(convention)에 따라 자유롭게 개발할 수 있다. 
+오브젝트에 붙여진 레이블 키는 고유해야 한다는 것을 기억해야 한다.
 
 ## 구문과 캐릭터 셋
 
-_레이블_ 은 키와 값의 쌍이다. 유효한 레이블 키에는 슬래시(`/`)로 구분되는 선택한 접두사와 이름이라는 2개의 세그먼트가 있다. 이름 세그먼트는 63자 미만으로 시작과 끝은 알파벳과 숫자(`[a-z0-9A-Z]`)이며, 대시(`-`), 밑줄(`_`), 점(`.`)과 함께 사용할 수 있다. 접두사는 선택이다. 만약 접두사를 지정한 경우 접두사는 DNS의 하위 도메인으로 해야 하며, 점(`.`)과 전체 253자 이하, 슬래시(`/`)로 구분되는 DNS 레이블이다.
+_레이블_ 은 키와 값의 쌍이다. 
+유효한 레이블 키에는 슬래시(`/`)로 구분되는 선택한 접두사와 이름이라는 2개의 세그먼트가 있다. 
+이름 세그먼트는 63자 미만으로 시작과 끝은 알파벳과 숫자(`[a-z0-9A-Z]`)이며, 
+대시(`-`), 밑줄(`_`), 점(`.`)과 함께 사용할 수 있다. 
+접두사는 선택이다. 
+만약 접두사를 지정한 경우 접두사는 DNS의 하위 도메인으로 해야 하며, 
+점(`.`)과 전체 253자 이하, 슬래시(`/`)로 구분되는 DNS 레이블이다.
 
-접두사를 생략하면 키 레이블은 개인용으로 간주한다. 최종 사용자의 오브젝트에 자동화된 시스템 컴포넌트(예: `kube-scheduler`, `kube-controller-manager`, `kube-apiserver`, `kubectl` 또는 다른 타사의 자동화 구성 요소)의 접두사를 지정해야 한다.
+접두사를 생략하면 키 레이블은 개인용으로 간주한다. 
+최종 사용자의 오브젝트에 자동화된 시스템 컴포넌트(예: 
+`kube-scheduler`, `kube-controller-manager`, `kube-apiserver`, 
+`kubectl` 또는 다른 타사의 자동화 구성 요소)의 접두사를 지정해야 한다.
 
-`kubernetes.io/`와 `k8s.io/` 접두사는 쿠버네티스의 핵심 컴포넌트로 [예약](/ko/docs/reference/labels-annotations-taints/)되어 있다.
+`kubernetes.io/`와 `k8s.io/` 접두사는 
+쿠버네티스의 핵심 컴포넌트로 [예약](/ko/docs/reference/labels-annotations-taints/)되어 있다.
 
 유효한 레이블 값은 다음과 같다.
+
 * 63 자 이하여야 하고 (공백일 수도 있음),
 * (공백이 아니라면) 시작과 끝은 알파벳과 숫자(`[a-z0-9A-Z]`)이며,
 * 알파벳과 숫자, 대시(`-`), 밑줄(`_`), 점(`.`)을 중간에 포함할 수 있다.
 
-다음의 예시는 파드에 `environment: production` 과 `app: nginx` 2개의 레이블이 있는 구성 파일이다.
+다음의 예시는 파드에 `environment: production` 과 `app: nginx` 
+2개의 레이블이 있는 매니페스트이다.
 
 ```yaml
-
 apiVersion: v1
 kind: Pod
 metadata:
@@ -74,34 +97,43 @@ spec:
     image: nginx:1.14.2
     ports:
     - containerPort: 80
-
 ```
 
 ## 레이블 셀렉터
 
-[이름과 UID](/ko/docs/concepts/overview/working-with-objects/names/)와 다르게 레이블은 고유하지 않다. 일반적으로 우리는 많은 오브젝트에 같은 레이블을 가질 것으로 예상한다.
+[이름과 UID](/ko/docs/concepts/overview/working-with-objects/names/)와 다르게 레이블은 고유하지 않다. 
+일반적으로 우리는 많은 오브젝트에 같은 레이블을 가질 것으로 예상한다.
 
-레이블 셀렉터를 통해 클라이언트와 사용자는 오브젝트를 식별할 수 있다. 레이블 셀렉터는 쿠버네티스 코어 그룹의 기본이다.
+레이블 셀렉터를 통해 클라이언트와 사용자는 오브젝트를 식별할 수 있다. 
+레이블 셀렉터는 쿠버네티스 코어 그룹의 기본이다.
 
 API는 현재 _일치성 기준_ 과 _집합성 기준_ 이라는 두 종류의 셀렉터를 지원한다.
-레이블 셀렉터는 쉼표로 구분된 다양한 _요구사항_ 에 따라 만들 수 있다. 다양한 요구사항이 있는 경우 쉼표 기호가 AND(`&&`) 연산자로 구분되는 역할을 하도록 해야 한다.
+레이블 셀렉터는 쉼표로 구분된 다양한 _요구사항_ 에 따라 만들 수 있다. 
+다양한 요구사항이 있는 경우 쉼표 기호가 
+AND(`&&`) 연산자로 구분되는 역할을 하도록 해야 한다.
 
 비어있거나 지정되지 않은 셀렉터는 상황에 따라 달라진다.
 셀렉터를 사용하는 API 유형은 유효성과 의미를
 문서화해야 한다.
 
 {{< note >}}
-레플리카셋(ReplicaSet)과 같은 일부 API 유형에서 두 인스턴스의 레이블 셀렉터는 네임스페이스 내에서 겹치지 않아야 한다. 그렇지 않으면 컨트롤러는 상충하는 명령으로 보고, 얼마나 많은 복제본이 필요한지 알 수 없다.
+레플리카셋(ReplicaSet)과 같은 일부 API 유형에서 
+두 인스턴스의 레이블 셀렉터는 네임스페이스 내에서 겹치지 않아야 한다. 
+그렇지 않으면 컨트롤러는 상충하는 명령으로 보고, 얼마나 많은 복제본이 필요한지 알 수 없다.
 {{< /note >}}
 
 {{< caution >}}
-일치성 기준과 집합성 기준 조건 모두에 대해 논리적인 _OR_ (`||`) 연산자가 없다. 필터 구문이 적절히 구성되어 있는지 확인해야 한다.
+일치성 기준과 집합성 기준 조건 모두에 대해 논리적 _OR_ (`||`) 연산자는 없다. 
+필터 구문이 적절히 구성되어 있는지 확인해야 한다.
 {{< /caution >}}
 
 ### _일치성 기준_ 요건
 
-_일치성 기준_ 또는 _불일치 기준_ 의 요구사항으로 레이블의 키와 값의 필터링을 허용한다. 일치하는 오브젝트는 추가 레이블을 가질 수 있지만, 레이블의 명시된 제약 조건을 모두 만족해야 한다.
-`=`,`==`,`!=` 이 세 가지 연산자만 허용한다. 처음 두 개의 연산자의 _일치성_(그리고 동의어), 나머지는 _불일치_ 를 의미한다. 예를 들면,
+_일치성 기준_ 또는 _불일치 기준_ 의 요구사항으로 레이블의 키와 값의 필터링을 허용한다. 
+일치하는 오브젝트는 추가 레이블을 가질 수 있지만, 레이블의 명시된 제약 조건을 모두 만족해야 한다.
+`=`,`==`,`!=` 이 세 가지 연산자만 허용한다. 
+처음 두 개의 연산자의 _일치성_(그리고 동의어), 나머지는 _불일치_ 를 의미한다. 
+예를 들면,
 
 ```
 environment = production
@@ -109,7 +141,8 @@ tier != frontend
 ```
 
 전자는 `environment`를 키로 가지는 것과 `production`을 값으로 가지는 모든 리소스를 선택한다.
-후자는 `tier`를 키로 가지고, 값을 `frontend`를 가지는 리소스를 제외한 모든 리소스를 선택하고, `tier`를 키로 가지며, 값을 공백으로 가지는 모든 리소스를 선택한다.
+후자는 `tier`를 키로 가지고, 값을 `frontend`를 가지는 리소스를 제외한 모든 리소스를 선택하고, 
+`tier`를 키로 가지며, 값을 공백으로 가지는 모든 리소스를 선택한다.
 `environment=production,tier!=frontend` 처럼 쉼표를 통해 한 문장으로 `frontend`를 제외한 `production`을 필터링할 수 있다.
 
 일치성 기준 레이블 요건에 대한 하나의 이용 시나리오는 파드가 노드를 선택하는 기준을 지정하는 것이다.
@@ -134,7 +167,9 @@ spec:
 
 ### _집합성 기준_ 요건
 
-_집합성 기준_ 레이블 요건에 따라 값 집합을 키로 필터링할 수 있다. `in`,`notin`과 `exists`(키 식별자만 해당)의 3개의 연산자를 지원한다. 예를 들면,
+_집합성 기준_ 레이블 요건에 따라 값 집합을 키로 필터링할 수 있다. 
+`in`,`notin`과 `exists`(키 식별자만 해당)의 3개의 연산자를 지원한다. 
+예를 들면,
 
 ```
 environment in (production, qa)
@@ -143,27 +178,38 @@ partition
 !partition
 ```
 
-* 첫 번째 예시에서 키가 `environment`이고 값이 `production` 또는 `qa`인 모든 리소스를 선택한다.
-* 두 번째 예시에서 키가 `tier`이고 값이 `frontend`와 `backend`를 가지는 리소스를 제외한 모든 리소스와 키로 `tier`를 가지고 값을 공백으로 가지는 모든 리소스를 선택한다.
-* 세 번째 예시에서 레이블의 값에 상관없이 키가 `partition`을 포함하는 모든 리소스를 선택한다.
-* 네 번째 예시에서 레이블의 값에 상관없이 키가 `partition`을 포함하지 않는 모든 리소스를 선택한다.
+- 첫 번째 예시는 키가 `environment`이고 
+  값이 `production` 또는 `qa`인 레이블이 있는 모든 리소스를 선택한다.
+- 두 번째 예시는 키가 `tier`이면서 값이 `frontend`와 `backend` 외의 것인 레이블이 있는 모든 리소스와, 
+  `tier` 키가 있는 레이블을 포함하지 않는 모든 리소스를 선택한다.
+- 세 번째 예시는 레이블의 값에 상관없이, 
+  `partition` 키가 있는 레이블을 포함하는 모든 리소스를 선택한다.
+- 네 번째 예시는 레이블의 값에 상관없이, 
+  `partition` 키가 있는 레이블을 포함하지 않는 모든 리소스를 선택한다.
 
-마찬가지로 쉼표는 _AND_ 연산자로 작동한다. 따라서 `partition,environment notin (qa)`와 같이 사용하면 값과 상관없이 키가 `partition`인 것과 키가 `environment`이고 값이 `qa`와 다른 리소스를 필터링할 수 있다.
-_집합성 기준_ 레이블 셀렉터는 일반적으로 `environment=production`과 `environment in (production)`을 같은 것으로 본다. 유사하게는 `!=`과 `notin`을 같은 것으로 본다.
+마찬가지로 쉼표는 _AND_ 연산자로 작동한다. 
+따라서 `partition,environment notin (qa)`와 같이 사용하면 
+값과 상관없이 키가 `partition`인 것과 
+키가 `environment`이고 값이 `qa`와 다른 리소스를 필터링할 수 있다.
+_집합성 기준_ 레이블 셀렉터는 일반적으로 `environment=production`과 `environment in (production)`을 같은 것으로 본다.
+유사하게는 `!=`과 `notin`을 같은 것으로 본다.
 
-_집합성 기준_ 요건은 _일치성 기준_ 요건과 조합해서 사용할 수 있다. 예를 들어 `partition in (customerA, customerB),environment!=qa`
-
+_집합성 기준_ 요건은 _일치성 기준_ 요건과 조합해서 사용할 수 있다. 
+예를 들어 `partition in (customerA, customerB),environment!=qa`
 
 ## API
 
 ### LIST와 WATCH 필터링
 
-LIST와 WATCH 작업은 쿼리 파라미터를 사용해서 반환되는 오브젝트 집합을 필터링하기 위해 레이블 셀렉터를 지정할 수 있다. 다음의 두 가지 요건 모두 허용된다(URL 쿼리 문자열을 그대로 표기함).
+LIST와 WATCH 작업은 반환되는 오브젝트 집합을 필터링하기 위해 
+쿼리 파라미터를 사용하여 레이블 셀렉터를 지정할 수 있다. 
+다음의 두 가지 요건 모두 허용된다(URL 쿼리 문자열을 그대로 표기함).
 
-  * _일치성 기준_ 요건: `?labelSelector=environment%3Dproduction,tier%3Dfrontend`
-  * _집합성 기준_ 요건: `?labelSelector=environment+in+%28production%2Cqa%29%2Ctier+in+%28frontend%29`
+* _일치성 기준_ 요건: `?labelSelector=environment%3Dproduction,tier%3Dfrontend`
+* _집합성 기준_ 요건: `?labelSelector=environment+in+%28production%2Cqa%29%2Ctier+in+%28frontend%29`
 
-두 가지 레이블 셀렉터 스타일은 모두 REST 클라이언트를 통해 선택된 리소스를 확인하거나 목록을 볼 수 있다. 예를 들어, `kubectl`로 `apiserver`를 대상으로 _일치성 기준_ 으로 하는 셀렉터를 다음과 같이 이용할 수 있다.
+두 가지 레이블 셀렉터 스타일은 모두 REST 클라이언트를 통해 선택된 리소스를 확인하거나 목록을 볼 수 있다. 
+예를 들어, `kubectl`로 `apiserver`를 대상으로 _일치성 기준_ 으로 하는 셀렉터를 다음과 같이 이용할 수 있다.
 
 ```shell
 kubectl get pods -l environment=production,tier=frontend
@@ -175,13 +221,14 @@ kubectl get pods -l environment=production,tier=frontend
 kubectl get pods -l 'environment in (production),tier in (frontend)'
 ```
 
-앞서 안내한 것처럼 _집합성 기준_ 요건은 더 보여준다. 예시에서 다음과 같이 OR 연산자를 구현할 수 있다.
+앞서 안내한 것처럼 _집합성 기준_ 요건이 더 표현적(expressive)이다. 
+예를 들어, 다음과 같이 OR 연산자를 구현할 수 있다.
 
 ```shell
 kubectl get pods -l 'environment in (production, qa)'
 ```
 
-또는 _exists_ 연산자에 불일치한 것으로 제한할 수 있다.
+또는 _notin_ 연산자를 사용하여 불일치하는 것으로 제한할 수 있다.
 
 ```shell
 kubectl get pods -l 'environment,environment notin (frontend)'
@@ -196,23 +243,28 @@ kubectl get pods -l 'environment,environment notin (frontend)'
 
 #### 서비스와 레플리케이션 컨트롤러
 
-`services`에서 지정하는 파드 집합은 레이블 셀렉터로 정의한다. 마찬가지로 `replicationcontrollers`가 관리하는 파드의 오브젝트 그룹도 레이블 셀렉터로 정의한다.
+`services`에서 지정하는 파드 집합은 레이블 셀렉터로 정의한다. 
+마찬가지로 `replicationcontrollers`가 관리하는 파드의 오브젝트 그룹도 
+레이블 셀렉터로 정의한다.
 
-서비스와 레플리케이션 컨트롤러의 레이블 셀렉터는 `json` 또는 `yaml` 파일에 매핑된 _일치성 기준_ 요구사항의 셀렉터만 지원한다.
+서비스와 레플리케이션 컨트롤러의 레이블 셀렉터는 매핑을 사용하여 `json` 또는 `yaml` 파일에 정의되어 있으며,
+_일치성 기준_ 요구사항의 셀렉터만 지원한다.
 
 ```json
 "selector": {
     "component" : "redis",
 }
 ```
-or
+
+또는
 
 ```yaml
 selector:
-    component: redis
+  component: redis
 ```
 
-`json` 또는 `yaml` 서식에서 셀렉터는 `component=redis` 또는 `component in (redis)` 모두 같은 것이다.
+(`json` 또는 `yaml` 형식의) 셀렉터는 
+`component=redis` 또는 `component in (redis)` 와 동일하다.
 
 #### 세트-기반 요건을 지원하는 리소스
 
@@ -227,13 +279,29 @@ selector:
   matchLabels:
     component: redis
   matchExpressions:
-    - {key: tier, operator: In, values: [cache]}
-    - {key: environment, operator: NotIn, values: [dev]}
+    - { key: tier, operator: In, values: [cache] }
+    - { key: environment, operator: NotIn, values: [dev] }
 ```
 
-`matchLabels`는 `{key,value}`의 쌍과 매칭된다. `matchLabels`에 매칭된 단일 `{key,value}`는 `matchExpressions`의 요소와 같으며 `key` 필드는 "key"로, `operator`는 "In" 그리고 `values`에는 "value"만 나열되어 있다. `matchExpressions`는 파드 셀렉터의 요건 목록이다. 유효한 연산자에는 In, NotIn, Exists 및 DoNotExist가 포함된다. In 및 NotIn은 설정된 값이 있어야 한다. `matchLabels`와 `matchExpressions` 모두 AND로 되어 있어 일치하기 위해서는 모든 요건을 만족해야 한다.
+`matchLabels`는 `{key,value}`의 쌍과 매칭된다. 
+`matchLabels`에 매칭된 단일 `{key,value}`는 `matchExpressions`의 요소와 같으며 
+`key` 필드는 "key"로, `operator`는 "In" 그리고 `values`에는 "value"만 나열되어 있다. 
+`matchExpressions`는 파드 셀렉터의 요건 목록이다. 
+유효한 연산자에는 In, NotIn, Exists 및 DoNotExist가 포함된다. 
+In 및 NotIn은 설정된 값이 있어야 한다. 
+`matchLabels`와 `matchExpressions` 모두 AND로 되어 있어 일치하기 위해서는 모든 요건을 만족해야 한다.
 
 #### 노드 셋 선택
 
 레이블을 통해 선택하는 사용 사례 중 하나는 파드를 스케줄 할 수 있는 노드 셋을 제한하는 것이다.
-자세한 내용은 [노드 선택](/ko/docs/concepts/scheduling-eviction/assign-pod-node/) 문서를 참조한다.
+자세한 내용은 
+[노드 선택](/ko/docs/concepts/scheduling-eviction/assign-pod-node/) 문서를 참조한다.
+
+## {{% heading "whatsnext" %}}
+
+- [노드에 레이블을 추가](/ko/docs/tasks/configure-pod-container/assign-pods-nodes/#노드에-레이블-추가)하는 방법 알아보기
+- [잘 알려진 레이블, 어노테이션, 테인트](/ko/docs/reference/labels-annotations-taints/) 살펴보기
+- [권장 레이블](/ko/docs/concepts/overview/working-with-objects/common-labels/) 살펴보기
+- [네임스페이스 레이블을 사용하여 파드 시큐리티 스탠다드 적용하기](/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/)
+- [레이블을 효과적으로 사용](/ko/docs/concepts/cluster-administration/manage-deployment/#효과적인-레이블-사용)하여 디플로이먼트 관리하기.
+- [파드 레이블을 위한 컨트롤러 만들기](/blog/2021/06/21/writing-a-controller-for-pod-labels/)에 대한 블로그 글 읽기

--- a/content/ko/docs/concepts/overview/working-with-objects/names.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/names.md
@@ -9,7 +9,7 @@ weight: 30
 
 <!-- overview -->
 
-클러스터의 각 오브젝트는 해당 유형의 리소스에 대하여 고유한 [_이름_](#names) 을 가지고 있다.
+클러스터의 각 {{< glossary_tooltip text="오브젝트" term_id="object" >}}는 해당 유형의 리소스에 대하여 고유한 [_이름_](#names) 을 가지고 있다.
 또한, 모든 쿠버네티스 오브젝트는 전체 클러스터에 걸쳐 고유한 [_UID_](#uids) 를 가지고 있다.
 
 예를 들어, 이름이 `myapp-1234`인 파드는 동일한 [네임스페이스](/ko/docs/concepts/overview/working-with-objects/namespaces/) 내에서 하나만 존재할 수 있지만, 이름이 `myapp-1234`인 파드와 디플로이먼트는 각각 존재할 수 있다.
@@ -23,6 +23,10 @@ weight: 30
 ## 이름 {#names}
 
 {{< glossary_definition term_id="name" length="all" >}}
+
+**이름은 해당 리소스의 모든 [API 버전](/ko/docs/concepts/overview/kubernetes-api/#api-그룹과-버전-규칙)에 대해 유일해야 한다. 
+각 API 리소스는 API 그룹, 리소스 종류, 네임스페이스(네임스페이스에 속하는 리소스에 한함), 이름의 조합으로 구별된다. 
+즉. API 버전으로는 구별할 수 없다.**
 
 {{< note >}}
 물리적 호스트를 나타내는 노드와 같이 오브젝트가 물리적 엔티티를 나타내는 경우, 노드를 삭제한 후 다시 생성하지 않은 채 동일한 이름으로 호스트를 다시 생성하면, 쿠버네티스는 새 호스트를 불일치로 이어질 수 있는 이전 호스트로 취급한다.

--- a/content/ko/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/namespaces.md
@@ -10,7 +10,7 @@ weight: 45
 
 <!-- overview -->
 
-쿠버네티스에서, _네임스페이스_ 는 단일 클러스터 내에서의 리소스 그룹 격리 메커니즘을 제공한다. 리소스의 이름은 네임스페이스 내에서 유일해야 하며, 네임스페이스 간에서 유일할 필요는 없다. 네임스페이스 기반 스코핑은 네임스페이스 기반 오브젝트 _(예: 디플로이먼트, 서비스 등)_ 에만 적용 가능하며 클러스터 범위의 오브젝트 _(예: 스토리지클래스, 노드, 퍼시스턴트볼륨 등)_ 에는 적용 불가능하다.
+쿠버네티스에서, _네임스페이스_ 는 단일 클러스터 내에서의 리소스 그룹 격리 메커니즘을 제공한다. 리소스의 이름은 네임스페이스 내에서 유일해야 하며, 네임스페이스 간에서 유일할 필요는 없다. 네임스페이스 기반 스코핑은 네임스페이스 기반 {{< glossary_tooltip text="오브젝트" term_id="object" >}} _(예: 디플로이먼트, 서비스 등)_ 에만 적용 가능하며 클러스터 범위의 오브젝트 _(예: 스토리지클래스, 노드, 퍼시스턴트볼륨 등)_ 에는 적용 불가능하다.
 
 <!-- body -->
 
@@ -44,7 +44,7 @@ weight: 45
 : 쿠버네티스에는 이 네임스페이스가 포함되어 있으므로 먼저 네임스페이스를 생성하지 않고도 새 클러스터를 사용할 수 있다.
 
 `kube-node-lease`
-: 이 네임스페이스는 각 노드와 연관된 [리스](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) 오브젝트를 갖는다. 노드 리스는 kubelet이 [하트비트](/ko/docs/concepts/architecture/nodes/#하트비트)를 보내서 컨트롤 플레인이 노드의 장애를 탐지할 수 있게 한다.
+: 이 네임스페이스는 각 노드와 연관된 [리스](/ko/docs/concepts/architecture/leases/) 오브젝트를 갖는다. 노드 리스는 kubelet이 [하트비트](/ko/docs/concepts/architecture/nodes/#하트비트)를 보내서 컨트롤 플레인이 노드의 장애를 탐지할 수 있게 한다.
 
 `kube-public`
 : 이 네임스페이스는 **모든** 클라이언트(인증되지 않은 클라이언트 포함)가 읽기 권한으로 접근할 수 있다. 이 네임스페이스는 주로 전체 클러스터 중에 공개적으로 드러나서 읽을 수 있는 리소스를 위해 예약되어 있다. 이 네임스페이스의 공개적인 성격은 단지 관례이지 요구 사항은 아니다.
@@ -146,7 +146,7 @@ kubectl api-resources --namespaced=false
 
 ## 자동 레이블링
 
-{{< feature-state state="beta" for_k8s_version="1.21" >}}
+{{< feature-state for_k8s_version="1.22" state="stable" >}}
 
 쿠버네티스 컨트롤 플레인은 `NamespaceDefaultLabelName` [기능 게이트](/ko/docs/reference/command-line-tools-reference/feature-gates/)가
 활성화된 경우 모든 네임스페이스에 변경할 수 없는(immutable) {{< glossary_tooltip text="레이블" term_id="label" >}}

--- a/content/ko/docs/concepts/overview/working-with-objects/object-management.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/object-management.md
@@ -5,7 +5,7 @@ weight: 20
 ---
 
 <!-- overview -->
-`kubectl` 커맨드라인 툴은 쿠버네티스 오브젝트를 생성하고 관리하기 위한
+`kubectl` 커맨드라인 툴은 쿠버네티스 {{< glossary_tooltip text="오브젝트" term_id="object" >}}를 생성하고 관리하기 위한
 몇 가지 상이한 방법을 지원한다. 이 문서는 여러가지 접근법에 대한 개요를
 제공한다. Kubectl로 오브젝트 관리하기에 대한 자세한 설명은
 [Kubectl 서적](https://kubectl.docs.kubernetes.io)에서 확인한다.


### PR DESCRIPTION
Related comment: https://github.com/kubernetes/website/issues/41631#issuecomment-1635116260

Upstream (English) issue: #39576

> * [ ]  M32.  `content/en/docs/concepts/overview/working-with-objects/annotations.md`  | 3(+XS) 10(-)
> * [ ]  M33.  `content/en/docs/concepts/overview/working-with-objects/common-labels.md`  | 1(+XS) 2(-)
> * [ ]  M34.  `content/en/docs/concepts/overview/working-with-objects/field-selectors.md`  | 2(+XS) 1(-)
> * [ ]  M35.  `content/en/docs/concepts/overview/working-with-objects/finalizers.md`  | 2(+XS) 2(-)
> * [ ]  **M36.**  `content/en/docs/concepts/overview/working-with-objects/labels.md`  | **121(+L) 53(-)**
> * [ ]  M37.  `content/en/docs/concepts/overview/working-with-objects/names.md`  | 5(+XS) 1(-)
> * [ ]  M38.  `content/en/docs/concepts/overview/working-with-objects/namespaces.md`  | 3(+XS) 3(-)
> * [ ]  M39.  `content/en/docs/concepts/overview/working-with-objects/object-management.md`  | 1(+XS) 1(-)