### PR TITLE
Improvement for k8s.io/docs/tasks/configmap-secret/managing-secret-us…

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -89,8 +89,31 @@ When a Secret is generated, the Secret name is created by hashing
 the Secret data and appending the hash value to the name. This ensures that
 a new Secret is generated each time the data is modified.
 
-To verify that the Secret was created and to decode the Secret data, refer to
-[Managing Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
+To verify that the Secret was created and to decode the Secret data, 
+
+```shell
+kubectl get -k <directory-path> -o jsonpath='{.data}' 
+```
+
+The output is similar to:
+
+```
+{ "password": "UyFCXCpkJHpEc2I9", "username": "YWRtaW4=" }
+```
+
+```
+echo 'UyFCXCpkJHpEc2I9' | base64 --decode
+```
+
+The output is similar to:
+
+```
+S!B\*d$zDsb=
+```
+
+For more information, refer to
+[Managing Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret) and
+[Declarative Management of Kubernetes Objects Using Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/).
 
 ## Edit a Secret {#edit-secret}
 


### PR DESCRIPTION
>Well, it's randomly creating a name for the secret. I don't think what/who is going to use that created secret is expected to be >a human. How, the rest of the system is expected to know the random name?
>
>It seems the default behavior of having auto-detection of something changed by creating random name, is less relevant that >be able to use it programatically.
>
>So my ask here, is to complete the doc, to show how the rest of Kustomization that define the 'user' of that newly created >secret will automatically get the generated name.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
