### PR TITLE
Remove Case-studies Link and Hyperlink from the bottom of the page

### DIFF
--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -5,7 +5,7 @@
 {{ $caseStudiesPages := where $caseStudiesSection.Pages "Params.featured" true | first 4 }}
 <section id="talkToUs">
   <div class="main-section">
-    <h3>{{ $caseStudiesSection.Title }}</h3>
+    <h3  style="text-align: center"><a href="/case-studies/" style="color: #3371E3; font-weight: 400">{{ $caseStudiesSection.LinkTitle }}</a></h3>
     <div id="caseStudiesWrapper">
       {{ range $caseStudiesPages }}
 			{{ $logo := .Resources.GetMatch "**{feature,logo}*.svg" }}
@@ -19,7 +19,6 @@
       </div>
       {{ end }}  
     </div>
-    <h5 style="text-align: center"><a href="/case-studies/" style="color: #3371E3; font-weight: 400">{{ $caseStudiesSection.LinkTitle }}</a></h5>
   </div>
 </section>
 {{ end }}


### PR DESCRIPTION
In the section featuring quotes from case studies on the home page, remove the "Case-studies" link from the bottom of the section. Instead, hyperlink the headline above the quotes to the case study tab. This change enhances the user experience and eliminates redundancy.
#43065 