### PR TITLE
Include IPv6 as an option for provided-node-ip annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1083,7 +1083,7 @@ Example: `alpha.kubernetes.io/provided-node-ip: "10.0.0.1"`
 
 Used on: Node
 
-The kubelet can set this annotation on a Node to denote its configured IPv4 address.
+The kubelet can set this annotation on a Node to denote its configured IPv4 and/or IPv6 address.
 
 When kubelet is started with the `--cloud-provider` flag set to any value (includes both external
 and legacy in-tree cloud providers), it sets this annotation on the Node to denote an IP address


### PR DESCRIPTION
This PR tries to complete the description of the annotation `alpha.kubernetes.io/provided-node-ip` https://kubernetes.io/docs/reference/labels-annotations-taints/#alpha-kubernetes-io-provided-node-ip

It currently states `IPv4 address`. However, it could also be an IPv6 address. Probably this description was written before dual-stack or IPv6 was supported in Kubernetes and was never updated when those got supported.