### PR TITLE
Replace Kubelet with kubelet in kubelet-config-file.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -2,14 +2,14 @@
 reviewers:
 - mtaufen
 - dawnchen
-title: Set Kubelet parameters via a config file
+title: Set Kubelet Parameters Via A Configuration File
 content_type: task
 weight: 330
 ---
 
 <!-- overview -->
 
-A subset of the Kubelet's configuration parameters may be
+A subset of the kubelet's configuration parameters may be
 set via an on-disk config file, as a substitute for command-line flags.
 
 Providing parameters via a config file is the recommended approach because
@@ -19,13 +19,13 @@ it simplifies node deployment and configuration management.
 
 ## Create the config file
 
-The subset of the Kubelet's configuration that can be configured via a file
+The subset of the kubelet's configuration that can be configured via a file
 is defined by the
 [`KubeletConfiguration`](/docs/reference/config-api/kubelet-config.v1beta1/)
 struct.
 
 The configuration file must be a JSON or YAML representation of the parameters
-in this struct. Make sure the Kubelet has read permissions on the file.
+in this struct. Make sure the kubelet has read permissions on the file.
 
 Here is an example of what this file might look like:
 ```yaml
@@ -38,10 +38,10 @@ evictionHard:
     memory.available:  "200Mi"
 ```
 
-In the example, the Kubelet is configured to serve on IP address 192.168.0.8 and port 20250, pull images in parallel,
+In the example, the kubelet is configured to serve on IP address 192.168.0.8 and port 20250, pull images in parallel,
 and evict Pods when available memory drops below 200Mi. Since only one of the four evictionHard thresholds is configured,
 other evictionHard thresholds are reset to 0 from their built-in defaults.
-All other Kubelet configuration values are left at their built-in defaults, unless overridden
+All other kubelet configuration values are left at their built-in defaults, unless overridden
 by flags. Command line flags which target the same value as a config file will override that value.
 
 {{< note >}}
@@ -51,45 +51,45 @@ will be set to zero. In order to provide custom values, you should provide all
 the threshold values respectively.
 {{< /note >}}
 
-## Start a Kubelet process configured via the config file
+## Start a kubelet process configured via the config file
 
 {{< note >}}
 If you use kubeadm to initialize your cluster, use the kubelet-config while creating your cluster with `kubeadm init`.
 See [configuring kubelet using kubeadm](/docs/setup/production-environment/tools/kubeadm/kubelet-integration/) for details.
 {{< /note >}}
 
-Start the Kubelet with the `--config` flag set to the path of the Kubelet's config file.
-The Kubelet will then load its config from this file.
+Start the kubelet with the `--config` flag set to the path of the kubelet's config file.
+The kubelet will then load its config from this file.
 
 Note that command line flags which target the same value as a config file will override that value.
 This helps ensure backwards compatibility with the command-line API.
 
-Note that relative file paths in the Kubelet config file are resolved relative to the
-location of the Kubelet config file, whereas relative paths in command line flags are resolved
-relative to the Kubelet's current working directory.
+Note that relative file paths in the kubelet config file are resolved relative to the
+location of the kubelet config file, whereas relative paths in command line flags are resolved
+relative to the kubelet's current working directory.
 
-Note that some default values differ between command-line flags and the Kubelet config file.
+Note that some default values differ between command-line flags and the kubelet config file.
 If `--config` is provided and the values are not specified via the command line, the
 defaults for the `KubeletConfiguration` version apply.
 In the above example, this version is `kubelet.config.k8s.io/v1beta1`.
 
-## Drop-in directory for Kubelet configuration files {#kubelet-conf-d}
+## Drop-in directory for kubelet configuration files {#kubelet-conf-d}
 
-As of Kubernetes v1.28.0, the Kubelet has been extended to support a drop-in configuration directory. The location of it can be specified with
+As of Kubernetes v1.28.0, the kubelet has been extended to support a drop-in configuration directory. The location of it can be specified with
 `--config-dir` flag, and it defaults to `""`, or disabled, by default.
 
 You can only set `--config-dir` if you set the environment variable `KUBELET_CONFIG_DROPIN_DIR_ALPHA` for the kubelet process (the value of that variable does not matter).
 For Kubernetes v{{< skew currentVersion >}}, the kubelet returns an error if you specify `--config-dir` without that variable set, and startup fails.
 You cannot specify the drop-in configuration directory using the kubelet configuration file; only the CLI argument `--config-dir` can set it.
 
-One can use the Kubelet configuration directory in a similar way to the Kubelet config file.
+One can use the kubelet configuration directory in a similar way to the kubelet config file.
 {{< note >}}
-The suffix of a valid Kubelet drop-in configuration file must be `.conf`. For instance: `99-kubelet-address.conf`
+The suffix of a valid kubelet drop-in configuration file must be `.conf`. For instance: `99-kubelet-address.conf`
 {{< /note >}}
 
-For instance, you may want a baseline Kubelet configuration for all nodes, but you may want to customize the `address` field. This can be done as follows:
+For instance, you may want a baseline kubelet configuration for all nodes, but you may want to customize the `address` field. This can be done as follows:
 
-Main Kubelet configuration file contents:
+Main kubelet configuration file contents:
 ```yaml
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
@@ -106,10 +106,10 @@ kind: KubeletConfiguration
 address: "192.168.0.8"
 ```
 
-On startup, the Kubelet merges configuration from:
+On startup, the kubelet merges configuration from:
 
 * Command line arguments (lowest precedence).
-* the Kubelet configuration
+* the kubelet configuration
 * Drop-in configuration files, according to sort order.
 * Feature gates specified over the command line (highest precedence).
 


### PR DESCRIPTION
Search in `./content/en/docs` and find:

- 1148 kubelet in 176 files
- 157 Kubelet in 56 files

In my opinion, `kubelet` is more commonly used. However, I would appreciate your review and confirmation on this matter. Thank you.