### PR TITLE
Local Preview of Website now works normally on windows

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -301,6 +301,7 @@ languageName = "English"
 # Weight used for sorting.
 weight = 1
 languagedirection = "ltr"
+i18nDir = "./data/i18n"
 
 [languages.zh-cn]
 title = "Kubernetes"


### PR DESCRIPTION
This PR aims to close #36937 and any other related issues which are already closed due to inactivity

I've modified hugo.toml to include a path for the i18n dir. This enables hugo to build the website on windows without explicitly building the symbolic links for it