### PR TITLE
[en] fix links for blog/_posts/2018-05-29-announcing-kustomize

### DIFF
--- a/content/en/blog/_posts/2018-05-29-announcing-kustomize.md
+++ b/content/en/blog/_posts/2018-05-29-announcing-kustomize.md
@@ -8,12 +8,11 @@ date: 2018-05-29
 
 [**kustomize**]: https://github.com/kubernetes-sigs/kustomize
 [hello world]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/helloWorld
-[kustomization]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#kustomization
 [mailing list]: https://groups.google.com/forum/#!forum/kustomize
 [open an issue]: https://github.com/kubernetes-sigs/kustomize/issues/new
-[subproject]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/0008-kustomize.md
+[subproject]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/2377-Kustomize/README.md
 [SIG-CLI]: https://github.com/kubernetes/community/tree/master/sig-cli
-[workflow]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/workflows.md
+[workflow]: https://github.com/kubernetes-sigs/kustomize/blob/1dd448e65c81aab9d09308b695691175ca6459cd/docs/workflows.md
 
 If you run a Kubernetes environment, chances are you’ve
 customized a Kubernetes configuration — you've copied


### PR DESCRIPTION
from #42634

Fixed some oudated links in blog post: [Introducing kustomize; Template-free Configuration Customization for Kubernetes](https://kubernetes.io/blog/2018/05/29/introducing-kustomize-template-free-configuration-customization-for-kubernetes/)

Page updated: content/en/blog/_posts/2018-05-29-announcing-kustomize.md

---

The same changes will be applied to the Korean translation of this page, that I am translating right now.