### PR TITLE
Tiny corrections for the Kubernetes basics tutorials

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -84,7 +84,7 @@ description: |-
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_fill">
-                    <p><i> Applications need to be packaged into one of the supported container formats in order to be deployed on Kubernetes </i></p>
+                    <p><i>Applications need to be packaged into one of the supported container formats in order to be deployed on Kubernetes.</i></p>
                 </div>
             </div>
         </div>
@@ -114,24 +114,24 @@ description: |-
             <div class="col-md-12">
                 <a id="deploy-an-app"></a>
                 <h3>Deploy an app</h3>
-                <p>Let’s deploy our first app on Kubernetes with the <code>kubectl create deployment</code> command. We need to provide the deployment name and app image location (include the full repository url for images hosted outside Docker Hub).</p>
+                <p>Let’s deploy our first app on Kubernetes with the <code>kubectl create deployment</code> command. We need to provide the Deployment name and app image location (include the full repository url for images hosted outside Docker Hub).</p>
                 <p><b><code>kubectl create deployment kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1</code></b></p>
-                <p>Great! You just deployed your first application by creating a deployment. This performed a few things for you:</p>
+                <p>Great! You just deployed your first application by creating a Deployment. This performed a few things for you:</p>
                 <ul>
                 <li>searched for a suitable node where an instance of the application could be run (we have only 1 available node)</li>
                 <li>scheduled the application to run on that Node</li>
                 <li>configured the cluster to reschedule the instance on a new Node when needed</li>
                 </ul>
-                <p>To list your deployments use the <code>kubectl get deployments</code> command:</p>
+                <p>To list your Deployments use the <code>kubectl get deployments</code> command:</p>
                 <p><b><code>kubectl get deployments</code></b></p>
-                <p>We see that there is 1 deployment running a single instance of your app. The instance is running inside a container on your node.</p>
+                <p>We see that there is 1 Deployment running a single instance of your app. The instance is running inside a container on your node.</p>
             </div>
         </div>
         <div class="row">
             <div class="col-md-12">
                 <h3>View the app</h3>
                 <p>Pods that are running inside Kubernetes are running on a private, isolated network.
-                By default they are visible from other pods and services within the same Kubernetes cluster, but not outside that network.
+                By default they are visible from other Pods and Services within the same Kubernetes cluster, but not outside that network.
                 When we use <code>kubectl</code>, we're interacting through an API endpoint to communicate with our application.</p>
                 <p>We will cover other options on how to expose your application outside the Kubernetes cluster later, in <a href="/docs/tutorials/kubernetes-basics/expose/">Module 4</a>.</p>
                 <p>The <code>kubectl proxy</code> command can create a proxy that will forward communications into the cluster-wide, private network. The proxy can be terminated by pressing control-C and won't show any output while its running.</p>
@@ -141,7 +141,7 @@ description: |-
                 <p>You can see all those APIs hosted through the proxy endpoint. For example, we can query the version directly through the API using the <code>curl</code> command:</p>
                 <p><b><code>curl http://localhost:8001/version</code></b></p>
                 <div class="alert alert-info note callout" role="alert"><strong>Note:</strong> If port 8001 is not accessible, ensure that the <code>kubectl proxy</code> that you started above is running in the second terminal.</div>
-                <p>The API server will automatically create an endpoint for each pod, based on the pod name, that is also accessible through the proxy.</p>
+                <p>The API server will automatically create an endpoint for each Pod, based on the Pod name, that is also accessible through the proxy.</p>
                 <p>First we need to get the Pod name, and we'll store in the environment variable <tt>POD_NAME</tt>:</p>
                 <p><b><code>export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')</code></b><br />
                    <b><code>echo Name of the Pod: $POD_NAME</code></b></p>

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -75,7 +75,7 @@ description: |-
         <div class="row">
             <div class="col-md-8">
                 <h2>Nodes</h2>
