### PR TITLE
Fix stars in the generated configuration APIs

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-audit.v1.md
@@ -325,9 +325,9 @@ The empty string represents the core API group.</p>
 <p>For example:
 'pods' matches pods.
 'pods/log' matches the log subresource of pods.
-'<em>' matches all resources and their subresources.
-'pods/</em>' matches all subresources of pods.
-'*/scale' matches all scale subresources.</p>
+'&ast;' matches all resources and their subresources.
+'pods/&ast;' matches all subresources of pods.
+'&ast;/scale' matches all scale subresources.</p>
 <p>If wildcard is present, the validation rule will ensure resources do not
 overlap with each other.</p>
 <p>An empty list implies all resources and subresources in this API groups apply.</p>
@@ -501,10 +501,10 @@ An empty list implies every namespace.</p>
 </td>
 <td>
    <p>NonResourceURLs is a set of URL paths that should be audited.
-<em>s are allowed, but only as the full, final step in the path.
+&ast;s are allowed, but only as the full, final step in the path.
 Examples:
 &quot;/metrics&quot; - Log requests for apiserver metrics
-&quot;/healthz</em>&quot; - Log all health checks</p>
+&quot;/healthz&ast;&quot; - Log all health checks</p>
 </td>
 </tr>
 <tr><td><code>omitStages</code><br/>

--- a/content/en/docs/reference/config-api/apiserver-encryption.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-encryption.v1.md
@@ -20,8 +20,8 @@ auto_generated: true
 
 <p>EncryptionConfiguration stores the complete configuration for encryption providers.
 It also allows the use of wildcards to specify the resources that should be encrypted.
-Use '<em>.<!-- raw HTML omitted -->' to encrypt all resources within a group or '</em>.<em>' to encrypt all resources.
-'</em>.' can be used to encrypt all resource in the core group.  '<em>.</em>' will encrypt all
+Use '&ast;.&lt;group&gt;' to encrypt all resources within a group or '&ast;.&ast;' to encrypt all resources.
+'&ast;.' can be used to encrypt all resource in the core group.  '&ast;.&ast;' will encrypt all
 resources, even custom resources that are added after API server start.
 Use of wildcards that overlap within the same resource list or across multiple
 entries are not allowed since part of the configuration would be ineffective.
@@ -283,9 +283,9 @@ Set to a negative value to disable caching. This field is only allowed for KMS v
 <td>
    <p>resources is a list of kubernetes resources which have to be encrypted. The resource names are derived from <code>resource</code> or <code>resource.group</code> of the group/version/resource.
 eg: pandas.awesome.bears.example is a custom resource with 'group': awesome.bears.example, 'resource': pandas.
-Use '<em>.</em>' to encrypt all resources and '<em>.<!-- raw HTML omitted -->' to encrypt all resources in a specific group.
-eg: '</em>.awesome.bears.example' will encrypt all resources in the group 'awesome.bears.example'.
-eg: '*.' will encrypt all resources in the core group (such as pods, configmaps, etc).</p>
+Use '&ast;.&ast;' to encrypt all resources and '&ast;.&lt;group&gt;' to encrypt all resources in a specific group.
+eg: '&ast;.awesome.bears.example' will encrypt all resources in the group 'awesome.bears.example'.
+eg: '&ast;.' will encrypt all resources in the core group (such as pods, configmaps, etc).</p>
 </td>
 </tr>
 <tr><td><code>providers</code> <B>[Required]</B><br/>

--- a/content/en/docs/reference/config-api/kubelet-config.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1.md
@@ -81,9 +81,9 @@ to provide credentials. Images are expected to contain the registry domain
 and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &ast;.io does not match &ast;.k8s.io.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -93,9 +93,9 @@ a single subdomain segment, so *.io does not match *.k8s.io.</p>
 <p>Example values of matchImages:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -1301,9 +1301,9 @@ to provide credentials. Images are expected to contain the registry domain
 and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &ast;.io does not match &ast;.k8s.io.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -1313,9 +1313,9 @@ a single subdomain segment, so *.io does not match *.k8s.io.</p>
 <p>Example values of matchImages:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
@@ -89,9 +89,9 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &ast;.io does not match &ast;.k8s.io.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -108,9 +108,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1alpha1.md
@@ -89,9 +89,9 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &ast;.io does not match &ast;.k8s.io.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -108,9 +108,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1beta1.md
@@ -89,9 +89,9 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &ast;.io does not match &ast;.k8s.io.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -108,9 +108,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>


### PR DESCRIPTION
The upstream source comments are not quite strict at using `*`s, `<`s or `>`s. These characters, when not enclosed in backtiqs, are interpreted as Markdown emphasize markers or HTML tags. Hacking the generator code is not the right solution. We should attempt to fix them in the source code instead.
Before that, let's keep fixing the generated outputs manually.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
