### PR TITLE
Fixed a link to spec (Ingress API)

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -84,7 +84,7 @@ is the [rewrite-target annotation](https://github.com/kubernetes/ingress-nginx/b
 Different [Ingress controllers](/docs/concepts/services-networking/ingress-controllers) support different annotations.
 Review the documentation for your choice of Ingress controller to learn which annotations are supported.
 
-The [Ingress spec](/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec)
+The Ingress [spec](/docs/concepts/overview/working-with-objects/#object-spec-and-status)
 has all the information needed to configure a load balancer or proxy server. Most importantly, it
 contains a list of rules matched against all incoming requests. Ingress resource only supports rules
 for directing HTTP(S) traffic.


### PR DESCRIPTION
This PR fixed the link for `spec` under [The Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource) in the [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) docs.
Here is the `spec` for the API convention of spec not specific to Ingress.

Part of the PR: #43110