### PR TITLE
Switch to finer controls on approver access

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- sig-docs-en-reviews # Defined in OWNERS_ALIASES
+- sig-docs-website-owners # Defined in OWNERS_ALIASES
 
 approvers:
-- sig-docs-en-owners # Defined in OWNERS_ALIASES
+- sig-docs-website-owners # Defined in OWNERS_ALIASES

--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- sig-docs-en-reviews # Defined in OWNERS_ALIASES
+- sig-docs-website-owners # Defined in OWNERS_ALIASES
 
 approvers:
-- sig-docs-en-owners # Defined in OWNERS_ALIASES
+- sig-docs-website-owners # Defined in OWNERS_ALIASES
 
 emeritus_approvers:
 # - chenopis, commented out to disable PR assignments

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,10 +8,26 @@ aliases:
     - mrbobbytables
     - nate-double-u
     - sftim
+  sig-docs-website-owners: # Admins for overall website
+    - divya-mohan0209
+    - natalisucks
+    - reylejano
+    - sftim
+    - tengqm
   sig-docs-localization-owners: # Admins for localization content
     - a-mccarthy
     - divya-mohan0209
     - natalisucks
+    - nate-double-u
+    - reylejano
+    - sftim
+    - seokho-son
+    - tengqm
+  sig-docs-localization-reviewers: # PR reviews for localization changes
+    - a-mccarthy
+    - divya-mohan0209
+    - natalisucks
+    - nate-double-u
     - reylejano
     - sftim
     - seokho-son

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,8 @@ aliases:
     - reylejano
     - sftim
     - tengqm
+    - drewhagen # RT 1.30 Docs Lead
+    - katcosgrove # RT 1.30 Lead
   sig-docs-localization-owners: # Admins for localization content
     - a-mccarthy
     - divya-mohan0209
@@ -42,8 +44,6 @@ aliases:
     - celestehorgan
     - dipesh-rawat
     - divya-mohan0209
-    - drewhagen # RT 1.30 Docs Lead
-    - katcosgrove # RT 1.30 Lead
     - natalisucks
     - nate-double-u
     - reylejano

--- a/assets/OWNERS
+++ b/assets/OWNERS
@@ -1,0 +1,9 @@
+# Label certain changes as web development
+
+filters:
+  "\\.js":
+    labels:
+    - area/web-development
+  "\\.scss$":
+    labels:
+    - area/web-development

--- a/assets/images/OWNERS
+++ b/assets/images/OWNERS
@@ -1,0 +1,22 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the directory for common images. Allow English localization
+# reviewers to review and approve.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-en-reviews
+
+approvers:
+- sig-docs-en-owners
+
+filters:
+  "\\.svg":
+    labels:
+    - area/web-development
+  "\\.png$":
+    labels:
+    - area/web-development
+  "\\.jpe?g$":
+    labels:
+    - area/web-development

--- a/content/OWNERS
+++ b/content/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the directory for all source content.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-localization-reviewers
+
+approvers:
+- sig-docs-localization-owners
+- sig-docs-website-owners

--- a/content/de/OWNERS
+++ b/content/de/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-de-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/de
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/es/OWNERS
+++ b/content/es/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-es-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/es
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/fr/OWNERS
+++ b/content/fr/OWNERS
@@ -8,6 +8,15 @@ reviewers:
 
 approvers:
 - sig-docs-fr-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/fr
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true
+

--- a/content/hi/OWNERS
+++ b/content/hi/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-hi-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/hi
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/id/OWNERS
+++ b/content/id/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# This is the localization project for Bahasa.
+# This is the localization project for Bahasa Indonesia.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
 reviewers:
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-id-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/id
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/it/OWNERS
+++ b/content/it/OWNERS
@@ -6,6 +6,14 @@ reviewers:
 
 approvers:
 - sig-docs-it-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/it
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/ja/OWNERS
+++ b/content/ja/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-ja-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/ja
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/ko/OWNERS
+++ b/content/ko/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-ko-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/ko
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/pl/OWNERS
+++ b/content/pl/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-pl-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/pl
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/pt-br/OWNERS
+++ b/content/pt-br/OWNERS
@@ -1,4 +1,4 @@
-# This is the localization project for Portuguese.
+# This is the localization project for (Brazilian) Portuguese.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
 reviewers:
@@ -6,6 +6,14 @@ reviewers:
 
 approvers:
 - sig-docs-pt-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/pt
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/ru/OWNERS
+++ b/content/ru/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-ru-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/ru
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/uk/OWNERS
+++ b/content/uk/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-uk-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/uk
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/vi/OWNERS
+++ b/content/vi/OWNERS
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-vi-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/vi
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/content/zh-cn/OWNERS
+++ b/content/zh-cn/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# This is the localization project for Chinese.
+# This is the localization project for Chinese (simplified / People's Republic of China)
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
 reviewers:
@@ -8,6 +8,14 @@ reviewers:
 
 approvers:
 - sig-docs-zh-owners
+- sig-docs-website-owners # important due to no_parent_owners option
 
 labels:
+- area/localization
 - language/zh
+
+# Disable inheritance so that the localization team don't end up as approvers for all
+# languages.
+# https://github.com/kubernetes/community/blob/master/communication/website-guidelines.md
+options:
+  no_parent_owners: true

--- a/data/canonical-tags/OWNERS
+++ b/data/canonical-tags/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is where we manage the categories for glossary entries.
+
+reviewers:
+- sig-docs-en-reviews
+
+approvers:
+- sig-docs-website-owners

--- a/data/i18n/OWNERS
+++ b/data/i18n/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the directory for all source content.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-localization-reviewers
+
+approvers:
+- sig-docs-localization-owners
+- sig-docs-website-owners

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -1,0 +1,2 @@
+# Scripts to help manage the website
+# No special ownership (as yet)

--- a/scripts/releng/OWNERS
+++ b/scripts/releng/OWNERS
@@ -4,11 +4,11 @@
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
 reviewers:
-  - sig-docs-en-reviews
+  - sig-docs-website-owners
   - release-engineering-reviewers
 
 approvers:
-  - sig-docs-en-owners
+  - sig-docs-website-owners
   - sig-release-leads
   - release-engineering-approvers
 

--- a/static/css/OWNERS
+++ b/static/css/OWNERS
@@ -1,0 +1,6 @@
+# Label certain changes as web development
+
+filters:
+  "\\.css$":
+    labels:
+    - area/web-development

--- a/static/js/OWNERS
+++ b/static/js/OWNERS
@@ -1,0 +1,9 @@
+# Label certain changes as web development
+
+approvers:
+- sig-docs-website-owners # Defined in OWNERS_ALIASES
+
+filters:
+  "\\.js":
+    labels:
+    - area/web-development


### PR DESCRIPTION
- Add a new website owners group
  - Separate out “I can approve changes to English” from “I can approve changes anywhere on the website”
- Add labels to PRs that make web development changes
- Let the localization team review changes that add new localizations (?)
- Don't allow English reviewers to review changes for other languages (website owners still can)