### PR TITLE
Remove KubeletPodResources switchable feature gatemention

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -384,10 +384,6 @@ will continue working.
 
 {{< /note >}}
 
-Support for the `PodResourcesLister service` requires `KubeletPodResources`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to be enabled.
-It is enabled by default starting with Kubernetes 1.15 and is v1 since Kubernetes 1.20.
-
 ### `Get` gRPC endpoint {#grpc-endpoint-get}
 
 {{< feature-state state="alpha" for_k8s_version="v1.27" >}}


### PR DESCRIPTION
The "KubeletPodResources" feature gate is GAed, but it's still mentioned as a switchable one in the [GetAllocatableResources gRPC endpoint](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#grpc-endpoint-getallocatableresources) section. Perhaps it's time to remove it from the page.

related issue: https://github.com/kubernetes/website/issues/42841