### PR TITLE
[ja] Switch out deprecated fullversion param

### DIFF
--- a/content/ja/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/ja/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -147,7 +147,7 @@ Windowsワーカーノードの(管理者)権限を持つPowerShell環境で実�
 
    ```PowerShell
    curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/kubeadm/scripts/PrepareNode.ps1
-   .\PrepareNode.ps1 -KubernetesVersion {{% param "fullversion" %}}
+   .\PrepareNode.ps1 -KubernetesVersion v{{% skew currentPatchVersion %}}
    ```
 
 1. `kubeadm`を実行してノードに参加します

--- a/content/ja/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/ja/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -32,8 +32,8 @@ Windowsノードをアップグレードする前にコントロールプレー�
 1.  Windowsノードから、kubeadmをアップグレードします。:
 
     ```powershell
-    # {{% param "fullversion" %}}を目的のバージョンに置き換えます
-    curl.exe -Lo C:\k\kubeadm.exe https://dl.k8s.io/{{% param "fullversion" %}}/bin/windows/amd64/kubeadm.exe
+    # {{% skew currentPatchVersion %}}を目的のバージョンに置き換えます
+    curl.exe -Lo C:\k\kubeadm.exe https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubeadm.exe
     ```
 
 ### ノードをドレインする
@@ -67,7 +67,7 @@ Windowsノードをアップグレードする前にコントロールプレー�
 
     ```powershell
     stop-service kubelet
-    curl.exe -Lo C:\k\kubelet.exe https://dl.k8s.io/{{% param "fullversion" %}}/bin/windows/amd64/kubelet.exe
+    curl.exe -Lo C:\k\kubelet.exe https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubelet.exe
     restart-service kubelet
     ```
 

--- a/content/ja/docs/tutorials/services/connect-applications-service.md
+++ b/content/ja/docs/tutorials/services/connect-applications-service.md
@@ -134,7 +134,7 @@ my-nginx-7vzhx   IPv4          80      10.244.2.5,10.244.3.4   21s
 ## Serviceへのアクセス
 
 KubernetesはServiceを探す2つの主要なモードとして、環境変数とDNSをサポートしています。
-前者はすぐに動かせるのに対し、後者は[CoreDNSクラスターアドオン](https://releases.k8s.io/{{< param "fullversion" >}}/cluster/addons/dns/coredns)が必要です。
+前者はすぐに動かせるのに対し、後者は[CoreDNSクラスターアドオン](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/coredns)が必要です。
 
 {{< note >}}
 もしServiceの環境変数が望ましくないなら(想定しているプログラムの環境変数と競合する可能性がある、処理する変数が多すぎる、DNSだけ使いたい、など)、[pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core)で`enableServiceLinks`のフラグを`false`にすることで、このモードを無効化できます。


### PR DESCRIPTION
Fixup for PR #41527

I haven't brought these pages up to date; some are stale. The only change is to swap to using `skew`.