### PR TITLE
[zh] sync concepts\services-networking\topology-aware-routing.md

### DIFF
--- a/content/zh-cn/docs/concepts/services-networking/topology-aware-routing.md
+++ b/content/zh-cn/docs/concepts/services-networking/topology-aware-routing.md
@@ -268,13 +268,13 @@ Kubernetes 控制平面和每个节点上的 kube-proxy 在使用拓扑感知提
 ## 限制 {#constraints}
 
 <!--
-* Topology Aware Hints are not used when either `externalTrafficPolicy` or
-  `internalTrafficPolicy` is set to `Local` on a Service. It is possible to use
-  both features in the same cluster on different Services, just not on the same
-  Service.
+* Topology Aware Hints are not used when `internalTrafficPolicy` is set to `Local`
+  on a Service. It is possible to use both features in the same cluster on different
+  Services, just not on the same Service.
 -->
-* 当 Service 的 `externalTrafficPolicy` 或 `internalTrafficPolicy` 设置值为 `Local` 时，
-  系统将不使用拓扑感知提示信息。你可以在同一集群中的不同服务上使用这两个特性，但不能在同一个服务上这么做。
+* 当 Service 的 `internalTrafficPolicy` 值设置为 `Local` 时，
+  系统将不使用拓扑感知提示信息。你可以在同一集群中的不同 Service 上使用这两个特性，
+  但不能在同一个 Service 上这么做。
 
 <!--
 * This approach will not work well for Services that have a large proportion of


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/services-networking/topology-aware-routing.md`
- **Sync to**: `content/zh-cn/docs/concepts/services-networking/topology-aware-routing.md`

Sync check by `scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/services-networking/topology-aware-routing.md
diff --git a/content/en/docs/concepts/services-networking/topology-aware-routing.md b/content/en/docs/concepts/services-networking/topology-aware-routing.md
index 1977f199d0..7092946e85 100644
--- a/content/en/docs/concepts/services-networking/topology-aware-routing.md
+++ b/content/en/docs/concepts/services-networking/topology-aware-routing.md
@@ -154,10 +154,9 @@ zone.

 ## Constraints

-* Topology Aware Hints are not used when either `externalTrafficPolicy` or
-  `internalTrafficPolicy` is set to `Local` on a Service. It is possible to use
-  both features in the same cluster on different Services, just not on the same
-  Service.
+* Topology Aware Hints are not used when `internalTrafficPolicy` is set to `Local`
+  on a Service. It is possible to use both features in the same cluster on different
+  Services, just not on the same Service.

 * This approach will not work well for Services that have a large proportion of
   traffic originating from a subset of zones. Instead this assumes that incoming
```
Sync check by`scripts/lsync.sh` on `sync/topology-aware-routing` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/services-networking/topology-aware-routing.md
content/zh-cn/docs/concepts/services-networking/topology-aware-routing.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
