### PR TITLE
Rename code shortcode to code_sample

### DIFF
--- a/content/en/docs/concepts/cluster-administration/flow-control.md
+++ b/content/en/docs/concepts/cluster-administration/flow-control.md
@@ -470,7 +470,7 @@ traffic, you can configure rules to block any health check requests
 that originate from outside your cluster.
 {{< /caution >}}
 
-{{% code file="priority-and-fairness/health-for-strangers.yaml" %}}
+{{% code_sample file="priority-and-fairness/health-for-strangers.yaml" %}}
 
 ## Diagnostics
 
@@ -885,7 +885,7 @@ from other requests.
 
 Example FlowSchema object to isolate list event requests:
 
-{{% code file="priority-and-fairness/list-events-default-service-account.yaml" %}}
+{{% code_sample file="priority-and-fairness/list-events-default-service-account.yaml" %}}
 
 - This FlowSchema captures all list event calls made by the default service
   account in the default namespace. The matching precedence 8000 is lower than the

--- a/content/en/docs/concepts/cluster-administration/logging.md
+++ b/content/en/docs/concepts/cluster-administration/logging.md
@@ -39,7 +39,7 @@ Kubernetes captures logs from each container in a running Pod.
 This example uses a manifest for a `Pod` with a container
 that writes text to the standard output stream, once per second.
 
-{{% code file="debug/counter-pod.yaml" %}}
+{{% code_sample file="debug/counter-pod.yaml" %}}
 
 To run this pod, use the following command:
 
@@ -255,7 +255,7 @@ For example, a pod runs a single container, and the container
 writes to two different log files using two different formats. Here's a
 manifest for the Pod:
 
-{{% code file="admin/logging/two-files-counter-pod.yaml" %}}
+{{% code_sample file="admin/logging/two-files-counter-pod.yaml" %}}
 
 It is not recommended to write log entries with different formats to the same log
 stream, even if you managed to redirect both components to the `stdout` stream of
@@ -265,7 +265,7 @@ the logs to its own `stdout` stream.
 
 Here's a manifest for a pod that has two sidecar containers:
 
-{{% code file="admin/logging/two-files-counter-pod-streaming-sidecar.yaml" %}}
+{{% code_sample file="admin/logging/two-files-counter-pod-streaming-sidecar.yaml" %}}
 
 Now when you run this pod, you can access each log stream separately by
 running the following commands:
@@ -332,7 +332,7 @@ Here are two example manifests that you can use to implement a sidecar container
 The first manifest contains a [`ConfigMap`](/docs/tasks/configure-pod-container/configure-pod-configmap/)
 to configure fluentd.
 
-{{% code file="admin/logging/fluentd-sidecar-config.yaml" %}}
+{{% code_sample file="admin/logging/fluentd-sidecar-config.yaml" %}}
 
 {{< note >}}
 In the sample configurations, you can replace fluentd with any logging agent, reading
@@ -342,7 +342,7 @@ from any source inside an application container.
 The second manifest describes a pod that has a sidecar container running fluentd.
 The pod mounts a volume where fluentd can pick up its configuration data.
 
-{{% code file="admin/logging/two-files-counter-pod-agent-sidecar.yaml" %}}
+{{% code_sample file="admin/logging/two-files-counter-pod-agent-sidecar.yaml" %}}
 
 ### Exposing logs directly from the application
 

--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -22,7 +22,7 @@ Many applications require multiple resources to be created, such as a Deployment
 Management of multiple resources can be simplified by grouping them together in the same file
 (separated by `---` in YAML). For example:
 
-{{% code file="application/nginx-app.yaml" %}}
+{{% code_sample file="application/nginx-app.yaml" %}}
 
 Multiple resources can be created the same way as a single resource:
 

--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -113,7 +113,7 @@ technique also lets you access a ConfigMap in a different namespace.
 
 Here's an example Pod that uses values from `game-demo` to configure a Pod:
 
-{{% code file="configmap/configure-pod.yaml" %}}
+{{% code_sample file="configmap/configure-pod.yaml" %}}
 
 A ConfigMap doesn't differentiate between single line property values and
 multi-line file-like values.

--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -77,7 +77,7 @@ request.
 
 Here's an example `.yaml` file that shows the required fields and object spec for a Kubernetes Deployment:
 
-{{% code file="application/deployment.yaml" %}}
+{{% code_sample file="application/deployment.yaml" %}}
 
 One way to create a Deployment using a `.yaml` file like the one above is to use the
 [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply) command

--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -54,12 +54,12 @@ A `LimitRange` does **not** check the consistency of the default values it appli
 
 For example, you define a `LimitRange` with this manifest:
 
-{{% code file="concepts/policy/limit-range/problematic-limit-range.yaml" %}}
+{{% code_sample file="concepts/policy/limit-range/problematic-limit-range.yaml" %}}
 
 
 along with a Pod that declares a CPU resource request of `700m`, but not a limit:
 
-{{% code file="concepts/policy/limit-range/example-conflict-with-limitrange-cpu.yaml" %}}
+{{% code_sample file="concepts/policy/limit-range/example-conflict-with-limitrange-cpu.yaml" %}}
 
 
 then that Pod will not be scheduled, failing with an error similar to:
@@ -69,7 +69,7 @@ Pod "example-conflict-with-limitrange-cpu" is invalid: spec.containers[0].resour
 
 If you set both `request` and `limit`, then that new Pod will be scheduled successfully even with the same `LimitRange` in place:
 
-{{% code file="concepts/policy/limit-range/example-no-conflict-with-limitrange-cpu.yaml" %}}
+{{% code_sample file="concepts/policy/limit-range/example-no-conflict-with-limitrange-cpu.yaml" %}}
 
 ## Example resource constraints
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -687,7 +687,7 @@ plugins:
 
 Then, create a resource quota object in the `kube-system` namespace:
 
-{{% code file="policy/priority-class-resourcequota.yaml" %}}
+{{% code_sample file="policy/priority-class-resourcequota.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/policy/priority-class-resourcequota.yaml -n kube-system

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -121,7 +121,7 @@ your Pod spec.
 
 For example, consider the following Pod spec:
 
-{{% code file="pods/pod-with-node-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-node-affinity.yaml" %}}
 
 In this example, the following rules apply:
 
@@ -171,7 +171,7 @@ scheduling decision for the Pod.
 
 For example, consider the following Pod spec:
 
-{{% code file="pods/pod-with-affinity-anti-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-affinity-anti-affinity.yaml" %}}
 
 If there are two possible nodes that match the
 `preferredDuringSchedulingIgnoredDuringExecution` rule, one with the
@@ -287,7 +287,7 @@ spec.
 
 Consider the following Pod spec:
 
-{{% code file="pods/pod-with-pod-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-pod-affinity.yaml" %}}
 
 This example defines one Pod affinity rule and one Pod anti-affinity rule. The
 Pod affinity rule uses the "hard"

--- a/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -31,7 +31,7 @@ each schedulingGate can be removed in arbitrary order, but addition of a new sch
 
 To mark a Pod not-ready for scheduling, you can create it with one or more scheduling gates like this:
 
-{{% code file="pods/pod-with-scheduling-gates.yaml" %}}
+{{% code_sample file="pods/pod-with-scheduling-gates.yaml" %}}
 
 After the Pod's creation, you can check its state using:
 
@@ -61,7 +61,7 @@ The output is:
 To inform scheduler this Pod is ready for scheduling, you can remove its `schedulingGates` entirely
 by re-applying a modified manifest:
 
-{{% code file="pods/pod-without-scheduling-gates.yaml" %}}
+{{% code_sample file="pods/pod-without-scheduling-gates.yaml" %}}
 
 You can check if the `schedulingGates` is cleared by running:
 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -64,7 +64,7 @@ tolerations:
 
 Here's an example of a pod that uses tolerations:
 
-{{% code file="pods/pod-with-toleration.yaml" %}}
+{{% code_sample file="pods/pod-with-toleration.yaml" %}}
 
 The default value for `operator` is `Equal`.
 

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -284,7 +284,7 @@ graph BT
 If you want an incoming Pod to be evenly spread with existing Pods across zones, you
 can use a manifest similar to:
 
-{{% code file="pods/topology-spread-constraints/one-constraint.yaml" %}}
+{{% code_sample file="pods/topology-spread-constraints/one-constraint.yaml" %}}
 
 From that manifest, `topologyKey: zone` implies the even distribution will only be applied
 to nodes that are labelled `zone: <any value>` (nodes that don't have a `zone` label
@@ -377,7 +377,7 @@ graph BT
 You can combine two topology spread constraints to control the spread of Pods both
 by node and by zone:
 
-{{% code file="pods/topology-spread-constraints/two-constraints.yaml" %}}
+{{% code_sample file="pods/topology-spread-constraints/two-constraints.yaml" %}}
 
 In this case, to match the first constraint, the incoming Pod can only be placed onto
 nodes in zone `B`; while in terms of the second constraint, the incoming Pod can only be
@@ -466,7 +466,7 @@ and you know that zone `C` must be excluded. In this case, you can compose a man
 as below, so that Pod `mypod` will be placed into zone `B` instead of zone `C`.
 Similarly, Kubernetes also respects `spec.nodeSelector`.
 
-{{% code file="pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml" %}}
+{{% code_sample file="pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml" %}}
 
 ## Implicit conventions
 

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -300,7 +300,7 @@ Below are the properties a user can specify in the `dnsConfig` field:
 
 The following is an example Pod with custom DNS settings:
 
-{{% code file="service/networking/custom-dns.yaml" %}}
+{{% code_sample file="service/networking/custom-dns.yaml" %}}
 
 When the Pod above is created, the container `test` gets the following contents
 in its `/etc/resolv.conf` file:

--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -135,7 +135,7 @@ These examples demonstrate the behavior of various dual-stack Service configurat
    [headless Services](/docs/concepts/services-networking/service/#headless-services) with selectors
    will behave in this same way.)
 
-   {{% code file="service/networking/dual-stack-default-svc.yaml" %}}
+   {{% code_sample file="service/networking/dual-stack-default-svc.yaml" %}}
 
 1. This Service specification explicitly defines `PreferDualStack` in `.spec.ipFamilyPolicy`. When
    you create this Service on a dual-stack cluster, Kubernetes assigns both IPv4 and IPv6
@@ -151,14 +151,14 @@ These examples demonstrate the behavior of various dual-stack Service configurat
    * On a cluster with dual-stack enabled, specifying `RequireDualStack` in `.spec.ipFamilyPolicy`
      behaves the same as `PreferDualStack`.
 
-   {{% code file="service/networking/dual-stack-preferred-svc.yaml" %}}
+   {{% code_sample file="service/networking/dual-stack-preferred-svc.yaml" %}}
 
 1. This Service specification explicitly defines `IPv6` and `IPv4` in `.spec.ipFamilies` as well
    as defining `PreferDualStack` in `.spec.ipFamilyPolicy`. When Kubernetes assigns an IPv6 and
    IPv4 address in `.spec.ClusterIPs`, `.spec.ClusterIP` is set to the IPv6 address because that is
    the first element in the `.spec.ClusterIPs` array, overriding the default.
 
-   {{% code file="service/networking/dual-stack-preferred-ipfamilies-svc.yaml" %}}
+   {{% code_sample file="service/networking/dual-stack-preferred-ipfamilies-svc.yaml" %}}
 
 #### Dual-stack defaults on existing Services
 
@@ -171,7 +171,7 @@ dual-stack.)
    `.spec.ipFamilies` to the address family of the existing Service. The existing Service cluster IP
    will be stored in `.spec.ClusterIPs`.
 
-   {{% code file="service/networking/dual-stack-default-svc.yaml" %}}
+   {{% code_sample file="service/networking/dual-stack-default-svc.yaml" %}}
 
    You can validate this behavior by using kubectl to inspect an existing service.
 
@@ -211,7 +211,7 @@ dual-stack.)
    `--service-cluster-ip-range` flag to the kube-apiserver) even though `.spec.ClusterIP` is set to
    `None`.
 
-   {{% code file="service/networking/dual-stack-default-svc.yaml" %}}
+   {{% code_sample file="service/networking/dual-stack-default-svc.yaml" %}}
 
    You can validate this behavior by using kubectl to inspect an existing headless service with selectors.
 

--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -73,7 +73,7 @@ Make sure you review your Ingress controller's documentation to understand the c
 
 A minimal Ingress resource example:
 
-{{% code file="service/networking/minimal-ingress.yaml" %}}
+{{% code_sample file="service/networking/minimal-ingress.yaml" %}}
 
 An Ingress needs `apiVersion`, `kind`, `metadata` and `spec` fields.
 The name of an Ingress object must be a valid
@@ -140,7 +140,7 @@ setting with Service, and will fail validation if both are specified. A common
 usage for a `Resource` backend is to ingress data to an object storage backend
 with static assets.
 
-{{% code file="service/networking/ingress-resource-backend.yaml" %}}
+{{% code_sample file="service/networking/ingress-resource-backend.yaml" %}}
 
 After creating the Ingress above, you can view it with the following command:
 
@@ -229,7 +229,7 @@ equal to the suffix of the wildcard rule.
 | `*.foo.com` | `baz.bar.foo.com` | No match, wildcard only covers a single DNS label |
 | `*.foo.com` | `foo.com`         | No match, wildcard only covers a single DNS label |
 
-{{% code file="service/networking/ingress-wildcard-host.yaml" %}}
+{{% code_sample file="service/networking/ingress-wildcard-host.yaml" %}}
 
 ## Ingress class
 
@@ -238,7 +238,7 @@ configuration. Each Ingress should specify a class, a reference to an
 IngressClass resource that contains additional configuration including the name
 of the controller that should implement the class.
 
-{{% code file="service/networking/external-lb.yaml" %}}
+{{% code_sample file="service/networking/external-lb.yaml" %}}
 
 The `.spec.parameters` field of an IngressClass lets you reference another
 resource that provides configuration related to that IngressClass.
