### PR TITLE
change terminationGracePeriodSeconds for pods to 1.28

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -516,7 +516,7 @@ to resolve it.
 
 ### Probe-level `terminationGracePeriodSeconds`
 
-{{< feature-state for_k8s_version="v1.27" state="stable" >}}
+{{< feature-state for_k8s_version="v1.28" state="stable" >}}
 
 Prior to release 1.21, the Pod-level `terminationGracePeriodSeconds` was used
 for terminating a container that failed its liveness or startup probe. This


### PR DESCRIPTION
This fixes the documentation to reflect 1.28 has the terminationGracePeriodSeconds for probes feature.

1.27 reverted the feature due to missing a PR, and 1.28 contains the feature.