### PR TITLE
Add patch releases dates for October and November 2023

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -81,6 +81,13 @@ releases may also occur in between these.
 | July 2023             | 2023-07-14           | 2023-07-19  |
 | August 2023           | 2023-08-04           | 2023-08-09  |
 | September 2023        | 2023-09-08           | 2023-09-13  |
+| October 2023          | 2023-10-13           | 2023-10-18  |
+| November 2023         | N/A                  | N/A         |
+| December 2023         | 2023-12-01           | 2023-12-06  |
+
+**Note:** Due to overlap with KubeCon NA 2023 and lack of availability of
+Release Managers and Google Build Admins, it has been decided to skip patch
+releases in November. Instead, we'll have patch releases early in December.
 
 ## Detailed Release History for Active Branches
 


### PR DESCRIPTION
As a follow up on #42106, this PR adds patch release dates for October and December 2023.

As discussed in this PR, we decided to skip patch releases in November because of overlap with KubeCon and lack of availability of Release Managers and Google Build Admins.

/hold
for discussion and to check availability of Google Build Admins

/assign @saschagrunert @cpanato @jeremyrickard @puerco @Verolop 
cc @kubernetes/release-engineering 