-                <p>A Pod always runs on a <b>Node</b>. A Node is a worker machine in Kubernetes and may be either a virtual or a physical machine, depending on the cluster. Each Node is managed by the control plane. A Node can have multiple pods, and the Kubernetes control plane automatically handles scheduling the pods across the Nodes in the cluster. The control plane's automatic scheduling takes into account the available resources on each Node.</p>
+                <p>A Pod always runs on a <b>Node</b>. A Node is a worker machine in Kubernetes and may be either a virtual or a physical machine, depending on the cluster. Each Node is managed by the control plane. A Node can have multiple Pods, and the Kubernetes control plane automatically handles scheduling the Pods across the Nodes in the cluster. The control plane's automatic scheduling takes into account the available resources on each Node.</p>
 
                 <p>Every Kubernetes Node runs at least:</p>
                 <ul>
@@ -86,7 +86,7 @@ description: |-
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_fill">
-                    <p><i> Containers should only be scheduled together in a single Pod if they are tightly coupled and need to share resources such as disk. </i></p>
+                    <p><i>Containers should only be scheduled together in a single Pod if they are tightly coupled and need to share resources such as disk.</i></p>
                 </div>
             </div>
         </div>
@@ -113,8 +113,8 @@ description: |-
                 <ul>
                     <li><tt><b>kubectl get</b></tt> - list resources</li>
                     <li><tt><b>kubectl describe</b></tt> - show detailed information about a resource</li>
-                    <li><tt><b>kubectl logs</b></tt> - print the logs from a container in a pod</li>
-                    <li><tt><b>kubectl exec</b></tt> - execute a command on a container in a pod</li>
+                    <li><tt><b>kubectl logs</b></tt> - print the logs from a container in a Pod</li>
+                    <li><tt><b>kubectl exec</b></tt> - execute a command on a container in a Pod</li>
                 </ul>
 
                 <p>You can use these commands to see when applications were deployed, what their current statuses are, where they are running and what their configurations are.</p>
@@ -124,7 +124,7 @@ description: |-
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_fill">
-                    <p><i> A node is a worker machine in Kubernetes and may be a VM or physical machine, depending on the cluster. Multiple Pods can run on one Node. </i></p>
+                    <p><i>A node is a worker machine in Kubernetes and may be a VM or physical machine, depending on the cluster. Multiple Pods can run on one Node.</i></p>
                 </div>
             </div>
         </div>
@@ -134,10 +134,10 @@ description: |-
                 <h3>Check application configuration</h3>
                 <p>Let's verify that the application we deployed in the previous scenario is running. We'll use the <code>kubectl get</code> command and look for existing Pods:</p>
                 <p><b><code>kubectl get pods</code></b></p>
-                <p>If no pods are running, please wait a couple of seconds and list the Pods again. You can continue once you see one Pod running.</p>
+                <p>If no Pods are running, please wait a couple of seconds and list the Pods again. You can continue once you see one Pod running.</p>
                 <p>Next, to view what containers are inside that Pod and what images are used to build those containers we run the <code>kubectl describe pods</code> command:</p>
                 <p><b><code>kubectl describe pods</code></b></p>
-                <p>We see here details about the Pod’s container: IP address, the ports used and a list of events related to the lifecycle of the Pod.</p>
+                <p>We see here details about the Pod’s container: IP address, the ports used and a list of events related to the <a href="/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase">lifecycle of the Pod</a>.</p>
                 <p>The output of the <tt>describe</tt> subcommand is extensive and covers some concepts that we didn’t explain yet, but don’t worry, they will become familiar by the end of this bootcamp.</p>
                 <p><em><strong>Note:</strong> the <tt>describe</tt> subcommand can be used to get detailed information about most of the Kubernetes primitives, including Nodes, Pods, and Deployments. The describe output is designed to be human readable, not to be scripted against.</em></p>
             </div>
@@ -149,7 +149,7 @@ description: |-
                 <p>Recall that Pods are running in an isolated, private network - so we need to proxy access
                 to them so we can debug and interact with them. To do this, we'll use the <code>kubectl proxy</code> command to run a proxy in a <strong>second terminal</strong>. Open a new terminal window, and in that new terminal, run:</p>
                 <p><code><b>kubectl proxy</b></code></p>
