### PR TITLE
fix: link text in glossary cri

### DIFF
--- a/content/en/docs/reference/glossary/container-runtime-interface.md
+++ b/content/en/docs/reference/glossary/container-runtime-interface.md
@@ -17,6 +17,6 @@ The main protocol for the communication between the {{< glossary_tooltip text="k
 
 The Kubernetes Container Runtime Interface (CRI) defines the main
 [gRPC](https://grpc.io) protocol for the communication between the
-[cluster components](/docs/concepts/overview/components/#node-components)
+[node components](/docs/concepts/overview/components/#node-components)
 {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} and
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}.


### PR DESCRIPTION
There is a wrong link text in the glossary for CRI.
Based on the content and link, the word should be `node components` instead of `cluster components`.


Ps. Same issue for other languages, not sure of the right process to solve it.