### PR TITLE
Document annotation service.kubernetes.io/topology-mode

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -948,8 +948,13 @@ Example: `service.kubernetes.io/topology-mode: "single"`
 
 Used on: Service
 
-This annotation provides a way to define how services handle network topology, allowing cluster administrators to configure services according to their specific requirements.
-Ensure that your Kubernetes version supports the `service.kubernetes.io/topology-mode` annotation, as it might be available in specific versions or configurations.
+This annotation provides a way to define how Services handle network topology;
+for example, you can configure a Service so that Kubernetes prefers keeping traffic between
+a client and server within a single topology zone.
+In some cases this can help reduce costs or improve network performance.
+
+See [Topology Aware Routing](/docs/concepts/services-networking/topology-aware-routing/)
+for more details.
 
 ### kubernetes.io/service-name {#kubernetesioservice-name}
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -944,7 +944,7 @@ for a Service, don't add this annotation.
 
 Type: Annotation
 
-Example: `service.kubernetes.io/topology-mode: "single"`
+Example: `service.kubernetes.io/topology-mode: Auto`
 
 Used on: Service
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -940,6 +940,17 @@ works in that release.
 There are no other valid values for this annotation. If you don't want topology aware hints
 for a Service, don't add this annotation.
 
+### service.kubernetes.io/topology-mode
+
+Type: Annotation
+
+Example: `service.kubernetes.io/topology-mode: "single"`
+
+Used on: Service
+
+This annotation provides a way to define how services handle network topology, allowing cluster administrators to configure services according to their specific requirements.
+Ensure that your Kubernetes version supports the `service.kubernetes.io/topology-mode` annotation, as it might be available in specific versions or configurations.
+
 ### kubernetes.io/service-name {#kubernetesioservice-name}
 
 Type: Label


### PR DESCRIPTION
Added the Annotation service.kubernetes.io/topology-mode in the  https://kubernetes.io/docs/reference/labels-annotations-taints/ 
#43389 