-                <p>Now again, we'll get the Pod name and query that pod directly through the proxy.
+                <p>Now again, we'll get the Pod name and query that Pod directly through the proxy.
                 To get the Pod name and store it in the <tt>POD_NAME</tt> environment variable:</p>
                 <p><code><b>export POD_NAME="$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"</b></code><br />
                 <code><b>echo Name of the Pod: $POD_NAME</b></code></p>
@@ -164,7 +164,7 @@ description: |-
                 <h3>View the container logs</h3>
                 <p>Anything that the application would normally send to standard output becomes logs for the container within the Pod. We can retrieve these logs using the <code>kubectl logs</code> command:</p>
                 <p><code><b>kubectl logs "$POD_NAME"</b></code></p>
-                <p><em><strong>Note:</strong> We don't need to specify the container name, because we only have one container inside the pod.</em></p>
+                <p><em><strong>Note:</strong> We don't need to specify the container name, because we only have one container inside the Pod.</em></p>
            </div>
         </div>
 
@@ -172,7 +172,7 @@ description: |-
             <div class="col-md-12">
                 <h3>Executing command on the container</h3>
                 <p>We can execute commands directly on the container once the Pod is up and running.
-                For this, we use the <code>exec</code> subcommand and use the name of the Pod as a parameter. Let’s list the environment variables:</p>
+                For this, we use the <code>exec</code> subcommand and use the name of the Pod as a parameter. Let’s list the environment variables in our container:</p>
                 <p><code><b>kubectl exec "$POD_NAME" -- env</b></code></p>
                 <p>Again, it's worth mentioning that the name of the container itself can be omitted since we only have a single container in the Pod.</p>
                 <p>Next let’s start a bash session in the Pod’s container:</p>
@@ -181,7 +181,7 @@ description: |-
                 <p><code><b>cat server.js</b></code></p>
                 <p>You can check that the application is up by running a <tt>curl</tt> command:</p>
                 <p><code><b>curl http://localhost:8080</b></code></p>
-                <p><em><strong>Note:</strong> here we used <tt>localhost</tt> because we executed the command inside the NodeJS Pod. If you cannot connect to localhost:8080, check to make sure you have run the <code>kubectl exec</code> command and are launching the command from within the Pod</em></p>
+                <p><em><strong>Note:</strong> here we used <tt>localhost</tt> because we executed the command inside the NodeJS Pod. If you cannot connect to localhost:8080, check to make sure you have run the <code>kubectl exec</code> command and are launching the <code>curl</code> command from within the Pod.</em></p>
                 <p>To close your container connection, type <code><b>exit</b></code>.</p>
            </div>
         </div>

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -68,7 +68,7 @@ description: |-
 
 		<div class="row">
 			<div class="col-md-8">
-				<p>A Service routes traffic across a set of Pods. Services are the abstraction that allows pods to die and replicate in Kubernetes without impacting your application. Discovery and routing among dependent Pods (such as the frontend and backend components in an application) are handled by Kubernetes Services.</p>
+				<p>A Service routes traffic across a set of Pods. Services are the abstraction that allows Pods to die and replicate in Kubernetes without impacting your application. Discovery and routing among dependent Pods (such as the frontend and backend components in an application) are handled by Kubernetes Services.</p>
 				<p>Services match a set of Pods using <a href="/docs/concepts/overview/working-with-objects/labels">labels and selectors</a>, a grouping primitive that allows logical operation on objects in Kubernetes. Labels are key/value pairs attached to objects and can be used in any number of ways:</p>
 				<ul>
 					<li>Designate objects for development, test, and production</li>
@@ -97,16 +97,16 @@ description: |-
 				<h3>Create a new Service</h3>
 				<p>Let’s verify that our application is running. We’ll use the <code>kubectl get</code> command and look for existing Pods:</p>
 				<p><code><b>kubectl get pods</b></code></p>
