### PR TITLE
doc(etcd-maintenance): add reference to etcd-defrag CronJob

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -412,6 +412,6 @@ will not run out of the storage quota. The Kubernetes project recommends that wh
 you perform defragmentation, you use a tool such as [etcd-defrag](https://github.com/ahrtr/etcd-defrag).
 
 You can also run the defragmentation tool as a Kubernetes CronJob, to make sure that
-defragmentation happens regularly. See [`etcd-defrag-job.yaml`](https://github.com/ahrtr/etcd-defrag/blob/main/doc/etcd-defrag-cronjob.yaml)
+defragmentation happens regularly. See [`etcd-defrag-cronjob.yaml`](https://github.com/ahrtr/etcd-defrag/blob/main/doc/etcd-defrag-cronjob.yaml)
 for details. 
 {{< /note >}}

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -410,4 +410,8 @@ Defragmentation is an expensive operation, so it should be executed as infrequen
 as possible. On the other hand, it's also necessary to make sure any etcd member
 will not run out of the storage quota. The Kubernetes project recommends that when
 you perform defragmentation, you use a tool such as [etcd-defrag](https://github.com/ahrtr/etcd-defrag).
+
+It can also be useful to run the defragmentation tool as a Kubernetes CronJob, 
+[as documented here](https://github.com/ahrtr/etcd-defrag/blob/main/doc/etcd-defrag-cronjob.yaml)
+, to make sure that defragmentation happens regularly.
 {{< /note >}}

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -411,7 +411,7 @@ as possible. On the other hand, it's also necessary to make sure any etcd member
 will not run out of the storage quota. The Kubernetes project recommends that when
 you perform defragmentation, you use a tool such as [etcd-defrag](https://github.com/ahrtr/etcd-defrag).
 
-It can also be useful to run the defragmentation tool as a Kubernetes CronJob, 
-[as documented here](https://github.com/ahrtr/etcd-defrag/blob/main/doc/etcd-defrag-cronjob.yaml)
-, to make sure that defragmentation happens regularly.
+You can also run the defragmentation tool as a Kubernetes CronJob, to make sure that
+defragmentation happens regularly. See [`etcd-defrag-job.yaml`](https://github.com/ahrtr/etcd-defrag/blob/main/doc/etcd-defrag-cronjob.yaml)
+for details. 
 {{< /note >}}


### PR DESCRIPTION
With [the recent documentation of a Kubernetes CronJob](https://github.com/ahrtr/etcd-defrag/pull/22) for the `etcd-defrag` tool, I think it would be valuable to also reference that possibility in the official documentation.

Indeed, running the tool as a CronJob has several benefits:
- simplicity of use: a typical kubeadm-deployed Cluster can use the referenced manifest as-is.
- period/automatic defragmentation is ensured

/cc @ahrtr 