### PR TITLE
Fix KubeletPodResourcesDynamicResources feature gate name

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -586,7 +586,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `KubeletPodResourcesGetAllocatable`: Enable the kubelet's pod resources
   `GetAllocatableResources` functionality. This API augments the
   [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)
-- `KubeletPodResourcesDynamiceResources`: Extend the kubelet's pod resources gRPC endpoint to
+- `KubeletPodResourcesDynamicResources`: Extend the kubelet's pod resources gRPC endpoint to
   to include resources allocated in `ResourceClaims` via `DynamicResourceAllocation` API.
   See [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources) for more details.
   with informations about the allocatable resources, enabling clients to properly


### PR DESCRIPTION
This change fixes a typo in the feature gate name `KubeletPodResourcesDynamiceResources`. 

Fixes #42842

Deploy Preview: [deploy-preview-42851-feature-gates](https://deploy-preview-42851--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates/)
