### PR TITLE
[ko] replaced {{< codenew ... >}} with {{% codenew ... %}}

### DIFF
--- a/content/ko/docs/concepts/cluster-administration/logging.md
+++ b/content/ko/docs/concepts/cluster-administration/logging.md
@@ -39,7 +39,7 @@ weight: 60
 아래 예시는, 초당 한 번씩 표준 출력에 텍스트를 기록하는
 컨테이너를 포함하는 `파드` 매니페스트를 사용한다.
 
-{{< codenew file="debug/counter-pod.yaml" >}}
+{{% codenew file="debug/counter-pod.yaml" %}}
 
 이 파드를 실행하려면, 다음의 명령을 사용한다.
 
@@ -247,7 +247,7 @@ etcd와 etcd의 로그를 기록하는 방식에 대한 자세한 정보는 [etc
 서로 다른 두 가지 형식을 사용하여 서로 다른 두 개의 로그 파일에 기록한다.
 다음은 파드에 대한 매니페스트이다.
 
-{{< codenew file="admin/logging/two-files-counter-pod.yaml" >}}
+{{% codenew file="admin/logging/two-files-counter-pod.yaml" %}}
 
 두 컴포넌트를 컨테이너의 `stdout` 스트림으로 리디렉션한 경우에도, 동일한 로그
 스트림에 서로 다른 형식의 로그 항목을 작성하는 것은
@@ -257,7 +257,7 @@ etcd와 etcd의 로그를 기록하는 방식에 대한 자세한 정보는 [etc
 
 다음은 사이드카 컨테이너가 두 개인 파드에 대한 매니페스트이다.
 
-{{< codenew file="admin/logging/two-files-counter-pod-streaming-sidecar.yaml" >}}
+{{% codenew file="admin/logging/two-files-counter-pod-streaming-sidecar.yaml" %}}
 
 이제 이 파드를 실행하면, 다음의 명령을 실행하여 각 로그 스트림에
 개별적으로 접근할 수 있다.
@@ -324,7 +324,7 @@ CPU 및 메모리 사용량이 낮은(몇 밀리코어 수준의 CPU와 몇 메�
 첫 번째 매니페스트는 fluentd를 구성하는
 [`컨피그맵(ConfigMap)`](/docs/tasks/configure-pod-container/configure-pod-configmap/)이 포함되어 있다.
 
-{{< codenew file="admin/logging/fluentd-sidecar-config.yaml" >}}
+{{% codenew file="admin/logging/fluentd-sidecar-config.yaml" %}}
 
 {{< note >}}
 예제 매니페스트에서, 꼭 fluentd가 아니더라도,
@@ -334,7 +334,7 @@ CPU 및 메모리 사용량이 낮은(몇 밀리코어 수준의 CPU와 몇 메�
 두 번째 매니페스트는 fluentd가 실행되는 사이드카 컨테이너가 있는 파드를 설명한다.
 파드는 fluentd가 구성 데이터를 가져올 수 있는 볼륨을 마운트한다.
 
-{{< codenew file="admin/logging/two-files-counter-pod-agent-sidecar.yaml" >}}
+{{% codenew file="admin/logging/two-files-counter-pod-agent-sidecar.yaml" %}}
 
 ### 애플리케이션에서 직접 로그 노출
 

--- a/content/ko/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/ko/docs/concepts/cluster-administration/manage-deployment.md
@@ -16,7 +16,7 @@ weight: 40
 
 많은 애플리케이션들은 디플로이먼트 및 서비스와 같은 여러 리소스를 필요로 한다. 여러 리소스의 관리는 동일한 파일에 그룹화하여 단순화할 수 있다(YAML에서 `---` 로 구분). 예를 들면 다음과 같다.
 
-{{< codenew file="application/nginx-app.yaml" >}}
+{{% codenew file="application/nginx-app.yaml" %}}
 
 단일 리소스와 동일한 방식으로 여러 리소스를 생성할 수 있다.
 

--- a/content/ko/docs/concepts/configuration/configmap.md
+++ b/content/ko/docs/concepts/configuration/configmap.md
@@ -111,7 +111,7 @@ data:
 
 다음은 `game-demo` 의 값을 사용하여 파드를 구성하는 파드 예시이다.
 
-{{< codenew file="configmap/configure-pod.yaml" >}}
+{{% codenew file="configmap/configure-pod.yaml" %}}
 
 컨피그맵은 단일 라인 속성(single line property) 값과 멀티 라인의 파일과 비슷한(multi-line file-like) 값을
 구분하지 않는다.

--- a/content/ko/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -72,7 +72,7 @@ JSON 형식으로 정보를 포함시켜 줘야만 한다. **대부분의 경우
 
 여기 쿠버네티스 디플로이먼트를 위한 필수 필드와 오브젝트 spec을 보여주는 `.yaml` 파일 예시가 있다.
 
-{{< codenew file="application/deployment.yaml" >}}
+{{% codenew file="application/deployment.yaml" %}}
 
 위 예시와 같이 .yaml 파일을 이용하여 디플로이먼트를 생성하기 위한 하나의 방식으로는
 `kubectl` 커맨드-라인 인터페이스에 인자값으로 `.yaml` 파일을 건네

--- a/content/ko/docs/concepts/policy/limit-range.md
+++ b/content/ko/docs/concepts/policy/limit-range.md
@@ -54,12 +54,12 @@ _리밋레인지_ 는 다음과 같은 제약 조건을 제공한다.
 
 예를 들어, 이 매니페스트에 `LimitRange`를 정의한다.
 
-{{< codenew file="concepts/policy/limit-range/problematic-limit-range.yaml" >}}
+{{% codenew file="concepts/policy/limit-range/problematic-limit-range.yaml" %}}
 
 
 이 때 CPU 리소스 요청을 `700m`로 선언하지만 제한은 선언하지 않는 파드를 포함한다.
 
-{{< codenew file="concepts/policy/limit-range/example-conflict-with-limitrange-cpu.yaml" >}}
+{{% codenew file="concepts/policy/limit-range/example-conflict-with-limitrange-cpu.yaml" %}}
 
 
 그러면 해당 파드는 스케줄링되지 않고 다음과 유사한 오류와 함께 실패한다.
@@ -69,7 +69,7 @@ Pod "example-conflict-with-limitrange-cpu" is invalid: spec.containers[0].resour
 
 `request`와 `limit`를 모두 설정하면, 동일한 `LimitRange`가 적용되어 있어도 새 파드는 성공적으로 스케줄링된다.
 
-{{< codenew file="concepts/policy/limit-range/example-no-conflict-with-limitrange-cpu.yaml" >}}
+{{% codenew file="concepts/policy/limit-range/example-no-conflict-with-limitrange-cpu.yaml" %}}
 
 ## 리소스 제약 예시
 

--- a/content/ko/docs/concepts/policy/resource-quotas.md
+++ b/content/ko/docs/concepts/policy/resource-quotas.md
@@ -687,7 +687,7 @@ plugins:
 
 그리고, `kube-system` 네임스페이스에 리소스 쿼터 오브젝트를 생성한다.
 
-{{< codenew file="policy/priority-class-resourcequota.yaml" >}}
+{{% codenew file="policy/priority-class-resourcequota.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/policy/priority-class-resourcequota.yaml -n kube-system

--- a/content/ko/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/ko/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -123,7 +123,7 @@ kubelet이 `node-restriction.kubernetes.io/` 접두사를 갖는 레이블을
 
 예를 들어, 다음과 같은 파드 스펙이 있다고 하자.
 
-{{< codenew file="pods/pod-with-node-affinity.yaml" >}}
+{{% codenew file="pods/pod-with-node-affinity.yaml" %}}
 
 이 예시에서는 다음의 규칙이 적용된다.
 
@@ -170,7 +170,7 @@ kubelet이 `node-restriction.kubernetes.io/` 접두사를 갖는 레이블을
 
 예를 들어, 다음과 같은 파드 스펙이 있다고 하자.
 
-{{< codenew file="pods/pod-with-affinity-anti-affinity.yaml" >}}
+{{% codenew file="pods/pod-with-affinity-anti-affinity.yaml" %}}
 
 `preferredDuringSchedulingIgnoredDuringExecution` 규칙을 만족하는 노드가 2개 있고, 
 하나에는 `label-1:key-1` 레이블이 있고 다른 하나에는 `label-2:key-2` 레이블이 있으면, 
@@ -286,7 +286,7 @@ Y는 쿠버네티스가 충족할 규칙이다.
 
 다음과 같은 파드 스펙을 가정한다.
 
-{{< codenew file="pods/pod-with-pod-affinity.yaml" >}}
+{{% codenew file="pods/pod-with-pod-affinity.yaml" %}}
 
 이 예시는 하나의 파드 어피니티 규칙과 
 하나의 파드 안티-어피니티 규칙을 정의한다.

--- a/content/ko/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ko/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -46,7 +46,7 @@ stateDiagram-v2
 
 파드가 스케줄링 될 준비가 되지 않았다고 표시하려면, 다음과 같이 하나 이상의 스케줄링 게이트를 생성하여 표시할 수 있다.
 
-{{< codenew file="pods/pod-with-scheduling-gates.yaml" >}}
+{{% codenew file="pods/pod-with-scheduling-gates.yaml" %}}
 
 파드가 생성된 후에는 다음 명령을 사용하여 상태를 확인할 수 있다.
 
@@ -76,7 +76,7 @@ kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
 스케줄러에게 이 파드가 스케줄링 될 준비가 되었음을 알리기 위해, 수정된 매니페스트를 다시 적용하여
 `schedulingGates`를 완전히 제거할 수 있다.
 
-{{< codenew file="pods/pod-without-scheduling-gates.yaml" >}}
+{{% codenew file="pods/pod-without-scheduling-gates.yaml" %}}
 
 `schedulingGates`가 지워졌는지 확인하려면 다음 명령을 실행하여 확인할 수 있다.
 

--- a/content/ko/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/ko/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -64,7 +64,7 @@ tolerations:
 
 톨러레이션을 사용하는 파드의 예는 다음과 같다.
 
-{{< codenew file="pods/pod-with-toleration.yaml" >}}
+{{% codenew file="pods/pod-with-toleration.yaml" %}}
 
 지정하지 않으면 `operator` 의 기본값은 `Equal` 이다.
 

--- a/content/ko/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/ko/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -274,7 +274,7 @@ graph BT
 신규 파드가 기존 파드와 함께 여러 존에 걸쳐 균등하게 분배되도록 하려면, 
 다음과 같은 매니페스트를 사용할 수 있다.
 
-{{< codenew file="pods/topology-spread-constraints/one-constraint.yaml" >}}
+{{% codenew file="pods/topology-spread-constraints/one-constraint.yaml" %}}
 
 위의 매니페스트에서, `topologyKey: zone`이 의미하는 것은 `zone: <any value>`로 레이블된 
 노드에 대해서만 균등한 분배를 적용한다는 뜻이다(`zone` 레이블이 없는 노드는 무시된다). 
@@ -367,7 +367,7 @@ graph BT
 사용자는 2개의 토폴로지 분배 제약 조건을 사용하여 
 노드 및 존 기반으로 파드가 분배되도록 제어할 수 있다.
 
-{{< codenew file="pods/topology-spread-constraints/two-constraints.yaml" >}}
+{{% codenew file="pods/topology-spread-constraints/two-constraints.yaml" %}}
 
 이 경우에는, 첫 번째 제약 조건에 부합하려면, 신규 파드는 오직 `B` 존에만 배치될 수 있다. 
 한편 두 번째 제약 조건에 따르면 신규 파드는 오직 `node4` 노드에만 배치될 수 있다. 
@@ -456,7 +456,7 @@ class zoneC cluster;
 이 경우에, 다음과 같이 매니페스트를 작성하여, `mypod` 파드가 `C` 존 대신 `B` 존에 배치되도록 할 수 있다. 
 유사하게, 쿠버네티스는 `spec.nodeSelector` 필드도 고려한다.
 
-{{< codenew file="pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml" >}}
+{{% codenew file="pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml" %}}
 
 ## 암묵적 규칙
 

--- a/content/ko/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/ko/docs/concepts/services-networking/dns-pod-service.md
@@ -300,7 +300,7 @@ spec:
 
 다음은 커스텀 DNS 세팅을 한 파드의 예시이다.
 
-{{< codenew file="service/networking/custom-dns.yaml" >}}
+{{% codenew file="service/networking/custom-dns.yaml" %}}
 
 위에서 파드가 생성되면,
 컨테이너 `test`의 `/etc/resolv.conf` 파일에는 다음과 같은 내용이 추가된다.

--- a/content/ko/docs/concepts/services-networking/dual-stack.md
+++ b/content/ko/docs/concepts/services-networking/dual-stack.md
@@ -129,7 +129,7 @@ IPv4, IPv6 또는 둘 다를 사용할 수 있는 {{< glossary_tooltip text="서
 [헤드리스 서비스](/ko/docs/concepts/services-networking/service/#헤드리스-headless-서비스)와
 같은 방식으로 동작한다.)
 
-{{< codenew file="service/networking/dual-stack-default-svc.yaml" >}}
+{{% codenew file="service/networking/dual-stack-default-svc.yaml" %}}
 
 1. 이 서비스 사양은 `.spec.ipFamilyPolicy`에 `PreferDualStack`을
    명시적으로 정의한다. 이중 스택 클러스터에서 이 서비스를 생성하면 쿠버네티스는
@@ -145,14 +145,14 @@ IPv4, IPv6 또는 둘 다를 사용할 수 있는 {{< glossary_tooltip text="서
    * 이중 스택이 활성화된 클러스터에서 `.spec.ipFamilyPolicy`에 `RequireDualStack`을
      지정하면 `PreferDualStack`과 동일하게 작동한다.
 
-{{< codenew file="service/networking/dual-stack-preferred-svc.yaml" >}}
+{{% codenew file="service/networking/dual-stack-preferred-svc.yaml" %}}
 
 1. 이 서비스 사양은 `.spec.ipFamilies`에` IPv6`과 `IPv4`를 명시적으로 정의하고
    `.spec.ipFamilyPolicy`에 `PreferDualStack`을 정의한다. 쿠버네티스가 `.spec.ClusterIPs`에
    IPv6 및 IPv4 주소를 할당할 때 `.spec.ClusterIP`는 `.spec.ClusterIPs` 배열의
    첫 번째 요소이므로 IPv6 주소로 설정되어 기본값을 재정의한다.
 
-{{< codenew file="service/networking/dual-stack-preferred-ipfamilies-svc.yaml" >}}
+{{% codenew file="service/networking/dual-stack-preferred-ipfamilies-svc.yaml" %}}
 
 #### 기존 서비스의 이중 스택 기본값
 
@@ -165,7 +165,7 @@ IPv4, IPv6 또는 둘 다를 사용할 수 있는 {{< glossary_tooltip text="서
    `.spec.ipFamilies`를 기존 서비스의 주소 계열로 설정한다.
    기존 서비스 클러스터 IP는 `.spec.ClusterIPs`에 저장한다.
 
-   {{< codenew file="service/networking/dual-stack-default-svc.yaml" >}}
+   {{% codenew file="service/networking/dual-stack-default-svc.yaml" %}}
 
    kubectl을 사용하여 기존 서비스를 검사하여 이 동작을 검증할 수 있다.
 
@@ -205,7 +205,7 @@ IPv4, IPv6 또는 둘 다를 사용할 수 있는 {{< glossary_tooltip text="서
    클러스터 IP 범위(kube-apiserver에 대한 `--service-cluster-ip-range` 플래그를 통해 구성)의 주소 계열으로
    지정한다.
 
-   {{< codenew file="service/networking/dual-stack-default-svc.yaml" >}}
+   {{% codenew file="service/networking/dual-stack-default-svc.yaml" %}}
 
    kubectl을 사용하여 셀렉터로 기존 헤드리스 서비스를 검사하여 이 동작의 유효성을 검사 할 수 있다.
 

--- a/content/ko/docs/concepts/services-networking/ingress.md
+++ b/content/ko/docs/concepts/services-networking/ingress.md
@@ -62,7 +62,7 @@ weight: 30
 
 최소한의 인그레스 리소스 예제:
 
-{{< codenew file="service/networking/minimal-ingress.yaml" >}}
+{{% codenew file="service/networking/minimal-ingress.yaml" %}}
 
 인그레스에는 `apiVersion`, `kind`, `metadata` 및 `spec` 필드가 명시되어야 한다.
 인그레스 오브젝트의 이름은 유효한
@@ -128,7 +128,7 @@ weight: 30
 백엔드의 일반적인 용도는 정적 자산이 있는 오브젝트 스토리지 백엔드로 데이터를
 수신하는 것이다.
 
-{{< codenew file="service/networking/ingress-resource-backend.yaml" >}}
+{{% codenew file="service/networking/ingress-resource-backend.yaml" %}}
 
 위의 인그레스를 생성한 후, 다음의 명령으로 확인할 수 있다.
 
@@ -213,7 +213,7 @@ Events:       <none>
 | `*.foo.com` | `baz.bar.foo.com` | 일치하지 않음, 와일드카드는 단일 DNS 레이블만 포함함          |
 | `*.foo.com` | `foo.com`         | 일치하지 않음, 와일드카드는 단일 DNS 레이블만 포함함          |
 
-{{< codenew file="service/networking/ingress-wildcard-host.yaml" >}}
+{{% codenew file="service/networking/ingress-wildcard-host.yaml" %}}
 
 ## 인그레스 클래스
 
@@ -222,7 +222,7 @@ Events:       <none>
 이름을 포함하여 추가 구성이 포함된 IngressClass
 리소스에 대한 참조 클래스를 지정해야 한다.
 
-{{< codenew file="service/networking/external-lb.yaml" >}}
+{{% codenew file="service/networking/external-lb.yaml" %}}
 
 인그레스클래스의 `.spec.parameters` 필드를 사용하여 
 해당 인그레스클래스와 연관있는 환경 설정을 제공하는 다른 리소스를 참조할 수 있다.
@@ -350,7 +350,7 @@ spec:
 하지만 다음과 같이 기본 `IngressClass`를 명시하는 것을 
 [권장](https://kubernetes.github.io/ingress-nginx/#i-have-only-one-instance-of-the-ingresss-nginx-controller-in-my-cluster-what-should-i-do)한다.
 
-{{< codenew file="service/networking/default-ingressclass.yaml" >}}
+{{% codenew file="service/networking/default-ingressclass.yaml" %}}
 
 ## 인그레스 유형들
 
@@ -360,7 +360,7 @@ spec:
 ([대안](#대안)을 본다). 인그레스에 규칙 없이 *기본 백엔드* 를 지정해서
 이를 수행할 수 있다.
 
-{{< codenew file="service/networking/test-ingress.yaml" >}}
+{{% codenew file="service/networking/test-ingress.yaml" %}}
 
 만약 `kubectl apply -f` 를 사용해서 생성한다면 추가한 인그레스의
 상태를 볼 수 있어야 한다.
@@ -393,7 +393,7 @@ test-ingress   external-lb   *       203.0.113.123   80      59s
 
 다음과 같은 인그레스가 필요하다.
 
-{{< codenew file="service/networking/simple-fanout-example.yaml" >}}
+{{% codenew file="service/networking/simple-fanout-example.yaml" %}}
 
 `kubectl apply -f` 를 사용해서 인그레스를 생성 할 때 다음과 같다.
 
@@ -439,7 +439,7 @@ Events:
 다음 인그레스는 [호스트 헤더](https://tools.ietf.org/html/rfc7230#section-5.4)에 기반한 요청을
 라우팅 하기 위해 뒷단의 로드 밸런서를 알려준다.
 
-{{< codenew file="service/networking/name-virtual-host-ingress.yaml" >}}
+{{% codenew file="service/networking/name-virtual-host-ingress.yaml" %}}
 
 만약 규칙에 정의된 호스트 없이 인그레스 리소스를 생성하는 경우,
 이름 기반 가상 호스트가 없어도 인그레스 컨트롤러의 IP 주소에 대한 웹
@@ -448,7 +448,7 @@ Events:
 예를 들어, 다음 인그레스는 `first.bar.com`에 요청된 트래픽을
 `service1`로, `second.bar.com`는 `service2`로, 그리고 요청 헤더가 `first.bar.com` 또는 `second.bar.com`에 해당되지 않는 모든 트래픽을 `service3`로 라우팅한다.
 
-{{< codenew file="service/networking/name-virtual-host-ingress-no-third-host.yaml" >}}
+{{% codenew file="service/networking/name-virtual-host-ingress-no-third-host.yaml" %}}
 
 ### TLS
 
@@ -486,7 +486,7 @@ TLS는 기본 규칙에서 작동하지 않는다. 따라서
 한다.
 {{< /note >}}
 
-{{< codenew file="service/networking/tls-example-ingress.yaml" >}}
+{{% codenew file="service/networking/tls-example-ingress.yaml" %}}
 
 {{< note >}}
 TLS 기능을 제공하는 다양한 인그레스 컨트롤러간의 기능

--- a/content/ko/docs/concepts/services-networking/network-policies.md
+++ b/content/ko/docs/concepts/services-networking/network-policies.md
@@ -50,7 +50,7 @@ pod- 또는 namespace- 기반의 네트워크폴리시를 정의할 때, {{< glo
 
 네트워크폴리시 의 예시는 다음과 같다.
 
-{{< codenew file="service/networking/networkpolicy.yaml" >}}
+{{% codenew file="service/networking/networkpolicy.yaml" %}}
 
 {{< note >}}
 선택한 네트워킹 솔루션이 네트워킹 정책을 지원하지 않으면 클러스터의 API 서버에 이를 POST 하더라도 효과가 없다.
@@ -150,7 +150,7 @@ __ipBlock__: 인그레스 소스 또는 이그레스 대상으로 허용할 IP C
 
 모든 파드를 선택하지만 해당 파드에 대한 인그레스 트래픽은 허용하지 않는 네트워크폴리시를 생성해서 네임스페이스에 대한 "기본" 인그레스 격리 정책을 생성할 수 있다.
 
-{{< codenew file="service/networking/network-policy-default-deny-ingress.yaml" >}}
+{{% codenew file="service/networking/network-policy-default-deny-ingress.yaml" %}}
 
 이렇게 하면 다른 네트워크폴리시에서 선택하지 않은 파드도 인그레스에 대해 여전히 격리된다. 이 정책은 다른 파드로부터의 이그레스 격리에는 영향을 미치지 않는다.
 
@@ -158,7 +158,7 @@ __ipBlock__: 인그레스 소스 또는 이그레스 대상으로 허용할 IP C
 
 한 네임스페이스의 모든 파드로의 인입(incoming) 연결을 허용하려면, 이를 명시적으로 허용하는 정책을 만들 수 있다.
 
-{{< codenew file="service/networking/network-policy-allow-all-ingress.yaml" >}}
+{{% codenew file="service/networking/network-policy-allow-all-ingress.yaml" %}}
 
 이 정책이 존재하면, 해당 파드로의 인입 연결을 막는 다른 정책은 효력이 없다. 이 정책은 모든 파드로부터의 이그레스 격리에는 영향을 미치지 않는다.
 
@@ -166,7 +166,7 @@ __ipBlock__: 인그레스 소스 또는 이그레스 대상으로 허용할 IP C
 
 모든 파드를 선택하지만, 해당 파드의 이그레스 트래픽을 허용하지 않는 네트워크폴리시를 생성해서 네임스페이스에 대한 "기본" 이그레스 격리 정책을 생성할 수 있다.
 
-{{< codenew file="service/networking/network-policy-default-deny-egress.yaml" >}}
+{{% codenew file="service/networking/network-policy-default-deny-egress.yaml" %}}
 
 이렇게 하면 다른 네트워크폴리시에서 선택하지 않은 파드조차도 이그레스 트래픽을 허용하지 않는다. 이 정책은
 모든 파드의 인그레스 격리 정책을 변경하지 않는다.
@@ -175,7 +175,7 @@ __ipBlock__: 인그레스 소스 또는 이그레스 대상으로 허용할 IP C
 
 한 네임스페이스의 모든 파드로부터의 모든 연결을 허용하려면, 해당 네임스페이스의 파드로부터 나가는(outgoing) 모든 연결을 명시적으로 허용하는 정책을 생성할 수 있다.
 
-{{< codenew file="service/networking/network-policy-allow-all-egress.yaml" >}}
+{{% codenew file="service/networking/network-policy-allow-all-egress.yaml" %}}
 
 이 정책이 존재하면, 해당 파드에서 나가는 연결을 막는 다른 정책은 효력이 없다. 이 정책은 모든 파드로의 인그레스 격리에는 영향을 미치지 않는다.
 
@@ -183,7 +183,7 @@ __ipBlock__: 인그레스 소스 또는 이그레스 대상으로 허용할 IP C
 
 해당 네임스페이스에 아래의 네트워크폴리시를 만들어 모든 인그레스와 이그레스 트래픽을 방지하는 네임스페이스에 대한 "기본" 정책을 만들 수 있다.
 
-{{< codenew file="service/networking/network-policy-default-deny-all.yaml" >}}
+{{% codenew file="service/networking/network-policy-default-deny-all.yaml" %}}
 
 이렇게 하면 다른 네트워크폴리시에서 선택하지 않은 파드도 인그레스 또는 이그레스 트래픽을 허용하지 않는다.
 

--- a/content/ko/docs/concepts/storage/projected-volumes.md
+++ b/content/ko/docs/concepts/storage/projected-volumes.md
@@ -30,11 +30,11 @@ weight: 21 # just after persistent volumes
 
 ### 시크릿, downwardAPI, 컨피그맵 구성 예시 {#example-configuration-secret-downwardapi-configmap}
 
-{{< codenew file="pods/storage/projected-secret-downwardapi-configmap.yaml" >}}
+{{% codenew file="pods/storage/projected-secret-downwardapi-configmap.yaml" %}}
 
 ### 기본 권한이 아닌 모드 설정의 시크릿 구성 예시 {#example-configuration-secrets-nondefault-permission-mode}
 
-{{< codenew file="pods/storage/projected-secrets-nondefault-permission-mode.yaml" >}}
+{{% codenew file="pods/storage/projected-secrets-nondefault-permission-mode.yaml" %}}
 
 각 프로젝티드 볼륨 소스는 `sources` 아래의 스펙에 나열된다.
 파라미터는 두 가지 예외를 제외하고 동일하다.
@@ -49,7 +49,7 @@ weight: 21 # just after persistent volumes
 파드의 지정된 경로에 [서비스어카운트토큰](/docs/reference/access-authn-authz/authentication/#service-account-tokens)을
 주입할 수 있다. 
 
-{{< codenew file="pods/storage/projected-service-account-token.yaml" >}}
+{{% codenew file="pods/storage/projected-service-account-token.yaml" %}}
 
 위 예시에는 파드에 주입된 서비스어카운트토큰이 포함된 프로젝티드 볼륨이 있다. 
 이 파드의 컨테이너는 서비스어카운트토큰을 사용하여 쿠버네티스 API 서버에 접근하고,

--- a/content/ko/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/ko/docs/concepts/workloads/controllers/cron-jobs.md
@@ -55,7 +55,7 @@ kube-controller-manager 컨테이너에 설정된 시간대는
 
 이 크론잡 매니페스트 예제는 현재 시간과 hello 메시지를 1분마다 출력한다.
 
-{{< codenew file="application/job/cronjob.yaml" >}}
+{{% codenew file="application/job/cronjob.yaml" %}}
 
 ([크론잡으로 자동화된 작업 실행하기](/ko/docs/tasks/job/automated-tasks-with-cron-jobs/)는
 이 예시를 더 자세히 설명한다.)

--- a/content/ko/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/ko/docs/concepts/workloads/controllers/daemonset.md
@@ -35,7 +35,7 @@ _데몬셋_ 은 모든(또는 일부) 노드가 파드의 사본을 실행하도
 YAML 파일에 데몬셋 명세를 작성할 수 있다. 예를 들어 아래 `daemonset.yaml` 파일은 
 fluentd-elasticsearch 도커 이미지를 실행하는 데몬셋을 설명한다.
 
-{{< codenew file="controllers/daemonset.yaml" >}}
+{{% codenew file="controllers/daemonset.yaml" %}}
 
 YAML 파일을 기반으로 데몬셋을 생성한다.
 

--- a/content/ko/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ko/docs/concepts/workloads/controllers/deployment.md
@@ -40,7 +40,7 @@ _디플로이먼트(Deployment)_ 는 {{< glossary_tooltip text="파드" term_id=
 
 다음은 디플로이먼트의 예시이다. 예시는 3개의 `nginx` 파드를 불러오기 위한 레플리카셋을 생성한다.
 
-{{< codenew file="controllers/nginx-deployment.yaml" >}}
+{{% codenew file="controllers/nginx-deployment.yaml" %}}
 
 이 예시에 대한 설명은 다음과 같다.
 

--- a/content/ko/docs/concepts/workloads/controllers/job.md
+++ b/content/ko/docs/concepts/workloads/controllers/job.md
@@ -36,7 +36,7 @@ weight: 50
 다음은 잡 설정 예시이다.  예시는 파이(π)의 2000 자리까지 계산해서 출력한다.
 이를 완료하는 데 약 10초가 소요된다.
 
-{{< codenew file="controllers/job.yaml" >}}
+{{% codenew file="controllers/job.yaml" %}}
 
 이 명령으로 예시를 실행할 수 있다.
 
@@ -749,7 +749,7 @@ spec:
 
 다음은 `podFailurePolicy`를 정의하는 잡의 매니페스트이다.
 
-{{< codenew file="/controllers/job-pod-failure-policy-example.yaml" >}}
+{{% codenew file="/controllers/job-pod-failure-policy-example.yaml" %}}
 
 위 예시에서, 파드 실패 정책의 첫 번째 규칙은 `main` 컨테이너가 42 종료코드와 
 함께 실패하면 잡도 실패로 표시되는 것으로 

--- a/content/ko/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/ko/docs/concepts/workloads/controllers/replicaset.md
@@ -52,7 +52,7 @@ OwnerReference가 없거나, OwnerReference가 {{< glossary_tooltip term_id="con
 
 ## 예시
 
-{{< codenew file="controllers/frontend.yaml" >}}
+{{% codenew file="controllers/frontend.yaml" %}}
 
 이 매니페스트를 `frontend.yaml`에 저장하고 쿠버네티스 클러스터에 적용하면 정의되어 있는 레플리카셋이
 생성되고 레플리카셋이 관리하는 파드가 생성된다.
@@ -162,7 +162,7 @@ metadata:
 
 이전 프런트엔드 레플리카셋 예제와 다음의 매니페스트에 명시된 파드를 가져와 참조한다.
 
-{{< codenew file="pods/pod-rs.yaml" >}}
+{{% codenew file="pods/pod-rs.yaml" %}}
 
 기본 파드는 소유자 관련 정보에 컨트롤러(또는 오브젝트)를 가지지 않기 때문에 프런트엔드
 레플리카셋의 셀렉터와 일치하면 즉시 레플리카셋에 소유된다.
@@ -373,7 +373,7 @@ apiserver에서 많은 양의 파드 업데이트를 동반하기 때문이다.
 즉, 레플리카셋은 HPA에 의해 오토스케일될 수 있다.
 다음은 이전에 만든 예시에서 만든 레플리카셋을 대상으로 하는 HPA 예시이다.
 
-{{< codenew file="controllers/hpa-rs.yaml" >}}
+{{% codenew file="controllers/hpa-rs.yaml" %}}
 
 이 매니페스트를 `hpa-rs.yaml`로 저장한 다음 쿠버네티스
 클러스터에 적용하면 CPU 사용량에 따라 파드가 복제되는

--- a/content/ko/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/ko/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -41,7 +41,7 @@ kubectl 명령에서 숏컷으로 사용된다.
 
 레플리케이션 컨트롤러 예제의 config는 nginx 웹서버의 복사본 세 개를 실행한다.
 
-{{< codenew file="controllers/replication.yaml" >}}
+{{% codenew file="controllers/replication.yaml" %}}
 
 예제 파일을 다운로드한 후 다음 명령을 실행하여 예제 작업을 실행하라.
 

--- a/content/ko/docs/concepts/workloads/pods/_index.md
+++ b/content/ko/docs/concepts/workloads/pods/_index.md
@@ -48,7 +48,7 @@ _파드_ (고래 떼(pod of whales)나 콩꼬투리(pea pod)와 마찬가지로)
 
 다음은 `nginx:1.14.2` 이미지를 실행하는 컨테이너로 구성되는 파드의 예시이다.
 
-{{< codenew file="pods/simple-pod.yaml" >}}
+{{% codenew file="pods/simple-pod.yaml" %}}
 
 위에서 설명한 파드를 생성하려면, 다음 명령을 실행한다.
 ```shell

--- a/content/ko/docs/contribute/style/write-new-topic.md
+++ b/content/ko/docs/contribute/style/write-new-topic.md
@@ -124,14 +124,14 @@ YAML 파일과 같은 새로운 독립형 샘플 파일을 추가할 때
 주제에 관한 언어이다. 문서 파일에서 `codenew` 단축 코드(shortcode)를 사용하자.
 
 ```none
-{{</* codenew file="<RELPATH>/my-example-yaml>" */>}}
+{{%/* codenew file="<RELPATH>/my-example-yaml>" */%}}
 ```
 여기서 `<RELPATH>` 는 `examples` 디렉터리와 관련하여 포함될
 파일의 경로이다. 다음 Hugo 단축 코드(shortcode)는 `/content/en/examples/pods/storage/gce-volume.yaml`
 에 있는 YAML 파일을 참조한다.
 
 ```none
-{{</* codenew file="pods/storage/gce-volume.yaml" */>}}
+{{%/* codenew file="pods/storage/gce-volume.yaml" */%}}
 ```
 
 {{< note >}}

--- a/content/ko/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/ko/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -259,7 +259,7 @@ kubelet이 _프로젝티드 볼륨_ 을 사용하여 이를 설정하기 때문�
 
 아래는 시크릿을 위한 예제 매니페스트이다.
 
-{{< codenew file="secret/serviceaccount/mysecretname.yaml" >}}
+{{% codenew file="secret/serviceaccount/mysecretname.yaml" %}}
 
 이 예제에 기반한 시크릿을 생성하려면, 아래의 명령어를 실행한다.
 

--- a/content/ko/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/content/ko/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -23,7 +23,7 @@ weight: 110
 통신에 사용할 수 있는 볼륨을 공유한다.
 아래는 이 파드의 구성 파일이다.
 
-{{< codenew file="pods/two-container-pod.yaml" >}}
+{{% codenew file="pods/two-container-pod.yaml" %}}
 
 이 구성 파일에는 파드가 `shared-data`로 명명한 볼륨을 가진 것을
 알 수 있다.

--- a/content/ko/docs/tasks/access-application-cluster/connecting-frontend-backend.md
+++ b/content/ko/docs/tasks/access-application-cluster/connecting-frontend-backend.md
@@ -36,7 +36,7 @@ weight: 70
 백엔드는 인사하기라는 간단한 마이크로서비스이다. 여기에 백엔드 디플로이먼트
 구성 파일이 있다.
 
-{{< codenew file="service/access/backend-deployment.yaml" >}}
+{{% codenew file="service/access/backend-deployment.yaml" %}}
 
 백엔드 디플로이먼트를 생성한다.
 
@@ -97,7 +97,7 @@ Events:
 
 먼저, 서비스 구성 파일을 살펴보자.
 
-{{< codenew file="service/access/backend-service.yaml" >}}
+{{% codenew file="service/access/backend-service.yaml" %}}
 
 구성 파일에서 `hello` 라는 이름의 서비스가 `app: hello` 및 `tier: backend` 레이블을 갖는
 파드에 트래픽을 보내는 것을 볼 수 있다.
@@ -125,7 +125,7 @@ kubectl apply -f https://k8s.io/examples/service/access/backend-service.yaml
 프론트엔드 디플로이먼트 안의 파드는 `hello` 백엔드 서비스에 대한 요청을
 프록시하도록 구성된 nginx 이미지를 실행한다. 다음은 nginx 구성 파일이다.
 
-{{< codenew file="service/access/frontend-nginx.conf" >}}
+{{% codenew file="service/access/frontend-nginx.conf" %}}
 
 백엔드와 같이, 프론트엔드는 디플로이먼트와 서비스를 갖고 있다. 백엔드
 서비스와 프론트엔드 서비스 간에 주목해야 할 중요한 차이점은 프론트엔드
@@ -133,9 +133,9 @@ kubectl apply -f https://k8s.io/examples/service/access/backend-service.yaml
 서비스가 클라우드 공급자가 프로비저닝한 로드 밸런서를 사용하고
 클러스터 외부에서 접근할 수 있음을 의미한다.
 
-{{< codenew file="service/access/frontend-service.yaml" >}}
+{{% codenew file="service/access/frontend-service.yaml" %}}
 
-{{< codenew file="service/access/frontend-deployment.yaml" >}}
+{{% codenew file="service/access/frontend-deployment.yaml" %}}
 
 프론트엔드 디플로이먼트와 서비스를 생성한다.
 

--- a/content/ko/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/ko/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -152,7 +152,7 @@ storage-provisioner                         1/1       Running   0          2m
 
 1. 다음 파일을 통해 `example-ingress.yaml`을 만든다.
 
-  {{< codenew file="service/networking/example-ingress.yaml" >}}
+  {{% codenew file="service/networking/example-ingress.yaml" %}}
 
 1. 다음 명령어를 실행하여 인그레스 오브젝트를 생성한다.
 

--- a/content/ko/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/ko/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -26,7 +26,7 @@ weight: 60
 
 다음은 애플리케이션 디플로이먼트(Deployment) 설정 파일이다.
 
-{{< codenew file="service/access/hello-application.yaml" >}}
+{{% codenew file="service/access/hello-application.yaml" %}}
 
 1. 클러스터 내 Hello World 애플리케이션을 실행하자.
    위 파일을 사용하여 애플리케이션 디플로이먼트를 생성하자.

--- a/content/ko/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/ko/docs/tasks/administer-cluster/declare-network-policy.md
@@ -86,7 +86,7 @@ remote file exists
 
 `access: true` 레이블을 가지고 있는 파드만 `nginx` 서비스에 접근할 수 있도록 하기 위하여, 다음과 같은 네트워크폴리시 오브젝트를 생성한다.
 
-{{< codenew file="service/networking/nginx-policy.yaml" >}}
+{{% codenew file="service/networking/nginx-policy.yaml" %}}
 
 네트워크폴리시 오브젝트의 이름은 유효한
 [DNS 서브도메인 이름](/ko/docs/concepts/overview/working-with-objects/names/#dns-서브도메인-이름)이어야 한다.

--- a/content/ko/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/ko/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -85,7 +85,7 @@ CoreDNS는 본래 kube-dns로 사용한 클러스터에서 작동할 수 있도�
 
 다음의 내용으로 `dns-horizontal-autoscaler.yaml`라는 파일을 만든다.
 
-{{< codenew file="admin/dns/dns-horizontal-autoscaler.yaml" >}}
+{{% codenew file="admin/dns/dns-horizontal-autoscaler.yaml" %}}
 
 파일에서, `<SCALE_TARGET>`을 사용자의 스케일 대상으로 변경한다.
 

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
@@ -47,7 +47,7 @@ kubectl create namespace constraints-cpu-example
 
 다음은 {{< glossary_tooltip text="리밋레인지" term_id="limitrange" >}} 예제 매니페스트이다.
 
-{{< codenew file="admin/resource/cpu-constraints.yaml" >}}
+{{% codenew file="admin/resource/cpu-constraints.yaml" %}}
 
 리밋레인지를 생성한다.
 
@@ -98,7 +98,7 @@ limits:
 500 millicpu의 CPU 요청량 및 800 millicpu의 CPU 상한을 지정하고 있다. 이는 이 네임스페이스의 리밋레인지에
 의해 부과된 CPU의 최소와 최대 제약 조건을 충족시킨다.
 
-{{< codenew file="admin/resource/cpu-constraints-pod.yaml" >}}
+{{% codenew file="admin/resource/cpu-constraints-pod.yaml" %}}
 
 파드를 생성한다.
 
@@ -140,7 +140,7 @@ kubectl delete pod constraints-cpu-demo --namespace=constraints-cpu-example
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 컨테이너는
 500 millicpu의 CPU 요청량과 1.5 cpu의 CPU 상한을 지정하고 있다.
 
-{{< codenew file="admin/resource/cpu-constraints-pod-2.yaml" >}}
+{{% codenew file="admin/resource/cpu-constraints-pod-2.yaml" %}}
 
 파드 생성을 시도한다.
 
@@ -161,7 +161,7 @@ pods "constraints-cpu-demo-2" is forbidden: maximum cpu usage per Container is 8
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 컨테이너는
 100 millicpu의 CPU 요청량과 800 millicpu의 CPU 상한을 지정하고 있다.
 
-{{< codenew file="admin/resource/cpu-constraints-pod-3.yaml" >}}
+{{% codenew file="admin/resource/cpu-constraints-pod-3.yaml" %}}
 
 파드 생성을 시도한다.
 
@@ -183,7 +183,7 @@ pods "constraints-cpu-demo-3" is forbidden: minimum cpu usage per Container is 2
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 컨테이너는
 CPU 요청량을 지정하지 않았으며, CPU 상한도 지정하지 않았다.
 
-{{< codenew file="admin/resource/cpu-constraints-pod-4.yaml" >}}
+{{% codenew file="admin/resource/cpu-constraints-pod-4.yaml" %}}
 
 파드를 생성한다.
 

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -49,7 +49,7 @@ kubectl create namespace default-cpu-example
 다음은 예시 {{< glossary_tooltip text="리밋레인지" term_id="limitrange" >}}에 대한 매니페스트이다.
 이 매니페스트는 기본 CPU 요청량 및 기본 CPU 상한을 지정한다.
 
-{{< codenew file="admin/resource/cpu-defaults.yaml" >}}
+{{% codenew file="admin/resource/cpu-defaults.yaml" %}}
 
 default-cpu-example 네임스페이스에 리밋레인지를 생성한다.
 
@@ -65,7 +65,7 @@ kubectl apply -f https://k8s.io/examples/admin/resource/cpu-defaults.yaml --name
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 
 해당 컨테이너는 CPU 요청량과 상한을 지정하지 않는다.
 
-{{< codenew file="admin/resource/cpu-defaults-pod.yaml" >}}
+{{% codenew file="admin/resource/cpu-defaults-pod.yaml" %}}
 
 파드를 생성한다.
 
@@ -100,7 +100,7 @@ containers:
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 
 해당 컨테이너는 CPU 상한은 지정하지만, 요청량은 지정하지 않는다.
 
-{{< codenew file="admin/resource/cpu-defaults-pod-2.yaml" >}}
+{{% codenew file="admin/resource/cpu-defaults-pod-2.yaml" %}}
 
 파드를 생성한다.
 
@@ -132,7 +132,7 @@ resources:
 다음은 컨테이너가 하나인 파드의 예시 매니페스트이다. 
 해당 컨테이너는 CPU 요청량은 지정하지만, 상한은 지정하지 않는다.
 
-{{< codenew file="admin/resource/cpu-defaults-pod-3.yaml" >}}
+{{% codenew file="admin/resource/cpu-defaults-pod-3.yaml" %}}
 
 파드를 생성한다.
 

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
@@ -43,7 +43,7 @@ kubectl create namespace constraints-mem-example
 
 다음은 리밋레인지의 예시 매니페스트이다.
 
-{{< codenew file="admin/resource/memory-constraints.yaml" >}}
+{{% codenew file="admin/resource/memory-constraints.yaml" %}}
 
 리밋레인지를 생성한다.
 
@@ -89,7 +89,7 @@ kubectl get limitrange mem-min-max-demo-lr --namespace=constraints-mem-example -
 파드 명세 내에, 파드의 유일한 컨테이너는 600 MiB의 메모리 요청량 및 800 MiB의 메모리 상한을 지정하고 있다. 
 이는 리밋레인지에 의해 부과된 최소 및 최대 메모리 제약 조건을 충족시킨다.
 
-{{< codenew file="admin/resource/memory-constraints-pod.yaml" >}}
+{{% codenew file="admin/resource/memory-constraints-pod.yaml" %}}
 
 파드를 생성한다.
 
@@ -132,7 +132,7 @@ kubectl delete pod constraints-mem-demo --namespace=constraints-mem-example
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 
 컨테이너는 800MiB의 메모리 요청량과 1.5GiB의 메모리 상한을 지정하고 있다.
 
-{{< codenew file="admin/resource/memory-constraints-pod-2.yaml" >}}
+{{% codenew file="admin/resource/memory-constraints-pod-2.yaml" %}}
 
 파드 생성을 시도한다.
 
@@ -153,7 +153,7 @@ pods "constraints-mem-demo-2" is forbidden: maximum memory usage per Container i
 다음은 컨테이너가 하나인 파드의 매니페스트이다.
 컨테이너는 100MiB의 메모리 요청량과 800MiB의 메모리 상한을 지정하고 있다.
 
-{{< codenew file="admin/resource/memory-constraints-pod-3.yaml" >}}
+{{% codenew file="admin/resource/memory-constraints-pod-3.yaml" %}}
 
 파드 생성을 시도한다.
 
@@ -174,7 +174,7 @@ pods "constraints-mem-demo-3" is forbidden: minimum memory usage per Container i
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 
 해당 컨테이너는 메모리 요청량과 상한을 지정하지 않는다.
 
-{{< codenew file="admin/resource/memory-constraints-pod-4.yaml" >}}
+{{% codenew file="admin/resource/memory-constraints-pod-4.yaml" %}}
 
 파드를 생성한다.
 

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -53,7 +53,7 @@ kubectl create namespace default-mem-example
 이 매니페스트는 기본 메모리 요청량 및 
 기본 메모리 상한을 지정한다.
 
-{{< codenew file="admin/resource/memory-defaults.yaml" >}}
+{{% codenew file="admin/resource/memory-defaults.yaml" %}}
 
 default-mem-example 네임스페이스에 리밋레인지를 생성한다.
 
@@ -70,7 +70,7 @@ kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults.yaml --n
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 
 해당 컨테이너는 메모리 요청량과 상한을 지정하지 않는다.
 
-{{< codenew file="admin/resource/memory-defaults-pod.yaml" >}}
+{{% codenew file="admin/resource/memory-defaults-pod.yaml" %}}
 
 파드를 생성한다.
 
@@ -110,7 +110,7 @@ kubectl delete pod default-mem-demo --namespace=default-mem-example
 다음은 컨테이너가 하나인 파드의 매니페스트이다. 
 해당 컨테이너는 메모리 상한은 지정하지만, 요청량은 지정하지 않는다.
 
-{{< codenew file="admin/resource/memory-defaults-pod-2.yaml" >}}
+{{% codenew file="admin/resource/memory-defaults-pod-2.yaml" %}}
 
 파드를 생성한다.
 
@@ -141,7 +141,7 @@ resources:
 다음은 컨테이너가 하나인 파드의 예시 매니페스트이다. 
 해당 컨테이너는 메모리 요청량은 지정하지만, 상한은 지정하지 않는다.
 
-{{< codenew file="admin/resource/memory-defaults-pod-3.yaml" >}}
+{{% codenew file="admin/resource/memory-defaults-pod-3.yaml" %}}
 
 파드를 생성한다.
 

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace.md
@@ -42,7 +42,7 @@ kubectl create namespace quota-mem-cpu-example
 
 다음은 예시 리소스쿼터 오브젝트에 대한 매니페스트이다.
 
-{{< codenew file="admin/resource/quota-mem-cpu.yaml" >}}
+{{% codenew file="admin/resource/quota-mem-cpu.yaml" %}}
 
 리소스쿼터를 생성한다.
 
@@ -71,7 +71,7 @@ kubectl get resourcequota mem-cpu-demo --namespace=quota-mem-cpu-example --outpu
 
 다음은 예시 파드에 대한 매니페스트이다.
 
-{{< codenew file="admin/resource/quota-mem-cpu-pod.yaml" >}}
+{{% codenew file="admin/resource/quota-mem-cpu-pod.yaml" %}}
 
 
 파드를 생성한다.
@@ -121,7 +121,7 @@ kubectl get resourcequota mem-cpu-demo --namespace=quota-mem-cpu-example -o json
 
 다음은 두 번째 파드에 대한 매니페스트이다.
 
-{{< codenew file="admin/resource/quota-mem-cpu-pod-2.yaml" >}}
+{{% codenew file="admin/resource/quota-mem-cpu-pod-2.yaml" %}}
 
 매니페스트에서, 파드의 메모리 요청량이 700MiB임을 알 수 있다.
 사용된 메모리 요청량과 이 새 메모리 요청량의 합계가

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace.md
@@ -39,7 +39,7 @@ kubectl create namespace quota-pod-example
 
 다음은 예시 리소스쿼터 오브젝트에 대한 매니페스트이다.
 
-{{< codenew file="admin/resource/quota-pod.yaml" >}}
+{{% codenew file="admin/resource/quota-pod.yaml" %}}
 
 리소스쿼터를 생성한다.
 
@@ -69,7 +69,7 @@ status:
 
 다음은 {{< glossary_tooltip text="디플로이먼트(Deployment)" term_id="deployment" >}}에 대한 예시 매니페스트이다.
 
-{{< codenew file="admin/resource/quota-pod-deployment.yaml" >}}
+{{% codenew file="admin/resource/quota-pod-deployment.yaml" %}}
 
 매니페스트에서, `replicas: 3` 은 쿠버네티스가 모두 동일한 애플리케이션을 실행하는 
 세 개의 새로운 파드를 만들도록 지시한다.

--- a/content/ko/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/ko/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -71,7 +71,7 @@ kubectl create namespace cpu-example
 이 예제에서는, 하나의 컨테이너를 가진 파드를 생성한다.
 컨테이너는 0.5 CPU 요청량과 1 CPU 상한을 갖는다. 아래는 파드의 구성 파일이다.
 
-{{< codenew file="pods/resource/cpu-request-limit.yaml" >}}
+{{% codenew file="pods/resource/cpu-request-limit.yaml" %}}
 
 구성 파일 내 `args` 섹션은 컨테이너가 시작될 때 인수(argument)를 제공한다.
 `-cpus "2"` 인수는 컨테이너가 2 CPU 할당을 시도하도록 한다.
@@ -163,7 +163,7 @@ CPU 요청량과 상한은 컨테이너와 연관되어 있지만,
 컨테이너는 100 CPU을 요청하고 있는데, 이것은 클러스터의 모든 노드 가용량을
 초과하는 것이다.
 
-{{< codenew file="pods/resource/cpu-request-limit-2.yaml" >}}
+{{% codenew file="pods/resource/cpu-request-limit-2.yaml" %}}
 
 파드 생성:
 

--- a/content/ko/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/ko/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -69,7 +69,7 @@ kubectl create namespace mem-example
 이 예제에서 하나의 컨테이너를 가진 파드를 생성한다. 생성된 컨테이너는
 100 MiB 메모리 요청량과 200 MiB 메모리 상한을 갖는다. 이 것이 파드 구성 파일이다.
 
-{{< codenew file="pods/resource/memory-request-limit.yaml" >}}
+{{% codenew file="pods/resource/memory-request-limit.yaml" %}}
 
 구성 파일 내 `args` 섹션은 컨테이너가 시작될 때 아규먼트를 제공한다.
 `"--vm-bytes", "150M"` 아규먼트는 컨테이너가 150 MiB 할당을 시도 하도록 한다.
@@ -139,7 +139,7 @@ kubectl delete pod memory-demo --namespace=mem-example
 이 것은 50 MiB 메모리 요청량과 100 MiB 메모리 상한을 갖는
 하나의 컨테이너를 갖는 파드의 구성 파일이다.
 
-{{< codenew file="pods/resource/memory-request-limit-2.yaml" >}}
+{{% codenew file="pods/resource/memory-request-limit-2.yaml" %}}
 
 구성 파일의 `args` 섹션에서 컨테이너가
 100 MiB 상한을 훨씬 초과하는 250 MiB의 메모리를 할당하려는 것을 볼 수 있다.
@@ -248,7 +248,7 @@ kubectl delete pod memory-demo-2 --namespace=mem-example
 컨테이너를 갖는
 파드의 구성 파일이다.
 
-{{< codenew file="pods/resource/memory-request-limit-3.yaml" >}}
+{{% codenew file="pods/resource/memory-request-limit-3.yaml" %}}
 
 파드 생성:
 

--- a/content/ko/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity.md
+++ b/content/ko/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity.md
@@ -64,7 +64,7 @@ weight: 120
 이 매니페스트는 `disktype: ssd` 라는 `requiredDuringSchedulingIgnoredDuringExecution` 노드 어피니티를 가진 파드를 설명한다.
 파드가 `disktype=ssd` 레이블이 있는 노드에만 스케줄될 것이라는 것을 의미한다.
 
-{{< codenew file="pods/pod-nginx-required-affinity.yaml" >}}
+{{% codenew file="pods/pod-nginx-required-affinity.yaml" %}}
 
 1. 매니페스트를 적용하여 선택한 노드에 스케줄된 파드를
    생성한다.
@@ -91,7 +91,7 @@ weight: 120
 이 매니페스트는 `disktype: ssd` 라는 `preferredDuringSchedulingIgnoredDuringExecution` 노드 어피니티를 가진 파드를 설명한다.
 파드가 `disktype=ssd` 레이블이 있는 노드를 선호한다는 것을 의미한다.
 
-{{< codenew file="pods/pod-nginx-preferred-affinity.yaml" >}}
+{{% codenew file="pods/pod-nginx-preferred-affinity.yaml" %}}
 
 1. 매니페스트를 적용하여 선택한 노드에 스케줄된 파드를
    생성한다.

--- a/content/ko/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/ko/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -67,7 +67,7 @@ weight: 120
 즉, `disktype=ssd` 레이블이 있는 노드에 파드가 스케줄될 것이라는
 것을 의미한다.
 
-{{< codenew file="pods/pod-nginx.yaml" >}}
+{{% codenew file="pods/pod-nginx.yaml" %}}
 
 1. 구성 파일을 사용해서 선택한 노드로 스케줄되도록 파드를
    생성하자.
@@ -93,7 +93,7 @@ weight: 120
 
 `nodeName` 설정을 통해 특정 노드로 파드를 배포할 수 있다.
 
-{{< codenew file="pods/pod-nginx-specific-node.yaml" >}}
+{{% codenew file="pods/pod-nginx-specific-node.yaml" %}}
 
 설정 파일을 사용해 `foo-node` 노드에 파드를 스케줄되도록 만들어 보자.
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -92,7 +92,7 @@ Block Store 볼륨과 같은 네트워크 자원을 프로비저닝한다. 클�
 
 hostPath 퍼시스턴트볼륨의 설정 파일은 아래와 같다.
 
-{{< codenew file="pods/storage/pv-volume.yaml" >}}
+{{% codenew file="pods/storage/pv-volume.yaml" %}}
 
 설정 파일에 클러스터 노드의 `/mnt/data` 에 볼륨이 있다고
 지정한다. 또한 설정에서 볼륨 크기를 10 기가바이트로 지정하고 단일 노드가
@@ -128,7 +128,7 @@ kubectl get pv task-pv-volume
 
 퍼시스턴트볼륨클레임에 대한 설정 파일은 다음과 같다.
 
-{{< codenew file="pods/storage/pv-claim.yaml" >}}
+{{% codenew file="pods/storage/pv-claim.yaml" %}}
 
 퍼시스턴트볼륨클레임을 생성한다.
 
@@ -168,7 +168,7 @@ kubectl get pvc task-pv-claim
 
 파드에 대한 설정 파일은 다음과 같다.
 
-{{< codenew file="pods/storage/pv-pod.yaml" >}}
+{{% codenew file="pods/storage/pv-pod.yaml" %}}
 
 파드의 설정 파일은 퍼시스턴트볼륨클레임을 지정하지만, 
 퍼시스턴트볼륨을 지정하지는 않는다는 것을 유념하자. 파드의 관점에서 볼때, 
@@ -238,7 +238,7 @@ sudo rmdir /mnt/data
 
 ## 하나의 퍼시스턴트볼륨을 두 경로에 마운트하기
 
-{{< codenew file="pods/storage/pv-duplicate.yaml" >}}
+{{% codenew file="pods/storage/pv-duplicate.yaml" %}}
 
 하나의 퍼시스턴트볼륨을 nginx 컨테이너의 두 경로에 마운트할 수 있다.
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-pod-initialization.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-pod-initialization.md
@@ -27,7 +27,7 @@ weight: 130
 
 아래는 해당 파드의 구성 파일이다.
 
-{{< codenew file="pods/init-containers.yaml" >}}
+{{% codenew file="pods/init-containers.yaml" %}}
 
 이 구성 파일에서, 파드가 가진 볼륨을 초기화
 컨테이너와 애플리케이션 컨테이너가 공유하는 것을 볼 수 있다.

--- a/content/ko/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -29,7 +29,7 @@ weight: 70
 
 다음은 파드의 구성 파일이다.
 
-{{< codenew file="pods/storage/projected.yaml" >}}
+{{% codenew file="pods/storage/projected.yaml" %}}
 
 1. 시크릿을 생성한다.
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-runasusername.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-runasusername.md
@@ -29,7 +29,7 @@ weight: 20
 
 다음은 `runAsUserName` 필드가 설정된 윈도우 파드의 구성 파일이다.
 
-{{< codenew file="windows/run-as-username-pod.yaml" >}}
+{{% codenew file="windows/run-as-username-pod.yaml" %}}
 
 파드를 생성한다.
 
@@ -69,7 +69,7 @@ ContainerUser
 
 다음은 한 개의 컨테이너에 `runAsUserName` 필드가 파드 수준 및 컨테이너 수준에서 설정되는 파드의 구성 파일이다.
 
-{{< codenew file="windows/run-as-username-container.yaml" >}}
+{{% codenew file="windows/run-as-username-container.yaml" %}}
 
 파드를 생성한다.
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -28,7 +28,7 @@ weight: 50
 유형의 볼륨이 있다.
 파드의 구성 파일은 다음과 같다.
 
-{{< codenew file="pods/storage/redis.yaml" >}}
+{{% codenew file="pods/storage/redis.yaml" %}}
 
 1. 파드 생성
 

--- a/content/ko/docs/tasks/configure-pod-container/extended-resource.md
+++ b/content/ko/docs/tasks/configure-pod-container/extended-resource.md
@@ -37,7 +37,7 @@ weight: 40
 
 다음은 컨테이너가 하나 있는 파드의 구성 파일이다.
 
-{{< codenew file="pods/resource/extended-resource-pod.yaml" >}}
+{{% codenew file="pods/resource/extended-resource-pod.yaml" %}}
 
 구성 파일에서 컨테이너가 3개의 동글을 요청하는 것을 알 수 있다.
 
@@ -73,7 +73,7 @@ Requests:
 다음은 컨테이너가 하나 있는 파드의 구성 파일이다.
 컨테이너는 두 개의 동글을 요청한다.
 
-{{< codenew file="pods/resource/extended-resource-pod-2.yaml" >}}
+{{% codenew file="pods/resource/extended-resource-pod-2.yaml" %}}
 
 첫 번째 파드가 사용 가능한 4개의 동글 중 3개를 사용했기 때문에
 쿠버네티스는 두 개의 동글에 대한 요청을 충족시킬 수 없을 것이다.

--- a/content/ko/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/ko/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -186,7 +186,7 @@ janedoe:xxxxxxxxxxx
 
 다음은 `regcred` 에 있는 도커 자격 증명에 접근해야 하는 예제 파드의 매니페스트이다.
 
-{{< codenew file="pods/private-reg-pod.yaml" >}}
+{{% codenew file="pods/private-reg-pod.yaml" %}}
 
 위 파일을 컴퓨터에 다운로드한다.
 

--- a/content/ko/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/ko/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -55,7 +55,7 @@ kubectl create namespace qos-example
 다음은 하나의 컨테이너를 갖는 파드의 구성 파일이다. 해당 컨테이너는 메모리 상한과
 메모리 요청량을 갖고 있고, 200MiB로 동일하다. 해당 컨테이너는 CPU 상한과 CPU 요청량을 가지며, 700 milliCPU로 동일하다.
 
-{{< codenew file="pods/qos/qos-pod.yaml" >}}
+{{% codenew file="pods/qos/qos-pod.yaml" %}}
 
 파드를 생성한다.
 
@@ -112,7 +112,7 @@ kubectl delete pod qos-demo --namespace=qos-example
 컨테이너가 하나인 파드의 구성 파일은 다음과 같다. 컨테이너는
 200MiB의 메모리 상한과 100MiB의 메모리 요청량을 가진다.
 
-{{< codenew file="pods/qos/qos-pod-2.yaml" >}}
+{{% codenew file="pods/qos/qos-pod-2.yaml" %}}
 
 파드를 생성한다.
 
@@ -158,7 +158,7 @@ kubectl delete pod qos-demo-2 --namespace=qos-example
 컨테이너가 하나인 파드의 구성 파일이다. 해당 컨테이너는 메모리 또는 CPU의
 상한이나 요청량을 갖지 않는다.
 
-{{< codenew file="pods/qos/qos-pod-3.yaml" >}}
+{{% codenew file="pods/qos/qos-pod-3.yaml" %}}
 
 파드를 생성한다.
 
@@ -195,7 +195,7 @@ kubectl delete pod qos-demo-3 --namespace=qos-example
 컨테이너가 두 개인 파드의 구성 파일이다. 한 컨테이너는 200MiB의 메모리
 요청량을 지정한다. 다른 컨테이너는 어떤 요청량이나 상한을 지정하지 않는다.
 
-{{< codenew file="pods/qos/qos-pod-4.yaml" >}}
+{{% codenew file="pods/qos/qos-pod-4.yaml" %}}
 
 참고로 이 파드는 Burstable QoS 클래스의 기준을 충족한다. 즉, Guaranteed QoS 클래스에 대한
 기준을 충족하지 않으며, 해당 컨테이너 중 하나가 메모리 요청량을 갖는다.

--- a/content/ko/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/ko/docs/tasks/configure-pod-container/user-namespaces.md
@@ -60,7 +60,7 @@ min-kubernetes-server-version: v1.25
 스테이트리스 파드의 유저 네임스페이스는 `.spec`의 `hostUsers` 필드를 
 `false`로 설정하여 사용할 수 있다. 다음은 예시이다.
 
-{{< codenew file="pods/user-namespaces-stateless.yaml" >}}
+{{% codenew file="pods/user-namespaces-stateless.yaml" %}}
 
 1. 클러스터에 파드를 생성한다.
 

--- a/content/ko/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/ko/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -25,7 +25,7 @@ content_type: task
 
 이 예제에서는 앞의 예제와 비슷하게 두 개의 파드를 생성하기 위해 디플로이먼트를 사용할 것이다.
 
-{{< codenew file="application/nginx-with-request.yaml" >}}
+{{% codenew file="application/nginx-with-request.yaml" %}}
 
 다음 명령을 실행하여 디플로이먼트를 생성한다.
 

--- a/content/ko/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
+++ b/content/ko/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
@@ -27,7 +27,7 @@ weight: 30
 이 예제에서는, 하나의 컨테이너를 실행하는 파드를 생성한다.
 파드의 매니페스트는 컨테이너가 시작될 때 수행하는 명령어를 지정한다.
 
-{{< codenew file="debug/termination.yaml" >}}
+{{% codenew file="debug/termination.yaml" %}}
 
 1. 다음의 YAML 설정 파일에 기반한 파드를 생성한다.
 

--- a/content/ko/docs/tasks/debug/debug-application/get-shell-running-container.md
+++ b/content/ko/docs/tasks/debug/debug-application/get-shell-running-container.md
@@ -29,7 +29,7 @@ content_type: task
 이 예시에서는 하나의 컨테이너를 가진 파드를 생성할 것이다. 이 컨테이너는
 nginx 이미지를 실행한다. 해당 파드에 대한 설정 파일은 다음과 같다.
 
-{{< codenew file="application/shell-demo.yaml" >}}
+{{% codenew file="application/shell-demo.yaml" %}}
 
 파드를 생성한다.
 

--- a/content/ko/docs/tasks/debug/debug-cluster/audit.md
+++ b/content/ko/docs/tasks/debug/debug-cluster/audit.md
@@ -80,7 +80,7 @@ API 오브젝트와는
 
 다음은 감사 정책 파일의 예이다.
 
-{{< codenew file="audit/audit-policy.yaml" >}}
+{{% codenew file="audit/audit-policy.yaml" %}}
 
 최소 감사 정책 파일을 사용하여 `Metadata` 수준에서 모든 요청을 기록할 수 있다.
 

--- a/content/ko/docs/tasks/debug/debug-cluster/monitor-node-health.md
+++ b/content/ko/docs/tasks/debug/debug-cluster/monitor-node-health.md
@@ -45,7 +45,7 @@ weight: 20
 
 1. `node-problem-detector.yaml`와 유사하게 노드 문제 감지기 구성을 생성한다:
 
-   {{< codenew file="debug/node-problem-detector.yaml" >}}
+   {{% codenew file="debug/node-problem-detector.yaml" %}}
 
    {{< note >}}
    현재 운영 체제 배포판의 시스템 로그 디렉토리와 일치하도록 기재했는지 확인해야 한다.
@@ -83,7 +83,7 @@ weight: 20
 
 1. `컨피그맵(ConfigMap)`을 사용하도록 `node-problem-detector.yaml`을 변경한다.
 
-   {{< codenew file="debug/node-problem-detector-configmap.yaml" >}}
+   {{% codenew file="debug/node-problem-detector-configmap.yaml" %}}
 
 4. 새로운 설정 파일을 사용하여 노드 문제 감지기를 재생성한다.
 

--- a/content/ko/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/ko/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -69,7 +69,7 @@ gcloud docker -- push gcr.io/my-gcp-project/my-kube-scheduler:1.0
 이는 또 파드를 관리하기 때문에 스케줄러에 대한 회복 탄력성을 제공한다.
 다음은 디플로이먼트에 대한 구성 파일이다. 이 파일을 `my-scheduler.yaml`으로 저장한다.
 
-{{< codenew file="admin/sched/my-scheduler.yaml" >}}
+{{% codenew file="admin/sched/my-scheduler.yaml" %}}
 
 해당 매니페스트에서는 [KubeSchedulerConfiguration](/ko/docs/reference/scheduling/config/)을 
 사용하여 구현할 스케줄러의 특성을 정의한다. 이러한 설정은 초기화 과정에서 `--config` 옵션을 통해 `kube-scheduler`에게 전달된다.
@@ -139,7 +139,7 @@ my-scheduler 파드가 실행("Running")되고 있다는 것을 목록에서 볼
 kubectl edit clusterrole system:kube-scheduler
 ```
 
-{{< codenew file="admin/sched/clusterrole.yaml" >}}
+{{% codenew file="admin/sched/clusterrole.yaml" %}}
 
 ## 파드의 스케줄러를 지정하기
 
@@ -150,7 +150,7 @@ kubectl edit clusterrole system:kube-scheduler
 
 - 스케줄러 이름을 명시하지 않은 파드 명세
 
-  {{< codenew file="admin/sched/pod1.yaml" >}}
+  {{% codenew file="admin/sched/pod1.yaml" %}}
 
   스케줄러 이름을 제공받지 못했다면,
   파드는 자동으로 기본 스케줄러에 의해 스케줄링이 수행된다.
@@ -163,7 +163,7 @@ kubectl edit clusterrole system:kube-scheduler
 
 - `default-scheduler`를 명시한 파드 명세
 
-  {{< codenew file="admin/sched/pod2.yaml" >}}
+  {{% codenew file="admin/sched/pod2.yaml" %}}
 
   `spec.schedulerName`의 값으로 스케줄러 이름을 제공함으로써 스케줄러가 정해진다.
   이와 같은 경우에서는, 기본 스케줄러의 이름인 `default-scheduler`를 명시하고 있다.
@@ -176,7 +176,7 @@ kubectl edit clusterrole system:kube-scheduler
 
 - `my-scheduler`를 명시한 파드 명세
 
-  {{< codenew file="admin/sched/pod3.yaml" >}}
+  {{% codenew file="admin/sched/pod3.yaml" %}}
 
   이와 같은 경우에서는, 직접 배치한 스케줄러 - `my-scheduler`를 통해
   해당 파드의 스케줄링이 수행되어야 한다는 것을 명시하고 있다.

--- a/content/ko/docs/tasks/extend-kubernetes/setup-konnectivity.md
+++ b/content/ko/docs/tasks/extend-kubernetes/setup-konnectivity.md
@@ -23,7 +23,7 @@ Konnectivity 서비스는 컨트롤 플레인에 클러스터 통신을 위한 T
 
 다음 단계에는 송신(egress) 설정이 필요하다. 예를 들면 다음과 같다.
 
-{{< codenew file="admin/konnectivity/egress-selector-configuration.yaml" >}}
+{{% codenew file="admin/konnectivity/egress-selector-configuration.yaml" %}}
 
 Konnectivity 서비스를 사용하고 네트워크 트래픽을 클러스터 노드로 보내도록 
 API 서버를 구성해야 한다.
@@ -74,12 +74,12 @@ rm -f konnectivity.crt konnectivity.key konnectivity.csr
 term_id="static-pod" >}}로 배포되었다고 가정한다. 그렇지 않은 경우에는 Konnectivity 
 서버를 데몬셋(DaemonSet)으로 배포할 수 있다.
 
-{{< codenew file="admin/konnectivity/konnectivity-server.yaml" >}}
+{{% codenew file="admin/konnectivity/konnectivity-server.yaml" %}}
 
 그런 다음 클러스터에 Konnectivity 에이전트를 배포한다.
 
-{{< codenew file="admin/konnectivity/konnectivity-agent.yaml" >}}
+{{% codenew file="admin/konnectivity/konnectivity-agent.yaml" %}}
 
 마지막으로 클러스터에서 RBAC가 활성화된 경우 관련 RBAC 규칙을 생성한다.
 
-{{< codenew file="admin/konnectivity/konnectivity-rbac.yaml" >}}
+{{% codenew file="admin/konnectivity/konnectivity-rbac.yaml" %}}

--- a/content/ko/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/ko/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -42,7 +42,7 @@ weight: 10
 이 예제에서는 한 개의 컨테이너를 실행하는 파드를 생성한다. 파드를 위한 구성
 파일에서 커맨드와 두 개의 인자를 정의한다.
 
-{{< codenew file="pods/commands.yaml" >}}
+{{% codenew file="pods/commands.yaml" %}}
 
 1. YAML 구성 파일을 활용해 파드를 생성한다.
 

--- a/content/ko/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/ko/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -26,7 +26,7 @@ weight: 20
 값을 가지는 환경 변수를 정의한다. 다음은 파드를 위한 구성 매니페스트
 예시이다.
 
-{{< codenew file="pods/inject/envars.yaml" >}}
+{{% codenew file="pods/inject/envars.yaml" %}}
 
 1. YAML 구성 파일을 활용해 파드를 생성한다.
 

--- a/content/ko/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
+++ b/content/ko/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
@@ -26,7 +26,7 @@ weight: 20
 파드를 위한 구성 파일은 일반적인 방식으로 정의된 종속 환경 변수를 정의한다.
 다음은 파드를 위한 구성 매니페스트 예시이다.
 
-{{< codenew file="pods/inject/dependent-envars.yaml" >}}
+{{% codenew file="pods/inject/dependent-envars.yaml" %}}
 
 1. YAML 구성 파일을 활용해 파드를 생성한다.
 

--- a/content/ko/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/ko/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -39,7 +39,7 @@ echo -n '39528$vdg7Jb' | base64
 다음은 사용자 이름과 암호가 들어 있는 시크릿을 생성하는 데 사용할 수 있는 
 구성 파일이다.
 
-{{< codenew file="pods/inject/secret.yaml" >}}
+{{% codenew file="pods/inject/secret.yaml" %}}
 
 1. 시크릿을 생성한다.
 
@@ -99,7 +99,7 @@ kubectl create secret generic test-secret --from-literal='username=my-app' --fro
 
 다음은 파드를 생성하는 데 사용할 수 있는 구성 파일이다.
 
-{{< codenew file="pods/inject/secret-pod.yaml" >}}
+{{% codenew file="pods/inject/secret-pod.yaml" %}}
 
 1. 파드를 생성한다.
 
@@ -161,7 +161,7 @@ kubectl create secret generic test-secret --from-literal='username=my-app' --fro
 
 *  시크릿에 정의된 `backend-username` 값을 파드 명세의 `SECRET_USERNAME` 환경 변수에 할당한다.
 
-   {{< codenew file="pods/inject/pod-single-secret-env-variable.yaml" >}}
+   {{% codenew file="pods/inject/pod-single-secret-env-variable.yaml" %}}
 
 *  파드를 생성한다.
 
@@ -191,7 +191,7 @@ kubectl create secret generic test-secret --from-literal='username=my-app' --fro
 
 *  파드 명세에 환경 변수를 정의한다.
 
-   {{< codenew file="pods/inject/pod-multiple-secret-env-variable.yaml" >}}
+   {{% codenew file="pods/inject/pod-multiple-secret-env-variable.yaml" %}}
 
 *  파드를 생성한다.
 
@@ -225,7 +225,7 @@ kubectl create secret generic test-secret --from-literal='username=my-app' --fro
 
 *  envFrom을 사용하여 시크릿의 모든 데이터를 컨테이너 환경 변수로 정의한다. 시크릿의 키는 파드에서 환경 변수의 이름이 된다.
 
-    {{< codenew file="pods/inject/pod-secret-envFrom.yaml" >}}
+    {{% codenew file="pods/inject/pod-secret-envFrom.yaml" %}}
 
 *  파드를 생성한다.
 

--- a/content/ko/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/ko/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -32,7 +32,7 @@ _downward API_ 라고 한다.
 파드 수준(Pod-level) 필드를 실행 중인 컨테이너에 파일 형태로 생성한다.
 다음은 파드를 위한 매니페스트를 보여준다.
 
-{{< codenew file="pods/inject/dapi-volume.yaml" >}}
+{{% codenew file="pods/inject/dapi-volume.yaml" %}}
 
 매니페스트에서, 파드에 `downwardAPI` 볼륨이 있고, 
 컨테이너가 `/etc/podinfo`에 볼륨을 마운트하는 것을 확인할 수 있다.
@@ -155,7 +155,7 @@ total 8
 컨테이너만 가진 파드의 매니페스트를
 보여준다.
 
-{{< codenew file="pods/inject/dapi-volume-resources.yaml" >}}
+{{% codenew file="pods/inject/dapi-volume-resources.yaml" %}}
 
 매니페스트에서 파드에 [`downwardAPI` 볼륨](/ko/docs/concepts/storage/volumes/#downwardapi)이 있고 
 단일 컨테이너는 `/etc/podinfo`에 

--- a/content/ko/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/ko/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -27,7 +27,7 @@ weight: 30
 
 이 연습에서 하나의 컨테이너가 있는 파드와 파드 수준의 필드를 실행 중인 컨테이너의 환경변수로 생성한다.
 
-{{< codenew file="pods/inject/dapi-envars-pod.yaml" >}}
+{{% codenew file="pods/inject/dapi-envars-pod.yaml" %}}
 
 매니페스트에서 5개의 환경 변수를 확인할 수 있다. `env` 필드는 
 환경 변수 정의의 배열이다. 배열의 첫 번째 요소는 `MY_NODE_NAME` 환경 변수가 파드의 `spec.nodeName` 필드에서 값을 가져오도록 지정한다. 마찬가지로 다른 환경 변수도 파드 필드에서 이름을 가져온다.
@@ -100,7 +100,7 @@ MY_POD_NAME=dapi-envars-fieldref
 
 여기, 다시 하나의 컨테이너만 가진 파드를 위한 매니페스트가 있다.
 
-{{< codenew file="pods/inject/dapi-envars-container.yaml" >}}
+{{% codenew file="pods/inject/dapi-envars-container.yaml" %}}
 
 매니페스트에서 4개의 환경 변수를 확인할 수 있다. `env` 필드는 
 환경 변수 정의의 배열이다. 배열의 첫 번째 요소는 `MY_CPU_REQUEST` 환경 변수가 `test-container`라는 컨테이너의 

--- a/content/ko/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/ko/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -33,7 +33,7 @@ weight: 10
 크론 잡은 구성 파일이 필요하다.
 다음은 1분마다 간단한 데모 작업을 실행하는 크론잡 매니페스트다.
 
-{{< codenew file="application/job/cronjob.yaml" >}}
+{{% codenew file="application/job/cronjob.yaml" %}}
 
 다음 명령을 사용하여 크론잡 예제를 실행한다.
 

--- a/content/ko/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/ko/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -186,7 +186,7 @@ done
 실제 프로그램을 실행해 볼 것이다.
 여기에 아주 간단한 예제 프로그램이 있다.
 
-{{< codenew language="python" file="application/job/rabbitmq/worker.py" >}}
+{{% codenew language="python" file="application/job/rabbitmq/worker.py" %}}
 
 스크립트에 실행 권한을 준다.
 
@@ -230,7 +230,7 @@ gcloud docker -- push gcr.io/<project>/job-wq-1
 이미지를 수정하고, 파일 이름을 `./job.yaml`이라 정한다.
 
 
-{{< codenew file="application/job/rabbitmq/job.yaml" >}}
+{{% codenew file="application/job/rabbitmq/job.yaml" %}}
 
 이 예시에서는, 각 파드가 대기열로부터 얻은 하나의 아이템을 수행하고 종료한다.
 그래서, 잡의 완료 횟수가 완료된 작업 아이템의 숫자에 대응한다.

--- a/content/ko/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/ko/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -119,7 +119,7 @@ rediswq.py([다운로드](/examples/application/job/redis/rediswq.py))라는
 잡의 각 파드에 있는 "워커" 프로그램은 작업 대기열
 클라이언트 라이브러리를 사용하여 작업을 가져온다. 다음은 워커 프로그램이다.
 
-{{< codenew language="python" file="application/job/redis/worker.py" >}}
+{{% codenew language="python" file="application/job/redis/worker.py" %}}
 
 [`worker.py`](/examples/application/job/redis/worker.py),
 [`rediswq.py`](/examples/application/job/redis/rediswq.py) 및
@@ -158,7 +158,7 @@ gcloud docker -- push gcr.io/<project>/job-wq-2
 
 다음은 잡 정의이다.
 
-{{< codenew file="application/job/redis/job.yaml" >}}
+{{% codenew file="application/job/redis/job.yaml" %}}
 
 사용자 자신의 경로로 `gcr.io/myproject` 를
 변경하려면 잡 템플릿을 편집해야 한다.

--- a/content/ko/docs/tasks/job/indexed-parallel-processing-static.md
+++ b/content/ko/docs/tasks/job/indexed-parallel-processing-static.md
@@ -77,7 +77,7 @@ rev data.txt
 
 다음은 색인된(`Indexed`) 완료 모드를 사용하는 잡 매니페스트의 예이다.
 
-{{< codenew language="yaml" file="application/job/indexed-job.yaml" >}}
+{{% codenew language="yaml" file="application/job/indexed-job.yaml" %}}
 
 위 예제에서, 잡 컨트롤러가 모든 컨테이너에 설정한 `JOB_COMPLETION_INDEX`
 내장 환경 변수를 사용한다. [초기화 컨테이너](/ko/docs/concepts/workloads/pods/init-containers/)는
@@ -92,7 +92,7 @@ rev data.txt
 /ko/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#파드-필드-저장)할
 수도 있다.
 
-{{< codenew language="yaml" file="application/job/indexed-job-vol.yaml" >}}
+{{% codenew language="yaml" file="application/job/indexed-job-vol.yaml" %}}
 
 ## 잡 실행하기
 

--- a/content/ko/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/ko/docs/tasks/job/parallel-processing-expansion.md
@@ -43,7 +43,7 @@ pip install --user jinja2
 먼저, 다음의 잡 템플릿을 다운로드해서 `job-tmpl.yaml` 파일로 저장한다.
 다운로드할 내용은 다음과 같다.
 
-{{< codenew file="application/job/job-tmpl.yaml" >}}
+{{% codenew file="application/job/job-tmpl.yaml" %}}
 
 ```shell
 # job-tmpl.yaml를 다운로드하기 위해 curl을 사용한다

--- a/content/ko/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/ko/docs/tasks/manage-daemon/update-daemon-set.md
@@ -46,7 +46,7 @@ weight: 10
 
 이 YAML 파일은 'RollingUpdate'를 업데이트 전략으로 사용하여 데몬셋을 명시한다.
 
-{{< codenew file="controllers/fluentd-daemonset.yaml" >}}
+{{% codenew file="controllers/fluentd-daemonset.yaml" %}}
 
 데몬셋 매니페스트의 업데이트 전략을 확인한 후, 데몬셋을 생성한다.
 
@@ -92,7 +92,7 @@ RollingUpdate
 `RollingUpdate` 데몬셋 `.spec.template` 에 대한 업데이트는 롤링 업데이트를
 트리거한다. 새 YAML 파일을 적용하여 데몬셋을 업데이트한다. 이것은 여러 가지 다른 `kubectl` 명령으로 수행할 수 있다.
 
-{{< codenew file="controllers/fluentd-daemonset-update.yaml" >}}
+{{% codenew file="controllers/fluentd-daemonset-update.yaml" %}}
 
 #### 선언적 커맨드
 

--- a/content/ko/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/ko/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -75,7 +75,7 @@ kubectl apply -f <디렉터리>/
 
 다음은 오브젝트 구성 파일에 대한 예시이다.
 
-{{< codenew file="application/simple_deployment.yaml" >}}
+{{% codenew file="application/simple_deployment.yaml" %}}
 
 생성될 오브젝트를 출력하려면 `kubectl diff`를 실행한다. 
 
@@ -167,7 +167,7 @@ kubectl apply -f <디렉터리>/
 
 다음은 구성 파일의 예시이다.
 
-{{< codenew file="application/simple_deployment.yaml" >}}
+{{% codenew file="application/simple_deployment.yaml" %}}
 
 `kubectl apply`를 사용하여 오브젝트를 생성한다.
 
@@ -285,7 +285,7 @@ spec:
 `nginx:1.14.2`에서 `nginx:1.16.1`로 이미지를 변경하기 위해 `simple_deployment.yaml`
 구성 파일을 업데이트 하고, `minReadySeconds` 필드를 삭제한다.
 
-{{< codenew file="application/update_deployment.yaml" >}}
+{{% codenew file="application/update_deployment.yaml" %}}
 
 구성 파일에 이루어진 변경사항을 적용한다.
 
@@ -445,7 +445,7 @@ API 서버에 패치 요청을 보냄으로써 그것을 수행한다.
 
 다음은 예시이다. 디플로이먼트 오브젝트에 대한 구성 파일이라고 가정한다.
 
-{{< codenew file="application/update_deployment.yaml" >}}
+{{% codenew file="application/update_deployment.yaml" %}}
 
 또한, 이것은 동일한 디플로이먼트 오브젝트에 대한 활성 구성이라고 가정한다.
 
@@ -741,7 +741,7 @@ is lost.
 
 다음은 디플로이먼트에 대한 구성 파일이다. 파일에는 `strategy`가 지정되지 않았다.
 
-{{< codenew file="application/simple_deployment.yaml" >}}
+{{% codenew file="application/simple_deployment.yaml" %}}
 
 `kubectl apply`를 사용하여 오브젝트를 생성한다.
 

--- a/content/ko/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/ko/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -69,7 +69,7 @@ fe00::2	ip6-allrouters
 `foo.remote`, `bar.remote`가 `10.1.2.3`로 해석될 수 있도록, `.spec.hostAliases` 항목에서 정의하여 파드에
 HostAliases를 추가하면 가능하다.
 
-{{< codenew file="service/networking/hostaliases-pod.yaml" >}}
+{{% codenew file="service/networking/hostaliases-pod.yaml" %}}
 
 다음을 실행하여 해당 구성으로 파드를 실행할 수 있다.
 

--- a/content/ko/docs/tasks/network/validate-dual-stack.md
+++ b/content/ko/docs/tasks/network/validate-dual-stack.md
@@ -106,7 +106,7 @@ fe00::2    ip6-allrouters
 
 `.spec.ipFamilyPolicy` 를 명시적으로 정의하지 않은 다음의 서비스를 생성한다. 쿠버네티스는 처음 구성된 `service-cluster-ip-range` 에서 서비스에 대한 클러스터 IP를 할당하고 `.spec.ipFamilyPolicy` 를 `SingleStack` 으로 설정한다.
 
-{{< codenew file="service/networking/dual-stack-default-svc.yaml" >}}
+{{% codenew file="service/networking/dual-stack-default-svc.yaml" %}}
 
 `kubectl` 을 사용하여 서비스의 YAML을 확인한다.
 
@@ -143,7 +143,7 @@ status:
 
 `.spec.ipFamilies` 의 첫 번째 배열 요소로 `IPv6` 을 명시적으로 정의하는 다음 서비스를 생성한다. Kubernetes는 `service-cluster-ip-range`로 구성된 IPv6 범위에서 서비스용 클러스터 IP를 할당하고 `.spec.ipFamilyPolicy` 를 `SingleStack` 으로 설정한다.
 
-{{< codenew file="service/networking/dual-stack-ipfamilies-ipv6.yaml" >}}
+{{% codenew file="service/networking/dual-stack-ipfamilies-ipv6.yaml" %}}
 
 `kubectl` 를 사용하여 서비스의 YAML을 확인한다.
 
@@ -181,7 +181,7 @@ status:
 
 `PreferDualStack` 에 `.spec.ipFamilyPolicy` 을 명시적으로 정의하는 다음 서비스를 생성한다. 쿠버네티스는 IPv4 및 IPv6 주소를 모두 할당하고 (이 클러스터에는 이중 스택을 사용하도록 설정되었으므로) `.spec.ipFamilies` 배열에 있는 첫 번째 요소의 주소 계열을 기반으로`.spec.ClusterIP` 목록에서 `.spec.ClusterIPs` 를 선택한다.
 
-{{< codenew file="service/networking/dual-stack-preferred-svc.yaml" >}}
+{{% codenew file="service/networking/dual-stack-preferred-svc.yaml" %}}
 
 {{< note >}}
 `kubectl get svc` 명령어는 오직 `CLUSTER-IP` 필드에 주요 IP만 표시한다.
@@ -222,7 +222,7 @@ Events:            <none>
 
 만약 클라우드 제공자가 IPv6 기반 외부 로드 밸런서 구성을 지원한다면 `.spec.ipFamilyPolicy` 의 `PreferDualStack` 과 `.spec.ipFamilies` 배열의 첫 번째 요소로 `IPv6` 및 `LoadBalancer` 로 설정된 `type` 필드를 사용하여 다음 서비스를 생성한다.
 
-{{< codenew file="service/networking/dual-stack-prefer-ipv6-lb-svc.yaml" >}}
+{{% codenew file="service/networking/dual-stack-prefer-ipv6-lb-svc.yaml" %}}
 
 Check the Service:
 

--- a/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -58,7 +58,7 @@ HorizontalPodAutoscaler 시연을 위해, `hpa-example` 이미지를 사용하�
 다음의 매니페스트를 사용하여 디플로이먼트를
 {{< glossary_tooltip term_id="service" text="서비스">}}로 노출한다.
 
-{{< codenew file="application/php-apache.yaml" >}}
+{{% codenew file="application/php-apache.yaml" %}}
 
 이를 위해, 다음의 명령어를 실행한다.
 
@@ -498,7 +498,7 @@ HorizontalPodAutoscaler와 메트릭 API에서 모든 메트릭은
 HorizontalPodAutoscaler를 생성하기 위해 `kubectl autoscale` 명령어를 사용하지 않고,
 명시적으로 다음 매니페스트를 사용하여 만들 수 있다.
 
-{{< codenew file="application/hpa/php-apache.yaml" >}}
+{{% codenew file="application/hpa/php-apache.yaml" %}}
 
 다음으로, 아래의 명령어를 실행하여 오토스케일러를 생성한다.
 

--- a/content/ko/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/content/ko/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -62,7 +62,7 @@ MySQL 디플로이먼트 예시는 컨피그맵과, 2개의 서비스, 그리고
 
 다음 YAML 설정 파일로부터 컨피그맵을 생성한다.
 
-{{< codenew file="application/mysql/mysql-configmap.yaml" >}}
+{{% codenew file="application/mysql/mysql-configmap.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/mysql/mysql-configmap.yaml
@@ -82,7 +82,7 @@ kubectl apply -f https://k8s.io/examples/application/mysql/mysql-configmap.yaml
 
 다음 YAML 설정 파일로부터 서비스를 생성한다.
 
-{{< codenew file="application/mysql/mysql-services.yaml" >}}
+{{% codenew file="application/mysql/mysql-services.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/mysql/mysql-services.yaml
@@ -109,7 +109,7 @@ Ready 상태인 모든 MySQL 파드들에게 커넥션을 분배하는 일반적
 
 마지막으로, 다음 YAML 설정 파일로부터 스테이트풀셋을 생성한다.
 
-{{< codenew file="application/mysql/mysql-statefulset.yaml" >}}
+{{% codenew file="application/mysql/mysql-statefulset.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/mysql/mysql-statefulset.yaml

--- a/content/ko/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/ko/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -50,8 +50,8 @@ MySQL을 실행하고 퍼시스턴트볼륨클레임을 참조하는 디플로�
 [쿠버네티스 시크릿](/ko/docs/concepts/configuration/secret/)
 을 보자
 
-{{< codenew file="application/mysql/mysql-deployment.yaml" >}}
-{{< codenew file="application/mysql/mysql-pv.yaml" >}}
+{{% codenew file="application/mysql/mysql-deployment.yaml" %}}
+{{% codenew file="application/mysql/mysql-pv.yaml" %}}
 
 1. YAML 파일의 PV와 PVC를 배포한다.
 

--- a/content/ko/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/content/ko/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -38,7 +38,7 @@ weight: 10
 디플로이먼트에 대한 명세를 YAML 파일에 기술할 수 있다. 예를 들어 이 YAML 파일은 
 nginx:1.14.2 도커 이미지를 실행하는 디플로이먼트에 대한 명세를 담고 있다.
 
-{{< codenew file="application/deployment.yaml" >}}
+{{% codenew file="application/deployment.yaml" %}}
 
 
 1. YAML 파일을 기반으로 디플로이먼트를 생성한다.
@@ -100,7 +100,7 @@ nginx:1.14.2 도커 이미지를 실행하는 디플로이먼트에 대한 명�
 새 YAML 파일을 적용하여 디플로이먼트를 업데이트할 수 있다. 이 YAML 파일은 
 nginx 1.16.1을 사용하도록 디플로이먼트를 업데이트해야 함을 명시하고 있다.
 
-{{< codenew file="application/deployment-update.yaml" >}}
+{{% codenew file="application/deployment-update.yaml" %}}
 
 1. 새 YAML 파일을 적용한다.
 
@@ -116,7 +116,7 @@ nginx 1.16.1을 사용하도록 디플로이먼트를 업데이트해야 함을 
 이 YAML 파일은 `replicas`를 4로 설정하여 디플로이먼트에 
 4개의 파드가 있어야 함을 명시하고 있다.
 
-{{< codenew file="application/deployment-scale.yaml" >}}
+{{% codenew file="application/deployment-scale.yaml" %}}
 
 1. 새 YAML 파일을 적용한다.
 

--- a/content/ko/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/ko/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -236,7 +236,7 @@ EOF
 
 ### 인증서 발급하기
 
-{{< codenew file="tls/server-signing-config.json" >}}
+{{% codenew file="tls/server-signing-config.json" %}}
 
 `server-signing-config.json` 서명 구성 파일, 인증 기관 키 파일 및 인증서를 사용하여 
 인증서 요청에 서명한다.

--- a/content/ko/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/ko/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -68,7 +68,7 @@ Redis 파드 매니페스트의 내용을 검토하고 다음의 사항을 염�
 이 내용은 위의 `example-redis-config` 컨피그맵의 `data.redis-config` 내부 데이터를 파드 안에 있는
 `/redis-master/redis.conf` 파일의 내용으로 노출시키는 순효과(net effect)를 낸다.
 
-{{< codenew file="pods/config/redis-pod.yaml" >}}
+{{% codenew file="pods/config/redis-pod.yaml" %}}
 
 생성된 오브젝트를 확인한다.
 
@@ -139,7 +139,7 @@ kubectl exec -it redis -- redis-cli
 
 이제 `example-redis-config` 컨피그맵에 몇 가지 설정값을 추가해 본다.
 
-{{< codenew file="pods/config/example-redis-config.yaml" >}}
+{{% codenew file="pods/config/example-redis-config.yaml" %}}
 
 갱신된 컨피그맵을 적용한다.
 

--- a/content/ko/docs/tutorials/security/apparmor.md
+++ b/content/ko/docs/tutorials/security/apparmor.md
@@ -210,7 +210,7 @@ done
 
 다음으로 쓰기 금지 프로파일된 "Hello AppArmor" 파드를 실행한다.
 
-{{< codenew file="pods/security/hello-apparmor.yaml" >}}
+{{% codenew file="pods/security/hello-apparmor.yaml" %}}
 
 ```shell
 kubectl create -f ./hello-apparmor.yaml

--- a/content/ko/docs/tutorials/services/connect-applications-service.md
+++ b/content/ko/docs/tutorials/services/connect-applications-service.md
@@ -26,7 +26,7 @@ weight: 20
 이 작업은 이전 예시에서 수행해 보았지만, 네트워킹 관점을 중점에 두고 다시 한번 수행해 보자.
 nginx 파드를 생성하고, 해당 파드에 컨테이너 포트 사양이 있는 것을 참고한다.
 
-{{< codenew file="service/networking/run-my-nginx.yaml" >}}
+{{% codenew file="service/networking/run-my-nginx.yaml" %}}
 
 이렇게 하면 클러스터의 모든 노드에서 접근할 수 있다. 파드를 실행 중인 노드를 확인한다.
 
@@ -71,7 +71,7 @@ service/my-nginx exposed
 
 이것은 다음 yaml 파일을 `kubectl apply -f` 로 실행한 것과 동일하다.
 
-{{< codenew file="service/networking/nginx-svc.yaml" >}}
+{{% codenew file="service/networking/nginx-svc.yaml" %}}
 
 이 사양은 `run: my-nginx` 레이블이 부착된 모든 파드에 TCP 포트 80을
 대상으로 하는 서비스를 만들고 추상화된 서비스 포트에 노출시킨다
@@ -298,7 +298,7 @@ nginxsecret           kubernetes.io/tls                     2         1m
 
 이제 nginx 레플리카를 수정하여 암호화된 인증서를 사용한 https 서버와 서비스를 실행하고, 두 포트(80과 443)를 노출한다.
 
-{{< codenew file="service/networking/nginx-secure-app.yaml" >}}
+{{% codenew file="service/networking/nginx-secure-app.yaml" %}}
 
 nginx-secure-app의 매니페스트에 대한 주목할만한 점:
 
@@ -331,7 +331,7 @@ node $ curl -k https://10.244.3.5
 curl에 CName 불일치를 무시하도록 지시해야하기 때문이다. 서비스를 생성해서 인증서에 사용된 CName을 서비스 조회시 파드에서 사용된 실제 DNS 이름과 연결했다.
 파드에서 이것을 테스트 해보자(단순히 동일한 시크릿이 재사용되고 있으며, 파드는 서비스에 접근하기위해 nginx.crt만 필요하다).
 
-{{< codenew file="service/networking/curlpod.yaml" >}}
+{{% codenew file="service/networking/curlpod.yaml" %}}
 
 ```shell
 kubectl apply -f ./curlpod.yaml

--- a/content/ko/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/ko/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -62,7 +62,7 @@ weight: 10
 [헤드리스 서비스](/ko/docs/concepts/services-networking/service/#헤드리스-headless-서비스)인
 `nginx` 를 생성한다.
 
-{{< codenew file="application/web/web.yaml" >}}
+{{% codenew file="application/web/web.yaml" %}}
 
 위에 예제를 다운로드 받아서 파일이름을 `web.yaml`으로 저장하자.
 
@@ -1090,7 +1090,7 @@ statefulset "web" deleted
 기다리지 않음을 뜻한다.
 이 옵션은 스케일링 동작에만 영향을 미치며, 업데이트 동작에는 영향을 미치지 않는다.
 
-{{< codenew file="application/web/web-parallel.yaml" >}}
+{{% codenew file="application/web/web-parallel.yaml" %}}
 
 상기 예제를 다운로드받아 파일 이름을 `web-parallel.yaml`로 저장하자.
 

--- a/content/ko/docs/tutorials/stateful-application/cassandra.md
+++ b/content/ko/docs/tutorials/stateful-application/cassandra.md
@@ -70,7 +70,7 @@ minikube start --memory 5120 --cpus=4
 
 다음의 서비스는 클러스터에서 카산드라 파드와 클라이언트 간에 DNS 찾아보기 용도로 사용한다.
 
-{{< codenew file="application/cassandra/cassandra-service.yaml" >}}
+{{% codenew file="application/cassandra/cassandra-service.yaml" %}}
 
 `cassandra-service.yaml` 파일에서 카산드라 스테이트풀셋 노드를 모두 추적하는 서비스를 생성한다.
 
@@ -107,7 +107,7 @@ cassandra   ClusterIP   None         <none>        9042/TCP   45s
 다음 스테이트풀셋을 작업하는 클라우드 환경에서 갱신한다.
 {{< /note >}}
 
-{{< codenew file="application/cassandra/cassandra-statefulset.yaml" >}}
+{{% codenew file="application/cassandra/cassandra-statefulset.yaml" %}}
 
 `cassandra-statefulset.yaml` 파일로 카산드라 스테이트풀셋 생성
 

--- a/content/ko/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/ko/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -95,14 +95,14 @@ EOF
 
 다음 매니페스트는 MySQL 디플로이먼트 단일 인스턴스를 기술한다. MySQL 컨케이너는 퍼시스턴트볼륨을 /var/lib/mysql에 마운트한다. `MYSQL_ROOT_PASSWORD` 환경 변수는 시크릿에서 가져와 데이터베이스 암호로 설정한다.
 
-{{< codenew file="application/wordpress/mysql-deployment.yaml" >}}
+{{% codenew file="application/wordpress/mysql-deployment.yaml" %}}
 
 다음의 매니페스트는 단일-인스턴스 WordPress 디플로이먼트를 기술한다. WordPress 컨테이너는
 웹사이트 데이터 파일을 위해 `/var/www/html`에 퍼시스턴트볼륨을 마운트한다. `WORDPRESS_DB_HOST` 환경 변수에는
 위에서 정의한 MySQL 서비스의 이름이 설정되며, WordPress는 서비스를 통해 데이터베이스에 접근한다.
 `WORDPRESS_DB_PASSWORD` 환경 변수에는 kustomize가 생성한 데이터베이스 패스워드가 설정된다.
 
-{{< codenew file="application/wordpress/wordpress-deployment.yaml" >}}
+{{% codenew file="application/wordpress/wordpress-deployment.yaml" %}}
 
 1. MySQL 디플로이먼트 구성 파일을 다운로드한다.
 

--- a/content/ko/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/ko/docs/tutorials/stateful-application/zookeeper.md
@@ -73,7 +73,7 @@ ZooKeeper는 전체 상태 머신을 메모리에 보존하고 모든 돌연변�
 [PodDisruptionBudget](/ko/docs/concepts/workloads/pods/disruptions/#파드-disruption-budgets),
 [스테이트풀셋](/ko/docs/concepts/workloads/controllers/statefulset/)을 포함한다.
 
-{{< codenew file="application/zookeeper/zookeeper.yaml" >}}
+{{% codenew file="application/zookeeper/zookeeper.yaml" %}}
 
 터미널을 열고
 [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands/#apply) 명령어로

--- a/content/ko/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/ko/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -31,7 +31,7 @@ weight: 10
 
 1. 클러스터에서 Hello World 애플리케이션을 실행한다.
 
-   {{< codenew file="service/load-balancer-example.yaml" >}}
+   {{% codenew file="service/load-balancer-example.yaml" %}}
 
    ```shell
    kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml

--- a/content/ko/docs/tutorials/stateless-application/guestbook.md
+++ b/content/ko/docs/tutorials/stateless-application/guestbook.md
@@ -46,7 +46,7 @@ _(운영 수준이 아닌)_ 멀티 티어 웹 애플리케이션을 빌드하고
 
 아래의 매니페스트 파일은 단일 복제본 Redis 파드를 실행하는 디플로이먼트 컨트롤러에 대한 명세를 담고 있다.
 
-{{< codenew file="application/guestbook/redis-leader-deployment.yaml" >}}
+{{% codenew file="application/guestbook/redis-leader-deployment.yaml" %}}
 
 1. 매니페스트 파일을 다운로드한 디렉터리에서 터미널 창을 시작한다.
 1. `redis-leader-deployment.yaml` 파일을 이용하여 Redis 디플로이먼트를 생성한다.
@@ -86,7 +86,7 @@ Redis 파드로 트래픽을 프록시하려면 [서비스](/ko/docs/concepts/se
 서비스는 파드에 접근하기 위한 정책을
 정의한다.
 
-{{< codenew file="application/guestbook/redis-leader-service.yaml" >}}
+{{% codenew file="application/guestbook/redis-leader-service.yaml" %}}
 
 1. `redis-leader-service.yaml` 파일을 이용하여 Redis 서비스를 실행한다.
 
@@ -124,7 +124,7 @@ Redis 파드로 라우팅한다.
 Redis 리더는 단일 파드이지만, 몇 개의 Redis 팔로워 또는 복제본을 추가하여
 가용성을 높이고 트래픽 요구를 충족할 수 있다.
 
-{{< codenew file="application/guestbook/redis-follower-deployment.yaml" >}}
+{{% codenew file="application/guestbook/redis-follower-deployment.yaml" %}}
 
 1. `redis-follower-deployment.yaml` 파일을 이용하여 Redis 서비스를 실행한다.
 
@@ -158,7 +158,7 @@ Redis 리더는 단일 파드이지만, 몇 개의 Redis 팔로워 또는 복제
 Redis 팔로워를 발견 가능(discoverable)하게 만드려면, 새로운
 [서비스](/ko/docs/concepts/services-networking/service/)를 구성해야 한다.
 
-{{< codenew file="application/guestbook/redis-follower-service.yaml" >}}
+{{% codenew file="application/guestbook/redis-follower-service.yaml" %}}
 
 1. `redis-follower-service.yaml` 파일을 이용하여 Redis 서비스를 실행한다.
 
@@ -205,7 +205,7 @@ jQuery-Ajax 기반 UX를 제공한다.
 
 ### 방명록 프론트엔드의 디플로이먼트 생성하기
 
-{{< codenew file="application/guestbook/frontend-deployment.yaml" >}}
+{{% codenew file="application/guestbook/frontend-deployment.yaml" %}}
 
 1. `frontend-deployment.yaml` 파일을 이용하여 프론트엔드 디플로이먼트를 생성한다.
 
@@ -253,7 +253,7 @@ Google Compute Engine 또는 Google Kubernetes Engine
 밸런서를 지원하고 이를 사용하려면 `type : LoadBalancer`의 주석을 제거해야 한다.
 {{< /note >}}
 
-{{< codenew file="application/guestbook/frontend-service.yaml" >}}
+{{% codenew file="application/guestbook/frontend-service.yaml" %}}
 
 1. `frontend-service.yaml` 파일을 이용하여 프론트엔드 서비스를 실행한다.
 


### PR DESCRIPTION
This is a continuation of PR https://github.com/kubernetes/website/pull/42180 (Replace {{< codenew ... >}} with {{% codenew ... %}})
Fixes https://github.com/kubernetes/website/issues/42179 (Copy To Clipboard breaks YAML format)