-				<p>If no Pods are running then it means the objects from the previous tutorials were cleaned up. In this case, go back and recreate the deployment from the <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro#deploy-an-app">Using kubectl to create a Deployment</a> tutorial.
+				<p>If no Pods are running then it means the objects from the previous tutorials were cleaned up. In this case, go back and recreate the Deployment from the <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro#deploy-an-app">Using kubectl to create a Deployment</a> tutorial.
           Please wait a couple of seconds and list the Pods again. You can continue once you see the one Pod running.</p>
 				<p>Next, let’s list the current Services from our cluster:</p>
 				<p><code><b>kubectl get services</b></code></p>
 				<p>We have a Service called <tt>kubernetes</tt> that is created by default when minikube starts the cluster.
-				To create a new service and expose it to external traffic we'll use the expose command with NodePort as parameter.</p>
+				To create a new Service and expose it to external traffic we'll use the <code>expose</code> command specifying the NodePort type as parameter.</p>
 				<p><code><b>kubectl expose deployment/kubernetes-bootcamp --type="NodePort" --port 8080</b></code></p>
 				<p>Let's run again the <code>get services</code> subcommand:</p>
 				<p><code><b>kubectl get services</b></code></p>
-				<p>We have now a running Service called kubernetes-bootcamp. Here we see that the Service received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).</p>
+				<p>We have now a running Service called <tt>kubernetes-bootcamp</tt>. Here we see that the Service received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).</p>
 				<p>To find out what port was opened externally (for the <tt>type: NodePort</tt> Service) we’ll run the <code>describe service</code> subcommand:</p>
 				<p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
 				<p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
@@ -120,11 +120,11 @@ description: |-
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Step 2: Using labels</h3>
+				<h3>Using labels</h3>
 				<div class="content">
 				<p>The Deployment created automatically a label for our Pod. With the <code>describe deployment</code> subcommand you can see the name (the <em>key</em>) of that label:</p>
 				<p><code><b>kubectl describe deployment</b></code></p>
-				<p>Let’s use this label to query our list of Pods. We’ll use the <code>kubectl get pods</code> command with <tt>-l</tt> as a parameter, followed by the label values:</p>
+				<p>Let’s use this label to query our list of Pods. We’ll use the <code>kubectl get pods</code> command with the <tt>-l</tt> flag, followed by the label values:</p>
 				<p><code><b>kubectl get pods -l app=kubernetes-bootcamp</b></code></p>
 				<p>You can do the same to list the existing Services:</p>
 				<p><code><b>kubectl get services -l app=kubernetes-bootcamp</b></code></p>
@@ -133,9 +133,9 @@ description: |-
 				   <code><b>echo "Name of the Pod: $POD_NAME"</b></code></p>
 				<p>To apply a new label we use the <code>label</code> subcommand followed by the object type, object name and the new label:</p>
 				<p><code><b>kubectl label pods "$POD_NAME" version=v1</b></code></p>
-				<p>This will apply a new label to our Pod (we pinned the application version to the Pod), and we can check it with the describe pod command:</p>
+				<p>This will apply a new label to our Pod (we pinned the application version to the Pod), and we can check it with the <code>describe pods</code> command:</p>
 				<p><code><b>kubectl describe pods "$POD_NAME"</b></code></p>
-				<p>We see here that the label is attached now to our Pod. And we can query now the list of pods using the new label:</p>
+				<p>We see here that the label is attached now to our Pod. And we can query now the list of Pods using the new label:</p>
 				<p><code><b>kubectl get pods -l version=v1</b></code></p>
 				<p>And we see the Pod.</p>
 			</div>
@@ -143,7 +143,7 @@ description: |-
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Deleting a service</h3>
+				<h3>Delete the Service</h3>
 				<p>To delete Services you can use the <code>delete service</code> subcommand. Labels can be used also here:</p>
 				<p><code><b>kubectl delete service -l app=kubernetes-bootcamp</b></code></p>
 				<p>Confirm that the Service is gone:</p>
