### PR TITLE
Small mistake between sections of the document

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -96,7 +96,7 @@ system daemon should ideally run within its own child control group. Refer to
 for more details on recommended control group hierarchy.
 
 Note that Kubelet **does not** create `--kube-reserved-cgroup` if it doesn't
-exist. Kubelet will fail if an invalid cgroup is specified. With `systemd`
+exist. `kubelet` will fail if an invalid cgroup is specified. With `systemd`
 cgroup driver, you should follow a specific pattern for the name of the cgroup you
 define: the name should be the value you set for `--kube-reserved-cgroup`,
 with `.slice` appended.

--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -96,7 +96,7 @@ system daemon should ideally run within its own child control group. Refer to
 for more details on recommended control group hierarchy.
 
 Note that Kubelet **does not** create `--kube-reserved-cgroup` if it doesn't
-exist. `kubelet` will fail if an invalid cgroup is specified. With `systemd`
+exist. The kubelet will fail to start if an invalid cgroup is specified. With `systemd`
 cgroup driver, you should follow a specific pattern for the name of the cgroup you
 define: the name should be the value you set for `--kube-reserved-cgroup`,
 with `.slice` appended.


### PR DESCRIPTION
The note for --kube-reserved-cgroup should match formatting for --system-reserved-cgroup.  This changes helps those match.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
