### PR TITLE
Fix grammatical issue with 'create workload object'

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/_index.md
+++ b/content/en/docs/concepts/workloads/controllers/_index.md
@@ -14,8 +14,8 @@ Pods would be a lot of effort. For example, if a Pod fails, you probably want to
 run a new Pod to replace it. Kubernetes can do that for you.
 
 You use the Kubernetes API to create a workload
-{{< glossary_tooltip text="object" term_id="object" >}} that represent a higher level
-abstraction than a Pod, and then the Kubernetes
+{{< glossary_tooltip text="object" term_id="object" >}} that represents a higher abstraction level
+than a Pod, and then the Kubernetes
 {{< glossary_tooltip text="control plane" term_id="control-plane" >}} automatically manages
 Pod objects on your behalf, based on the specification for the workload object you defined.
 

--- a/content/en/docs/concepts/workloads/controllers/_index.md
+++ b/content/en/docs/concepts/workloads/controllers/_index.md
@@ -13,7 +13,7 @@ Ultimately, your applications run as containers inside
 Pods would be a lot of effort. For example, if a Pod fails, you probably want to
 run a new Pod to replace it. Kubernetes can do that for you.
 
-You use the Kubernetes API to create workload
+You use the Kubernetes API to create a workload
 {{< glossary_tooltip text="object" term_id="object" >}} that represent a higher level
 abstraction than a Pod, and then the Kubernetes
 {{< glossary_tooltip text="control plane" term_id="control-plane" >}} automatically manages


### PR DESCRIPTION
Using indefinite article for 'create a workload object'