### PR TITLE
Fix: static pod example pod name

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -189,8 +189,8 @@ You can see the mirror Pod on the API server:
 kubectl get pods
 ```
 ```
-NAME         READY   STATUS    RESTARTS        AGE
-static-web   1/1     Running   0               2m
+NAME                  READY   STATUS    RESTARTS        AGE
+static-web-my-node1   1/1     Running   0               2m
 ```
 
 {{< note >}}
@@ -206,18 +206,18 @@ If you try to use `kubectl` to delete the mirror Pod from the API server,
 the kubelet _doesn't_ remove the static Pod:
 
 ```shell
-kubectl delete pod static-web
+kubectl delete pod static-web-my-node1
 ```
 ```
-pod "static-web" deleted
+pod "static-web-my-node1" deleted
 ```
 You can see that the Pod is still running:
 ```shell
 kubectl get pods
 ```
 ```
-NAME         READY   STATUS    RESTARTS   AGE
-static-web   1/1     Running   0          4s
+NAME                  READY   STATUS    RESTARTS   AGE
+static-web-my-node1   1/1     Running   0          4s
 ```
 
 Back on your node where the kubelet is running, you can try to stop the container manually.


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
In the document, we assume node name is `my-node1`, so the pod name should be `static-web-my-node1`. It would be more clear to readers.