### PR TITLE
Remove alpha environment variable because feature is in beta

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -362,14 +362,6 @@ kubectl [flags]
 </tr>
 
 <tr>
-<td colspan="2">KUBECTL_ENABLE_CMD_SHADOW</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, external plugins can be used as subcommands for builtin commands if subcommand does not exist. In alpha stage, this feature can only be used for create command(e.g. kubectl create networkpolicy). 
-</td>
-</tr>
-
-<tr>
 <td colspan="2">KUBECTL_INTERACTIVE_DELETE</td>
 </tr>
 <tr>


### PR DESCRIPTION
Since https://github.com/kubernetes/enhancements/issues/3638 has been promoted to beta, environment
variable representing alpha feature enablement has become obsolete. This PR removes this from website.