### PR TITLE
Mark “Moving Forward From Beta” evergreen

### DIFF
--- a/content/en/blog/_posts/2020-08-21-Moving-Forward-From-Beta/index.md
+++ b/content/en/blog/_posts/2020-08-21-Moving-Forward-From-Beta/index.md
@@ -3,6 +3,13 @@ layout: blog
 title: "Moving Forward From Beta"
 date: 2020-08-21
 slug: moving-forward-from-beta
+
+# note to localizers: including this means you are marking
+# the article as maintained. That should be fine, but if
+# there is ever an update, you're committing to also updating
+# the localized version.
+# If unsure: omit this next field.
+evergreen: true
 ---
 
 **Author**: Tim Bannister, The Scale Factory


### PR DESCRIPTION
This [article](https://kubernetes.io/blog/2020/08/21/moving-forward-from-beta/) is written to be true even after future releases have happened, and should need minimal maintenance.

Let's suppress the staleness warning.