### PR TITLE
Fix incorrect translation for resource-metrics-pipeline.md

### DIFF
--- a/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -357,7 +357,7 @@ to collect metrics from each node. Depending on the metrics-server version it us
 * Summary API endpoint `/stats/summary` in older versions
 -->
 metrics-server 调用 [kubelet](/zh-cn/docs/reference/command-line-tools-reference/kubelet/) API
-从每个节点收集指标。根据它使用的度量服务器版本：
+从每个节点收集指标。根据它使用的 metrics-server 版本：
 
 * 版本 v0.6.0+ 中，使用指标资源端点 `/metrics/resource`
 * 旧版本中使用 Summary  API 端点 `/stats/summary`


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
While browsing through the metrics-server related documentation, an error was found.

The specific application name `metrics-server` should not be translated.