### PR TITLE
content: id: Fix incorrect letter case for data storage units

### DIFF
--- a/content/id/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/id/docs/concepts/workloads/controllers/statefulset.md
@@ -154,7 +154,7 @@ Domain klaster akan diatur menjadi `cluster.local` kecuali
 
 Kubernetes membuat sebuah [PersistentVolume](/id/docs/concepts/storage/persistent-volumes/) untuk setiap 
 VolumeClaimTemplate. Pada contoh nginx di atas, setiap Pod akan menerima sebuah PersistentVolume
-dengan StorageClass `my-storage-class` dan penyimpanan senilai 1 Gib yang sudah di-_provisioning_. Jika tidak ada StorageClass
+dengan StorageClass `my-storage-class` dan penyimpanan senilai 1 GiB yang sudah di-_provisioning_. Jika tidak ada StorageClass
 yang dispesifikasikan, maka StorageClass _default_ akan digunakan. Ketika sebuah Pod dilakukan _(re)schedule_
 pada sebuah Node, `volumeMounts` akan me-_mount_ PersistentVolumes yang terkait dengan 
 PersistentVolume Claim-nya. Perhatikan bahwa, PersistentVolume yang terkait dengan 
@@ -273,6 +273,5 @@ StatefulSet akan mulai membuat Pod dengan templat konfigurasi yang sudah di-_rev
 
 * Ikuti contoh yang ada pada [bagaimana cara melakukan deployi aplikasi stateful](/docs/tutorials/stateful-application/basic-stateful-set/).
 * Ikuti contoh yang ada pada [bagaimana cara melakukan deploy Cassandra dengan StatefulSets](/docs/tutorials/stateful-application/cassandra/).
-
 
 

--- a/content/id/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
+++ b/content/id/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
@@ -202,7 +202,7 @@ dari LimitRange.
 
 Pada tahap ini, Containermu mungkin saja berjalan ataupun mungkin juga tidak berjalan. Ingat bahwa prasyarat
 untuk tugas ini adalah Node harus memiliki setidaknya 1 GiB memori. Jika tiap Node hanya memiliki
-1 GiB memori, maka tidak akan ada cukup memori untuk dialokasikan pada setiap Node untuk memenuhi permintaan 1 Gib memori. Jika ternyata kamu menggunakan Node dengan 2 GiB memori, maka kamu mungkin memiliki cukup ruang untuk memenuhi permintaan 1 GiB tersebut.
+1 GiB memori, maka tidak akan ada cukup memori untuk dialokasikan pada setiap Node untuk memenuhi permintaan 1 GiB memori. Jika ternyata kamu menggunakan Node dengan 2 GiB memori, maka kamu mungkin memiliki cukup ruang untuk memenuhi permintaan 1 GiB tersebut.
 
 Menghapus Pod:
 


### PR DESCRIPTION
**Gib** (Gibibit) was used where **GiB** (Gibibyte) is intended.

#### Related PRs

- #43238
- #43319
- #43320
- #43322
- #43323
- #43324