### PR TITLE
Updated resources of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,15 @@ Make sure to install the Hugo extended version specified by the `HUGO_VERSION` e
 To build and test the site locally, run:
 
 ```bash
-# Install dependencies, for Linux and MacOS
-npm ci
+# For Linux, MacOS etc.
+
+npm ci # Install dependencies
 make serve
 ```
-```bash
-# Install dependencies, for Windows
-npm ci
+```powershell
+# Windows (PowerShell)
+
+npm ci # Install dependencies
 hugo.exe server --buildFuture --environment development
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ Make sure to install the Hugo extended version specified by the `HUGO_VERSION` e
 To build and test the site locally, run:
 
 ```bash
-# install dependencies
+# Install dependencies, for Linux and MacOS
 npm ci
 make serve
+```
+```bash
+# Install dependencies, for Windows
+npm ci
+hugo.exe server --buildFuture --environment development
 ```
 
 This will start the local Hugo server on port 1313. Open up your browser to <http://localhost:1313> to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To build the site in a container, run the following:
 make container-serve
 ```
 
-If you see errors, it probably means that the hugo container did not have enough computing resources available. To solve it, increase the amount of allowed CPU and memory usage for Docker on your machine ([MacOSX](https://docs.docker.com/docker-for-mac/#resources) and [Windows](https://docs.docker.com/docker-for-windows/#resources)).
+If you see errors, it probably means that the hugo container did not have enough computing resources available. To solve it, increase the amount of allowed CPU and memory usage for Docker on your machine ([MacOS](https://docs.docker.com/desktop/settings/mac/) and [Windows](https://docs.docker.com/desktop/settings/windows/)).
 
 Open up your browser to <http://localhost:1313> to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -30,7 +30,7 @@ etcd cluster of three members that can be used by kubeadm during cluster creatio
   document assumes these default ports. However, they are configurable through
   the kubeadm config file.
 - Each host must have systemd and a bash compatible shell installed.
-- Each host must [have a container runtime, kubelet, and kubeadm installed](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
+- Each host must have a container runtime, kubelet and [kubeadm installed](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
 - Each host should have access to the Kubernetes container image registry (`registry.k8s.io`) or list/pull the required etcd image using
   `kubeadm config images list/pull`. This guide will set up etcd instances as
   [static pods](/docs/tasks/configure-pod-container/static-pod/) managed by a kubelet.


### PR DESCRIPTION
Earlier the resources (2 links) provided were just making user/dev land to that website, and then user have to figure out from there like where is actual solution listed in whole website? I faced this same issue a few minutes ago, while going through this documentation. But now these minor changes in resources (Updation of 2 links) will point user/dev to the right page/resource that will solve their problem.
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
