### PR TITLE
Remove some vertical space between lines of text

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -20,31 +20,24 @@ Before walking through each tutorial, you may want to bookmark the
 ## Basics
 
 * [Kubernetes Basics](/docs/tutorials/kubernetes-basics/) is an in-depth interactive tutorial that helps you understand the Kubernetes system and try out some basic Kubernetes features.
-
 * [Introduction to Kubernetes (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
-
 * [Hello Minikube](/docs/tutorials/hello-minikube/)
 
 ## Configuration
 
 * [Example: Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
-
 * [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Stateless Applications
 
 * [Exposing an External IP Address to Access an Application in a Cluster](/docs/tutorials/stateless-application/expose-external-ip-address/)
-
 * [Example: Deploying PHP Guestbook application with Redis](/docs/tutorials/stateless-application/guestbook/)
 
 ## Stateful Applications
 
 * [StatefulSet Basics](/docs/tutorials/stateful-application/basic-stateful-set/)
-
 * [Example: WordPress and MySQL with Persistent Volumes](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
-
 * [Example: Deploying Cassandra with Stateful Sets](/docs/tutorials/stateful-application/cassandra/)
-
 * [Running ZooKeeper, A CP Distributed System](/docs/tutorials/stateful-application/zookeeper/)
 
 ## Services


### PR DESCRIPTION
_issue : unnecessary spaces present between the lines._

**ISSUE DETAILS**
There is unnecessary spaces present between the lines in the section : **Basics, Configuration, Stateless Applications ,Stateful Applications**
_To see the issue go to this link_ "https://kubernetes.io/docs/tutorials/"
<img width="1024" alt="extra_space" src="https://github.com/kubernetes/website/assets/102309095/c58c4d92-f178-4abc-99c7-52a6515042c8">

**WHY IT NEEDS TO BE CHANGED?**

To maintain uniformity of documentation writing style. So to maintain this uniformity i have removed the extra spaces. You can see these links and screenshots provided below , how the sections are maintained in other pages : 

_Visit this link and go to section **What's next**_ : https://kubernetes.io/docs/setup/
<img width="752" alt="what's next" src="https://github.com/kubernetes/website/assets/102309095/477486d9-bdee-4f27-b9e4-bc25b05ea55c">
_Visit this link and go to section **Services , Security**_: https://kubernetes.io/docs/tutorials/


<img width="583" alt="uniform_space2" src="https://github.com/kubernetes/website/assets/102309095/f3956d5e-9476-4862-8ab8-48bec1a4a665">
