### PR TITLE
Fix incorrect letter casing for data storage units

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -225,7 +225,7 @@ Cluster Domain will be set to `cluster.local` unless
 
 For each VolumeClaimTemplate entry defined in a StatefulSet, each Pod receives one
 PersistentVolumeClaim. In the nginx example above, each Pod receives a single PersistentVolume
-with a StorageClass of `my-storage-class` and 1 Gib of provisioned storage. If no StorageClass
+with a StorageClass of `my-storage-class` and 1 GiB of provisioned storage. If no StorageClass
 is specified, then the default StorageClass will be used. When a Pod is (re)scheduled
 onto a node, its `volumeMounts` mount the PersistentVolumes associated with its
 PersistentVolume Claims. Note that, the PersistentVolumes associated with the


### PR DESCRIPTION
Usage of **Gib** (Gibibit) was used where **GiB** (Gibibyte) was intended.