### PR TITLE
Update config API reference

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-admission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-admission.v1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [AdmissionReview](#admission-k8s-io-v1-AdmissionReview)
   
-    
 
 ## `AdmissionReview`     {#admission-k8s-io-v1-AdmissionReview}
     

--- a/content/en/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-audit.v1.md
@@ -14,7 +14,6 @@ auto_generated: true
 - [Policy](#audit-k8s-io-v1-Policy)
 - [PolicyList](#audit-k8s-io-v1-PolicyList)
   
-    
 
 ## `Event`     {#audit-k8s-io-v1-Event}
     

--- a/content/en/docs/reference/config-api/apiserver-config.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1.md
@@ -12,7 +12,6 @@ auto_generated: true
 
 - [AdmissionConfiguration](#apiserver-config-k8s-io-v1-AdmissionConfiguration)
   
-    
 
 ## `AdmissionConfiguration`     {#apiserver-config-k8s-io-v1-AdmissionConfiguration}
     

--- a/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
@@ -15,6 +15,47 @@ auto_generated: true
 - [TracingConfiguration](#apiserver-k8s-io-v1alpha1-TracingConfiguration)
   
     
+    
+
+## `TracingConfiguration`     {#TracingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+- [TracingConfiguration](#apiserver-k8s-io-v1alpha1-TracingConfiguration)
+
+
+<p>TracingConfiguration provides versioned configuration for OpenTelemetry tracing clients.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>endpoint</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Endpoint of the collector this component will report traces to.
+The connection is insecure, and does not currently support TLS.
+Recommended is unset, and endpoint is the otlp grpc default, localhost:4317.</p>
+</td>
+</tr>
+<tr><td><code>samplingRatePerMillion</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
+Recommended is unset. If unset, sampler respects its parent span's sampling
+rate, but otherwise never samples.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
 
 ## `AdmissionConfiguration`     {#apiserver-k8s-io-v1alpha1-AdmissionConfiguration}
     
@@ -361,44 +402,3 @@ This does not use a unix:// prefix. (Eg: /etc/srv/kubernetes/konnectivity-server
 </tbody>
 </table>
   
-  
-    
-
-## `TracingConfiguration`     {#TracingConfiguration}
-    
-
-**Appears in:**
-
-- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
-
-- [TracingConfiguration](#apiserver-k8s-io-v1alpha1-TracingConfiguration)
-
-
-<p>TracingConfiguration provides versioned configuration for OpenTelemetry tracing clients.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>endpoint</code><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Endpoint of the collector this component will report traces to.
-The connection is insecure, and does not currently support TLS.
-Recommended is unset, and endpoint is the otlp grpc default, localhost:4317.</p>
-</td>
-</tr>
-<tr><td><code>samplingRatePerMillion</code><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
-Recommended is unset. If unset, sampler respects its parent span's sampling
-rate, but otherwise never samples.</p>
-</td>
-</tr>
-</tbody>
-</table>

--- a/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
@@ -14,6 +14,49 @@ auto_generated: true
 - [TracingConfiguration](#apiserver-k8s-io-v1beta1-TracingConfiguration)
   
     
+    
+
+## `TracingConfiguration`     {#TracingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+- [TracingConfiguration](#apiserver-k8s-io-v1alpha1-TracingConfiguration)
+
+- [TracingConfiguration](#apiserver-k8s-io-v1beta1-TracingConfiguration)
+
+
+<p>TracingConfiguration provides versioned configuration for OpenTelemetry tracing clients.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>endpoint</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Endpoint of the collector this component will report traces to.
+The connection is insecure, and does not currently support TLS.
+Recommended is unset, and endpoint is the otlp grpc default, localhost:4317.</p>
+</td>
+</tr>
+<tr><td><code>samplingRatePerMillion</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
+Recommended is unset. If unset, sampler respects its parent span's sampling
+rate, but otherwise never samples.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
 
 ## `EgressSelectorConfiguration`     {#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration}
     
@@ -292,46 +335,3 @@ This does not use a unix:// prefix. (Eg: /etc/srv/kubernetes/konnectivity-server
 </tbody>
 </table>
   
-  
-    
-
-## `TracingConfiguration`     {#TracingConfiguration}
-    
-
-**Appears in:**
-
-- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
-
-- [TracingConfiguration](#apiserver-k8s-io-v1alpha1-TracingConfiguration)
-
-- [TracingConfiguration](#apiserver-k8s-io-v1beta1-TracingConfiguration)
-
-
-<p>TracingConfiguration provides versioned configuration for OpenTelemetry tracing clients.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>endpoint</code><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Endpoint of the collector this component will report traces to.
-The connection is insecure, and does not currently support TLS.
-Recommended is unset, and endpoint is the otlp grpc default, localhost:4317.</p>
-</td>
-</tr>
-<tr><td><code>samplingRatePerMillion</code><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
-Recommended is unset. If unset, sampler respects its parent span's sampling
-rate, but otherwise never samples.</p>
-</td>
-</tr>
-</tbody>
-</table>

--- a/content/en/docs/reference/config-api/apiserver-encryption.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-encryption.v1.md
@@ -12,7 +12,6 @@ auto_generated: true
 
 - [EncryptionConfiguration](#apiserver-config-k8s-io-v1-EncryptionConfiguration)
   
-    
 
 ## `EncryptionConfiguration`     {#apiserver-config-k8s-io-v1-EncryptionConfiguration}
     
@@ -20,7 +19,7 @@ auto_generated: true
 
 <p>EncryptionConfiguration stores the complete configuration for encryption providers.
 It also allows the use of wildcards to specify the resources that should be encrypted.
-Use '&ast;.&lt;group&gt;' to encrypt all resources within a group or '&ast;.&ast;' to encrypt all resources.
+Use '&ast;&lt;group&gt;o encrypt all resources within a group or '&ast;.&ast;' to encrypt all resources.
 '&ast;.' can be used to encrypt all resource in the core group.  '&ast;.&ast;' will encrypt all
 resources, even custom resources that are added after API server start.
 Use of wildcards that overlap within the same resource list or across multiple

--- a/content/en/docs/reference/config-api/apiserver-eventratelimit.v1alpha1.md
+++ b/content/en/docs/reference/config-api/apiserver-eventratelimit.v1alpha1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [Configuration](#eventratelimit-admission-k8s-io-v1alpha1-Configuration)
   
-    
 
 ## `Configuration`     {#eventratelimit-admission-k8s-io-v1alpha1-Configuration}
     

--- a/content/en/docs/reference/config-api/apiserver-webhookadmission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-webhookadmission.v1.md
@@ -12,7 +12,6 @@ auto_generated: true
 
 - [WebhookAdmission](#apiserver-config-k8s-io-v1-WebhookAdmission)
   
-    
 
 ## `WebhookAdmission`     {#apiserver-config-k8s-io-v1-WebhookAdmission}
     

--- a/content/en/docs/reference/config-api/client-authentication.v1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [ExecCredential](#client-authentication-k8s-io-v1-ExecCredential)
   
-    
 
 ## `ExecCredential`     {#client-authentication-k8s-io-v1-ExecCredential}
     

--- a/content/en/docs/reference/config-api/client-authentication.v1beta1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1beta1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
   
-    
 
 ## `ExecCredential`     {#client-authentication-k8s-io-v1beta1-ExecCredential}
     

--- a/content/en/docs/reference/config-api/imagepolicy.v1alpha1.md
+++ b/content/en/docs/reference/config-api/imagepolicy.v1alpha1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [ImageReview](#imagepolicy-k8s-io-v1alpha1-ImageReview)
   
-    
 
 ## `ImageReview`     {#imagepolicy-k8s-io-v1alpha1-ImageReview}
     

--- a/content/en/docs/reference/config-api/kube-controller-manager-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kube-controller-manager-config.v1alpha1.md
@@ -9,11 +9,491 @@ auto_generated: true
 ## Resource Types 
 
 
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
 - [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
 - [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
   
     
+    
+
+## `NodeControllerConfiguration`     {#NodeControllerConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+
+<p>NodeControllerConfiguration contains elements describing NodeController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentNodeSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>ConcurrentNodeSyncs is the number of workers
+concurrently synchronizing nodes</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
+
+## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
+    
+
+
+<p>CloudControllerManagerConfiguration contains elements describing cloud-controller manager.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>CloudControllerManagerConfiguration</code></td></tr>
+    
+  
+<tr><td><code>Generic</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
+</td>
+<td>
+   <p>Generic holds configuration for a generic controller-manager</p>
+</td>
+</tr>
+<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
+</td>
+<td>
+   <p>KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</p>
+</td>
+</tr>
+<tr><td><code>NodeController</code> <B>[Required]</B><br/>
+<a href="#NodeControllerConfiguration"><code>NodeControllerConfiguration</code></a>
+</td>
+<td>
+   <p>NodeController holds configuration for node controller
+related features.</p>
+</td>
+</tr>
+<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
+<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
+</td>
+<td>
+   <p>ServiceControllerConfiguration holds configuration for ServiceController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>NodeStatusUpdateFrequency</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</p>
+</td>
+</tr>
+<tr><td><code>Webhook</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-WebhookConfiguration"><code>WebhookConfiguration</code></a>
+</td>
+<td>
+   <p>Webhook is the configuration for cloud-controller-manager hosted webhooks</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CloudProviderConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration}
+    
+
+**Appears in:**
+
+- [KubeCloudSharedConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration)
+
+
+<p>CloudProviderConfiguration contains basically elements about cloud provider.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>Name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the provider for cloud services.</p>
+</td>
+</tr>
+<tr><td><code>CloudConfigFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>cloudConfigFile is the path to the cloud provider configuration file.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `KubeCloudSharedConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>CloudProvider</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration"><code>CloudProviderConfiguration</code></a>
+</td>
+<td>
+   <p>CloudProviderConfiguration holds configuration for CloudProvider related features.</p>
+</td>
+</tr>
+<tr><td><code>ExternalCloudVolumePlugin</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>externalCloudVolumePlugin specifies the plugin to use when cloudProvider is &quot;external&quot;.
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</p>
+</td>
+</tr>
+<tr><td><code>UseServiceAccountCredentials</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.</p>
+</td>
+</tr>
+<tr><td><code>AllowUntaggedCloud</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>run with untagged cloud instances</p>
+</td>
+</tr>
+<tr><td><code>RouteReconciliationPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</p>
+</td>
+</tr>
+<tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</p>
+</td>
+</tr>
+<tr><td><code>ClusterName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clusterName is the instance prefix for the cluster.</p>
+</td>
+</tr>
+<tr><td><code>ClusterCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clusterCIDR is CIDR Range for Pods in cluster.</p>
+</td>
+</tr>
+<tr><td><code>AllocateNodeCIDRs</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.</p>
+</td>
+</tr>
+<tr><td><code>CIDRAllocatorType</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</p>
+</td>
+</tr>
+<tr><td><code>ConfigureCloudRoutes</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.</p>
+</td>
+</tr>
+<tr><td><code>NodeSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+periods will result in fewer calls to cloud provider, but may delay addition
+of new nodes to cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WebhookConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-WebhookConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+
+<p>WebhookConfiguration contains configuration related to
+cloud-controller-manager hosted webhooks</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>Webhooks</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>Webhooks is the list of webhooks to enable or disable
+'*' means &quot;all enabled by default webhooks&quot;
+'foo' means &quot;enable 'foo'&quot;
+'-foo' means &quot;disable 'foo'&quot;
+first item for a particular name wins</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
+  
+
+## `LeaderMigrationConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration}
+    
+
+**Appears in:**
+
+- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
+
+
+<p>LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>controllermanager.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>LeaderMigrationConfiguration</code></td></tr>
+    
+  
+<tr><td><code>leaderName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM</p>
+</td>
+</tr>
+<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>ResourceLock indicates the resource object type that will be used to lock
+Should be &quot;leases&quot; or &quot;endpoints&quot;</p>
+</td>
+</tr>
+<tr><td><code>controllerLeaders</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration"><code>[]ControllerLeaderConfiguration</code></a>
+</td>
+<td>
+   <p>ControllerLeaders contains a list of migrating leader lock configurations</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerLeaderConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration}
+    
+
+**Appears in:**
+
+- [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
+
+
+<p>ControllerLeaderConfiguration provides the configuration for a migrating leader lock.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc</p>
+</td>
+</tr>
+<tr><td><code>component</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Component is the name of the component in which the controller should be running.
+E.g. kube-controller-manager, cloud-controller-manager, etc
+Or '*' meaning the controller can be run under any component that participates in the migration</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `GenericControllerManagerConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>GenericControllerManagerConfiguration holds configuration for a generic controller-manager.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>Port</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>port is the port that the controller-manager's http service runs on.</p>
+</td>
+</tr>
+<tr><td><code>Address</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</p>
+</td>
+</tr>
+<tr><td><code>MinResyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2*minResyncPeriod.</p>
+</td>
+</tr>
+<tr><td><code>ClientConnection</code> <B>[Required]</B><br/>
+<a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
+</td>
+<td>
+   <p>ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</p>
+</td>
+</tr>
+<tr><td><code>ControllerStartInterval</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>How long to wait between starting controller managers</p>
+</td>
+</tr>
+<tr><td><code>LeaderElection</code> <B>[Required]</B><br/>
+<a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
+</td>
+<td>
+   <p>leaderElection defines the configuration of leader election client.</p>
+</td>
+</tr>
+<tr><td><code>Controllers</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>Controllers is the list of controllers to enable or disable
+'*' means &quot;all enabled by default controllers&quot;
+'foo' means &quot;enable 'foo'&quot;
+'-foo' means &quot;disable 'foo'&quot;
+first item for a particular name wins</p>
+</td>
+</tr>
+<tr><td><code>Debugging</code> <B>[Required]</B><br/>
+<a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
+</td>
+<td>
+   <p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+</td>
+</tr>
+<tr><td><code>LeaderMigrationEnabled</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>LeaderMigrationEnabled indicates whether Leader Migration should be enabled for the controller manager.</p>
+</td>
+</tr>
+<tr><td><code>LeaderMigration</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration"><code>LeaderMigrationConfiguration</code></a>
+</td>
+<td>
+   <p>LeaderMigration holds the configuration for Leader Migration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
+  
 
 ## `KubeControllerManagerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration}
     
@@ -1462,488 +1942,6 @@ that supports dynamic provisioning. Defaults to true.</p>
 <td>
    <p>volumePluginDir is the full path of the directory in which the flex
 volume plugin should search for additional third party volume plugins</p>
-</td>
-</tr>
-</tbody>
-</table>
-  
-  
-    
-
-## `NodeControllerConfiguration`     {#NodeControllerConfiguration}
-    
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-
-<p>NodeControllerConfiguration contains elements describing NodeController.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>ConcurrentNodeSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>ConcurrentNodeSyncs is the number of workers
-concurrently synchronizing nodes</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
-    
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-<p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>concurrentServiceSyncs is the number of services that are
-allowed to sync concurrently. Larger number = more responsive service
-management, but more CPU (and network) load.</p>
-</td>
-</tr>
-</tbody>
-</table>
-  
-    
-
-## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
-    
-
-
-<p>CloudControllerManagerConfiguration contains elements describing cloud-controller manager.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-<tr><td><code>apiVersion</code><br/>string</td><td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
-<tr><td><code>kind</code><br/>string</td><td><code>CloudControllerManagerConfiguration</code></td></tr>
-    
-  
-<tr><td><code>Generic</code> <B>[Required]</B><br/>
-<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
-</td>
-<td>
-   <p>Generic holds configuration for a generic controller-manager</p>
-</td>
-</tr>
-<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
-<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
-</td>
-<td>
-   <p>KubeCloudSharedConfiguration holds configuration for shared related features
-both in cloud controller manager and kube-controller manager.</p>
-</td>
-</tr>
-<tr><td><code>NodeController</code> <B>[Required]</B><br/>
-<a href="#NodeControllerConfiguration"><code>NodeControllerConfiguration</code></a>
-</td>
-<td>
-   <p>NodeController holds configuration for node controller
-related features.</p>
-</td>
-</tr>
-<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
-<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
-</td>
-<td>
-   <p>ServiceControllerConfiguration holds configuration for ServiceController
-related features.</p>
-</td>
-</tr>
-<tr><td><code>NodeStatusUpdateFrequency</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</p>
-</td>
-</tr>
-<tr><td><code>Webhook</code> <B>[Required]</B><br/>
-<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-WebhookConfiguration"><code>WebhookConfiguration</code></a>
-</td>
-<td>
-   <p>Webhook is the configuration for cloud-controller-manager hosted webhooks</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `CloudProviderConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration}
-    
-
-**Appears in:**
-
-- [KubeCloudSharedConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration)
-
-
-<p>CloudProviderConfiguration contains basically elements about cloud provider.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>Name</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Name is the provider for cloud services.</p>
-</td>
-</tr>
-<tr><td><code>CloudConfigFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>cloudConfigFile is the path to the cloud provider configuration file.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `KubeCloudSharedConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration}
-    
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-<p>KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
-and cloud-controller manager, but not genericconfig.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>CloudProvider</code> <B>[Required]</B><br/>
-<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration"><code>CloudProviderConfiguration</code></a>
-</td>
-<td>
-   <p>CloudProviderConfiguration holds configuration for CloudProvider related features.</p>
-</td>
-</tr>
-<tr><td><code>ExternalCloudVolumePlugin</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>externalCloudVolumePlugin specifies the plugin to use when cloudProvider is &quot;external&quot;.
-It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</p>
-</td>
-</tr>
-<tr><td><code>UseServiceAccountCredentials</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>useServiceAccountCredentials indicates whether controllers should be run with
-individual service account credentials.</p>
-</td>
-</tr>
-<tr><td><code>AllowUntaggedCloud</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>run with untagged cloud instances</p>
-</td>
-</tr>
-<tr><td><code>RouteReconciliationPeriod</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</p>
-</td>
-</tr>
-<tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</p>
-</td>
-</tr>
-<tr><td><code>ClusterName</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>clusterName is the instance prefix for the cluster.</p>
-</td>
-</tr>
-<tr><td><code>ClusterCIDR</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>clusterCIDR is CIDR Range for Pods in cluster.</p>
-</td>
-</tr>
-<tr><td><code>AllocateNodeCIDRs</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
-ConfigureCloudRoutes is true, to be set on the cloud provider.</p>
-</td>
-</tr>
-<tr><td><code>CIDRAllocatorType</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</p>
-</td>
-</tr>
-<tr><td><code>ConfigureCloudRoutes</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
-to be configured on the cloud provider.</p>
-</td>
-</tr>
-<tr><td><code>NodeSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
-periods will result in fewer calls to cloud provider, but may delay addition
-of new nodes to cluster.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `WebhookConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-WebhookConfiguration}
-    
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-
-<p>WebhookConfiguration contains configuration related to
-cloud-controller-manager hosted webhooks</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>Webhooks</code> <B>[Required]</B><br/>
-<code>[]string</code>
-</td>
-<td>
-   <p>Webhooks is the list of webhooks to enable or disable
-'*' means &quot;all enabled by default webhooks&quot;
-'foo' means &quot;enable 'foo'&quot;
-'-foo' means &quot;disable 'foo'&quot;
-first item for a particular name wins</p>
-</td>
-</tr>
-</tbody>
-</table>
-  
-  
-    
-
-## `LeaderMigrationConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration}
-    
-
-**Appears in:**
-
-- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
-
-
-<p>LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-<tr><td><code>apiVersion</code><br/>string</td><td><code>controllermanager.config.k8s.io/v1alpha1</code></td></tr>
-<tr><td><code>kind</code><br/>string</td><td><code>LeaderMigrationConfiguration</code></td></tr>
-    
-  
-<tr><td><code>leaderName</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>LeaderName is the name of the leader election resource that protects the migration
-E.g. 1-20-KCM-to-1-21-CCM</p>
-</td>
-</tr>
-<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>ResourceLock indicates the resource object type that will be used to lock
-Should be &quot;leases&quot; or &quot;endpoints&quot;</p>
-</td>
-</tr>
-<tr><td><code>controllerLeaders</code> <B>[Required]</B><br/>
-<a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration"><code>[]ControllerLeaderConfiguration</code></a>
-</td>
-<td>
-   <p>ControllerLeaders contains a list of migrating leader lock configurations</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `ControllerLeaderConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration}
-    
-
-**Appears in:**
-
-- [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
-
-
-<p>ControllerLeaderConfiguration provides the configuration for a migrating leader lock.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Name is the name of the controller being migrated
-E.g. service-controller, route-controller, cloud-node-controller, etc</p>
-</td>
-</tr>
-<tr><td><code>component</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Component is the name of the component in which the controller should be running.
-E.g. kube-controller-manager, cloud-controller-manager, etc
-Or '*' meaning the controller can be run under any component that participates in the migration</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `GenericControllerManagerConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration}
-    
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-<p>GenericControllerManagerConfiguration holds configuration for a generic controller-manager.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>Port</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>port is the port that the controller-manager's http service runs on.</p>
-</td>
-</tr>
-<tr><td><code>Address</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</p>
-</td>
-</tr>
-<tr><td><code>MinResyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>minResyncPeriod is the resync period in reflectors; will be random between
-minResyncPeriod and 2*minResyncPeriod.</p>
-</td>
-</tr>
-<tr><td><code>ClientConnection</code> <B>[Required]</B><br/>
-<a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
-</td>
-<td>
-   <p>ClientConnection specifies the kubeconfig file and client connection
-settings for the proxy server to use when communicating with the apiserver.</p>
-</td>
-</tr>
-<tr><td><code>ControllerStartInterval</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>How long to wait between starting controller managers</p>
-</td>
-</tr>
-<tr><td><code>LeaderElection</code> <B>[Required]</B><br/>
-<a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
-</td>
-<td>
-   <p>leaderElection defines the configuration of leader election client.</p>
-</td>
-</tr>
-<tr><td><code>Controllers</code> <B>[Required]</B><br/>
-<code>[]string</code>
-</td>
-<td>
-   <p>Controllers is the list of controllers to enable or disable
-'*' means &quot;all enabled by default controllers&quot;
-'foo' means &quot;enable 'foo'&quot;
-'-foo' means &quot;disable 'foo'&quot;
-first item for a particular name wins</p>
-</td>
-</tr>
-<tr><td><code>Debugging</code> <B>[Required]</B><br/>
-<a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
-</td>
-<td>
-   <p>DebuggingConfiguration holds configuration for Debugging related features.</p>
-</td>
-</tr>
-<tr><td><code>LeaderMigrationEnabled</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>LeaderMigrationEnabled indicates whether Leader Migration should be enabled for the controller manager.</p>
-</td>
-</tr>
-<tr><td><code>LeaderMigration</code> <B>[Required]</B><br/>
-<a href="#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration"><code>LeaderMigrationConfiguration</code></a>
-</td>
-<td>
-   <p>LeaderMigration holds the configuration for Leader Migration.</p>
 </td>
 </tr>
 </tbody>

--- a/content/en/docs/reference/config-api/kube-proxy-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kube-proxy-config.v1alpha1.md
@@ -12,6 +12,7 @@ auto_generated: true
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
   
     
+    
 
 ## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
     
@@ -80,9 +81,9 @@ client.</p>
 
 **Appears in:**
 
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration)
-
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration)
 
 - [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
 
@@ -201,7 +202,6 @@ during leader election cycles.</p>
 </tbody>
 </table>
   
-    
 
 ## `KubeProxyConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration}
     

--- a/content/en/docs/reference/config-api/kube-scheduler-config.v1.md
+++ b/content/en/docs/reference/config-api/kube-scheduler-config.v1.md
@@ -19,6 +19,7 @@ auto_generated: true
 - [VolumeBindingArgs](#kubescheduler-config-k8s-io-v1-VolumeBindingArgs)
   
     
+    
 
 ## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
     
@@ -119,9 +120,9 @@ enableProfiling is true.</p>
 
 **Appears in:**
 
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration)
-
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration)
 
 
 <p>LeaderElectionConfiguration defines the configuration of leader election
@@ -200,7 +201,6 @@ during leader election cycles.</p>
 </tbody>
 </table>
   
-    
 
 ## `DefaultPreemptionArgs`     {#kubescheduler-config-k8s-io-v1-DefaultPreemptionArgs}
     

--- a/content/en/docs/reference/config-api/kube-scheduler-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kube-scheduler-config.v1beta3.md
@@ -19,6 +19,182 @@ auto_generated: true
 - [VolumeBindingArgs](#kubescheduler-config-k8s-io-v1beta3-VolumeBindingArgs)
   
     
+    
+
+## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
+    
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+
+<p>ClientConnectionConfiguration contains details for constructing a client.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>kubeconfig is the path to a KubeConfig file.</p>
+</td>
+</tr>
+<tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
+default value of 'application/json'. This field will control all connections to the server used by a particular
+client.</p>
+</td>
+</tr>
+<tr><td><code>contentType</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>contentType is the content type used when sending data to the server from this client.</p>
+</td>
+</tr>
+<tr><td><code>qps</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>qps controls the number of queries per second allowed for this connection.</p>
+</td>
+</tr>
+<tr><td><code>burst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DebuggingConfiguration`     {#DebuggingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+
+<p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enableProfiling enables profiling via web interface host:port/debug/pprof/</p>
+</td>
+</tr>
+<tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enableContentionProfiling enables block profiling, if
+enableProfiling is true.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
+    
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+
+<p>LeaderElectionConfiguration defines the configuration of leader election
+clients for components that can run with leader election enabled.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>leaderElect</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>leaderElect enables a leader election client to gain leadership
+before executing the main loop. Enable this when running replicated
+components for high availability.</p>
+</td>
+</tr>
+<tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>leaseDuration is the duration that non-leader candidates will wait
+after observing a leadership renewal until attempting to acquire
+leadership of a led but unrenewed leader slot. This is effectively the
+maximum duration that a leader can be stopped before it is replaced
+by another candidate. This is only applicable if leader election is
+enabled.</p>
+</td>
+</tr>
+<tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>renewDeadline is the interval between attempts by the acting master to
+renew a leadership slot before it stops leading. This must be less
+than or equal to the lease duration. This is only applicable if leader
+election is enabled.</p>
+</td>
+</tr>
+<tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>retryPeriod is the duration the clients should wait between attempting
+acquisition and renewal of a leadership. This is only applicable if
+leader election is enabled.</p>
+</td>
+</tr>
+<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resourceLock indicates the resource object type that will be used to lock
+during leader election cycles.</p>
+</td>
+</tr>
+<tr><td><code>resourceName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resourceName indicates the name of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
+</tr>
+<tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resourceName indicates the namespace of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
 
 ## `DefaultPreemptionArgs`     {#kubescheduler-config-k8s-io-v1beta3-DefaultPreemptionArgs}
     
@@ -1075,179 +1251,3 @@ Weight defaults to 1 if not specified or explicitly set to 0.</p>
 </tbody>
 </table>
   
-  
-    
-
-## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
-    
-
-**Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
-
-
-<p>ClientConnectionConfiguration contains details for constructing a client.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>kubeconfig is the path to a KubeConfig file.</p>
-</td>
-</tr>
-<tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
-default value of 'application/json'. This field will control all connections to the server used by a particular
-client.</p>
-</td>
-</tr>
-<tr><td><code>contentType</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>contentType is the content type used when sending data to the server from this client.</p>
-</td>
-</tr>
-<tr><td><code>qps</code> <B>[Required]</B><br/>
-<code>float32</code>
-</td>
-<td>
-   <p>qps controls the number of queries per second allowed for this connection.</p>
-</td>
-</tr>
-<tr><td><code>burst</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>burst allows extra queries to accumulate when a client is exceeding its rate.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `DebuggingConfiguration`     {#DebuggingConfiguration}
-    
-
-**Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
-
-
-<p>DebuggingConfiguration holds configuration for Debugging related features.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>enableProfiling enables profiling via web interface host:port/debug/pprof/</p>
-</td>
-</tr>
-<tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>enableContentionProfiling enables block profiling, if
-enableProfiling is true.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
-    
-
-**Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
-
-
-<p>LeaderElectionConfiguration defines the configuration of leader election
-clients for components that can run with leader election enabled.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>leaderElect</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>leaderElect enables a leader election client to gain leadership
-before executing the main loop. Enable this when running replicated
-components for high availability.</p>
-</td>
-</tr>
-<tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>leaseDuration is the duration that non-leader candidates will wait
-after observing a leadership renewal until attempting to acquire
-leadership of a led but unrenewed leader slot. This is effectively the
-maximum duration that a leader can be stopped before it is replaced
-by another candidate. This is only applicable if leader election is
-enabled.</p>
-</td>
-</tr>
-<tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>renewDeadline is the interval between attempts by the acting master to
-renew a leadership slot before it stops leading. This must be less
-than or equal to the lease duration. This is only applicable if leader
-election is enabled.</p>
-</td>
-</tr>
-<tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>retryPeriod is the duration the clients should wait between attempting
-acquisition and renewal of a leadership. This is only applicable if
-leader election is enabled.</p>
-</td>
-</tr>
-<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>resourceLock indicates the resource object type that will be used to lock
-during leader election cycles.</p>
-</td>
-</tr>
-<tr><td><code>resourceName</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>resourceName indicates the name of resource object that will be used to lock
-during leader election cycles.</p>
-</td>
-</tr>
-<tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>resourceName indicates the namespace of resource object that will be used to lock
-during leader election cycles.</p>
-</td>
-</tr>
-</tbody>
-</table>

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -264,6 +264,109 @@ node only (e.g. the node ip).</p>
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta3-JoinConfiguration)
   
     
+    
+
+## `BootstrapToken`     {#BootstrapToken}
+    
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta3-InitConfiguration)
+
+
+<p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<a href="#BootstrapTokenString"><code>BootstrapTokenString</code></a>
+</td>
+<td>
+   <p><code>token</code> is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.</p>
+</td>
+</tr>
+<tr><td><code>description</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p><code>description</code> sets a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.</p>
+</td>
+</tr>
+<tr><td><code>ttl</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p><code>ttl</code> defines the time to live for this token. Defaults to <code>24h</code>.
+<code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
+</tr>
+<tr><td><code>expires</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the <code>ttl</code>. <code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
+</tr>
+<tr><td><code>usages</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p><code>usages</code> describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.</p>
+</td>
+</tr>
+<tr><td><code>groups</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p><code>groups</code> specifies the extra groups that this token will authenticate as when/if
+used for authentication</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `BootstrapTokenString`     {#BootstrapTokenString}
+    
+
+**Appears in:**
+
+- [BootstrapToken](#BootstrapToken)
+
+
+<p>BootstrapTokenString is a token of the format <code>abcdef.abcdef0123456789</code> that is used
+for both validation of the practically of the API server from a joining node's point
+of view and as an authentication method for the node in the bootstrap phase of
+&quot;kubeadm join&quot;. This token is and should be short-lived.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+</tbody>
+</table>
+  
 
 ## `ClusterConfiguration`     {#kubeadm-k8s-io-v1beta3-ClusterConfiguration}
     
@@ -1238,106 +1341,3 @@ first alpha-numerically.</p>
 </tbody>
 </table>
   
-  
-    
-
-## `BootstrapToken`     {#BootstrapToken}
-    
-
-**Appears in:**
-
-- [InitConfiguration](#kubeadm-k8s-io-v1beta3-InitConfiguration)
-
-
-<p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>token</code> <B>[Required]</B><br/>
-<a href="#BootstrapTokenString"><code>BootstrapTokenString</code></a>
-</td>
-<td>
-   <p><code>token</code> is used for establishing bidirectional trust between nodes and control-planes.
-Used for joining nodes in the cluster.</p>
-</td>
-</tr>
-<tr><td><code>description</code><br/>
-<code>string</code>
-</td>
-<td>
-   <p><code>description</code> sets a human-friendly message why this token exists and what it's used
-for, so other administrators can know its purpose.</p>
-</td>
-</tr>
-<tr><td><code>ttl</code><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p><code>ttl</code> defines the time to live for this token. Defaults to <code>24h</code>.
-<code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
-</td>
-</tr>
-<tr><td><code>expires</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>meta/v1.Time</code></a>
-</td>
-<td>
-   <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
-dynamically at runtime based on the <code>ttl</code>. <code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
-</td>
-</tr>
-<tr><td><code>usages</code><br/>
-<code>[]string</code>
-</td>
-<td>
-   <p><code>usages</code> describes the ways in which this token can be used. Can by default be used
-for establishing bidirectional trust, but that can be changed here.</p>
-</td>
-</tr>
-<tr><td><code>groups</code><br/>
-<code>[]string</code>
-</td>
-<td>
-   <p><code>groups</code> specifies the extra groups that this token will authenticate as when/if
-used for authentication</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `BootstrapTokenString`     {#BootstrapTokenString}
-    
-
-**Appears in:**
-
-- [BootstrapToken](#BootstrapToken)
-
-
-<p>BootstrapTokenString is a token of the format <code>abcdef.abcdef0123456789</code> that is used
-for both validation of the practically of the API server from a joining node's point
-of view and as an authentication method for the node in the bootstrap phase of
-&quot;kubeadm join&quot;. This token is and should be short-lived.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>-</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <span class="text-muted">No description provided.</span></td>
-</tr>
-<tr><td><code>-</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <span class="text-muted">No description provided.</span></td>
-</tr>
-</tbody>
-</table>

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
@@ -291,6 +291,111 @@ node only (e.g. the node ip).</p>
 - [ResetConfiguration](#kubeadm-k8s-io-v1beta4-ResetConfiguration)
   
     
+    
+
+## `BootstrapToken`     {#BootstrapToken}
+    
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta3-InitConfiguration)
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta4-InitConfiguration)
+
+
+<p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<a href="#BootstrapTokenString"><code>BootstrapTokenString</code></a>
+</td>
+<td>
+   <p><code>token</code> is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.</p>
+</td>
+</tr>
+<tr><td><code>description</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p><code>description</code> sets a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.</p>
+</td>
+</tr>
+<tr><td><code>ttl</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p><code>ttl</code> defines the time to live for this token. Defaults to <code>24h</code>.
+<code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
+</tr>
+<tr><td><code>expires</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the <code>ttl</code>. <code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
+</tr>
+<tr><td><code>usages</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p><code>usages</code> describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.</p>
+</td>
+</tr>
+<tr><td><code>groups</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p><code>groups</code> specifies the extra groups that this token will authenticate as when/if
+used for authentication</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `BootstrapTokenString`     {#BootstrapTokenString}
+    
+
+**Appears in:**
+
+- [BootstrapToken](#BootstrapToken)
+
+
+<p>BootstrapTokenString is a token of the format <code>abcdef.abcdef0123456789</code> that is used
+for both validation of the practically of the API server from a joining node's point
+of view and as an authentication method for the node in the bootstrap phase of
+&quot;kubeadm join&quot;. This token is and should be short-lived.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+</tbody>
+</table>
+  
 
 ## `ClusterConfiguration`     {#kubeadm-k8s-io-v1beta4-ClusterConfiguration}
     
@@ -424,7 +529,7 @@ information.</p>
     
   
 <tr><td><code>bootstrapTokens</code><br/>
-<code>[]invalid type</code>
+<a href="#BootstrapToken"><code>[]BootstrapToken</code></a>
 </td>
 <td>
    <p>BootstrapTokens is respected at <code>kubeadm init</code> time and describes a set of Bootstrap Tokens to create.
@@ -1323,106 +1428,3 @@ first alpha-numerically.</p>
 </tbody>
 </table>
   
-  
-    
-
-## `BootstrapToken`     {#BootstrapToken}
-    
-
-**Appears in:**
-
-- [InitConfiguration](#kubeadm-k8s-io-v1beta3-InitConfiguration)
-
-
-<p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>token</code> <B>[Required]</B><br/>
-<a href="#BootstrapTokenString"><code>BootstrapTokenString</code></a>
-</td>
-<td>
-   <p><code>token</code> is used for establishing bidirectional trust between nodes and control-planes.
-Used for joining nodes in the cluster.</p>
-</td>
-</tr>
-<tr><td><code>description</code><br/>
-<code>string</code>
-</td>
-<td>
-   <p><code>description</code> sets a human-friendly message why this token exists and what it's used
-for, so other administrators can know its purpose.</p>
-</td>
-</tr>
-<tr><td><code>ttl</code><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p><code>ttl</code> defines the time to live for this token. Defaults to <code>24h</code>.
-<code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
-</td>
-</tr>
-<tr><td><code>expires</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>meta/v1.Time</code></a>
-</td>
-<td>
-   <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
-dynamically at runtime based on the <code>ttl</code>. <code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
-</td>
-</tr>
-<tr><td><code>usages</code><br/>
-<code>[]string</code>
-</td>
-<td>
-   <p><code>usages</code> describes the ways in which this token can be used. Can by default be used
-for establishing bidirectional trust, but that can be changed here.</p>
-</td>
-</tr>
-<tr><td><code>groups</code><br/>
-<code>[]string</code>
-</td>
-<td>
-   <p><code>groups</code> specifies the extra groups that this token will authenticate as when/if
-used for authentication</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `BootstrapTokenString`     {#BootstrapTokenString}
-    
-
-**Appears in:**
-
-- [BootstrapToken](#BootstrapToken)
-
-
-<p>BootstrapTokenString is a token of the format <code>abcdef.abcdef0123456789</code> that is used
-for both validation of the practically of the API server from a joining node's point
-of view and as an authentication method for the node in the bootstrap phase of
-&quot;kubeadm join&quot;. This token is and should be short-lived.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>-</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <span class="text-muted">No description provided.</span></td>
-</tr>
-<tr><td><code>-</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <span class="text-muted">No description provided.</span></td>
-</tr>
-</tbody>
-</table>

--- a/content/en/docs/reference/config-api/kubeconfig.v1.md
+++ b/content/en/docs/reference/config-api/kubeconfig.v1.md
@@ -11,6 +11,83 @@ auto_generated: true
 - [Config](#Config)
   
     
+    
+
+## `Config`     {#Config}
+    
+
+
+<p>Config holds the information needed to build connect to remote kubernetes clusters as a given user</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Config</code></td></tr>
+    
+  
+<tr><td><code>kind</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Legacy field from pkg/api/types.go TypeMeta.
+TODO(jlowdermilk): remove this after eliminating downstream dependencies.</p>
+</td>
+</tr>
+<tr><td><code>apiVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Legacy field from pkg/api/types.go TypeMeta.
+TODO(jlowdermilk): remove this after eliminating downstream dependencies.</p>
+</td>
+</tr>
+<tr><td><code>preferences</code> <B>[Required]</B><br/>
+<a href="#Preferences"><code>Preferences</code></a>
+</td>
+<td>
+   <p>Preferences holds general information to be use for cli interactions</p>
+</td>
+</tr>
+<tr><td><code>clusters</code> <B>[Required]</B><br/>
+<a href="#NamedCluster"><code>[]NamedCluster</code></a>
+</td>
+<td>
+   <p>Clusters is a map of referencable names to cluster configs</p>
+</td>
+</tr>
+<tr><td><code>users</code> <B>[Required]</B><br/>
+<a href="#NamedAuthInfo"><code>[]NamedAuthInfo</code></a>
+</td>
+<td>
+   <p>AuthInfos is a map of referencable names to user configs</p>
+</td>
+</tr>
+<tr><td><code>contexts</code> <B>[Required]</B><br/>
+<a href="#NamedContext"><code>[]NamedContext</code></a>
+</td>
+<td>
+   <p>Contexts is a map of referencable names to context configs</p>
+</td>
+</tr>
+<tr><td><code>current-context</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>CurrentContext is the name of the context that you would like to use by default</p>
+</td>
+</tr>
+<tr><td><code>extensions</code><br/>
+<a href="#NamedExtension"><code>[]NamedExtension</code></a>
+</td>
+<td>
+   <p>Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields</p>
+</td>
+</tr>
+</tbody>
+</table>
 
 ## `AuthInfo`     {#AuthInfo}
     

--- a/content/en/docs/reference/config-api/kubelet-config.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [CredentialProviderConfig](#kubelet-config-k8s-io-v1-CredentialProviderConfig)
   
-    
 
 ## `CredentialProviderConfig`     {#kubelet-config-k8s-io-v1-CredentialProviderConfig}
     
@@ -82,7 +81,7 @@ and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
 as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
-Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
 a single subdomain segment, so &ast;.io does not match &ast;.k8s.io.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
 <ul>

--- a/content/en/docs/reference/config-api/kubelet-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1alpha1.md
@@ -11,7 +11,6 @@ auto_generated: true
 
 - [CredentialProviderConfig](#kubelet-config-k8s-io-v1alpha1-CredentialProviderConfig)
   
-    
 
 ## `CredentialProviderConfig`     {#kubelet-config-k8s-io-v1alpha1-CredentialProviderConfig}
     

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -14,6 +14,279 @@ auto_generated: true
 - [SerializedNodeConfigSource](#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource)
   
     
+    
+
+## `FormatOptions`     {#FormatOptions}
+    
+
+**Appears in:**
+
+- [LoggingConfiguration](#LoggingConfiguration)
+
+
+<p>FormatOptions contains options for the different logging formats.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>json</code> <B>[Required]</B><br/>
+<a href="#JSONOptions"><code>JSONOptions</code></a>
+</td>
+<td>
+   <p>[Alpha] JSON contains options for logging format &quot;json&quot;.
+Only available when the LoggingAlphaOptions feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `JSONOptions`     {#JSONOptions}
+    
+
+**Appears in:**
+
+- [FormatOptions](#FormatOptions)
+
+
+<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>splitStream</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>[Alpha] SplitStream redirects error messages to stderr while
+info messages go to stdout, with buffering. The default is to write
+both to stdout, without buffering. Only available when
+the LoggingAlphaOptions feature gate is enabled.</p>
+</td>
+</tr>
+<tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
+</td>
+<td>
+   <p>[Alpha] InfoBufferSize sets the size of the info stream when
+using split streams. The default is zero, which disables buffering.
+Only available when the LoggingAlphaOptions feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LogFormatFactory`     {#LogFormatFactory}
+    
+
+
+<p>LogFormatFactory provides support for a certain additional,
+non-default log format.</p>
+
+
+
+
+## `LoggingConfiguration`     {#LoggingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+<p>LoggingConfiguration contains logging options.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>format</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Format Flag specifies the structure of log messages.
+default value of format is <code>text</code></p>
+</td>
+</tr>
+<tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
+<a href="#TimeOrMetaDuration"><code>TimeOrMetaDuration</code></a>
+</td>
+<td>
+   <p>Maximum time between log flushes.
+If a string, parsed as a duration (i.e. &quot;1s&quot;)
+If an int, the maximum number of nanoseconds (i.e. 1s = 1000000000).
+Ignored if the selected logging backend writes log messages without buffering.</p>
+</td>
+</tr>
+<tr><td><code>verbosity</code> <B>[Required]</B><br/>
+<a href="#VerbosityLevel"><code>VerbosityLevel</code></a>
+</td>
+<td>
+   <p>Verbosity is the threshold that determines which log messages are
+logged. Default is zero which logs only the most important
+messages. Higher values enable additional messages. Error messages
+are always logged.</p>
+</td>
+</tr>
+<tr><td><code>vmodule</code> <B>[Required]</B><br/>
+<a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
+</td>
+<td>
+   <p>VModule overrides the verbosity threshold for individual files.
+Only supported for &quot;text&quot; log format.</p>
+</td>
+</tr>
+<tr><td><code>options</code> <B>[Required]</B><br/>
+<a href="#FormatOptions"><code>FormatOptions</code></a>
+</td>
+<td>
+   <p>[Alpha] Options holds additional parameters that are specific
+to the different logging formats. Only the options for the selected
+format get used, but all of them get validated.
+Only available when the LoggingAlphaOptions feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LoggingOptions`     {#LoggingOptions}
+    
+
+
+<p>LoggingOptions can be used with ValidateAndApplyWithOptions to override
+certain global defaults.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ErrorStream</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/io#Writer"><code>io.Writer</code></a>
+</td>
+<td>
+   <p>ErrorStream can be used to override the os.Stderr default.</p>
+</td>
+</tr>
+<tr><td><code>InfoStream</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/io#Writer"><code>io.Writer</code></a>
+</td>
+<td>
+   <p>InfoStream can be used to override the os.Stdout default.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TimeOrMetaDuration`     {#TimeOrMetaDuration}
+    
+
+**Appears in:**
+
+- [LoggingConfiguration](#LoggingConfiguration)
+
+
+<p>TimeOrMetaDuration is present only for backwards compatibility for the
+flushFrequency field, and new fields should use metav1.Duration.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>Duration</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>Duration holds the duration</p>
+</td>
+</tr>
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>SerializeAsString controls whether the value is serialized as a string or an integer</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TracingConfiguration`     {#TracingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+<p>TracingConfiguration provides versioned configuration for OpenTelemetry tracing clients.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>endpoint</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Endpoint of the collector this component will report traces to.
+The connection is insecure, and does not currently support TLS.
+Recommended is unset, and endpoint is the otlp grpc default, localhost:4317.</p>
+</td>
+</tr>
+<tr><td><code>samplingRatePerMillion</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
+Recommended is unset. If unset, sampler respects its parent span's sampling
+rate, but otherwise never samples.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `VModuleConfiguration`     {#VModuleConfiguration}
+    
+(Alias of `[]k8s.io/component-base/logs/api/v1.VModuleItem`)
+
+**Appears in:**
+
+- [LoggingConfiguration](#LoggingConfiguration)
+
+
+<p>VModuleConfiguration is a collection of individual file names or patterns
+and the corresponding verbosity threshold.</p>
+
+
+
+
+## `VerbosityLevel`     {#VerbosityLevel}
+    
+(Alias of `uint32`)
+
+**Appears in:**
+
+- [LoggingConfiguration](#LoggingConfiguration)
+
+
+
+<p>VerbosityLevel represents a klog or logr verbosity threshold.</p>
+
+
+
+  
 
 ## `CredentialProviderConfig`     {#kubelet-config-k8s-io-v1beta1-CredentialProviderConfig}
     
@@ -1698,275 +1971,3 @@ managers (secret, configmap) are discovering object changes.</p>
 </tbody>
 </table>
   
-  
-    
-
-## `FormatOptions`     {#FormatOptions}
-    
-
-**Appears in:**
-
-- [LoggingConfiguration](#LoggingConfiguration)
-
-
-<p>FormatOptions contains options for the different logging formats.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>json</code> <B>[Required]</B><br/>
-<a href="#JSONOptions"><code>JSONOptions</code></a>
-</td>
-<td>
-   <p>[Alpha] JSON contains options for logging format &quot;json&quot;.
-Only available when the LoggingAlphaOptions feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `JSONOptions`     {#JSONOptions}
-    
-
-**Appears in:**
-
-- [FormatOptions](#FormatOptions)
-
-
-<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>splitStream</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>[Alpha] SplitStream redirects error messages to stderr while
-info messages go to stdout, with buffering. The default is to write
-both to stdout, without buffering. Only available when
-the LoggingAlphaOptions feature gate is enabled.</p>
-</td>
-</tr>
-<tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
-</td>
-<td>
-   <p>[Alpha] InfoBufferSize sets the size of the info stream when
-using split streams. The default is zero, which disables buffering.
-Only available when the LoggingAlphaOptions feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `LogFormatFactory`     {#LogFormatFactory}
-    
-
-
-<p>LogFormatFactory provides support for a certain additional,
-non-default log format.</p>
-
-
-
-
-## `LoggingConfiguration`     {#LoggingConfiguration}
-    
-
-**Appears in:**
-
-- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
-
-
-<p>LoggingConfiguration contains logging options.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>format</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Format Flag specifies the structure of log messages.
-default value of format is <code>text</code></p>
-</td>
-</tr>
-<tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
-<a href="#TimeOrMetaDuration"><code>TimeOrMetaDuration</code></a>
-</td>
-<td>
-   <p>Maximum time between log flushes.
-If a string, parsed as a duration (i.e. &quot;1s&quot;)
-If an int, the maximum number of nanoseconds (i.e. 1s = 1000000000).
-Ignored if the selected logging backend writes log messages without buffering.</p>
-</td>
-</tr>
-<tr><td><code>verbosity</code> <B>[Required]</B><br/>
-<a href="#VerbosityLevel"><code>VerbosityLevel</code></a>
-</td>
-<td>
-   <p>Verbosity is the threshold that determines which log messages are
-logged. Default is zero which logs only the most important
-messages. Higher values enable additional messages. Error messages
-are always logged.</p>
-</td>
-</tr>
-<tr><td><code>vmodule</code> <B>[Required]</B><br/>
-<a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
-</td>
-<td>
-   <p>VModule overrides the verbosity threshold for individual files.
-Only supported for &quot;text&quot; log format.</p>
-</td>
-</tr>
-<tr><td><code>options</code> <B>[Required]</B><br/>
-<a href="#FormatOptions"><code>FormatOptions</code></a>
-</td>
-<td>
-   <p>[Alpha] Options holds additional parameters that are specific
-to the different logging formats. Only the options for the selected
-format get used, but all of them get validated.
-Only available when the LoggingAlphaOptions feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `LoggingOptions`     {#LoggingOptions}
-    
-
-
-<p>LoggingOptions can be used with ValidateAndApplyWithOptions to override
-certain global defaults.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>ErrorStream</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/io#Writer"><code>io.Writer</code></a>
-</td>
-<td>
-   <p>ErrorStream can be used to override the os.Stderr default.</p>
-</td>
-</tr>
-<tr><td><code>InfoStream</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/io#Writer"><code>io.Writer</code></a>
-</td>
-<td>
-   <p>InfoStream can be used to override the os.Stdout default.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `TimeOrMetaDuration`     {#TimeOrMetaDuration}
-    
-
-**Appears in:**
-
-- [LoggingConfiguration](#LoggingConfiguration)
-
-
-<p>TimeOrMetaDuration is present only for backwards compatibility for the
-flushFrequency field, and new fields should use metav1.Duration.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>Duration</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>Duration holds the duration</p>
-</td>
-</tr>
-<tr><td><code>-</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   <p>SerializeAsString controls whether the value is serialized as a string or an integer</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `TracingConfiguration`     {#TracingConfiguration}
-    
-
-**Appears in:**
-
-- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
-
-
-<p>TracingConfiguration provides versioned configuration for OpenTelemetry tracing clients.</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>endpoint</code><br/>
-<code>string</code>
-</td>
-<td>
-   <p>Endpoint of the collector this component will report traces to.
-The connection is insecure, and does not currently support TLS.
-Recommended is unset, and endpoint is the otlp grpc default, localhost:4317.</p>
-</td>
-</tr>
-<tr><td><code>samplingRatePerMillion</code><br/>
-<code>int32</code>
-</td>
-<td>
-   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
-Recommended is unset. If unset, sampler respects its parent span's sampling
-rate, but otherwise never samples.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `VModuleConfiguration`     {#VModuleConfiguration}
-    
-(Alias of `[]k8s.io/component-base/logs/api/v1.VModuleItem`)
-
-**Appears in:**
-
-- [LoggingConfiguration](#LoggingConfiguration)
-
-
-<p>VModuleConfiguration is a collection of individual file names or patterns
-and the corresponding verbosity threshold.</p>
-
-
-
-
-## `VerbosityLevel`     {#VerbosityLevel}
-    
-(Alias of `uint32`)
-
-**Appears in:**
-
-- [LoggingConfiguration](#LoggingConfiguration)
-
-
-
-<p>VerbosityLevel represents a klog or logr verbosity threshold.</p>
-
-

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
@@ -12,7 +12,6 @@ auto_generated: true
 - [CredentialProviderRequest](#credentialprovider-kubelet-k8s-io-v1-CredentialProviderRequest)
 - [CredentialProviderResponse](#credentialprovider-kubelet-k8s-io-v1-CredentialProviderResponse)
   
-    
 
 ## `CredentialProviderRequest`     {#credentialprovider-kubelet-k8s-io-v1-CredentialProviderRequest}
     

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1alpha1.md
@@ -12,7 +12,6 @@ auto_generated: true
 - [CredentialProviderRequest](#credentialprovider-kubelet-k8s-io-v1alpha1-CredentialProviderRequest)
 - [CredentialProviderResponse](#credentialprovider-kubelet-k8s-io-v1alpha1-CredentialProviderResponse)
   
-    
 
 ## `CredentialProviderRequest`     {#credentialprovider-kubelet-k8s-io-v1alpha1-CredentialProviderRequest}
     

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1beta1.md
@@ -12,7 +12,6 @@ auto_generated: true
 - [CredentialProviderRequest](#credentialprovider-kubelet-k8s-io-v1beta1-CredentialProviderRequest)
 - [CredentialProviderResponse](#credentialprovider-kubelet-k8s-io-v1beta1-CredentialProviderResponse)
   
-    
 
 ## `CredentialProviderRequest`     {#credentialprovider-kubelet-k8s-io-v1beta1-CredentialProviderRequest}
     
@@ -110,7 +109,7 @@ stopping after the first successfully authenticated pull.</p>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
 <li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li>&ast;.&ast;registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>


### PR DESCRIPTION
This PR updates the config API reference using updated generator.
The updated generator fixed several things:
- It makes sure there is a deterministic order for packages and types in a API reference page. This has been a problem before, some diffs were caused by non-deterministic order in the types. And that problem has been a pain point for downstream localization teams.
- It allows manually specify the main package name so that the generator won't get confused when multiple API packages are involved in a traveral.
- It fixes the logic for filtering resource types.



closes: #43229
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
