### PR TITLE
Adding and correcting canonical URLs

### DIFF
--- a/content/en/blog/_posts/2023-07-20-sig-cli-spotlight.md
+++ b/content/en/blog/_posts/2023-07-20-sig-cli-spotlight.md
@@ -3,7 +3,7 @@ layout: blog
 title: "Spotlight on SIG CLI"
 date: 2023-07-20
 slug: sig-cli-spotlight-2023
-canonicalUrl: https://www.kubernetes.dev/blog/2023/07/13/sig-cli-spotlight-2023/
+canonicalUrl: https://www.kubernetes.dev/blog/2023/07/20/sig-cli-spotlight-2023/
 ---
 
 **Author**: Arpit Agrawal

--- a/content/en/blog/_posts/2023-10-02-steering-committee-results-2023.md
+++ b/content/en/blog/_posts/2023-10-02-steering-committee-results-2023.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Announcing the 2023 Steering Committee Election Results"
 date: 2023-10-02
 slug: steering-committee-results-2023
+canonicalUrl: https://www.kubernetes.dev/blog/2023/10/02/steering-committee-results-2023/
 ---
 
 **Author**: Kaslin Fields


### PR DESCRIPTION
Adding a link to the correct canonical location for the blog post that went out yesterday, per @sftim as explained in https://github.com/kubernetes/website/pull/43294#issuecomment-1744076802.

Also, while I was checking on how the canonical URLs worked, I noticed a typo in the canonical URL for blog post from this summer, which I'm correcting.

Please merge after https://github.com/kubernetes/contributor-site/pull/442 is merged and the updated site is available.