### PR TITLE
Remove Link Of AMD for SEV_ES

### DIFF
--- a/content/en/blog/_posts/2023-07-06-confidential-kubernetes.md
+++ b/content/en/blog/_posts/2023-07-06-confidential-kubernetes.md
@@ -129,7 +129,7 @@ signature of the memory contents, which can be sent to the VM's owner as an atte
 the initial guest memory was not manipulated.
 
 The second generation of SEV, known as
-[Encrypted State](https://www.amd.com/system/files/TechDocs/Protecting%20VM%20Register%20State%20with%20SEV-ES.pdf)
+Encrypted State
 or SEV-ES, provides additional protection from the hypervisor by encrypting all
 CPU register contents when a context switch occurs.
 

--- a/content/en/blog/_posts/2023-07-06-confidential-kubernetes.md
+++ b/content/en/blog/_posts/2023-07-06-confidential-kubernetes.md
@@ -129,7 +129,7 @@ signature of the memory contents, which can be sent to the VM's owner as an atte
 the initial guest memory was not manipulated.
 
 The second generation of SEV, known as
-Encrypted State
+[Encrypted State](https://www.amd.com/content/dam/amd/en/documents/epyc-business-docs/white-papers/Protecting-VM-Register-State-with-SEV-ES.pdf)
 or SEV-ES, provides additional protection from the hypervisor by encrypting all
 CPU register contents when a context switch occurs.
 


### PR DESCRIPTION
Removed Link of [Encrypted State](https://www.amd.com/system/files/TechDocs/Protecting%20VM%20Register%20State%20with%20SEV-ES.pdf) from AMD SEV as the LINK is referring to 404 Page. also, there is an error 404 from the official AMD website for SEV-ES