### PR TITLE
kubeadm: remove system:masters organization from apiserver-etcd-client certificate

### DIFF
--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -90,7 +90,7 @@ Required certificates:
 | kube-etcd                     | etcd-ca                   |                | server, client   | `<hostname>`, `<Host_IP>`, `localhost`, `127.0.0.1` |
 | kube-etcd-peer                | etcd-ca                   |                | server, client   | `<hostname>`, `<Host_IP>`, `localhost`, `127.0.0.1` |
 | kube-etcd-healthcheck-client  | etcd-ca                   |                | client           |                                                     |
-| kube-apiserver-etcd-client    | etcd-ca                   | system:masters | client           |                                                     |
+| kube-apiserver-etcd-client    | etcd-ca                   |                | client           |                                                     |
 | kube-apiserver                | kubernetes-ca             |                | server           | `<hostname>`, `<Host_IP>`, `<advertise_IP>`, `[1]`  |
 | kube-apiserver-kubelet-client | kubernetes-ca             | system:masters | client           |                                                     |
 | front-proxy-client            | kubernetes-front-proxy-ca |                | client           |                                                     |


### PR DESCRIPTION
kubeadm: remove system:masters organization from apiserver-etcd-client certificate

Ref: https://github.com/kubernetes/kubernetes/pull/120521 

Fixes https://github.com/kubernetes/kubeadm/issues/2926 #42724

