### PR TITLE
Move feature gates CronJobTimeZone, JobMutableNodeSchedulingDirectives and LegacyServiceAccountTokenNoAutoGeneration to feature-gates-removed page

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
@@ -120,6 +120,9 @@ In the following table:
 | `CronJobControllerV2` | `false` | Alpha | 1.20 | 1.20 |
 | `CronJobControllerV2` | `true` | Beta | 1.21 | 1.21 |
 | `CronJobControllerV2` | `true` | GA | 1.22 | 1.23 |
+| `CronJobTimeZone` | `false` | Alpha | 1.24 | 1.24 |
+| `CronJobTimeZone` | `true` | Beta | 1.25 | 1.26 |
+| `CronJobTimeZone` | `true` | GA | 1.27 | 1.28 |
 | `CustomPodDNS` | `false` | Alpha | 1.9 | 1.9 |
 | `CustomPodDNS` | `true` | Beta| 1.10 | 1.13 |
 | `CustomPodDNS` | `true` | GA | 1.14 | 1.16 |
@@ -228,6 +231,8 @@ In the following table:
 | `IngressClassNamespacedParams` | `true` | GA | 1.23 | 1.24 |
 | `Initializers` | `false` | Alpha | 1.7 | 1.13 |
 | `Initializers` | - | Deprecated | 1.14 | 1.14 |
+| `JobMutableNodeSchedulingDirectives` | `true` | Beta | 1.23 | 1.26 |
+| `JobMutableNodeSchedulingDirectives` | `true` | GA | 1.27 | 1.28 |
 | `KMSv1` | `true` | Deprecated | 1.28 | |
 | `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
 | `KubeletConfigFile` | - | Deprecated | 1.10 | 1.10 |
@@ -240,6 +245,8 @@ In the following table:
 | `LegacyNodeRoleBehavior` | `false` | Alpha | 1.16 | 1.18 |
 | `LegacyNodeRoleBehavior` | `true` | Beta | 1.19 | 1.20 |
 | `LegacyNodeRoleBehavior` | `false` | GA | 1.21 | 1.22 |
+| `LegacyServiceAccountTokenNoAutoGeneration` | `true` | Beta | 1.24 | 1.25 |
+| `LegacyServiceAccountTokenNoAutoGeneration` | `true` | GA | 1.26 | 1.28 |
 | `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | 1.9 |
 | `LocalStorageCapacityIsolation` | `true` | Beta | 1.10 | 1.24 |
 | `LocalStorageCapacityIsolation` | `true` | GA | 1.25 | 1.26 |
@@ -591,16 +598,18 @@ In the following table:
   [Configure volume permission and ownership change policy for Pods](/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods)
   for more details.
 
