### PR TITLE
Remove redundant text from "Administer a Cluster" page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md
@@ -3,7 +3,6 @@ title: Configure a kubelet image credential provider
 reviewers:
 - liggitt
 - cheftako
-description: Configure the kubelet's image credential provider plugin
 content_type: task
 min-kubernetes-server-version: v1.26
 weight: 120


### PR DESCRIPTION
This will fix #43237

Problem shown below
![image](https://github.com/kubernetes/website/assets/132999137/bf67fc53-fb62-411b-8176-b96524803aa3)
