### PR TITLE
fix(doc): add "service" command name for lb and np

### DIFF
--- a/static/docs/reference/generated/kubectl/kubectl-commands.html
+++ b/static/docs/reference/generated/kubectl/kubectl-commands.html
@@ -2001,7 +2001,7 @@ inspect them.</p>
 </code></pre>
 <p>Create a LoadBalancer service with the specified name.</p>
 <h3 id="usage">Usage</h3>
-<p><code>$ kubectl create loadbalancer NAME [--tcp=port:targetPort] [--dry-run=server|client|none]</code></p>
+<p><code>$ kubectl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run=server|client|none]</code></p>
 <h3 id="flags">Flags</h3>
 <table>
 <thead>
@@ -2078,7 +2078,7 @@ inspect them.</p>
 </code></pre>
 <p>Create a NodePort service with the specified name.</p>
 <h3 id="usage">Usage</h3>
-<p><code>$ kubectl create nodeport NAME [--tcp=port:targetPort] [--dry-run=server|client|none]</code></p>
+<p><code>$ kubectl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=server|client|none]</code></p>
 <h3 id="flags">Flags</h3>
 <table>
 <thead>


### PR DESCRIPTION
- `kubectl create loadbalancer NAME [--tcp=port:targetPort] [--dry-run=server|client|none]`
- `kubectl create nodeport NAME [--tcp=port:targetPort] [--dry-run=server|client|none]`

This command is missing "service". 

Correct command must be:

- `kubectl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run=server|client|none]`
- `kubectl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=server|client|none]`