### PR TITLE
[zh] Clean up kubeadm_certs files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs.md
@@ -1,7 +1,7 @@
 <!--
 Commands related to handling kubernetes certificates
 -->
-处理 Kubernetes 证书的相关命令
+处理 Kubernetes 证书的相关命令。
 
 <!--
 ### Synopsis
@@ -11,7 +11,7 @@ Commands related to handling kubernetes certificates
 <!--
 Commands related to handling kubernetes certificates
 -->
-处理 Kubernetes 证书相关的命令
+处理 Kubernetes 证书相关的命令。
 
 ```
 kubeadm certs [flags]
@@ -34,7 +34,12 @@ kubeadm certs [flags]
 </tr>
 <tr>
 <!-- td></td><td style="line-height: 130%; word-wrap: break-word;"><p>help for certs</p></td -->
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><!-- help for certs--><p>certs 命令的帮助</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+help for certs
+-->
+<p>certs 操作的帮助命令。</p>
+</td>
 </tr>
 
 </tbody>
@@ -62,5 +67,3 @@ kubeadm certs [flags]
 
 </tbody>
 </table>
-
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew.md
@@ -1,15 +1,4 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-<!--
 Renew certificates for a Kubernetes cluster
 -->
 为 Kubernetes 集群更新证书
@@ -86,4 +75,3 @@ renew 操作的帮助命令
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-peer.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-peer.md
@@ -1,19 +1,7 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-
-<!--
 Renew the certificate for etcd nodes to communicate with each other
 -->
-续订 etcd 节点间用来相互通信的证书
+续订 etcd 节点间用来相互通信的证书。
 
 <!--
 ### Synopsis
@@ -39,7 +27,7 @@ Renewal by default tries to use the certificate authority in the local PKI manag
 <!--
 After renewal, in order to make changes effective, is is required to restart control-plane components and eventually re-distribute the renewed certificate in case the file is used elsewhere.
 -->
-续订后，为了使更改生效，需要重新启动控制平面组件，并最终重新分发更新的证书，以防证书文件在其他地方使用。
+续订后，为了使更改生效，需要重新启动控制平面组件，并最终重新分发续订的证书，以防证书文件在其他地方使用。
 
 ```
 kubeadm certs renew etcd-peer [flags]
@@ -98,7 +86,7 @@ kubeadm 配置文件的路径。
 <!--
 help for etcd-peer
 -->
-etcd-peer 操作的帮助命令
+etcd-peer 操作的帮助命令。
 </td>
 </tr>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-server.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-server.md
@@ -1,18 +1,7 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-<!--
 Renew the certificate for serving etcd
 -->
-续订用于提供 etcd 服务的证书
+续订用于提供 etcd 服务的证书。
 
 <!--
 ### Synopsis
@@ -38,7 +27,7 @@ Renewal by default tries to use the certificate authority in the local PKI manag
 <!--
 After renewal, in order to make changes effective, is required to restart control-plane components and eventually re-distribute the renewed certificate in case the file is used elsewhere.
 -->
