### PR TITLE
[zh] sync workloads/controllers/*.md headers for #42004

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/daemonset.md
@@ -1,7 +1,10 @@
 ---
 title: DaemonSet
+description: >-
+  DaemonSet 定义了提供节点本地设施的 Pod。这些设施可能对于集群的运行至关重要，例如网络辅助工具，或者作为 add-on 的一部分。
 content_type: concept
 weight: 40
+hide_summary: true # 在章节索引中单独列出
 ---
 
 <!--
@@ -12,8 +15,11 @@ reviewers:
 - janetkuo
 - kow3ns
 title: DaemonSet
+description: >-
+ A DaemonSet defines Pods that provide node-local facilities. These might be fundamental to the operation of your cluster, such as a networking helper tool, or be part of an add-on.
 content_type: concept
 weight: 40
+hide_summary: true # Listed separately in section index
 --->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/workloads/controllers/deployment.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/deployment.md
@@ -4,8 +4,11 @@ feature:
   title: 自动化上线和回滚
   description: >
     Kubernetes 会分步骤地将针对应用或其配置的更改上线，同时监视应用程序运行状况以确保你不会同时终止所有实例。如果出现问题，Kubernetes 会为你回滚所作更改。你应该充分利用不断成长的部署方案生态系统。
+description: >-
+  Deployment 用于管理运行一个应用负载的一组 Pod，通常适用于不保持状态的负载。
 content_type: concept
 weight: 10
+hide_summary: true # 在章节索引中单独列出
 ---
 <!--
 reviewers:
@@ -15,9 +18,11 @@ feature:
   title: Automated rollouts and rollbacks
   description: >
     Kubernetes progressively rolls out changes to your application or its configuration, while monitoring application health to ensure it doesn't kill all your instances at the same time. If something goes wrong, Kubernetes will rollback the change for you. Take advantage of a growing ecosystem of deployment solutions.
-
+description: >-
+  A Deployment manages a set of Pods to run an application workload, usually one that doesn't maintain state.
 content_type: concept
 weight: 10
+hide_summary: true # Listed separately in section index
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/workloads/controllers/job.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/job.md
@@ -1,11 +1,14 @@
 ---
 title: Job
 content_type: concept
+description: >-
+  Job 表示一次性任务，运行完成后就会停止。
 feature:
   title: 批量执行
   description: >
     除了服务之外，Kubernetes 还可以管理你的批处理和 CI 工作负载，在期望时替换掉失效的容器。
 weight: 50
+hide_summary: true # 在章节索引中单独列出
 ---
 <!--
 reviewers:
@@ -14,11 +17,14 @@ reviewers:
 - soltysh
 title: Jobs
 content_type: concept
+description: >-
+  Jobs represent one-off tasks that run to completion and then stop.
 feature:
   title: Batch execution
   description: >
     In addition to services, Kubernetes can manage your batch and CI workloads, replacing containers that fail, if desired.
 weight: 50
+hide_summary: true # Listed separately in section index
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/replicaset.md
@@ -8,7 +8,11 @@ feature:
     杀死不响应用户定义的健康检查的容器，
     并且在它们准备好服务之前不会将它们公布给客户端。
 content_type: concept
+description: >-
+  ReplicaSet 的作用是维持在任何给定时间运行的一组稳定的副本 Pod。
+  通常，你会定义一个 Deployment，并用这个 Deployment 自动管理 ReplicaSet。
 weight: 20
+hide_summary: true # 在章节索引中单独列出
 ---
 <!--
 reviewers:
@@ -24,7 +28,11 @@ feature:
     kills containers that don't respond to your user-defined health check,
     and doesn't advertise them to clients until they are ready to serve.
 content_type: concept
+description: >-
+  A ReplicaSet's purpose is to maintain a stable set of replica Pods running at any given time.
+  Usually, you define a Deployment and let that Deployment manage ReplicaSets automatically.
 weight: 20
+hide_summary: true # Listed separately in section index
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/statefulset.md
@@ -1,7 +1,11 @@
 ---
 title: StatefulSet
 content_type: concept
+description: >-
+  StatefulSet 运行一组 Pod，并为每个 Pod 保留一个稳定的标识。
+  这可用于管理需要持久化存储或稳定、唯一网络标识的应用。
 weight: 30
+hide_summary: true # 在章节索引中单独列出
 ---
 <!--
 reviewers:
@@ -13,7 +17,11 @@ reviewers:
 - smarterclayton
 title: StatefulSets
 content_type: concept
+description: >-
+  A StatefulSet runs a group of Pods, and maintains a sticky identity for each of those Pods. This is useful for managing
+  applications that need persistent storage or a stable, unique network identity.
 weight: 30
+hide_summary: true # Listed separately in section index
 -->
 
 <!-- overview -->


### PR DESCRIPTION
## PR Summary

One observation we can make is that the file `content/zh-cn/docs/concepts/workloads/controllers/_index.md` contains a header attributtion `simple_list: true`. This attribution is used to detect the header attribution `hide_summary: true | false` on the child pages within the `content/zh-cn/docs/concepts/workloads/controllers` folder. Its purpose is to determine whether to display these child pages at the end of `content/zh-cn/docs/concepts/workloads/controllers/_index.md`.

Considering this, it would be prudent to synchronize all the pages' headers in the `content/zh-cn/docs/concepts/workloads/controllers` folder to ensure that the sub-page list matches the one on the English upstream page in PR #42004.


Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang
