### PR TITLE
Add note after restore cmd to specify that data-dir will be (re)created

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -271,16 +271,16 @@ that is not currently used by an etcd process. Taking the snapshot will
 not affect the performance of the member.
 
 Below is an example for taking a snapshot of the keyspace served by
-`$ENDPOINT` to the file `snapshotdb`:
+`$ENDPOINT` to the file `snapshot.db`:
 
 ```shell
-ETCDCTL_API=3 etcdctl --endpoints $ENDPOINT snapshot save snapshotdb
+ETCDCTL_API=3 etcdctl --endpoints $ENDPOINT snapshot save snapshot.db
 ```
 
 Verify the snapshot:
 
 ```shell
-ETCDCTL_API=3 etcdctl --write-out=table snapshot status snapshotdb
+ETCDCTL_API=3 etcdctl --write-out=table snapshot status snapshot.db
 ```
 
 ```console
@@ -339,19 +339,25 @@ employed to recover the data of a failed cluster.
 Before starting the restore operation, a snapshot file must be present. It can
 either be a snapshot file from a previous backup operation, or from a remaining
 [data directory](https://etcd.io/docs/current/op-guide/configuration/#--data-dir).
+
 Here is an example:
 
 ```shell
-ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshotdb
+ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshot.db
 ```
-Another example for restoring using etcdctl options:
+
+Another example for restoring using `etcdctl` options:
+
 ```shell
-ETCDCTL_API=3 etcdctl snapshot restore --data-dir <data-dir-location> snapshotdb
+ETCDCTL_API=3 etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
-Yet another example would be to first export the environment variable
+where `<data-dir-location>` is a directory that will be created during the restore process.
+
+Yet another example would be to first export the `ETCDCTL_API` environment variable:
+
 ```shell
 export ETCDCTL_API=3
-etcdctl snapshot restore --data-dir <data-dir-location> snapshotdb
+etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
 
 For more information and examples on restoring a cluster from a snapshot file, see


### PR DESCRIPTION
Add n ote after `etcdctl restore` command to specify that <data-dir-location> will be (re)created during the restore operation. 
Fixes #36784 
