### PR TITLE
Update taint-and-toleration.md  with types of taint effects

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -96,7 +96,7 @@ running on the node as follows
     * pods that tolerate the taint with a specified `tolerationSeconds` remain
    bound for the specified amount of time
 * `NoSchedule`: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
-* `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`, the system will *try* to avoid placing a
+* `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 
 All the taint effects are enforced by Kubernetes scheduler except for `NoExecute` which is enforced by NodeController.

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -87,7 +87,7 @@ An empty `effect` matches all effects with key `key1`.
 The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.
 
 
-There are three types of taint `effects` enforced by the Kubernetes scheduler
+There are three types of taint `effects` 
 * `NoExecute`: This affects pods that are already
 running on the node as follows
     * pods that do not tolerate the taint are evicted immediately
@@ -99,6 +99,7 @@ running on the node as follows
 * `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`, the system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 
+All the taint effects are enforced by Kubernetes scheduler except for `NoExecute` which is enforced by NodeController.
 
 You can put multiple taints on the same node and multiple tolerations on the same pod.
 The way Kubernetes processes multiple taints and tolerations is like a filter: start

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -85,9 +85,21 @@ An empty `effect` matches all effects with key `key1`.
 {{< /note >}}
 
 The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.
-This is a "preference" or "soft" version of `NoSchedule` -- the system will *try* to avoid placing a
-pod that does not tolerate the taint on the node, but it is not required. The third kind of `effect` is
-`NoExecute`, described later.
+
+
+There are three types of taint `effects` 
+* `NoExecute`: This  affects pods that are already
+running on the node as follows
+    * pods that do not tolerate the taint are evicted immediately
+    * pods that tolerate the taint without specifying `tolerationSeconds` in
+   their toleration specification remain bound forever
+    * pods that tolerate the taint with a specified `tolerationSeconds` remain
+   bound for the specified amount of time
+    * `NoSchedule`: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
+* `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`, the system will *try* to avoid placing a
+pod that does not tolerate the taint on the node, but it is not required. 
+
+
 
 You can put multiple taints on the same node and multiple tolerations on the same pod.
 The way Kubernetes processes multiple taints and tolerations is like a filter: start

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -87,7 +87,7 @@ An empty `effect` matches all effects with key `key1`.
 The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.
 
 
-Allowed values for taint `effects` are:
+The allowed values for the `effect` field are:
 
 `NoExecute`
 : This affects pods that are already running on the node as follows
@@ -95,13 +95,15 @@ Allowed values for taint `effects` are:
     * pods that tolerate the taint without specifying `tolerationSeconds` in
    their toleration specification remain bound forever
     * pods that tolerate the taint with a specified `tolerationSeconds` remain
-   bound for the specified amount of time
+  * pods that tolerate the taint with a specified `tolerationSeconds` remain
+   bound for the specified amount of time. After that time elapses, the node
+   lifecycle controller (within the control plane) evicts the Pod from the node.
    
 `NoSchedule`
-: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
+: No new pods with this will be scheduled on the tainted node unless they have the matching toleration. Pods that are currently running on the node are **not** evicted.
 
 `PreferNoSchedule`
-: This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
+: `PreferNoSchedule` is a "preference" or "soft" version of `NoSchedule`. The control plane will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 
 You can put multiple taints on the same node and multiple tolerations on the same pod.

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -226,7 +226,7 @@ are true. The following taints are built in:
     this node, the kubelet removes this taint.
 
 In case a node is to be drained, the node controller or the kubelet adds relevant taints
-with `NoExecute` effect. This effect added by default for the  `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taint.  If the fault condition returns to normal the kubelet or node
+with `NoExecute` effect. This effect is added by default for the  `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taints.  If the fault condition returns to normal the kubelet or node
 controller can remove the relevant taint(s).
 
 In some cases when the node is unreachable, the API server is unable to communicate

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -88,6 +88,7 @@ The above example used `effect` of `NoSchedule`. Alternatively, you can use `eff
 
 
 Allowed values for taint `effects` are:
+
 `NoExecute`
 : This affects pods that are already running on the node as follows
     * pods that do not tolerate the taint are evicted immediately
