### PR TITLE
[zh] sync kubeadm_config_print_reset-defaults.md

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_reset-defaults.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_reset-defaults.md
@@ -1,0 +1,119 @@
+<!--
+Print default reset configuration, that can be used for 'kubeadm reset'
+-->
+打印默认的 reset 配置，该配置可用于 'kubeadm reset' 命令。
+
+<!--
+### Synopsis
+-->
+### 概要
+
+<!--
+This command prints objects such as the default reset configuration that is used for 'kubeadm reset'.
+-->
+此命令打印 'kubeadm reset' 所用的默认 reset 配置等这类对象。
+
+<!--
+Note that sensitive values like the Bootstrap Token fields are replaced with placeholder values like "abcdef.0123456789abcdef" in order to pass validation but
+not perform the real computation for creating a token.
+-->
+请注意，诸如启动引导令牌（Bootstrap Token）字段这类敏感值已替换为 "abcdef.0123456789abcdef"
+这类占位符值用来通过合法性检查，但不执行创建令牌的实际计算。
+
+```
+kubeadm config print reset-defaults [flags]
+```
+
+<!--
+### Options
+-->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--component-configs strings</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+A comma-separated list for component config API objects to print the default values for. Available values: [KubeProxyConfiguration KubeletConfiguration]. If this flag is not set, no component configs will be printed.
+-->
+组件配置 API 对象的逗号分隔列表，打印其默认值。
+可用值：[KubeProxyConfiguration KubeletConfiguration]。
+如果此参数未被设置，则不会打印任何组件配置。
+</p>
+</td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+help for reset-defaults
+-->
+reset-defaults 操作的帮助命令。
+</p>
+</td>
+</tr>
+
+</tbody>
+</table>
+
+<!--
+### Options inherited from parent commands
+-->
+### 从父命令继承的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">
+<!--
+--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/admin.conf"
+-->
+--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："/etc/kubernetes/admin.conf"
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
+-->
+与集群通信时所使用的 kubeconfig 文件。
+如果该参数未被设置，则可以在一组标准位置中搜索现有的 kubeconfig 文件。
+</p>
+</td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
+-->
+[试验性] 指向“真实”主机根文件系统的路径。
+</p>
+</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
Add zh text to this page:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_reset-defaults.md
```
See [preview](https://deploy-preview-42742--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_reset-defaults/) please.