### PR TITLE
improve: Update alt attributes for images on the front page

### DIFF
--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -13,7 +13,7 @@
 				{{ $logo = .Resources.GetMatch "**logo*.png" }}
 			{{ end }}
       <div>
-        {{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ .Title }}">{{ end }}
+        {{ with $logo }}<img src="{{ .RelPermalink }}" alt="">{{ end }}
         <p>"{{ .Params.quote | truncate 100 }}"</p>
         <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
       </div>

--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -13,7 +13,7 @@
 				{{ $logo = .Resources.GetMatch "**logo*.png" }}
 			{{ end }}
       <div>
-        {{ with $logo }}<img src="{{ .RelPermalink }}" alt="">{{ end }}
+        {{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ .Title }}">{{ end }}
         <p>"{{ .Params.quote | truncate 100 }}"</p>
         <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
       </div>

--- a/layouts/shortcodes/blocks/feature.html
+++ b/layouts/shortcodes/blocks/feature.html
@@ -8,7 +8,7 @@ It can be given a "image" parameter with a name partially matching a file in the
 {{ if  $imageName }}{{- template "shortcodes-blocks_getimage" (dict "name" $imageName "ctx" . "target" "feature-image") -}}{{ end }}
 {{- $image := $.Scratch.Get "feature-image" -}}
 <div class="main-section">
-	{{ with $image }}<div class="image-wrapper"><img src="{{ .RelPermalink }}" alt="{{ .Title }}"></div>{{ end }}
+	{{ with $image }}<div class="image-wrapper"><img src="{{ .RelPermalink }}" alt=""></div>{{ end }}
 	<div class="content">
 		{{ $.Inner }}
 	</div>


### PR DESCRIPTION
Lots of the images on the front page of the Kubernetes website (https://kubernetes.io/) have unhelpful alt attributes, such as the filename. This commit addresses this issue by updating the alt attributes with the empty string.
#42832