### PR TITLE
system-logs: warn about log output changes

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-logs.md
+++ b/content/en/docs/concepts/cluster-administration/system-logs.md
@@ -17,6 +17,13 @@ scheduler decisions).
 
 <!-- body -->
 
+{{< warning >}}
+In contrast to the command line flags described here, the *log
+output* itself does *not* fall under the Kubernetes API stability guarantees:
+individual log entries and their formatting may change from one release
+to the next!
+{{< /warning >}}
+
 ## Klog
 
 klog is the Kubernetes logging library. [klog](https://github.com/kubernetes/klog)


### PR DESCRIPTION
This is not a new policy: there never has been any promise of stability and log output has changed frequently (whenever a log call got modified), including changes that affect all log calls (when changing the underlying output code). We just have not explicit warned about this.
