### PR TITLE
Update patch releases calendar after July releases

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,6 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| July 2023             | 2023-07-14           | 2023-07-19  |
 | August 2023           | 2023-08-04           | 2023-08-09  |
 | September 2023        | 2023-09-08           | 2023-09-13  |
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,10 +7,13 @@ schedules:
   maintenanceModeStartDate: 2024-04-28
   endOfLifeDate: 2024-06-28
   next:
-    release: 1.27.4
-    cherryPickDeadline: 2023-07-14
-    targetDate: 2023-07-19
+    release: 1.27.5
+    cherryPickDeadline: 2023-08-04
+    targetDate: 2023-08-09
   previousPatches:
+    - release: 1.27.4
+      cherryPickDeadline: 2023-07-14
+      targetDate: 2023-07-19
     - release: 1.27.3
       cherryPickDeadline: 2023-06-09
       targetDate: 2023-06-14
@@ -30,10 +33,13 @@ schedules:
   maintenanceModeStartDate: 2023-12-28
   endOfLifeDate: 2024-02-28
   next:
-    release: 1.26.7
-    cherryPickDeadline: 2023-07-14
-    targetDate: 2023-07-19
+    release: 1.26.8
+    cherryPickDeadline: 2023-08-04
+    targetDate: 2023-08-09
   previousPatches:
+    - release: 1.26.7
+      cherryPickDeadline: 2023-07-14
+      targetDate: 2023-07-19
     - release: 1.26.6
       cherryPickDeadline: 2023-06-09
       targetDate: 2023-06-14
@@ -62,10 +68,13 @@ schedules:
   maintenanceModeStartDate: 2023-08-28
   endOfLifeDate: 2023-10-28
   next:
-    release: 1.25.12
-    cherryPickDeadline: 2023-07-14
-    targetDate: 2023-07-19
+    release: 1.25.13
+    cherryPickDeadline: 2023-08-04
+    targetDate: 2023-08-09
   previousPatches:
+    - release: 1.25.12
+      cherryPickDeadline: 2023-07-14
+      targetDate: 2023-07-19
     - release: 1.25.11
       cherryPickDeadline: 2023-06-09
       targetDate: 2023-06-14
@@ -113,10 +122,13 @@ schedules:
   maintenanceModeStartDate: 2023-05-28
   endOfLifeDate: 2023-07-28
   next:
-    release: 1.24.16
-    cherryPickDeadline: 2023-07-14
-    targetDate: 2023-07-19
+    release: N/A
+    cherryPickDeadline: ""
+    targetDate: ""
   previousPatches:
+    - release: 1.24.16
+      cherryPickDeadline: 2023-07-14
+      targetDate: 2023-07-19
     - release: 1.24.15
       cherryPickDeadline: 2023-06-09
       targetDate: 2023-06-14


### PR DESCRIPTION
The Kubernetes patch releases scheduled for July went out yesterday so this PR updates the release calendar.

Patch release dates for October and November will be added as part of #42108

/assign @saschagrunert @cpanato @puerco @jeremyrickard 
cc @kubernetes/release-engineering 