### PR TITLE
Remove a deprecated param

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -52,7 +52,7 @@ The following methods exist for installing kubectl on Linux:
    And for Linux ARM64, type:
 
    ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/arm64/kubectl
+   curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/arm64/kubectl
    ```
 
    {{< /note >}}


### PR DESCRIPTION
Use the `skew` shortcode instead. Helps with #41005 (but doesn't close it).