### PR TITLE
Update In-tree storage driver status

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -185,7 +185,7 @@ another claim because the previous claimant's data remains on the volume.
 An administrator can manually reclaim the volume with the following steps.
 
 1. Delete the PersistentVolume. The associated storage asset in external infrastructure
-   (such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume) still exists after the PV is deleted.
+   (such as an AWS EBS or GCE PD volume) still exists after the PV is deleted.
 1. Manually clean up the data on the associated storage asset accordingly.
 1. Manually delete the associated storage asset.
 
@@ -196,8 +196,7 @@ the same storage asset definition.
 
 For volume plugins that support the `Delete` reclaim policy, deletion removes
 both the PersistentVolume object from Kubernetes, as well as the associated
-storage asset in the external infrastructure, such as an AWS EBS, GCE PD,
-Azure Disk, or Cinder volume. Volumes that were dynamically provisioned
+storage asset in the external infrastructure, such as an AWS EBS or GCE PD volume. Volumes that were dynamically provisioned
 inherit the [reclaim policy of their StorageClass](#reclaim-policy), which
 defaults to `Delete`. The administrator should configure the StorageClass
 according to users' expectations; otherwise, the PV must be edited or
@@ -368,15 +367,12 @@ to `Retain`, including cases where you are reusing an existing PV.
 Support for expanding PersistentVolumeClaims (PVCs) is enabled by default. You can expand
 the following types of volumes:
 
-* azureDisk
-* azureFile
-* awsElasticBlockStore
-* cinder (deprecated)
+* azureFile (deprecated)
 * {{< glossary_tooltip text="csi" term_id="csi" >}}
 * flexVolume (deprecated)
-* gcePersistentDisk
+* gcePersistentDisk (deprecated)
 * rbd
-* portworxVolume
+* portworxVolume (deprecated)
 
 You can only expand a PVC if its storage class's `allowVolumeExpansion` field is set to true.
 
@@ -520,14 +516,8 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 The following types of PersistentVolume are deprecated.
 This means that support is still available but will be removed in a future Kubernetes release.
 
-* [`awsElasticBlockStore`](/docs/concepts/storage/volumes/#awselasticblockstore) - AWS Elastic Block Store (EBS)
-  (**deprecated** in v1.17)
-* [`azureDisk`](/docs/concepts/storage/volumes/#azuredisk) - Azure Disk
-  (**deprecated** in v1.19)
 * [`azureFile`](/docs/concepts/storage/volumes/#azurefile) - Azure File
   (**deprecated** in v1.21)
-* [`cinder`](/docs/concepts/storage/volumes/#cinder) - Cinder (OpenStack block storage)
-  (**deprecated** in v1.18)
 * [`flexVolume`](/docs/concepts/storage/volumes/#flexvolume) - FlexVolume
   (**deprecated** in v1.23)
 * [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk) - GCE Persistent Disk
@@ -539,6 +529,12 @@ This means that support is still available but will be removed in a future Kuber
 
 Older versions of Kubernetes also supported the following in-tree PersistentVolume types:
 
+* [`awsElasticBlockStore`](/docs/concepts/storage/volumes/#awselasticblockstore) - AWS Elastic Block Store (EBS)
+  (**not available** in v1.27)
+* [`azureDisk`](/docs/concepts/storage/volumes/#azuredisk) - Azure Disk
+  (**not available** in v1.27)
+* [`cinder`](/docs/concepts/storage/volumes/#cinder) - Cinder (OpenStack block storage)
+  (**not available** in v1.26)
 * `photonPersistentDisk` - Photon controller persistent disk.
   (**not available** starting v1.15)
 * [`scaleIO`](/docs/concepts/storage/volumes/#scaleio) - ScaleIO volume
@@ -670,11 +666,8 @@ are specified as ReadWriteOncePod, the volume is constrained and can be mounted 
 
 | Volume Plugin        | ReadWriteOnce          | ReadOnlyMany          | ReadWriteMany | ReadWriteOncePod       |
 | :---                 | :---:                  | :---:                 | :---:         | -                      |
-| AWSElasticBlockStore | &#x2713;               | -                     | -             | -                      |
 | AzureFile            | &#x2713;               | &#x2713;              | &#x2713;      | -                      |
-| AzureDisk            | &#x2713;               | -                     | -             | -                      |
 | CephFS               | &#x2713;               | &#x2713;              | &#x2713;      | -                      |
-| Cinder               | &#x2713;               | -                     | ([if multi-attach volumes are available](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/features.md#multi-attach-volumes))            | -                      |
 | CSI                  | depends on the driver  | depends on the driver | depends on the driver | depends on the driver |
 | FC                   | &#x2713;               | &#x2713;              | -             | -                      |
 | FlexVolume           | &#x2713;               | &#x2713;              | depends on the driver | -              |
@@ -706,11 +699,9 @@ Current reclaim policies are:
 
 * Retain -- manual reclamation
 * Recycle -- basic scrub (`rm -rf /thevolume/*`)
-* Delete -- associated storage asset such as AWS EBS, GCE PD, Azure Disk,
-  or OpenStack Cinder volume is deleted
+* Delete -- associated storage asset such as AWS EBS or GCE PD volume is deleted
 
-Currently, only NFS and HostPath support recycling. AWS EBS, GCE PD, Azure Disk,
-and Cinder volumes support deletion.
+Currently, only NFS and HostPath support recycling. AWS EBS and GCE PD volumes support deletion.
 
 ### Mount Options
 
@@ -723,11 +714,8 @@ Not all Persistent Volume types support mount options.
 
 The following volume types support mount options:
 
-* `awsElasticBlockStore`
-* `azureDisk`
 * `azureFile`
 * `cephfs`
-* `cinder` (**deprecated** in v1.18)
 * `gcePersistentDisk`
 * `iscsi`
 * `nfs`
@@ -744,10 +732,8 @@ it will become fully deprecated in a future Kubernetes release.
 
 {{< note >}}
 For most volume types, you do not need to set this field. It is automatically
-populated for [AWS EBS](/docs/concepts/storage/volumes/#awselasticblockstore),
-[GCE PD](/docs/concepts/storage/volumes/#gcepersistentdisk) and
-[Azure Disk](/docs/concepts/storage/volumes/#azuredisk) volume block types. You
-need to explicitly set this for [local](/docs/concepts/storage/volumes/#local) volumes.
+populated for [GCE PD](/docs/concepts/storage/volumes/#gcepersistentdisk) volume block types.
+You need to explicitly set this for [local](/docs/concepts/storage/volumes/#local) volumes.
 {{< /note >}}
 
 A PV can specify node affinity to define constraints that limit what nodes this
@@ -944,14 +930,11 @@ network-attached storage. See
 The following volume plugins support raw block volumes, including dynamic provisioning where
 applicable:
 
-* AWSElasticBlockStore
-* AzureDisk
 * CSI
 * FC (Fibre Channel)
 * GCEPersistentDisk
 * iSCSI
 * Local volume
-* OpenStack Cinder
 * RBD (Ceph Block Device)
 * VsphereVolume
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -75,11 +75,8 @@ for provisioning PVs. This field must be specified.
 
 | Volume Plugin        | Internal Provisioner |            Config Example             |
 | :------------------- | :------------------: | :-----------------------------------: |
-| AWSElasticBlockStore |       &#x2713;       |          [AWS EBS](#aws-ebs)          |
 | AzureFile            |       &#x2713;       |       [Azure File](#azure-file)       |
-| AzureDisk            |       &#x2713;       |       [Azure Disk](#azure-disk)       |
 | CephFS               |          -           |                   -                   |
-| Cinder               |       &#x2713;       | [OpenStack Cinder](#openstack-cinder) |
 | FC                   |          -           |                   -                   |
 | FlexVolume           |          -           |                   -                   |
 | GCEPersistentDisk    |       &#x2713;       |           [GCE PD](#gce-pd)           |
@@ -130,11 +127,8 @@ StorageClass has the field `allowVolumeExpansion` set to true.
 | Volume type          | Required Kubernetes version |
 | :------------------- | :-------------------------- |
 | gcePersistentDisk    | 1.11                        |
-| awsElasticBlockStore | 1.11                        |
-| Cinder               | 1.11                        |
 | rbd                  | 1.11                        |
 | Azure File           | 1.11                        |
-| Azure Disk           | 1.11                        |
 | Portworx             | 1.11                        |
 | FlexVolume           | 1.13                        |
 | CSI                  | 1.14 (alpha), 1.16 (beta)   |
@@ -178,9 +172,7 @@ and [taints and tolerations](/docs/concepts/scheduling-eviction/taint-and-tolera
 
 The following plugins support `WaitForFirstConsumer` with dynamic provisioning:
 
-- [AWSElasticBlockStore](#aws-ebs)
 - [GCEPersistentDisk](#gce-pd)
-- [AzureDisk](#azure-disk)
 
 The following plugins support `WaitForFirstConsumer` with pre-created PersistentVolume binding:
 
@@ -376,27 +368,6 @@ Here are some examples:
 
 - [NFS Ganesha server and external provisioner](https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner)
 - [NFS subdir external provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)
-
-### OpenStack Cinder
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: gold
-provisioner: kubernetes.io/cinder
-parameters:
-  availability: nova
-```
-
-- `availability`: Availability Zone. If not specified, volumes are generally
-  round-robin-ed across all active zones where Kubernetes cluster has a node.
-
-{{< note >}}
-{{< feature-state state="deprecated" for_k8s_version="v1.11" >}}
-This internal provisioner of OpenStack is deprecated. Please use
-[the external cloud provider for OpenStack](https://github.com/kubernetes/cloud-provider-openstack).
-{{< /note >}}
 
 ### vSphere
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -62,102 +62,31 @@ a different volume.
 
 Kubernetes supports several types of volumes.
 
-### awsElasticBlockStore (deprecated) {#awselasticblockstore}
+### awsElasticBlockStore (removed) {#awselasticblockstore}
 
-{{< feature-state for_k8s_version="v1.17" state="deprecated" >}}
+<!-- maintenance note: OK to remove all mention of awsElasticBlockStore once the v1.27 release of
+Kubernetes has gone out of support -->
 
-An `awsElasticBlockStore` volume mounts an Amazon Web Services (AWS)
-[EBS volume](https://aws.amazon.com/ebs/) into your pod. Unlike
-`emptyDir`, which is erased when a pod is removed, the contents of an EBS
-volume are persisted and the volume is unmounted. This means that an
-EBS volume can be pre-populated with data, and that data can be shared between pods.
+Kubernetes {{< skew currentVersion >}} does not include a `awsElasticBlockStore` volume type.
 
-{{< note >}}
-You must create an EBS volume by using `aws ec2 create-volume` or the AWS API before you can use it.
-{{< /note >}}
+The AWSElasticBlockStore in-tree storage driver was deprecated in the Kubernetes v1.19 release
+and then removed entirely in the v1.27 release.
 
-There are some restrictions when using an `awsElasticBlockStore` volume:
+The Kubernetes project suggests that you use the [AWS EBS](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) third party
+storage driver instead.
 
-* the nodes on which pods are running must be AWS EC2 instances
-* those instances need to be in the same region and availability zone as the EBS volume
-* EBS only supports a single EC2 instance mounting a volume
+### azureDisk (removed) {#azuredisk}
 
-#### Creating an AWS EBS volume
+<!-- maintenance note: OK to remove all mention of azureDisk once the v1.27 release of
+Kubernetes has gone out of support -->
 
-Before you can use an EBS volume with a pod, you need to create it.
+Kubernetes {{< skew currentVersion >}} does not include a `azureDisk` volume type.
 
-```shell
-aws ec2 create-volume --availability-zone=eu-west-1a --size=10 --volume-type=gp2
-```
+The AzureDisk in-tree storage driver was deprecated in the Kubernetes v1.19 release
+and then removed entirely in the v1.27 release.
 
-Make sure the zone matches the zone you brought up your cluster in. Check that the size and EBS volume
-type are suitable for your use.
-
-#### AWS EBS configuration example
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-ebs
-spec:
-  containers:
-  - image: registry.k8s.io/test-webserver
-    name: test-container
-    volumeMounts:
-    - mountPath: /test-ebs
-      name: test-volume
-  volumes:
-  - name: test-volume
-    # This AWS EBS volume must already exist.
-    awsElasticBlockStore:
-      volumeID: "<volume id>"
-      fsType: ext4
-```
-
-If the EBS volume is partitioned, you can supply the optional field `partition: "<partition number>"` to specify which partition to mount on.
-
-#### AWS EBS CSI migration
-
-{{< feature-state for_k8s_version="v1.25" state="stable" >}}
-
-The `CSIMigration` feature for `awsElasticBlockStore`, when enabled, redirects
-all plugin operations from the existing in-tree plugin to the `ebs.csi.aws.com` Container
-Storage Interface (CSI) driver. In order to use this feature, the [AWS EBS CSI
-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
-must be installed on the cluster.
-
-#### AWS EBS CSI migration complete
-
-{{< feature-state for_k8s_version="v1.17" state="alpha" >}}
-
-To disable the `awsElasticBlockStore` storage plugin from being loaded by the controller manager
-and the kubelet, set the `InTreePluginAWSUnregister` flag to `true`.
-
-### azureDisk (deprecated) {#azuredisk}
-
-{{< feature-state for_k8s_version="v1.19" state="deprecated" >}}
-
-The `azureDisk` volume type mounts a Microsoft Azure [Data Disk](https://docs.microsoft.com/en-us/azure/aks/csi-storage-drivers) into a pod.
-
-For more details, see the [`azureDisk` volume plugin](https://github.com/kubernetes/examples/tree/master/staging/volumes/azure_disk/README.md).
-
-#### azureDisk CSI migration
-
-{{< feature-state for_k8s_version="v1.24" state="stable" >}}
-
-The `CSIMigration` feature for `azureDisk`, when enabled, redirects all plugin operations
-from the existing in-tree plugin to the `disk.csi.azure.com` Container
-Storage Interface (CSI) Driver. In order to use this feature, the
-[Azure Disk CSI Driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver)
-must be installed on the cluster.
-
-#### azureDisk CSI migration complete
-
-{{< feature-state for_k8s_version="v1.21" state="alpha" >}}
-
-To disable the `azureDisk` storage plugin from being loaded by the controller manager
-and the kubelet, set the `InTreePluginAzureDiskUnregister` flag to `true`.
+The Kubernetes project suggests that you use the [Azure Disk](https://github.com/kubernetes-sigs/azuredisk-csi-driver) third party
+storage driver instead.
 
 ### azureFile (deprecated) {#azurefile}
 
@@ -204,51 +133,19 @@ You must have your own Ceph server running with the share exported before you ca
 
 See the [CephFS example](https://github.com/kubernetes/examples/tree/master/volumes/cephfs/) for more details.
 
-### cinder (deprecated) {#cinder}
+### cinder (removed) {#cinder}
 
-{{< feature-state for_k8s_version="v1.18" state="deprecated" >}}
+<!-- maintenance note: OK to remove all mention of cinder once the v1.26 release of
+Kubernetes has gone out of support -->
 
-{{< note >}}
-Kubernetes must be configured with the OpenStack cloud provider.
-{{< /note >}}
+Kubernetes {{< skew currentVersion >}} does not include a `cinder` volume type.
 
-The `cinder` volume type is used to mount the OpenStack Cinder volume into your pod.
+The OpenStack Cinder in-tree storage driver was deprecated in the Kubernetes v1.11 release
+and then removed entirely in the v1.26 release.
 
-#### Cinder volume configuration example
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-cinder
-spec:
-  containers:
-  - image: registry.k8s.io/test-webserver
-    name: test-cinder-container
-    volumeMounts:
-    - mountPath: /test-cinder
-      name: test-volume
-  volumes:
-  - name: test-volume
-    # This OpenStack volume must already exist.
-    cinder:
-      volumeID: "<volume id>"
-      fsType: ext4
-```
-
-#### OpenStack CSI migration
-
-{{< feature-state for_k8s_version="v1.24" state="stable" >}}
-
-The `CSIMigration` feature for Cinder is enabled by default since Kubernetes 1.21.
-It redirects all plugin operations from the existing in-tree plugin to the
-`cinder.csi.openstack.org` Container Storage Interface (CSI) Driver.
-[OpenStack Cinder CSI Driver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md)
-must be installed on the cluster.
-
-To disable the in-tree Cinder plugin from being loaded by the controller manager
-and the kubelet, you can enable the `InTreePluginOpenStackUnregister`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
+The Kubernetes project suggests that you use the 
+[OpenStack Cinder](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md)
+third party storage driver instead.
 
 ### configMap
 
@@ -1245,8 +1142,6 @@ are listed in [Types of Volumes](#volume-types).
 
 The following in-tree plugins support persistent storage on Windows nodes:
 
-* [`awsElasticBlockStore`](#awselasticblockstore)
-* [`azureDisk`](#azuredisk)
 * [`azureFile`](#azurefile)
 * [`gcePersistentDisk`](#gcepersistentdisk)
 * [`vsphereVolume`](#vspherevolume)

--- a/content/en/docs/concepts/storage/windows-storage.md
+++ b/content/en/docs/concepts/storage/windows-storage.md
@@ -65,8 +65,6 @@ The following broad classes of Kubernetes volume plugins are supported on Window
 
 The following in-tree plugins support persistent storage on Windows nodes:
 
-* [`awsElasticBlockStore`](/docs/concepts/storage/volumes/#awselasticblockstore)
-* [`azureDisk`](/docs/concepts/storage/volumes/#azuredisk)
 * [`azureFile`](/docs/concepts/storage/volumes/#azurefile)
 * [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk)
 * [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume)


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Fixes: https://github.com/kubernetes/website/issues/42256


Checked kubernetes upstream PRs：
plugin | deprecated| removed
-- | -- | --
AWSElasticBlockStore | 1.19 | 1.27 https://github.com/kubernetes/kubernetes/pull/115838
AzureDisk | 1.19 | 1.27 https://github.com/kubernetes/kubernetes/pull/116301 
OpenStack Cinder | 1.11  https://github.com/kubernetes/kubernetes/pull/63524  <br>The deprecated version of [previous PR](https://github.com/kubernetes/website/pull/32924#discussion_r850223194) update was incorrect| 1.26 https://github.com/kubernetes/kubernetes/pull/67782
GCEPersistentDisk|1.17|1.28 https://github.com/kubernetes/kubernetes/pull/117055


Preview pages:
- [persistent-volumes](https://deploy-preview-42302--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/persistent-volumes/)
- [volume](https://deploy-preview-42302--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/volumes/#awselasticblockstore)
- [storage class](https://deploy-preview-42302--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/storage-classes/)