### PR TITLE
Correct mixture of api

### DIFF
--- a/content/en/docs/concepts/security/pod-security-admission.md
+++ b/content/en/docs/concepts/security/pod-security-admission.md
@@ -130,7 +130,7 @@ current policy level:
 Here are the Prometheus metrics exposed by kube-apiserver:
 
 - `pod_security_errors_total`: This metric indicates the number of errors preventing normal evaluation.
-  Non-fatal errors may result in the latest restricted profile being used for evaluation.
+  Non-fatal errors may result in the latest restricted profile being used for enforcement.
 - `pod_security_evaluations_total`: This metric indicates the number of policy evaluations that have occurred,
   not counting ignored or exempt requests during exporting.
 - `pod_security_exemptions_total`: This metric indicates the number of exempt requests, not counting ignored

--- a/content/en/docs/reference/instrumentation/metrics.md
+++ b/content/en/docs/reference/instrumentation/metrics.md
@@ -2533,7 +2533,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 <tr class="metric"><td class="metric_name">pod_security_errors_total</td>
 <td class="metric_stability_level" data-stability="alpha">ALPHA</td>
 <td class="metric_type" data-type="counter">Counter</td>
-<td class="metric_description">Number of errors preventing normal evaluation. Non-fatal errors may result in the latest restricted profile being used for evaluation.</td>
+<td class="metric_description">Number of errors preventing normal evaluation. Non-fatal errors may result in the latest restricted profile being used for enforcement.</td>
 <td class="metric_labels_varying"><div class="metric_label">fatal</div><div class="metric_label">request_operation</div><div class="metric_label">resource</div><div class="metric_label">subresource</div></td>
 <td class="metric_labels_constant"></td>
 <td class="metric_deprecated_version"></td></tr>

--- a/content/en/docs/reference/instrumentation/metrics.md
+++ b/content/en/docs/reference/instrumentation/metrics.md
@@ -2533,7 +2533,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 <tr class="metric"><td class="metric_name">pod_security_errors_total</td>
 <td class="metric_stability_level" data-stability="alpha">ALPHA</td>
 <td class="metric_type" data-type="counter">Counter</td>
-<td class="metric_description">Number of errors preventing normal evaluation. Non-fatal errors may result in the latest restricted profile being used for enforcement.</td>
+<td class="metric_description">Number of errors preventing normal evaluation. Non-fatal errors may result in the latest restricted profile being used for evaluation.</td>
 <td class="metric_labels_varying"><div class="metric_label">fatal</div><div class="metric_label">request_operation</div><div class="metric_label">resource</div><div class="metric_label">subresource</div></td>
 <td class="metric_labels_constant"></td>
 <td class="metric_deprecated_version"></td></tr>

--- a/content/en/examples/validatingadmissionpolicy/basic-example-binding.yaml
+++ b/content/en/examples/validatingadmissionpolicy/basic-example-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "demo-binding-test.example.com"


### PR DESCRIPTION
The page about ValidatingAdmissionPolicy uses a mixture of API groups: now it will use only admissionregistration.k8s.io/v1beta1 to maintain consistency.
#42876 