### PR TITLE
Ensure all letters in kind are in lowercase

### DIFF
--- a/content/en/docs/tutorials/security/cluster-level-pss.md
+++ b/content/en/docs/tutorials/security/cluster-level-pss.md
@@ -25,7 +25,7 @@ check the documentation for that version.
 
 Install the following on your workstation:
 
-- [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 - [kubectl](/docs/tasks/tools/)
 
 This tutorial demonstrates what you can configure for a Kubernetes cluster that you fully
@@ -252,7 +252,7 @@ following:
    ```
 
    {{<note>}}
-   If you use Docker Desktop with KinD on macOS, you can
+   If you use Docker Desktop with *kind* on macOS, you can
    add `/tmp` as a Shared Directory under the menu item
    **Preferences > Resources > File Sharing**.
    {{</note>}}


### PR DESCRIPTION
I have found the word 'kind' is written like 'KinD'.So i have changed all the letters in 'KinD' to lowercase.

**ISSUE DETAILS**
_To see this issue go to these links:_
https://kubernetes.io/docs/tutorials/security/cluster-level-pss/#before-you-begin
<img width="567" alt="kind_lowercase1" src="https://github.com/kubernetes/website/assets/102309095/fc8e604e-9d04-4171-b380-4f5eb52e00b9">

https://kubernetes.io/docs/tutorials/security/cluster-level-pss/#set-modes-versions-and-standards and go to Note section that is under the step number 4
<img width="513" alt="kind_lowercase" src="https://github.com/kubernetes/website/assets/102309095/b4b38103-ce6e-44d5-bac7-779aff60cae6">
Here in the above issue i have changed the letters into lowercase and converted to italic for easy readability.

**WHY I HAVE CHANGED IT?**
In some other section of documentation i found out that 'kind' is written in lowercase. You can see these screenshots and links below:
https://kubernetes.io/docs/tasks/tools/#kind
<img width="687" alt="correct_kind" src="https://github.com/kubernetes/website/assets/102309095/551f0884-ca40-44e8-aa01-c516789860c3">



 
