### PR TITLE
Promote parallel image pulls to beta

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -182,7 +182,7 @@ behalf of the two different Pods, when parallel image pulls is enabled.
 
 ### Maximum parallel image pulls
 
-{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.28" state="beta" >}}
 
 When `serializeImagePulls` is set to false, the kubelet defaults to no limit on the
 maximum number of images being pulled at the same time. If you would like to


### PR DESCRIPTION
/sig node
See https://github.com/kubernetes/enhancements/issues/3673#issuecomment-1632759221

This is promoting the feature to beta. This feature has no feature gates, see https://github.com/kubernetes/kubernetes/pull/115220