### PR TITLE
[zh] Clean up kubeadm_init_phase_certs files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
@@ -1,42 +1,27 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the certificate the apiserver uses to access etcd 
 -->
-生成 apiserver 用来访问 etcd 的证书
+生成 apiserver 用来访问 etcd 的证书。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
 Generate the certificate the apiserver uses to access etcd, and save them into apiserver-etcd-client.crt and apiserver-etcd-client.key files.
 -->
-
 生成 apiserver 用于访问 etcd 的证书，并将其保存到 apiserver-etcd-client.crt 和 apiserver-etcd-client.key 文件中。
 
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
-
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-
-Alpha 免责声明：此命令当前为 Alpha 功能。
+Alpha 免责声明：此命令目前处于 Alpha 阶段。
 
 ```
 kubeadm init phase certs apiserver-etcd-client [flags]
@@ -45,7 +30,6 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -104,7 +88,7 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <!-- 
 <p>help for apiserver-etcd-client</p>
 -->
-<p>apiserver-etcd-client 操作的帮助命令</p>
+<p>apiserver-etcd-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -129,7 +113,6 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-kubelet-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-kubelet-client.md
@@ -1,23 +1,11 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference conent, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the certificate for the API server to connect to kubelet 
 -->
-生成供 API 服务器连接 kubelet 的证书
+生成供 API 服务器连接 kubelet 的证书。
 
 <!-- 
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -28,14 +16,12 @@ Generate the certificate for the API server to connect to kubelet, and save them
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
-
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-
-Alpha 免责声明：此命令当前为 Alpha 功能。
+Alpha 免责声明：此命令目前处于 Alpha 阶段。
 
 ```
 kubeadm init phase certs apiserver-kubelet-client [flags]
@@ -44,7 +30,6 @@ kubeadm init phase certs apiserver-kubelet-client [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -105,7 +90,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>help for apiserver-kubelet-client</p>
 -->
-<p>apiserver-kubelet-client 操作的帮助命令</p>
+<p>apiserver-kubelet-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -132,7 +117,6 @@ Don't apply any changes; just output what would be done.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -156,4 +140,3 @@ Don't apply any changes; just output what would be done.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
@@ -1,23 +1,11 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the certificate for serving the Kubernetes API 
 -->
-生成用于服务 Kubernetes API 的证书
+生成用于服务 Kubernetes API 的证书。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -25,18 +13,15 @@ Generate the certificate for serving the Kubernetes API, and save them into apis
 -->
 生成用于服务 Kubernetes API 的证书，并将其保存到 apiserver.crt 和 apiserver.key 文件中。
 
-
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
-
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-
-Alpha 免责声明：此命令当前为 Alpha 功能。
+Alpha 免责声明：此命令目前处于 Alpha 阶段。
 
 ```
 kubeadm init phase certs apiserver [flags]
@@ -45,7 +30,6 @@ kubeadm init phase certs apiserver [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -142,7 +126,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>help for apiserver</p>
 -->
-<p>apiserver 操作的帮助命令</p>
+<p>apiserver 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -203,7 +187,6 @@ Don't apply any changes; just output what would be done.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_ca.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_ca.md
@@ -1,23 +1,11 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the self-signed Kubernetes CA to provision identities for other Kubernetes components 
 -->
-生成自签名的 Kubernetes CA 以便为其他 Kubernetes 组件提供身份标识
+生成自签名的 Kubernetes CA 以便为其他 Kubernetes 组件提供身份标识。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -33,7 +21,7 @@ If both files already exist, kubeadm skips the generation step and existing file
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-Alpha 免责声明：此命令当前为 Alpha 功能。
+Alpha 免责声明：此命令目前处于 Alpha 阶段。
 
 ```
 kubeadm init phase certs ca [flags]
@@ -42,7 +30,6 @@ kubeadm init phase certs ca [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -103,7 +90,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>help for ca</p>
 -->
-<p>ca 操作的帮助命令</p>
+<p>ca 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -130,7 +117,6 @@ Don't apply any changes; just output what would be done.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -155,4 +141,3 @@ Don't apply any changes; just output what would be done.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-ca.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-ca.md
@@ -1,29 +1,16 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-<!--
 Generate the self-signed CA to provision identities for etcd
 -->
-生成用于为 etcd 设置身份的自签名 CA
+生成用于为 etcd 设置身份的自签名 CA。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
 Generate the self-signed CA to provision identities for etcd, and save them into etcd/ca.crt and etcd/ca.key files.
 -->
-
 生成用于为 etcd 设置身份的自签名 CA，并将其保存到 etcd/ca.crt 和 etcd/ca.key 文件中。
 
 <!--
@@ -35,8 +22,7 @@ If both files already exist, kubeadm skips the generation step and existing file
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-
-Alpha 免责声明：此命令当前为 Alpha 功能。
+Alpha 免责声明：此命令目前处于 Alpha 阶段。
 
 ```
 kubeadm init phase certs etcd-ca [flags]
@@ -45,7 +31,6 @@ kubeadm init phase certs etcd-ca [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -111,7 +96,7 @@ Don't apply any changes; just output what would be done.
 help for etcd-ca
 -->
 <p>
-etcd-ca 操作的帮助命令
+etcd-ca 操作的帮助命令。
 </p>
 </td>
 </tr>
@@ -141,7 +126,6 @@ Choose a specific Kubernetes version for the control plane.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">


### PR DESCRIPTION
Update 5 files:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-kubelet-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_ca.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-ca.md
```