### PR TITLE
remove "O=system:masters" from "kube-apiserver-etcd-client".md

### DIFF
--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -90,7 +90,7 @@ Required certificates:
 | kube-etcd                     | etcd-ca                   |                | server, client   | `<hostname>`, `<Host_IP>`, `localhost`, `127.0.0.1` |
 | kube-etcd-peer                | etcd-ca                   |                | server, client   | `<hostname>`, `<Host_IP>`, `localhost`, `127.0.0.1` |
 | kube-etcd-healthcheck-client  | etcd-ca                   |                | client           |                                                     |
-| kube-apiserver-etcd-client    | etcd-ca                   | system:masters | client           |                                                     |
+| kube-apiserver-etcd-client    | etcd-ca                   |                | client           |                                                     |
 | kube-apiserver                | kubernetes-ca             |                | server           | `<hostname>`, `<Host_IP>`, `<advertise_IP>`, `[1]`  |
 | kube-apiserver-kubelet-client | kubernetes-ca             | system:masters | client           |                                                     |
 | front-proxy-client            | kubernetes-front-proxy-ca |                | client           |                                                     |


### PR DESCRIPTION
`O=system:masters` doesn't required by `kube-apiserver-etcd-client` certificate, because etcd doesn't take it into account.

fixes https://github.com/kubernetes/kubeadm/issues/2926
fixes https://github.com/kubernetes/website/issues/42724