### PR TITLE
[zh] Clean up kubeadm_init_phase_certs files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
@@ -1,24 +1,11 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-
 <!-- 
 Generate the certificate for liveness probes to healthcheck etcd 
 -->
-生成用于 etcd 健康检查的活跃性探针的证书
+生成用于 etcd 健康检查的活跃性探针的证书。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -34,7 +21,7 @@ If both files already exist, kubeadm skips the generation step and existing file
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-Alpha 免责声明：此命令当前为 alpha 功能。
+Alpha 免责声明：此命令当前为 Alpha 功能。
 
 ```
 kubeadm init phase certs etcd-healthcheck-client [flags]
@@ -43,7 +30,6 @@ kubeadm init phase certs etcd-healthcheck-client [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -104,7 +90,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>help for etcd-healthcheck-client</p>
 -->
-<p>etcd-healthcheck-client 操作的帮助命令</p>
+<p>etcd-healthcheck-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -131,7 +117,6 @@ Don't apply any changes; just output what would be done.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -155,4 +140,3 @@ Don't apply any changes; just output what would be done.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
@@ -1,48 +1,32 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the certificate for etcd nodes to communicate with each other 
 -->
-生成 etcd 节点相互通信的证书
+生成 etcd 节点相互通信的证书。
 
 <!-- 
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
 Generate the certificate for etcd nodes to communicate with each other, and save them into etcd/peer.crt and etcd/peer.key files.
 -->
-
 生成 etcd 节点相互通信的证书，并将其保存到 etcd/peer.crt 和 etcd/peer.key 文件中。
 
 <!--
 Default SANs are localhost, 127.0.0.1, 127.0.0.1, ::1
 -->
-
 默认 SAN 为 localhost、127.0.0.1、127.0.0.1、:: 1
 
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
-
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-
-Alpha 免责声明：此命令当前为 alpha 功能。
+Alpha 免责声明：此命令当前为 Alpha 功能。
 
 ```
 kubeadm init phase certs etcd-peer [flags]
@@ -51,7 +35,6 @@ kubeadm init phase certs etcd-peer [flags]
 <!-- 
 ### Options 
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -112,7 +95,7 @@ Don't apply any changes; just output what would be done.
 <!-- 
 <p>help for etcd-peer</p> 
 -->
-<p>etcd-peer 操作的帮助命令</p>
+<p>etcd-peer 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -139,7 +122,6 @@ Don't apply any changes; just output what would be done.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 继承于父命令的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -163,4 +145,3 @@ Don't apply any changes; just output what would be done.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
@@ -1,25 +1,12 @@
 <!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
-
-<!--
 Generate the certificate for serving etcd
 -->
-生成用于提供 etcd 服务的证书
+生成用于提供 etcd 服务的证书。
 
 <!-- 
 ### Synopsis
 -->
 ### 概要
-
 
 <!--
 Generate the certificate for serving etcd, and save them into etcd/server.crt and etcd/server.key files.
@@ -39,7 +26,7 @@ If both files already exist, kubeadm skips the generation step and existing file
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-Alpha 免责声明：此命令当前为 alpha 功能。
+Alpha 免责声明：此命令当前为 Alpha 功能。
 
 ```
 kubeadm init phase certs etcd-server [flags]
@@ -106,7 +93,7 @@ kubeadm init phase certs etcd-server [flags]
 <!--
 <p>help for etcd-server</p>
 -->
-<p>etcd-server 操作的帮助命令<p>
+<p>etcd-server 操作的帮助命令。<p>
 </td>
 </tr>
 
@@ -129,8 +116,6 @@ kubeadm init phase certs etcd-server [flags]
 
 </tbody>
 </table>
-
-
 
 <!--
 ### Options inherited from parent commands
@@ -158,4 +143,3 @@ kubeadm init phase certs etcd-server [flags]
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-ca.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-ca.md
@@ -1,42 +1,27 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the self-signed CA to provision identities for front proxy 
 -->
-生成自签名 CA 来提供前端代理的身份
+生成自签名 CA 来提供前端代理的身份。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
 Generate the self-signed CA to provision identities for front proxy, and save them into front-proxy-ca.cert and front-proxy-ca.key files.
 -->
-
 生成自签名 CA 来提供前端代理的身份，并将其保存到 front-proxy-ca.cert 和 front-proxy-ca.key 文件中。
 
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
-
 如果两个文件都已存在，kubeadm 将跳过生成步骤并将使用现有文件。
 
 <!--
 Alpha Disclaimer: this command is currently alpha.
 -->
-
-Alpha 免责声明：此命令目前是 alpha 阶段。
+Alpha 免责声明：此命令目前是 Alpha 阶段。
 
 ```
 kubeadm init phase certs front-proxy-ca [flags]
@@ -45,7 +30,6 @@ kubeadm init phase certs front-proxy-ca [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -106,7 +90,7 @@ Don't apply any changes; just output what would be done.
 <!--
 <p>help for front-proxy-ca</p>
 -->
-<p>front-proxy-ca 操作的帮助命令</p>
+<p>front-proxy-ca 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -133,7 +117,6 @@ Don't apply any changes; just output what would be done.
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 从父命令继承的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -157,4 +140,3 @@ Don't apply any changes; just output what would be done.
 
 </tbody>
 </table>
-

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
@@ -1,34 +1,25 @@
-<!--
-The file is auto-generated from the Go source code of the component using a generic
-[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
-to generate the reference documentation, please read
-[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the
-[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
-guide. You can file document formatting bugs against the
-[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
--->
-
 <!-- 
 Generate the certificate for the front proxy client 
 -->
-为前端代理客户端生成证书
+为前端代理客户端生成证书。
 
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
 Generate the certificate for the front proxy client, and save them into front-proxy-client.crt and front-proxy-client.key files.
+
 If both files already exist, kubeadm skips the generation step and existing files will be used.
+
 Alpha Disclaimer: this command is currently alpha.
 -->
-
 为前端代理客户端生成证书，并将其保存到 front-proxy-client.crt 和 front-proxy-client.key 文件中。
+
 如果两个文件都已存在，kubeadm 将跳过生成步骤并将使用现有文件。
-Alpha 免责声明：此命令目前是 alpha 阶段。
+
+Alpha 免责声明：此命令目前是 Alpha 阶段。
 
 ```
 kubeadm init phase certs front-proxy-client [flags]
@@ -37,7 +28,6 @@ kubeadm init phase certs front-proxy-client [flags]
 <!--
 ### Options
 -->
-
 ### 选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -95,7 +85,7 @@ kubeadm init phase certs front-proxy-client [flags]
 <!--
 <p>help for front-proxy-client</p>
 -->
-<p>front-proxy-client 操作的帮助命令</p>
+<p>front-proxy-client 操作的帮助命令。</p>
 </td>
 </tr>
 
@@ -122,7 +112,6 @@ kubeadm init phase certs front-proxy-client [flags]
 <!--
 ### Options inherited from parent commands
 -->
-
 ### 从父命令继承的选项
 
    <table style="width: 100%; table-layout: fixed;">
@@ -146,4 +135,3 @@ kubeadm init phase certs front-proxy-client [flags]
 
 </tbody>
 </table>
-


### PR DESCRIPTION
Updated 5 files:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-ca.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
```
/kind cleanup