### PR TITLE
Update Japanese Translation of PriorityClass Documentation

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -146,8 +146,7 @@ Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) 
 
 ## Object Count Quota
 
-You can set quotas for the total number of certain resources using the count/* syntax. 
-This syntax applies to various standard, namespaced resource types:
+You can set quotas for the total number of certain resources using the count/* syntax. This syntax applies to various standard, namespaced resource types:
 
 * `count/<resource>.<group>` syntax is used for resources from non-core groups.
 * `count/<resource>` syntax is used for resources from the core group.

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -146,11 +146,11 @@ Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) 
 
 ## Object Count Quota
 
-You can set quota for the total number of certain resources of all standard,
-namespaced resource types using the following syntax:
+You can set quotas for the total number of certain resources using the count/* syntax. 
+This syntax applies to various standard, namespaced resource types:
 
-* `count/<resource>.<group>` for resources from non-core groups
-* `count/<resource>` for resources from the core group
+* `count/<resource>.<group>` syntax is used for resources from non-core groups.
+* `count/<resource>` syntax is used for resources from the core group.
 
 Here is an example set of resources users may want to put under object count quota:
 

--- a/content/ja/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -51,7 +51,7 @@ PriorityClassオブジェクトのメタデータの`name`フィールドにて�
 値が大きいほど、高い優先度を示します。
 PriorityClassオブジェクトの名称は[DNSサブドメイン名](/ja/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)として適切であり、かつ`system-`から始まってはいけません。
 
-PriorityClassオブジェクトは10億以下の任意の32ビットの整数値を持つことができます。
+PriorityClassオブジェクトは、-2147483648から1000000000までの任意の32ビットの整数値を持つことができます。
 それよりも大きな値は通常はプリエンプトや追い出すべきではない重要なシステム用のPodのために予約されています。
 クラスターの管理者は割り当てたい優先度に対して、PriorityClassオブジェクトを1つずつ作成すべきです。
 


### PR DESCRIPTION
Updated the Japanese translation of the PriorityClass documentation to include the negative range for the value of PriorityClass.
Made sure that the translation accurately reflects the full range of values that a PriorityClass object can have.
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
