### PR TITLE
feature gates: clarify beta enabling state

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -346,7 +346,7 @@ An *Alpha* feature means:
 
 A *Beta* feature means:
 
-* Enabled by default.
+* Usually enabled by default. Beta API groups are [disabled by default](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default).
 * The feature is well tested. Enabling the feature is considered safe.
 * Support for the overall feature will not be dropped, though details may change.
 * The schema and/or semantics of objects may change in incompatible ways in a


### PR DESCRIPTION
There's still a lingering misconception that "beta" implies "enabled", the documentation should better not perpetuate that: the feature gate usually gets changed to "enabled", but there are exceptions. API groups are intentionally left as disabled.

/cc @bart0sh 