### PR TITLE
[zh] sync kubeadm_init_phase_control-plane files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
@@ -1,7 +1,7 @@
 <!--
 Generate all static Pod manifest files
 -->
-生成所有静态 Pod 清单文件
+生成所有静态 Pod 清单文件。
 
 <!--
 ### Synopsis
@@ -11,7 +11,7 @@ Generate all static Pod manifest files
 <!--
 Generate all static Pod manifest files
 -->
-生成所有的静态 Pod 清单文件
+生成所有的静态 Pod 清单文件。
 
 ```
 kubeadm init phase control-plane all [flags]
@@ -90,7 +90,7 @@ A set of extra flags to pass to the API Server or override default ones in form 
 -->
 <p>
 形式为 &lt;flagname&gt;=&lt;value&gt; 的一组额外参数，用来传递给 API 服务器，
-或者覆盖其默认配置值
+或者覆盖其默认配置值。
 </p>
 </td>
 </tr>
@@ -152,7 +152,7 @@ A set of extra flags to pass to the Controller Manager or override default ones 
 -->
 <p>
 一组形式为 &lt;flagname&gt;=&lt;value&gt; 的额外参数，用来传递给控制管理器（Controller Manager）
-或覆盖其默认设置值
+或覆盖其默认设置值。
 </p>
 </td>
 </tr>
@@ -175,13 +175,18 @@ Don't apply any changes; just output what would be done.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-A set of key=value pairs that describe feature gates for various features. Options are:<br/>EtcdLearnerMode=true|false (ALPHA - default=false)<br/>PublicKeysECDSA=true|false (ALPHA - default=false)<br/>RootlessControlPlane=true|false (ALPHA - default=false)
+A set of key=value pairs that describe feature gates for various features. Options are:<br/>
+EtcdLearnerMode=true|false (ALPHA - default=false)<br/>
+PublicKeysECDSA=true|false (ALPHA - default=false)<br/>
+RootlessControlPlane=true|false (ALPHA - default=false)<br/>
+UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)
 -->
 <p>
-一组用来描述各种特性门控的键值（key=value）对。选项是：
-<br/>EtcdLearnerMode=true|false (ALPHA - 默认值=false)
-<br/>PublicKeysECDSA=true|false (ALPHA - 默认值=false)
-<br/>RootlessControlPlane=true|false (ALPHA - 默认值=false)
+一组用来描述各种特性门控的键值（key=value）对。选项是：<br/>
+EtcdLearnerMode=true|false (ALPHA - 默认值=false)<br/>
+PublicKeysECDSA=true|false (ALPHA - 默认值=false)<br/>
+RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
+UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)
 </p>
 </td>
 </tr>
@@ -195,7 +200,7 @@ A set of key=value pairs that describe feature gates for various features. Optio
 help for all
 -->
 <p>
-all 操作的帮助命令
+all 操作的帮助命令。
 </p>
 </td>
 </tr>
@@ -214,7 +219,7 @@ all 操作的帮助命令
 Choose a container registry to pull control plane images from
 -->
 <p>
-选择用于拉取控制平面镜像的容器仓库
+选择用于拉取控制平面镜像的容器仓库。
 </p>
 </td>
 </tr>
@@ -283,9 +288,7 @@ A set of extra flags to pass to the Scheduler or override default ones in form o
 -->
 <p>
 一组形式为 &lt;flagname&gt;=&lt;value&gt; 的额外参数，用来传递给调度器（Scheduler）
-或覆盖其默认设置值
-
-传递给调度器（scheduler）一组额外的参数或者以 &lt;flagname&gt;=&lt;value&gt; 形式覆盖其默认值。
+或覆盖其默认设置值。
 <p>
 </td>
 </tr>
@@ -340,4 +343,3 @@ Use alternative range of IP address for service VIPs.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
@@ -1,7 +1,7 @@
 <!--
 Generates the kube-apiserver static Pod manifest
 -->
-生成 kube-apiserver 静态 Pod 清单
+生成 kube-apiserver 静态 Pod 清单。
 
 <!-- 
 ### Synopsis 
@@ -11,7 +11,7 @@ Generates the kube-apiserver static Pod manifest
 <!-- 
 Generates the kube-apiserver static Pod manifest 
 -->
-生成 kube-apiserver 静态 Pod 清单
+生成 kube-apiserver 静态 Pod 清单。
 
 ```
 kubeadm init phase control-plane apiserver [flags]
@@ -71,8 +71,8 @@ Port for the API Server to bind to.
 A set of extra flags to pass to the API Server or override default ones in form of &lt;flagname&gt;=&lt;value&gt;
 -->
 <p>
-一组 &lt;flagname&gt;=&lt;value&gt; 形式的额外参数，用来传递给 API 服务器
-或者覆盖其默认参数配置
+一组 &lt;flagname&gt;=&lt;value&gt; 形式的额外参数，用来传递给 API
+服务器或者覆盖其默认参数配置。
 </p>
 </td>
 </tr>
