### PR TITLE
Update link text to "Localizing" 

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -8,7 +8,7 @@ weight: 50
 card:
   name: contribute
   weight: 50
-  title: Localizng the docs
+  title: Localizing the docs
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -8,7 +8,7 @@ weight: 50
 card:
   name: contribute
   weight: 50
-  title: Translating the docs
+  title: Localizng the docs
 ---
 
 <!-- overview -->


### PR DESCRIPTION
Updated link text terminology to 'Localizing' instead of 'Translating' on docs home page

Fixes https://github.com/kubernetes/website/issues/43148