### PR TITLE
Update package manager instructions with community-hosted repos

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -76,9 +76,8 @@ Install a {{< glossary_tooltip term_id="container-runtime" text="container runti
 For detailed instructions and other prerequisites, see [Installing kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
 
 {{< note >}}
-If you have already installed kubeadm, run
-`apt-get update && apt-get upgrade` or
-`yum update` to get the latest version of kubeadm.
+If you have already installed kubeadm, see the first two steps of the
+[Upgrading Linux nodes](/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes) document for instructions on how to upgrade kubeadm.
 
 When you upgrade, the kubelet restarts every few seconds as it waits in a crashloop for
 kubeadm to tell it what to do. This crashloop is expected and normal.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -161,8 +161,6 @@ There are some important considerations for the Kubernetes package repositories:
   When upgrading to to a different minor release, you must bear in mind that
   the package repository details also change.
 
-To learn more, you can read the official announcement ["pkgs.k8s.io: Introducing
-Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 {{< /note >}}
 
 {{< tabs name="k8s_install" >}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -162,7 +162,7 @@ There are some important considerations for the Kubernetes package repositories:
   the package repository details also change.
 
 To learn more, you can read the official announcement ["pkgs.k8s.io: Introducing
-Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
+Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 {{< /note >}}
 
 {{< tabs name="k8s_install" >}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -162,7 +162,7 @@ There are some important considerations for the Kubernetes package repositories:
   the package repository details also change.
 
 To learn more, you can read the official announcement ["pkgs.k8s.io: Introducing
-Kubernetes community-owned package repositories"](TBD).
+Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
 {{< /note >}}
 
 {{< tabs name="k8s_install" >}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -190,7 +190,7 @@ These instructions are for Kubernetes {{< skew currentVersion >}}.
 
    ```shell
    # This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
-   echo 'deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
 4. Update the `apt` package index, install kubelet, kubeadm and kubectl, and pin their version:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -12,14 +12,14 @@ repositories, the Kubernetes package repositories are structured in a way that
 there's a dedicated package repository for each Kubernetes minor version.
 
 For more information about the Kubernetes community-owned package repositories,
-see ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
+see ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 ## {{% heading "prerequisites" %}}
 
 This document assumes that you're already using the Kubernetes community-owned
 package repositories. If that's not the case, it's strongly recommend to migrate
 to the Kubernetes package repositories as described in
-["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
+["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 ### Verifying if the Kubernetes package repositories are used
 
@@ -44,7 +44,7 @@ deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
 Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
-as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
+as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
@@ -70,7 +70,7 @@ exclude=kubelet kubeadm kubectl
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
 Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
-as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
+as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -1,17 +1,15 @@
 ---
-title: Changing the Kubernetes package repository
-min-kubernetes-server-version: 1.24
+title: Changing The Kubernetes Package Repository
 content_type: task
 weight: 120
 ---
 
 <!-- overview -->
 
-This page explains how to switch from one to another Kubernetes package repository
-upon upgrading from one to another Kubernetes minor release. Unlike Google-hosted
-repositories, the Kubernetes community-owned package repositories are structured
-in a way that there's a dedicated package repository for each Kubernetes minor version.
-
+This page explains how to switch from one Kubernetes package repository to another
+when upgrading Kubernetes minor releases. Unlike deprecated Google-hosted
+repositories, the Kubernetes package repositories are structured in a way that
+there's a dedicated package repository for each Kubernetes minor version.
 
 For more information about the Kubernetes community-owned package repositories,
 see the ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](TBD)
@@ -24,26 +22,22 @@ package repositories. If that's not the case, it's strongly recommend to migrate
 from the Google-hosted repository to the Kubernetes package repositories
 as described in [the blog post](TBD).
 
+### Verifying if the Kubernetes package repositories are used
+
 If you're unsure if you're using the Kubernetes package repositories or the
-Google-hosted repository, the first step of this document explains how to check
-what repository is in use.
-
-<!-- steps -->
-
-## Verifying if the Kubernetes package repositories are used
-
-The purpose of this step is to verify if you're using the Kubernetes package repositories.
+Google-hosted repository, take the following steps to verify:
 
 {{< tabs name="k8s_install_versions" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 
-Print contents of the file that defines the Kubernetes `apt` repository:
+Print the contents of the file that defines the Kubernetes `apt` repository:
 
 ```shell
-cat /etc/apt/sources.list.d/kubernetes.list
+# On your system, this configuration file could have a different name
+pager /etc/apt/sources.list.d/kubernetes.list
 ```
 
-If you see the URL similar to:
+If you see a line similar to:
 
 ```
 deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
@@ -56,9 +50,10 @@ as described in [the blog post](TBD).
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
 
-Print contents of the file that defines the Kubernetes `yum` repository:
+Print the contents of the file that defines the Kubernetes `yum` repository:
 
 ```shell
+# On your system, this configuration file could have a different name
 cat /etc/yum.repos.d/kubernetes.repo
 ```
 
@@ -91,10 +86,12 @@ it can also be one of:
 - `packages.kubernetes.io`
 {{</ note >}}
 
+<!-- steps -->
+
 ## Switching to another Kubernetes package repository
 
 This step should be done upon upgrading from one to another Kubernetes minor
-release in order to get access to packages for the desired Kubernetes minor
+release in order to get access to the packages of the desired Kubernetes minor
 version.
 
 {{< tabs name="k8s_install_versions" >}}
@@ -120,7 +117,7 @@ deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}
 deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /
 ```
 
-3. Save the file and exit your text editor. Proceed with following the relevant upgrade guidelines.
+3. Save the file and exit your text editor. Continue following the relevant upgrade instructions.
 
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
@@ -157,7 +154,7 @@ gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/repodata/r
 exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
 ```
 
-3. Save the file and exit your text editor. Proceed with following the relevant upgrade guidelines.
+3. Save the file and exit your text editor. Continue following the relevant upgrade instructions.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -11,15 +11,11 @@ when upgrading Kubernetes minor releases. Unlike deprecated Google-hosted
 repositories, the Kubernetes package repositories are structured in a way that
 there's a dedicated package repository for each Kubernetes minor version.
 
-For more information about the Kubernetes community-owned package repositories,
-see ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
-
 ## {{% heading "prerequisites" %}}
 
 This document assumes that you're already using the Kubernetes community-owned
 package repositories. If that's not the case, it's strongly recommend to migrate
-to the Kubernetes package repositories as described in
-["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
+to the Kubernetes package repositories.
 
 ### Verifying if the Kubernetes package repositories are used
 
@@ -43,8 +39,7 @@ deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io
 ```
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
-Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
-as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
+Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories.
 
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
@@ -69,8 +64,7 @@ exclude=kubelet kubeadm kubectl
 ```
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
-Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
-as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/blog/2023/08/15/pkgs-k8s-io-introduction/).
+Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -1,0 +1,168 @@
+---
+title: Changing the Kubernetes package repository
+min-kubernetes-server-version: 1.24
+content_type: task
+weight: 120
+---
+
+<!-- overview -->
+
+This page explains how to switch from one to another Kubernetes package repository
+upon upgrading from one to another Kubernetes minor release. Unlike Google-hosted
+repositories, the Kubernetes community-owned package repositories are structured
+in a way that there's a dedicated package repository for each Kubernetes minor version.
+
+
+For more information about the Kubernetes community-owned package repositories,
+see the ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](TBD)
+blog post.
+
+## {{% heading "prerequisites" %}}
+
+This document assumes that you're already using the Kubernetes community-owned
+package repositories. If that's not the case, it's strongly recommend to migrate
+from the Google-hosted repository to the Kubernetes package repositories
+as described in [the blog post](TBD).
+
+If you're unsure if you're using the Kubernetes package repositories or the
+Google-hosted repository, the first step of this document explains how to check
+what repository is in use.
+
+<!-- steps -->
+
+## Verifying if the Kubernetes package repositories are used
+
+The purpose of this step is to verify if you're using the Kubernetes package repositories.
+
+{{< tabs name="k8s_install_versions" >}}
+{{% tab name="Ubuntu, Debian or HypriotOS" %}}
+
+Print contents of the file that defines the Kubernetes `apt` repository:
+
+```shell
+cat /etc/apt/sources.list.d/kubernetes.list
+```
+
+If you see the URL similar to:
+
+```
+deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
+```
+
+**You're using the Kubernetes package repositories and this guide applies to you.**
+Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
+as described in [the blog post](TBD).
+
+{{% /tab %}}
+{{% tab name="CentOS, RHEL or Fedora" %}}
+
+Print contents of the file that defines the Kubernetes `yum` repository:
+
+```shell
+cat /etc/yum.repos.d/kubernetes.repo
+```
+
+If you see `baseurl` similar to the `baseurl` in the output below:
+
+```
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl
+```
+
+**You're using the Kubernetes package repositories and this guide applies to you.**
+Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
+as described in [the blog post](TBD).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< note >}}
+The URL used for the Kubernetes package repositories is not limited to `pkgs.k8s.io`,
+it can also be one of:
+
+- `pkgs.k8s.io`
+- `pkgs.kubernetes.io`
+- `packages.kubernetes.io`
+- `packages.kubernetes.io`
+{{</ note >}}
+
+## Switching to another Kubernetes package repository
+
+This step should be done upon upgrading from one to another Kubernetes minor
+release in order to get access to packages for the desired Kubernetes minor
+version.
+
+{{< tabs name="k8s_install_versions" >}}
+{{% tab name="Ubuntu, Debian or HypriotOS" %}}
+
+1. Open the file that defines the Kubernetes `apt` repository using a text editor of your choice:
+
+```shell
+nano /etc/apt/sources.list.d/kubernetes.list
+```
+
+You should see a single line with the URL that contains your current Kubernetes
+minor version. For example, if you're using v{{< skew currentVersionAddMinor -1 "." >}},
+you should see this:
+
+```
+deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
+```
+
+2. Change the version in the URL to **the next available minor release**, for example:
+
+```
+deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /
+```
+
+3. Save the file and exit your text editor. Proceed with following the relevant upgrade guidelines.
+
+{{% /tab %}}
+{{% tab name="CentOS, RHEL or Fedora" %}}
+
+1. Open the file that defines the Kubernetes `yum` repository using a text editor of your choice:
+
+```shell
+nano /etc/yum.repos.d/kubernetes.repo
+```
+
+You should see a file with two URLs that contain your current Kubernetes
+minor version. For example, if you're using v{{< skew currentVersionAddMinor -1 "." >}},
+you should see this:
+
+```
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
+```
+
+2. Change the version in these URLs to **the next available minor release**, for example:
+
+```
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
+```
+
+3. Save the file and exit your text editor. Proceed with following the relevant upgrade guidelines.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## {{% heading "whatsnext" %}}
+
+* See how to [Upgrade Linux nodes](/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes/).
+* See how to [Upgrade Windows nodes](/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes/).

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -12,7 +12,7 @@ repositories, the Kubernetes package repositories are structured in a way that
 there's a dedicated package repository for each Kubernetes minor version.
 
 For more information about the Kubernetes community-owned package repositories,
-see the ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](TBD)
+see the ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/)
 blog post.
 
 ## {{% heading "prerequisites" %}}
@@ -45,7 +45,7 @@ deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
 Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
-as described in [the blog post](TBD).
+as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
@@ -71,7 +71,7 @@ exclude=kubelet kubeadm kubectl
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
 Otherwise, it's strongly recommend to migrate to the Kubernetes package repositories
-as described in [the blog post](TBD).
+as described in ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -12,15 +12,14 @@ repositories, the Kubernetes package repositories are structured in a way that
 there's a dedicated package repository for each Kubernetes minor version.
 
 For more information about the Kubernetes community-owned package repositories,
-see the ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/)
-blog post.
+see ["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
 
 ## {{% heading "prerequisites" %}}
 
 This document assumes that you're already using the Kubernetes community-owned
 package repositories. If that's not the case, it's strongly recommend to migrate
-from the Google-hosted repository to the Kubernetes package repositories
-as described in [the blog post](TBD).
+to the Kubernetes package repositories as described in
+["pkgs.k8s.io: Introducing Kubernetes community-owned package repositories"](/2023/08/15/pkgs-k8s-io-introduction/).
 
 ### Verifying if the Kubernetes package repositories are used
 
@@ -40,7 +39,7 @@ pager /etc/apt/sources.list.d/kubernetes.list
 If you see a line similar to:
 
 ```
-deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
 ```
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
@@ -108,13 +107,13 @@ minor version. For example, if you're using v{{< skew currentVersionAddMinor -1 
 you should see this:
 
 ```
-deb https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
 ```
 
 2. Change the version in the URL to **the next available minor release**, for example:
 
 ```
-deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /
 ```
 
 3. Save the file and exit your text editor. Continue following the relevant upgrade instructions.

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -68,7 +68,7 @@ Find the latest patch release for Kubernetes {{< skew currentVersion >}} using t
 
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
-# It should look like {{< skew currentVersion >}}.x-00, where x is the latest patch.
+# It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
 apt update
 apt-cache madison kubeadm
 ```
@@ -78,7 +78,7 @@ apt-cache madison kubeadm
 
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
-# It should look like {{< skew currentVersion >}}.x-0, where x is the latest patch.
+# It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
 yum list --showduplicates kubeadm --disableexcludes=kubernetes
 ```
 
@@ -100,9 +100,9 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 
    ```shell
-   # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    apt-mark unhold kubeadm && \
-   apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
+   apt-get update && apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
    apt-mark hold kubeadm
    ```
 
@@ -110,8 +110,8 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    {{% tab name="CentOS, RHEL or Fedora" %}}
 
    ```shell
-   # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
-   yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+   yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
 
    {{% /tab %}}
@@ -214,9 +214,9 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 
    ```shell
-   # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    apt-mark unhold kubelet kubectl && \
-   apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+   apt-get update && apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
    apt-mark hold kubelet kubectl
    ```
 
@@ -224,8 +224,8 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    {{% tab name="CentOS, RHEL or Fedora" %}}
 
    ```shell
-   # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
-   yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+   yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
 
    {{% /tab %}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -52,6 +52,13 @@ The upgrade workflow at high level is the following:
 
 <!-- steps -->
 
+## Changing the package repository
+
+If you're using the Kubernetes community-owned repositories, you need to change
+the package repository to one that contains packages for your desired Kubernetes
+minor version. This is explained in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
+document.
+
 ## Determine which version to upgrade to
 
 Find the latest patch release for Kubernetes {{< skew currentVersion >}} using the OS package manager:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -17,6 +17,13 @@ upgrade the control plane nodes before upgrading your Linux Worker nodes.
 
 <!-- steps -->
 
+## Changing the package repository
+
+If you're using the Kubernetes community-owned repositories, you need to change
+the package repository to one that contains packages for your desired Kubernetes
+minor version. This is explained in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
+document.
+
 ## Upgrading worker nodes
 
 ### Upgrade kubeadm

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -33,16 +33,16 @@ Upgrade kubeadm:
 {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 ```shell
-# replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
+# replace x in {{< skew currentVersion >}}.x-* with the latest patch version
 apt-mark unhold kubeadm && \
-apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
+apt-get update && apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
 apt-mark hold kubeadm
 ```
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
 ```shell
-# replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
-yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+# replace x in {{< skew currentVersion >}}.x- with the latest patch version
+yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -71,16 +71,16 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    {{< tabs name="k8s_kubelet_and_kubectl" >}}
    {{% tab name="Ubuntu, Debian or HypriotOS" %}}
    ```shell
-   # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    apt-mark unhold kubelet kubectl && \
-   apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+   apt-get update && apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
    apt-mark hold kubelet kubectl
    ```
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
    ```shell
-   # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
-   yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+   yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
    {{% /tab %}}
    {{< /tabs >}}

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -22,9 +22,9 @@ Using the latest compatible version of kubectl helps avoid unforeseen issues.
 
 The following methods exist for installing kubectl on Linux:
 
-- [Install kubectl binary with curl on Linux](#install-kubectl-binary-with-curl-on-linux)
-- [Install using native package management](#install-using-native-package-management)
-- [Install using other package management](#install-using-other-package-management)
+ - [Install kubectl binary with curl on Linux](#install-kubectl-binary-with-curl-on-linux)
+ - [Install using native package management](#install-using-native-package-management)
+ - [Install using other package management](#install-using-other-package-management)
 
 ### Install kubectl binary with curl on Linux
 
@@ -145,28 +145,27 @@ The following methods exist for installing kubectl on Linux:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl
    ```
 
-   If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
+2. Download the public signing key for the Kubernetes package repositories. The same signing key is used for all repositories so you can disregard the version in the URL:
 
    ```shell
-   sudo apt-get install -y apt-transport-https
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
-2. Download the Google Cloud public signing key:
+3. Add the appropriate Kubernetes `apt` repository. If you want to use Kubernetes version different than {{< param "version" >}},
+   replace {{< param "version" >}} with the desired minor version in the command below:
 
    ```shell
-   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+   echo 'deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-3. Add the Kubernetes `apt` repository:
+   {{< note >}}
+   If you desire to upgrade kubectl to another minor release at some point, you'll need to change version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/) document.
+   {{< /note >}}
 
-   ```shell
-   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-   ```
-
-4. Update `apt` package index with the new repository and install kubectl:
+4. Update `apt` package index, then install kubectl:
 
    ```shell
    sudo apt-get update
@@ -180,15 +179,28 @@ In releases older than Debian 12 and Ubuntu 22.04, `/etc/apt/keyrings` does not 
 {{% /tab %}}
 
 {{% tab name="Red Hat-based distributions" %}}
+
+1. Add the Kubernetes `yum` repository. If you want to use Kubernetes version different than {{< param "version" >}}, replace {{< param "version" >}} with the desired minor version in the command below:
+
 ```bash
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
+baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
 EOF
+```
+
+{{< note >}}
+If you desire to upgrade kubectl to another minor release at some point, you'll need to change version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/) document.
+{{< /note >}}
+
+2. Install kubectl using `yum`:
+
+```bash
 sudo yum install -y kubectl
 ```
 

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -160,7 +160,7 @@ The following methods exist for installing kubectl on Linux:
 
    ```shell
    # This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
-   echo 'deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
    {{< note >}}

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -22,9 +22,9 @@ Using the latest compatible version of kubectl helps avoid unforeseen issues.
 
 The following methods exist for installing kubectl on Linux:
 
- - [Install kubectl binary with curl on Linux](#install-kubectl-binary-with-curl-on-linux)
- - [Install using native package management](#install-using-native-package-management)
- - [Install using other package management](#install-using-other-package-management)
+- [Install kubectl binary with curl on Linux](#install-kubectl-binary-with-curl-on-linux)
+- [Install using native package management](#install-using-native-package-management)
+- [Install using other package management](#install-using-other-package-management)
 
 ### Install kubectl binary with curl on Linux
 
@@ -145,6 +145,7 @@ The following methods exist for installing kubectl on Linux:
 
    ```shell
    sudo apt-get update
+   # apt-transport-https may be a dummy package; if so, you can skip that package
    sudo apt-get install -y apt-transport-https ca-certificates curl
    ```
 
@@ -158,11 +159,12 @@ The following methods exist for installing kubectl on Linux:
    replace {{< param "version" >}} with the desired minor version in the command below:
 
    ```shell
+   # This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
    echo 'deb https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
    {{< note >}}
-   If you desire to upgrade kubectl to another minor release at some point, you'll need to change version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/) document.
+   To upgrade kubectl to another minor release at some point, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
    {{< /note >}}
 
 4. Update `apt` package index, then install kubectl:
@@ -180,9 +182,15 @@ In releases older than Debian 12 and Ubuntu 22.04, `/etc/apt/keyrings` does not 
 
 {{% tab name="Red Hat-based distributions" %}}
 
-1. Add the Kubernetes `yum` repository. If you want to use Kubernetes version different than {{< param "version" >}}, replace {{< param "version" >}} with the desired minor version in the command below:
+1. Add the Kubernetes `yum` repository. If you want to use Kubernetes version
+   different than {{< param "version" >}}, replace {{< param "version" >}} with
+   the desired minor version in the command below. The `exclude` parameter in the
+   repository definition ensures that the packages related to Kubernetes are
+   not upgraded upon running `yum update` as there's a special procedure that
+   must be followed for upgrading Kubernetes.
 
 ```bash
+# This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -195,10 +203,10 @@ EOF
 ```
 
 {{< note >}}
-If you desire to upgrade kubectl to another minor release at some point, you'll need to change version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/) document.
+To upgrade kubectl to another minor release at some point, you'll need to bump the version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}
 
-2. Install kubectl using `yum`:
+1. Install kubectl using `yum`:
 
 ```bash
 sudo yum install -y kubectl

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -164,7 +164,7 @@ The following methods exist for installing kubectl on Linux:
    ```
 
    {{< note >}}
-   To upgrade kubectl to another minor release at some point, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+   To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
    {{< /note >}}
 
 4. Update `apt` package index, then install kubectl:
@@ -184,10 +184,7 @@ In releases older than Debian 12 and Ubuntu 22.04, `/etc/apt/keyrings` does not 
 
 1. Add the Kubernetes `yum` repository. If you want to use Kubernetes version
    different than {{< param "version" >}}, replace {{< param "version" >}} with
-   the desired minor version in the command below. The `exclude` parameter in the
-   repository definition ensures that the packages related to Kubernetes are
-   not upgraded upon running `yum update` as there's a special procedure that
-   must be followed for upgrading Kubernetes.
+   the desired minor version in the command below.
 
 ```bash
 # This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
@@ -198,12 +195,11 @@ baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
 enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
-exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
 EOF
 ```
 
 {{< note >}}
-To upgrade kubectl to another minor release at some point, you'll need to bump the version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}
 
 1. Install kubectl using `yum`:


### PR DESCRIPTION
This PR documents usage of the community-hosted repositories, implemented as part of [KEP-1731](https://github.com/kubernetes/enhancements/issues/1731).

All documents that mention the deprecated Google-hosted repository are updated to:

- Highlight that the Google-hosted repository is deprecated and that using the community-hosted repositories is strongly recommended
- Highlight the most important differences between the Google-hosted repository and the community-hosted repositories
- Show how to setup both the community-hosted repositories and the Google-hosted repository

I decided to go with `Google-hosted repository` and `Community-hosted repositories` for wording to distinct between repositories hosted on Google and our infra.

It's important to note that the infrastructure and repositories, and the KEP, don't have the same graduation criteria. We consider the infrastructure and repositories to be GA, but the KEP itself is graduating to alpha. That's because KEP covers more than the infrastructure and repositories and those tasks are still to be done in the upcoming release cycles.