### PR TITLE
Fix a link in kubeadm-certs

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -330,7 +330,7 @@ During cluster creation, kubeadm signs the certificate in the `admin.conf` to ha
 `Subject: O = system:masters, CN = kubernetes-admin`.
 [`system:masters`](/docs/reference/access-authn-authz/rbac/#user-facing-roles)
 is a break-glass, super user group that bypasses the authorization layer (for example,
-[RBAC](/docs/reference/access-authn-authz/authorization/rbac/)).
+[RBAC](/docs/reference/access-authn-authz/rbac/)).
 Sharing the `admin.conf` with additional users is **not recommended**!
 
 Instead, you can use the [`kubeadm kubeconfig user`](/docs/reference/setup-tools/kubeadm/kubeadm-kubeconfig)


### PR DESCRIPTION
Fix a 404 link to the rbac page.
