### PR TITLE
fix: configmap-pod CrashLoopBackOff

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -174,7 +174,7 @@ spec:
   containers:
     - name: test
       image: busybox:1.28
-      command: ['sh', '-c', 'echo The app is running! && sleep 3600']
+      command: ['sh', '-c', 'echo "The app is running!" && tail -f /dev/null']
       volumeMounts:
         - name: config-vol
           mountPath: /etc/config

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -174,6 +174,7 @@ spec:
   containers:
     - name: test
       image: busybox:1.28
+      command: ['sh', '-c', 'echo The app is running! && sleep 3600']
       volumeMounts:
         - name: config-vol
           mountPath: /etc/config


### PR DESCRIPTION
with the "configmap-pod" yaml,the container "test"fail to run with reason of "CrashLoopBackOff".  
I suggest adding  a command.
