### PR TITLE
[zh] Clean up kubeadm_config files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config.md
@@ -1,23 +1,11 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Manage configuration for a kubeadm cluster persisted in a ConfigMap in the cluster 
 -->
-管理持久化在 ConfigMap 中的 kubeadm 集群的配置
+管理持久化在 ConfigMap 中的 kubeadm 集群的配置。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -28,10 +16,9 @@ initialized your cluster using kubeadm v1.7.x or lower, you must use the 'config
 command to create this ConfigMap. This is required so that 'kubeadm upgrade' can configure
 your upgraded cluster correctly.
 -->
-
 kube-system 命名空间里有一个名为 "kubeadm-config" 的 ConfigMap，kubeadm 用它来存储有关集群的内部配置。
 kubeadm CLI v1.8.0+ 通过一个配置自动创建该 ConfigMap，这个配置是和 'kubeadm init' 共用的。
-但是您如果使用 kubeadm v1.7.x 或更低的版本初始化集群，那么必须使用 'config upload' 命令创建该 ConfigMap。
+但是你如果使用 kubeadm v1.7.x 或更低的版本初始化集群，那么必须使用 'config upload' 命令创建此 ConfigMap。
 这是必要的操作，目的是使 'kubeadm upgrade' 能够正确地配置升级后的集群。
 
 ```
@@ -41,7 +28,6 @@ kubeadm config [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -59,7 +45,7 @@ kubeadm config [flags]
 <!-- 
 <p>help for config</p>
 -->
-<p>config 操作的帮助命令</p>
+<p>config 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -77,7 +63,7 @@ kubeadm config [flags]
 <p>The kubeconfig file to use when talking to the cluster.
 If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.</p>
 -->
-<p>用于和集群通信的 kubeconfig 文件。如果它没有被设置，那么 kubeadm 将会搜索一个已经存在于标准路径的 kubeconfig 文件
+<p>用于和集群通信的 kubeconfig 文件。如果它没有被设置，那么 kubeadm 将会搜索一个已经存在于标准路径的 kubeconfig 文件。</p>
 </td>
 </tr>
 
@@ -87,7 +73,6 @@ If the flag is not set, a set of standard locations can be searched for an exist
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 从父命令继承的选项
 
    <table style="width: 100%; table-layout: fixed;">

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
@@ -1,15 +1,4 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-<!--
 Print configuration
 -->
 打印配置
@@ -23,8 +12,8 @@ Print configuration
 This command prints configurations for subcommands provided.
 For details, see: https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#section-directories
 -->
-此命令打印子命令所提供的配置信息。
-相关细节可参阅: https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#section-directories
+此命令打印子命令所提供的配置信息。相关细节可参阅：
+https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#section-directories
 
 ```
 kubeadm config print [flags]
@@ -46,12 +35,11 @@ kubeadm config print [flags]
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p><!--help for print-->print 命令的帮助信息</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p><!--help for print-->print 命令的帮助信息。</p></td>
 </tr>
 
 </tbody>
 </table>
-
 
 <!--
 ### Options inherited from parent commands
@@ -69,20 +57,25 @@ kubeadm config print [flags]
 <td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值："/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<!--td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.</p></td -->
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>与集群通信时使用的 kubeconfig 文件。如此标志未设置，将在一组标准位置中搜索现有的kubeconfig 文件。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+<p>The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.</p>
+-->
+<p>与集群通信时使用的 kubeconfig 文件。如此标志未设置，将在一组标准位置中搜索现有的 kubeconfig 文件。</p>
+</td>
 </tr>
 
 <tr>
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<!--td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p></td-->
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[试验性] 指向“真实”宿主根文件系统的路径。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+-->
+<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
+</td>
 </tr>
 
 </tbody>
 </table>
-
-
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
@@ -1,18 +1,7 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Print default init configuration, that can be used for 'kubeadm init' 
 -->
-打印用于 'kubeadm init' 的默认 init 配置
+打印用于 'kubeadm init' 的默认 init 配置。
 
 <!--
 ### Synopsis
@@ -22,15 +11,14 @@ Print default init configuration, that can be used for 'kubeadm init'
 <!--
 This command prints objects such as the default init configuration that is used for 'kubeadm init'.
 -->
