### PR TITLE
Update path to save PGP key to for Debian 12 - bookworm

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -159,14 +159,19 @@ The following methods exist for installing kubectl on Linux:
    ```shell
    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
    ```
+   On Debian 12 (bookworm) import the Google Cloud signing key with:
 
-3. Add the Kubernetes `apt` repository:
+   ```shell
+   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg
+   ```
+   
+4. Add the Kubernetes `apt` repository:
 
    ```shell
    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-4. Update `apt` package index with the new repository and install kubectl:
+5. Update `apt` package index with the new repository and install kubectl:
 
    ```shell
    sudo apt-get update


### PR DESCRIPTION
Update path to save gpg key to for Debian 12 - bookworm. This fixes apt error :

W: https://apt.kubernetes.io/dists/kubernetes-xenial/InRelease の取得に失敗しました  Could not handshake: A TLS fatal alert has been received. [IP: 2600:1901:0:26f3:: 443]
