### PR TITLE
Add k8s.io/linuxrepos short link

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -372,6 +372,9 @@
 /dockershim /blog/2022/02/17/dockershim-faq/ 302
 /dockershim/ /blog/2022/02/17/dockershim-faq/ 302
 
+/linuxrepos /blog/2023/08/31/legacy-package-repository-deprecation/ 302
+/linuxrepos/ /blog/2023/08/31/legacy-package-repository-deprecation/ 302
+
 /image-registry-redirect  /blog/2023/03/10/image-registry-redirect/ 302
 /image-registry-redirect/ /blog/2022/02/10/image-registry-redirect/ 302
 /image-registry-change  /blog/2023/03/10/image-registry-redirect/ 302


### PR DESCRIPTION
Add k8s.io/linuxrepos short link that redirects to the announcement for freezing legacy package repositories: https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/

We plan on sharing this link a lot, especially on social media, and short link would be much helpful. See the following Slack thread: https://kubernetes.slack.com/archives/C1J0BPD2M/p1693522696343469

Thanks a lot to @sftim for the idea and the `linuxrepos` name!

Note: I'm not sure if that's all or if any other change is required. Please let me know if there's anything else needed.

/assign @sftim @jeremyrickard 
cc @kubernetes/release-engineering 