### PR TITLE
Add links to What's next section of Annotations page

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/annotations.md
+++ b/content/en/docs/concepts/overview/working-with-objects/annotations.md
@@ -93,4 +93,5 @@ spec:
 
 ## {{% heading "whatsnext" %}}
 
-Learn more about [Labels and Selectors](/docs/concepts/overview/working-with-objects/labels/).
+- Learn more about [Labels and Selectors](/docs/concepts/overview/working-with-objects/labels/).
+- [Well-known labels, Annotations and Taints](/docs/reference/labels-annotations-taints/)

--- a/content/en/docs/concepts/overview/working-with-objects/annotations.md
+++ b/content/en/docs/concepts/overview/working-with-objects/annotations.md
@@ -94,4 +94,4 @@ spec:
 ## {{% heading "whatsnext" %}}
 
 - Learn more about [Labels and Selectors](/docs/concepts/overview/working-with-objects/labels/).
-- [Well-known labels, Annotations and Taints](/docs/reference/labels-annotations-taints/)
+- Find [Well-known labels, Annotations and Taints](/docs/reference/labels-annotations-taints/)


### PR DESCRIPTION
Added relevant links in 'What Section' of Annotations page.

Fixes #43086