### PR TITLE
Add Liveness, Readiness, and Startup Probes concept

### DIFF
--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -1,0 +1,43 @@
+---
+title: Liveness, Readiness, and Startup Probes
+content_type: concept
+weight: 40
+---
+
+<!-- overview -->
+
+Kubernetes has various types of probes:
+
+- [Liveness probe](#liveness-probe)
+- [Readiness probe](#readiness-probe)
+- [Startup probe](#startup-probe)
+
+<!-- body -->
+
+## Liveness probe
+
+Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock, where an application is running, but unable to make progress.
+
+If a Pod fails health-checks continuously, the Kubernetes terminates the Pod and starts a new one.
+
+Liveness probes do not wait for readiness probes to succeed. If you want to wait before executing a liveness probe you should use initialDelaySeconds or a startupProbe.
+
+
+## Readiness probe
+
+Readiness probes determine when a container is ready to start accepting traffic. This is useful when waiting for an application to perform time-consuming initial tasks, such as establishing network connections, loading files, and warming caches. 
+
+If the readiness probe returns a failed state, Kubernetes removes the pod from all matching service endpoints.
+
+Readiness probes runs on the container during its whole lifecycle.
+
+
+## Startup probe
+
+A startup probe verifies whether the application within a container is started. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.
+
+If such a probe is configured, it disables liveness and readiness checks until it succeeds.
+
+This type of probe is only executed at startup, unlike readiness probes, which are run periodically.
+
+* Read more about the [Configure Liveness, Readiness and Startup Probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes).

--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -20,7 +20,9 @@ Liveness probes determine when to restart a container. For example, liveness pro
 
 If a container fails its liveness probe repeatedly, the kubelet restarts the container.
 
-Liveness probes do not wait for readiness probes to succeed. If you want to wait before executing a liveness probe you should use initialDelaySeconds or a startupProbe.
+Liveness probes do not wait for readiness probes to succeed. If you want to wait before
+executing a liveness probe you can either define `initialDelaySeconds`, or use a
+[startup probe](#startup-probe).
 
 
 ## Readiness probe

--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -18,7 +18,7 @@ Kubernetes has various types of probes:
 
 Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock, where an application is running, but unable to make progress.
 
-If a Pod fails health-checks continuously, the Kubernetes terminates the Pod and starts a new one.
+If a container fails its liveness probe repeatedly, the kubelet restarts the container.
 
 Liveness probes do not wait for readiness probes to succeed. If you want to wait before executing a liveness probe you should use initialDelaySeconds or a startupProbe.
 

--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -16,7 +16,7 @@ Kubernetes has various types of probes:
 
 ## Liveness probe
 
-Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock, where an application is running, but unable to make progress.
+Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock, when an application is running, but unable to make progress.
 
 If a container fails its liveness probe repeatedly, the kubelet restarts the container.
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -8,6 +8,8 @@ weight: 140
 
 This page shows how to configure liveness, readiness and startup probes for containers.
 
+For more information about probes, see [Liveness, Readiness and Startup Probes](/docs/concepts/configuration/liveness-readiness-startup-probes)
+
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/) uses
 liveness probes to know when to restart a container. For example, liveness
 probes could catch a deadlock, where an application is running, but unable to


### PR DESCRIPTION
> https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ is more of a tutorial than a task.
> 
> If someone has the capacity to, we could split it into:
> 
> * a new tutorial page that walks people through learning about container probes
> * a focused guide for people who have already learned, and want to set up one of the four types of probe
>   
>   * with signposting to the tutorial, in case someone wants to learn the background first

