### PR TITLE
Highlighting an important point regarding ConfigMaps

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -29,10 +29,12 @@ that exposes the database component to your cluster.
 This lets you fetch a container image running in the cloud and
 debug the exact same code locally if needed.
 
+{{< note >}}
 A ConfigMap is not designed to hold large chunks of data. The data stored in a
 ConfigMap cannot exceed 1 MiB. If you need to store settings that are
 larger than this limit, you may want to consider mounting a volume or use a
 separate database or file service.
+{{< /note >}}
 
 ## ConfigMap object
 


### PR DESCRIPTION
The maximum size limit of a ConfigMap is something that should be emphasized in the document to immediately catch the reader's attention. 

By highlighting this paragraph, users can quickly discern this information and decide whether to proceed with it or explore the other options mentioned in the same paragraph.

