### PR TITLE
Remove alpha environment variable because feature is in beta

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -369,14 +369,6 @@ kubectl [flags]
 </td>
 </tr>
 
-<tr>
-<td colspan="2">KUBECTL_INTERACTIVE_DELETE</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, the --interactive flag in the kubectl delete command will be activated, allowing users to preview and confirm resources before proceeding to delete by passing this flag.
-</td>
-</tr>
-
 </tbody>
 </table>
 


### PR DESCRIPTION
Since https://github.com/kubernetes/enhancements/issues/3895 has been promoted to beta, environment
variable representing alpha feature enablement has become obsolete. This PR removes this from website.