### PR TITLE
[ja] sync architecture/cri.md

### DIFF
--- a/content/ja/docs/concepts/architecture/cri.md
+++ b/content/ja/docs/concepts/architecture/cri.md
@@ -20,7 +20,7 @@ Kubernetes Container Runtime Interface(CRI)は、[クラスターコンポーネ
 
 {{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
-kubeletは、gRPCを介してコンテナランタイムに接続するときにクライアントとして機能します。ランタイムおよびイメージサービスエンドポイントは、コンテナランタイムで使用可能である必要があります。コンテナランタイムは、`--image-service-endpoint`および`--container-runtime-endpoint`[コマンドラインフラグ](/ja/docs/reference/command-line-tools-reference/kubelet)を使用して、kubelet内で個別に設定できます。
+kubeletは、gRPCを介してコンテナランタイムに接続するときにクライアントとして機能します。ランタイムおよびイメージサービスエンドポイントは、コンテナランタイムで使用可能である必要があります。コンテナランタイムは、`--image-service-endpoint`[コマンドラインフラグ](/ja/docs/reference/command-line-tools-reference/kubelet)を使用して、kubelet内で個別に設定できます。
 
 Kubernetes v{{< skew currentVersion >}}の場合、kubeletはCRI `v1`の使用を優先します。
 コンテナランタイムがCRIの`v1`をサポートしていない場合、kubeletはサポートされている古いバージョンのネゴシエーションを試みます。


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/architecture/cri.md`
- **Sync to**: `content/ja/docs/concepts/architecture/cri.md`

Sync check by `scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/ja/docs/concepts/architecture/cri.md
diff --git a/content/en/docs/concepts/architecture/cri.md b/content/en/docs/concepts/architecture/cri.md
index 2b8fe79a5b..055df28b4f 100644
--- a/content/en/docs/concepts/architecture/cri.md
+++ b/content/en/docs/concepts/architecture/cri.md
@@ -26,8 +26,7 @@ each Node in your cluster, so that the
 The kubelet acts as a client when connecting to the container runtime via gRPC.
 The runtime and image service endpoints have to be available in the container
 runtime, which can be configured separately within the kubelet by using the
-`--image-service-endpoint` and `--container-runtime-endpoint` [command line
-flags](/docs/reference/command-line-tools-reference/kubelet)
+`--image-service-endpoint` [command line flags](/docs/reference/command-line-tools-reference/kubelet).

 For Kubernetes v{{< skew currentVersion >}}, the kubelet prefers to use CRI `v1`.
 If a container runtime does not support `v1` of the CRI, then the kubelet tries to
```
Sync check by`scripts/lsync.sh` on `ja/sync/architecture_cri` branch:
```diff
$ scripts/lsync.sh content/ja/docs/concepts/architecture/cri.md
content/ja/docs/concepts/architecture/cri.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang