### PR TITLE
Cleanup the networking concepts page

### DIFF
--- a/content/en/docs/concepts/cluster-administration/networking.md
+++ b/content/en/docs/concepts/cluster-administration/networking.md
@@ -34,12 +34,21 @@ To learn about the Kubernetes networking model, see [here](/docs/concepts/servic
 
 ## How to implement the Kubernetes network model
 
-The network model is implemented by the container runtime on each node. The most common container runtimes use [Container Network Interface](https://github.com/containernetworking/cni) (CNI) plugins to manage their network and security capabilities. Many different CNI plugins exist from many different vendors. Some of these provide only basic features of adding and removing network interfaces, while others provide more sophisticated solutions, such as integration with other container orchestration systems, running multiple CNI plugins, advanced IPAM features etc.
+The network model is implemented by the container runtime on each node. The most common container
+runtimes use [Container Network Interface](https://github.com/containernetworking/cni) (CNI)
+plugins to manage their network and security capabilities. Many different CNI plugins exist from
+many different vendors. Some of these provide only basic features of adding and removing network
+interfaces, while others provide more sophisticated solutions, such as integration with other
+container orchestration systems, running multiple CNI plugins, advanced IPAM features etc.
 
-See [this page](/docs/concepts/cluster-administration/addons/#networking-and-network-policy) for a non-exhaustive list of networking addons supported by Kubernetes.
+See [this page](/docs/concepts/cluster-administration/addons/#networking-and-network-policy)
+for a non-exhaustive list of networking addons supported by Kubernetes.
 
 ## {{% heading "whatsnext" %}}
 
-The early design of the networking model and its rationale, and some future
-plans are described in more detail in the
+The early design of the networking model and its rationale are described in more detail in the
 [networking design document](https://git.k8s.io/design-proposals-archive/network/networking.md).
+For future plans and some on-going efforts that aim to improve Kubernetes networking, please
+refer to the SIG-Network
+[KEPs](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network).
+


### PR DESCRIPTION
This PR modifies the "what's next" section of the networking concept page. The pointer to the **archived** design proposals is only about the original design and it was archived two years ago. For people interested on "future plans", they should be redirected to the KEPs for SIG-Network.
This PR also fixes the line wrapping problems in two paragraphs (no content changes there).

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
