### PR TITLE
Use correct `which` command instead of non-existent `where`

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -296,7 +296,7 @@ Depending on how you installed `kubectl`, use one of the following methods.
 1.  Locate the `kubectl` binary on your system:
 
     ```bash
-    where kubectl
+    which kubectl
     ```
 
 1.  Remove the `kubectl` binary:

--- a/content/zh-cn/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-macos.md
@@ -468,7 +468,7 @@ Depending on how you installed `kubectl`, use one of the following methods.
 1. 找到你系统上的 `kubectl` 可执行文件：
 
    ```bash
-   where kubectl
+   which kubectl
    ```
 
 <!--

--- a/content/zh-cn/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-macos.md
@@ -468,7 +468,7 @@ Depending on how you installed `kubectl`, use one of the following methods.
 1. 找到你系统上的 `kubectl` 可执行文件：
 
    ```bash
-   which kubectl
+   where kubectl
    ```
 
 <!--


### PR DESCRIPTION
This fixes the instructions for finding the location of the `kubectl` binary.