### PR TITLE
delay august patch releases

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,7 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| August 2023           | 2023-08-04           | 2023-08-09  |
+| August 2023           | 2023-08-04           | 2023-08-23  |
 | September 2023        | 2023-09-08           | 2023-09-13  |
 | October 2023          | 2023-10-13           | 2023-10-18  |
 | November 2023         | N/A                  | N/A         |

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -9,7 +9,7 @@ schedules:
   next:
     release: 1.27.5
     cherryPickDeadline: 2023-08-04
-    targetDate: 2023-08-09
+    targetDate: 2023-08-23
   previousPatches:
     - release: 1.27.4
       cherryPickDeadline: 2023-07-14
@@ -35,7 +35,7 @@ schedules:
   next:
     release: 1.26.8
     cherryPickDeadline: 2023-08-04
-    targetDate: 2023-08-09
+    targetDate: 2023-08-23
   previousPatches:
     - release: 1.26.7
       cherryPickDeadline: 2023-07-14
@@ -70,7 +70,7 @@ schedules:
   next:
     release: 1.25.13
     cherryPickDeadline: 2023-08-04
-    targetDate: 2023-08-09
+    targetDate: 2023-08-23
   previousPatches:
     - release: 1.25.12
       cherryPickDeadline: 2023-07-14


### PR DESCRIPTION
The August patch releases will be delayed until August 23rd, so this PR updates the calendar to reflect this

/assign @saschagrunert @cpanato @jeremyrickard @puerco @Verolop
cc https://github.com/orgs/kubernetes/teams/release-engineering