### PR TITLE
Fix sidecar example in init-container doc

### DIFF
--- a/content/en/examples/application/deployment-sidecar.yaml
+++ b/content/en/examples/application/deployment-sidecar.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: myapp
           image: alpine:latest
-          command: ['sh', '-c', 'echo "logging" > /opt/logs.txt']
+          command: ['sh', '-c', 'while true; do echo "logging" > /opt/logs.txt; sleep 1; done']
           volumeMounts:
             - name: data
               mountPath: /opt
@@ -25,10 +25,10 @@ spec:
         - name: logshipper
           image: alpine:latest
           restartPolicy: Always
-          command: ['sh', '-c', 'tail /opt/logs.txt']
+          command: ['sh', '-c', 'touch /opt/logs.txt && tail -f /opt/logs.txt']
           volumeMounts:
             - name: data
               mountPath: /opt
-  volumes:
-    - name: data
-      emptyDir: {}
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/content/en/examples/application/deployment-sidecar.yaml
+++ b/content/en/examples/application/deployment-sidecar.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: myapp
           image: alpine:latest
-          command: ['sh', '-c', 'while true; do echo "logging" > /opt/logs.txt; sleep 1; done']
+          command: ['sh', '-c', 'while true; do echo "logging" >> /opt/logs.txt; sleep 1; done']
           volumeMounts:
             - name: data
               mountPath: /opt

--- a/content/en/examples/application/deployment-sidecar.yaml
+++ b/content/en/examples/application/deployment-sidecar.yaml
@@ -25,7 +25,7 @@ spec:
         - name: logshipper
           image: alpine:latest
           restartPolicy: Always
-          command: ['sh', '-c', 'touch /opt/logs.txt && tail -f /opt/logs.txt']
+          command: ['sh', '-c', 'tail -F /opt/logs.txt']
           volumeMounts:
             - name: data
               mountPath: /opt

--- a/content/en/examples/application/job/job-sidecar.yaml
+++ b/content/en/examples/application/job/job-sidecar.yaml
@@ -16,7 +16,7 @@ spec:
         - name: logshipper
           image: alpine:latest
           restartPolicy: Always
-          command: ['sh', '-c', 'tail /opt/logs.txt']
+          command: ['sh', '-c', 'touch /opt/logs.txt && tail -f /opt/logs.txt']
           volumeMounts:
             - name: data
               mountPath: /opt

--- a/content/en/examples/application/job/job-sidecar.yaml
+++ b/content/en/examples/application/job/job-sidecar.yaml
@@ -16,7 +16,7 @@ spec:
         - name: logshipper
           image: alpine:latest
           restartPolicy: Always
-          command: ['sh', '-c', 'touch /opt/logs.txt && tail -f /opt/logs.txt']
+          command: ['sh', '-c', 'tail -F /opt/logs.txt']
           volumeMounts:
             - name: data
               mountPath: /opt


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
# Why we need this PR
When I follow the [sidecar containers doc](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#api-for-sidecar-containers) to deploy a sidecar demo, the default example with wrong config(invaild spec and cannot start success).
- fix the startup command
- fix the `spec.volumes` in [deployment-sidecar.yaml]
