### PR TITLE
[WIP] Revert "Promote parallel image pulls to beta"

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -184,7 +184,7 @@ behalf of the two different Pods, when parallel image pulls is enabled.
 
 ### Maximum parallel image pulls
 
-{{< feature-state for_k8s_version="v1.28" state="beta" >}}
+{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
 
 When `serializeImagePulls` is set to false, the kubelet defaults to no limit on the
 maximum number of images being pulled at the same time. If you would like to

--- a/content/en/docs/reference/using-api/deprecation-policy.md
+++ b/content/en/docs/reference/using-api/deprecation-policy.md
@@ -441,6 +441,12 @@ deprecating and removing a metric are as follows:
    * **STABLE: 3 releases or 9 months (whichever is longer)**
    * **BETA: 1 releases or 4 months (whichever is longer)**
    * **ALPHA: 0 releases**
+   
+It is permissible, in certain cases, for metrics to skip stability levels in the process
+of graduation. This is done on a case by case basis, at the discretion of the SIG which
+owns the metric. Since the stability framework was introduced far after the conception
+of Kubernetes, there are many existing metrics which may not want or need to go through
+the entire graduation process, since people already likely rely on these metrics.
 
 Deprecated metrics will have their description text prefixed with a deprecation notice
 string '(Deprecated from x.y)' and a warning log will be emitted during metric


### PR DESCRIPTION
Reverts kubernetes/website#42061

See https://github.com/kubernetes/enhancements/issues/3673.

To promote it to beta, we need to add some e2e tests. Revert this. I will update the doc once the e2e test are merged.