### PR TITLE
Remove DisableAcceleratorUsageMetrics feature gate description in acc…

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/en/docs/concepts/cluster-administration/system-metrics.md
@@ -119,21 +119,6 @@ If you're upgrading from release `1.12` to `1.13`, but still depend on a metric 
 `1.12`, you should set hidden metrics via command line: `--show-hidden-metrics=1.12` and remember
 to remove this metric dependency before upgrading to `1.14`
 
-## Disable accelerator metrics
-
-The kubelet collects accelerator metrics through cAdvisor. To collect these metrics, for
-accelerators like NVIDIA GPUs, kubelet held an open handle on the driver. This meant that in order
-to perform infrastructure changes (for example, updating the driver), a cluster administrator
-needed to stop the kubelet agent.
-
-The responsibility for collecting accelerator metrics now belongs to the vendor rather than the
-kubelet. Vendors must provide a container that collects metrics and exposes them to the metrics
-service (for example, Prometheus).
-
-The [`DisableAcceleratorUsageMetrics` feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-disables metrics collected by the kubelet, with a
-[timeline for enabling this feature by default](https://github.com/kubernetes/enhancements/tree/411e51027db842355bd489691af897afc1a41a5e/keps/sig-node/1867-disable-accelerator-usage-metrics#graduation-criteria).
-
 ## Component metrics
 
 ### kube-controller-manager metrics


### PR DESCRIPTION
try to resolve https://github.com/kubernetes/website/issues/42779

According to [the documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/) the "DisableAcceleratorUsageMetrics" feature gate has already been removed, so the section "Disable accelerator metrics" needs to be updated.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