@@ -95,8 +96,10 @@ Allowed values for taint `effects` are:
    their toleration specification remain bound forever
     * pods that tolerate the taint with a specified `tolerationSeconds` remain
    bound for the specified amount of time
+   
 `NoSchedule`
 : No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
+
 `PreferNoSchedule`
 : This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -87,8 +87,8 @@ An empty `effect` matches all effects with key `key1`.
 The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.
 
 
-There are three types of taint `effects` 
-* `NoExecute`: This  affects pods that are already
+There are three types of taint `effects` enforced by the Kubernetes scheduler
+* `NoExecute`: This affects pods that are already
 running on the node as follows
     * pods that do not tolerate the taint are evicted immediately
     * pods that tolerate the taint without specifying `tolerationSeconds` in
@@ -98,7 +98,6 @@ running on the node as follows
     * `NoSchedule`: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
 * `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`, the system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
-
 
 
 You can put multiple taints on the same node and multiple tolerations on the same pod.
@@ -206,14 +205,7 @@ when there are node problems, which is described in the next section.
 
 {{< feature-state for_k8s_version="v1.18" state="stable" >}}
 
-The `NoExecute` taint effect, mentioned above, affects pods that are already
-running on the node as follows
 
- * pods that do not tolerate the taint are evicted immediately
- * pods that tolerate the taint without specifying `tolerationSeconds` in
-   their toleration specification remain bound forever
- * pods that tolerate the taint with a specified `tolerationSeconds` remain
-   bound for the specified amount of time
 
 The node controller automatically taints a Node when certain conditions
 are true. The following taints are built in:
@@ -233,7 +225,7 @@ are true. The following taints are built in:
     this node, the kubelet removes this taint.
 
 In case a node is to be drained, the node controller or the kubelet adds relevant taints
-with `NoExecute` effect. If the fault condition returns to normal the kubelet or node
+with `NoExecute` effect. This effect added by default for the  `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taint.  If the fault condition returns to normal the kubelet or node
 controller can remove the relevant taint(s).
 
 In some cases when the node is unreachable, the API server is unable to communicate

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -95,7 +95,7 @@ running on the node as follows
    their toleration specification remain bound forever
     * pods that tolerate the taint with a specified `tolerationSeconds` remain
    bound for the specified amount of time
-    * `NoSchedule`: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
+* `NoSchedule`: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
 * `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`, the system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -104,8 +104,6 @@ Allowed values for taint `effects` are:
 : This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 
-All the taint effects are enforced by Kubernetes scheduler except for `NoExecute` which is enforced by NodeController.
-
 You can put multiple taints on the same node and multiple tolerations on the same pod.
 The way Kubernetes processes multiple taints and tolerations is like a filter: start
 with all of a node's taints, then ignore the ones for which the pod has a matching toleration; the

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -226,7 +226,7 @@ are true. The following taints are built in:
     this node, the kubelet removes this taint.
 
 In case a node is to be drained, the node controller or the kubelet adds relevant taints
-with `NoExecute` effect. This effect is added by default for the  `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taints.  If the fault condition returns to normal the kubelet or node
+with `NoExecute` effect. This effect is added by default for the  `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taints. If the fault condition returns to normal the kubelet or node
 controller can remove the relevant taint(s).
 
 In some cases when the node is unreachable, the API server is unable to communicate

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -87,7 +87,7 @@ An empty `effect` matches all effects with key `key1`.
 The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.
 
 
-There are three types of taint `effects` 
+Allowed values for taint `effects` are:
 * `NoExecute`: This affects pods that are already
 running on the node as follows
     * pods that do not tolerate the taint are evicted immediately

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -88,17 +88,17 @@ The above example used `effect` of `NoSchedule`. Alternatively, you can use `eff
 
 
 Allowed values for taint `effects` are:
-### `NoExecute`
-This affects pods that are already running on the node as follows
+`NoExecute`
+: This affects pods that are already running on the node as follows
     * pods that do not tolerate the taint are evicted immediately
     * pods that tolerate the taint without specifying `tolerationSeconds` in
    their toleration specification remain bound forever
     * pods that tolerate the taint with a specified `tolerationSeconds` remain
    bound for the specified amount of time
