### PR TITLE
Remove 1.24 and update august patch releases

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,6 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| August 2023           | 2023-08-04           | 2023-08-23  |
 | September 2023        | 2023-09-08           | 2023-09-13  |
 | October 2023          | 2023-10-13           | 2023-10-18  |
 | November 2023         | N/A                  | N/A         |

--- a/data/releases/eol.yaml
+++ b/data/releases/eol.yaml
@@ -1,4 +1,9 @@
 branches:
+  - release: "1.24"
+    finalPatchRelease: "1.24.17"
+    endOfLifeDate: 2023-07-28
+    note: >-
+      1.24.17 was released in August 2023 (after the EOL date) to fix CVE-2023-3676 and CVE-2023-3955
   - release: "1.23"
     finalPatchRelease: "1.23.17"
     endOfLifeDate: 2023-02-28

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -25,7 +25,7 @@ schedules:
   next:
     release: 1.27.6
     cherryPickDeadline: 2023-09-08
-    targetDate: 2023-09-11
+    targetDate: 2023-09-13
   previousPatches:
     - release: 1.27.5
       cherryPickDeadline: 2023-08-04
@@ -91,7 +91,7 @@ schedules:
   endOfLifeDate: 2023-10-28
   next:
     release: 1.25.14
-    cherryPickDeadline: 2023-09-09
+    cherryPickDeadline: 2023-09-08
     targetDate: 2023-09-13
   previousPatches:
     - release: 1.25.13

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -5,12 +5,17 @@ schedules:
 - release: 1.28
   releaseDate: 2023-08-15
   next:
-   release: 1.28.1
-  cherryPickDeadline: 2023-09-08
+    release: 1.28.2
+    cherryPickDeadline: 2023-09-08
+    targetDate: 2023-09-13
   maintenanceModeStartDate: 2024-08-28
-  targetDate: 2023-09-13
   endOfLifeDate: 2024-10-28
   previousPatches:
+    - release: 1.28.1
+      cherryPickDeadline: N/A
+      targetDate: 2023-08-23
+      note: >-
+        Unplanned release to include CVE fixes
     - release: 1.28.0
       targetDate: 2023-08-15
 - release: 1.27
@@ -18,10 +23,13 @@ schedules:
   maintenanceModeStartDate: 2024-04-28
   endOfLifeDate: 2024-06-28
   next:
-    release: 1.27.5
-    cherryPickDeadline: 2023-08-04
-    targetDate: 2023-08-23
+    release: 1.27.6
+    cherryPickDeadline: 2023-09-08
+    targetDate: 2023-09-11
   previousPatches:
+    - release: 1.27.5
+      cherryPickDeadline: 2023-08-04
+      targetDate: 2023-08-23
     - release: 1.27.4
       cherryPickDeadline: 2023-07-14
       targetDate: 2023-07-19
@@ -44,10 +52,13 @@ schedules:
   maintenanceModeStartDate: 2023-12-28
   endOfLifeDate: 2024-02-28
   next:
-    release: 1.26.8
-    cherryPickDeadline: 2023-08-04
-    targetDate: 2023-08-23
+    release: 1.26.9
+    cherryPickDeadline: 2023-09-08
+    targetDate: 2023-09-13
   previousPatches:
+    - release: 1.26.8
+      cherryPickDeadline: 2023-08-04
+      targetDate: 2023-08-23
     - release: 1.26.7
       cherryPickDeadline: 2023-07-14
       targetDate: 2023-07-19
@@ -79,10 +90,13 @@ schedules:
   maintenanceModeStartDate: 2023-08-28
   endOfLifeDate: 2023-10-28
   next:
-    release: 1.25.13
-    cherryPickDeadline: 2023-08-04
-    targetDate: 2023-08-23
+    release: 1.25.14
+    cherryPickDeadline: 2023-09-09
+    targetDate: 2023-09-13
   previousPatches:
+    - release: 1.25.13
+      cherryPickDeadline: 2023-08-04
+      targetDate: 2023-08-23
     - release: 1.25.12
       cherryPickDeadline: 2023-07-14
       targetDate: 2023-07-19
@@ -128,69 +142,3 @@ schedules:
     - release: 1.25.0
       cherryPickDeadline: ""
       targetDate: 2022-08-23
-- release: 1.24
-  releaseDate: 2022-05-03
-  maintenanceModeStartDate: 2023-05-28
-  endOfLifeDate: 2023-07-28
-  next:
-    release: N/A
-    cherryPickDeadline: ""
-    targetDate: ""
-  previousPatches:
-    - release: 1.24.16
-      cherryPickDeadline: 2023-07-14
-      targetDate: 2023-07-19
-    - release: 1.24.15
-      cherryPickDeadline: 2023-06-09
-      targetDate: 2023-06-14
-    - release: 1.24.14
-      cherryPickDeadline: 2023-05-12
-      targetDate: 2023-05-17
-    - release: 1.24.13
-      cherryPickDeadline: 2023-04-07
-      targetDate: 2023-04-12
-    - release: 1.24.12
-      cherryPickDeadline: 2023-03-10
-      targetDate: 2023-03-15
-    - release: 1.24.11
-      cherryPickDeadline: 2023-02-10
-      targetDate: 2023-02-15
-      note: >-
-        [Some container images might be **unsigned** due to a temporary issue with the promotion process](https://groups.google.com/a/kubernetes.io/g/dev/c/MwSx761slM0/m/4ajkeUl0AQAJ)
-    - release: 1.24.10
-      cherryPickDeadline: 2023-01-13
-      targetDate: 2023-01-18
-    - release: 1.24.9
-      cherryPickDeadline: 2022-12-02
-      targetDate: 2022-12-08
-    - release: 1.24.8
-      cherryPickDeadline: 2022-11-04
-      targetDate: 2022-11-09
-    - release: 1.24.7
-      cherryPickDeadline: 2022-10-07
-      targetDate: 2022-10-12
-    - release: 1.24.6
-      cherryPickDeadline: 2022-09-20
-      targetDate: 2022-09-21
-      note: >-
-        [Out-of-Band release to fix the regression introduced in 1.24.5](https://groups.google.com/a/kubernetes.io/g/dev/c/tA6LNOQTR4Q/m/zL73maPTAQAJ)
-    - release: 1.24.5
-      cherryPickDeadline: 2022-09-09
-      targetDate: 2022-09-14
-      note: >-
-        [Regression](https://groups.google.com/a/kubernetes.io/g/dev/c/tA6LNOQTR4Q/m/zL73maPTAQAJ)
-    - release: 1.24.4
-      cherryPickDeadline: 2022-08-12
-      targetDate: 2022-08-17
-    - release: 1.24.3
-      cherryPickDeadline: 2022-07-08
-      targetDate: 2022-07-13
-    - release: 1.24.2
-      cherryPickDeadline: 2022-06-10
-      targetDate: 2022-06-15
-    - release: 1.24.1
-      cherryPickDeadline: 2022-05-20
-      targetDate: 2022-05-24
-    - release: 1.24.0
-      cherryPickDeadline: ""
-      targetDate: 2022-05-03


### PR DESCRIPTION
This PR wraps a few updates into one PR:

* Drop 1.24 from the schedule.yaml as it is now EOL
* Update to reflect august patch releases

/assign @saschagrunert @cpanato @puerco @xmudrii 
cc https://github.com/orgs/kubernetes/teams/release-engineering