### PR TITLE
kubeadm: EtcdLearnerMode is beta in v1.29

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -157,9 +157,9 @@ List of feature gates:
 {{< table caption="kubeadm feature gates" >}}
 Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
+`EtcdLearnerMode` | `true` | 1.27 | 1.29 | -
 `PublicKeysECDSA` | `false` | 1.19 | - | -
 `RootlessControlPlane` | `false` | 1.22 | - | -
-`EtcdLearnerMode` | `false` | 1.27 | - | -
 {{< /table >}}
 
 {{< note >}}
@@ -167,6 +167,10 @@ Once a feature gate goes GA its value becomes locked to `true` by default.
 {{< /note >}}
 
 Feature gate descriptions:
+
+`EtcdLearnerMode`
+: With this feature gate enabled, when joining a new control plane node, a new etcd member will be created
+as a learner and promoted to a voting member only after the etcd data are fully aligned.
 
 `PublicKeysECDSA`
 : Can be used to create a cluster that uses ECDSA certificates instead of the default RSA algorithm.
@@ -178,10 +182,6 @@ switch between the RSA and ECDSA algorithms on the fly or during upgrades.
 for `kube-apiserver`, `kube-controller-manager`, `kube-scheduler` and `etcd` to run as non-root users.
 If the flag is not set, those components run as root. You can change the value of this feature gate before
 you upgrade to a newer version of Kubernetes.
-
-`EtcdLearnerMode`
-: With this feature gate enabled, when joining a new control plane node, a new etcd member will be created
-as a learner and promoted to a voting member only after the etcd data are fully aligned.
 
 List of deprecated feature gates:
 
@@ -212,11 +212,15 @@ List of removed feature gates:
 {{< table caption="kubeadm removed feature gates" >}}
 Feature | Alpha | Beta | GA | Removed
 :-------|:------|:-----|:---|:-------
-`UnversionedKubeletConfigMap` | 1.22 | 1.23 | 1.25 | 1.26
 `IPv6DualStack` | 1.16 | 1.21 | 1.23 | 1.24
+`UnversionedKubeletConfigMap` | 1.22 | 1.23 | 1.25 | 1.26
 {{< /table >}}
 
 Feature gate descriptions:
+
+`IPv6DualStack`
+: This flag helps to configure components dual stack when the feature is in progress. For more details on Kubernetes
+dual-stack support see [Dual-stack support with kubeadm](/docs/setup/production-environment/tools/kubeadm/dual-stack-support/).
 
 `UnversionedKubeletConfigMap`
 : This flag controls the name of the {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} where kubeadm stores
@@ -227,10 +231,6 @@ that ConfigMap are appropriate for the value you set. When kubeadm writes this C
 or `kubeadm upgrade apply`), kubeadm respects the value of `UnversionedKubeletConfigMap`. When reading that ConfigMap
 (during `kubeadm join`, `kubeadm reset`, `kubeadm upgrade ...`), kubeadm attempts to use unversioned ConfigMap name first;
 if that does not succeed, kubeadm falls back to using the legacy (versioned) name for that ConfigMap.
-
-`IPv6DualStack`
-: This flag helps to configure components dual stack when the feature is in progress. For more details on Kubernetes
-dual-stack support see [Dual-stack support with kubeadm](/docs/setup/production-environment/tools/kubeadm/dual-stack-support/).
 
 ### Adding kube-proxy parameters {#kube-proxy}
 


### PR DESCRIPTION
Since https://github.com/kubernetes/kubernetes/pull/120228 is merged.

- commit 42e282b442710826a6e5ad5728798883ba17caf2 is from https://github.com/kubernetes/website/pull/42771
- the only change is https://github.com/kubernetes/website/pull/42801/commits/e91265b62e8af79ece52c7d9812dd5c485600d16: update  EtcdLearnerMode  beta in v1.29 