### PR TITLE
Add banner with message that legacy repos are getting frozen

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -174,3 +174,23 @@ announcements:
     k8s.gcr.io image registry is gradually being redirected to registry.k8s.io (since Monday March 20th).<br>
     All images available in k8s.gcr.io are available at registry.k8s.io.</br>
     Please read our [announcement](/blog/2023/03/10/image-registry-redirect/) for more details.
+
+- name: Freezing the legacy package repositories - Before
+  startTime: 2023-09-01T00:00:00
+  endTime: 2023-09-13T19:59:59
+  style: "background: #d95e00"
+  title: Changes to the location of Linux packages for Kubernetes
+  message: |
+    The legacy Linux package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`)<br/>
+    have been deprecated and will be frozen starting from September 13, 2023.<br/>
+    Please read our [announcement](/blog/2023/08/31/legacy-package-repository-deprecation/) for more details.
+
+- name: Freezing the legacy package repositories - After
+  startTime: 2023-09-13T20:00:00
+  endTime: 2023-10-01T00:00:00
+  style: "background: #d95e00"
+  title: Changes to the location of Linux packages for Kubernetes
+  message: |
+    The legacy Linux package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`)<br/>
+    have been frozen starting from September 13, 2023.<br/>
+    Please read our [announcement](/blog/2023/08/31/legacy-package-repository-deprecation/) for more details.


### PR DESCRIPTION
This is a proposal to add a banner with the message that the legacy Google-hosted package repositories are now deprecated and will be frozen starting from September 13, 2023. The original announcement can be found here: https://k8s.io/linuxrepos

The banner is scheduled to go live from today until KubeCon NA 2023.

This change has **NOT** been discussed at all, so I'm putting this PR on hold until we don't reach consensus.
/hold

![image](https://github.com/kubernetes/website/assets/18719127/5224e322-d146-4607-9996-a831280cc84d)

/assign @jeremyrickard
cc @kubernetes/release-engineering 