### PR TITLE
fix:"Hello Minikube" tutorial objective discrepancy: 'View Application Logs' mentioned but not covered .

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -145,11 +145,6 @@ recommended way to manage the creation and scaling of Pods.
 1. View application logs for a container in a pod.
    
    ```shell
-   # Return a snapshot of the logs from pod <pod-name>.
-   kubectl logs <pod-name>
-   ```
-
-   ```shell
    kubectl logs hello-node-5f76cf6ccf-br9b5
    ```
 

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -142,6 +142,25 @@ recommended way to manage the creation and scaling of Pods.
     kubectl config view
     ```
 
+1. View application logs for a container in a pod.
+   
+   ```shell
+   # Return a snapshot of the logs from pod <pod-name>.
+   kubectl logs <pod-name>
+   ```
+
+   ```shell
+   kubectl logs hello-node-5f76cf6ccf-br9b5
+   ```
+
+   The output is similar to:
+
+   ```
+   I0911 09:19:26.677397       1 log.go:195] Started HTTP server on port 8080
+   I0911 09:19:26.677586       1 log.go:195] Started UDP server on port  8081
+   ```
+
+
 {{< note >}}
 For more information about `kubectl` commands, see the [kubectl overview](/docs/reference/kubectl/).
 {{< /note >}}


### PR DESCRIPTION

One of the objectives stated at the beginning of the tutorial is to "View application logs", added in this pr
 https://kubernetes.io/docs/tutorials/hello-minikube/
#42984 