### PR TITLE
Update field-selectors.md with info about set based requirements

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -44,8 +44,6 @@ kubectl get services  --all-namespaces --field-selector metadata.namespace!=defa
 (`in`, `notin`,`exists`) are not supported for field selectors. 
 {{< /note >}}
 
-
-
 ## Chained selectors
 
 As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors, field selectors can be chained together as a comma-separated list. This `kubectl` command selects all Pods for which the `status.phase` does not equal `Running` and the `spec.restartPolicy` field equals `Always`:

--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -40,7 +40,8 @@ You can use the `=`, `==`, and `!=` operators with field selectors (`=` and `==`
 kubectl get services  --all-namespaces --field-selector metadata.namespace!=default
 ```
 {{< note >}}
-[Set based operators (`in`, `notin`,`exists`)](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) are not supported for field selectors. 
+[Set based operators](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)
+(`in`, `notin`,`exists`) are not supported for field selectors. 
 {{< /note >}}
 
 

--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -40,7 +40,7 @@ You can use the `=`, `==`, and `!=` operators with field selectors (`=` and `==`
 kubectl get services  --all-namespaces --field-selector metadata.namespace!=default
 ```
 {{< note >}}
-[Set based operators](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)
+[Set-based operators](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)
 (`in`, `notin`,`exists`) are not supported for field selectors. 
 {{< /note >}}
 

--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -41,7 +41,7 @@ kubectl get services  --all-namespaces --field-selector metadata.namespace!=defa
 ```
 {{< note >}}
 [Set-based operators](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)
-(`in`, `notin`,`exists`) are not supported for field selectors. 
+(`in`, `notin`, `exists`) are not supported for field selectors. 
 {{< /note >}}
 
 ## Chained selectors

--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -39,6 +39,11 @@ You can use the `=`, `==`, and `!=` operators with field selectors (`=` and `==`
 ```shell
 kubectl get services  --all-namespaces --field-selector metadata.namespace!=default
 ```
+{{< note >}}
+[Set based operators (`in`, `notin`,`exists`)](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) are not supported for field selectors. 
+{{< /note >}}
+
+
 
 ## Chained selectors
 


### PR DESCRIPTION
Adding an explicit note for lack of support for set based operators for field selectors 


Article link: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/

https://github.com/kubernetes/kubernetes/issues/32946

