### PR TITLE
Feature addition in section why do you need Kubernetes

### DIFF
--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -129,6 +129,14 @@ Kubernetes provides you with:
   Kubernetes lets you store and manage sensitive information, such as passwords, OAuth tokens,
   and SSH keys. You can deploy and update secrets and application configuration without
   rebuilding your container images, and without exposing secrets in your stack configuration.
+* **Batch execution**
+  In addition to services, Kubernetes can manage your batch and CI workloads, replacing containers that fail, if desired.
+* **Horizontal scaling**
+  Scale your application up and down with a simple command, with a UI, or automatically based on CPU usage.
+* **IPv4/IPv6 dual-stack**
+  Allocation of IPv4 and IPv6 addresses to Pods and Services
+* **Designed for extensibility**
+  Add features to your Kubernetes cluster without changing upstream source code.
 
 ## What Kubernetes is not
 


### PR DESCRIPTION
Problem Description : - At K8s [Home page] (https://kubernetes.io/) there is a section where 10 features of K8s are highlighted. But at docs page [Why you need Kubernetes, What can it do](https://kubernetes.io/docs/concepts/overview/#why-you-need-kubernetes-and-what-can-it-do), there only 6 features of K8s are written. If at home page those 10 features highlighted are that much relevant that they are written at Main page (Home) then, why not to add those points to this section of [docs](https://kubernetes.io/docs/concepts/overview/#why-you-need-kubernetes-and-what-can-it-do)

solution : - I added those features which are not added in this file https://github.com/kubernetes/website/edit/main/content/en/docs/concepts/overview/_index.md
