### PR TITLE
Clean up distribute-credentials-secure.md

### DIFF
--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -112,12 +112,14 @@ Here is a configuration file you can use to create a Pod:
    ```
 
    Output:
+
    ```
    NAME              READY     STATUS    RESTARTS   AGE
    secret-test-pod   1/1       Running   0          42m
    ```
 
 1. Get a shell into the Container that is running in your Pod:
+
    ```shell
    kubectl exec -i -t secret-test-pod -- /bin/bash
    ```
@@ -126,22 +128,28 @@ Here is a configuration file you can use to create a Pod:
    `/etc/secret-volume`.
 
    In your shell, list the files in the `/etc/secret-volume` directory:
+
    ```shell
    # Run this in the shell inside the container
    ls /etc/secret-volume
    ```
+
    The output shows two files, one for each piece of secret data:
+
    ```
    password username
    ```
 
 1. In your shell, display the contents of the `username` and `password` files:
+
    ```shell
    # Run this in the shell inside the container
    echo "$( cat /etc/secret-volume/username )"
    echo "$( cat /etc/secret-volume/password )"
    ```
+
    The output is your username and password:
+
    ```
    my-app
    39528$vdg7Jb
@@ -153,8 +161,8 @@ in this directory.
 
 ### Project Secret keys to specific file paths
 
-You can also control the paths within the volume where Secret keys are projected. Use the `.spec.volumes[].secret.items` field to change the target
-path of each key:
+You can also control the paths within the volume where Secret keys are projected. Use the
+`.spec.volumes[].secret.items` field to change the target path of each key:
 
 ```yaml
 apiVersion: v1
@@ -260,13 +268,14 @@ secrets change.
   kubectl create -f https://k8s.io/examples/pods/inject/pod-single-secret-env-variable.yaml
   ```
 
-- In your shell, display the content of `SECRET_USERNAME` container environment variable
+- In your shell, display the content of `SECRET_USERNAME` container environment variable.
 
   ```shell
   kubectl exec -i -t env-single-secret -- /bin/sh -c 'echo $SECRET_USERNAME'
   ```
 
-  The output is
+  The output is similar to:
+
   ```
   backend-admin
   ```
@@ -290,12 +299,14 @@ secrets change.
   kubectl create -f https://k8s.io/examples/pods/inject/pod-multiple-secret-env-variable.yaml
   ```
 
-- In your shell, display the container environment variables
+- In your shell, display the container environment variables.
 
   ```shell
   kubectl exec -i -t envvars-multiple-secrets -- /bin/sh -c 'env | grep _USERNAME'
   ```
-  The output is
+
+  The output is similar to:
+
   ```
   DB_USERNAME=db-admin
   BACKEND_USERNAME=backend-admin
@@ -313,7 +324,8 @@ This functionality is available in Kubernetes v1.6 and later.
   kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
   ```
 
-- Use envFrom to define all of the Secret's data as container environment variables. The key from the Secret becomes the environment variable name in the Pod.
+- Use envFrom to define all of the Secret's data as container environment variables.
+  The key from the Secret becomes the environment variable name in the Pod.
 
   {{% code file="pods/inject/pod-secret-envFrom.yaml" %}}
 
@@ -323,13 +335,14 @@ This functionality is available in Kubernetes v1.6 and later.
   kubectl create -f https://k8s.io/examples/pods/inject/pod-secret-envFrom.yaml
   ```
 
-- In your shell, display `username` and `password` container environment variables
+- In your shell, display `username` and `password` container environment variables.
 
   ```shell
   kubectl exec -i -t envfrom-secret -- /bin/sh -c 'echo "username: $username\npassword: $password\n"'
   ```
 
-  The output is
+  The output is similar to:
+
   ```
   username: my-app
   password: 39528$vdg7Jb
@@ -364,72 +377,76 @@ another Pod which consumes a secret with test environment credentials.
    secret "test-db-secret" created
    ```
 
