### PR TITLE
Fix: broken link in init-containers.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -46,7 +46,7 @@ field).
 Init containers support all the fields and features of app containers,
 including resource limits, [volumes](/docs/concepts/storage/volumes/), and security settings. However, the
 resource requests and limits for an init container are handled differently,
-as documented in [Resources](#resources).
+as documented in [Resource sharing within containers](#resource-sharing-within-containers).
 
 Also, init containers do not support `lifecycle`, `livenessProbe`, `readinessProbe`, or
 `startupProbe` because they must run to completion before the Pod can be ready.


### PR DESCRIPTION
Init-containers describes how resource requests and limits for an init container are handled differently, but the section it referenced to did no longer exist.

Looking through the page I edited the link to what I believe is the correct section of the page.