### PR TITLE
[zh] Clean up /kubernetes-api/common-definitions files

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/common-definitions/_index.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/common-definitions/_index.md
@@ -2,4 +2,8 @@
 title: "公共定义"
 weight: 9
 ---
-
+<!--
+title: "Common Definitions"
+weight: 9
+auto_generated: true
+-->

--- a/content/zh-cn/docs/reference/kubernetes-api/common-definitions/delete-options.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/common-definitions/delete-options.md
@@ -7,9 +7,7 @@ content_type: "api_reference"
 description: "删除 API 对象时可以提供 DeleteOptions。"
 title: "DeleteOptions"
 weight: 1
-auto_generated: true
 ---
-
 <!--
 api_metadata:
   apiVersion: ""
@@ -24,7 +22,9 @@ auto_generated: true
 
 `import "k8s.io/apimachinery/pkg/apis/meta/v1"`
 
-<!--DeleteOptions may be provided when deleting an API object.-->
+<!--
+DeleteOptions may be provided when deleting an API object.
+-->
 删除 API 对象时可以提供 DeleteOptions。
 
 <hr>
@@ -34,32 +34,29 @@ auto_generated: true
 
   APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 -->
-
 - **apiVersion** (string)
 
   `APIVersion` 定义对象表示的版本化模式。
-  服务器应将已识别的模式转换为最新的内部值，并可能拒绝无法识别的值。
-  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+  服务器应将已识别的模式转换为最新的内部值，并可能拒绝无法识别的值。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 
 <!--
 - **dryRun** ([]string)
 
   When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed
 -->
-
 - **dryRun** ([]string)
 
   该值如果存在，则表示不应保留修改。
   无效或无法识别的 `dryRun` 指令将导致错误响应并且不会进一步处理请求。有效值为：
 
-   - `All`：处理所有试运行阶段（Dry Run Stages）
+  - `All`：处理所有试运行阶段（Dry Run Stages）
 
 <!--
 - **gracePeriodSeconds** (int64)
 
   The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.
 -->
-
 - **gracePeriodSeconds** (int64)
 
   表示对象被删除之前的持续时间（以秒为单位）。
@@ -70,19 +67,17 @@ auto_generated: true
 
   Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 -->
-
 - **kind** (string)
 
   `kind` 是一个字符串值，表示此对象代表的 REST 资源。
-  服务器可以从客户端提交请求的端点推断出此值。此值无法更新，是驼峰的格式。
-  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 。
+  服务器可以从客户端提交请求的端点推断出此值。此值无法更新，是驼峰的格式。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
 <!--
 - **orphanDependents** (boolean)
 
   Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.
 -->
-
 - **orphanDependents** (boolean)
 
   已弃用：该字段将在 1.7 中弃用，请使用 `propagationPolicy` 字段。
@@ -105,13 +100,12 @@ auto_generated: true
 
     Specifies the target UID.
 -->
-
 - **preconditions** (Preconditions)
 
   先决条件必须在执行删除之前完成。如果无法满足这些条件，将返回 409（冲突）状态。
 
   <a name="Preconditions"></a>
-  *执行操作（更新、删除等）之前必须满足先决条件。*
+  **执行操作（更新、删除等）之前必须满足先决条件。**
 
   - **preconditions.resourceVersion** (string)
 
@@ -126,14 +120,8 @@ auto_generated: true
 
   Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.
 -->
-
 - **propagationPolicy** (string)
 
   表示是否以及如何执行垃圾收集。可以设置此字段或 `orphanDependents` 字段，但不能同时设置二者。
   默认策略由 `metadata.finalizers` 中现有终结器（Finalizer）集合和特定资源的默认策略决定。
   可接受的值为：`Orphan` - 令依赖对象成为孤儿对象；`Background` - 允许垃圾收集器在后台删除依赖项；`Foreground` - 一个级联策略，前台删除所有依赖项。
-
-
-
-
-

--- a/content/zh-cn/docs/reference/kubernetes-api/common-definitions/label-selector.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/common-definitions/label-selector.md
@@ -7,9 +7,7 @@ content_type: "api_reference"
 description: "标签选择器是对一组资源的标签查询。"
 title: "LabelSelector"
 weight: 2
-auto_generated: true
 ---
-
 <!--
 api_metadata:
   apiVersion: ""
@@ -19,6 +17,7 @@ content_type: "api_reference"
 description: "A label selector is a label query over a set of resources."
 title: "LabelSelector"
 weight: 2
+auto_generated: true
 -->
 
 `import "k8s.io/apimachinery/pkg/apis/meta/v1"`
@@ -26,45 +25,44 @@ weight: 2
 <!-- 
 A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
 -->
-
 标签选择器是对一组资源的标签查询。
-
 `matchLabels` 和 `matchExpressions` 的结果按逻辑与的关系组合。
 一个 `empty` 标签选择器匹配所有对象。一个 `null` 标签选择器不匹配任何对象。
 
 <hr>
 
-  <!--
-   - **matchExpressions** ([]LabelSelectorRequirement)
-   
-   matchExpressions is a list of label selector requirements. The requirements are ANDed. 
-   
-   <a name="LabelSelectorRequirement"></a> 
-  *A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.*
-  -->
+<!--
+- **matchExpressions** ([]LabelSelectorRequirement)
 
