### PR TITLE
[zh] sync compute-storage-net/device-plugins.md

### DIFF
--- a/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -266,13 +266,13 @@ The general workflow of a device plugin includes the following steps:
    这些修改包括：
 
    <!--
-   * annotations
+   * [Annotations](/docs/concepts/overview/working-with-objects/annotations/)
    * device nodes
    * environment variables
    * mounts
    * fully-qualified CDI device names
    -->
-   * 注解
+   * [注解](/zh-cn/docs/concepts/overview/working-with-objects/annotations/)
    * 设备节点
    * 环境变量
    * 挂载点
@@ -281,11 +281,14 @@ The general workflow of a device plugin includes the following steps:
    {{< note >}}
    <!--
    The processing of the fully-qualified CDI device names by the Device Manager requires
-   the `DevicePluginCDIDevices` feature gate to be enabled. This was added as an alpha feature in
+   that the `DevicePluginCDIDevices` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+   is enabled for the kubelet and the kube-apiserver. This was added as an alpha feature in Kubernetes
    v1.28.
    -->
-   设备管理器处理完全限定的 CDI 设备名称时需要启用 `DevicePluginCDIDevices` 特性门控。
-   这是在 v1.28 版本中作为 Alpha 特性添加的。
+   设备管理器处理完全限定的 CDI 设备名称时，
+   需要为 kubelet 和 kube-apiserver 启用 `DevicePluginCDIDevices`
+   [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)。
+   这在 Kubernetes v1.28 版本中作为 Alpha 特性被加入。
    {{< /note >}}
 
 <!--


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md`
- **Sync to**: `content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md`

Sync check by `scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
diff --git a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
index c86bd3a224..3531587381 100644
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -151,7 +151,7 @@ The general workflow of a device plugin includes the following steps:
    device plugin defines modifications that must be made to a container's definition to provide
    access to the device. These modifications include:

-   * annotations
+   * [Annotations](/docs/concepts/overview/working-with-objects/annotations/)
    * device nodes
    * environment variables
    * mounts
@@ -159,7 +159,8 @@ The general workflow of a device plugin includes the following steps:

    {{< note >}}
    The processing of the fully-qualified CDI device names by the Device Manager requires
-   the `DevicePluginCDIDevices` feature gate to be enabled. This was added as an alpha feature in
+   that the `DevicePluginCDIDevices` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+   is enabled for the kubelet and the kube-apiserver. This was added as an alpha feature in Kubernetes
    v1.28.
    {{< /note >}}
```
Sync check by`scripts/lsync.sh` on `sync/device-plugins` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang