### PR TITLE
[de] Removing old CSS includes from K8s basics tutorials

### DIFF
--- a/content/de/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/de/docs/tutorials/kubernetes-basics/_index.html
@@ -14,8 +14,6 @@ card:
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-
 <div class="layout" id="top">
 
   <main class="content">

--- a/content/de/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/de/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/de/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -9,8 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-
 <div class="layout" id="top">
 
     <main class="content">

--- a/content/de/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/de/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/de/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -9,8 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-
 <div class="layout" id="top">
 
     <main class="content">

--- a/content/de/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/de/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/de/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -9,9 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-
-
 <div class="layout" id="top">
 
     <main class="content">

--- a/content/de/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/de/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/de/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -9,8 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-
 <div class="layout" id="top">
 
 	<main class="content">

--- a/content/de/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/de/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/de/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -9,8 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-
 <div class="layout" id="top">
 
     <main class="content">

--- a/content/de/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/de/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/de/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -9,9 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300,400,700" rel="stylesheet">
-
 <div class="layout" id="top">
 
     <main class="content">


### PR DESCRIPTION
[German tutorials](https://kubernetes.io/de/docs/tutorials/kubernetes-basics/) still include old CSS files. However, if you visit these pages, the browser will try to access them and return 404 ([e.g.](https://kubernetes.io/docs/tutorials/kubernetes-basics/public/css/styles.css)). They were removed from the English tutorials in #34188. This PR removes them from the German localisation.

/sig docs
/language de
/area localization