@@ -143,13 +143,18 @@ Don't apply any changes; just output what would be done.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-A set of key=value pairs that describe feature gates for various features. Options are:<br/>EtcdLearnerMode=true|false (ALPHA - default=false)<br/>PublicKeysECDSA=true|false (ALPHA - default=false)<br/>RootlessControlPlane=true|false (ALPHA - default=false)
+A set of key=value pairs that describe feature gates for various features. Options are:<br/>
+EtcdLearnerMode=true|false (ALPHA - default=false)<br/>
+PublicKeysECDSA=true|false (ALPHA - default=false)<br/>
+RootlessControlPlane=true|false (ALPHA - default=false)<br/>
+UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)
 -->
 <p>
-一组键值对，用于描述各种功能特性的特性门控。选项是：
-<br/>EtcdLearnerMode=true|false (ALPHA - 默认值=false)
-<br/>PublicKeysECDSA=true|false (ALPHA - 默认值=false)
-<br/>RootlessControlPlane=true|false (ALPHA - 默认值=false)
+一组键值对，用于描述各种功能特性的特性门控。选项是：<br/>
+EtcdLearnerMode=true|false (ALPHA - 默认值=false)<br/>
+PublicKeysECDSA=true|false (ALPHA - 默认值=false)<br/>
+RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
+UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)
 </p>
 </td>
 </tr>
@@ -163,7 +168,7 @@ A set of key=value pairs that describe feature gates for various features. Optio
 help for apiserver
 -->
 <p>
-apiserver 操作的帮助命令
+apiserver 操作的帮助命令。
 </p>
 </td>
 </tr>
@@ -182,7 +187,7 @@ apiserver 操作的帮助命令
 Choose a container registry to pull control plane images from
 -->
 <p>
-选择要从中拉取控制平面镜像的容器仓库
+选择要从中拉取控制平面镜像的容器仓库。
 </p>
 </td>
 </tr>
@@ -201,7 +206,7 @@ Choose a container registry to pull control plane images from
 Choose a specific Kubernetes version for the control plane.
 -->
 <p>
-为控制平面选择特定的 Kubernetes 版本
+为控制平面选择特定的 Kubernetes 版本。
 </p>
 </td>
 </tr>
@@ -249,11 +254,9 @@ Use alternative range of IP address for service VIPs.
 </tbody>
 </table>
 
-
 <!-- 
 ### Options inherited from parent commands 
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -279,4 +282,3 @@ Use alternative range of IP address for service VIPs.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
@@ -1,18 +1,7 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generates the kube-controller-manager static Pod manifest 
 -->
-生成 kube-controller-manager 静态 Pod 清单
+生成 kube-controller-manager 静态 Pod 清单。
 
 <!--
 ### Synopsis
@@ -22,7 +11,7 @@ Generates the kube-controller-manager static Pod manifest
 <!--
 Generates the kube-controller-manager static Pod manifest
 -->
-生成 kube-controller-manager 静态 Pod 清单
+生成 kube-controller-manager 静态 Pod 清单。
 
 ```
 kubeadm init phase control-plane controller-manager [flags]
@@ -98,7 +87,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>help for controller-manager</p>
 -->
-<p>controller-manager 操作的帮助命令</p>
+<p>controller-manager 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -115,7 +104,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>Choose a container registry to pull control plane images from</p>
 -->
-<p>选择要从中拉取控制平面镜像的容器仓库</p>
+<p>选择要从中拉取控制平面镜像的容器仓库。</p>
 </td>
 </tr>
 
@@ -195,4 +184,3 @@ Don't apply any changes; just output what would be done.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
@@ -1,18 +1,7 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generates the kube-scheduler static Pod manifest
 -->
-生成 kube-scheduler 静态 Pod 清单
+生成 kube-scheduler 静态 Pod 清单。
 
 <!-- 
 ### Synopsis
@@ -22,7 +11,7 @@ Generates the kube-scheduler static Pod manifest
 <!--
 Generates the kube-scheduler static Pod manifest
 -->
-生成 kube-scheduler 静态 Pod 清单
+生成 kube-scheduler 静态 Pod 清单。
 
 ```
 kubeadm init phase control-plane scheduler [flags]
@@ -89,7 +78,7 @@ kubeadm init phase control-plane scheduler [flags]
 <!--
 <p>help for scheduler</p>
 -->
-<p>scheduler 操作的帮助命令</p>
+<p>scheduler 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -106,7 +95,7 @@ kubeadm init phase control-plane scheduler [flags]
 <!--
 <p>Choose a container registry to pull control plane images from</p>
 -->
-<p>选择要从中拉取控制平面镜像的容器仓库</p>
+<p>选择要从中拉取控制平面镜像的容器仓库。</p>
 </td>
 </tr>
 
@@ -156,8 +145,7 @@ kubeadm init phase control-plane scheduler [flags]
 <!--
 <p>A set of extra flags to pass to the Scheduler or override default ones in form of &lt;flagname&gt;=&lt;value&gt;</p>
 -->
-<p>一组 &lt;flagname&gt;=&lt;value&gt; 形式的额外参数，用来传递给调度器
-或者覆盖其默认参数配置</p>
+<p>一组 &lt;flagname&gt;=&lt;value&gt; 形式的额外参数，用来传递给调度器或者覆盖其默认参数配置。</p>
 </td>
 </tr>
 
@@ -190,4 +178,3 @@ kubeadm init phase control-plane scheduler [flags]
 
 </tbody>
 </table>
-


### PR DESCRIPTION
Sync 4 files:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
```