### PR TITLE
Update Steering members following 2023 election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -42,7 +42,7 @@ aliases:
     - tengqm
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol
-    - dipesh-rawat    
+    - dipesh-rawat
     - divya-mohan0209
     - kbhawkey
     - mehabhalodiya
@@ -209,13 +209,13 @@ aliases:
     - Potapy4
   # authoritative source: git.k8s.io/community/OWNERS_ALIASES
   committee-steering: # provide PR approvals for announcements
-    - cblecker
-    - cpanato
     - bentheelder
     - justaugustus
     - mrbobbytables
+    - pacoxu
     - palnabarun
-    - tpepper
+    - pohly
+    - soltysh
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES
   sig-release-leads:
     - cpanato # SIG Technical Lead


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/273.)

Add:

    Maciej Szulik - @soltysh
    Paco Xu 徐俊杰 - @pacoxu
    Patrick Ohly - @pohly

Remove:

    Carlos Tadeu Panato Jr. - @cpanato
    Christoph Blecker - @cblecker
    Tim Pepper - @tpepper

/assign @mrbobbytables @BenTheElder @palnabarun
cc: https://github.com/orgs/kubernetes/teams/steering-committee