### PR TITLE
update release webinar link and wording

### DIFF
--- a/content/en/blog/_posts/2023-08-15-kubernetes-1.28-blog.md
+++ b/content/en/blog/_posts/2023-08-15-kubernetes-1.28-blog.md
@@ -272,7 +272,7 @@ In the v1.28 release cycle, which [ran for 14 weeks](https://github.com/kubernet
 
 ## Upcoming Release Webinar
 
-Join members of the Kubernetes v1.28 release team on Friday, September 14, 2023, at 10 a.m. PDT to learn about the major features of this release, as well as deprecations and removals to help plan for upgrades. For more information and registration, visit the [event page](https://community.cncf.io/events/) on the CNCF Online Programs site to stay tuned for when this is on.
+Join members of the Kubernetes v1.28 release team on Friday, September 14, 2023, at 10 A.M. PDT to learn about the major features of this release, as well as deprecations and removals to help plan for upgrades. For more information and registration, visit the [event page](https://community.cncf.io/events/) on the CNCF Online Programs site.
 
 ## Get Involved
 

--- a/content/en/blog/_posts/2023-08-15-kubernetes-1.28-blog.md
+++ b/content/en/blog/_posts/2023-08-15-kubernetes-1.28-blog.md
@@ -272,7 +272,7 @@ In the v1.28 release cycle, which [ran for 14 weeks](https://github.com/kubernet
 
 ## Upcoming Release Webinar
 
-Join members of the Kubernetes v1.28 release team on Friday, September 14, 2023, at 10 a.m. PDT to learn about the major features of this release, as well as deprecations and removals to help plan for upgrades. For more information and registration, visit the [event page](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-live-webinar-kubernetes-v128-release/) on the CNCF Online Programs site.
+Join members of the Kubernetes v1.28 release team on Friday, September 14, 2023, at 10 a.m. PDT to learn about the major features of this release, as well as deprecations and removals to help plan for upgrades. For more information and registration, visit the [event page](https://community.cncf.io/events/) on the CNCF Online Programs site to stay tuned for when this is on.
 
 ## Get Involved
 


### PR DESCRIPTION
Update wording and broken release link. Once we get the correct link we will add this back.

Closes https://github.com/kubernetes/website/issues/42563#issuecomment-1679905162

cc @gracenng @divya-mohan0209 