### PR TITLE
“Install and Set Up kubectl…” tasks mention fixed bug

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -118,18 +118,6 @@ The following methods exist for installing kubectl on Linux:
    kubectl version --client
    ```
 
-   {{< note >}}
-   The above command will generate a warning:
-
-   ```
-   WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.
-   ```
-
-   You can ignore this warning. You are only checking the version of `kubectl` that you
-   have installed.
-
-   {{< /note >}}
-
    Or use this for detailed view of version:
 
    ```cmd

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -121,18 +121,6 @@ The following methods exist for installing kubectl on macOS:
    kubectl version --client
    ```
    
-   {{< note >}}
-   The above command will generate a warning:
-
-   ```
-   WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.
-   ```
-
-   You can ignore this warning. You are only checking the version of `kubectl` that you
-   have installed.
-   
-   {{< /note >}}
-   
    Or use this for detailed view of version:
 
    ```cmd

--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -72,17 +72,6 @@ The following methods exist for installing kubectl on Windows:
    ```cmd
    kubectl version --client
    ```
-
-   {{< note >}}
-   The above command will generate a warning:
-
-   ```
-   WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.
-   ```
-
-   You can ignore this warning. You are only checking the version of `kubectl` that you
-   have installed.
-   {{< /note >}}
    
    Or use this for detailed view of version:
 


### PR DESCRIPTION
> **This is a Bug Report**
> 
> **Problem:**
> 
> * https://k8.io/docs/tasks/tools/install-kubectl-linux/
> * https://k8s.io/docs/tasks/tools/install-kubectl-macos/
> * https://k8s.io/docs/tasks/tools/install-kubectl-windows/
> 
> each tell readers about a warning message:
> 
> > The above command will generate a warning:
> > > **WARNING**: This version information is deprecated and will be replaced with the output from `kubectl version --short`.
> > 
> > 
> > You can ignore this warning. You are only checking the version of kubectl that you have installed.
> 
> However, `kubectl` from Kubernetes v1.28.0 doesn't show that warning.
> 
> **Proposed Solution:**
> 
> * Find the text “_This version information is deprecated and will be replaced with the output from_” in the website source.
> * Remove the note about the warning.
> 
> **Pages to Update:**
> 
> * https://k8.io/docs/tasks/tools/install-kubectl-linux/
> * https://k8s.io/docs/tasks/tools/install-kubectl-macos/
> * https://k8s.io/docs/tasks/tools/install-kubectl-windows/
> 
> **Additional Information:** /sig cli /language en /help