### PR TITLE
docs: document kubelet cgroup driver detection from the runtime

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -563,10 +563,11 @@ Each feature gate is designed for enabling/disabling a specific feature:
   track of the finished Pods to count towards completion.
 - `KMSv2`: Enables KMS v2 API for encryption at rest. See [Using a KMS Provider for data encryption](/docs/tasks/administer-cluster/kms-provider) for more details.
 - `KubeletCgroupDriverFromCRI`: Enable detection of the kubelet cgroup driver
-  configuration option from the CRI. The container runtime also needs to support
-  this feature in which case the kubelet will ignore the cgroupDriver
+  configuration option from the CRI. This feature gate requires the user run a
+  container runtime that supports the `RuntimeConfig` CRI call. If both CRI and
+  Kubelet support this feature, the kubelet will ignore the cgroupDriver
   (--cgroup-driver) configuration option. If the container runtime doesn't
-  support it, the kubelet will fallback to using it's cgroupDriver option.
+  support it, the kubelet will fallback to using its cgroupDriver option.
   See [Configuring a cgroup driver](/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver)
   for more details.
 - `KubeletCredentialProviders`: Enable kubelet exec credential providers for

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -129,6 +129,7 @@ For a reference to old feature gates that are removed, please refer to
 | `JobReadyPods` | `true` | Beta | 1.24 | |
 | `KMSv2` | `false` | Alpha | 1.25 | 1.26 |
 | `KMSv2` | `true` | Beta | 1.27 | |
+| `KubeletCgroupDriverFromCRI` | `false` | Alpha | 1.28 | |
 | `KubeletInUserNamespace` | `false` | Alpha | 1.22 | |
 | `KubeletPodResources` | `false` | Alpha | 1.13 | 1.14 |
 | `KubeletPodResources` | `true` | Beta | 1.15 | |
@@ -561,6 +562,13 @@ Each feature gate is designed for enabling/disabling a specific feature:
   The Job controller uses Pod finalizers and a field in the Job status to keep
   track of the finished Pods to count towards completion.
 - `KMSv2`: Enables KMS v2 API for encryption at rest. See [Using a KMS Provider for data encryption](/docs/tasks/administer-cluster/kms-provider) for more details.
+- `KubeletCgroupDriverFromCRI`: Enable detection of the kubelet cgroup driver
+  configuration option from the CRI. The container runtime also needs to support
+  this feature in which case the kubelet will ignore the cgroupDriver
+  (--cgroup-driver) configuration option. If the container runtime doesn't
+  support it, the kubelet will fallback to using it's cgroupDriver option.
+  See [Configuring a cgroup driver](/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver)
+  for more details.
 - `KubeletCredentialProviders`: Enable kubelet exec credential providers for
   image pull credentials.
 - `KubeletInUserNamespace`: Enables support for running kubelet in a

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -157,6 +157,13 @@ Starting with v1.22 and later, when creating a cluster with kubeadm, if the user
 the `cgroupDriver` field under `KubeletConfiguration`, kubeadm defaults it to `systemd`.
 {{< /note >}}
 
+{{< note >}}
+Starting with v1.28 and later, with KubeletCgroupDriverFromCRI feature gate
+enabled and a container runtime that supports the RuntimeConfig CRI rpc,
+kubelet will automatically detect the cgroup driver from the runtime and the
+cgroupDriver setting in kubelet configuration is ignored.
+{{< /note >}}
+
 If you configure `systemd` as the cgroup driver for the kubelet, you must also
 configure `systemd` as the cgroup driver for the container runtime. Refer to
 the documentation for your container runtime for instructions. For example:
@@ -251,6 +258,12 @@ sudo systemctl restart containerd
 When using kubeadm, manually configure the
 [cgroup driver for kubelet](/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#configuring-the-kubelet-cgroup-driver).
 
+{{< note >}}
+Starting with v1.28 and later, kubelet cgroup driver does not need to be
+configured if the KubeletCgroupDriverFromCRI feature gate is enabled and a
+version of containerd that supports the RuntimeConfig CRI rpc is being used.
+{{< /note >}}
+
 #### Overriding the sandbox (pause) image {#override-pause-image-containerd}
 
 In your [containerd config](https://github.com/containerd/containerd/blob/main/docs/cri/config.md) you can overwrite the
@@ -291,6 +304,12 @@ You should also note the changed `conmon_cgroup`, which has to be set to the val
 `pod` when using CRI-O with `cgroupfs`. It is generally necessary to keep the
 cgroup driver configuration of the kubelet (usually done via kubeadm) and CRI-O
 in sync.
+
+{{< note >}}
+Starting with v1.28 and later, kubelet cgroup driver does not need to be
+configured if the KubeletCgroupDriverFromCRI feature gate is enabled and a
+version of CRI-O that supports the RuntimeConfig CRI rpc is being used.
+{{< /note >}}
 
 For CRI-O, the CRI socket is `/var/run/crio/crio.sock` by default.
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -38,6 +38,13 @@ In v1.22 and later, if the user does not set the `cgroupDriver` field under `Kub
 kubeadm defaults it to `systemd`.
 {{< /note >}}
 
+{{< note >}}
+In v1.28 and later, with KubeletCgroupDriverFromCRI feature gate
+enabled and a container runtime that supports the RuntimeConfig CRI rpc,
+kubelet will automatically detect the cgroup driver from the runtime and the
+kubelet cgroup driver setting does not need to be manually configured.
+{{< /note >}}
+
 A minimal example of configuring the field explicitly:
 
 ```yaml


### PR DESCRIPTION
Document the KubeletCgroupDriverFromCRI feature gate. Also, add notes of this feature in parts of the documentation that describe cgroup driver configuration.

Refs https://github.com/kubernetes/enhancements/issues/4033

NOTE: no container runtime supports this new feature, yet, so we cannot refer to specific versions of runtimes (yet)

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
