### PR TITLE
Added-link-beginner-starting-out-in-#sig-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ For more information about contributing to the Kubernetes documentation, see:
 - [Page Content Types](https://kubernetes.io/docs/contribute/style/page-content-types/)
 - [Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
 - [Localizing Kubernetes Documentation](https://kubernetes.io/docs/contribute/localization/)
+- [Introduction to Kubernetes Docs](https://www.youtube.com/watch?v=1SDYzXtD5JA)
 
 ### New contributor ambassadors
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ For more information about contributing to the Kubernetes documentation, see:
 - [Page Content Types](https://kubernetes.io/docs/contribute/style/page-content-types/)
 - [Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
 - [Localizing Kubernetes Documentation](https://kubernetes.io/docs/contribute/localization/)
-- [Introduction to Kubernetes Docs](https://www.youtube.com/watch?v=1SDYzXtD5JA)
+- [Introduction to Kubernetes Docs](https://www.youtube.com/watch?v=pprMgmNzDcw)
 
 ### New contributor ambassadors
 


### PR DESCRIPTION
 Add link for the video in README.md  for issue https://github.com/kubernetes/website/issues/42927

What would you like to be added

Add a tutorial video [YouTube video link](https://youtu.be/1SDYzXtD5JA?si=-Ap7OcaYRV0vviql) to the contributing section of Readme.md

Why is this needed
It covers almost all the doubts of a beginner starting out in #sig-docs and very helpful for especially for those people who prefers to learn through video tutorials.


