### PR TITLE
Fix storageclass pvc statement

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -847,9 +847,9 @@ is turned on.
   PVs of that default. Specifying a default StorageClass is done by setting the
   annotation `storageclass.kubernetes.io/is-default-class` equal to `true` in
   a StorageClass object. If the administrator does not specify a default, the
-  cluster responds to PVC creation as if the admission plugin were turned off. If
-  more than one default is specified, the admission plugin forbids the creation of
-  all PVCs.
+  cluster responds to PVC creation as if the admission plugin were turned off. If more than one
+  default StorageClass is specified, the newest default is used when the
+  PVC is dynamically provisioned.
 * If the admission plugin is turned off, there is no notion of a default
   StorageClass. All PVCs that have `storageClassName` set to `""` can be
   bound only to PVs that have `storageClassName` also set to `""`.


### PR DESCRIPTION
This fixes #42176

**Here is what I did:**
![Screenshot from 2023-07-31 20-16-10](https://github.com/kubernetes/website/assets/72978371/8af0d057-0c06-4100-9cf2-7e27b2233a39)

I created two default storage classes. And applied the following manifest file for creating a PVC with no explicit 'storageClassName' attribute.

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 3Gi
```

The PVC got bound with the newest storageclass(local-storage).

Here is a reference: kubernetes/kubernetes#110559

>Admission control plugin "DefaultStorageClass": If more than one StorageClass is designated as default (via the "storageclass.kubernetes.io/is-default-class" annotation), choose the newest one instead of throwing an error.
