### PR TITLE
Fix banner image scaling on Case Studies pages

### DIFF
--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -4,8 +4,7 @@
 {{ else }}
 	{{ if .Params.new_case_study_styles }}
 		<!-- Heading -->
-		<div class="banner {{ if .Params.use_gradient_overlay }}overlay{{ end }}" {{ if isset .Params "heading_background" }}style="background-image: url({{ .Params.heading_background }}); background-position: center;
-  background-size: cover;"{{ end }}>
+		<div class="banner {{ if .Params.use_gradient_overlay }}overlay{{ end }}" {{ if isset .Params "heading_background" }}style="background-image: url({{ .Params.heading_background }});"{{ end }}>
 			<h1>
 				<span class="heading">{{ .Params.title_prefix | default "CASE STUDY:" }}</span>
 				{{- if isset .Params "heading_title_logo" -}}

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -4,7 +4,8 @@
 {{ else }}
 	{{ if .Params.new_case_study_styles }}
 		<!-- Heading -->
-		<div class="banner {{ if .Params.use_gradient_overlay }}overlay{{ end }}" {{ if isset .Params "heading_background" }}style="background-image: url({{ .Params.heading_background }})"{{ end }}>
+		<div class="banner {{ if .Params.use_gradient_overlay }}overlay{{ end }}" {{ if isset .Params "heading_background" }}style="background-image: url({{ .Params.heading_background }}); background-position: center;
+  background-size: cover;"{{ end }}>
 			<h1>
 				<span class="heading">{{ .Params.title_prefix | default "CASE STUDY:" }}</span>
 				{{- if isset .Params "heading_title_logo" -}}

--- a/layouts/shortcodes/case-studies/quote.html
+++ b/layouts/shortcodes/case-studies/quote.html
@@ -1,6 +1,5 @@
 {{ if .Get "image" }}
-<div class="quote banner {{ if $.Page.Params.use_gradient_overlay }}overlay{{ end }}" style="background-image: url({{ .Get "image" }});background-position: center;
-  background-size: cover;">
+<div class="quote banner {{ if $.Page.Params.use_gradient_overlay }}overlay{{ end }}" style="background-image: url({{ .Get "image" }});">
 {{ else }}
 <div class="quote banner">
 {{ end }}

--- a/layouts/shortcodes/case-studies/quote.html
+++ b/layouts/shortcodes/case-studies/quote.html
@@ -1,5 +1,6 @@
 {{ if .Get "image" }}
-<div class="quote banner {{ if $.Page.Params.use_gradient_overlay }}overlay{{ end }}" style="background-image: url({{ .Get "image" }})">
+<div class="quote banner {{ if $.Page.Params.use_gradient_overlay }}overlay{{ end }}" style="background-image: url({{ .Get "image" }});background-position: center;
+  background-size: cover;">
 {{ else }}
 <div class="quote banner">
 {{ end }}

--- a/static/css/new-case-studies.css
+++ b/static/css/new-case-studies.css
@@ -66,7 +66,8 @@ h4[id]:before {
   padding-left: 11.9%;
   padding-right: 11.9%;
   font-size: 1.2em;
-  background-size: 100% auto;
+  background-position: center;
+  background-size: cover;
   background-color: #666;
   background-repeat: no-repeat;
 }


### PR DESCRIPTION
**Description:**

In page case study some images were not covering whole section of the body:

![Screenshot from 2023-09-15 11-56-10](https://github.com/kubernetes/website/assets/120774363/411e35d1-946c-49ee-bda7-dfa9f681e87b)

**What this PR do ?**
fixes #43019

Fixed the issue 

![Screenshot from 2023-09-15 10-04-35](https://github.com/kubernetes/website/assets/120774363/bbfce4e8-2468-4b56-971b-3ed1ab9fd350)
![Screenshot from 2023-09-15 10-05-56](https://github.com/kubernetes/website/assets/120774363/d772f859-1a99-46bc-b1fc-73c84f420de7)
