### PR TITLE
Mention CephFS and RBD in-tree storage driver deprecation

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -375,7 +375,7 @@ the following types of volumes:
 * {{< glossary_tooltip text="csi" term_id="csi" >}}
 * flexVolume (deprecated)
 * gcePersistentDisk
-* rbd
+* rbd ( **deprecated** in v1.28)
 * portworxVolume
 
 You can only expand a PVC if its storage class's `allowVolumeExpansion` field is set to true.
@@ -505,7 +505,6 @@ Kubernetes does not support shrinking a PVC to less than its current size.
 
 PersistentVolume types are implemented as plugins. Kubernetes currently supports the following plugins:
 
-* [`cephfs`](/docs/concepts/storage/volumes/#cephfs) - CephFS volume
 * [`csi`](/docs/concepts/storage/volumes/#csi) - Container Storage Interface (CSI)
 * [`fc`](/docs/concepts/storage/volumes/#fc) - Fibre Channel (FC) storage
 * [`hostPath`](/docs/concepts/storage/volumes/#hostpath) - HostPath volume
@@ -515,7 +514,6 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 * [`local`](/docs/concepts/storage/volumes/#local) - local storage devices
   mounted on nodes.
 * [`nfs`](/docs/concepts/storage/volumes/#nfs) - Network File System (NFS) storage
-* [`rbd`](/docs/concepts/storage/volumes/#rbd) - Rados Block Device (RBD) volume
 
 The following types of PersistentVolume are deprecated.
 This means that support is still available but will be removed in a future Kubernetes release.
@@ -536,6 +534,10 @@ This means that support is still available but will be removed in a future Kuber
   (**deprecated** in v1.25)
 * [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume) - vSphere VMDK volume
   (**deprecated** in v1.19)
+* [`cephfs`](/docs/concepts/storage/volumes/#cephfs) - CephFS volume
+  (**deprecated** in v1.28)
+* [`rbd`](/docs/concepts/storage/volumes/#rbd) - Rados Block Device (RBD) volume
+  (**deprecated** in v1.28)
 
 Older versions of Kubernetes also supported the following in-tree PersistentVolume types:
 
@@ -726,12 +728,12 @@ The following volume types support mount options:
 * `awsElasticBlockStore`
 * `azureDisk`
 * `azureFile`
-* `cephfs`
+* `cephfs` ( **deprecated** in v1.28)
 * `cinder` (**deprecated** in v1.18)
 * `gcePersistentDisk`
 * `iscsi`
 * `nfs`
-* `rbd`
+* `rbd` ( **deprecated** in v1.28)
 * `vsphereVolume`
 
 Mount options are not validated. If a mount option is invalid, the mount fails.
@@ -952,7 +954,7 @@ applicable:
 * iSCSI
 * Local volume
 * OpenStack Cinder
-* RBD (Ceph Block Device)
+* RBD (Ceph Block Device) ( **deprecated** in v1.28)
 * VsphereVolume
 
 ### PersistentVolume using a Raw Block Volume {#persistent-volume-using-a-raw-block-volume}

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -375,7 +375,7 @@ the following types of volumes:
 * {{< glossary_tooltip text="csi" term_id="csi" >}}
 * flexVolume (deprecated)
 * gcePersistentDisk
-* rbd ( **deprecated** in v1.28)
+* rbd (deprecated)
 * portworxVolume
 
 You can only expand a PVC if its storage class's `allowVolumeExpansion` field is set to true.
@@ -954,7 +954,7 @@ applicable:
 * iSCSI
 * Local volume
 * OpenStack Cinder
-* RBD (Ceph Block Device) ( **deprecated** in v1.28)
+* RBD (deprecated)
 * VsphereVolume
 
 ### PersistentVolume using a Raw Block Volume {#persistent-volume-using-a-raw-block-volume}

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -471,6 +471,11 @@ There are few
 which you try out for persistent volume management inside Kubernetes for vSphere.
 
 ### Ceph RBD
+{{< note >}}
+{{< feature-state state="deprecated" for_k8s_version="v1.28" >}}
+This internal provisioner of Ceph RBD is deprecated. Please use
+[CephFS RBD CSI driver](https://github.com/ceph/ceph-csi).
+{{< /note >}}
 
 ```yaml
 apiVersion: storage.k8s.io/v1

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -190,6 +190,11 @@ To disable the `azureFile` storage plugin from being loaded by the controller ma
 and the kubelet, set the `InTreePluginAzureFileUnregister` flag to `true`.
 
 ### cephfs
+{{< feature-state for_k8s_version="v1.28" state="deprecated" >}}
+
+{{< note >}}
+The Kubernetes project recommends to use [CephFS CSI](https://github.com/ceph/ceph-csi) out-of-tree driver instead.
+{{< /note >}}
 
 A `cephfs` volume allows an existing CephFS volume to be
 mounted into your Pod. Unlike `emptyDir`, which is erased when a pod is
@@ -865,6 +870,11 @@ A projected volume maps several existing volume sources into the same
 directory. For more details, see [projected volumes](/docs/concepts/storage/projected-volumes/).
 
 ### rbd
+{{< feature-state for_k8s_version="v1.28" state="deprecated" >}}
+
+{{< note >}}
+The Kubernetes project recommends to use [Ceph RBD CSI](https://github.com/ceph/ceph-csi)  out-of-tree driver instead.
+{{< /note >}}
 
 An `rbd` volume allows a
 [Rados Block Device](https://docs.ceph.com/en/latest/rbd/) (RBD) volume to mount
@@ -943,7 +953,7 @@ For more details, see [Configuring Secrets](/docs/concepts/configuration/secret/
 ### vsphereVolume (deprecated) {#vspherevolume}
 
 {{< note >}}
-We recommend to use vSphere CSI out-of-tree driver instead.
+The Kubernetes project recommends to use vSphere CSI out-of-tree driver instead.
 {{< /note >}}
 
 A `vsphereVolume` is used to mount a vSphere VMDK volume into your Pod.  The contents

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -193,7 +193,8 @@ and the kubelet, set the `InTreePluginAzureFileUnregister` flag to `true`.
 {{< feature-state for_k8s_version="v1.28" state="deprecated" >}}
 
 {{< note >}}
-The Kubernetes project recommends to use [CephFS CSI](https://github.com/ceph/ceph-csi) out-of-tree driver instead.
+The Kubernetes project suggests that you use the [CephFS CSI](https://github.com/ceph/ceph-csi) third party
+storage driver instead.
 {{< /note >}}
 
 A `cephfs` volume allows an existing CephFS volume to be
@@ -873,7 +874,8 @@ directory. For more details, see [projected volumes](/docs/concepts/storage/proj
 {{< feature-state for_k8s_version="v1.28" state="deprecated" >}}
 
 {{< note >}}
-The Kubernetes project recommends to use [Ceph RBD CSI](https://github.com/ceph/ceph-csi)  out-of-tree driver instead.
+The Kubernetes project suggests that you use the [Ceph CSI](https://github.com/ceph/ceph-csi)
+third party storage driver instead, in RBD mode.
 {{< /note >}}
 
 An `rbd` volume allows a
@@ -953,7 +955,8 @@ For more details, see [Configuring Secrets](/docs/concepts/configuration/secret/
 ### vsphereVolume (deprecated) {#vspherevolume}
 
 {{< note >}}
-The Kubernetes project recommends to use vSphere CSI out-of-tree driver instead.
+The Kubernetes project recommends using the [vSphere CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver)
+out-of-tree storage driver instead.
 {{< /note >}}
 
 A `vsphereVolume` is used to mount a vSphere VMDK volume into your Pod.  The contents


### PR DESCRIPTION
Ceph RBD driver is in deprecation path :

https://github.com/kubernetes/kubernetes/pull/118552

CephFS driver is in deprecation path: 

https://github.com/kubernetes/kubernetes/pull/118143
