### PR TITLE
Update _index.md

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -57,7 +57,7 @@ Before walking through each tutorial, you may want to bookmark the
 * [Apply Pod Security Standards at Cluster level](/docs/tutorials/security/cluster-level-pss/)
 * [Apply Pod Security Standards at Namespace level](/docs/tutorials/security/ns-level-pss/)
 * [AppArmor](/docs/tutorials/security/apparmor/)
-* [seccomp](/docs/tutorials/security/seccomp/)
+* [Seccomp](/docs/tutorials/security/seccomp/)
 ## {{% heading "whatsnext" %}}
 
 If you would like to write a tutorial, see


### PR DESCRIPTION
_issue : seccomp starts with small letter_

In security section all the points are starting with capital letter but seccomp starts with small letter. So to maintain uniformity i have changed seccomp to Seccomp.

**STEPS TO SEE THE ISSUE**

- Go to kubernetes documentation
- Then find section "Set up a K8s cluster" and click "Setup up Kubernetes"
- Then go to Tutorials section and scroll down to Security section

<img width="1280" alt="seccomp-to-Seccomp" src="https://github.com/kubernetes/website/assets/102309095/1669d8c1-9195-4f4f-8e58-15e4b6c455d4">