@@ -151,7 +151,7 @@ description: |-
 				<p>This confirms that our Service was removed. To confirm that route is not exposed anymore you can <tt>curl</tt> the previously exposed IP and port:</p>
 				<p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>
 				<p>This proves that the application is not reachable anymore from outside of the cluster.
-				You can confirm that the app is still running with a <tt>curl</tt> from inside the pod:</p>
+				You can confirm that the app is still running with a <tt>curl</tt> from inside the Pod:</p>
 				<p><code><b>kubectl exec -ti $POD_NAME -- curl http://localhost:8080</b></code></p>
 				<p>We see here that the application is up. This is because the Deployment is managing the application. To shut down the application, you would need to delete the Deployment as well.</p>
 			</div>

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -27,7 +27,7 @@ description: |-
             <div class="col-md-8">
        <h3>Scaling an application</h3>
 
-            <p>Previously we created a <a href="/docs/concepts/workloads/controllers/deployment/"> Deployment</a>, and then exposed it publicly via a <a href="/docs/concepts/services-networking/service/">Service</a>. The Deployment created only one Pod for running our application.  When traffic increases, we will need to scale the application to keep up with user demand.</p>
+            <p>Previously we created a <a href="/docs/concepts/workloads/controllers/deployment/">Deployment</a>, and then exposed it publicly via a <a href="/docs/concepts/services-networking/service/">Service</a>. The Deployment created only one Pod for running our application. When traffic increases, we will need to scale the application to keep up with user demand.</p>
             <p>If you haven't worked through the earlier sections, start from <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/">Using minikube to create a cluster</a>.</p>
 
             <p><em>Scaling</em> is accomplished by changing the number of replicas in a Deployment</p>
@@ -41,7 +41,7 @@ description: |-
                     </ul>
                 </div>
                 <div class="content__box content__box_fill">
-                    <p><i> You can create from the start a Deployment with multiple instances using the --replicas parameter for the kubectl create deployment command </i></p>
+                    <p><i>You can create from the start a Deployment with multiple instances using the --replicas parameter for the kubectl create deployment command.</i></p>
                 </div>
             </div>
         </div>
@@ -103,7 +103,7 @@ description: |-
 
         <div class="row">
             <div class="col-md-8">
-                <p> Once you have multiple instances of an application running, you would be able to do Rolling updates without downtime. We'll cover that in the next section of the tutorial. Now, let's go to the terminal and scale our application.</p>
+                <p>Once you have multiple instances of an application running, you would be able to do Rolling updates without downtime. We'll cover that in the next section of the tutorial. Now, let's go to the terminal and scale our application.</p>
             </div>
         </div>
 
@@ -133,13 +133,13 @@ description: |-
                <li><em>DESIRED</em> displays the desired number of replicas of the application, which you define when you create the Deployment. This is the desired state.</li>
                <li><em>CURRENT</em> displays how many replicas are currently running.</li>
                </ul>
-               <p>Next, let’s scale the Deployment to 4 replicas. We’ll use the <code>kubectl scale</code> command, followed by the Deployment type, name and desired number of instances:</p>
+               <p>Next, let’s scale the Deployment to 4 replicas. We’ll use the <code>kubectl scale</code> command, followed by the object type (Deployment), name and desired number of instances:</p>
                <p><code><b>kubectl scale deployments/kubernetes-bootcamp --replicas=4</b></code></p>
                <p>To list your Deployments once again, use <code>get deployments</code>:</p>
                <p><code><b>kubectl get deployments</b></code></p>
                <p>The change was applied, and we have 4 instances of the application available. Next, let’s check if the number of Pods changed:</p>
                <p><code><b>kubectl get pods -o wide</b></code></p>
-               <p>There are 4 Pods now, with different IP addresses. The change was registered in the Deployment events log. To check that, use the describe subcommand:</p>
+               <p>There are 4 Pods now, with different IP addresses. The change was registered in the Deployment events log. To check that, use the <tt>describe</tt> subcommand:</p>
                <p><code><b>kubectl describe deployments/kubernetes-bootcamp</b></code></p>
                <p>You can also view in the output of this command that there are 4 replicas now.</p>
             </div>