-- `CronJobControllerV2`: Use an alternative implementation of the
-  {{< glossary_tooltip text="CronJob" term_id="cronjob" >}} controller. Otherwise,
-  version 1 of the same controller is selected.
-
 - `ControllerManagerLeaderMigration`: Enables Leader Migration for
   [kube-controller-manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/#initial-leader-migration-configuration) and
   [cloud-controller-manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/#deploy-cloud-controller-manager)
   which allows a cluster operator to live migrate
   controllers from the kube-controller-manager into an external controller-manager
   (e.g. the cloud-controller-manager) in an HA cluster without downtime.
+
+- `CronJobControllerV2`: Use an alternative implementation of the
+  {{< glossary_tooltip text="CronJob" term_id="cronjob" >}} controller. Otherwise,
+  version 1 of the same controller is selected.
+
+- `CronJobTimeZone`: Allow the use of the `timeZone` optional field in [CronJobs](/docs/concepts/workloads/controllers/cron-jobs/)
 
 - `CustomPodDNS`: Enable customizing the DNS settings for a Pod using its `dnsConfig` property.
   Check [Pod's DNS Config](/docs/concepts/services-networking/dns-pod-service/#pods-dns-config)
@@ -731,6 +740,9 @@ In the following table:
 - `Initializers`: Allow asynchronous coordination of object creation using the
   Initializers admission plugin.
 
+- `JobMutableNodeSchedulingDirectives`: Allows updating node scheduling directives in
+  the pod template of [Job](/docs/concepts/workloads/controllers/job).
+
 - `KubeletConfigFile`: Enable loading kubelet configuration from
   a file specified using a config file.
   See [setting kubelet parameters via a config file](/docs/tasks/administer-cluster/kubelet-config-file/)
@@ -745,6 +757,9 @@ In the following table:
 - `LegacyNodeRoleBehavior`: When disabled, legacy behavior in service load balancers and
   node disruption will ignore the `node-role.kubernetes.io/master` label in favor of the
   feature-specific labels provided by `NodeDisruptionExclusion` and `ServiceNodeExclusion`.
+
+- `LegacyServiceAccountTokenNoAutoGeneration`: Stop auto-generation of Secret-based
+  [service account tokens](/docs/concepts/security/service-accounts/#get-a-token).
 
 - `LocalStorageCapacityIsolation`: Enable the consumption of
   [local ephemeral storage](/docs/concepts/configuration/manage-resources-containers/)

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -245,9 +245,6 @@ For a reference to old feature gates that are removed, please refer to
 | `CSIMigrationvSphere` | `true` | Beta | 1.25 | 1.25 |
 | `CSIMigrationvSphere` | `true` | GA | 1.26 | - |
 | `ConsistentHTTPGetHandlers` | `true` | GA | 1.25 | - |
-| `CronJobTimeZone` | `false` | Alpha | 1.24 | 1.24 |
-| `CronJobTimeZone` | `true` | Beta | 1.25 | 1.26 |
-| `CronJobTimeZone` | `true` | GA | 1.27 | - |
 | `DaemonSetUpdateSurge` | `false` | Alpha | 1.21 | 1.21 |
 | `DaemonSetUpdateSurge` | `true` | Beta | 1.22 | 1.24 |
 | `DaemonSetUpdateSurge` | `true` | GA | 1.25 | |
@@ -273,8 +270,6 @@ For a reference to old feature gates that are removed, please refer to
 | `IPTablesOwnershipCleanup` | `true` | GA | 1.28 | |
 | `InTreePluginRBDUnregister` | `false` | Alpha | 1.23 | 1.27 |
 | `InTreePluginRBDUnregister` | `false` | Deprecated | 1.28 | |
-| `JobMutableNodeSchedulingDirectives` | `true` | Beta | 1.23 | 1.26 |
-| `JobMutableNodeSchedulingDirectives` | `true` | GA | 1.27 | |
 | `JobTrackingWithFinalizers` | `false` | Alpha | 1.22 | 1.22 |
 | `JobTrackingWithFinalizers` | `false` | Beta | 1.23 | 1.24 |
 | `JobTrackingWithFinalizers` | `true` | Beta | 1.25 | 1.25 |
@@ -286,8 +281,6 @@ For a reference to old feature gates that are removed, please refer to
 | `KubeletPodResourcesGetAllocatable` | `false` | Alpha | 1.21 | 1.22 |
 | `KubeletPodResourcesGetAllocatable` | `true` | Beta | 1.23 | 1.27 |
 | `KubeletPodResourcesGetAllocatable` | `true` | GA | 1.28 | |
-| `LegacyServiceAccountTokenNoAutoGeneration` | `true` | Beta | 1.24 | 1.25 |
-| `LegacyServiceAccountTokenNoAutoGeneration` | `true` | GA | 1.26 | |
 | `LegacyServiceAccountTokenTracking` | `false` | Alpha | 1.26 | 1.26 |
 | `LegacyServiceAccountTokenTracking` | `true` | Beta | 1.27 | 1.27 |
 | `LegacyServiceAccountTokenTracking` | `true` | GA | 1.28 | |
@@ -457,7 +450,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `CronJobsScheduledAnnotation`: Set the scheduled job time as an
   {{< glossary_tooltip text="annotation" term_id="annotation" >}} on Jobs that were created
   on behalf of a CronJob.
-- `CronJobTimeZone`: Allow the use of the `timeZone` optional field in [CronJobs](/docs/concepts/workloads/controllers/cron-jobs/)
 - `CRDValidationRatcheting`: Enable updates to custom resources to contain 
    violations of their OpenAPI schema if the offending portions of the resource
    update did not change. See [Validation Ratcheting](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting) for more details.
@@ -550,8 +542,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
   and volume controllers.
 - `InTreePluginvSphereUnregister`: Stops registering the vSphere in-tree plugin in kubelet
   and volume controllers.
-- `JobMutableNodeSchedulingDirectives`: Allows updating node scheduling directives in
-  the pod template of [Job](/docs/concepts/workloads/controllers/job).
 - `JobBackoffLimitPerIndex`: Allows specifying the maximal number of pod
   retries per index in Indexed jobs.
 - `JobPodFailurePolicy`: Allow users to specify handling of pod failures based on container
@@ -604,8 +594,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
   When enabled, kubelet CRI interface and authenticated http servers are instrumented to generate
   OpenTelemetry trace spans.
   See [Traces for Kubernetes System Components](/docs/concepts/cluster-administration/system-traces) for more details.
-- `LegacyServiceAccountTokenNoAutoGeneration`: Stop auto-generation of Secret-based
-  [service account tokens](/docs/concepts/security/service-accounts/#get-a-token).
 - `LegacyServiceAccountTokenCleanUp`: Enable cleaning up Secret-based
   [service account tokens](/docs/concepts/security/service-accounts/#get-a-token)
   when they are not used in a specified time (default to be one year).


### PR DESCRIPTION
Move feature gates CronJobTimeZone, JobMutableNodeSchedulingDirectives and LegacyServiceAccountTokenNoAutoGeneration to feature-gates-removed page

Ref: https://github.com/kubernetes/kubernetes/pull/120192