@@ -369,7 +369,7 @@ configured with a [flag](https://kubernetes.github.io/ingress-nginx/#what-is-the
 `--watch-ingress-without-class`. It is [recommended](https://kubernetes.github.io/ingress-nginx/#i-have-only-one-instance-of-the-ingresss-nginx-controller-in-my-cluster-what-should-i-do)  though, to specify the
 default `IngressClass`:
 
-{{% code file="service/networking/default-ingressclass.yaml" %}}
+{{% code_sample file="service/networking/default-ingressclass.yaml" %}}
 
 ## Types of Ingress
 
@@ -379,7 +379,7 @@ There are existing Kubernetes concepts that allow you to expose a single Service
 (see [alternatives](#alternatives)). You can also do this with an Ingress by specifying a
 *default backend* with no rules.
 
-{{% code file="service/networking/test-ingress.yaml" %}}
+{{% code_sample file="service/networking/test-ingress.yaml" %}}
 
 If you create it using `kubectl apply -f` you should be able to view the state
 of the Ingress you added:
@@ -411,7 +411,7 @@ down to a minimum. For example, a setup like:
 
 It would require an Ingress such as:
 
-{{% code file="service/networking/simple-fanout-example.yaml" %}}
+{{% code_sample file="service/networking/simple-fanout-example.yaml" %}}
 
 When you create the Ingress with `kubectl apply -f`:
 
@@ -456,7 +456,7 @@ Name-based virtual hosts support routing HTTP traffic to multiple host names at 
 The following Ingress tells the backing load balancer to route requests based on
 the [Host header](https://tools.ietf.org/html/rfc7230#section-5.4).
 
-{{% code file="service/networking/name-virtual-host-ingress.yaml" %}}
+{{% code_sample file="service/networking/name-virtual-host-ingress.yaml" %}}
 
 If you create an Ingress resource without any hosts defined in the rules, then any
 web traffic to the IP address of your Ingress controller can be matched without a name based
@@ -467,7 +467,7 @@ requested for `first.bar.com` to `service1`, `second.bar.com` to `service2`,
 and any traffic whose request host header doesn't match `first.bar.com`
 and `second.bar.com` to `service3`.
 
-{{% code file="service/networking/name-virtual-host-ingress-no-third-host.yaml" %}}
+{{% code_sample file="service/networking/name-virtual-host-ingress-no-third-host.yaml" %}}
 
 ### TLS
 
@@ -505,7 +505,7 @@ certificates would have to be issued for all the possible sub-domains. Therefore
 section.
 {{< /note >}}
 
-{{% code file="service/networking/tls-example-ingress.yaml" %}}
+{{% code_sample file="service/networking/tls-example-ingress.yaml" %}}
 
 {{< note >}}
 There is a gap between TLS features supported by various Ingress

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -83,7 +83,7 @@ reference for a full definition of the resource.
 
 An example NetworkPolicy might look like this:
 
-{{% code file="service/networking/networkpolicy.yaml" %}}
+{{% code_sample file="service/networking/networkpolicy.yaml" %}}
 
 {{< note >}}
 POSTing this to the API server for your cluster will have no effect unless your chosen networking
@@ -212,7 +212,7 @@ in that namespace.
 You can create a "default" ingress isolation policy for a namespace by creating a NetworkPolicy
 that selects all pods but does not allow any ingress traffic to those pods.
 
-{{% code file="service/networking/network-policy-default-deny-ingress.yaml" %}}
+{{% code_sample file="service/networking/network-policy-default-deny-ingress.yaml" %}}
 
 This ensures that even pods that aren't selected by any other NetworkPolicy will still be isolated
 for ingress. This policy does not affect isolation for egress from any pod.
@@ -222,7 +222,7 @@ for ingress. This policy does not affect isolation for egress from any pod.
 If you want to allow all incoming connections to all pods in a namespace, you can create a policy
 that explicitly allows that.
 
-{{% code file="service/networking/network-policy-allow-all-ingress.yaml" %}}
+{{% code_sample file="service/networking/network-policy-allow-all-ingress.yaml" %}}
 
 With this policy in place, no additional policy or policies can cause any incoming connection to
 those pods to be denied.  This policy has no effect on isolation for egress from any pod.
@@ -232,7 +232,7 @@ those pods to be denied.  This policy has no effect on isolation for egress from
 You can create a "default" egress isolation policy for a namespace by creating a NetworkPolicy
 that selects all pods but does not allow any egress traffic from those pods.
 
-{{% code file="service/networking/network-policy-default-deny-egress.yaml" %}}
+{{% code_sample file="service/networking/network-policy-default-deny-egress.yaml" %}}
 
 This ensures that even pods that aren't selected by any other NetworkPolicy will not be allowed
 egress traffic. This policy does not change the ingress isolation behavior of any pod.
@@ -242,7 +242,7 @@ egress traffic. This policy does not change the ingress isolation behavior of an
 If you want to allow all connections from all pods in a namespace, you can create a policy that
 explicitly allows all outgoing connections from pods in that namespace.
 
-{{% code file="service/networking/network-policy-allow-all-egress.yaml" %}}
+{{% code_sample file="service/networking/network-policy-allow-all-egress.yaml" %}}
 
 With this policy in place, no additional policy or policies can cause any outgoing connection from
 those pods to be denied.  This policy has no effect on isolation for ingress to any pod.
@@ -252,7 +252,7 @@ those pods to be denied.  This policy has no effect on isolation for ingress to 
 You can create a "default" policy for a namespace which prevents all ingress AND egress traffic by
 creating the following NetworkPolicy in that namespace.
 
-{{% code file="service/networking/network-policy-default-deny-all.yaml" %}}
+{{% code_sample file="service/networking/network-policy-default-deny-all.yaml" %}}
 
 This ensures that even pods that aren't selected by any other NetworkPolicy will not be allowed
 ingress or egress traffic.
@@ -280,7 +280,7 @@ When writing a NetworkPolicy, you can target a range of ports instead of a singl
 
 This is achievable with the usage of the `endPort` field, as the following example:
 
-{{% code file="service/networking/networkpolicy-multiport-egress.yaml" %}}
+{{% code_sample file="service/networking/networkpolicy-multiport-egress.yaml" %}}
 
 The above rule allows any Pod with label `role=db` on the namespace `default` to communicate 
 with any IP within the range `10.0.0.0/24` over TCP, provided that the target 

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -30,11 +30,11 @@ see the [all-in-one volume](https://git.k8s.io/design-proposals-archive/node/all
 
 ### Example configuration with a secret, a downwardAPI, and a configMap {#example-configuration-secret-downwardapi-configmap}
 
-{{% code file="pods/storage/projected-secret-downwardapi-configmap.yaml" %}}
+{{% code_sample file="pods/storage/projected-secret-downwardapi-configmap.yaml" %}}
 
 ### Example configuration: secrets with a non-default permission mode set {#example-configuration-secrets-nondefault-permission-mode}
 
-{{% code file="pods/storage/projected-secrets-nondefault-permission-mode.yaml" %}}
+{{% code_sample file="pods/storage/projected-secrets-nondefault-permission-mode.yaml" %}}
 
 Each projected volume source is listed in the spec under `sources`. The
 parameters are nearly the same with two exceptions:
@@ -49,7 +49,7 @@ parameters are nearly the same with two exceptions:
 You can inject the token for the current [service account](/docs/reference/access-authn-authz/authentication/#service-account-tokens)
 into a Pod at a specified path. For example:
 
-{{% code file="pods/storage/projected-service-account-token.yaml" %}}
+{{% code_sample file="pods/storage/projected-service-account-token.yaml" %}}
 
 The example Pod has a projected volume containing the injected service account
 token. Containers in this Pod can use that token to access the Kubernetes API

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -41,7 +41,7 @@ length of a Job name is no more than 63 characters.
 
 This example CronJob manifest prints the current time and a hello message every minute:
 
-{{% code file="application/job/cronjob.yaml" %}}
+{{% code_sample file="application/job/cronjob.yaml" %}}
 
 ([Running Automated Tasks with a CronJob](/docs/tasks/job/automated-tasks-with-cron-jobs/)
 takes you through this example in more detail).

--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -38,7 +38,7 @@ different flags and/or different memory and cpu requests for different hardware 
 You can describe a DaemonSet in a YAML file. For example, the `daemonset.yaml` file below
 describes a DaemonSet that runs the fluentd-elasticsearch Docker image:
 
-{{% code file="controllers/daemonset.yaml" %}}
+{{% code_sample file="controllers/daemonset.yaml" %}}
 
 Create a DaemonSet based on the YAML file:
 

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -42,7 +42,7 @@ The following are typical use cases for Deployments:
 
 The following is an example of a Deployment. It creates a ReplicaSet to bring up three `nginx` Pods:
 
-{{% code file="controllers/nginx-deployment.yaml" %}}
+{{% code_sample file="controllers/nginx-deployment.yaml" %}}
 
 In this example:
 

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -39,7 +39,7 @@ see [CronJob](/docs/concepts/workloads/controllers/cron-jobs/).
 Here is an example Job config. It computes π to 2000 places and prints it out.
 It takes around 10s to complete.
 
-{{% code file="controllers/job.yaml" %}}
+{{% code_sample file="controllers/job.yaml" %}}
 
 You can run the example with this command:
 
@@ -416,7 +416,7 @@ controller, by setting the Failed condition in the Job status.
 
 Here is an example manifest for a Job that defines a `backoffLimitPerIndex`:
 
-{{< codenew file="/controllers/job-backoff-limit-per-index-example.yaml" >}}
+{{< code_sample file="/controllers/job-backoff-limit-per-index-example.yaml" >}}
 
 In the example above, the Job controller allows for one restart for each
 of the indexes. When the total number of failed indexes exceeds 5, then
@@ -483,7 +483,7 @@ container exit codes and the Pod conditions.
 
 Here is a manifest for a Job that defines a `podFailurePolicy`:
 
-{{% code file="/controllers/job-pod-failure-policy-example.yaml" %}}
+{{% code_sample file="/controllers/job-pod-failure-policy-example.yaml" %}}
 
 In the example above, the first rule of the Pod failure policy specifies that
 the Job should be marked failed if the `main` container fails with the 42 exit

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -56,7 +56,7 @@ use a Deployment instead, and define your application in the spec section.
 
 ## Example
 
-{{% code file="controllers/frontend.yaml" %}}
+{{% code_sample file="controllers/frontend.yaml" %}}
 
 Saving this manifest into `frontend.yaml` and submitting it to a Kubernetes cluster will
 create the defined ReplicaSet and the Pods that it manages.
@@ -166,7 +166,7 @@ to owning Pods specified by its template-- it can acquire other Pods in the mann
 
 Take the previous frontend ReplicaSet example, and the Pods specified in the following manifest:
 
-{{% code file="pods/pod-rs.yaml" %}}
+{{% code_sample file="pods/pod-rs.yaml" %}}
 
 As those Pods do not have a Controller (or any object) as their owner reference and match the selector of the frontend
 ReplicaSet, they will immediately be acquired by it.
@@ -381,7 +381,7 @@ A ReplicaSet can also be a target for
 a ReplicaSet can be auto-scaled by an HPA. Here is an example HPA targeting
 the ReplicaSet we created in the previous example.
 
-{{% code file="controllers/hpa-rs.yaml" %}}
+{{% code_sample file="controllers/hpa-rs.yaml" %}}
 
 Saving this manifest into `hpa-rs.yaml` and submitting it to a Kubernetes cluster should
 create the defined HPA that autoscales the target ReplicaSet depending on the CPU usage

--- a/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -44,7 +44,7 @@ service, such as web servers.
 
 This example ReplicationController config runs three copies of the nginx web server.
 
-{{% code file="controllers/replication.yaml" %}}
+{{% code_sample file="controllers/replication.yaml" %}}
 
 Run the example job by downloading the example file and then running this command:
 

--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -43,7 +43,7 @@ A Pod is similar to a set of containers with shared namespaces and shared filesy
 
 The following is an example of a Pod which consists of a container running the image `nginx:1.14.2`.
 
-{{% code file="pods/simple-pod.yaml" %}}
+{{% code_sample file="pods/simple-pod.yaml" %}}
 
 To create the Pod shown above, run the following command:
 ```shell

--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -321,7 +321,7 @@ robust way, as the kubelet always restarts a sidecar container if it fails.
 
 Here's an example of a Deployment with two containers, one of which is a sidecar:
 
-{{% codenew language="yaml" file="application/deployment-sidecar.yaml" %}}
+{{% code_sample language="yaml" file="application/deployment-sidecar.yaml" %}}
 
 This feature is also useful for running Jobs with sidecars, as the sidecar
 container will not prevent the Job from completing after the main container
@@ -329,7 +329,7 @@ has finished.
 
 Here's an example of a Job with two containers, one of which is a sidecar:
 
-{{% codenew language="yaml" file="application/job/job-sidecar.yaml" %}}
+{{% code_sample language="yaml" file="application/job/job-sidecar.yaml" %}}
 
 #### Resource sharing within containers
 

--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -273,33 +273,33 @@ Renders to:
 
 ## Source code files
 
-You can use the `{{%/* code */%}}` shortcode to embed the contents of file in a code block to allow users to download or copy its content to their clipboard. This shortcode is used when the contents of the sample file is generic and reusable, and you want the users to try it out themselves.
+You can use the `{{%/* code_sample */%}}` shortcode to embed the contents of file in a code block to allow users to download or copy its content to their clipboard. This shortcode is used when the contents of the sample file is generic and reusable, and you want the users to try it out themselves.
 
 This shortcode takes in two named parameters: `language` and `file`. The mandatory parameter `file` is used to specify the path to the file being displayed. The optional parameter `language` is used to specify the programming language of the file. If the `language` parameter is not provided, the shortcode will attempt to guess the language based on the file extension.
 
 For example:
 
 ```none
-{{%/* code language="yaml" file="application/deployment-scale.yaml" */%}}
+{{%/* code_sample language="yaml" file="application/deployment-scale.yaml" */%}}
 ```
 
 The output is:
 
-{{% code language="yaml" file="application/deployment-scale.yaml" %}}
+{{% code_sample language="yaml" file="application/deployment-scale.yaml" %}}
 
 When adding a new sample file, such as a YAML file, create the file in one of the `<LANG>/examples/` subdirectories where `<LANG>` is the language for the page. In the markdown of your page, use the `code` shortcode:
 
 ```none
-{{%/* code file="<RELATIVE-PATH>/example-yaml>" */%}}
+{{%/* code_sample file="<RELATIVE-PATH>/example-yaml>" */%}}
 ```
 where `<RELATIVE-PATH>` is the path to the sample file to include, relative to the `examples` directory. The following shortcode references a YAML file located at `/content/en/examples/configmap/configmaps.yaml`.
 
 ```none
-{{%/* code file="configmap/configmaps.yaml" */%}}
+{{%/* code_sample file="configmap/configmaps.yaml" */%}}
 ```
 
-The legacy `{{%/* codenew */%}}` shortcode is being replaced by `{{%/* code */%}}`.
-Use `{{%/* code */%}}` in new documentation.
+The legacy `{{%/* codenew */%}}` shortcode is being replaced by `{{%/* code_sample */%}}`.
+Use `{{%/* code_sample */%}}` (not `{{%/* codenew */%}}` or `{{%/* code */%}}`) in new documentation.
 
 ## Third party content marker
 

--- a/content/en/docs/contribute/style/write-new-topic.md
+++ b/content/en/docs/contribute/style/write-new-topic.md
@@ -121,17 +121,17 @@ reusable, and you want the reader to try it out themselves.
 
 When adding a new standalone sample file, such as a YAML file, place the code in
 one of the `<LANG>/examples/` subdirectories where `<LANG>` is the language for
-the topic. In your topic file, use the `codenew` shortcode:
+the topic. In your topic file, use the `code_sample` shortcode:
 
 ```none
-{{%/* codenew file="<RELPATH>/my-example-yaml>" */%}}
+{{%/* code_sample file="<RELPATH>/my-example-yaml>" */%}}
 ```
 where `<RELPATH>` is the path to the file to include, relative to the
 `examples` directory. The following Hugo shortcode references a YAML
 file located at `/content/en/examples/pods/storage/gce-volume.yaml`.
 
 ```none
-{{%/* codenew file="pods/storage/gce-volume.yaml" */%}}
+{{%/* code_sample file="pods/storage/gce-volume.yaml" */%}}
 ```
 
 ## Showing how to create an API object from a configuration file

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -78,7 +78,7 @@ To allow creating a CertificateSigningRequest and retrieving any CertificateSign
 
 For example:
 
-{{% code file="access/certificate-signing-request/clusterrole-create.yaml" %}}
+{{% code_sample file="access/certificate-signing-request/clusterrole-create.yaml" %}}
 
 To allow approving a CertificateSigningRequest:
 
@@ -88,7 +88,7 @@ To allow approving a CertificateSigningRequest:
 
 For example:
 
-{{% code file="access/certificate-signing-request/clusterrole-approve.yaml" %}}
+{{% code_sample file="access/certificate-signing-request/clusterrole-approve.yaml" %}}
 
 To allow signing a CertificateSigningRequest:
 
@@ -96,7 +96,7 @@ To allow signing a CertificateSigningRequest:
 * Verbs: `update`, group: `certificates.k8s.io`, resource: `certificatesigningrequests/status`
 * Verbs: `sign`, group: `certificates.k8s.io`, resource: `signers`, resourceName: `<signerNameDomain>/<signerNamePath>` or `<signerNameDomain>/*`
 
-{{% code file="access/certificate-signing-request/clusterrole-sign.yaml" %}}
+{{% code_sample file="access/certificate-signing-request/clusterrole-sign.yaml" %}}
 
 
 ## Signers

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -1240,7 +1240,7 @@ guidance for restricting this access in existing clusters.
 If you want new clusters to retain this level of access in the aggregated roles,
 you can create the following ClusterRole:
 
-{{% code file="access/endpoints-aggregated.yaml" %}}
+{{% code_sample file="access/endpoints-aggregated.yaml" %}}
 
 ## Upgrading from ABAC
 

--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -265,7 +265,7 @@ updates that Secret with that generated token data.
 
 Here is a sample manifest for such a Secret:
 
-{{% code file="secret/serviceaccount/mysecretname.yaml" %}}
+{{% code_sample file="secret/serviceaccount/mysecretname.yaml" %}}
 
 To create a Secret based on this example, run:
 

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -61,7 +61,7 @@ with great caution. The following describes how to quickly experiment with Valid
 
 The following is an example of a ValidatingAdmissionPolicy.
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/basic-example-policy.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/basic-example-policy.yaml" %}}
 
 `spec.validations` contains CEL expressions which use the [Common Expression Language (CEL)](https://github.com/google/cel-spec)
 to validate the request. If an expression evaluates to false, the validation check is enforced
@@ -70,7 +70,7 @@ according to the `spec.failurePolicy` field.
 To configure a validating admission policy for use in a cluster, a binding is required.
 The following is an example of a ValidatingAdmissionPolicyBinding.:
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/basic-example-binding.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/basic-example-binding.yaml" %}}
 
 When trying to create a deployment with replicas set not satisfying the validation expression, an
 error will return containing message:
@@ -121,7 +121,7 @@ and then a policy binding ties a policy by name (via policyName) to a particular
 If parameter configuration is needed, the following is an example of a ValidatingAdmissionPolicy
 with parameter configuration.
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/policy-with-param.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/policy-with-param.yaml" %}}
 
 The `spec.paramKind` field of the ValidatingAdmissionPolicy specifies the kind of resources used
 to parameterize this policy. For this example, it is configured by ReplicaLimit custom resources. 
@@ -140,28 +140,28 @@ are created. The following is an example of a ValidatingAdmissionPolicyBinding
 that uses a **cluster-wide** param - the same param will be used to validate
 every resource request that matches the binding:
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/binding-with-param.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/binding-with-param.yaml" %}}
 
 Notice this binding applies a parameter to the policy for all resources which
 are in the `test` environment.
 
 The parameter resource could be as following:
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/replicalimit-param.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/replicalimit-param.yaml" %}}
 
 This policy parameter resource limits deployments to a max of 3 replicas.
 
 An admission policy may have multiple bindings. To bind all other environments
 to have a maxReplicas limit of 100, create another ValidatingAdmissionPolicyBinding:
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/binding-with-param-prod.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/binding-with-param-prod.yaml" %}}
 
 Notice this binding applies a different parameter to resources which
 are not in the `test` environment.
 
 And have a parameter resource:
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/replicalimit-param-prod.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/replicalimit-param-prod.yaml" %}}
 
 For each admission request, the API server evaluates CEL expressions of each 
 (policy, binding, param) combination that match the request. For a request
@@ -261,7 +261,7 @@ admission policy are handled. Allowed values are `Ignore` or `Fail`.
 
 Note that the `failurePolicy` is defined inside `ValidatingAdmissionPolicy`:
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/failure-policy-ignore.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/failure-policy-ignore.yaml" %}}
 
 ### Validation Expression
 
@@ -360,7 +360,7 @@ resource to be evaluated.
 
 Here is an example illustrating a few different uses for match conditions:
 
-{{% code file="access/validating-admission-policy-match-conditions.yaml" %}}
+{{% code_sample file="access/validating-admission-policy-match-conditions.yaml" %}}
 
 Match conditions have access to the same CEL variables as validation expressions.
 
@@ -378,7 +378,7 @@ the request is determined as follows:
 
 For example, here is an admission policy with an audit annotation:
 
-{{% code file="access/validating-admission-policy-audit-annotation.yaml" %}}
+{{% code_sample file="access/validating-admission-policy-audit-annotation.yaml" %}}
 
 When an API request is validated with this admission policy, the resulting audit event will look like:
 
@@ -415,7 +415,7 @@ Unlike validations, message expression must evaluate to a string.
 For example, to better inform the user of the reason of denial when the policy refers to a parameter,
 we can have the following validation:
 
-{{% code file="access/deployment-replicas-policy.yaml" %}}
+{{% code_sample file="access/deployment-replicas-policy.yaml" %}}
 
 After creating a params object that limits the replicas to 3 and setting up the binding,
 when we try to create a deployment with 5 replicas, we will receive the following message.
@@ -445,7 +445,7 @@ and an empty `status.typeChecking` means that no errors were detected.
 
 For example, given the following policy definition:
 
-{{< codenew language="yaml" file="validatingadmissionpolicy/typechecking.yaml" >}}
+{{< code_sample language="yaml" file="validatingadmissionpolicy/typechecking.yaml" >}}
 
 The status will yield the following information:
 
@@ -463,7 +463,7 @@ status:
 If multiple resources are matched in `spec.matchConstraints`, all of matched resources will be checked against.
 For example, the following policy definition 
 
-{{% codenew language="yaml" file="validatingadmissionpolicy/typechecking-multiple-match.yaml" %}}
+{{% code_sample language="yaml" file="validatingadmissionpolicy/typechecking-multiple-match.yaml" %}}
 
 
 will have multiple types and type checking result of each type in the warning message.
@@ -516,7 +516,7 @@ This ordering prevents circular references.
 
 The following is a more complex example of enforcing that image repo names match the environment defined in its namespace.
 
-{{< codenew file="access/image-matches-namespace-environment.policy.yaml" >}}
+{{< code_sample file="access/image-matches-namespace-environment.policy.yaml" >}}
 
 With the policy bound to the namespace `default`, which is labeled `environment: prod`,
 the following attempt to create a deployment would be rejected.

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -409,7 +409,7 @@ resource and its accompanying controller.
 
 Say a user has defined Deployment with `replicas` set to the desired value:
 
-{{% code file="application/ssa/nginx-deployment.yaml" %}}
+{{% code_sample file="application/ssa/nginx-deployment.yaml" %}}
 
 And the user has created the Deployment using Server-Side Apply, like so:
 
@@ -476,7 +476,7 @@ process than it sometimes does.
 
 At this point the user may remove the `replicas` field from their manifest:
 
-{{% code file="application/ssa/nginx-deployment-no-replicas.yaml" %}}
+{{% code_sample file="application/ssa/nginx-deployment-no-replicas.yaml" %}}
 
 Note that whenever the HPA controller sets the `replicas` field to a new value,
 the temporary field manager will no longer own any fields and will be

--- a/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -23,7 +23,7 @@ In this exercise, you create a Pod that runs two Containers. The two containers
 share a Volume that they can use to communicate. Here is the configuration file
 for the Pod:
 
-{{% code file="pods/two-container-pod.yaml" %}}
+{{% code_sample file="pods/two-container-pod.yaml" %}}
 
 In the configuration file, you can see that the Pod has a Volume named
 `shared-data`.

--- a/content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md
+++ b/content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md
@@ -36,7 +36,7 @@ require a supported environment. If your environment does not support this, you 
 The backend is a simple hello greeter microservice. Here is the configuration
 file for the backend Deployment:
 
-{{% code file="service/access/backend-deployment.yaml" %}}
+{{% code_sample file="service/access/backend-deployment.yaml" %}}
 
 Create the backend Deployment:
 
@@ -97,7 +97,7 @@ the Pods that it routes traffic to.
 
 First, explore the Service configuration file:
 
-{{% code file="service/access/backend-service.yaml" %}}
+{{% code_sample file="service/access/backend-service.yaml" %}}
 
 In the configuration file, you can see that the Service, named `hello` routes 
 traffic to Pods that have the labels `app: hello` and `tier: backend`.
@@ -125,7 +125,7 @@ configuration file.
 The Pods in the frontend Deployment run a nginx image that is configured
 to proxy requests to the `hello` backend Service. Here is the nginx configuration file:
 
-{{% code file="service/access/frontend-nginx.conf" %}}
+{{% code_sample file="service/access/frontend-nginx.conf" %}}
 
 Similar to the backend, the frontend has a Deployment and a Service. An important
 difference to notice between the backend and frontend services, is that the
@@ -133,9 +133,9 @@ configuration for the frontend Service has `type: LoadBalancer`, which means tha
 the Service uses a load balancer provisioned by your cloud provider and will be
 accessible from outside the cluster.
 
-{{% code file="service/access/frontend-service.yaml" %}}
+{{% code_sample file="service/access/frontend-service.yaml" %}}
 
-{{% code file="service/access/frontend-deployment.yaml" %}}
+{{% code_sample file="service/access/frontend-deployment.yaml" %}}
 
 Create the frontend Deployment and Service:
 

--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -126,7 +126,7 @@ The following manifest defines an Ingress that sends traffic to your Service via
 
 1. Create `example-ingress.yaml` from the following file:
 
-   {{% code file="service/networking/example-ingress.yaml" %}}
+   {{% code_sample file="service/networking/example-ingress.yaml" %}}
 
 1. Create the Ingress object by running the following command:
 

--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -26,7 +26,7 @@ provides load balancing for an application that has two running instances.
 
 Here is the configuration file for the application Deployment:
 
-{{% code file="service/access/hello-application.yaml" %}}
+{{% code_sample file="service/access/hello-application.yaml" %}}
 
 1. Run a Hello World application in your cluster:
    Create the application Deployment using the file above:

--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -87,7 +87,7 @@ remote file exists
 
 To limit the access to the `nginx` service so that only Pods with the label `access: true` can query it, create a NetworkPolicy object as follows:
 
-{{% code file="service/networking/nginx-policy.yaml" %}}
+{{% code_sample file="service/networking/nginx-policy.yaml" %}}
 
 The name of a NetworkPolicy object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).

--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -24,7 +24,7 @@ kube-dns.
 
 ### Create a simple Pod to use as a test environment
 
-{{% code file="admin/dns/dnsutils.yaml" %}}
+{{% code_sample file="admin/dns/dnsutils.yaml" %}}
 
 {{< note >}}
 This example creates a pod in the `default` namespace. DNS name resolution for 

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -86,7 +86,7 @@ container based on the `cluster-proportional-autoscaler-amd64` image.
 
 Create a file named `dns-horizontal-autoscaler.yaml` with this content:
 
-{{% code file="admin/dns/dns-horizontal-autoscaler.yaml" %}}
+{{% code_sample file="admin/dns/dns-horizontal-autoscaler.yaml" %}}
 
 In the file, replace `<SCALE_TARGET>` with your scale target.
 

--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
@@ -47,7 +47,7 @@ kubectl create namespace constraints-cpu-example
 
 Here's a manifest for an example {{< glossary_tooltip text="LimitRange" term_id="limitrange" >}}:
 
-{{% code file="admin/resource/cpu-constraints.yaml" %}}
+{{% code_sample file="admin/resource/cpu-constraints.yaml" %}}
 
 Create the LimitRange:
 
@@ -98,7 +98,7 @@ Here's a manifest for a Pod that has one container. The container manifest
 specifies a CPU request of 500 millicpu and a CPU limit of 800 millicpu. These satisfy the
 minimum and maximum CPU constraints imposed by the LimitRange for this namespace.
 
-{{% code file="admin/resource/cpu-constraints-pod.yaml" %}}
+{{% code_sample file="admin/resource/cpu-constraints-pod.yaml" %}}
 
 Create the Pod:
 
@@ -140,7 +140,7 @@ kubectl delete pod constraints-cpu-demo --namespace=constraints-cpu-example
 Here's a manifest for a Pod that has one container. The container specifies a
 CPU request of 500 millicpu and a cpu limit of 1.5 cpu.
 
-{{% code file="admin/resource/cpu-constraints-pod-2.yaml" %}}
+{{% code_sample file="admin/resource/cpu-constraints-pod-2.yaml" %}}
 
 Attempt to create the Pod:
 
@@ -161,7 +161,7 @@ pods "constraints-cpu-demo-2" is forbidden: maximum cpu usage per Container is 8
 Here's a manifest for a Pod that has one container. The container specifies a
 CPU request of 100 millicpu and a CPU limit of 800 millicpu.
 
-{{% code file="admin/resource/cpu-constraints-pod-3.yaml" %}}
+{{% code_sample file="admin/resource/cpu-constraints-pod-3.yaml" %}}
 
 Attempt to create the Pod:
 
@@ -183,7 +183,7 @@ pods "constraints-cpu-demo-3" is forbidden: minimum cpu usage per Container is 2
 Here's a manifest for a Pod that has one container. The container does not
 specify a CPU request, nor does it specify a CPU limit.
 
-{{% code file="admin/resource/cpu-constraints-pod-4.yaml" %}}
+{{% code_sample file="admin/resource/cpu-constraints-pod-4.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -49,7 +49,7 @@ kubectl create namespace default-cpu-example
 Here's a manifest for an example {{< glossary_tooltip text="LimitRange" term_id="limitrange" >}}.
 The manifest specifies a default CPU request and a default CPU limit.
 
-{{% code file="admin/resource/cpu-defaults.yaml" %}}
+{{% code_sample file="admin/resource/cpu-defaults.yaml" %}}
 
 Create the LimitRange in the default-cpu-example namespace:
 
@@ -65,7 +65,7 @@ CPU limit of 1.
 Here's a manifest for a Pod that has one container. The container
 does not specify a CPU request and limit.
 
-{{% code file="admin/resource/cpu-defaults-pod.yaml" %}}
+{{% code_sample file="admin/resource/cpu-defaults-pod.yaml" %}}
 
 Create the Pod.
 
@@ -100,7 +100,7 @@ containers:
 Here's a manifest for a Pod that has one container. The container
 specifies a CPU limit, but not a request:
 
-{{% code file="admin/resource/cpu-defaults-pod-2.yaml" %}}
+{{% code_sample file="admin/resource/cpu-defaults-pod-2.yaml" %}}
 
 Create the Pod:
 
@@ -132,7 +132,7 @@ resources:
 Here's an example manifest for a Pod that has one container. The container
 specifies a CPU request, but not a limit:
 
-{{% code file="admin/resource/cpu-defaults-pod-3.yaml" %}}
+{{% code_sample file="admin/resource/cpu-defaults-pod-3.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
@@ -43,7 +43,7 @@ kubectl create namespace constraints-mem-example
 
 Here's an example manifest for a LimitRange:
 
-{{% code file="admin/resource/memory-constraints.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints.yaml" %}}
 
 Create the LimitRange:
 
@@ -89,7 +89,7 @@ Here's a manifest for a Pod that has one container. Within the Pod spec, the sol
 container specifies a memory request of 600 MiB and a memory limit of 800 MiB. These satisfy the
 minimum and maximum memory constraints imposed by the LimitRange.
 
-{{% code file="admin/resource/memory-constraints-pod.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod.yaml" %}}
 
 Create the Pod:
 
@@ -132,7 +132,7 @@ kubectl delete pod constraints-mem-demo --namespace=constraints-mem-example
 Here's a manifest for a Pod that has one container. The container specifies a
 memory request of 800 MiB and a memory limit of 1.5 GiB.
 
-{{% code file="admin/resource/memory-constraints-pod-2.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod-2.yaml" %}}
 
 Attempt to create the Pod:
 
@@ -153,7 +153,7 @@ pods "constraints-mem-demo-2" is forbidden: maximum memory usage per Container i
 Here's a manifest for a Pod that has one container. That container specifies a
 memory request of 100 MiB and a memory limit of 800 MiB.
 
-{{% code file="admin/resource/memory-constraints-pod-3.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod-3.yaml" %}}
 
 Attempt to create the Pod:
 
@@ -174,7 +174,7 @@ pods "constraints-mem-demo-3" is forbidden: minimum memory usage per Container i
 Here's a manifest for a Pod that has one container. The container does not
 specify a memory request, and it does not specify a memory limit.
 
-{{% code file="admin/resource/memory-constraints-pod-4.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod-4.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -53,7 +53,7 @@ Here's a manifest for an example {{< glossary_tooltip text="LimitRange" term_id=
 The manifest specifies a default memory
 request and a default memory limit.
 
-{{% code file="admin/resource/memory-defaults.yaml" %}}
+{{% code_sample file="admin/resource/memory-defaults.yaml" %}}
 
 Create the LimitRange in the default-mem-example namespace:
 
@@ -70,7 +70,7 @@ applies default values: a memory request of 256MiB and a memory limit of 512MiB.
 Here's an example manifest for a Pod that has one container. The container
 does not specify a memory request and limit.
 
-{{% code file="admin/resource/memory-defaults-pod.yaml" %}}
+{{% code_sample file="admin/resource/memory-defaults-pod.yaml" %}}
 
 Create the Pod.
 
@@ -110,7 +110,7 @@ kubectl delete pod default-mem-demo --namespace=default-mem-example
 Here's a manifest for a Pod that has one container. The container
 specifies a memory limit, but not a request:
 
-{{% code file="admin/resource/memory-defaults-pod-2.yaml" %}}
+{{% code_sample file="admin/resource/memory-defaults-pod-2.yaml" %}}
 
 Create the Pod:
 
@@ -141,7 +141,7 @@ resources:
 Here's a manifest for a Pod that has one container. The container
 specifies a memory request, but not a limit:
 
-{{% code file="admin/resource/memory-defaults-pod-3.yaml" %}}
+{{% code_sample file="admin/resource/memory-defaults-pod-3.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace.md
@@ -42,7 +42,7 @@ kubectl create namespace quota-mem-cpu-example
 
 Here is a manifest for an example ResourceQuota:
 
-{{% code file="admin/resource/quota-mem-cpu.yaml" %}}
+{{% code_sample file="admin/resource/quota-mem-cpu.yaml" %}}
 
 Create the ResourceQuota:
 
@@ -71,7 +71,7 @@ to learn what Kubernetes means by “1 CPU”.
 
 Here is a manifest for an example Pod:
 
-{{% code file="admin/resource/quota-mem-cpu-pod.yaml" %}}
+{{% code_sample file="admin/resource/quota-mem-cpu-pod.yaml" %}}
 
 
 Create the Pod:
@@ -121,7 +121,7 @@ kubectl get resourcequota mem-cpu-demo --namespace=quota-mem-cpu-example -o json
 
 Here is a manifest for a second Pod:
 
-{{% code file="admin/resource/quota-mem-cpu-pod-2.yaml" %}}
+{{% code_sample file="admin/resource/quota-mem-cpu-pod-2.yaml" %}}
 
 In the manifest, you can see that the Pod has a memory request of 700 MiB.
 Notice that the sum of the used memory request and this new memory

--- a/content/en/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace.md
@@ -39,7 +39,7 @@ kubectl create namespace quota-pod-example
 
 Here is an example manifest for a ResourceQuota:
 
-{{% code file="admin/resource/quota-pod.yaml" %}}
+{{% code_sample file="admin/resource/quota-pod.yaml" %}}
 
 Create the ResourceQuota:
 
@@ -69,7 +69,7 @@ status:
 
 Here is an example manifest for a {{< glossary_tooltip term_id="deployment" >}}:
 
-{{% code file="admin/resource/quota-pod-deployment.yaml" %}}
+{{% code_sample file="admin/resource/quota-pod-deployment.yaml" %}}
 
 In that manifest, `replicas: 3` tells Kubernetes to attempt to create three new Pods, all
 running the same application.

--- a/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -73,7 +73,7 @@ Let's create two new namespaces to hold our work.
 
 Use the file [`namespace-dev.yaml`](/examples/admin/namespace-dev.yaml) which describes a `development` namespace:
 
-{{% code language="yaml" file="admin/namespace-dev.yaml" %}}
+{{% code_sample language="yaml" file="admin/namespace-dev.yaml" %}}
 
 Create the `development` namespace using kubectl.
 
@@ -83,7 +83,7 @@ kubectl create -f https://k8s.io/examples/admin/namespace-dev.yaml
 
 Save the following contents into file [`namespace-prod.yaml`](/examples/admin/namespace-prod.yaml) which describes a `production` namespace:
 
-{{% code language="yaml" file="admin/namespace-prod.yaml" %}}
+{{% code_sample language="yaml" file="admin/namespace-prod.yaml" %}}
 
 And then let's create the `production` namespace using kubectl.
 
@@ -226,7 +226,7 @@ At this point, all requests we make to the Kubernetes cluster from the command l
 
 Let's create some contents.
 
-{{% code file="admin/snowflake-deployment.yaml" %}}
+{{% code_sample file="admin/snowflake-deployment.yaml" %}}
 
 Apply the manifest to create a Deployment 
 

--- a/content/en/docs/tasks/administer-cluster/quota-api-object.md
+++ b/content/en/docs/tasks/administer-cluster/quota-api-object.md
@@ -40,7 +40,7 @@ kubectl create namespace quota-object-example
 
 Here is the configuration file for a ResourceQuota object:
 
-{{% code file="admin/resource/quota-objects.yaml" %}}
+{{% code_sample file="admin/resource/quota-objects.yaml" %}}
 
 Create the ResourceQuota:
 
@@ -74,7 +74,7 @@ status:
 
 Here is the configuration file for a PersistentVolumeClaim object:
 
-{{% code file="admin/resource/quota-objects-pvc.yaml" %}}
+{{% code_sample file="admin/resource/quota-objects-pvc.yaml" %}}
 
 Create the PersistentVolumeClaim:
 
@@ -99,7 +99,7 @@ pvc-quota-demo   Pending
 
 Here is the configuration file for a second PersistentVolumeClaim:
 
-{{% code file="admin/resource/quota-objects-pvc-2.yaml" %}}
+{{% code_sample file="admin/resource/quota-objects-pvc-2.yaml" %}}
 
 Attempt to create the second PersistentVolumeClaim:
 

--- a/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -92,7 +92,7 @@ projects in repositories maintained by cloud vendors or by SIGs.
 For providers already in Kubernetes core, you can run the in-tree cloud controller
 manager as a DaemonSet in your cluster, use the following as a guideline:
 
-{{% code file="admin/cloud/ccm-example.yaml" %}}
+{{% code_sample file="admin/cloud/ccm-example.yaml" %}}
 
 ## Limitations
 

--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -71,7 +71,7 @@ in the Container resource manifest. To specify a CPU limit, include `resources:l
 In this exercise, you create a Pod that has one container. The container has a request
 of 0.5 CPU and a limit of 1 CPU. Here is the configuration file for the Pod:
 
-{{% code file="pods/resource/cpu-request-limit.yaml" %}}
+{{% code_sample file="pods/resource/cpu-request-limit.yaml" %}}
 
 The `args` section of the configuration file provides arguments for the container when it starts.
 The `-cpus "2"` argument tells the Container to attempt to use 2 CPUs.
@@ -163,7 +163,7 @@ the capacity of any Node in your cluster. Here is the configuration file for a P
 that has one Container. The Container requests 100 CPU, which is likely to exceed the
 capacity of any Node in your cluster.
 
-{{% code file="pods/resource/cpu-request-limit-2.yaml" %}}
+{{% code_sample file="pods/resource/cpu-request-limit-2.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -69,7 +69,7 @@ In this exercise, you create a Pod that has one Container. The Container has a m
 request of 100 MiB and a memory limit of 200 MiB. Here's the configuration file
 for the Pod:
 
-{{% code file="pods/resource/memory-request-limit.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit.yaml" %}}
 
 The `args` section in the configuration file provides arguments for the Container when it starts.
 The `"--vm-bytes", "150M"` arguments tell the Container to attempt to allocate 150 MiB of memory.
@@ -139,7 +139,7 @@ In this exercise, you create a Pod that attempts to allocate more memory than it
 Here is the configuration file for a Pod that has one Container with a
 memory request of 50 MiB and a memory limit of 100 MiB:
 
-{{% code file="pods/resource/memory-request-limit-2.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit-2.yaml" %}}
 
 In the `args` section of the configuration file, you can see that the Container
 will attempt to allocate 250 MiB of memory, which is well above the 100 MiB limit.
@@ -248,7 +248,7 @@ capacity of any Node in your cluster. Here is the configuration file for a Pod t
 Container with a request for 1000 GiB of memory, which likely exceeds the capacity
 of any Node in your cluster.
 
-{{% code file="pods/resource/memory-request-limit-3.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit-3.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity.md
@@ -64,7 +64,7 @@ Kubernetes cluster.
 This manifest describes a Pod that has a `requiredDuringSchedulingIgnoredDuringExecution` node affinity,`disktype: ssd`. 
 This means that the pod will get scheduled only on a node that has a `disktype=ssd` label. 
 
-{{% code file="pods/pod-nginx-required-affinity.yaml" %}}
+{{% code_sample file="pods/pod-nginx-required-affinity.yaml" %}}
 
 1. Apply the manifest to create a Pod that is scheduled onto your
    chosen node:
@@ -91,7 +91,7 @@ This means that the pod will get scheduled only on a node that has a `disktype=s
 This manifest describes a Pod that has a `preferredDuringSchedulingIgnoredDuringExecution` node affinity,`disktype: ssd`. 
 This means that the pod will prefer a node that has a `disktype=ssd` label. 
 
-{{% code file="pods/pod-nginx-preferred-affinity.yaml" %}}
+{{% code_sample file="pods/pod-nginx-preferred-affinity.yaml" %}}
 
 1. Apply the manifest to create a Pod that is scheduled onto your
    chosen node:

--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -66,7 +66,7 @@ This pod configuration file describes a pod that has a node selector,
 `disktype: ssd`. This means that the pod will get scheduled on a node that has
 a `disktype=ssd` label.
 
-{{% code file="pods/pod-nginx.yaml" %}}
+{{% code_sample file="pods/pod-nginx.yaml" %}}
 
 1. Use the configuration file to create a pod that will get scheduled on your
    chosen node:
@@ -91,7 +91,7 @@ a `disktype=ssd` label.
 
 You can also schedule a pod to one specific node via setting `nodeName`.
 
-{{% code file="pods/pod-nginx-specific-node.yaml" %}}
+{{% code_sample file="pods/pod-nginx-specific-node.yaml" %}}
 
 Use the configuration file to create a pod that will get scheduled on `foo-node` only.
 

--- a/content/en/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
+++ b/content/en/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
@@ -30,7 +30,7 @@ for the postStart and preStop events.
 
 Here is the configuration file for the Pod:
 
-{{% code file="pods/lifecycle-events.yaml" %}}
+{{% code_sample file="pods/lifecycle-events.yaml" %}}
 
 In the configuration file, you can see that the postStart command writes a `message`
 file to the Container's `/usr/share` directory. The preStop command shuts down

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -57,7 +57,7 @@ liveness probes to detect and remedy such situations.
 In this exercise, you create a Pod that runs a container based on the
 `registry.k8s.io/busybox` image. Here is the configuration file for the Pod:
 
-{{% code file="pods/probe/exec-liveness.yaml" %}}
+{{% code_sample file="pods/probe/exec-liveness.yaml" %}}
 
 In the configuration file, you can see that the Pod has a single `Container`.
 The `periodSeconds` field specifies that the kubelet should perform a liveness
@@ -142,7 +142,7 @@ liveness-exec   1/1       Running   1          1m
 Another kind of liveness probe uses an HTTP GET request. Here is the configuration
 file for a Pod that runs a container based on the `registry.k8s.io/liveness` image.
 
-{{% code file="pods/probe/http-liveness.yaml" %}}
+{{% code_sample file="pods/probe/http-liveness.yaml" %}}
 
 In the configuration file, you can see that the Pod has a single container.
 The `periodSeconds` field specifies that the kubelet should perform a liveness
@@ -203,7 +203,7 @@ kubelet will attempt to open a socket to your container on the specified port.
 If it can establish a connection, the container is considered healthy, if it
 can't it is considered a failure.
 
-{{% code file="pods/probe/tcp-liveness-readiness.yaml" %}}
+{{% code_sample file="pods/probe/tcp-liveness-readiness.yaml" %}}
 
 As you can see, configuration for a TCP check is quite similar to an HTTP check.
 This example uses both readiness and liveness probes. The kubelet will send the
@@ -241,7 +241,7 @@ Similarly you can configure readiness and startup probes.
 
 Here is an example manifest:
 
-{{% code file="pods/probe/grpc-liveness.yaml" %}}
+{{% code_sample file="pods/probe/grpc-liveness.yaml" %}}
 
 To use a gRPC probe, `port` must be configured. If you want to distinguish probes of different types
 and probes for different features you can use the `service` field.

--- a/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -89,7 +89,7 @@ to set up
 
 Here is the configuration file for the hostPath PersistentVolume:
 
-{{% code file="pods/storage/pv-volume.yaml" %}}
+{{% code_sample file="pods/storage/pv-volume.yaml" %}}
 
 The configuration file specifies that the volume is at `/mnt/data` on the
 cluster's Node. The configuration also specifies a size of 10 gibibytes and
@@ -127,7 +127,7 @@ access for at most one Node at a time.
 
 Here is the configuration file for the PersistentVolumeClaim:
 
-{{% code file="pods/storage/pv-claim.yaml" %}}
+{{% code_sample file="pods/storage/pv-claim.yaml" %}}
 
 Create the PersistentVolumeClaim:
 
@@ -173,7 +173,7 @@ The next step is to create a Pod that uses your PersistentVolumeClaim as a volum
 
 Here is the configuration file for the Pod:
 
-{{% code file="pods/storage/pv-pod.yaml" %}}
+{{% code_sample file="pods/storage/pv-pod.yaml" %}}
 
 Notice that the Pod's configuration file specifies a PersistentVolumeClaim, but
 it does not specify a PersistentVolume. From the Pod's point of view, the claim
@@ -244,7 +244,7 @@ You can now close the shell to your Node.
 
 ## Mounting the same persistentVolume in two places
 
-{{% code file="pods/storage/pv-duplicate.yaml" %}}
+{{% code_sample file="pods/storage/pv-duplicate.yaml" %}}
 
 You can perform 2 volume mounts on your nginx container:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -547,7 +547,7 @@ section, and learn how to use these objects with Pods.
 2. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY`
    environment variable in the Pod specification.
 
-   {{% code file="pods/pod-single-configmap-env-variable.yaml" %}}
+   {{% code_sample file="pods/pod-single-configmap-env-variable.yaml" %}}
 
    Create the Pod:
 
@@ -562,7 +562,7 @@ section, and learn how to use these objects with Pods.
 As with the previous example, create the ConfigMaps first.
 Here is the manifest you will use:
 
-{{% code file="configmap/configmaps.yaml" %}}
+{{% code_sample file="configmap/configmaps.yaml" %}}
 
 * Create the ConfigMap:
 
@@ -572,7 +572,7 @@ Here is the manifest you will use:
 
 * Define the environment variables in the Pod specification.
 
-  {{% code file="pods/pod-multiple-configmap-env-variable.yaml" %}}
+  {{% code_sample file="pods/pod-multiple-configmap-env-variable.yaml" %}}
 
   Create the Pod:
 
@@ -591,7 +591,7 @@ Here is the manifest you will use:
 
 * Create a ConfigMap containing multiple key-value pairs.
 
-  {{% code file="configmap/configmap-multikeys.yaml" %}}
+  {{% code_sample file="configmap/configmap-multikeys.yaml" %}}
 
   Create the ConfigMap:
 
@@ -602,7 +602,7 @@ Here is the manifest you will use:
 * Use `envFrom` to define all of the ConfigMap's data as container environment variables. The
   key from the ConfigMap becomes the environment variable name in the Pod.
 
-  {{% code file="pods/pod-configmap-envFrom.yaml" %}}
+  {{% code_sample file="pods/pod-configmap-envFrom.yaml" %}}
 
   Create the Pod:
 
@@ -624,7 +624,7 @@ using the `$(VAR_NAME)` Kubernetes substitution syntax.
 
 For example, the following Pod manifest:
 
-{{% code file="pods/pod-configmap-env-var-valueFrom.yaml" %}}
+{{% code_sample file="pods/pod-configmap-env-var-valueFrom.yaml" %}}
 
 Create that Pod, by running:
 
@@ -654,7 +654,7 @@ the ConfigMap. The file contents become the key's value.
 
 The examples in this section refer to a ConfigMap named `special-config`:
 
-{{% code file="configmap/configmap-multikeys.yaml" %}}
+{{% code_sample file="configmap/configmap-multikeys.yaml" %}}
 
 Create the ConfigMap:
 
@@ -669,7 +669,7 @@ This adds the ConfigMap data to the directory specified as `volumeMounts.mountPa
 case, `/etc/config`). The `command` section lists directory files with names that match the
 keys in ConfigMap.
 
-{{% code file="pods/pod-configmap-volume.yaml" %}}
+{{% code_sample file="pods/pod-configmap-volume.yaml" %}}
 
 Create the Pod:
 
@@ -703,7 +703,7 @@ kubectl delete pod dapi-test-pod --now
 Use the `path` field to specify the desired file path for specific ConfigMap items.
 In this case, the `SPECIAL_LEVEL` item will be mounted in the `config-volume` volume at `/etc/config/keys`.
 
-{{% code file="pods/pod-configmap-volume-specific-key.yaml" %}}
+{{% code_sample file="pods/pod-configmap-volume-specific-key.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md
@@ -23,7 +23,7 @@ container starts.
 
 Here is the configuration file for the Pod:
 
-{{% code file="pods/init-containers.yaml" %}}
+{{% code_sample file="pods/init-containers.yaml" %}}
 
 In the configuration file, you can see that the Pod has a Volume that the init
 container and the application container share.

--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -29,7 +29,7 @@ In this exercise, you create username and password {{< glossary_tooltip text="Se
 
 Here is the configuration file for the Pod:
 
-{{% code file="pods/storage/projected.yaml" %}}
+{{% code_sample file="pods/storage/projected.yaml" %}}
 
 1. Create the Secrets:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-runasusername.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-runasusername.md
@@ -29,7 +29,7 @@ The Windows security context options that you specify for a Pod apply to all Con
 
 Here is a configuration file for a Windows Pod that has the `runAsUserName` field set:
 
-{{% code file="windows/run-as-username-pod.yaml" %}}
+{{% code_sample file="windows/run-as-username-pod.yaml" %}}
 
 Create the Pod:
 
@@ -69,7 +69,7 @@ The Windows security context options that you specify for a Container apply only
 
 Here is the configuration file for a Pod that has one Container, and the `runAsUserName` field is set at the Pod level and the Container level:
 
-{{% code file="windows/run-as-username-container.yaml" %}}
+{{% code_sample file="windows/run-as-username-container.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -403,7 +403,7 @@ You can configure this behavior for the `spec` of a Pod using a
 To provide a Pod with a token with an audience of `vault` and a validity duration
 of two hours, you could define a Pod manifest that is similar to:
 
-{{% code file="pods/pod-projected-svc-token.yaml" %}}
+{{% code_sample file="pods/pod-projected-svc-token.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -28,7 +28,7 @@ Volume of type
 that lasts for the life of the Pod, even if the Container terminates and
 restarts. Here is the configuration file for the Pod:
 
-{{% code file="pods/storage/redis.yaml" %}}
+{{% code_sample file="pods/storage/redis.yaml" %}}
 
 1. Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/extended-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/extended-resource.md
@@ -37,7 +37,7 @@ descriptive resource name.
 
 Here is the configuration file for a Pod that has one Container:
 
-{{% code file="pods/resource/extended-resource-pod.yaml" %}}
+{{% code_sample file="pods/resource/extended-resource-pod.yaml" %}}
 
 In the configuration file, you can see that the Container requests 3 dongles.
 
@@ -73,7 +73,7 @@ Requests:
 Here is the configuration file for a Pod that has one Container. The Container requests
 two dongles.
 
-{{% code file="pods/resource/extended-resource-pod-2.yaml" %}}
+{{% code_sample file="pods/resource/extended-resource-pod-2.yaml" %}}
 
 Kubernetes will not be able to satisfy the request for two dongles, because the first Pod
 used three of the four available dongles.

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -185,7 +185,7 @@ You have successfully set your Docker credentials as a Secret called `regcred` i
 
 Here is a manifest for an example Pod that needs access to your Docker credentials in `regcred`:
 
-{{% code file="pods/private-reg-pod.yaml" %}}
+{{% code_sample file="pods/private-reg-pod.yaml" %}}
 
 Download the above file onto your computer:
 

--- a/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -56,7 +56,7 @@ cannot define resources so these restrictions do not apply.
 Here is a manifest for a Pod that has one Container. The Container has a memory limit and a
 memory request, both equal to 200 MiB. The Container has a CPU limit and a CPU request, both equal to 700 milliCPU:
 
-{{% code file="pods/qos/qos-pod.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod.yaml" %}}
 
 Create the Pod:
 
@@ -116,7 +116,7 @@ A Pod is given a QoS class of `Burstable` if:
 Here is a manifest for a Pod that has one Container. The Container has a memory limit of 200 MiB
 and a memory request of 100 MiB.
 
-{{% code file="pods/qos/qos-pod-2.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-2.yaml" %}}
 
 Create the Pod:
 
@@ -165,7 +165,7 @@ have any memory or CPU limits or requests.
 Here is a manifest for a Pod that has one Container. The Container has no memory or CPU
 limits or requests:
 
-{{% code file="pods/qos/qos-pod-3.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-3.yaml" %}}
 
 Create the Pod:
 
@@ -205,7 +205,7 @@ kubectl delete pod qos-demo-3 --namespace=qos-example
 Here is a manifest for a Pod that has two Containers. One container specifies a memory
 request of 200 MiB. The other Container does not specify any requests or limits.
 
-{{% code file="pods/qos/qos-pod-4.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-4.yaml" %}}
 
 Notice that this Pod meets the criteria for QoS class `Burstable`. That is, it does not meet the
 criteria for QoS class `Guaranteed`, and one of its Containers has a memory request.

--- a/content/en/docs/tasks/configure-pod-container/resize-container-resources.md
+++ b/content/en/docs/tasks/configure-pod-container/resize-container-resources.md
@@ -107,7 +107,7 @@ class pod by specifying requests and/or limits for a pod's containers.
 
 Consider the following manifest for a Pod that has one Container.
 
-{{% code file="pods/qos/qos-pod-5.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-5.yaml" %}}
 
 Create the pod in the `qos-example` namespace:
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -58,7 +58,7 @@ in the Pod specification. The `securityContext` field is a
 The security settings that you specify for a Pod apply to all Containers in the Pod.
 Here is a configuration file for a Pod that has a `securityContext` and an `emptyDir` volume:
 
-{{% code file="pods/security/security-context.yaml" %}}
+{{% code_sample file="pods/security/security-context.yaml" %}}
 
 In the configuration file, the `runAsUser` field specifies that for any Containers in
 the Pod, all processes run with user ID 1000. The `runAsGroup` field specifies the primary group ID of 3000 for
@@ -221,7 +221,7 @@ there is overlap. Container settings do not affect the Pod's Volumes.
 Here is the configuration file for a Pod that has one Container. Both the Pod
 and the Container have a `securityContext` field:
 
-{{% code file="pods/security/security-context-2.yaml" %}}
+{{% code_sample file="pods/security/security-context-2.yaml" %}}
 
 Create the Pod:
 
@@ -274,7 +274,7 @@ of the root user. To add or remove Linux capabilities for a Container, include t
 First, see what happens when you don't include a `capabilities` field.
 Here is configuration file that does not add or remove any Container capabilities:
 
-{{% code file="pods/security/security-context-3.yaml" %}}
+{{% code_sample file="pods/security/security-context-3.yaml" %}}
 
 Create the Pod:
 
@@ -336,7 +336,7 @@ that it has additional capabilities set.
 Here is the configuration file for a Pod that runs one Container. The configuration
 adds the `CAP_NET_ADMIN` and `CAP_SYS_TIME` capabilities:
 
-{{% code file="pods/security/security-context-4.yaml" %}}
+{{% code_sample file="pods/security/security-context-4.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -29,7 +29,7 @@ include debugging utilities like a shell.
 Process namespace sharing is enabled using the `shareProcessNamespace` field of
 `.spec` for a Pod. For example:
 
-{{% code file="pods/share-process-namespace.yaml" %}}
+{{% code_sample file="pods/share-process-namespace.yaml" %}}
 
 1. Create the pod `nginx` on your cluster:
 

--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -68,7 +68,7 @@ created without user namespaces.**
 A user namespace for a pod is enabled setting the `hostUsers` field of `.spec`
 to `false`. For example:
 
-{{% code file="pods/user-namespaces-stateless.yaml" %}}
+{{% code_sample file="pods/user-namespaces-stateless.yaml" %}}
 
 1. Create the pod on your cluster:
 

--- a/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -25,7 +25,7 @@ This page explains how to debug Pods running (or crashing) on a Node.
 
 For this example we'll use a Deployment to create two pods, similar to the earlier example.
 
-{{% code file="application/nginx-with-request.yaml" %}}
+{{% code_sample file="application/nginx-with-request.yaml" %}}
 
 Create deployment by running following command:
 

--- a/content/en/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
@@ -27,7 +27,7 @@ the general
 In this exercise, you create a Pod that runs one container.
 The manifest for that Pod specifies a command that runs when the container starts:
 
-{{% code file="debug/termination.yaml" %}}
+{{% code_sample file="debug/termination.yaml" %}}
 
 1. Create a Pod based on the YAML configuration file:
 

--- a/content/en/docs/tasks/debug/debug-application/get-shell-running-container.md
+++ b/content/en/docs/tasks/debug/debug-application/get-shell-running-container.md
@@ -29,7 +29,7 @@ running container.
 In this exercise, you create a Pod that has one container. The container
 runs the nginx image. Here is the configuration file for the Pod:
 
-{{% code file="application/shell-demo.yaml" %}}
+{{% code_sample file="application/shell-demo.yaml" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/debug/debug-cluster/audit.md
+++ b/content/en/docs/tasks/debug/debug-cluster/audit.md
@@ -80,7 +80,7 @@ A policy with no (0) rules is treated as illegal.
 
 Below is an example audit policy file:
 
-{{% code file="audit/audit-policy.yaml" %}}
+{{% code_sample file="audit/audit-policy.yaml" %}}
 
 You can use a minimal audit policy file to log all requests at the `Metadata` level:
 

--- a/content/en/docs/tasks/debug/debug-cluster/monitor-node-health.md
+++ b/content/en/docs/tasks/debug/debug-cluster/monitor-node-health.md
@@ -42,7 +42,7 @@ to detect customized node problems. For example:
 
 1. Create a Node Problem Detector configuration similar to `node-problem-detector.yaml`:
 
-   {{% code file="debug/node-problem-detector.yaml" %}}
+   {{% code_sample file="debug/node-problem-detector.yaml" %}}
 
    {{< note >}}
    You should verify that the system log directory is right for your operating system distribution.
@@ -80,7 +80,7 @@ to overwrite the configuration:
 
 1. Change the `node-problem-detector.yaml` to use the `ConfigMap`:
 
-   {{% code file="debug/node-problem-detector-configmap.yaml" %}}
+   {{% code_sample file="debug/node-problem-detector-configmap.yaml" %}}
 
 1. Recreate the Node Problem Detector with the new configuration file:
 

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -69,7 +69,7 @@ for this example. A [Deployment](/docs/concepts/workloads/controllers/deployment
 thereby making the scheduler resilient to failures. Here is the deployment
 config. Save it as `my-scheduler.yaml`:
 
-{{% code file="admin/sched/my-scheduler.yaml" %}}
+{{% code_sample file="admin/sched/my-scheduler.yaml" %}}
 
 In the above manifest, you use a [KubeSchedulerConfiguration](/docs/reference/scheduling/config/)
 to customize the behavior of your scheduler implementation. This configuration has been passed to
@@ -139,7 +139,7 @@ Add your scheduler name to the resourceNames of the rule applied for `endpoints`
 kubectl edit clusterrole system:kube-scheduler
 ```
 
-{{% code file="admin/sched/clusterrole.yaml" %}}
+{{% code_sample file="admin/sched/clusterrole.yaml" %}}
 
 ## Specify schedulers for pods
 
@@ -150,7 +150,7 @@ scheduler in that pod spec. Let's look at three examples.
 
 - Pod spec without any scheduler name
 
-  {{% code file="admin/sched/pod1.yaml" %}}
+  {{% code_sample file="admin/sched/pod1.yaml" %}}
 
   When no scheduler name is supplied, the pod is automatically scheduled using the
   default-scheduler.
@@ -163,7 +163,7 @@ scheduler in that pod spec. Let's look at three examples.
 
 - Pod spec with `default-scheduler`
 
-  {{% code file="admin/sched/pod2.yaml" %}}
+  {{% code_sample file="admin/sched/pod2.yaml" %}}
 
   A scheduler is specified by supplying the scheduler name as a value to `spec.schedulerName`. In this case, we supply the name of the
   default scheduler which is `default-scheduler`.
@@ -176,7 +176,7 @@ scheduler in that pod spec. Let's look at three examples.
 
 - Pod spec with `my-scheduler`
 
-  {{% code file="admin/sched/pod3.yaml" %}}
+  {{% code_sample file="admin/sched/pod3.yaml" %}}
 
   In this case, we specify that this pod should be scheduled using the scheduler that we
   deployed - `my-scheduler`. Note that the value of `spec.schedulerName` should match the name supplied for the scheduler

--- a/content/en/docs/tasks/extend-kubernetes/setup-konnectivity.md
+++ b/content/en/docs/tasks/extend-kubernetes/setup-konnectivity.md
@@ -23,7 +23,7 @@ plane hosts. If you do not already have a cluster, you can create one by using
 
 The following steps require an egress configuration, for example:
 
-{{% code file="admin/konnectivity/egress-selector-configuration.yaml" %}}
+{{% code_sample file="admin/konnectivity/egress-selector-configuration.yaml" %}}
 
 You need to configure the API Server to use the Konnectivity service
 and direct the network traffic to the cluster nodes:
@@ -74,12 +74,12 @@ that the Kubernetes components are deployed as a {{< glossary_tooltip text="stat
 term_id="static-pod" >}} in your cluster. If not, you can deploy the Konnectivity
 server as a DaemonSet.
 
-{{% code file="admin/konnectivity/konnectivity-server.yaml" %}}
+{{% code_sample file="admin/konnectivity/konnectivity-server.yaml" %}}
 
 Then deploy the Konnectivity agents in your cluster:
 
-{{% code file="admin/konnectivity/konnectivity-agent.yaml" %}}
+{{% code_sample file="admin/konnectivity/konnectivity-agent.yaml" %}}
 
 Last, if RBAC is enabled in your cluster, create the relevant RBAC rules:
 
-{{% code file="admin/konnectivity/konnectivity-rbac.yaml" %}}
+{{% code_sample file="admin/konnectivity/konnectivity-rbac.yaml" %}}

--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -42,7 +42,7 @@ The `command` field corresponds to `entrypoint` in some container runtimes.
 In this exercise, you create a Pod that runs one container. The configuration
 file for the Pod defines a command and two arguments:
 
-{{% code file="pods/commands.yaml" %}}
+{{% code_sample file="pods/commands.yaml" %}}
 
 1. Create a Pod based on the YAML configuration file:
 

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -42,7 +42,7 @@ file for the Pod defines an environment variable with name `DEMO_GREETING` and
 value `"Hello from the environment"`. Here is the configuration manifest for the
 Pod:
 
-{{% code file="pods/inject/envars.yaml" %}}
+{{% code_sample file="pods/inject/envars.yaml" %}}
 
 1. Create a Pod based on that manifest:
 

--- a/content/en/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
+++ b/content/en/docs/tasks/inject-data-application/define-interdependent-environment-variables.md
@@ -26,7 +26,7 @@ In this exercise, you create a Pod that runs one container. The configuration
 file for the Pod defines a dependent environment variable with common usage defined. Here is the configuration manifest for the
 Pod:
 
-{{% code file="pods/inject/dependent-envars.yaml" %}}
+{{% code_sample file="pods/inject/dependent-envars.yaml" %}}
 
 1. Create a Pod based on that manifest:
 

--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -38,7 +38,7 @@ Use a local tool trusted by your OS to decrease the security risks of external t
 Here is a configuration file you can use to create a Secret that holds your
 username and password:
 
-{{% code file="pods/inject/secret.yaml" %}}
+{{% code_sample file="pods/inject/secret.yaml" %}}
 
 1. Create the Secret
 
@@ -97,7 +97,7 @@ through each step explicitly to demonstrate what is happening.
 
 Here is a configuration file you can use to create a Pod:
 
-{{% code file="pods/inject/secret-pod.yaml" %}}
+{{% code_sample file="pods/inject/secret-pod.yaml" %}}
 
 1. Create the Pod:
 
@@ -260,7 +260,7 @@ secrets change.
 
 - Assign the `backend-username` value defined in the Secret to the `SECRET_USERNAME` environment variable in the Pod specification.
 
-  {{% code file="pods/inject/pod-single-secret-env-variable.yaml" %}}
+  {{% code_sample file="pods/inject/pod-single-secret-env-variable.yaml" %}}
 
 - Create the Pod:
 
@@ -291,7 +291,7 @@ secrets change.
 
 - Define the environment variables in the Pod specification.
 
-  {{% code file="pods/inject/pod-multiple-secret-env-variable.yaml" %}}
+  {{% code_sample file="pods/inject/pod-multiple-secret-env-variable.yaml" %}}
 
 - Create the Pod:
 
@@ -327,7 +327,7 @@ This functionality is available in Kubernetes v1.6 and later.
 - Use envFrom to define all of the Secret's data as container environment variables.
   The key from the Secret becomes the environment variable name in the Pod.
 
-  {{% code file="pods/inject/pod-secret-envFrom.yaml" %}}
+  {{% code_sample file="pods/inject/pod-secret-envFrom.yaml" %}}
 
 - Create the Pod:
 

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -32,7 +32,7 @@ In this part of exercise, you create a Pod that has one container, and you
 project Pod-level fields into the running container as files.
 Here is the manifest for the Pod:
 
-{{% code file="pods/inject/dapi-volume.yaml" %}}
+{{% code_sample file="pods/inject/dapi-volume.yaml" %}}
 
 In the manifest, you can see that the Pod has a `downwardAPI` Volume,
 and the container mounts the volume at `/etc/podinfo`.
@@ -155,7 +155,7 @@ definition, but taken from the specific
 rather than from the Pod overall. Here is a manifest for a Pod that again has
 just one container:
 
-{{% code file="pods/inject/dapi-volume-resources.yaml" %}}
+{{% code_sample file="pods/inject/dapi-volume-resources.yaml" %}}
 
 In the manifest, you can see that the Pod has a
 [`downwardAPI` volume](/docs/concepts/storage/volumes/#downwardapi),

--- a/content/en/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -34,7 +34,7 @@ Read more about accessing Services [here](/docs/tutorials/services/connect-appli
 In this part of exercise, you create a Pod that has one container, and you
 project Pod-level fields into the running container as environment variables.
 
-{{% code file="pods/inject/dapi-envars-pod.yaml" %}}
+{{% code_sample file="pods/inject/dapi-envars-pod.yaml" %}}
 
 In that manifest, you can see five environment variables. The `env`
 field is an array of
@@ -119,7 +119,7 @@ rather than from the Pod overall.
 
 Here is a manifest for another Pod that again has just one container:
 
-{{% code file="pods/inject/dapi-envars-container.yaml" %}}
+{{% code_sample file="pods/inject/dapi-envars-container.yaml" %}}
 
 In this manifest, you can see four environment variables. The `env`
 field is an array of

--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -22,7 +22,7 @@ This page shows how to run automated tasks using Kubernetes {{< glossary_tooltip
 Cron jobs require a config file.
 Here is a manifest for a CronJob that runs a simple demonstration task every minute:
 
-{{% code file="application/job/cronjob.yaml" %}}
+{{% code_sample file="application/job/cronjob.yaml" %}}
 
 Run the example CronJob by using this command:
 

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -186,7 +186,7 @@ We will use the `amqp-consume` utility to read the message
 from the queue and run our actual program.  Here is a very simple
 example program:
 
-{{% code language="python" file="application/job/rabbitmq/worker.py" %}}
+{{% code_sample language="python" file="application/job/rabbitmq/worker.py" %}}
 
 Give the script execution permission:
 
@@ -230,7 +230,7 @@ Here is a job definition.  You'll need to make a copy of the Job and edit the
 image to match the name you used, and call it `./job.yaml`.
 
 
-{{% code file="application/job/rabbitmq/job.yaml" %}}
+{{% code_sample file="application/job/rabbitmq/job.yaml" %}}
 
 In this example, each pod works on one item from the queue and then exits.
 So, the completion count of the Job corresponds to the number of work items

--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -119,7 +119,7 @@ called rediswq.py ([Download](/examples/application/job/redis/rediswq.py)).
 The "worker" program in each Pod of the Job uses the work queue
 client library to get work.  Here it is:
 
-{{% code language="python" file="application/job/redis/worker.py" %}}
+{{% code_sample language="python" file="application/job/redis/worker.py" %}}
 
 You could also download [`worker.py`](/examples/application/job/redis/worker.py),
 [`rediswq.py`](/examples/application/job/redis/rediswq.py), and
@@ -158,7 +158,7 @@ gcloud docker -- push gcr.io/<project>/job-wq-2
 
 Here is the job definition:
 
-{{% code file="application/job/redis/job.yaml" %}}
+{{% code_sample file="application/job/redis/job.yaml" %}}
 
 Be sure to edit the job template to
 change `gcr.io/myproject` to your own path.

--- a/content/en/docs/tasks/job/indexed-parallel-processing-static.md
+++ b/content/en/docs/tasks/job/indexed-parallel-processing-static.md
@@ -77,7 +77,7 @@ the start of the clip.
 
 Here is a sample Job manifest that uses `Indexed` completion mode:
 
-{{% code language="yaml" file="application/job/indexed-job.yaml" %}}
+{{% code_sample language="yaml" file="application/job/indexed-job.yaml" %}}
 
 In the example above, you use the builtin `JOB_COMPLETION_INDEX` environment
 variable set by the Job controller for all containers. An [init container](/docs/concepts/workloads/pods/init-containers/)
@@ -92,7 +92,7 @@ Alternatively, you can directly [use the downward API to pass the annotation
 value as a volume file](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#store-pod-fields),
 like shown in the following example:
 
-{{% code language="yaml" file="application/job/indexed-job-vol.yaml" %}}
+{{% code_sample language="yaml" file="application/job/indexed-job-vol.yaml" %}}
 
 ## Running the Job
 

--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -43,7 +43,7 @@ pip install --user jinja2
 First, download the following template of a Job to a file called `job-tmpl.yaml`.
 Here's what you'll download:
 
-{{% code file="application/job/job-tmpl.yaml" %}}
+{{% code_sample file="application/job/job-tmpl.yaml" %}}
 
 ```shell
 # Use curl to download job-tmpl.yaml

--- a/content/en/docs/tasks/job/pod-failure-policy.md
+++ b/content/en/docs/tasks/job/pod-failure-policy.md
@@ -39,7 +39,7 @@ software bug.
 
 First, create a Job based on the config:
 
-{{% code file="/controllers/job-pod-failure-policy-failjob.yaml" %}}
+{{% code_sample file="/controllers/job-pod-failure-policy-failjob.yaml" %}}
 
 by running:
 
@@ -85,7 +85,7 @@ node while the Pod is running on it (within 90s since the Pod is scheduled).
 
 1. Create a Job based on the config:
 
-   {{% code file="/controllers/job-pod-failure-policy-ignore.yaml" %}}
+   {{% code_sample file="/controllers/job-pod-failure-policy-ignore.yaml" %}}
 
    by running:
 
@@ -145,7 +145,7 @@ deleted pods, in the `Pending` phase, to a terminal phase
 
 1. First, create a Job based on the config:
 
-   {{% code file="/controllers/job-pod-failure-policy-config-issue.yaml" %}}
+   {{% code_sample file="/controllers/job-pod-failure-policy-config-issue.yaml" %}}
 
    by running:
 

--- a/content/en/docs/tasks/manage-daemon/pods-some-nodes.md
+++ b/content/en/docs/tasks/manage-daemon/pods-some-nodes.md
@@ -33,7 +33,7 @@ Let's create a {{<glossary_tooltip term_id="daemonset" text="DaemonSet">}} which
 Next, use a `nodeSelector` to ensure that the DaemonSet only runs Pods on nodes
 with the `ssd` label set to `"true"`.
 
-{{% code file="controllers/daemonset-label-selector.yaml" %}}
+{{% code_sample file="controllers/daemonset-label-selector.yaml" %}}
 
 ### Step 3: Create the DaemonSet
 

--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -46,7 +46,7 @@ You may want to set
 
 This YAML file specifies a DaemonSet with an update strategy as 'RollingUpdate'
 
-{{% code file="controllers/fluentd-daemonset.yaml" %}}
+{{% code_sample file="controllers/fluentd-daemonset.yaml" %}}
 
 After verifying the update strategy of the DaemonSet manifest, create the DaemonSet:
 
@@ -92,7 +92,7 @@ manifest accordingly.
 Any updates to a `RollingUpdate` DaemonSet `.spec.template` will trigger a rolling
 update. Let's update the DaemonSet by applying a new YAML file. This can be done with several different `kubectl` commands.
 
-{{% code file="controllers/fluentd-daemonset-update.yaml" %}}
+{{% code_sample file="controllers/fluentd-daemonset-update.yaml" %}}
 
 #### Declarative commands
 

--- a/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -71,7 +71,7 @@ Add the `-R` flag to recursively process directories.
 
 Here's an example of an object configuration file:
 
-{{% code file="application/simple_deployment.yaml" %}}
+{{% code_sample file="application/simple_deployment.yaml" %}}
 
 Run `kubectl diff` to print the object that will be created:
 
@@ -163,7 +163,7 @@ Add the `-R` flag to recursively process directories.
 
 Here's an example configuration file:
 
-{{% code file="application/simple_deployment.yaml" %}}
+{{% code_sample file="application/simple_deployment.yaml" %}}
 
 Create the object using `kubectl apply`:
 
@@ -281,7 +281,7 @@ spec:
 Update the `simple_deployment.yaml` configuration file to change the image from
 `nginx:1.14.2` to `nginx:1.16.1`, and delete the `minReadySeconds` field:
 
-{{% code file="application/update_deployment.yaml" %}}
+{{% code_sample file="application/update_deployment.yaml" %}}
 
 Apply the changes made to the configuration file:
 
@@ -513,7 +513,7 @@ to calculate which fields should be deleted or set:
 
 Here's an example. Suppose this is the configuration file for a Deployment object:
 
-{{% code file="application/update_deployment.yaml" %}}
+{{% code_sample file="application/update_deployment.yaml" %}}
 
 Also, suppose this is the live configuration for the same Deployment object:
 
@@ -809,7 +809,7 @@ not specified when the object is created.
 
 Here's a configuration file for a Deployment. The file does not specify `strategy`:
 
-{{% code file="application/simple_deployment.yaml" %}}
+{{% code_sample file="application/simple_deployment.yaml" %}}
 
 Create the object using `kubectl apply`:
 

--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -27,7 +27,7 @@ in this task demonstrate a strategic merge patch and a JSON merge patch.
 Here's the configuration file for a Deployment that has two replicas. Each replica
 is a Pod that has one container:
 
-{{% code file="application/deployment-patch.yaml" %}}
+{{% code_sample file="application/deployment-patch.yaml" %}}
 
 Create the Deployment:
 
@@ -288,7 +288,7 @@ patch-demo-1307768864-c86dc   1/1       Running   0          1m
 
 Here's the configuration file for a Deployment that uses the `RollingUpdate` strategy:
 
-{{% code file="application/deployment-retainkeys.yaml" %}}
+{{% code_sample file="application/deployment-retainkeys.yaml" %}}
 
 Create the deployment:
 
@@ -439,7 +439,7 @@ examples which supports these subresources.
 
 Here's a manifest for a Deployment that has two replicas:
 
-{{% code file="application/deployment.yaml" %}}
+{{% code_sample file="application/deployment.yaml" %}}
 
 Create the Deployment:
 

--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -69,7 +69,7 @@ For example: to resolve `foo.local`, `bar.local` to `127.0.0.1` and `foo.remote`
 `bar.remote` to `10.1.2.3`, you can configure HostAliases for a Pod under
 `.spec.hostAliases`:
 
-{{% code file="service/networking/hostaliases-pod.yaml" %}}
+{{% code_sample file="service/networking/hostaliases-pod.yaml" %}}
 
 You can start a Pod with that configuration by running:
 

--- a/content/en/docs/tasks/network/validate-dual-stack.md
+++ b/content/en/docs/tasks/network/validate-dual-stack.md
@@ -106,7 +106,7 @@ fe00::2    ip6-allrouters
 
 Create the following Service that does not explicitly define `.spec.ipFamilyPolicy`. Kubernetes will assign a cluster IP for the Service from the first configured `service-cluster-ip-range` and set the `.spec.ipFamilyPolicy` to `SingleStack`.
 
-{{% code file="service/networking/dual-stack-default-svc.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-default-svc.yaml" %}}
 
 Use `kubectl` to view the YAML for the Service.
 
@@ -143,7 +143,7 @@ status:
 
 Create the following Service that explicitly defines `IPv6` as the first array element in `.spec.ipFamilies`. Kubernetes will assign a cluster IP for the Service from the IPv6 range configured `service-cluster-ip-range` and set the `.spec.ipFamilyPolicy` to `SingleStack`.
 
-{{% code file="service/networking/dual-stack-ipfamilies-ipv6.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-ipfamilies-ipv6.yaml" %}}
 
 Use `kubectl` to view the YAML for the Service.
 
@@ -181,7 +181,7 @@ status:
 
 Create the following Service that explicitly defines `PreferDualStack` in `.spec.ipFamilyPolicy`. Kubernetes will assign both IPv4 and IPv6 addresses (as this cluster has dual-stack enabled) and select the `.spec.ClusterIP` from the list of `.spec.ClusterIPs` based on the address family of the first element in the `.spec.ipFamilies` array.
 
-{{% code file="service/networking/dual-stack-preferred-svc.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-preferred-svc.yaml" %}}
 
 {{< note >}}
 The `kubectl get svc` command will only show the primary IP in the `CLUSTER-IP` field.
@@ -222,7 +222,7 @@ Events:            <none>
 
 If the cloud provider supports the provisioning of IPv6 enabled external load balancers, create the following Service with `PreferDualStack` in `.spec.ipFamilyPolicy`, `IPv6` as the first element of the `.spec.ipFamilies` array and the `type` field set to `LoadBalancer`.
 
-{{% code file="service/networking/dual-stack-prefer-ipv6-lb-svc.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-prefer-ipv6-lb-svc.yaml" %}}
 
 Check the Service:
 

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -165,11 +165,11 @@ You can find examples of pod disruption budgets defined below. They match pods w
 
 Example PDB Using minAvailable:
 
-{{% code file="policy/zookeeper-pod-disruption-budget-minavailable.yaml" %}}
+{{% code_sample file="policy/zookeeper-pod-disruption-budget-minavailable.yaml" %}}
 
 Example PDB Using maxUnavailable:
 
-{{% code file="policy/zookeeper-pod-disruption-budget-maxunavailable.yaml" %}}
+{{% code_sample file="policy/zookeeper-pod-disruption-budget-maxunavailable.yaml" %}}
 
 For example, if the above `zk-pdb` object selects the pods of a StatefulSet of size 3, both
 specifications have the exact same meaning. The use of `maxUnavailable` is recommended as it

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -58,7 +58,7 @@ To demonstrate a HorizontalPodAutoscaler, you will first start a Deployment that
 `hpa-example` image, and expose it as a {{< glossary_tooltip term_id="service">}}
 using the following manifest:
 
-{{% code file="application/php-apache.yaml" %}}
+{{% code_sample file="application/php-apache.yaml" %}}
 
 To do so, run the following command:
 
@@ -498,7 +498,7 @@ between `1` and `1500m`, or `1` and `1.5` when written in decimal notation.
 Instead of using `kubectl autoscale` command to create a HorizontalPodAutoscaler imperatively we
 can use the following manifest to create it declaratively:
 
-{{% code file="application/hpa/php-apache.yaml" %}}
+{{% code_sample file="application/hpa/php-apache.yaml" %}}
 
 Then, create the autoscaler by executing the following command:
 

--- a/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -56,7 +56,7 @@ and a StatefulSet.
 
 Create the ConfigMap from the following YAML configuration file:
 
-{{% code file="application/mysql/mysql-configmap.yaml" %}}
+{{% code_sample file="application/mysql/mysql-configmap.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/mysql/mysql-configmap.yaml
@@ -76,7 +76,7 @@ based on information provided by the StatefulSet controller.
 
 Create the Services from the following YAML configuration file:
 
-{{% code file="application/mysql/mysql-services.yaml" %}}
+{{% code_sample file="application/mysql/mysql-services.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/mysql/mysql-services.yaml
@@ -103,7 +103,7 @@ writes.
 
 Finally, create the StatefulSet from the following YAML configuration file:
 
-{{% code file="application/mysql/mysql-statefulset.yaml" %}}
+{{% code_sample file="application/mysql/mysql-statefulset.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/mysql/mysql-statefulset.yaml

--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -39,8 +39,8 @@ Note: The password is defined in the config yaml, and this is insecure. See
 [Kubernetes Secrets](/docs/concepts/configuration/secret/)
 for a secure solution.
 
-{{% code file="application/mysql/mysql-deployment.yaml" %}}
-{{% code file="application/mysql/mysql-pv.yaml" %}}
+{{% code_sample file="application/mysql/mysql-deployment.yaml" %}}
+{{% code_sample file="application/mysql/mysql-pv.yaml" %}}
 
 1. Deploy the PV and PVC of the YAML file:
 

--- a/content/en/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/content/en/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -27,7 +27,7 @@ You can run an application by creating a Kubernetes Deployment object, and you
 can describe a Deployment in a YAML file. For example, this YAML file describes
 a Deployment that runs the nginx:1.14.2 Docker image:
 
-{{% code file="application/deployment.yaml" %}}
+{{% code_sample file="application/deployment.yaml" %}}
 
 1. Create a Deployment based on the YAML file:
 
@@ -100,7 +100,7 @@ a Deployment that runs the nginx:1.14.2 Docker image:
 You can update the deployment by applying a new YAML file. This YAML file
 specifies that the deployment should be updated to use nginx 1.16.1.
 
-{{% code file="application/deployment-update.yaml" %}}
+{{% code_sample file="application/deployment-update.yaml" %}}
 
 1. Apply the new YAML file:
 
@@ -120,7 +120,7 @@ You can increase the number of Pods in your Deployment by applying a new YAML
 file. This YAML file sets `replicas` to 4, which specifies that the Deployment
 should have four Pods:
 
-{{% code file="application/deployment-scale.yaml" %}}
+{{% code_sample file="application/deployment-scale.yaml" %}}
 
 1. Apply the new YAML file:
 

--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -236,7 +236,7 @@ This produces a certificate authority key file (`ca-key.pem`) and certificate (`
 
 ### Issue a certificate
 
-{{% code file="tls/server-signing-config.json" %}}
+{{% code_sample file="tls/server-signing-config.json" %}}
 
 Use a `server-signing-config.json` signing configuration and the certificate authority key file 
 and certificate to sign the certificate request:

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -68,7 +68,7 @@ Examine the contents of the Redis pod manifest and note the following:
 This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
 ConfigMap above as `/redis-master/redis.conf` inside the Pod.
 
-{{% code file="pods/config/redis-pod.yaml" %}}
+{{% code_sample file="pods/config/redis-pod.yaml" %}}
 
 Examine the created objects:
 
@@ -139,7 +139,7 @@ Which should also yield its default value of `noeviction`:
 
 Now let's add some configuration values to the `example-redis-config` ConfigMap:
 
-{{% code file="pods/config/example-redis-config.yaml" %}}
+{{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
 Apply the updated ConfigMap:
 

--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -209,7 +209,7 @@ done
 
 Next, we'll run a simple "Hello AppArmor" pod with the deny-write profile:
 
-{{% code file="pods/security/hello-apparmor.yaml" %}}
+{{% code_sample file="pods/security/hello-apparmor.yaml" %}}
 
 ```shell
 kubectl create -f ./hello-apparmor.yaml

--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -71,13 +71,13 @@ into the cluster.
 
 {{< tabs name="tab_with_code" >}}
 {{< tab name="audit.json" >}}
-{{% code file="pods/security/seccomp/profiles/audit.json" %}}
+{{% code_sample file="pods/security/seccomp/profiles/audit.json" %}}
 {{< /tab >}}
 {{< tab name="violation.json" >}}
-{{% code file="pods/security/seccomp/profiles/violation.json" %}}
+{{% code_sample file="pods/security/seccomp/profiles/violation.json" %}}
 {{< /tab >}}
 {{< tab name="fine-grained.json" >}}
-{{% code file="pods/security/seccomp/profiles/fine-grained.json" %}}
+{{% code_sample file="pods/security/seccomp/profiles/fine-grained.json" %}}
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -104,7 +104,7 @@ so each node of the cluster is a container. This allows for files
 to be mounted in the filesystem of each container similar to loading files
 onto a node.
 
-{{% code file="pods/security/seccomp/kind.yaml" %}}
+{{% code_sample file="pods/security/seccomp/kind.yaml" %}}
 
 Download that example kind configuration, and save it to a file named `kind.yaml`:
 ```shell
@@ -176,7 +176,7 @@ no other seccomp profile is specified. Otherwise, the default is `Unconfined`.
 Here's a manifest for a Pod that requests the `RuntimeDefault` seccomp profile
 for all its containers:
 
-{{% code file="pods/security/seccomp/ga/default-pod.yaml" %}}
+{{% code_sample file="pods/security/seccomp/ga/default-pod.yaml" %}}
 
 Create that Pod:
 ```shell
@@ -206,7 +206,7 @@ process, to a new Pod.
 
 Here's a manifest for that Pod:
 
-{{% code file="pods/security/seccomp/ga/audit-pod.yaml" %}}
+{{% code_sample file="pods/security/seccomp/ga/audit-pod.yaml" %}}
 
 {{< note >}}
 Older versions of Kubernetes allowed you to configure seccomp
@@ -311,7 +311,7 @@ syscalls.
 
 The manifest for this demonstration is:
 
-{{% code file="pods/security/seccomp/ga/violation-pod.yaml" %}}
+{{% code_sample file="pods/security/seccomp/ga/violation-pod.yaml" %}}
 
 Attempt to create the Pod in the cluster:
 
@@ -354,7 +354,7 @@ sent to `syslog`.
 
 The manifest for this example is:
 
-{{% code file="pods/security/seccomp/ga/fine-pod.yaml" %}}
+{{% code_sample file="pods/security/seccomp/ga/fine-pod.yaml" %}}
 
 Create the Pod in your cluster:
 

--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -31,7 +31,7 @@ This tutorial uses a simple nginx web server to demonstrate the concept.
 We did this in a previous example, but let's do it once again and focus on the networking perspective.
 Create an nginx Pod, and note that it has a container port specification:
 
-{{% code file="service/networking/run-my-nginx.yaml" %}}
+{{% code_sample file="service/networking/run-my-nginx.yaml" %}}
 
 This makes it accessible from any node in your cluster. Check the nodes the Pod is running on:
 
@@ -92,7 +92,7 @@ service/my-nginx exposed
 
 This is equivalent to `kubectl apply -f` the following yaml:
 
-{{% code file="service/networking/nginx-svc.yaml" %}}
+{{% code_sample file="service/networking/nginx-svc.yaml" %}}
 
 This specification will create a Service which targets TCP port 80 on any Pod
 with the `run: my-nginx` label, and expose it on an abstracted Service port
@@ -340,7 +340,7 @@ nginxsecret           kubernetes.io/tls                     2         1m
 Now modify your nginx replicas to start an https server using the certificate
 in the secret, and the Service, to expose both ports (80 and 443):
 
-{{% code file="service/networking/nginx-secure-app.yaml" %}}
+{{% code_sample file="service/networking/nginx-secure-app.yaml" %}}
 
 Noteworthy points about the nginx-secure-app manifest:
 
@@ -376,7 +376,7 @@ linked the CName used in the certificate with the actual DNS name used by pods
 during Service lookup. Let's test this from a pod (the same secret is being reused
 for simplicity, the pod only needs nginx.crt to access the Service):
 
-{{% code file="service/networking/curlpod.yaml" %}}
+{{% code_sample file="service/networking/curlpod.yaml" %}}
 
 ```shell
 kubectl apply -f ./curlpod.yaml

--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -36,9 +36,9 @@ document.
 Let's say you have a Deployment containing of a single `nginx` replica
 (just for demonstration purposes) and a Service:
 
-{{% code file="service/pod-with-graceful-termination.yaml" %}}
+{{% code_sample file="service/pod-with-graceful-termination.yaml" %}}
 
-{{% code file="service/explore-graceful-termination-nginx.yaml" %}}
+{{% code_sample file="service/explore-graceful-termination-nginx.yaml" %}}
 
 Now create the Deployment Pod and Service using the above files:
 

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -63,7 +63,7 @@ example presented in the
 It creates a [headless Service](/docs/concepts/services-networking/service/#headless-services),
 `nginx`, to publish the IP addresses of Pods in the StatefulSet, `web`.
 
-{{% code file="application/web/web.yaml" %}}
+{{% code_sample file="application/web/web.yaml" %}}
 
 Download the example above, and save it to a file named `web.yaml`
 
@@ -1090,7 +1090,7 @@ terminate all Pods in parallel, and not to wait for Pods to become Running
 and Ready or completely terminated prior to launching or terminating another
 Pod. This option only affects the behavior for scaling operations. Updates are not affected.
 
-{{% code file="application/web/web-parallel.yaml" %}}
+{{% code_sample file="application/web/web-parallel.yaml" %}}
 
 Download the example above, and save it to a file named `web-parallel.yaml`
 

--- a/content/en/docs/tutorials/stateful-application/cassandra.md
+++ b/content/en/docs/tutorials/stateful-application/cassandra.md
@@ -68,7 +68,7 @@ In Kubernetes, a {{< glossary_tooltip text="Service" term_id="service" >}} descr
 
 The following Service is used for DNS lookups between Cassandra Pods and clients within your cluster:
 
-{{% code file="application/cassandra/cassandra-service.yaml" %}}
+{{% code_sample file="application/cassandra/cassandra-service.yaml" %}}
 
 Create a Service to track all Cassandra StatefulSet members from the `cassandra-service.yaml` file:
 
@@ -105,7 +105,7 @@ This example uses the default provisioner for Minikube.
 Please update the following StatefulSet for the cloud you are working with.
 {{< /note >}}
 
-{{% code file="application/cassandra/cassandra-statefulset.yaml" %}}
+{{% code_sample file="application/cassandra/cassandra-statefulset.yaml" %}}
 
 Create the Cassandra StatefulSet from the `cassandra-statefulset.yaml` file:
 

--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -117,14 +117,14 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL
 container mounts the PersistentVolume at /var/lib/mysql. The `MYSQL_ROOT_PASSWORD`
 environment variable sets the database password from the Secret.
 
-{{% code file="application/wordpress/mysql-deployment.yaml" %}}
+{{% code_sample file="application/wordpress/mysql-deployment.yaml" %}}
 
 The following manifest describes a single-instance WordPress Deployment. The WordPress container mounts the
 PersistentVolume at `/var/www/html` for website data files. The `WORDPRESS_DB_HOST` environment variable sets
 the name of the MySQL Service defined above, and WordPress will access the database by Service. The
 `WORDPRESS_DB_PASSWORD` environment variable sets the database password from the Secret kustomize generated.
 
-{{% code file="application/wordpress/wordpress-deployment.yaml" %}}
+{{% code_sample file="application/wordpress/wordpress-deployment.yaml" %}}
 
 1. Download the MySQL deployment configuration file.
 

--- a/content/en/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/en/docs/tutorials/stateful-application/zookeeper.md
@@ -74,7 +74,7 @@ a [Service](/docs/concepts/services-networking/service/),
 a [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets),
 and a [StatefulSet](/docs/concepts/workloads/controllers/statefulset/).
 
-{{% code file="application/zookeeper/zookeeper.yaml" %}}
+{{% code_sample file="application/zookeeper/zookeeper.yaml" %}}
 
 Open a terminal, and use the
 [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands/#apply) command to create the

--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -31,7 +31,7 @@ external IP address.
 
 1. Run a Hello World application in your cluster:
 
-   {{% code file="service/load-balancer-example.yaml" %}}
+   {{% code_sample file="service/load-balancer-example.yaml" %}}
 
    ```shell
    kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml

--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -46,7 +46,7 @@ The guestbook application uses Redis to store its data.
 
 The manifest file, included below, specifies a Deployment controller that runs a single replica Redis Pod.
 
-{{% code file="application/guestbook/redis-leader-deployment.yaml" %}}
+{{% code_sample file="application/guestbook/redis-leader-deployment.yaml" %}}
 
 1. Launch a terminal window in the directory you downloaded the manifest files.
 1. Apply the Redis Deployment from the `redis-leader-deployment.yaml` file:
@@ -86,7 +86,7 @@ You need to apply a [Service](/docs/concepts/services-networking/service/) to
 proxy the traffic to the Redis Pod. A Service defines a policy to access the
 Pods.
 
-{{% code file="application/guestbook/redis-leader-service.yaml" %}}
+{{% code_sample file="application/guestbook/redis-leader-service.yaml" %}}
 
 1. Apply the Redis Service from the following `redis-leader-service.yaml` file:
 
@@ -124,7 +124,7 @@ traffic to the Redis Pod.
 Although the Redis leader is a single Pod, you can make it highly available
 and meet traffic demands by adding a few Redis followers, or replicas.
 
-{{% code file="application/guestbook/redis-follower-deployment.yaml" %}}
+{{% code_sample file="application/guestbook/redis-follower-deployment.yaml" %}}
 
 1. Apply the Redis Deployment from the following `redis-follower-deployment.yaml` file:
 
@@ -158,7 +158,7 @@ The guestbook application needs to communicate with the Redis followers to
 read data. To make the Redis followers discoverable, you must set up another
 [Service](/docs/concepts/services-networking/service/).
 
-{{% code file="application/guestbook/redis-follower-service.yaml" %}}
+{{% code_sample file="application/guestbook/redis-follower-service.yaml" %}}
 
 1. Apply the Redis Service from the following `redis-follower-service.yaml` file:
 
@@ -205,7 +205,7 @@ jQuery-Ajax-based UX.
 
 ### Creating the Guestbook Frontend Deployment
 
-{{% code file="application/guestbook/frontend-deployment.yaml" %}}
+{{% code_sample file="application/guestbook/frontend-deployment.yaml" %}}
 
 1. Apply the frontend Deployment from the `frontend-deployment.yaml` file:
 
@@ -253,7 +253,7 @@ support external load balancers. If your cloud provider supports load
 balancers and you want to use it, uncomment `type: LoadBalancer`.
 {{< /note >}}
 
-{{% code file="application/guestbook/frontend-service.yaml" %}}
+{{% code_sample file="application/guestbook/frontend-service.yaml" %}}
 
 1. Apply the frontend Service from the `frontend-service.yaml` file:
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -147,7 +147,7 @@ deprecated = false
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 
-# See codenew shortcode
+# See code_sample shortcode
 githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 
 # GitHub repository link for editing a page and opening issues.

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -5,7 +5,7 @@
 <!-- scripts for algolia docsearch -->
 {{ end }}
 {{/* copy-and-paste helper for codenew shortcode */}}
-{{- if or (.HasShortcode "code") (.HasShortcode "codenew") -}}
+{{- if or (.HasShortcode "code_sample") (.HasShortcode "code") (.HasShortcode "codenew") -}}
 <script async src="{{ "js/sweetalert-2.1.2.min.js" | relURL }}"></script>
 <script type="text/javascript">
 function copyCode(elem){

--- a/layouts/shortcodes/code_sample.html
+++ b/layouts/shortcodes/code_sample.html
@@ -1,0 +1,32 @@
+{{ $p := .Page }}
+{{ $file := .Get "file" }}
+{{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }} 
+{{ $fileDir := path.Split $file }}
+{{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
+{{ $filename := printf "/content/%s/examples/%s" .Page.Lang $file | safeURL }}
+{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
+{{/* First assume this is a bundle and the file is inside it. */}}
+{{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}
+{{ with $resource }}
+{{ $.Scratch.Set "content" .Content }}
+{{ else }}
+{{/* Read the file relative to the content root. */}}
+{{ $resource := readFile $filename}}
+{{ with $resource }}{{ $.Scratch.Set "content" . }}{{ end }}
+{{ end }}
+{{ if not ($.Scratch.Get "content") }}
+{{ errorf "[%s] %q not found in %q" site.Language.Lang $fileDir.File $bundlePath }}
+{{ end }}
+{{ with $.Scratch.Get "content" }}
+<div class="highlight">
+    <div class="copy-code-icon" style="text-align:right">
+    {{ with $ghlink }}<a href="{{ . }}" download="{{ $file }}">{{ end }}<code>{{ $file }}</code>
+    {{ if $ghlink }}</a>{{ end }}
+    <img src="{{ "images/copycode.svg" | relURL }}" style="max-height:24px; cursor: pointer" onclick="copyCode('{{ $file | anchorize }}')" title="Copy {{ $file }} to clipboard">
+    </img>
+    </div>
+    <div class="includecode" id="{{ $file | anchorize }}">
+    {{- highlight . $codelang "" -}}
+    </div>
+</div>
+{{ end }}


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Rename code shortcode to code_sample

see https://github.com/kubernetes/website/issues/42203#issuecomment-1691439368
> It's not too late to switch now, I looked at it and now only zh-cn downstream uses code shortcode.
After the Chinese synchronization is completed again, I can remove the `code` shortcode.


[preview page](https://deploy-preview-42703--kubernetes-io-main-staging.netlify.app/docs/contribute/style/hugo-shortcodes/#source-code-files).