### PR TITLE
Update labels.md

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -231,7 +231,7 @@ kubectl get pods -l 'environment in (production, qa)'
 or restricting negative matching via _notin_ operator:
 
 ```shell
-kubectl get pods -l 'environment,environment notin (frontend)'
+kubectl get pods -l 'environment,tier notin (frontend)'
 ```
 
 ### Set references in API objects


### PR DESCRIPTION
updated line 234 , "environment" with "tier"

The Keys Here,
"environment" refers to values "Production" , "qa"
"tier" refers to values "frontend","backend"

Mistakenly environment key referring value frontend i.e., key is wrong , the actual key tier. Suggested that change in this commit


 
