### PR TITLE
Missing dashs in networkpolicy.yaml

### DIFF
--- a/content/en/examples/service/networking/networkpolicy.yaml
+++ b/content/en/examples/service/networking/networkpolicy.yaml
@@ -22,14 +22,14 @@ spec:
         - podSelector:
             matchLabels:
               role: frontend
-      ports:
+    - ports:
         - protocol: TCP
           port: 6379
   egress:
     - to:
         - ipBlock:
             cidr: 10.0.0.0/24
-      ports:
+    - ports:
         - protocol: TCP
           port: 5978
 


### PR DESCRIPTION
Referring to https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/,  there is missing dash before the "ports" sections.

