### PR TITLE
keeping (Doc) topologyKey above minDomain

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -92,6 +92,13 @@ your cluster. Those fields are:
   - if you select `whenUnsatisfiable: ScheduleAnyway`, the scheduler gives higher
     precedence to topologies that would help reduce the skew.
 
+- **topologyKey** is the key of [node labels](#node-labels). Nodes that have a label with this key
+	and identical values are considered to be in the same topology.
+  We call each instance of a topology (in other words, a <key, value> pair) a domain. The scheduler
+  will try to put a balanced number of pods into each domain.
+	Also, we define an eligible domain as a domain whose nodes meet the requirements of
+	nodeAffinityPolicy and nodeTaintsPolicy.
+
 - **minDomains** indicates a minimum number of eligible domains. This field is optional.
   A domain is a particular instance of a topology. An eligible domain is a domain whose
   nodes match the node selector.
@@ -110,13 +117,7 @@ your cluster. Those fields are:
   - When the number of eligible domains with matching topology keys equals or is greater than
     `minDomains`, this value has no effect on scheduling.
   - If you do not specify `minDomains`, the constraint behaves as if `minDomains` is 1.
-
-- **topologyKey** is the key of [node labels](#node-labels). Nodes that have a label with this key
-	and identical values are considered to be in the same topology.
-  We call each instance of a topology (in other words, a <key, value> pair) a domain. The scheduler
-  will try to put a balanced number of pods into each domain.
-	Also, we define an eligible domain as a domain whose nodes meet the requirements of
-	nodeAffinityPolicy and nodeTaintsPolicy.
+    
 
 - **whenUnsatisfiable** indicates how to deal with a Pod if it doesn't satisfy the spread constraint:
   - `DoNotSchedule` (default) tells the scheduler not to schedule it.

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -93,11 +93,11 @@ your cluster. Those fields are:
     precedence to topologies that would help reduce the skew.
 
 - **topologyKey** is the key of [node labels](#node-labels). Nodes that have a label with this key
-	and identical values are considered to be in the same topology.
+  and identical values are considered to be in the same topology.
   We call each instance of a topology (in other words, a <key, value> pair) a domain. The scheduler
   will try to put a balanced number of pods into each domain.
-	Also, we define an eligible domain as a domain whose nodes meet the requirements of
-	nodeAffinityPolicy and nodeTaintsPolicy.
+  Also, we define an eligible domain as a domain whose nodes meet the requirements of
+  nodeAffinityPolicy and nodeTaintsPolicy.
 
 - **minDomains** indicates a minimum number of eligible domains. This field is optional.
   A domain is a particular instance of a topology. An eligible domain is a domain whose


### PR DESCRIPTION
topologyKey (Domain) is mentioned in minDomain. So putting topologyKey above minDomain.
