### PR TITLE
Irrelevant Url link has been removed

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -47,7 +47,7 @@ kubectl get pods/<podname> -o yaml
 ```
 
 In the output, you see a field `spec.serviceAccountName`.
-Kubernetes [automatically](/docs/concepts/overview/working-with-objects/object-management/)
+Kubernetes automatically
 sets that value if you don't specify it when you create a Pod.
 
 An application running inside a Pod can access the Kubernetes API using


### PR DESCRIPTION
There is a link has been provided for the word [automatically] and it redirects to the [object-management](https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/) page.
which is an irrelevant link removed it as a URL with a normal word.
#42912 