### PR TITLE
Update CRICTL_VERSION to v1.28.0

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -353,7 +353,7 @@ sudo mkdir -p "$DOWNLOAD_DIR"
 Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI))
 
 ```bash
-CRICTL_VERSION="v1.27.0"
+CRICTL_VERSION="v1.28.0"
 ARCH="amd64"
 curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | sudo tar -C $DOWNLOAD_DIR -xz
 ```


### PR DESCRIPTION
This is the latest supported release, which is now also used by the new OBS packages.

cc @kubernetes/release-engineering 