### PR TITLE
Refine hugo layout for outdated k8s.io versions with subsection links

### DIFF
--- a/content/en/releases/_index.md
+++ b/content/en/releases/_index.md
@@ -3,6 +3,7 @@ linktitle: Release History
 title: Releases
 type: docs
 layout: release-info
+notoc: true
 ---
 
 

--- a/layouts/docs/release-info.html
+++ b/layouts/docs/release-info.html
@@ -1,5 +1,15 @@
 {{ define "main" }}
 {{ if not .Site.Params.deprecated }}
   {{ .Content }}
+{{ else }}
+<div class="section-index">
+  {{ range where .Site.Pages "Section" "releases" }}
+    {{ if not .IsNode }}
+      <div class="entry">
+        <h5><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+      </div>
+    {{ end }}
+  {{ end }}
+</div>    
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Addressing the comment feedback https://github.com/kubernetes/website/pull/41370#issuecomment-1702438756, this pull request updates the layout to improve navigation on outdated k8s.io/releases/ pages by adding links to subsections along with the deprecation notice.

- _Refer screenshot below on how the page will be rendered for deprecated version after these changes:_

<img width="1466" alt="k8s_deprecated_layout" src="https://github.com/kubernetes/website/assets/13051389/53048f95-b022-41e8-816f-be6da075a911">


/cc @sftim 
