### PR TITLE
Mark post release blog article as draft

### DIFF
--- a/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
+++ b/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Kubernetes 1.28: Non-Graceful Node Shutdown Moves to GA"
 date: 2023-08-16T10:00:00-08:00
 slug: kubernetes-1-28-non-graceful-node-shutdown-GA
+draft: true
 ---
 
 **Authors:** Xing Yang (VMware) and Ashutosh Kumar (Elastic)


### PR DESCRIPTION
https://k8s.io/blog/2023/08/16/kubernetes-1-28-non-graceful-node-shutdown-ga/ has merged too early (you still can't see it on the live site, because it's future dated)

We should mark it as draft until v1.28 is actually released.