### PR TITLE
Added Notes to implementation-details and kubeadm-join docs

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -542,6 +542,10 @@ This is split into discovery (having the Node trust the Kubernetes Master) and T
 see [Authenticating with Bootstrap Tokens](/docs/reference/access-authn-authz/bootstrap-tokens/)
 or the corresponding [design proposal](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md).
 
+Please note that:
+
+1. Kubeadm uses cluster-info for bootstrap with bootstrap tokens.
+
 ### Preflight checks
 
 `kubeadm` executes a set of preflight checks before starting the join, with the aim to verify
@@ -621,4 +625,3 @@ Please note that:
   during the `kubeadm init` process
 - The automatic CSR approval is managed by the csrapprover controller, according with
   configuration done the `kubeadm init` process
-

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -74,6 +74,8 @@ The kubeadm discovery has several options, each with security tradeoffs.
 The right method for your environment depends on how you provision nodes and the
 security expectations you have about your network and node lifecycles.
 
+Note: Kubeadm uses cluster-info for bootstrap with bootstrap tokens.
+
 #### Token-based discovery with CA pinning
 
 This is the default mode in kubeadm. In this mode, kubeadm downloads
@@ -123,6 +125,7 @@ if the `kubeadm init` command was called with `--upload-certs`.
   which can make it more difficult to build automated provisioning tools that
   use kubeadm. By generating your CA in beforehand, you may workaround this
   limitation.
+
 
 #### Token-based discovery without CA pinning
 


### PR DESCRIPTION
Referring to issue #42258, Added a note to the **implementation-details** under the _Kubeadm join phases internal design_ Sub-Heading , And to **kubeadm-join** under the _Discovering what CA Cluster to use_ Sub-Heading
