### PR TITLE
minor syntax update in configure-access-multiple-clusters.md

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -186,7 +186,7 @@ kubectl config --kubeconfig=config-demo use-context dev-frontend
 ```
 
 Now whenever you enter a `kubectl` command, the action will apply to the cluster 
-and namespace listed in the `dev-frontend` context, and the command will use
+and namespace listed in the `dev-frontend` context; the action will use
 the credentials of the user listed in the `dev-frontend` context.
 
 To see only the configuration information associated with

--- a/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -185,8 +185,8 @@ Set the current context:
 kubectl config --kubeconfig=config-demo use-context dev-frontend
 ```
 
-Now whenever you enter a `kubectl` command, the action will apply to the cluster,
-and namespace listed in the `dev-frontend` context. And the command will use
+Now whenever you enter a `kubectl` command, the action will apply to the cluster 
+and namespace listed in the `dev-frontend` context, and the command will use
 the credentials of the user listed in the `dev-frontend` context.
 
 To see only the configuration information associated with


### PR DESCRIPTION
minor syntax update

The sentence originally said 
>Now whenever you enter a `kubectl` command, the action will apply to the cluster,
and namespace listed in the `dev-frontend` context.

The comma after "cluster" looks like incorrect syntax to me. I moved the comma so it makes sense