### PR TITLE
Update blog publish date for 1.28 feature blog for non graceful node shutdown to GA

### DIFF
--- a/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
+++ b/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes 1.28: Non-Graceful Node Shutdown Moves to GA"
-date: 2023-08-15T10:00:00-08:00
+date: 2023-08-16T10:00:00-08:00
 slug: kubernetes-1-28-non-graceful-node-shutdown-GA
 ---
 


### PR DESCRIPTION
Update the publication date for a 1.28 feature blog for non graceful node shutdown from August 15 (scheduled 1.28 release date) to August 16 per [1.28 enhancements tracking sheet](https://github.com/orgs/kubernetes/projects/140/views/6)
/assign @bradmccoydev 
cc: @krol3 @mashby2022 @ramrodo @thschue 