### PR TITLE
Fix & Clarify files secretGenerator

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -35,7 +35,7 @@ secretGenerator:
   - password=1f2d1e2e67df
 {{< /tab >}}
 {{% tab name="Files" %}}
-1.  Store the credentials in files with the values encoded in base64:
+1.  Store the credentials in files. The filenames will be the keys of the secret:
 
     ```shell
     echo -n 'admin' > ./username.txt

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -35,7 +35,7 @@ secretGenerator:
   - password=1f2d1e2e67df
 {{< /tab >}}
 {{% tab name="Files" %}}
-1.  Store the credentials in files. The filenames will be the keys of the secret:
+1.  Store the credentials in files. The filenames are the keys of the secret:
 
     ```shell
     echo -n 'admin' > ./username.txt


### PR DESCRIPTION
fixes error: file contents should not be base64 encoded
clarifies: full filenames are used for the secret's keys

```bash
❯ cat username.txt
test=abc

❯ cat kustomization.yaml
secretGenerator:
- name: db-user-pass
  files:
  - username.txt

❯ kustomize build
apiVersion: v1
data:
  username.txt: dGVzdD1hYmMK
kind: Secret
metadata:
  name: db-user-pass-429b77m65b
type: Opaque
```