### PR TITLE
Fix: secret missing in docker-registry secret command in kubectl-command docs

### DIFF
--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -5,7 +5,7 @@
 {{ $caseStudiesPages := where $caseStudiesSection.Pages "Params.featured" true | first 4 }}
 <section id="talkToUs">
   <div class="main-section">
-    <h3>{{ $caseStudiesSection.Title }}</h3>
+    <h3  style="text-align: center"><a href="/case-studies/" style="color: #3371E3; font-weight: 400">{{ $caseStudiesSection.LinkTitle }}</a></h3>
     <div id="caseStudiesWrapper">
       {{ range $caseStudiesPages }}
 			{{ $logo := .Resources.GetMatch "**{feature,logo}*.svg" }}
@@ -19,7 +19,6 @@
       </div>
       {{ end }}  
     </div>
-    <h5 style="text-align: center"><a href="/case-studies/" style="color: #3371E3; font-weight: 400">{{ $caseStudiesSection.LinkTitle }}</a></h5>
   </div>
 </section>
 {{ end }}

--- a/static/docs/reference/generated/kubectl/kubectl-commands.html
+++ b/static/docs/reference/generated/kubectl/kubectl-commands.html
@@ -1503,7 +1503,7 @@ inspect them.</p>
   nodes to pull images on your behalf, they must have the credentials.  You can provide this information
   by creating a dockercfg secret and attaching it to your service account.</p>
 <h3 id="usage">Usage</h3>
-<p><code>$ kubectl create docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-file=[key=]source] [--dry-run=server|client|none]</code></p>
+<p><code>$ kubectl create secret docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-file=[key=]source] [--dry-run=server|client|none]</code></p>
 <h3 id="flags">Flags</h3>
 <table>
 <thead>


### PR DESCRIPTION
Problem:
Corrected the usage section for the 'kubectl create docker-registry' command to accurately reflect the command syntax.

Original:
$ kubectl create docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-file=[key=]source] [--dry-run=server|client|none]

Corrected:
$ kubectl create secret docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-file=[key=]source] [--dry-run=server|client|none]
#43180 


