### PR TITLE
Update enforcing-pod-security-standards.md

### DIFF
--- a/content/en/docs/setup/best-practices/enforcing-pod-security-standards.md
+++ b/content/en/docs/setup/best-practices/enforcing-pod-security-standards.md
@@ -61,7 +61,7 @@ few different ways:
   them update those resources to become compliant.
 - In Namespaces that pin `enforce` to a specific non-latest version, setting the `audit` and `warn`
   modes to the same level as `enforce`, but to the `latest` version, gives visibility into settings
-  that were allowed by previous versions but are not allowed per current best practices.
+  that were allowed by previous versions but are not allowed as per current best practices.
 
 ## Third-party alternatives
 


### PR DESCRIPTION
Replaces "per" with "as per", turning "... allowed per current best practices" into "... allowed as per current best practices" because I think the intention was to mean "according to current best practices" and "as per" conveys that meaning while "per" does not/need not.

