### PR TITLE
Update Well known labels, annotation and taints with annotation apf.kubernetes.io/autoupdate-spec

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -20,7 +20,7 @@ This document serves both as a reference to the values and as a coordination poi
 
 Type: Annotation
 
-Example: `apf.kubernetes.io/autoupdate-spec: true`
+Example: `apf.kubernetes.io/autoupdate-spec: "true"`
 
 Used on: [All APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -22,9 +22,9 @@ Type: Annotation
 
 Example: `apf.kubernetes.io/autoupdate-spec: "true"`
 
-Used on: [All APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
+Used on: [Mandatory and suggested APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
 
-Depending on whether this annotation is set to true or false, the object is controlled by the kube-apiservers or the user.
+If the annotation is set to true, the object is controller by the kube-apiserver.  The object is controlled by the user if the annotation is set to false. For more details, read  [Maintenance of the Mandatory and Suggested Configuration Objects](/docs/concepts/cluster-administration/flow-control/#maintenance-of-the-mandatory-and-suggested-configuration-objects)
 
 ### app.kubernetes.io/component
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -15,6 +15,15 @@ This document serves both as a reference to the values and as a coordination poi
 
 ## Labels, annotations and taints used on API objects
 
+
+### apf.kubernetes.io/autoupdate-spec
+
+Type: annotation
+Example: `apf.kubernetes.io/autoupdate-spec: true`
+Used on: [All APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
+
+
+
 ### app.kubernetes.io/component
 
 Type: Label

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -18,11 +18,13 @@ This document serves both as a reference to the values and as a coordination poi
 
 ### apf.kubernetes.io/autoupdate-spec
 
-Type: annotation
+Type: Annotation
+
 Example: `apf.kubernetes.io/autoupdate-spec: true`
+
 Used on: [All APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
 
-
+Depending on whether this annotation is set to true or false, the object is controlled by the kube-apiservers or the user.
 
 ### app.kubernetes.io/component
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -24,7 +24,11 @@ Example: `apf.kubernetes.io/autoupdate-spec: "true"`
 
 Used on: [Mandatory and suggested APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
 
-If the annotation is set to true, the object is controller by the kube-apiserver.  The object is controlled by the user if the annotation is set to false. For more details, read  [Maintenance of the Mandatory and Suggested Configuration Objects](/docs/concepts/cluster-administration/flow-control/#maintenance-of-the-mandatory-and-suggested-configuration-objects)
+If this annotation is set to true on a FlowSchema or PriorityLevelConfiguration, the `spec` for that object
+is managed by the kube-apiserver. If the API server does not recognize an APF object, and you annotate it
+for automatic update, the API server deletes the entire object. Otherwise, the API server does not manage the
+object spec.
+For more details, read  [Maintenance of the Mandatory and Suggested Configuration Objects](/docs/concepts/cluster-administration/flow-control/#maintenance-of-the-mandatory-and-suggested-configuration-objects).
 
 ### app.kubernetes.io/component
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -22,7 +22,7 @@ Type: Annotation
 
 Example: `apf.kubernetes.io/autoupdate-spec: "true"`
 
-Used on: [Mandatory and suggested APF configuration objects](/concepts/cluster-administration/flow-control/#defaults)
+Used on: [`FlowSchema` and `PriorityLevelConfiguration` Objects](/concepts/cluster-administration/flow-control/#defaults)
 
 If this annotation is set to true on a FlowSchema or PriorityLevelConfiguration, the `spec` for that object
 is managed by the kube-apiserver. If the API server does not recognize an APF object, and you annotate it


### PR DESCRIPTION
This PR adds the details for annotation apf.kubernetes.io/autoupdate-spec  in the page https://kubernetes.io/docs/reference/labels-annotations-taints/


fixes #42456