### PR TITLE
Publish article "Kubernetes 1.28: Non-Graceful Node Shutdown Moves to GA"

### DIFF
--- a/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
+++ b/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
@@ -3,7 +3,6 @@ layout: blog
 title: "Kubernetes 1.28: Non-Graceful Node Shutdown Moves to GA"
 date: 2023-08-16T10:00:00-08:00
 slug: kubernetes-1-28-non-graceful-node-shutdown-GA
-draft: true
 ---
 
 **Authors:** Xing Yang (VMware) and Ashutosh Kumar (Elastic)


### PR DESCRIPTION
Announce generally available support for recovering storage following an ungraceful node shutdown.

This is only publishing an existing article
/approve
/hold

OK to unhold once Kubernetes v1.28 is released