### PR TITLE
Document snag with stringData and server-side apply

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -387,6 +387,10 @@ stringData:
   password: t0p-Secret # required field for kubernetes.io/basic-auth
 ```
 
+{{< note >}}
+`stringData` for a Secret does not work well with server-side apply
+{{< /note >}}
+
 The basic authentication Secret type is provided only for convenience.
 You can create an `Opaque` type for credentials used for basic authentication.
 However, using the defined and public Secret type (`kubernetes.io/basic-auth`) helps other
@@ -544,6 +548,10 @@ stringData:
   # and it can be used for signing
   usage-bootstrap-signing: "true"
 ```
+
+{{< note >}}
+`stringData` for a Secret does not work well with server-side apply
+{{< /note >}}
 
 ## Working with Secrets
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -388,7 +388,7 @@ stringData:
 ```
 
 {{< note >}}
-`stringData` for a Secret does not work well with server-side apply
+The `stringData` field for a Secret does not work well with server-side apply.
 {{< /note >}}
 
 The basic authentication Secret type is provided only for convenience.
@@ -550,7 +550,7 @@ stringData:
 ```
 
 {{< note >}}
-`stringData` for a Secret does not work well with server-side apply
+The `stringData` field for a Secret does not work well with server-side apply.
 {{< /note >}}
 
 ## Working with Secrets

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -109,6 +109,10 @@ stringData:
     password: <password>
 ```
 
+{{< note >}}
+`stringData` for a Secret does not work well with server-side apply
+{{< /note >}}
+
 When you retrieve the Secret data, the command returns the encoded values,
 and not the plaintext values you provided in `stringData`.
 
@@ -151,6 +155,10 @@ data:
 stringData:
   username: administrator
 ```
+
+{{< note >}}
+`stringData` for a Secret does not work well with server-side apply
+{{< /note >}}
 
 The `Secret` object is created as follows:
 

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -110,7 +110,7 @@ stringData:
 ```
 
 {{< note >}}
-`stringData` for a Secret does not work well with server-side apply
+The `stringData` field for a Secret does not work well with server-side apply.
 {{< /note >}}
 
 When you retrieve the Secret data, the command returns the encoded values,
@@ -157,7 +157,7 @@ stringData:
 ```
 
 {{< note >}}
-`stringData` for a Secret does not work well with server-side apply
+The `stringData` field for a Secret does not work well with server-side apply.
 {{< /note >}}
 
 The `Secret` object is created as follows:


### PR DESCRIPTION
> **This is a Feature Request**
> 
> **What would you like to be added**
> 
> * Update the docs for server-side apply to mention that `stringData` for a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) does not work well with [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
> * * Update the docs for Secrets to mention that `stringData` for a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) does not work well with [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
>   * https://kubernetes.io/docs/concepts/configuration/secret/
>   * https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/ 
>   * https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/
>   * https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kustomize/
> 
> **Why is this needed** [kubernetes/kubernetes#118519](https://github.com/kubernetes/kubernetes/issues/118519) etc
> 
> **Comments** /language en /kind feature /triage accepted /priority backlog

I only finds 2 reference in these 4 files.

>   * https://kubernetes.io/docs/concepts/configuration/secret/
>   * https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/

Feel free to correct me if I am wrong.