### PR TITLE
Mark Job tracking with finalizers as always enabled

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -831,31 +831,11 @@ mismatch.
 
 {{< feature-state for_k8s_version="v1.26" state="stable" >}}
 
-{{< note >}}
-The control plane doesn't track Jobs using finalizers, if the Jobs were created
-when the feature gate `JobTrackingWithFinalizers` was disabled, even after you
-upgrade the control plane to 1.26.
-{{< /note >}}
-
 The control plane keeps track of the Pods that belong to any Job and notices if
 any such Pod is removed from the API server. To do that, the Job controller
 creates Pods with the finalizer `batch.kubernetes.io/job-tracking`. The
 controller removes the finalizer only after the Pod has been accounted for in
 the Job status, allowing the Pod to be removed by other controllers or users.
-
-Jobs created before upgrading to Kubernetes 1.26 or before the feature gate
-`JobTrackingWithFinalizers` is enabled are tracked without the use of Pod
-finalizers.
-The Job {{< glossary_tooltip term_id="controller" text="controller" >}} updates
-the status counters for `succeeded` and `failed` Pods based only on the Pods
-that exist in the cluster. The contol plane can lose track of the progress of
-the Job if Pods are deleted from the cluster.
-
-You can determine if the control plane is tracking a Job using Pod finalizers by
-checking if the Job has the annotation
-`batch.kubernetes.io/job-tracking`. You should **not** manually add or remove
-this annotation from Jobs. Instead, you can recreate the Jobs to ensure they
-are tracked using Pod finalizers.
 
 ### Elastic Indexed Jobs
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1094,17 +1094,10 @@ Example: `batch.kubernetes.io/job-tracking: ""`
 
 Used on: Jobs
 
-The presence of this annotation on a Job indicates that the control plane is
+The presence of this annotation on a Job used to indicate that the control plane is
 [tracking the Job status using finalizers](/docs/concepts/workloads/controllers/job/#job-tracking-with-finalizers).
-The control plane uses this annotation to safely transition to tracking Jobs
-using finalizers, while the feature is in development.
-You should **not** manually add or remove this annotation.
-
-{{< note >}}
-Starting from Kubernetes 1.26, this annotation is deprecated.
-Kubernetes 1.27 and newer will ignore this annotation and always track Jobs
-using finalizers.
-{{< /note >}}
+Adding or removing this annotation no longer has an effect (Kubernetes v1.27 and later)
+All Jobs are tracked with finalizers.
 
 ### job-name (deprecated) {#job-name}
 


### PR DESCRIPTION
In Kubernetes 1.27, we made tracking with finalizers always enabled, even for Jobs created before tracking with finalizers was enabled.
As part of this, we also removed the use of `bactch.kubernetes.io/job-tracking` as an annotation for the Job.

This was documented in the KEP https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2307-job-tracking-without-lingering-pods#deprecation
and in https://kubernetes.io/docs/reference/labels-annotations-taints/#batch-kubernetes-io-job-tracking
