### PR TITLE
Fix for namespace not specified in example yaml 

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -58,7 +58,7 @@ request and a default memory limit.
 Create the LimitRange in the default-mem-example namespace:
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults.yaml
 ```
 
 Now if you create a Pod in the default-mem-example namespace, and any container
@@ -75,7 +75,7 @@ does not specify a memory request and limit.
 Create the Pod.
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod.yaml
 ```
 
 View detailed information about the Pod:
@@ -116,7 +116,7 @@ Create the Pod:
 
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod-2.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod-2.yaml
 ```
 
 View detailed information about the Pod:
@@ -146,7 +146,7 @@ specifies a memory request, but not a limit:
 Create the Pod:
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod-3.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod-3.yaml
 ```
 
 View the Pod's specification:

--- a/content/en/examples/admin/resource/memory-defaults-pod-2.yaml
+++ b/content/en/examples/admin/resource/memory-defaults-pod-2.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: default-mem-demo-2
+  namespace: default-mem-example
 spec:
   containers:
   - name: default-mem-demo-2-ctr

--- a/content/en/examples/admin/resource/memory-defaults-pod-3.yaml
+++ b/content/en/examples/admin/resource/memory-defaults-pod-3.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: default-mem-demo-3
+  namespace: default-mem-example
 spec:
   containers:
   - name: default-mem-demo-3-ctr

--- a/content/en/examples/admin/resource/memory-defaults-pod.yaml
+++ b/content/en/examples/admin/resource/memory-defaults-pod.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: default-mem-demo
+  namespace: default-mem-example
 spec:
   containers:
   - name: default-mem-demo-ctr

--- a/content/en/examples/admin/resource/memory-defaults.yaml
+++ b/content/en/examples/admin/resource/memory-defaults.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: mem-limit-range
+  namespace: default-mem-example
 spec:
   limits:
   - default:


### PR DESCRIPTION
Issue: [#42772](https://github.com/kubernetes/website/issues/42772)