### PR TITLE
kubeadm: update feature gates and add removed FGs

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -205,9 +205,10 @@ feature gate will be removed in a future release.
 List of removed feature gates:
 
 {{< table caption="kubeadm removed feature gates" >}}
-Feature | Default | Alpha | Beta | GA | Removed
-:-------|:--------|:------|:-----|:---|:-------
-`UnversionedKubeletConfigMap` | `true` | 1.22 | 1.23 | 1.25 | 1.26
+Feature | Alpha | Beta | GA | Removed
+:-------|:------|:-----|:---|:-------
+`UnversionedKubeletConfigMap` | 1.22 | 1.23 | 1.25 | 1.26
+`IPv6DualStack` | 1.16 | 1.21 | 1.23 | 1.24
 {{< /table >}}
 
 Feature gate descriptions:
@@ -221,6 +222,10 @@ that ConfigMap are appropriate for the value you set. When kubeadm writes this C
 or `kubeadm upgrade apply`), kubeadm respects the value of `UnversionedKubeletConfigMap`. When reading that ConfigMap
 (during `kubeadm join`, `kubeadm reset`, `kubeadm upgrade ...`), kubeadm attempts to use unversioned ConfigMap name first;
 if that does not succeed, kubeadm falls back to using the legacy (versioned) name for that ConfigMap.
+
+`IPv6DualStack`
+: This flag helps to configure components dual stack when the feature is in progress. For more details on Kubernetes
+dual-stack support see [Dual-stack support with kubeadm](/docs/setup/production-environment/tools/kubeadm/dual-stack-support/).
 
 ### Adding kube-proxy parameters {#kube-proxy}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -159,6 +159,7 @@ Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
 `PublicKeysECDSA` | `false` | 1.19 | - | -
 `RootlessControlPlane` | `false` | 1.22 | - | -
+`EtcdLearnerMode` | `false` | 1.27 | - | -
 {{< /table >}}
 
 {{< note >}}
@@ -177,6 +178,10 @@ switch between the RSA and ECDSA algorithms on the fly or during upgrades.
 for `kube-apiserver`, `kube-controller-manager`, `kube-scheduler` and `etcd` to run as non-root users.
 If the flag is not set, those components run as root. You can change the value of this feature gate before
 you upgrade to a newer version of Kubernetes.
+
+`EtcdLearnerMode`
+: With this feature gate enabled, when joining a new control plane node, a new etcd member will be created
+as a learner and promoted to a voting member only after the etcd data are fully aligned.
 
 List of deprecated feature gates:
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -159,7 +159,6 @@ Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
 `PublicKeysECDSA` | `false` | 1.19 | - | -
 `RootlessControlPlane` | `false` | 1.22 | - | -
-`UnversionedKubeletConfigMap` | `true` | 1.22 | 1.23 | 1.25
 {{< /table >}}
 
 {{< note >}}
@@ -178,16 +177,6 @@ switch between the RSA and ECDSA algorithms on the fly or during upgrades.
 for `kube-apiserver`, `kube-controller-manager`, `kube-scheduler` and `etcd` to run as non-root users.
 If the flag is not set, those components run as root. You can change the value of this feature gate before
 you upgrade to a newer version of Kubernetes.
-
-`UnversionedKubeletConfigMap`
-: This flag controls the name of the {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} where kubeadm stores
-kubelet configuration data. With this flag not specified or set to `true`, the ConfigMap is named `kubelet-config`.
-If you set this flag to `false`, the name of the ConfigMap includes the major and minor version for Kubernetes
-(for example: `kubelet-config-{{< skew currentVersion >}}`). Kubeadm ensures that RBAC rules for reading and writing
-that ConfigMap are appropriate for the value you set. When kubeadm writes this ConfigMap (during `kubeadm init`
-or `kubeadm upgrade apply`), kubeadm respects the value of `UnversionedKubeletConfigMap`. When reading that ConfigMap
-(during `kubeadm join`, `kubeadm reset`, `kubeadm upgrade ...`), kubeadm attempts to use unversioned ConfigMap name first;
-if that does not succeed, kubeadm falls back to using the legacy (versioned) name for that ConfigMap.
 
 List of deprecated feature gates:
 
@@ -212,6 +201,26 @@ other control plane instances have been upgraded completely, and the addons upgr
 instance is upgraded. The deprecated `UpgradeAddonsBeforeControlPlane` feature gate gives you a chance to keep the old upgrade
 behavior. You should not need this old behavior; if you do, you should consider changing your cluster or upgrade processes, as this
 feature gate will be removed in a future release.
+
+List of removed feature gates:
+
+{{< table caption="kubeadm removed feature gates" >}}
+Feature | Default | Alpha | Beta | GA | Removed
+:-------|:--------|:------|:-----|:---|:-------
+`UnversionedKubeletConfigMap` | `true` | 1.22 | 1.23 | 1.25 | 1.26
+{{< /table >}}
+
+Feature gate descriptions:
+
+`UnversionedKubeletConfigMap`
+: This flag controls the name of the {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} where kubeadm stores
+kubelet configuration data. With this flag not specified or set to `true`, the ConfigMap is named `kubelet-config`.
+If you set this flag to `false`, the name of the ConfigMap includes the major and minor version for Kubernetes
+(for example: `kubelet-config-{{< skew currentVersion >}}`). Kubeadm ensures that RBAC rules for reading and writing
+that ConfigMap are appropriate for the value you set. When kubeadm writes this ConfigMap (during `kubeadm init`
+or `kubeadm upgrade apply`), kubeadm respects the value of `UnversionedKubeletConfigMap`. When reading that ConfigMap
+(during `kubeadm join`, `kubeadm reset`, `kubeadm upgrade ...`), kubeadm attempts to use unversioned ConfigMap name first;
+if that does not succeed, kubeadm falls back to using the legacy (versioned) name for that ConfigMap.
 
 ### Adding kube-proxy parameters {#kube-proxy}
 


### PR DESCRIPTION
Action items

- [x] add EtcdLearnerMode FG docs: only add it is alpha since v1.27. (For v1.29, I will update the doc to dev-v1.29 branch later)
- [x] add back some old FGs to removed session: IPv6DualStack


https://github.com/kubernetes/kubernetes/blob/a3ccea9d8743f2ff82e41b6c2af6dc2c41dc7b10/cmd/kubeadm/app/features/features.go#L45-L47

CoreDNS/ DynamicKubeletConfig/Auditing are feature gates before 2020 IIRC. I will not include them here.

