### PR TITLE
[zh] sync init-containers.md

### DIFF
--- a/content/zh-cn/examples/application/deployment-sidecar.yaml
+++ b/content/zh-cn/examples/application/deployment-sidecar.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  labels:
+    app: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: myapp
+          image: alpine:latest
+          command: ['sh', '-c', 'echo "logging" > /opt/logs.txt']
+          volumeMounts:
+            - name: data
+              mountPath: /opt
+      initContainers:
+        - name: logshipper
+          image: alpine:latest
+          restartPolicy: Always
+          command: ['sh', '-c', 'tail /opt/logs.txt']
+          volumeMounts:
+            - name: data
+              mountPath: /opt
+  volumes:
+    - name: data
+      emptyDir: {}

--- a/content/zh-cn/examples/application/job/job-sidecar.yaml
+++ b/content/zh-cn/examples/application/job/job-sidecar.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: myjob
+spec:
+  template:
+    spec:
+      containers:
+        - name: myjob
+          image: alpine:latest
+          command: ['sh', '-c', 'echo "logging" > /opt/logs.txt']
+          volumeMounts:
+            - name: data
+              mountPath: /opt
+      initContainers:
+        - name: logshipper
+          image: alpine:latest
+          restartPolicy: Always
+          command: ['sh', '-c', 'tail /opt/logs.txt']
+          volumeMounts:
+            - name: data
+              mountPath: /opt
+      restartPolicy: Never
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
Sync with en text:

```
content/zh-cn/docs/concepts/workloads/pods/init-containers.md
```
See [preview](https://deploy-preview-42575--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/workloads/pods/init-containers/) please.