### PR TITLE
Add link for kubelet & cloud-control-manager

### DIFF
--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -12,7 +12,7 @@ tags:
 - operation
 ---
  A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component
-that embeds cloud-specific control logic. The [cloud controller manager](docs/concepts/architecture/cloud-controller/)
+that embeds cloud-specific control logic. The [cloud controller manager](/docs/concepts/architecture/cloud-controller/)
 lets you link your cluster into your cloud provider's API, and separates out the components that
 interact with that cloud platform from components that only interact with your cluster.
 

--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -12,9 +12,9 @@ tags:
 - operation
 ---
  A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component
-that embeds cloud-specific control logic. The cloud controller manager lets you link your
-cluster into your cloud provider's API, and separates out the components that interact
-with that cloud platform from components that only interact with your cluster.
+that embeds cloud-specific control logic. The [cloud controller manager](docs/concepts/architecture/cloud-controller/)
+lets you link your cluster into your cloud provider's API, and separates out the components that
+interact with that cloud platform from components that only interact with your cluster.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/kubelet.md
+++ b/content/en/docs/reference/glossary/kubelet.md
@@ -14,4 +14,4 @@ tags:
 
 <!--more-->
 
-The kubelet takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.
+The [kubelet](docs/reference/command-line-tools-reference/kubelet/) takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.

--- a/content/en/docs/reference/glossary/kubelet.md
+++ b/content/en/docs/reference/glossary/kubelet.md
@@ -14,4 +14,4 @@ tags:
 
 <!--more-->
 
-The [kubelet](docs/reference/command-line-tools-reference/kubelet/) takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.
+The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.


### PR DESCRIPTION
This fixes #40820

Page that is updated: https://deploy-preview-42332--kubernetes-io-main-staging.netlify.app/docs/concepts/overview/components/#cloud-controller-manager

The `kubernetes/content/en/docs/concepts/overview/components.md` use glossary_definition template under the hood, like the following.

`{{< glossary_definition term_id="kubelet" length="all" >}}`

So I updated the glossary pages.

