### PR TITLE
recommend draining the node before updating kubelet

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cluster-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-upgrade.md
@@ -59,6 +59,11 @@ For each node in your cluster, [drain](/docs/tasks/administer-cluster/safely-dra
 that node and then either replace it with a new node that uses the {{< skew currentVersion >}}
 kubelet, or upgrade the kubelet on that node and bring the node back into service.
 
+{{< caution >}}
+Draining nodes before upgrading kubelet ensures that pods are re-admitted and containers are
+re-created, which may be necessary to resolve some security issues or other important bugs.
+{{</ caution >}}
+
 ### Other deployments {#upgrade-other}
 
 Refer to the documentation for your cluster deployment tool to learn the recommended set


### PR DESCRIPTION
The Kubernetes docs [state](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) that minor upgrades of kubelet require draining the node:

> If you are performing a minor version upgrade for any kubelet, you must first drain the node (or nodes) that you are upgrading.


It’s also been [stated](https://github.com/kubernetes/kubernetes/issues/63814#issuecomment-760450426), but not in documentation that patch upgrades don’t require draining the node:


> in place minor version kubelet upgrades are not supported without draining. I think in place patch version upgrades are.


My contention is that currently in-place patch upgrades of kubelet are unsafe and we should clarify the K8s documentation to explicitly state that you must drain the node in all circumstances when updating kubelet.

# Why?

I suspect there are other examples of when in-place kubelet upgrades fail, but the most recent one I've found is a failure to resolve a CVE for running pods.  A recent bug in kubelet allowed pods to bypass seccomp enforcement. A CVE ([CVE-2023-2431](https://nvd.nist.gov/vuln/detail/CVE-2023-2431)) was published and the [announcement](https://groups.google.com/g/kubernetes-security-announce/c/QHmx0HOQa10) was sent to the community.  A fix for this CVE was [backported](https://github.com/kubernetes/kubernetes/pull/117147) into the 1.27.2 patch release of kubelet.

Without this docs change, users may assume that in-place updating of kubelet will resolve this CVE. It will, but only for newly admitted pods. An in-place update will not terminate any running pods allowing them to continue to bypass seccomp enforcement.

To demonstrate the failure, I launched a pod with an empty string `localhostProfile` on a node with kubelet 1.27.0. I then stopped kubelet and replaced its binary with the 1.27.6 patch version of kubelet before restarting it. The pod is still running on the node with no seccomp enforcement, but any vulnerability scans which look at the kubelet version will indicate that it’s patched and not susceptible to the CVE.
```
$ kubectl get pod test-pod -o json | jq '{status:  .status.phase, seccomp: .spec.containers[0].securityContext, nodeName: .spec.nodeName}'
{
  "status": "Running",
  "seccomp": {
    "seccompProfile": {
      "localhostProfile": "",
      "type": "Localhost"
    }
  },
  "nodeName": "i-05a72568b9cceb470.us-west-2.compute.internal"
}

$ kubectl get node i-05a72568b9cceb470.us-west-2.compute.internal
NAME                                             STATUS   ROLES    AGE     VERSION
i-05a72568b9cceb470.us-west-2.compute.internal   Ready    <none>   9m50s   v1.27.6
```