### PR TITLE
Fix release date for 1.27 in schedule.yaml

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -19,7 +19,7 @@ schedules:
     - release: 1.28.0
       targetDate: 2023-08-15
 - release: 1.27
-  releaseDate: 2024-04-11
+  releaseDate: 2023-04-11
   maintenanceModeStartDate: 2024-04-28
   endOfLifeDate: 2024-06-28
   next:


### PR DESCRIPTION
Unless a secret flux compensator was discovered in the CNCF basement, I think this was a simple typo :-)