### PR TITLE
[zh] Sync the blog filename of non-graceful-node-shutdown-GA

### DIFF
--- a/content/zh-cn/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
+++ b/content/zh-cn/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
@@ -1,21 +1,21 @@
 ---
 layout: blog
 title: "Kubernetes 1.28: 节点非体面关闭进入 GA 阶段（正式发布）"
-date: 2023-08-15T10:00:00-08:00
+date: 2023-08-16T10:00:00-08:00
 slug: kubernetes-1-28-non-graceful-node-shutdown-GA
 ---
 
 <!--
 layout: blog
 title: "Kubernetes 1.28: Non-Graceful Node Shutdown Moves to GA"
-date: 2023-08-15T10:00:00-08:00
+date: 2023-08-16T10:00:00-08:00
 slug: kubernetes-1-28-non-graceful-node-shutdown-GA
 -->
 
 <!--
 **Authors:** Xing Yang (VMware) and Ashutosh Kumar (Elastic)
 -->
-**作者：** Xing Yang (VMware) and Ashutosh Kumar (Elastic)
+**作者：** Xing Yang (VMware) 和 Ashutosh Kumar (Elastic)
 
 **译者：** Xin Li (Daocloud)
 


### PR DESCRIPTION
The en filename is changed from `08-15` to `08-16`, so change the zh version accordingly.