### PR TITLE
Address spelling error around own and manage in SSA Docs

### DIFF
--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -394,7 +394,7 @@ read-modify-write and/or patch are the following:
   to be specified.
 
 It is strongly recommended for controllers to always force conflicts on objects that
-the own and manage, since they might not be able to resolve or act on these conflicts.
+they own and manage, since they might not be able to resolve or act on these conflicts.
 
 ## Transferring ownership
 


### PR DESCRIPTION
**Description** In the Server-Side Apply docs there is a small spelling error 


```
It is strongly recommended for controllers to always force conflicts on objects that
the own and manage, since they might not be able to resolve or act on these conflicts.
```

Should be `...that they own and manage...`

[Link to error in site - Server Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller)
[Link to error in code](https://github.com/kubernetes/website/blob/b90ff432446aea88e57de36ca86810755f375f38/content/en/docs/reference/using-api/server-side-apply.md?plain=1#L397)

