### PR TITLE
[zh-cn] Fix typo in zh-cn/docs/tasks/administer-cluster/topology-manager.md

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/topology-manager.md
@@ -400,7 +400,7 @@ admission failure.
 -->
 ### single-numa-node 策略 {#policy-single-numa-node}
 
-对于 Pod 中的每个容器，配置了 `single-numa-nodde` 拓扑管理策略的
+对于 Pod 中的每个容器，配置了 `single-numa-node` 拓扑管理策略的
 kubelet 调用每个建议提供者以确定其资源可用性。
 使用此信息，拓扑管理器确定是否支持单 NUMA 节点亲和性。
 如果支持，则拓扑管理器将存储此信息，然后 **建议提供者** 可以在做出资源分配决定时使用此信息。


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fix a typo in the page [topology-manager/#policy-single-numa-node](https://kubernetes.io/zh-cn/docs/tasks/administer-cluster/topology-manager/#policy-single-numa-node).
