### PR TITLE
Add a blog: kubecon-contributor-summit in 2023

### DIFF
--- a/content/en/blog/_posts/2023-09-11-kubecon-contributor-summit.md
+++ b/content/en/blog/_posts/2023-09-11-kubecon-contributor-summit.md
@@ -1,0 +1,62 @@
+---
+layout: blog
+title: "Join Us at the K8s Contributor Summit in Shanghai"
+date: 2023-09-11
+slug: join-k8s-contributor-summit-in-shanghai
+---
+
+**Author:** [Michael Yao](https://github.com/windsonsea) (DaoCloud)
+
+- Date: September 26, 2023 (Tuesday)
+- Time: 9:00 AM - 1:00 PM
+- Location: Shanghai Convention & Exhibition Center of International Sourcing
+- Address: No.2739 West Guangfu Road, Putuo District, Shanghai 200062
+
+After a three-year hiatus, the Linux Foundation and Cloud Native Computing Foundation (CNCF)
+are thrilled to announce the return of
+[KubeCon + CloudNativeCon + Open Source Summit China 2023](https://www.lfasiallc.com/kubecon-cloudnativecon-open-source-summit-china/program/schedule/)
+in the vibrant city of Shanghai, often referred to as the Oriental Pearl. The first day of the summit
+will be dedicated to all Kubernetes contributors, recognizing their countless days and nights of hard work,
+the lines of code they have submitted, and the wonderful sparks of ideas that have shaped the prosperity
+and glory of the K8s community through continuous technical exchanges.
+
+Today, developers from around the world come together in this dreamlike city of the East.
+The organizing committee has meticulously prepared exquisite food and drinks,
+complemented by exclusive topics, as a tribute to the contributions and efforts made by
+contributors in the past, present, and future. Our hearts brim with gratitude.
+
+Whether you are a seasoned veteran of the Kubernetes community or someone eager to
+bring new energy and ideas, we extend a sincere invitation to register for this contributor summit.
+The [summit registration page](https://wj.qq.com/s2/12996651/2260/) includes questionnaires and provides
+an opportunity to suggest topics of interest. We value your input: What topics would you like to explore
+during the contributor summit? What questions do you wish to discuss with fellow contributors?
+Do you have any noteworthy subjects you would like to share at the contributor summit?
+
+## Schedule
+
+Here is the schedule for the Kubernetes Contributor Summit in Shanghai:
+
+| Time                | Activity                                               |
+| ------------------- | ------------------------------------------------------ |
+| 9:00 - 9:15 AM      | Welcome Speech <br />by Wang Zefeng (Huawei) and Puja Abbassi (Giant Swarm)  |
+| 9:15 - 9:45 AM      | Talk 1                                                 |
+| 9:45 - 10:15 AM     | Talk 2                                                 |
+| 10:15 - 10:30 AM    | Tea Break & Group Photo                                |
+| 10:30 - 11:00 AM    | Talk 3                                                 |
+| 11:00 AM - 12:30 PM | Discussions                                            |
+| 12:30 - 13:30 PM    | Lunch & Social Interaction                             |
+
+## Past Reviews
+
+Here are some reviews from past Kubernetes Contributor Summits in recent years:
+
+- [Kubernetes 2018 North American Contributor Summit](/blog/2018/10/16/kubernetes-2018-north-american-contributor-summit/)
+- [Welcome Blog of Contributor Summit in Shanghai (2019)](/blog/2019/06/12/join-us-at-the-contributor-summit-in-shanghai/)
+- [A Look Back and What's in Store for Kubernetes Contributor Summits in 2019](/blog/2019/03/20/A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits/)
+
+For any questions regarding this summit, contact <summit-team@kubernetes.io>
+
+## Reference Links
+
+- [KubeCon + CloudNativeCon + Open Source Summit China 2023 Schedule](https://www.lfasiallc.com/kubecon-cloudnativecon-open-source-summit-china/program/schedule/)
+- [Contributor Summit Registration Page](https://wj.qq.com/s2/12996651/2260/)


### PR DESCRIPTION
Add a blog to call more contributors join the 2023 KubeCon Contributor Summit in Shanghai

See [preview](https://deploy-preview-42999--kubernetes-io-main-staging.netlify.app/blog/2023/09/11/join-k8s-contributor-summit-in-shanghai/) please.