### PR TITLE
Use a consistent code reference in pods-and-endpoint-termination-flow

### DIFF
--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -38,7 +38,7 @@ Let's say you have a Deployment containing of a single `nginx` replica
 
 {{% code file="service/pod-with-graceful-termination.yaml" %}}
 
-{{< codenew file="service/explore-graceful-termination-nginx.yaml" >}}
+{{% code file="service/explore-graceful-termination-nginx.yaml" %}}
 
 Now create the Deployment Pod and Service using the above files:
 


### PR DESCRIPTION
Use a consistent style `{{% code file="*.yaml" %}}` to reference code blocks in such a close context.

The current is:
```
{{% code file="service/pod-with-graceful-termination.yaml" %}}

{{< codenew file="service/explore-graceful-termination-nginx.yaml" >}}
```