### PR TITLE
[uk] replaced {{< codenew ... >}} with {{% codenew ... %}}

### DIFF
--- a/content/uk/docs/tutorials/hello-minikube.md
+++ b/content/uk/docs/tutorials/hello-minikube.md
@@ -58,9 +58,9 @@ You can also follow this tutorial if you've installed [Minikube locally](/docs/t
 -->
 У цьому навчальному матеріалі ми використовуємо образ контейнера, зібраний із наступних файлів:
 
-{{< codenew language="js" file="minikube/server.js" >}}
+{{% codenew language="js" file="minikube/server.js" %}}
 
-{{< codenew language="conf" file="minikube/Dockerfile" >}}
+{{% codenew language="conf" file="minikube/Dockerfile" %}}
 
 <!--For more information on the `docker build` command, read the [Docker documentation](https://docs.docker.com/engine/reference/commandline/build/).
 -->


### PR DESCRIPTION
This is a continuation of PR https://github.com/kubernetes/website/pull/42180 (Replace {{< codenew ... >}} with {{% codenew ... %}})
Fixes https://github.com/kubernetes/website/issues/42179 (Copy To Clipboard breaks YAML format)