### PR TITLE
Fix stale advice on changing the Container Runtime on a Node

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -76,6 +76,8 @@ instructions for that tool.
 1.  Open `/var/lib/kubelet/kubeadm-flags.env` on each affected node.
 1.  Modify the `--container-runtime-endpoint` flag to
     `unix:///var/run/cri-dockerd.sock`.
+1.  Modify the `--container-runtime` flag to `remote`
+    in Kubernetes 1.27 and earlier.
 
 The kubeadm tool stores the node's socket as an annotation on the `Node` object
 in the control plane. To modify this socket for each affected node:  

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -77,7 +77,7 @@ instructions for that tool.
 1.  Modify the `--container-runtime-endpoint` flag to
     `unix:///var/run/cri-dockerd.sock`.
 1.  Modify the `--container-runtime` flag to `remote`
-    in Kubernetes 1.27 and earlier.
+    (available in Kubernetes 1.26 and earlier).
 
 The kubeadm tool stores the node's socket as an annotation on the `Node` object
 in the control plane. To modify this socket for each affected node:  

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -77,7 +77,7 @@ instructions for that tool.
 1.  Modify the `--container-runtime-endpoint` flag to
     `unix:///var/run/cri-dockerd.sock`.
 1.  Modify the `--container-runtime` flag to `remote`
-    (available in Kubernetes 1.26 and earlier).
+    (unavailable in Kubernetes v1.27 and later).
 
 The kubeadm tool stores the node's socket as an annotation on the `Node` object
 in the control plane. To modify this socket for each affected node:  


### PR DESCRIPTION
Stale advice on changing the Container Runtime on a Node from Docker Engine to containerd.

> At least in Kubernetes version 1.22, it is also necessary to add the flag --container-runtime=remote

see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md?plain=1#L1329

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
