### PR TITLE
List all images of the workload resources

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -56,7 +56,8 @@ Pod is returned instead of a list of items.
 Listing Pods may yield different results based on the Pods defined lifecycle.
 
 The following example lists all the images possible run in the cluster, except 
-for Orphaned Pods created directly without using workload resources. 
+for {{< glossary_tooltip text="static" term_id="static-pod" >}} or standalone
+Pods (standalone means Pods that you created directly without using workload resources).
 
 ```shell
 kubectl get Deployment,ReplicaSet,StatefulSet,DaemonSet,Job,CronJob --all-namespaces \

--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -51,6 +51,18 @@ the `.items[*]` portion of the path should be omitted because a single
 Pod is returned instead of a list of items.
 {{< /note >}}
 
+## List all images of the workload resources
+
+Listing Pods may yield different results based on the Pods defined lifecycle.
+
+The following example list all the images possible run in the cluster, except 
+for Orphaned Pods created directly without using workload resources. 
+
+```shell
+kubectl get Deployment,ReplicaSet,StatefulSet,DaemonSet,Job,CronJob --all-namespaces \
+        -o=custom-columns='NAME:metadata.namespace,KIND:kind,NAME:metadata.name,IMAGE:..image'
+```
+
 ## List Container images by Pod
 
 The formatting can be controlled further by using the `range` operation to

--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -61,7 +61,7 @@ Pods (standalone means Pods that you created directly without using workload res
 
 ```shell
 kubectl get Deployment,ReplicaSet,StatefulSet,DaemonSet,Job,CronJob --all-namespaces \
-        -o=custom-columns='NAME:metadata.namespace,KIND:kind,NAME:metadata.name,IMAGE:..image'
+        -o=custom-columns='NAMESPACE:metadata.namespace,KIND:kind,NAME:metadata.name,IMAGE:..image'
 ```
 
 ## List Container images by Pod

--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -55,7 +55,7 @@ Pod is returned instead of a list of items.
 
 Listing Pods may yield different results based on the Pods defined lifecycle.
 
-The following example list all the images possible run in the cluster, except 
+The following example lists all the images possible run in the cluster, except 
 for Orphaned Pods created directly without using workload resources. 
 
 ```shell


### PR DESCRIPTION
Added an example to list all the images possible run in the cluster, except 
for Orphaned Pods created directly without using workload resources. 