-    {{< note >}}
-    Special characters such as `$`, `\`, `*`, `=`, and `!` will be interpreted by your
-    [shell](https://en.wikipedia.org/wiki/Shell_(computing)) and require escaping.
+   {{< note >}}
+   Special characters such as `$`, `\`, `*`, `=`, and `!` will be interpreted by your
+   [shell](https://en.wikipedia.org/wiki/Shell_(computing)) and require escaping.
 
-    In most shells, the easiest way to escape the password is to surround it with single quotes (`'`).
-    For example, if your actual password is `S!B\*d$zDsb=`, you should execute the command as follows:
+   In most shells, the easiest way to escape the password is to surround it with single quotes (`'`).
+   For example, if your actual password is `S!B\*d$zDsb=`, you should execute the command as follows:
 
-    ```shell
-    kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password='S!B\*d$zDsb='
-    ```
+   ```shell
+   kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password='S!B\*d$zDsb='
+   ```
 
-    You do not need to escape special characters in passwords from files (`--from-file`).
-    {{< /note >}}
+   You do not need to escape special characters in passwords from files (`--from-file`).
+   {{< /note >}}
 
 1. Create the Pod manifests:
 
-    ```shell
-    cat <<EOF > pod.yaml
-    apiVersion: v1
-    kind: List
-    items:
-    - kind: Pod
-      apiVersion: v1
-      metadata:
-        name: prod-db-client-pod
-        labels:
-          name: prod-db-client
-      spec:
-        volumes:
-        - name: secret-volume
-          secret:
-            secretName: prod-db-secret
-        containers:
-        - name: db-client-container
-          image: myClientImage
-          volumeMounts:
-          - name: secret-volume
-            readOnly: true
-            mountPath: "/etc/secret-volume"
-    - kind: Pod
-      apiVersion: v1
-      metadata:
-        name: test-db-client-pod
-        labels:
-          name: test-db-client
-      spec:
-        volumes:
-        - name: secret-volume
-          secret:
-            secretName: test-db-secret
-        containers:
-        - name: db-client-container
-          image: myClientImage
-          volumeMounts:
-          - name: secret-volume
-            readOnly: true
-            mountPath: "/etc/secret-volume"
-    EOF
-    ```
-    Note how the specs for the two Pods differ only in one field; this facilitates creating Pods with different capabilities from a common Pod template.
+   ```shell
+   cat <<EOF > pod.yaml
+   apiVersion: v1
+   kind: List
+   items:
+   - kind: Pod
+     apiVersion: v1
+     metadata:
+       name: prod-db-client-pod
+       labels:
+         name: prod-db-client
+     spec:
+       volumes:
+       - name: secret-volume
+         secret:
+           secretName: prod-db-secret
+       containers:
+       - name: db-client-container
+         image: myClientImage
+         volumeMounts:
+         - name: secret-volume
+           readOnly: true
+           mountPath: "/etc/secret-volume"
+   - kind: Pod
+     apiVersion: v1
+     metadata:
+       name: test-db-client-pod
+       labels:
+         name: test-db-client
+     spec:
+       volumes:
+       - name: secret-volume
+         secret:
+           secretName: test-db-secret
+       containers:
+       - name: db-client-container
+         image: myClientImage
+         volumeMounts:
+         - name: secret-volume
+           readOnly: true
+           mountPath: "/etc/secret-volume"
+   EOF
+   ```
+
+   {{< note >}}
+   How the specs for the two Pods differ only in one field; this facilitates creating Pods
+   with different capabilities from a common Pod template.
+   {{< /note >}}
 
 1. Apply all those objects on the API server by running:
 
-    ```shell
-    kubectl create -f pod.yaml
-    ```
+   ```shell
+   kubectl create -f pod.yaml
+   ```
 
 Both containers will have the following files present on their filesystems with the values
 for each container's environment:


### PR DESCRIPTION
Performed actions below:

- Added a blank line between paragraphs
- Tweaked long lines
- Used a consistent text statement like `The output is similar to:` in context
- Used the same indentations from top to bottom on a single page

See [preview](https://deploy-preview-42479--kubernetes-io-main-staging.netlify.app/docs/tasks/inject-data-application/distribute-credentials-secure/) please.