### PR TITLE
[zh-cn] Use Chinese version image in blog container-image-signature-verification

### DIFF
--- a/content/zh-cn/blog/_posts/2023-06-29-container-image-signature-verification/index.md
+++ b/content/zh-cn/blog/_posts/2023-06-29-container-image-signature-verification/index.md
@@ -73,7 +73,7 @@ The general usage flow for an admission controller based verification is:
 <!--
 {{< figure src="/blog/2023/06/29/container-image-signature-verification/flow.svg" alt="Create an instance of the policy and annotate the namespace to validate the signatures. Then create the pod. The controller evaluates the policy and if it passes, then it does the image pull if necessary. If the policy evaluation fails, then it will not admit the pod." >}}
 -->
-{{< figure src="/blog/2023/06/29/container-image-signature-verification/flow.svg" alt="创建一个策略的实例，并对命名空间添加注解以验证签名。然后创建 Pod。控制器会评估策略，如果评估通过，则根据需要执行镜像拉取。如果策略评估失败，则不允许该 Pod 运行。" >}}
+{{< figure src="/zh-cn/blog/2023/06/29/container-image-signature-verification/flow.svg" alt="创建一个策略的实例，并对命名空间添加注解以验证签名。然后创建 Pod。控制器会评估策略，如果评估通过，则根据需要执行镜像拉取。如果策略评估失败，则不允许该 Pod 运行。" >}}
 
 <!--
 A key benefit of this architecture is simplicity: A single instance within the


### PR DESCRIPTION


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
The Chinese version image exists but is not used.

page: https://kubernetes.io/zh-cn/blog/2023/06/29/container-image-signature-verification/

Related: https://github.com/kubernetes/website/pull/42055