### PR TITLE
Add CEL Playground link

### DIFF
--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -67,6 +67,10 @@ The following is an example of a ValidatingAdmissionPolicy.
 to validate the request. If an expression evaluates to false, the validation check is enforced
 according to the `spec.failurePolicy` field.
 
+{{< note >}}
+You can quickly test CEL expressions in [CEL Playground](https://playcel.undistro.io).
+{{< /note >}}
+
 To configure a validating admission policy for use in a cluster, a binding is required.
 The following is an example of a ValidatingAdmissionPolicyBinding.:
 

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -849,6 +849,10 @@ The CronTab "my-new-cron-object" is invalid:
 * spec: Invalid value: map[string]interface {}{"maxReplicas":10, "minReplicas":0, "replicas":20}: failed rule: self.replicas <= self.maxReplicas
 ```
 
+{{< note >}}
+You can quickly test CEL expressions in [CEL Playground](https://playcel.undistro.io).
+{{< /note >}}
+
 Validation rules are compiled when CRDs are created/updated.
 The request of CRDs create/update will fail if compilation of validation rules fail.
 Compilation process includes type checking as well.


### PR DESCRIPTION
Hi there,

I'm proposing some changes that include adding a link to the [CEL Playground](https://playcel.undistro.io) in the following sections:

- https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/

As discussed in [this GitHub issue](https://github.com/kubernetes/website/issues/41788), CEL Playground allows users to easily test expressions from their browsers and also provides some helpful examples.

Additionally, it's worth noting that all [Kubernetes CEL libraries](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-cel-libraries) are available in the playground.

Feel free to join us in improving the CEL Playground. Your contributions are welcome!

Please review these suggestions, and let me know if any further adjustments are needed.

Thank you!

Closes https://github.com/kubernetes/website/issues/41788