### PR TITLE
[zh] Clean up kubeadm_certs_renew files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_all.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_all.md
@@ -1,18 +1,7 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Renew all available certificates 
 -->
-续订所有可用证书
+续订所有可用证书。
 
 <!--
 ### Synopsis
@@ -77,7 +66,7 @@ kubeadm certs renew all [flags]
 <!--
 <p>help for all</p>
 -->
-<p>all 操作的帮助命令</p>
+<p>all 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -107,7 +96,7 @@ kubeadm certs renew all [flags]
 <!--
 Use the Kubernetes certificate API to renew certificates
 -->
-使用 Kubernetes 证书 API 续订证书
+使用 Kubernetes 证书 API 续订证书。
 </td>
 </tr>
 
@@ -140,4 +129,3 @@ Use the Kubernetes certificate API to renew certificates
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-etcd-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-etcd-client.md
@@ -1,18 +1,7 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Renew the certificate the apiserver uses to access etcd 
 -->
-续订 apiserver 用于访问 etcd 的证书
+续订 apiserver 用于访问 etcd 的证书。
 
 <!-- 
 ### Synopsis
@@ -58,7 +47,9 @@ kubeadm certs renew apiserver-etcd-client [flags]
 
 <tr>
 <td colspan="2">
-<!-- cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki" -->
+<!--
+cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"
+-->
 --cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："/etc/kubernetes/pki"
 </td>
 </tr>
@@ -91,7 +82,7 @@ kubeadm certs renew apiserver-etcd-client [flags]
 <!-- 
 <p>help for apiserver-etcd-client</p>
 -->
-<p>apiserver-etcd-client 操作的帮助命令</p>
+<p>apiserver-etcd-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -115,8 +106,6 @@ kubeadm certs renew apiserver-etcd-client [flags]
 
 </tbody>
 </table>
-
-
 
 <!--
 ### Options inherited from parent commands
@@ -144,4 +133,3 @@ kubeadm certs renew apiserver-etcd-client [flags]
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-kubelet-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-kubelet-client.md
@@ -1,14 +1,3 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Renew the certificate for the API server to connect to kubelet 
 -->
@@ -93,7 +82,7 @@ kubeadm certs renew apiserver-kubelet-client [flags]
 <!--
 <p>help for apiserver-kubelet-client</p>
 -->
-<p>apiserver-kubelet-client 操作的帮助命令</p>
+<p>apiserver-kubelet-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -123,7 +112,7 @@ kubeadm certs renew apiserver-kubelet-client [flags]
 <!--
 Use the Kubernetes certificate API to renew certificates
 -->
-使用 Kubernetes 证书 API 续订证书
+使用 Kubernetes 证书 API 续订证书。
 </td>
 </tr>
 
@@ -156,4 +145,3 @@ Use the Kubernetes certificate API to renew certificates
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver.md
@@ -1,19 +1,7 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-
-<!--
 Renew the certificate for serving the Kubernetes API
 -->
-续订用于提供 Kubernetes API 的证书
+续订用于提供 Kubernetes API 的证书。
 
 <!--
 ### Synopsis
@@ -99,19 +87,23 @@ kubeadm 配置文件的路径。
 help for apiserver
 -->
 <p>
-apiserver 子操作的帮助命令
+apiserver 子操作的帮助命令。
 </p>
 </td>
 </tr>
 
 <tr>
-<td colspan="2"><!-- --kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/admin.conf" -->
+<td colspan="2">
+<!--
+--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/admin.conf"
+-->
 --kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："/etc/kubernetes/admin.conf"
 </td>
 </tr>
 
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><!--
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
 -->
 <p>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_controller-manager.conf.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_controller-manager.conf.md
@@ -1,14 +1,3 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Renew the certificate embedded in the kubeconfig file for the controller manager to use 
 -->
@@ -93,7 +82,7 @@ kubeadm alpha renew controller-manager.conf [flags]
 <!--
 <p>help for controller-manager.conf</p>
 -->
-<p>controller-manager.conf 操作的帮助命令</p>
+<p>controller-manager.conf 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -123,7 +112,7 @@ kubeadm alpha renew controller-manager.conf [flags]
 <!--
 Use the Kubernetes certificate API to renew certificates
 -->
-使用 Kubernetes 证书 API 续订证书
+使用 Kubernetes 证书 API 续订证书。
 </td>
 </tr>
 
@@ -156,4 +145,3 @@ Use the Kubernetes certificate API to renew certificates
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-healthcheck-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-healthcheck-client.md
@@ -1,18 +1,7 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-<!--
 Renew the certificate for liveness probes to healthcheck etcd
 -->
-续订存活态探针的证书，用于对 etcd 执行健康检查
+续订存活态探针的证书，用于对 etcd 执行健康检查。
 
 <!--
 ### Synopsis
@@ -97,7 +86,7 @@ kubeadm 配置文件的路径。
 help for etcd-healthcheck-client
 -->
 <p>
-etcd-healthcheck-client 操作的帮助命令
+etcd-healthcheck-client 操作的帮助命令。
 </p>
 </td>
 </tr>


### PR DESCRIPTION
Provide a consistent style to these pages in the editing view:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_all.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-etcd-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-kubelet-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_controller-manager.conf.md
```
/kind cleanup