### PR TITLE
content: fr: Fix incorrect letter case for data storage units

### DIFF
--- a/content/fr/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/fr/docs/concepts/workloads/controllers/statefulset.md
@@ -165,7 +165,7 @@ Le domaine cluster sera `cluster.local` à moins qu'il soit
 
 Kubernetes crée un [PersistentVolume](/docs/concepts/storage/persistent-volumes/) pour chaque
 VolumeClaimTemplate. Dans l'exemple nginx ci-dessus, chaque Pod se verra affecter un unique PersistentVolume
-avec un StorageClass de `my-storage-class` et 1 Gib de stockage provisionné. Si aucun StorageClass
+avec un StorageClass de `my-storage-class` et 1 GiB de stockage provisionné. Si aucun StorageClass
 n'est spécifié, alors le StorageClass par défaut sera utilisé. Lorsqu'un Pod est (re)schedulé
 sur un noeud, ses `volumeMounts` montent les PersistentVolumes associés aux  
 PersistentVolumeClaims. Notez que les PersistentVolumes associés avec les PersistentVolumeClaims des Pods


### PR DESCRIPTION
**Gib** (Gibibit) was used where **GiB** (Gibibyte) is intended.

#### Related PRs

- #43238
- #43319
- #43321
- #43322
- #43323
- #43324