### PR TITLE
Fix pod replacement policy link

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -931,7 +931,7 @@ is disabled, `.spec.completions` is immutable.
 Use cases for elastic Indexed Jobs include batch workloads which require 
 scaling an indexed Job, such as MPI, Horovord, Ray, and PyTorch training jobs.
 
-### Delayed creation of replacement pods
+### Delayed creation of replacement pods {#pod-replacement-policy}
 
 {{< feature-state for_k8s_version="v1.28" state="alpha" >}}
 


### PR DESCRIPTION
Fixes the non-working link from the bottom of this section: https://deploy-preview-41165--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/controllers/job/#pod-failure-policy.

Alternative solution would be to fix the link to `#delayed-creation-of-replacement-pods`, but it feels beneficial to make the link independent from the title.

It is also needed for the links to work in https://github.com/kubernetes/website/pull/41924

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
