### PR TITLE
Update service.md of Incorrect example for 'Services without selector…

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -246,7 +246,8 @@ ports:
     port: 9376
 endpoints:
   - addresses:
-      - "10.4.5.6" # the IP addresses in this list can appear in any order
+      - "10.4.5.6"
+  - addresses:
       - "10.1.2.3"
 ```
 


### PR DESCRIPTION
In the documentation page of  service-networking, it is mentioned

https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors

```
apiVersion: discovery.k8s.io/v1
kind: EndpointSlice
metadata:
  name: my-service-1 # by convention, use the name of the Service
………………omit………the following part is wrong………
endpoints:
  - addresses:
      - "10.4.5.6" # the IP addresses in this list can appear in any order
      - "10.1.2.3"
```

Changes done in PR

```
endpoints:
  - addresses:
      - "10.4.5.6"
  - addresses:
      - "10.1.2.3"
```
Why is this needed

Incorrect example for 'Services without selectors' in "Service" page, need to change.

Issue : https://github.com/kubernetes/website/issues/42405