@@ -148,7 +148,7 @@ description: |-
         <div class="row">
             <div class="col-md-12">
                <h3>Load Balancing</h3>
-               <p>Let's check that the Service is load-balancing the traffic. To find out the exposed IP and Port we can use the describe service as we learned in the previous part of the tutorial:</p>
+               <p>Let's check that the Service is load-balancing the traffic. To find out the exposed IP and Port we can use the <tt>describe service</tt> subcommand as we learned in <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/">the previous part</a> of the tutorial:</p>
                <p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
                <p>Create an environment variable called <tt>NODE_PORT</tt> that has a value as the Node port:</p>
                <p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')"</b></code><br />

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -41,7 +41,7 @@ description: |-
                     </ul>
                 </div>
                 <div class="content__box content__box_fill">
-                    <p><i>Rolling updates allow Deployments' update to take place with zero downtime by incrementally updating Pods instances with new ones. </i></p>
+                    <p><i>Rolling updates allow Deployments' update to take place with zero downtime by incrementally updating Pods instances with new ones.</i></p>
                 </div>
             </div>
         </div>
@@ -108,7 +108,7 @@ description: |-
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_fill">
-                    <p><i>If a Deployment is exposed publicly, the Service will load-balance the traffic only to available Pods during the update. </i></p>
+                    <p><i>If a Deployment is exposed publicly, the Service will load-balance the traffic only to available Pods during the update.</i></p>
                 </div>
             </div>
         </div>
@@ -117,7 +117,7 @@ description: |-
 
         <div class="row">
             <div class="col-md-8">
-                <p> In the following interactive tutorial, we'll update our application to a new version, and also perform a rollback.</p>
+                <p>In the following interactive tutorial, we'll update our application to a new version, and also perform a rollback.</p>
             </div>
         </div>
         <br>
@@ -132,7 +132,7 @@ description: |-
                <p>To view the current image version of the app, run the <code>describe pods</code> subcommand
                and look for the <code>Image</code> field:</p>
                <p><code><b>kubectl describe pods</b></code></p>
-               <p>To update the image of the application to version 2, use the <code>set image</code> subcommand, followed by the deployment name and the new image version:</p>
+               <p>To update the image of the application to version 2, use the <code>set image</code> subcommand, followed by the Deployment name and the new image version:</p>
                <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=jocatalin/kubernetes-bootcamp:v2</b></code></p>
                <p>The command notified the Deployment to use a different image for your app and initiated a rolling update. Check the status of the new Pods, and view the old one terminating with the <code>get pods</code> subcommand:</p>
                <p><code><b>kubectl get pods</b></code></p>
@@ -170,7 +170,7 @@ description: |-
                <p>To get more insight into the problem, run the <code>describe pods</code> subcommand:</p>
                <p><code><b>kubectl describe pods</b></code></p>
                <p>In the <code>Events</code> section of the output for the affected Pods, notice that the <code>v10</code> image version did not exist in the repository.</p>
-               <p>To roll back the deployment to your last working version, use the <code>rollout undo</code> subcommand:</p>
+               <p>To roll back the Deployment to your last working version, use the <code>rollout undo</code> subcommand:</p>
                <p><code><b>kubectl rollout undo deployments/kubernetes-bootcamp</b></code></p>
                <p>The <code>rollout undo</code> command reverts the deployment to the previous known state (v2 of the image). Updates are versioned and you can revert to any previously known state of a Deployment.</p>
                <p>Use the <code>get pods</code> subcommand to list the Pods again:</p>


### PR DESCRIPTION
This PR is an extension of #42504 (now I know I should have combined them, but I was unsure whether I'd have enough time for other fixes). During my work on the Kubernetes Basics tutorials localisation, I found some inconsistencies (_pod_ vs. _Pod_ naming, missing code blocks, extra spaces) and a few other small things (not 100% precise wording, good spots for adding internal links). I suggest all these minor fixes here.