### PR TITLE
[zh] Fix page layout of installing kubectl on linux

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -147,9 +147,9 @@ The following methods exist for installing kubectl on Linux:
    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-   {{< note >}}
-   To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
-   {{< /note >}}
+{{< note >}}
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+{{< /note >}}
 
 4. Update `apt` package index, then install kubectl:
 

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -147,9 +147,9 @@ The following methods exist for installing kubectl on Linux:
    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-{{< note >}}
-To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
-{{< /note >}}
+   {{< note >}}
+   To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+   {{< /note >}}
 
 4. Update `apt` package index, then install kubectl:
 

--- a/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
@@ -239,14 +239,14 @@ Or use this for detailed view of version:
    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-   {{< note >}}
-   <!--
-   To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
-   -->
-   要升级 kubectl 到别的次要版本，你需要先升级 `/etc/apt/sources.list.d/kubernetes.list` 中的版本，
-   再运行 `apt-get update` 和 `apt-get upgrade`。
-   更详细的步骤可以在[更改 Kubernetes 软件包仓库](/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository/)中找到。
-   {{< /note >}}
+{{< note >}}
+<!--
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+-->
+要升级 kubectl 到别的次要版本，你需要先升级 `/etc/apt/sources.list.d/kubernetes.list` 中的版本，
+再运行 `apt-get update` 和 `apt-get upgrade`。
+更详细的步骤可以在[更改 Kubernetes 软件包仓库](/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository/)中找到。
+{{< /note >}}
 
 <!--
 4. Update `apt` package index, then install kubectl:


### PR DESCRIPTION
This PR fixes indentation for the **native packagemanagement** installation documentation.
Currently this is broken in **en** and **zh-cn**, as a result you cannot switch to the instruction tab for "Red Hat" based distributions. Correcting the `note` indentation fixes this issue.

- https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
- https://kubernetes.io/zh-cn/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management

Validated on local system via `make container-serve`.

Before:
![Screenshot from 2023-09-05 09-43-36](https://github.com/kubernetes/website/assets/56306041/a4ac9560-d299-4b81-ae29-c73d1aaf5e87)

After:
![Screenshot from 2023-09-05 09-42-47](https://github.com/kubernetes/website/assets/56306041/fb13babc-d01a-4f09-bc94-c6ab3774240b)
