### PR TITLE
fix:Mismatch of footer colour at Case-Study pages

### DIFF
--- a/assets/scss/_case-studies.scss
+++ b/assets/scss/_case-studies.scss
@@ -1,7 +1,7 @@
 // SASS for Case Studies pages go here:
 
 hr {
-  background-color: #999999;
+  background-color: #303030;
   margin-top: 0;
 }
 


### PR DESCRIPTION
Fix the background color of the footer case study page mismatched with the original footer color of the K8 website.
#43020 