### PR TITLE
Fixed description of Gt and Lt operators

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -513,8 +513,8 @@ The following operators can only be used with `nodeAffinity`.
 
 |    Operator    |    Behaviour    |
 | :------------: | :-------------: |
-| `Gt` | The supplied value will be parsed as an integer, and that integer is less than or equal to the integer that results from parsing the value of a label named by this selector | 
-| `Lt` | The supplied value will be parsed as an integer, and that integer is greater than or equal to the integer that results from parsing the value of a label named by this selector | 
+| `Gt` | The supplied value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector | 
+| `Lt` | The supplied value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector | 
 
 
 {{<note>}}


### PR DESCRIPTION
Fixed incorrect description of `Gt` and `Lt` operators on page [Assigning Pods to Nodes / Operators](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators):

  - removing "_**or equal to**_" from the phrases "_...and that integer is less/greater than **or equal to** the integer..._"

![image](https://github.com/kubernetes/website/assets/19605995/d82d4b5c-8d3a-4d38-b34d-ca0ec49c5efe)

Сorresponding [place](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/labels/selector.go#L263) in the source code:

```go
return (r.operator == selection.GreaterThan && lsValue > rValue) || (r.operator == selection.LessThan && lsValue < rValue)
```
