### PR TITLE
clarification for ResourceQuota concept

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -165,7 +165,11 @@ Here is an example set of resources users may want to put under object count quo
 * `count/jobs.batch`
 * `count/cronjobs.batch`
 
-The same syntax can be used for custom resources.
+If you define a quota this way, it applies to Kubernetes' APIs that are part of the API server, and
+to any custom resources backed by a CustomResourceDefinition. If you use [API aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) to
+add additional, custom APIs that are not defined as CustomResourceDefinitions, the core Kubernetes
+control plane does not enforce quota for the aggregated API. The extension API  server is expected to
+provide quota enforcement if that's appropriate for the custom API.
 For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
 
 When using such a resource quota (nearly for all object kinds), an object is charged

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -146,7 +146,7 @@ Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) 
 
 ## Object Count Quota
 
-You can set quota for **the total number of one particular resource** of all standard, namespaced resource types 
+You can set quota for **the total number of one particular resource** of built-in API and CRD 
 using the following syntax:
 
 * `count/<resource>.<group>` for resources from non-core groups

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -168,7 +168,7 @@ Here is an example set of resources users may want to put under object count quo
 The same syntax can be used for custom resources.
 For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
 
-When using such a resource quota (only available for some object kinds), an object is charged
+When using such a resource quota (nearly for all object kinds), an object is charged
 against the quota if the control plane has a stored copy.
 These types of quotas are useful to protect against exhaustion of storage resources.  For example, you may
 want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -146,7 +146,7 @@ Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) 
 
 ## Object Count Quota
 
-You can set quota for **the total number of one particular resource** of built-in API and CRD 
+You can set quota for *the total number of one particular resource kind* in the Kubernetes API,
 using the following syntax:
 
 * `count/<resource>.<group>` for resources from non-core groups

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -169,7 +169,7 @@ The same syntax can be used for custom resources.
 For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
 
 When using such a resource quota (nearly for all object kinds), an object is charged
-against the quota if the control plane has a stored copy.
+against the quota if the object kind exists (is defined) in the control plane.
 These types of quotas are useful to protect against exhaustion of storage resources.  For example, you may
 want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can
 actually prevent servers and controllers from starting. You can set a quota for Jobs to protect against

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -168,7 +168,7 @@ Here is an example set of resources users may want to put under object count quo
 The same syntax can be used for custom resources.
 For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
 
-When using `count/*` resource quota, an object is charged against the quota if it exists in server storage.
+When using `count/*` resource quota for certain resources type, an object is charged against the quota if it exists in server storage.
 These types of quotas are useful to protect against exhaustion of storage resources.  For example, you may
 want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can
 actually prevent servers and controllers from starting. You can set a quota for Jobs to protect against
@@ -193,6 +193,8 @@ For example, `pods` quota counts and enforces a maximum on the number of `pods`
 created in a single namespace that are not terminal. You might want to set a `pods`
 quota on a namespace to avoid the case where a user creates many small pods and
 exhausts the cluster's supply of Pod IPs.
+
+You can find more examples on [Viewing and Setting Quotas](/docs/concepts/policy/resource-quotas/#viewing-and-setting-quotas).
 
 ## Quota Scopes
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -146,8 +146,8 @@ Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) 
 
 ## Object Count Quota
 
-You can set quota for the total number of certain resources of all standard,
-namespaced resource types using the following syntax:
+You can set quota for **the total number of one particular resource**
+for certain resources of all standard, namespaced resource types using the following syntax:
 
 * `count/<resource>.<group>` for resources from non-core groups
 * `count/<resource>` for resources from the core group
@@ -168,14 +168,14 @@ Here is an example set of resources users may want to put under object count quo
 The same syntax can be used for custom resources.
 For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
 
-When using `count/*` resource quota (only available for some object kinds), an object is charged
+When using such a resource quota (only available for some object kinds), an object is charged
 against the quota if the control plane has a stored copy.
 These types of quotas are useful to protect against exhaustion of storage resources.  For example, you may
 want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can
 actually prevent servers and controllers from starting. You can set a quota for Jobs to protect against
 a poorly configured CronJob. CronJobs that create too many Jobs in a namespace can lead to a denial of service.
 
-It is also possible to do generic object count quota on a limited set of resources.
+There is another syntax only to set the same type of quota for certain resources.
 The following types are supported:
 
 | Resource Name | Description |
@@ -195,7 +195,7 @@ created in a single namespace that are not terminal. You might want to set a `po
 quota on a namespace to avoid the case where a user creates many small pods and
 exhausts the cluster's supply of Pod IPs.
 
-You can find more examples on [Viewing and Setting Quotas](/docs/concepts/policy/resource-quotas/#viewing-and-setting-quotas).
+You can find more examples on [Viewing and Setting Quotas](#viewing-and-setting-quotas).
 
 ## Quota Scopes
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -168,7 +168,8 @@ Here is an example set of resources users may want to put under object count quo
 The same syntax can be used for custom resources.
 For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
 
-When using `count/*` resource quota for certain resources type, an object is charged against the quota if it exists in server storage.
+When using `count/*` resource quota (only available for some object kinds), an object is charged
+against the quota if the control plane has a stored copy.
 These types of quotas are useful to protect against exhaustion of storage resources.  For example, you may
 want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can
 actually prevent servers and controllers from starting. You can set a quota for Jobs to protect against

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -146,8 +146,8 @@ Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) 
 
 ## Object Count Quota
 
-You can set quota for **the total number of one particular resource**
-for certain resources of all standard, namespaced resource types using the following syntax:
+You can set quota for **the total number of one particular resource** of all standard, namespaced resource types 
+using the following syntax:
 
 * `count/<resource>.<group>` for resources from non-core groups
 * `count/<resource>` for resources from the core group


### PR DESCRIPTION
> 1. `count/*` — it's precieved as a wildcard mask as if it contains all the resources such as a pods, services, persistentvolumeclaims. But this doesn’t not work that way. Consider rewording or adding some information about the meaning, maybe as a warning block or as a note block.

> 2\. `quota for the total number of certain resources` and `generic object count quota` means the same, so there could be two syntaxes for the same object, for example `count/pods` and `pods`. I found the only difference — you cannot set any quota in `count/`-less syntax except what mentioned in the table. The problem is the wording — it looks like you can specify something different using different syntaxes, but in fact it's the same things with some limitations for `count/`-less syntax. Consider rewording to highlight that this is just another syntax for the same resources (if I'm not mistaken).

It seems owner @whitebear009 has solved #1 by https://github.com/whitebeard10/website/pull/2.
I've mades some minor change on #1

For #2, my suggestion is we should add a link to below paragraph.
Then count/pod and pod would be clear.
In my opinion, we should use `pods` in resource quota yaml, and counts/pods for directly use kubectl.