-续订后，为了使更改生效，需要重新启动控制平面组件，并最终重新分发更新的证书，以防文件在其他地方使用。
+续订后，为了使更改生效，需要重新启动控制平面组件，并最终重新分发续订的证书，以防文件在其他地方使用。
 
 ```
 kubeadm certs renew etcd-server [flags]
@@ -98,7 +87,7 @@ kubeadm 配置文件的路径。
 help for etcd-server
 -->
 <p>
-etcd-server 操作的帮助命令
+etcd-server 操作的帮助命令。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_front-proxy-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_front-proxy-client.md
@@ -1,14 +1,3 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Renew the certificate for the front proxy client 
 -->
@@ -33,7 +22,7 @@ Renewals run unconditionally, regardless of certificate expiration date; extra a
 Renewal by default tries to use the certificate authority in the local PKI managed by kubeadm; as alternative it is possible to use K8s certificate API for certificate renewal, or as a last option, to generate a CSR request.
 -->
 默认情况下，续订尝试使用位于 kubeadm 所管理的本地 PKI 中的证书颁发机构；作为替代方案，
-也可以使用 K8s 证书 API 进行证书续订；亦或者，作为最后一种方案，生成 CSR 请求。
+也可以使用 K8s certificate API 进行证书续订；亦或者，作为最后一种方案，生成 CSR 请求。
 
 <!--
 After renewal, in order to make changes effective, is is required to restart control-plane components and eventually re-distribute the renewed certificate in case the file is used elsewhere.
@@ -89,7 +78,7 @@ kubeadm certs renew front-proxy-client [flags]
 <!--
 <p>help for front-proxy-client</p>
 -->
-<p>front-proxy-client 操作的帮助命令</p>
+<p>front-proxy-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -119,7 +108,7 @@ kubeadm certs renew front-proxy-client [flags]
 <!--
 Use the Kubernetes certificate API to renew certificates
 -->
-使用 Kubernetes 证书 API 续订证书
+使用 Kubernetes certificate API 续订证书。
 </td>
 </tr>
 
@@ -152,4 +141,3 @@ Use the Kubernetes certificate API to renew certificates
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_scheduler.conf.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_scheduler.conf.md
@@ -1,18 +1,7 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Renew the certificate embedded in the kubeconfig file for the scheduler manager to use 
 -->
-续订 kubeconfig 文件中嵌入的证书，以供调度管理器使用
+续订 kubeconfig 文件中嵌入的证书，以供调度管理器使用。
 
 <!--
 ### Synopsis
@@ -33,7 +22,7 @@ Renewals run unconditionally, regardless of certificate expiration date; extra a
 Renewal by default tries to use the certificate authority in the local PKI managed by kubeadm; as alternative it is possible to use K8s certificate API for certificate renewal, or as a last option, to generate a CSR request.
 -->
 默认情况下，续订会尝试使用在 kubeadm 所管理的本地 PKI 中的证书颁发机构；作为替代方案，
-也可以使用 K8s 证书 API 进行证书续订；亦或者，作为最后一种选择，生成 CSR 请求。
+也可以使用 K8s certificate API 进行证书续订；亦或者，作为最后一种选择，生成 CSR 请求。
 
 <!--
 After renewal, in order to make changes effective, is is required to restart control-plane components and eventually re-distribute the renewed certificate in case the file is used elsewhere.
@@ -93,7 +82,7 @@ kubeadm certs renew scheduler.conf [flags]
 <!--
 <p>help for scheduler.conf</p>
 -->
-<p>scheduler.conf 操作的帮助命令</p>
+<p>scheduler.conf 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -144,4 +133,3 @@ kubeadm certs renew scheduler.conf [flags]
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_completion.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_completion.md
@@ -1,23 +1,11 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-<!--
 Output shell completion code for the specified shell (bash or zsh)
 -->
-为指定 Shell（Bash 或 Zsh） 输出 Shell 补全代码
+为指定的 shell（bash 或 zsh）输出 shell 补全代码。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -26,15 +14,13 @@ The shell code must be evaluated to provide interactive
 completion of kubeadm commands. This can be done by sourcing it from
 the .bash_profile.
 -->
-
-为指定的 shell（bash 或 zsh）输出 shell 自动补全代码。
+为指定的 shell（bash 或 zsh）输出 shell 补全代码。
 必须激活 shell 代码以提供交互式 kubeadm 命令补全。这可以通过加载 .bash_profile 文件完成。
 
 <!--
 Note: this requires the bash-completion framework.
 -->
-
-注意: 此功能依赖于 `bash-completion` 框架。
+注意：此功能依赖于 `bash-completion` 框架。
 
 <!--
 To install it on Mac use homebrew:
@@ -43,14 +29,13 @@ Once installed, bash_completion must be evaluated. This can be done by adding th
 following line to the .bash_profile
     $ source $(brew --prefix)/etc/bash_completion
 -->
-
-在 Mac 上使用 homebrew 安装:
+在 Mac 上使用 homebrew 安装：
 
 ```
 brew install bash-completion
 ```
 
-安装后，必须激活 bash_completion。这可以通过在 .bash_profile 文件中添加下面的命令行来完成
+安装后，必须激活 bash_completion。这可以通过在 .bash_profile 文件中添加下面的命令行来完成：
 
 ```
 source $(brew --prefix)/etc/bash_completion
@@ -60,14 +45,12 @@ source $(brew --prefix)/etc/bash_completion
 If bash-completion is not installed on Linux, please install the 'bash-completion' package
 via your distribution's package manager.
 -->
-
 如果在 Linux 上没有安装 bash-completion，请通过你的发行版的包管理器安装 `bash-completion` 软件包。
 
 <!--
 Note for zsh users: [1] zsh completions are only supported in versions of zsh &gt;= 5.2
 -->
-
-zsh 用户注意事项：[1] zsh 自动补全仅在 &gt;=v5.2 及以上版本中支持。
+zsh 用户注意事项：[1] zsh 自动补全仅在 v5.2 及以上版本中支持。
 
 ```
 kubeadm completion SHELL [flags]
@@ -76,7 +59,6 @@ kubeadm completion SHELL [flags]
 <!--
 ### Examples
 -->
-
 ### 示例
 
 <!--
@@ -96,7 +78,6 @@ source $HOME/.bash_profile
 # Load the kubeadm completion code for zsh[1] into the current shell
 source <(kubeadm completion zsh)
 -->
-
 ```
 # 在 Mac 上使用 homebrew 安装 bash completion
 brew install bash-completion
@@ -117,7 +98,6 @@ source <(kubeadm completion zsh)
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -132,9 +112,11 @@ source <(kubeadm completion zsh)
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- help for completion -->
+<!--
+help for completion
+-->
 <p>
-completion 操作的帮助命令
+completion 操作的帮助命令。
 </p>
 </td>
 </tr>
@@ -145,7 +127,6 @@ completion 操作的帮助命令
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 从父命令继承的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -171,4 +152,3 @@ completion 操作的帮助命令
 
 </tbody>
 </table>
-


### PR DESCRIPTION
Update 6 files:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-peer.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_etcd-server.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_front-proxy-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_scheduler.conf.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_completion.md
```