### PR TITLE
Update outdated scripts for generating the OpenAPI spec

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -133,9 +133,8 @@ you will do a second commit. It is important to keep your changes separated into
 Go to `<k8s-base>` and run these scripts:
 
 ```shell
-hack/update-generated-swagger-docs.sh
-hack/update-openapi-spec.sh
-hack/update-generated-protobuf.sh
+./hack/update-codegen.sh
+./hack/update-openapi-spec.sh
 ```
 
 Run `git status` to see what was generated.
@@ -206,10 +205,8 @@ release-{{< skew prevMinorVersion >}} branch, the next step is to run these scri
 release-{{< skew prevMinorVersion >}} branch of your local environment.
 
 ```shell
-hack/update-generated-swagger-docs.sh
-hack/update-openapi-spec.sh
-hack/update-generated-protobuf.sh
-hack/update-api-reference-docs.sh
+./hack/update-codegen.sh
+./hack/update-openapi-spec.sh
 ```
 
 Now add a commit to your cherry-pick pull request that has the recently generated OpenAPI spec


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->


While reviewing the PR https://github.com/kubernetes/kubernetes/pull/119575#discussion_r1275170601
, I noticed that some of the scripts that generate the OpenAPI had changed.

The following scripts have been removed in Kubernetes upstream.
```
hack/update-generated-swagger-docs.sh
hack/update-generated-protobuf.sh
hack/update-api-reference-docs.sh
```

`hack/update-generated-swagger-docs.sh` and `hack/update-generated-protobuf.sh` were removed.
- https://github.com/kubernetes/kubernetes/pull/115246/ 


`hack/update-api-reference-docs.sh` was removed.
- https://github.com/kubernetes/kubernetes/pull/72924/

xref:
- https://github.com/kubernetes/website/pull/28087 