### PR TITLE
fix CustomResourceDefinition version is 'apiextensions.k8s.io/v1'

### DIFF
--- a/content/zh-cn/docs/reference/using-api/deprecation-guide.md
+++ b/content/zh-cn/docs/reference/using-api/deprecation-guide.md
@@ -347,7 +347,7 @@ The **apiextensions.k8s.io/v1beta1** API version of CustomResourceDefinition is 
 **apiextensions.k8s.io/v1beta1** API 版本的 CustomResourceDefinition
 不在 v1.22 版本中继续提供。
 
-* 迁移清单和 API 客户端使用 **apiextensions/v1** API 版本，此 API 从 v1.16 版本开始可用；
+* 迁移清单和 API 客户端使用 **apiextensions.k8s.io/v1** API 版本，此 API 从 v1.16 版本开始可用；
 * 所有的已保存的对象都可以通过新的 API 来访问；
 <!--
 * Notable changes:


### PR DESCRIPTION


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
fix bug: in content/zh-cn/docs/reference/using-api/deprecation-guide.md,CustomResourceDefinition version is ```apiextensions.k8s.io/v1```,not ```apiextensions/v1```.
