### PR TITLE
Use code shortcode for Tutorials section

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -68,7 +68,7 @@ Examine the contents of the Redis pod manifest and note the following:
 This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
 ConfigMap above as `/redis-master/redis.conf` inside the Pod.
 
-{{% codenew file="pods/config/redis-pod.yaml" %}}
+{{% code file="pods/config/redis-pod.yaml" %}}
 
 Examine the created objects:
 
@@ -139,7 +139,7 @@ Which should also yield its default value of `noeviction`:
 
 Now let's add some configuration values to the `example-redis-config` ConfigMap:
 
-{{% codenew file="pods/config/example-redis-config.yaml" %}}
+{{% code file="pods/config/example-redis-config.yaml" %}}
 
 Apply the updated ConfigMap:
 

--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -209,7 +209,7 @@ done
 
 Next, we'll run a simple "Hello AppArmor" pod with the deny-write profile:
 
-{{% codenew file="pods/security/hello-apparmor.yaml" %}}
+{{% code file="pods/security/hello-apparmor.yaml" %}}
 
 ```shell
 kubectl create -f ./hello-apparmor.yaml

--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -71,13 +71,13 @@ into the cluster.
 
 {{< tabs name="tab_with_code" >}}
 {{< tab name="audit.json" >}}
-{{% codenew file="pods/security/seccomp/profiles/audit.json" %}}
+{{% code file="pods/security/seccomp/profiles/audit.json" %}}
 {{< /tab >}}
 {{< tab name="violation.json" >}}
-{{% codenew file="pods/security/seccomp/profiles/violation.json" %}}
+{{% code file="pods/security/seccomp/profiles/violation.json" %}}
 {{< /tab >}}
 {{< tab name="fine-grained.json" >}}
-{{% codenew file="pods/security/seccomp/profiles/fine-grained.json" %}}
+{{% code file="pods/security/seccomp/profiles/fine-grained.json" %}}
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -104,7 +104,7 @@ so each node of the cluster is a container. This allows for files
 to be mounted in the filesystem of each container similar to loading files
 onto a node.
 
-{{% codenew file="pods/security/seccomp/kind.yaml" %}}
+{{% code file="pods/security/seccomp/kind.yaml" %}}
 
 Download that example kind configuration, and save it to a file named `kind.yaml`:
 ```shell
@@ -176,7 +176,7 @@ no other seccomp profile is specified. Otherwise, the default is `Unconfined`.
 Here's a manifest for a Pod that requests the `RuntimeDefault` seccomp profile
 for all its containers:
 
-{{% codenew file="pods/security/seccomp/ga/default-pod.yaml" %}}
+{{% code file="pods/security/seccomp/ga/default-pod.yaml" %}}
 
 Create that Pod:
 ```shell
@@ -206,7 +206,7 @@ process, to a new Pod.
 
 Here's a manifest for that Pod:
 
-{{% codenew file="pods/security/seccomp/ga/audit-pod.yaml" %}}
+{{% code file="pods/security/seccomp/ga/audit-pod.yaml" %}}
 
 {{< note >}}
 Older versions of Kubernetes allowed you to configure seccomp
@@ -311,7 +311,7 @@ syscalls.
 
 The manifest for this demonstration is:
 
-{{% codenew file="pods/security/seccomp/ga/violation-pod.yaml" %}}
+{{% code file="pods/security/seccomp/ga/violation-pod.yaml" %}}
 
 Attempt to create the Pod in the cluster:
 
@@ -354,7 +354,7 @@ sent to `syslog`.
 
 The manifest for this example is:
 
-{{% codenew file="pods/security/seccomp/ga/fine-pod.yaml" %}}
+{{% code file="pods/security/seccomp/ga/fine-pod.yaml" %}}
 
 Create the Pod in your cluster:
 

--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -31,7 +31,7 @@ This tutorial uses a simple nginx web server to demonstrate the concept.
 We did this in a previous example, but let's do it once again and focus on the networking perspective.
 Create an nginx Pod, and note that it has a container port specification:
 
-{{% codenew file="service/networking/run-my-nginx.yaml" %}}
+{{% code file="service/networking/run-my-nginx.yaml" %}}
 
 This makes it accessible from any node in your cluster. Check the nodes the Pod is running on:
 
@@ -92,7 +92,7 @@ service/my-nginx exposed
 
 This is equivalent to `kubectl apply -f` the following yaml:
 
-{{% codenew file="service/networking/nginx-svc.yaml" %}}
+{{% code file="service/networking/nginx-svc.yaml" %}}
 
 This specification will create a Service which targets TCP port 80 on any Pod
 with the `run: my-nginx` label, and expose it on an abstracted Service port
@@ -340,7 +340,7 @@ nginxsecret           kubernetes.io/tls                     2         1m
 Now modify your nginx replicas to start an https server using the certificate
 in the secret, and the Service, to expose both ports (80 and 443):
 
-{{% codenew file="service/networking/nginx-secure-app.yaml" %}}
+{{% code file="service/networking/nginx-secure-app.yaml" %}}
 
 Noteworthy points about the nginx-secure-app manifest:
 
@@ -376,7 +376,7 @@ linked the CName used in the certificate with the actual DNS name used by pods
 during Service lookup. Let's test this from a pod (the same secret is being reused
 for simplicity, the pod only needs nginx.crt to access the Service):
 
-{{% codenew file="service/networking/curlpod.yaml" %}}
+{{% code file="service/networking/curlpod.yaml" %}}
 
 ```shell
 kubectl apply -f ./curlpod.yaml

--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -36,7 +36,7 @@ document.
 Let's say you have a Deployment containing of a single `nginx` replica
 (just for demonstration purposes) and a Service:
 
-{{% codenew file="service/pod-with-graceful-termination.yaml" %}}
+{{% code file="service/pod-with-graceful-termination.yaml" %}}
 
 ```yaml
 apiVersion: apps/v1

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -63,7 +63,7 @@ example presented in the
 It creates a [headless Service](/docs/concepts/services-networking/service/#headless-services),
 `nginx`, to publish the IP addresses of Pods in the StatefulSet, `web`.
 
-{{% codenew file="application/web/web.yaml" %}}
+{{% code file="application/web/web.yaml" %}}
 
 Download the example above, and save it to a file named `web.yaml`
 
@@ -1090,7 +1090,7 @@ terminate all Pods in parallel, and not to wait for Pods to become Running
 and Ready or completely terminated prior to launching or terminating another
 Pod. This option only affects the behavior for scaling operations. Updates are not affected.
 
-{{% codenew file="application/web/web-parallel.yaml" %}}
+{{% code file="application/web/web-parallel.yaml" %}}
 
 Download the example above, and save it to a file named `web-parallel.yaml`
 

--- a/content/en/docs/tutorials/stateful-application/cassandra.md
+++ b/content/en/docs/tutorials/stateful-application/cassandra.md
@@ -68,7 +68,7 @@ In Kubernetes, a {{< glossary_tooltip text="Service" term_id="service" >}} descr
 
 The following Service is used for DNS lookups between Cassandra Pods and clients within your cluster:
 
-{{% codenew file="application/cassandra/cassandra-service.yaml" %}}
+{{% code file="application/cassandra/cassandra-service.yaml" %}}
 
 Create a Service to track all Cassandra StatefulSet members from the `cassandra-service.yaml` file:
 
@@ -105,7 +105,7 @@ This example uses the default provisioner for Minikube.
 Please update the following StatefulSet for the cloud you are working with.
 {{< /note >}}
 
-{{% codenew file="application/cassandra/cassandra-statefulset.yaml" %}}
+{{% code file="application/cassandra/cassandra-statefulset.yaml" %}}
 
 Create the Cassandra StatefulSet from the `cassandra-statefulset.yaml` file:
 

--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -117,14 +117,14 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL
 container mounts the PersistentVolume at /var/lib/mysql. The `MYSQL_ROOT_PASSWORD`
 environment variable sets the database password from the Secret.
 
-{{% codenew file="application/wordpress/mysql-deployment.yaml" %}}
+{{% code file="application/wordpress/mysql-deployment.yaml" %}}
 
 The following manifest describes a single-instance WordPress Deployment. The WordPress container mounts the
 PersistentVolume at `/var/www/html` for website data files. The `WORDPRESS_DB_HOST` environment variable sets
 the name of the MySQL Service defined above, and WordPress will access the database by Service. The
 `WORDPRESS_DB_PASSWORD` environment variable sets the database password from the Secret kustomize generated.
 
-{{% codenew file="application/wordpress/wordpress-deployment.yaml" %}}
+{{% code file="application/wordpress/wordpress-deployment.yaml" %}}
 
 1. Download the MySQL deployment configuration file.
 

--- a/content/en/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/en/docs/tutorials/stateful-application/zookeeper.md
@@ -74,7 +74,7 @@ a [Service](/docs/concepts/services-networking/service/),
 a [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets),
 and a [StatefulSet](/docs/concepts/workloads/controllers/statefulset/).
 
-{{% codenew file="application/zookeeper/zookeeper.yaml" %}}
+{{% code file="application/zookeeper/zookeeper.yaml" %}}
 
 Open a terminal, and use the
 [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands/#apply) command to create the

--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -31,7 +31,7 @@ external IP address.
 
 1. Run a Hello World application in your cluster:
 
-   {{% codenew file="service/load-balancer-example.yaml" %}}
+   {{% code file="service/load-balancer-example.yaml" %}}
 
    ```shell
    kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml

--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -46,7 +46,7 @@ The guestbook application uses Redis to store its data.
 
 The manifest file, included below, specifies a Deployment controller that runs a single replica Redis Pod.
 
-{{% codenew file="application/guestbook/redis-leader-deployment.yaml" %}}
+{{% code file="application/guestbook/redis-leader-deployment.yaml" %}}
 
 1. Launch a terminal window in the directory you downloaded the manifest files.
 1. Apply the Redis Deployment from the `redis-leader-deployment.yaml` file:
@@ -86,7 +86,7 @@ You need to apply a [Service](/docs/concepts/services-networking/service/) to
 proxy the traffic to the Redis Pod. A Service defines a policy to access the
 Pods.
 
-{{% codenew file="application/guestbook/redis-leader-service.yaml" %}}
+{{% code file="application/guestbook/redis-leader-service.yaml" %}}
 
 1. Apply the Redis Service from the following `redis-leader-service.yaml` file:
 
@@ -124,7 +124,7 @@ traffic to the Redis Pod.
 Although the Redis leader is a single Pod, you can make it highly available
 and meet traffic demands by adding a few Redis followers, or replicas.
 
-{{% codenew file="application/guestbook/redis-follower-deployment.yaml" %}}
+{{% code file="application/guestbook/redis-follower-deployment.yaml" %}}
 
 1. Apply the Redis Deployment from the following `redis-follower-deployment.yaml` file:
 
@@ -158,7 +158,7 @@ The guestbook application needs to communicate with the Redis followers to
 read data. To make the Redis followers discoverable, you must set up another
 [Service](/docs/concepts/services-networking/service/).
 
-{{% codenew file="application/guestbook/redis-follower-service.yaml" %}}
+{{% code file="application/guestbook/redis-follower-service.yaml" %}}
 
 1. Apply the Redis Service from the following `redis-follower-service.yaml` file:
 
@@ -205,7 +205,7 @@ jQuery-Ajax-based UX.
 
 ### Creating the Guestbook Frontend Deployment
 
-{{% codenew file="application/guestbook/frontend-deployment.yaml" %}}
+{{% code file="application/guestbook/frontend-deployment.yaml" %}}
 
 1. Apply the frontend Deployment from the `frontend-deployment.yaml` file:
 
@@ -253,7 +253,7 @@ support external load balancers. If your cloud provider supports load
 balancers and you want to use it, uncomment `type: LoadBalancer`.
 {{< /note >}}
 
-{{% codenew file="application/guestbook/frontend-service.yaml" %}}
+{{% code file="application/guestbook/frontend-service.yaml" %}}
 
 1. Apply the frontend Service from the `frontend-service.yaml` file:
 


### PR DESCRIPTION
Replace legacy `{{% codenew file="…" %}}` shortcode with `{{% code file="…" %}}` shortcode.

Part of https://github.com/kubernetes/website/issues/42203

This covers the Tutorials section of the English docs.
/language en
/kind cleanup