### PR TITLE
Fix incorrect parameter name

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -134,7 +134,7 @@ with `.slice` appended.
 {{< feature-state for_k8s_version="v1.17" state="stable" >}}
 
 **Kubelet Flag**: `--reserved-cpus=0-3`
-**KubeletConfiguration Flag**: `reservedSystemCpus: 0-3`
+**KubeletConfiguration Flag**: `reservedSystemCPUs: 0-3`
 
 `reserved-cpus` is meant to define an explicit CPU set for OS system daemons and
 kubernetes system daemons. `reserved-cpus` is for systems that do not intend to


### PR DESCRIPTION
Fixes #43027.

One of the [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/) parameters, `reservedSystemCPUs`, is incorrectly listed as `reservedSystemCpus` in the page below. 

https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list

This PR fixes parameter name.
