### PR TITLE
Add description about allocatableMemory.available in node eviction

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -50,14 +50,15 @@ the resource that should be available on the node.
 
 Kubelet uses the following eviction signals:
 
-| Eviction Signal      | Description                                                                           |
-|----------------------|---------------------------------------------------------------------------------------|
-| `memory.available`   | `memory.available` := `node.status.capacity[memory]` - `node.stats.memory.workingSet` |
-| `nodefs.available`   | `nodefs.available` := `node.stats.fs.available`                                       |
-| `nodefs.inodesFree`  | `nodefs.inodesFree` := `node.stats.fs.inodesFree`                                     |
-| `imagefs.available`  | `imagefs.available` := `node.stats.runtime.imagefs.available`                         |
-| `imagefs.inodesFree` | `imagefs.inodesFree` := `node.stats.runtime.imagefs.inodesFree`                       |
-| `pid.available`      | `pid.available` := `node.stats.rlimit.maxpid` - `node.stats.rlimit.curproc`           |
+| Eviction Signal                 | Description                                                                           |
+|---------------------------------|---------------------------------------------------------------------------------------|
+| `memory.available`              | `memory.available` := `node.status.capacity[memory]` - `node.stats.memory.workingSet` |
+| `allocatableMemory.available`   | `allocatableMemory.available` := `node.status.allocatable[memory]` - `pods.stats.memory.workingSet` |
+| `nodefs.available`              | `nodefs.available` := `node.stats.fs.available`                                       |
+| `nodefs.inodesFree`             | `nodefs.inodesFree` := `node.stats.fs.inodesFree`                                     |
+| `imagefs.available`             | `imagefs.available` := `node.stats.runtime.imagefs.available`                         |
+| `imagefs.inodesFree`            | `imagefs.inodesFree` := `node.stats.runtime.imagefs.inodesFree`                       |
+| `pid.available`                 | `pid.available` := `node.stats.rlimit.maxpid` - `node.stats.rlimit.curproc`           |
 
 In this table, the `Description` column shows how kubelet gets the value of the
 signal. Each signal supports either a percentage or a literal value. Kubelet
@@ -66,14 +67,14 @@ the signal.
 
 The value for `memory.available` is derived from the cgroupfs instead of tools
 like `free -m`. This is important because `free -m` does not work in a
-container, and if users use the [node allocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)
-feature, out of resource decisions
-are made local to the end user Pod part of the cgroup hierarchy as well as the
-root node. This [script](/examples/admin/resource/memory-available.sh)
+container. This [script](/examples/admin/resource/memory-available.sh)
 reproduces the same set of steps that the kubelet performs to calculate
 `memory.available`. The kubelet excludes inactive_file (i.e. # of bytes of
 file-backed memory on inactive LRU list) from its calculation as it assumes that
 memory is reclaimable under pressure.
+
+From v1.6, [node allocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable) is enforced by default across all pods on a node using cgroups, out of resource decisions are made local to the end user Pod part of the cgroup hierarchy as well as the
+root node. The threshold value for `allocatableMemory.available` is the same with `memory.available`.
 
 The kubelet supports the following filesystem partitions:
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

/sig node

Add description about allocatableMemory.available in node eviction.  `allocatableMemory.available` signal is enable by default.
