### PR TITLE
admission controllers: document types

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -121,11 +121,15 @@ the `admissionregistration.k8s.io/v1alpha1` API.
 This admission controller allows all pods into the cluster. It is **deprecated** because
 its behavior is the same as if there were no admission controller at all.
 
+**Type**: Validating.
+
 ### AlwaysDeny {#alwaysdeny}
 
 {{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
 
 Rejects all requests. AlwaysDeny is **deprecated** as it has no real meaning.
+
+**Type**: Validating.
 
 ### AlwaysPullImages {#alwayspullimages}
 
@@ -137,6 +141,8 @@ scheduled onto the right node), without any authorization check against the imag
 is enabled, images are always pulled prior to starting containers, which means valid credentials are
 required.
 
+**Type**: Mutating and Validating.
+
 ### CertificateApproval {#certificateapproval}
 
 This admission controller observes requests to approve CertificateSigningRequest resources and performs additional
@@ -145,6 +151,8 @@ authorization checks to ensure the approving user has permission to **approve** 
 
 See [Certificate Signing Requests](/docs/reference/access-authn-authz/certificate-signing-requests/) for more
 information on the permissions required to perform different actions on CertificateSigningRequest resources.
+
+**Type**: Validating.
 
 ### CertificateSigning {#certificatesigning}
 
@@ -155,11 +163,15 @@ requests with the `spec.signerName` requested on the CertificateSigningRequest r
 See [Certificate Signing Requests](/docs/reference/access-authn-authz/certificate-signing-requests/) for more
 information on the permissions required to perform different actions on CertificateSigningRequest resources.
 
+**Type**: Validating.
+
 ### CertificateSubjectRestriction {#certificatesubjectrestriction}
 
 This admission controller observes creation of CertificateSigningRequest resources that have a `spec.signerName`
 of `kubernetes.io/kube-apiserver-client`. It rejects any request that specifies a 'group' (or 'organization attribute')
 of `system:masters`.
+
+**Type**: Validating.
 
 ### DefaultIngressClass {#defaultingressclass}
 
@@ -177,6 +189,8 @@ updates; it acts only on creation.
 See the [Ingress](/docs/concepts/services-networking/ingress/) documentation for more about ingress
 classes and how to mark one as default.
 
+**Type**: Mutating.
+
 ### DefaultStorageClass {#defaultstorageclass}
 
 This admission controller observes creation of `PersistentVolumeClaim` objects that do not request any specific storage class
@@ -192,6 +206,8 @@ This admission controller ignores any `PersistentVolumeClaim` updates; it acts o
 See [persistent volume](/docs/concepts/storage/persistent-volumes/) documentation about persistent volume claims and
 storage classes and how to mark a storage class as default.
 
+**Type**: Mutating.
+
 ### DefaultTolerationSeconds {#defaulttolerationseconds}
 
 This admission controller sets the default forgiveness toleration for pods to tolerate
@@ -200,6 +216,8 @@ the taints `notready:NoExecute` and `unreachable:NoExecute` based on the k8s-api
 have toleration for taints `node.kubernetes.io/not-ready:NoExecute` or
 `node.kubernetes.io/unreachable:NoExecute`.
 The default value for `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` is 5 minutes.
+
+**Type**: Mutating.
 
 ### DenyServiceExternalIPs
 
@@ -215,6 +233,8 @@ Clusters that do need to use this feature should consider using some custom poli
 of it.
 
 This admission controller is disabled by default.
+
+**Type**: Validating.
 
 ### EventRateLimit {#eventratelimit}
 
@@ -264,6 +284,8 @@ for more details.
 
 This admission controller is disabled by default.
 
+**Type**: Validating.
+
 ### ExtendedResourceToleration {#extendedresourcetoleration}
 
 This plug-in facilitates creation of dedicated nodes with extended resources.
@@ -275,11 +297,15 @@ add these tolerations.
 
 This admission controller is disabled by default.
 
+**Type**: Mutating.
+
 ### ImagePolicyWebhook {#imagepolicywebhook}
 
 The ImagePolicyWebhook admission controller allows a backend webhook to make admission decisions.
 
 This admission controller is disabled by default.
+
+**Type**: Validating.
 
 #### Configuration file format {#imagereview-config-file-format}
 
@@ -444,6 +470,8 @@ This admission controller denies any pod that defines `AntiAffinity` topology ke
 
 This admission controller is disabled by default.
 
+**Type**: Validating.
+
 ### LimitRanger {#limitranger}
 
 This admission controller will observe the incoming request and ensure that it does not violate
@@ -456,6 +484,8 @@ Pods in the `default` namespace.
 See the [LimitRange API reference](/docs/reference/kubernetes-api/policy-resources/limit-range-v1/)
 and the [example of LimitRange](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
 for more details.
+
+**Type**: Mutating and Validating.
 
 ### MutatingAdmissionWebhook {#mutatingadmissionwebhook}
 
@@ -471,6 +501,8 @@ webhooks or validating admission controllers will permit the request to finish.
 If you disable the MutatingAdmissionWebhook, you must also disable the
 `MutatingWebhookConfiguration` object in the `admissionregistration.k8s.io/v1`
 group/version via the `--runtime-config` flag, both are on by default.
+
+**Type**: Mutating.
 
 #### Use caution when authoring and installing mutating webhooks
 
@@ -493,10 +525,14 @@ It creates a namespace if it cannot be found.
 This admission controller is useful in deployments that do not want to restrict creation of
 a namespace prior to its usage.
 
+**Type**: Mutating.
+
 ### NamespaceExists {#namespaceexists}
 
 This admission controller checks all requests on namespaced resources other than `Namespace` itself.
 If the namespace referenced from a request doesn't exist, the request is rejected.
+
+**Type**: Validating.
 
 ### NamespaceLifecycle {#namespacelifecycle}
 
@@ -508,6 +544,8 @@ This admission controller also prevents deletion of three system reserved namesp
 A `Namespace` deletion kicks off a sequence of operations that remove all objects (pods, services,
 etc.) in that namespace.  In order to enforce integrity of that process, we strongly recommend
 running this admission controller.
+
+**Type**: Validating.
 
 ### NodeRestriction {#noderestriction}
 
@@ -541,6 +579,8 @@ and may be disallowed or allowed by the `NodeRestriction` admission plugin in th
 Future versions may add additional restrictions to ensure kubelets have the minimal set of
 permissions required to operate correctly.
 
+**Type**: Validating.
+
 ### OwnerReferencesPermissionEnforcement {#ownerreferencespermissionenforcement}
 
 This admission controller protects the access to the `metadata.ownerReferences` of an object
@@ -548,6 +588,8 @@ so that only users with **delete** permission to the object can change it.
 This admission controller also protects the access to `metadata.ownerReferences[x].blockOwnerDeletion`
 of an object, so that only users with **update** permission to the `finalizers`
 subresource of the referenced *owner* can change it.
+
+**Type**: Validating.
 
 ### PersistentVolumeClaimResize {#persistentvolumeclaimresize}
 
@@ -578,6 +620,8 @@ allowVolumeExpansion: true
 
 For more information about persistent volume claims, see [PersistentVolumeClaims](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 
+**Type**: Validating.
+
 ### PersistentVolumeLabel {#persistentvolumelabel}
 
 {{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
@@ -593,6 +637,8 @@ the {{< glossary_tooltip text="cloud-controller-manager" term_id="cloud-controll
 
 This admission controller is disabled by default.
 
+**Type**: Mutating.
+
 ### PodNodeSelector {#podnodeselector}
 
 {{< feature-state for_k8s_version="v1.5" state="alpha" >}}
@@ -601,6 +647,8 @@ This admission controller defaults and limits what node selectors may be used wi
 by reading a namespace annotation and a global configuration.
 
 This admission controller is disabled by default.
+
+**Type**: Validating.
 
 #### Configuration file format
 
@@ -673,6 +721,8 @@ documentation for more information.
 
 PodSecurity replaced an older admission controller named PodSecurityPolicy.
 
+**Type**: Validating.
+
 ### PodTolerationRestriction {#podtolerationrestriction}
 
 {{< feature-state for_k8s_version="v1.7" state="alpha" >}}
@@ -705,11 +755,15 @@ metadata:
 
 This admission controller is disabled by default.
 
+**Type**: Mutating and Validating.
+
 ### Priority {#priority}
 
 The priority admission controller uses the `priorityClassName` field and populates the integer
 value of the priority.
 If the priority class is not found, the Pod is rejected.
+
+**Type**: Mutating and Validating.
 
 ### ResourceQuota {#resourcequota}
 
@@ -720,6 +774,8 @@ controller to enforce quota constraints.
 
 See the [ResourceQuota API reference](/docs/reference/kubernetes-api/policy-resources/resource-quota-v1/)
 and the [example of Resource Quota](/docs/concepts/policy/resource-quotas/) for more details.
+
+**Type**: Validating.
 
 ### RuntimeClass {#runtimeclass}
 
@@ -733,6 +789,8 @@ defined in the corresponding RuntimeClass.
 
 See also [Pod Overhead](/docs/concepts/scheduling-eviction/pod-overhead/)
 for more information.
+
+**Type**: Mutating and Validating.
 
 ### SecurityContextDeny {#securitycontextdeny}
 
@@ -775,6 +833,8 @@ from the Kubernetes blog article about PodSecurityPolicy and its removal. The
 article details the PodSecurityPolicy historical context and the birth of the
 `securityContext` field for Pods.
 
+**Type**: Validating.
+
 ### ServiceAccount {#serviceaccount}
 
 This admission controller implements automation for
@@ -782,6 +842,8 @@ This admission controller implements automation for
 The Kubernetes project strongly recommends enabling this admission controller.
 You should enable this admission controller if you intend to make any use of Kubernetes
 `ServiceAccount` objects.
+
+**Type**: Mutating and Validating.
 
 ### StorageObjectInUseProtection
 
@@ -793,6 +855,8 @@ Refer to the
 [Storage Object in Use Protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection)
 for more detailed information.
 
+**Type**: Mutating.
+
 ### TaintNodesByCondition {#taintnodesbycondition}
 
 This admission controller {{< glossary_tooltip text="taints" term_id="taint" >}} newly created
@@ -800,11 +864,15 @@ Nodes as `NotReady` and `NoSchedule`. That tainting avoids a race condition that
 to be scheduled on new Nodes before their taints were updated to accurately reflect their reported
 conditions.
 
+**Type**: Mutating.
+
 ### ValidatingAdmissionPolicy {#validatingadmissionpolicy}
 
 [This admission controller](/docs/reference/access-authn-authz/validating-admission-policy/) implements the CEL validation for incoming matched requests. 
 It is enabled when both feature gate `validatingadmissionpolicy` and `admissionregistration.k8s.io/v1alpha1` group/version are enabled.
 If any of the ValidatingAdmissionPolicy fails, the request fails.
+
+**Type**: Validating.
 
 ### ValidatingAdmissionWebhook {#validatingadmissionwebhook}
 
@@ -820,6 +888,8 @@ webhooks or other validating admission controllers will permit the request to fi
 If you disable the ValidatingAdmissionWebhook, you must also disable the
 `ValidatingWebhookConfiguration` object in the `admissionregistration.k8s.io/v1`
 group/version via the `--runtime-config` flag.
+
+**Type**: Validating.
 
 ## Is there a recommended set of admission controllers to use?
 

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -118,20 +118,22 @@ the `admissionregistration.k8s.io/v1alpha1` API.
 
 {{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
 
+**Type**: Validating.
+
 This admission controller allows all pods into the cluster. It is **deprecated** because
 its behavior is the same as if there were no admission controller at all.
-
-**Type**: Validating.
 
 ### AlwaysDeny {#alwaysdeny}
 
 {{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
 
-Rejects all requests. AlwaysDeny is **deprecated** as it has no real meaning.
-
 **Type**: Validating.
 
+Rejects all requests. AlwaysDeny is **deprecated** as it has no real meaning.
+
 ### AlwaysPullImages {#alwayspullimages}
+
+**Type**: Mutating and Validating.
 
 This admission controller modifies every new Pod to force the image pull policy to `Always`. This is useful in a
 multitenant cluster so that users can be assured that their private images can only be used by those
@@ -141,9 +143,9 @@ scheduled onto the right node), without any authorization check against the imag
 is enabled, images are always pulled prior to starting containers, which means valid credentials are
 required.
 
-**Type**: Mutating and Validating.
-
 ### CertificateApproval {#certificateapproval}
+
+**Type**: Validating.
 
 This admission controller observes requests to approve CertificateSigningRequest resources and performs additional
 authorization checks to ensure the approving user has permission to **approve** certificate requests with the
@@ -152,9 +154,9 @@ authorization checks to ensure the approving user has permission to **approve** 
 See [Certificate Signing Requests](/docs/reference/access-authn-authz/certificate-signing-requests/) for more
 information on the permissions required to perform different actions on CertificateSigningRequest resources.
 
-**Type**: Validating.
-
 ### CertificateSigning {#certificatesigning}
+
+**Type**: Validating.
 
 This admission controller observes updates to the `status.certificate` field of CertificateSigningRequest resources
 and performs an additional authorization checks to ensure the signing user has permission to **sign** certificate
@@ -163,17 +165,17 @@ requests with the `spec.signerName` requested on the CertificateSigningRequest r
 See [Certificate Signing Requests](/docs/reference/access-authn-authz/certificate-signing-requests/) for more
 information on the permissions required to perform different actions on CertificateSigningRequest resources.
 
-**Type**: Validating.
-
 ### CertificateSubjectRestriction {#certificatesubjectrestriction}
+
+**Type**: Validating.
 
 This admission controller observes creation of CertificateSigningRequest resources that have a `spec.signerName`
 of `kubernetes.io/kube-apiserver-client`. It rejects any request that specifies a 'group' (or 'organization attribute')
 of `system:masters`.
 
-**Type**: Validating.
-
 ### DefaultIngressClass {#defaultingressclass}
+
+**Type**: Mutating.
 
 This admission controller observes creation of `Ingress` objects that do not request any specific
 ingress class and automatically adds a default ingress class to them.  This way, users that do not
@@ -189,9 +191,9 @@ updates; it acts only on creation.
 See the [Ingress](/docs/concepts/services-networking/ingress/) documentation for more about ingress
 classes and how to mark one as default.
 
-**Type**: Mutating.
-
 ### DefaultStorageClass {#defaultstorageclass}
+
+**Type**: Mutating.
 
 This admission controller observes creation of `PersistentVolumeClaim` objects that do not request any specific storage class
 and automatically adds a default storage class to them.
@@ -206,9 +208,9 @@ This admission controller ignores any `PersistentVolumeClaim` updates; it acts o
 See [persistent volume](/docs/concepts/storage/persistent-volumes/) documentation about persistent volume claims and
 storage classes and how to mark a storage class as default.
 
-**Type**: Mutating.
-
 ### DefaultTolerationSeconds {#defaulttolerationseconds}
+
+**Type**: Mutating.
 
 This admission controller sets the default forgiveness toleration for pods to tolerate
 the taints `notready:NoExecute` and `unreachable:NoExecute` based on the k8s-apiserver input parameters
@@ -217,9 +219,9 @@ have toleration for taints `node.kubernetes.io/not-ready:NoExecute` or
 `node.kubernetes.io/unreachable:NoExecute`.
 The default value for `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` is 5 minutes.
 
-**Type**: Mutating.
-
 ### DenyServiceExternalIPs
+
+**Type**: Validating.
 
 This admission controller rejects all net-new usage of the `Service` field `externalIPs`.  This
 feature is very powerful (allows network traffic interception) and not well
@@ -234,11 +236,11 @@ of it.
 
 This admission controller is disabled by default.
 
-**Type**: Validating.
-
 ### EventRateLimit {#eventratelimit}
 
 {{< feature-state for_k8s_version="v1.13" state="alpha" >}}
+
+**Type**: Validating.
 
 This admission controller mitigates the problem where the API server gets flooded by
 requests to store new Events. The cluster admin can specify event rate limits by:
@@ -284,9 +286,9 @@ for more details.
 
 This admission controller is disabled by default.
 
-**Type**: Validating.
-
 ### ExtendedResourceToleration {#extendedresourcetoleration}
+
+**Type**: Mutating.
 
 This plug-in facilitates creation of dedicated nodes with extended resources.
 If operators want to create dedicated nodes with extended resources (like GPUs, FPGAs etc.), they are expected to
@@ -297,15 +299,13 @@ add these tolerations.
 
 This admission controller is disabled by default.
 
-**Type**: Mutating.
-
 ### ImagePolicyWebhook {#imagepolicywebhook}
+
+**Type**: Validating.
 
 The ImagePolicyWebhook admission controller allows a backend webhook to make admission decisions.
 
 This admission controller is disabled by default.
-
-**Type**: Validating.
 
 #### Configuration file format {#imagereview-config-file-format}
 
@@ -465,14 +465,16 @@ In any case, the annotations are provided by the user and are not validated by K
 
 ### LimitPodHardAntiAffinityTopology {#limitpodhardantiaffinitytopology}
 
+**Type**: Validating.
+
 This admission controller denies any pod that defines `AntiAffinity` topology key other than
 `kubernetes.io/hostname` in `requiredDuringSchedulingRequiredDuringExecution`.
 
 This admission controller is disabled by default.
 
-**Type**: Validating.
-
 ### LimitRanger {#limitranger}
+
+**Type**: Mutating and Validating.
 
 This admission controller will observe the incoming request and ensure that it does not violate
 any of the constraints enumerated in the `LimitRange` object in a `Namespace`.  If you are using
@@ -485,9 +487,9 @@ See the [LimitRange API reference](/docs/reference/kubernetes-api/policy-resourc
 and the [example of LimitRange](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
 for more details.
 
-**Type**: Mutating and Validating.
-
 ### MutatingAdmissionWebhook {#mutatingadmissionwebhook}
+
+**Type**: Mutating.
 
 This admission controller calls any mutating webhooks which match the request. Matching
 webhooks are called in serial; each one may modify the object if it desires.
@@ -501,8 +503,6 @@ webhooks or validating admission controllers will permit the request to finish.
 If you disable the MutatingAdmissionWebhook, you must also disable the
 `MutatingWebhookConfiguration` object in the `admissionregistration.k8s.io/v1`
 group/version via the `--runtime-config` flag, both are on by default.
-
-**Type**: Mutating.
 
 #### Use caution when authoring and installing mutating webhooks
 
@@ -519,22 +519,24 @@ group/version via the `--runtime-config` flag, both are on by default.
 
 ### NamespaceAutoProvision {#namespaceautoprovision}
 
+**Type**: Mutating.
+
 This admission controller examines all incoming requests on namespaced resources and checks
 if the referenced namespace does exist.
 It creates a namespace if it cannot be found.
 This admission controller is useful in deployments that do not want to restrict creation of
 a namespace prior to its usage.
 
-**Type**: Mutating.
-
 ### NamespaceExists {#namespaceexists}
+
+**Type**: Validating.
 
 This admission controller checks all requests on namespaced resources other than `Namespace` itself.
 If the namespace referenced from a request doesn't exist, the request is rejected.
 
-**Type**: Validating.
-
 ### NamespaceLifecycle {#namespacelifecycle}
+
+**Type**: Validating.
 
 This admission controller enforces that a `Namespace` that is undergoing termination cannot have
 new objects created in it, and ensures that requests in a non-existent `Namespace` are rejected.
@@ -545,9 +547,9 @@ A `Namespace` deletion kicks off a sequence of operations that remove all object
 etc.) in that namespace.  In order to enforce integrity of that process, we strongly recommend
 running this admission controller.
 
-**Type**: Validating.
-
 ### NodeRestriction {#noderestriction}
+
+**Type**: Validating.
 
 This admission controller limits the `Node` and `Pod` objects a kubelet can modify. In order to be limited by this admission controller,
 kubelets must use credentials in the `system:nodes` group, with a username in the form `system:node:<nodeName>`.
@@ -579,9 +581,9 @@ and may be disallowed or allowed by the `NodeRestriction` admission plugin in th
 Future versions may add additional restrictions to ensure kubelets have the minimal set of
 permissions required to operate correctly.
 
-**Type**: Validating.
-
 ### OwnerReferencesPermissionEnforcement {#ownerreferencespermissionenforcement}
+
+**Type**: Validating.
 
 This admission controller protects the access to the `metadata.ownerReferences` of an object
 so that only users with **delete** permission to the object can change it.
@@ -589,11 +591,11 @@ This admission controller also protects the access to `metadata.ownerReferences[
 of an object, so that only users with **update** permission to the `finalizers`
 subresource of the referenced *owner* can change it.
 
-**Type**: Validating.
-
 ### PersistentVolumeClaimResize {#persistentvolumeclaimresize}
 
 {{< feature-state for_k8s_version="v1.24" state="stable" >}}
+
+**Type**: Validating.
 
 This admission controller implements additional validations for checking incoming
 `PersistentVolumeClaim` resize requests.
@@ -620,11 +622,11 @@ allowVolumeExpansion: true
 
 For more information about persistent volume claims, see [PersistentVolumeClaims](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 
-**Type**: Validating.
-
 ### PersistentVolumeLabel {#persistentvolumelabel}
 
 {{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
+
+**Type**: Mutating.
 
 This admission controller automatically attaches region or zone labels to PersistentVolumes
 as defined by the cloud provider (for example, Azure or GCP).
@@ -637,18 +639,16 @@ the {{< glossary_tooltip text="cloud-controller-manager" term_id="cloud-controll
 
 This admission controller is disabled by default.
 
-**Type**: Mutating.
-
 ### PodNodeSelector {#podnodeselector}
 
 {{< feature-state for_k8s_version="v1.5" state="alpha" >}}
+
+**Type**: Validating.
 
 This admission controller defaults and limits what node selectors may be used within a namespace
 by reading a namespace annotation and a global configuration.
 
 This admission controller is disabled by default.
-
-**Type**: Validating.
 
 #### Configuration file format
 
@@ -711,6 +711,8 @@ admission plugin, which allows preventing pods from running on specifically tain
 
 {{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
+**Type**: Validating.
+
 The PodSecurity admission controller checks new Pods before they are
 admitted, determines if it should be admitted based on the requested security context and the restrictions on permitted
 [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
@@ -721,11 +723,11 @@ documentation for more information.
 
 PodSecurity replaced an older admission controller named PodSecurityPolicy.
 
-**Type**: Validating.
-
 ### PodTolerationRestriction {#podtolerationrestriction}
 
 {{< feature-state for_k8s_version="v1.7" state="alpha" >}}
+
+**Type**: Mutating and Validating.
 
 The PodTolerationRestriction admission controller verifies any conflict between tolerations of a
 pod and the tolerations of its namespace.
@@ -755,17 +757,17 @@ metadata:
 
 This admission controller is disabled by default.
 
-**Type**: Mutating and Validating.
-
 ### Priority {#priority}
+
+**Type**: Mutating and Validating.
 
 The priority admission controller uses the `priorityClassName` field and populates the integer
 value of the priority.
 If the priority class is not found, the Pod is rejected.
 
-**Type**: Mutating and Validating.
-
 ### ResourceQuota {#resourcequota}
+
+**Type**: Validating.
 
 This admission controller will observe the incoming request and ensure that it does not violate
 any of the constraints enumerated in the `ResourceQuota` object in a `Namespace`.  If you are
@@ -775,9 +777,9 @@ controller to enforce quota constraints.
 See the [ResourceQuota API reference](/docs/reference/kubernetes-api/policy-resources/resource-quota-v1/)
 and the [example of Resource Quota](/docs/concepts/policy/resource-quotas/) for more details.
 
-**Type**: Validating.
-
 ### RuntimeClass {#runtimeclass}
+
+**Type**: Mutating and Validating.
 
 If you define a RuntimeClass with [Pod overhead](/docs/concepts/scheduling-eviction/pod-overhead/)
 configured, this admission controller checks incoming Pods.
@@ -790,9 +792,9 @@ defined in the corresponding RuntimeClass.
 See also [Pod Overhead](/docs/concepts/scheduling-eviction/pod-overhead/)
 for more information.
 
-**Type**: Mutating and Validating.
-
 ### SecurityContextDeny {#securitycontextdeny}
+
+**Type**: Validating.
 
 {{< feature-state for_k8s_version="v1.27" state="deprecated" >}}
 
@@ -833,9 +835,9 @@ from the Kubernetes blog article about PodSecurityPolicy and its removal. The
 article details the PodSecurityPolicy historical context and the birth of the
 `securityContext` field for Pods.
 
-**Type**: Validating.
-
 ### ServiceAccount {#serviceaccount}
+
+**Type**: Mutating and Validating.
 
 This admission controller implements automation for
 [serviceAccounts](/docs/tasks/configure-pod-container/configure-service-account/).
@@ -843,9 +845,9 @@ The Kubernetes project strongly recommends enabling this admission controller.
 You should enable this admission controller if you intend to make any use of Kubernetes
 `ServiceAccount` objects.
 
-**Type**: Mutating and Validating.
-
 ### StorageObjectInUseProtection
+
+**Type**: Mutating.
 
 The `StorageObjectInUseProtection` plugin adds the `kubernetes.io/pvc-protection` or `kubernetes.io/pv-protection`
 finalizers to newly created Persistent Volume Claims (PVCs) or Persistent Volumes (PV).
@@ -855,26 +857,26 @@ Refer to the
 [Storage Object in Use Protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection)
 for more detailed information.
 
-**Type**: Mutating.
-
 ### TaintNodesByCondition {#taintnodesbycondition}
+
+**Type**: Mutating.
 
 This admission controller {{< glossary_tooltip text="taints" term_id="taint" >}} newly created
 Nodes as `NotReady` and `NoSchedule`. That tainting avoids a race condition that could cause Pods
 to be scheduled on new Nodes before their taints were updated to accurately reflect their reported
 conditions.
 
-**Type**: Mutating.
-
 ### ValidatingAdmissionPolicy {#validatingadmissionpolicy}
+
+**Type**: Validating.
 
 [This admission controller](/docs/reference/access-authn-authz/validating-admission-policy/) implements the CEL validation for incoming matched requests. 
 It is enabled when both feature gate `validatingadmissionpolicy` and `admissionregistration.k8s.io/v1alpha1` group/version are enabled.
 If any of the ValidatingAdmissionPolicy fails, the request fails.
 
-**Type**: Validating.
-
 ### ValidatingAdmissionWebhook {#validatingadmissionwebhook}
+
+**Type**: Validating.
 
 This admission controller calls any validating webhooks which match the request. Matching
 webhooks are called in parallel; if any of them rejects the request, the request
@@ -888,8 +890,6 @@ webhooks or other validating admission controllers will permit the request to fi
 If you disable the ValidatingAdmissionWebhook, you must also disable the
 `ValidatingWebhookConfiguration` object in the `admissionregistration.k8s.io/v1`
 group/version via the `--runtime-config` flag.
-
-**Type**: Validating.
 
 ## Is there a recommended set of admission controllers to use?
 


### PR DESCRIPTION
Recently I have been asked which built-in Admission controllers are validating and which ones are mutating. Upon checking the documentation I noticed that this information is provided only in the source code, so I went ahead and documented this.