### PR TITLE
Link Static Pod Task page with Static Pod Concept

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -326,7 +326,7 @@ using the kubelet to supervise the individual [control plane components](/docs/c
 The kubelet automatically tries to create a {{< glossary_tooltip text="mirror Pod" term_id="mirror-pod" >}}
 on the Kubernetes API server for each static Pod.
 This means that the Pods running on a node are visible on the API server,
-but cannot be controlled from there.
+but cannot be controlled from there. See the guide [Create static Pods](/docs/tasks/configure-pod-container/static-pod) for more information.
 
 {{< note >}}
 The `spec` of a static Pod cannot refer to other API objects


### PR DESCRIPTION
# Description

Page updated: [kubernetes.io/docs/concepts/workloads/pods/#static-pods](https://kubernetes.io/docs/concepts/workloads/pods/#static-pods)

Changd [kubernetes.io/docs/concepts/workloads/pods/#static-pods](https://kubernetes.io/docs/concepts/workloads/pods/#static-pods) to link to [kubernetes.io/docs/tasks/configure-pod-container/static-pod](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)

Resolves: https://github.com/kubernetes/website/issues/42195