### PR TITLE
fix expression err in content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -177,7 +177,7 @@ scheduled onto the node (if it is not yet running on the node).
   则 Kubernetes 会 **尝试** 不将 Pod 调度到该节点。
 * 如果未被忽略的污点中存在至少一个 effect 值为 `NoExecute` 的污点，
   则 Kubernetes 不会将 Pod 调度到该节点（如果 Pod 还未在节点上运行），
-  或者将 Pod 从该节点驱逐（如果 Pod 已经在节点上运行）。
+  并且会将 Pod 从该节点驱逐（如果 Pod 已经在节点上运行）。
 
 <!--
 For example, imagine you taint a node like this


### PR DESCRIPTION
use  “并且”(and) install of  "或者"(or)
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
