### PR TITLE
Fix broken link in "Moving Forward From Beta" blog

### DIFF
--- a/content/en/blog/_posts/2020-08-21-Moving-Forward-From-Beta/index.md
+++ b/content/en/blog/_posts/2020-08-21-Moving-Forward-From-Beta/index.md
@@ -12,7 +12,7 @@ In Kubernetes, features follow a defined
 First, as the twinkle of an eye in an interested developer. Maybe, then,
 sketched in online discussions, drawn on the online equivalent of a cafe
 napkin. This rough work typically becomes a
-[Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements/blob/master/keps/0001-kubernetes-enhancement-proposal-process.md#kubernetes-enhancement-proposal-process) (KEP), and
+[Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/0000-kep-process/README.md#kubernetes-enhancement-proposal-process) (KEP), and
 from there it usually turns into code.
 
 For Kubernetes v1.20 and onwards, we're focusing on helping that code


### PR DESCRIPTION
PR addresses the broken link within the "[Moving Forward From Beta](https://kubernetes.io//blog/2020/08/21/moving-forward-from-beta/)" blog post. Since the blog post is more than 1 year old, this PR could serve as companion to PR https://github.com/kubernetes/website/pull/42694, which focuses on eliminating the staleness warning from the same blog. 

#### Additional Context
The broken URL problem arose due to the relocation of the original content as part of commit https://github.com/kubernetes/enhancements/commit/353137c2716c4d56895974e198139e5e3bd2282d

**[Blog Deploy Preview](https://deploy-preview-42768--kubernetes-io-main-staging.netlify.app/blog/2020/08/21/moving-forward-from-beta/)**




