### PR TITLE
Remove misleading docs around eviction and image garbage collection

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -105,13 +105,11 @@ does not support other configurations.
 
 Some kubelet garbage collection features are deprecated in favor of eviction:
 
-| Existing Flag | New Flag | Rationale |
-| ------------- | -------- | --------- |
-| `--image-gc-high-threshold` | `--eviction-hard` or `--eviction-soft` | existing eviction signals can trigger image garbage collection |
-| `--image-gc-low-threshold` | `--eviction-minimum-reclaim` | eviction reclaims achieve the same behavior |
-| `--maximum-dead-containers` | - | deprecated once old logs are stored outside of container's context |
-| `--maximum-dead-containers-per-container` | - | deprecated once old logs are stored outside of container's context |
-| `--minimum-container-ttl-duration` | - | deprecated once old logs are stored outside of container's context |
+| Existing Flag | Rationale |
+| ------------- | --------- |
+| `--maximum-dead-containers` | deprecated once old logs are stored outside of container's context |
+| `--maximum-dead-containers-per-container` | deprecated once old logs are stored outside of container's context |
+| `--minimum-container-ttl-duration` | deprecated once old logs are stored outside of container's context |
 
 ### Eviction thresholds
 


### PR DESCRIPTION
This closes #43303

Deploy preview: https://deploy-preview-43336--kubernetes-io-main-staging.netlify.app/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals