### PR TITLE
Correct the incorrect label in kubectl command for inspecting Leases for kube-apiserver

### DIFF
--- a/content/en/docs/concepts/architecture/leases.md
+++ b/content/en/docs/concepts/architecture/leases.md
@@ -42,16 +42,17 @@ Existence of kube-apiserver leases enables future capabilities that may require 
 each kube-apiserver.
 
 You can inspect Leases owned by each kube-apiserver by checking for lease objects in the `kube-system` namespace
-with the name `kube-apiserver-<sha256-hash>`. Alternatively you can use the label selector `k8s.io/component=kube-apiserver`:
+with the name `kube-apiserver-<sha256-hash>`. Alternatively you can use the label selector `apiserver.kubernetes.io/identity=kube-apiserver`:
 
 ```shell
-kubectl -n kube-system get lease -l k8s.io/component=kube-apiserver
+kubectl -n kube-system get lease -l apiserver.kubernetes.io/identity=kube-apiserver
 ```
 ```
 NAME                                        HOLDER                                                                           AGE
-kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a   kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a_9cbf54e5-1136-44bd-8f9a-1dcd15c346b4   5m33s
-kube-apiserver-dz2dqprdpsgnm756t5rnov7yka   kube-apiserver-dz2dqprdpsgnm756t5rnov7yka_84f2a85d-37c1-4b14-b6b9-603e62e4896f   4m23s
-kube-apiserver-fyloo45sdenffw2ugwaz3likua   kube-apiserver-fyloo45sdenffw2ugwaz3likua_c5ffa286-8a9a-45d4-91e7-61118ed58d2e   4m43s
+apiserver-07a5ea9b9b072c4a5f3d1c3702        apiserver-07a5ea9b9b072c4a5f3d1c3702_0c8914f7-0f35-440e-8676-7844977d3a05        5m33s
+apiserver-7be9e061c59d368b3ddaf1376e        apiserver-7be9e061c59d368b3ddaf1376e_84f2a85d-37c1-4b14-b6b9-603e62e4896f        4m23s
+apiserver-1dfef752bcb36637d2763d1868        apiserver-1dfef752bcb36637d2763d1868_c5ffa286-8a9a-45d4-91e7-61118ed58d2e        4m43s
+
 ```
 
 The SHA256 hash used in the lease name is based on the OS hostname as seen by that API server. Each kube-apiserver should be
@@ -60,24 +61,24 @@ will take over existing Leases using a new holder identity, as opposed to instan
 hostname used by kube-apisever by checking the value of the `kubernetes.io/hostname` label:
 
 ```shell
-kubectl -n kube-system get lease kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a -o yaml
+kubectl -n kube-system get lease apiserver-07a5ea9b9b072c4a5f3d1c3702 -o yaml
 ```
 ```yaml
 apiVersion: coordination.k8s.io/v1
 kind: Lease
 metadata:
-  creationTimestamp: "2022-11-30T15:37:15Z"
+  creationTimestamp: "2023-07-02T13:16:48Z"
   labels:
-    k8s.io/component: kube-apiserver
-    kubernetes.io/hostname: kind-control-plane
-  name: kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a
+    apiserver.kubernetes.io/identity: kube-apiserver
+    kubernetes.io/hostname: master-1
+  name: apiserver-07a5ea9b9b072c4a5f3d1c3702
   namespace: kube-system
-  resourceVersion: "18171"
-  uid: d6c68901-4ec5-4385-b1ef-2d783738da6c
+  resourceVersion: "334899"
+  uid: 90870ab5-1ba9-4523-b215-e4d4e662acb1
 spec:
-  holderIdentity: kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a_9cbf54e5-1136-44bd-8f9a-1dcd15c346b4
+  holderIdentity: apiserver-07a5ea9b9b072c4a5f3d1c3702_0c8914f7-0f35-440e-8676-7844977d3a05
   leaseDurationSeconds: 3600
-  renewTime: "2022-11-30T18:04:27.912073Z"
+  renewTime: "2023-07-04T21:58:48.065888Z"
 ```
 
 Expired leases from kube-apiservers that no longer exist are garbage collected by new kube-apiservers after 1 hour.


### PR DESCRIPTION
This fixes #41881

Corrected the incorrect(old) label in kubectl command for inspecting Leases for kube-apiserver.