### PR TITLE
Bump API level in docs for the podFailurePolicy field (manual bump)

### DIFF
--- a/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -117,14 +117,14 @@ JobSpec describes how the job execution will look like.
 
   manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
 
-### Alpha level
+### Beta level
 
 
 - **podFailurePolicy** (PodFailurePolicy)
 
   Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
   
-  This field is alpha-level. To use this field, you must enable the `JobPodFailurePolicy` feature gate (disabled by default).
+  This field is beta-level. It can be used when the `JobPodFailurePolicy` feature gate is enabled (enabled by default).
 
   <a name="PodFailurePolicy"></a>
   *PodFailurePolicy describes how failed pods influence the backoffLimit.*


### PR DESCRIPTION
Update the docs as podFailurePolicy is now Beta, see: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-failure-policy

We may need to cherry-pick it as it is Beta since 1.26.
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