-### `NoSchedule`
-No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
-### `PreferNoSchedule`
-This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
+`NoSchedule`
+: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
+`PreferNoSchedule`
+: This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 
 All the taint effects are enforced by Kubernetes scheduler except for `NoExecute` which is enforced by NodeController.

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -88,15 +88,17 @@ The above example used `effect` of `NoSchedule`. Alternatively, you can use `eff
 
 
 Allowed values for taint `effects` are:
-* `NoExecute`: This affects pods that are already
-running on the node as follows
+### `NoExecute`
+This affects pods that are already running on the node as follows
     * pods that do not tolerate the taint are evicted immediately
     * pods that tolerate the taint without specifying `tolerationSeconds` in
    their toleration specification remain bound forever
     * pods that tolerate the taint with a specified `tolerationSeconds` remain
    bound for the specified amount of time
-* `NoSchedule`: No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
-* `PreferNoSchedule`: This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
+### `NoSchedule`
+No new pods will be scheduled on the node unless they have the matching toleration. Pods that are currently running on the node are not evicted.
+### `PreferNoSchedule`
+This is a "preference" or "soft" version of `NoSchedule`. The system will *try* to avoid placing a
 pod that does not tolerate the taint on the node, but it is not required. 
 
 All the taint effects are enforced by Kubernetes scheduler except for `NoExecute` which is enforced by NodeController.

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -99,11 +99,13 @@ The allowed values for the `effect` field are:
     lifecycle controller evicts the Pods from the node.
    
 `NoSchedule`
-: No new pods with this will be scheduled on the tainted node unless they have the matching toleration. Pods that are currently running on the node are **not** evicted.
+: No new Pods will be scheduled on the tainted node unless they have a matching
+  toleration. Pods currently running on the node are **not** evicted.
 
 `PreferNoSchedule`
-: `PreferNoSchedule` is a "preference" or "soft" version of `NoSchedule`. The control plane will *try* to avoid placing a
-pod that does not tolerate the taint on the node, but it is not required. 
+: `PreferNoSchedule` is a "preference" or "soft" version of `NoSchedule`.
+  The control plane will *try* to avoid placing a Pod that does not tolerate
+  the taint on the node, but it is not guaranteed. 
 
 You can put multiple taints on the same node and multiple tolerations on the same pod.
 The way Kubernetes processes multiple taints and tolerations is like a filter: start
@@ -230,7 +232,9 @@ are true. The following taints are built in:
     this node, the kubelet removes this taint.
 
 In case a node is to be drained, the node controller or the kubelet adds relevant taints
-with `NoExecute` effect. This effect is added by default for the  `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taints. If the fault condition returns to normal the kubelet or node
+with `NoExecute` effect. This effect is added by default for the
+`node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taints.
+If the fault condition returns to normal, the kubelet or node
 controller can remove the relevant taint(s).
 
 In some cases when the node is unreachable, the API server is unable to communicate

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -90,14 +90,13 @@ The above example used `effect` of `NoSchedule`. Alternatively, you can use `eff
 The allowed values for the `effect` field are:
 
 `NoExecute`
-: This affects pods that are already running on the node as follows
-    * pods that do not tolerate the taint are evicted immediately
-    * pods that tolerate the taint without specifying `tolerationSeconds` in
-   their toleration specification remain bound forever
-    * pods that tolerate the taint with a specified `tolerationSeconds` remain
-  * pods that tolerate the taint with a specified `tolerationSeconds` remain
-   bound for the specified amount of time. After that time elapses, the node
-   lifecycle controller (within the control plane) evicts the Pod from the node.
+: This affects pods that are already running on the node as follows:
+  * Pods that do not tolerate the taint are evicted immediately
+  * Pods that tolerate the taint without specifying `tolerationSeconds` in
+    their toleration specification remain bound forever
+  * Pods that tolerate the taint with a specified `tolerationSeconds` remain
+    bound for the specified amount of time. After that time elapses, the node
+    lifecycle controller evicts the Pods from the node.
    
 `NoSchedule`
 : No new pods with this will be scheduled on the tainted node unless they have the matching toleration. Pods that are currently running on the node are **not** evicted.


### PR DESCRIPTION

https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/


Revamped taint effects to introduce the effects early in the article


- Added three types of taint effects including their implications in the concepts
- Added a brief note about when taint effects are added for NoExecute

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