+  matchExpressions is a list of label selector requirements. The requirements are ANDed.
+
+  <a name="LabelSelectorRequirement"></a>
+  *A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.*
+-->
 - **matchExpressions** ([]LabelSelectorRequirement)
   
-   `matchExpressions` 是标签选择器要求的列表，这些要求的结果按逻辑与的关系来计算。
+  `matchExpressions` 是标签选择器要求的列表，这些要求的结果按逻辑与的关系来计算。
    
-   <a name="LabelSelectorRequirement"></a> 
-   *标签选择器要求是包含值、键和关联键和值的运算符的选择器。*
+  <a name="LabelSelectorRequirement"></a> 
+  **标签选择器要求是包含值、键和关联键和值的运算符的选择器。**
  
-    <!-- 
-       - **matchExpressions.key** (string), required
-       key is the label key that the selector applies to.
-    -->
+  <!-- 
+  - **matchExpressions.key** (string), required
 
-  - **matchExpressions.key** (string)， 必填
+    key is the label key that the selector applies to.
+  -->
+
+  - **matchExpressions.key** (string)，必需
     
     `key` 是选择器应用的标签键。
   
-   <!-- 
-       - **matchExpressions.operator** (string), required
-       operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.        
-   -->
+  <!-- 
+  - **matchExpressions.operator** (string), required
+
+    operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.        
+  -->
    
-  - **matchExpressions.operator** (string)，必填
+  - **matchExpressions.operator** (string)，必需
  
     `operator` 表示键与一组值的关系。有效的运算符包括 `In`、`NotIn`、`Exists` 和 `DoesNotExist`。
     
@@ -77,9 +75,7 @@ A label selector is a label query over a set of resources. The result of matchLa
   - **matchExpressions.values** ([]string)
   
     `values` 是一个字符串值数组。如果运算符为 `In` 或 `NotIn`，则 `values` 数组必须为非空。
-    
     如果运算符是 `Exists` 或 `DoesNotExist`，则 `values` 数组必须为空。
-    
     该数组在策略性合并补丁（Strategic Merge Patch）期间被替换。
   
 <!--
@@ -87,17 +83,11 @@ A label selector is a label query over a set of resources. The result of matchLa
 
   matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
 -->
+- **matchLabels** (map[string]string)
   
- - **matchLabels** (map[string]string)
-  
-    `matchLabels` 是 {`key`,`value`} 键值对的映射。
+  `matchLabels` 是 {`key`,`value`} 键值对的映射。
+
+  `matchLabels` 映射中的单个 {`key`,`value`} 键值对相当于 `matchExpressions` 的一个元素，
+  其键字段为 `key`，运算符为 `In`，`values` 数组仅包含 `value`。
     
-    `matchLabels` 映射中的单个 {`key`,`value`} 键值对相当于 `matchExpressions` 的一个元素，其键字段为 `key`，运算符为 `In`，`values` 数组仅包含 `value`。
-    
-    所表达的需求最终要按逻辑与的关系组合。
-   
-
-
-
-
-
+  所表达的需求最终要按逻辑与的关系组合。

--- a/content/zh-cn/docs/reference/kubernetes-api/common-definitions/list-meta.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/common-definitions/list-meta.md
@@ -7,9 +7,7 @@ content_type: "api_reference"
 description: "ListMeta 描述了合成资源必须具有的元数据，包括列表和各种状态对象。"
 title: "ListMeta"
 weight: 3
-auto_generated: true
 ---
-
 <!--
 api_metadata:
   apiVersion: ""
@@ -21,7 +19,6 @@ title: "ListMeta"
 weight: 3
 auto_generated: true
 -->
-
 
 `import "k8s.io/apimachinery/pkg/apis/meta/v1"`
 
@@ -38,7 +35,6 @@ ListMeta describes metadata that synthetic resources must have, including lists 
 
   continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
 -->
-
 - **continue** (string)
 
   如果用户对返回的条目数量设置了限制，则 `continue` 可能被设置，表示服务器有更多可用的数据。
@@ -52,7 +48,6 @@ ListMeta describes metadata that synthetic resources must have, including lists 
 
   remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
 -->
-
 - **remainingItemCount** (int64)
 
   `remainingItemCount` 是列表中未包含在此列表响应中的后续项目的数量。
@@ -66,24 +61,19 @@ ListMeta describes metadata that synthetic resources must have, including lists 
 
   String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 -->
-
 - **resourceVersion** (string)
 
   标识该对象的服务器内部版本的字符串，客户端可以用该字段来确定对象何时被更改。
-  该值对客户端是不透明的，并且应该原样传回给服务器。该值由系统填充，只读。
-  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency 。
+  该值对客户端是不透明的，并且应该原样传回给服务器。该值由系统填充，只读。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 
 <!--
+- **selfLink** (string)
+
   Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 -->
-
 - **selfLink** (string)
   
   selfLink 表示此对象的 URL，由系统填充，只读。
   
   已弃用：selfLink 是一个遗留的只读字段，不再由系统填充。
-
-
-
-
-


### PR DESCRIPTION
Updated 4 files:

```
content/zh-cn/docs/reference/kubernetes-api/common-definitions/_index.md
content/zh-cn/docs/reference/kubernetes-api/common-definitions/delete-options.md
content/zh-cn/docs/reference/kubernetes-api/common-definitions/label-selector.md
content/zh-cn/docs/reference/kubernetes-api/common-definitions/list-meta.md
```