-
 此命令打印对象，例如用于 'kubeadm init' 的默认 init 配置对象。
 
 <!--
-<p>Note that sensitive values like the Bootstrap Token fields are replaced with placeholder values like "abcdef.0123456789abcdef" in order to pass validation but
+Note that sensitive values like the Bootstrap Token fields are replaced with placeholder values like "abcdef.0123456789abcdef" in order to pass validation but
 not perform the real computation for creating a token.
 -->
-
-<p>请注意，Bootstrap Token 字段之类的敏感值已替换为 "abcdef.0123456789abcdef" 之类的占位符值以通过验证，但不执行创建令牌的实际计算。
+请注意，Bootstrap Token 字段之类的敏感值已替换为 "abcdef.0123456789abcdef"
+之类的占位符值以通过验证，但不执行创建令牌的实际计算。
 
 ```
 kubeadm config print init-defaults [flags]
@@ -39,7 +27,6 @@ kubeadm config print init-defaults [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -57,7 +44,8 @@ kubeadm config print init-defaults [flags]
 <!--
 <p>A comma-separated list for component config API objects to print the default values for. Available values: [KubeProxyConfiguration KubeletConfiguration]. If this flag is not set, no component configs will be printed.</p>
 -->
-<p>组件配置 API 对象的逗号分隔列表，打印其默认值。可用值：[KubeProxyConfiguration KubeletConfiguration]。如果未设置此参数，则不会打印任何组件配置。</p>
+<p>以逗号分隔的组件配置 API 对象的列表，打印其默认值。可用值：[KubeProxyConfiguration KubeletConfiguration]。
+如果未设置此参数，则不会打印任何组件配置。</p>
 </td>
 </tr>
 
@@ -69,7 +57,7 @@ kubeadm config print init-defaults [flags]
 <!--
 <p>help for init-defaults</p>
 -->
-<p>init-defaults 操作的帮助命令</p>
+<p>init-defaults 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -79,7 +67,6 @@ kubeadm config print init-defaults [flags]
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 从父命令继承的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -120,4 +107,3 @@ kubeadm config print init-defaults [flags]
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
@@ -1,37 +1,22 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-
-<!--
 Print default join configuration, that can be used for 'kubeadm join'
 -->
-打印默认的节点添加配置，该配置可用于 'kubeadm join' 命令
+打印默认的节点添加配置，该配置可用于 'kubeadm join' 命令。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
 This command prints objects such as the default join configuration that is used for 'kubeadm join'.
 -->
-
 此命令打印对象，例如用于 'kubeadm join' 的默认 join 配置对象。
 
 <!--
 Note that sensitive values like the Bootstrap Token fields are replaced with placeholder values like "abcdef.0123456789abcdef" in order to pass validation but
 not perform the real computation for creating a token.
 -->
-
 请注意，诸如启动引导令牌字段之类的敏感值已替换为 "abcdef.0123456789abcdef" 之类的占位符值以通过验证，
 但不执行创建令牌的实际计算。
 
@@ -42,7 +27,6 @@ kubeadm config print join-defaults [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -61,7 +45,8 @@ kubeadm config print join-defaults [flags]
 A comma-separated list for component config API objects to print the default values for. Available values: [KubeProxyConfiguration KubeletConfiguration]. If this flag is not set, no component configs will be printed.
 -->
 <p>
-组件配置 API 对象的逗号分隔列表，打印其默认值。可用值：[KubeProxyConfiguration KubeletConfiguration]。如果未设置此参数，则不会打印任何组件配置。
+以逗号分隔的组件配置 API 对象的列表，打印其默认值。可用值：[KubeProxyConfiguration KubeletConfiguration]。
+如果未设置此参数，则不会打印任何组件配置。
 </p>
 </td>
 </tr>
@@ -75,7 +60,7 @@ A comma-separated list for component config API objects to print the default val
 help for join-defaults
 -->
 <p>
-join-defaults 操作的帮助命令
+join-defaults 操作的帮助命令。
 </p>
 </td>
 </tr>
@@ -86,7 +71,6 @@ join-defaults 操作的帮助命令
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 从父命令继承的选项
 
    <table style="width: 100%; table-layout: fixed;">


### PR DESCRIPTION
Updated 4 files:
```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
```