### PR TITLE
Rewording message to reflect build process changes

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -83,9 +83,9 @@ releases may also occur in between these.
 | November 2023         | N/A                  | N/A         |
 | December 2023         | 2023-12-01           | 2023-12-06  |
 
-**Note:** Due to overlap with KubeCon NA 2023 and lack of availability of
-Release Managers and Google Build Admins, it has been decided to skip patch
-releases in November. Instead, we'll have patch releases early in December.
+**Note:** Due to overlap with KubeCon NA 2023 and the resulting lack of
+availability of Release Managers, it has been decided to skip patch releases
+in November. Instead, we'll have patch releases early in December.
 
 ## Detailed Release History for Active Branches
 


### PR DESCRIPTION
Back when @xmudrii added the [note about skipping November patch releases](https://github.com/kubernetes/website/pull/42108), the Google Build Admin team availability was part of the reason. As a result of the change explained in [Kubernetes Legacy Package Repositories Will Be Frozen On September 13, 2023](https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/), I think that the Google Build Admin team availability will not factor into releases after September.

If correct, this clarifying edit removes that no-longer-relevant detail while preserving the main reason (the release team will have KubeCon as their focus at that time).