### PR TITLE
Remove instructions for legacy package repos

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -6,21 +6,23 @@ weight: 120
 
 <!-- overview -->
 
-This page explains how to switch from one Kubernetes package repository to another
-when upgrading Kubernetes minor releases. Unlike deprecated Google-hosted
-repositories, the Kubernetes package repositories are structured in a way that
-there's a dedicated package repository for each Kubernetes minor version.
+This page explains how to enable a package repository for a new Kubernetes minor release
+for users of the community-owned package repositories hosted at `pkgs.k8s.io`.
+Unlike the legacy package repositories, the community-owned package repositories are
+structured in a way that there's a dedicated package repository for each Kubernetes
+minor version.
 
 ## {{% heading "prerequisites" %}}
 
-This document assumes that you're already using the Kubernetes community-owned
-package repositories. If that's not the case, it's strongly recommended to migrate
-to the Kubernetes package repositories.
+This document assumes that you're already using the community-owned
+package repositories (`pkgs.k8s.io`). If that's not the case, it's strongly
+recommended to migrate to the community-owned package repositories as described
+in the [official announcement](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 ### Verifying if the Kubernetes package repositories are used
 
-If you're unsure whether you're using the Kubernetes package repositories or the
-Google-hosted repository, take the following steps to verify:
+If you're unsure whether you're using the community-owned package repositories or the
+legacy package repositories, take the following steps to verify:
 
 {{< tabs name="k8s_install_versions" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -39,7 +41,8 @@ deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io
 ```
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
-Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories.
+Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories
+as described in the [official announcement](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
@@ -64,7 +67,8 @@ exclude=kubelet kubeadm kubectl
 ```
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
-Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories.
+Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories
+as described in the [official announcement](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 
@@ -90,7 +94,8 @@ exclude=kubelet kubeadm kubectl
 ```
 
 **You're using the Kubernetes package repositories and this guide applies to you.**
-Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories.
+Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories
+as described in the [official announcement](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -54,9 +54,9 @@ The upgrade workflow at high level is the following:
 
 ## Changing the package repository
 
-If you're using the Kubernetes community-owned repositories, you need to change
-the package repository to one that contains packages for your desired Kubernetes
-minor version. This is explained in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
+If you're using the community-owned package repositories (`pkgs.k8s.io`), you need to 
+enable the package repository for the desired Kubernetes minor release. This is explained in
+[Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
 document.
 
 ## Determine which version to upgrade to

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -19,9 +19,9 @@ upgrade the control plane nodes before upgrading your Linux Worker nodes.
 
 ## Changing the package repository
 
-If you're using the Kubernetes community-owned repositories, you need to change
-the package repository to one that contains packages for your desired Kubernetes
-minor version. This is explained in [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
+If you're using the community-owned package repositories (`pkgs.k8s.io`), you need to 
+enable the package repository for the desired Kubernetes minor release. This is explained in
+[Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
 document.
 
 ## Upgrading worker nodes


### PR DESCRIPTION
The legacy package repositories are deprecated and we don't publish packages to the legacy repositories any longer. Because of that, it doesn't make much sense to provide installation instructions based on the legacy repositories.

This PR removes references to the legacy package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`), as well as, updates wording in the relevant documents to highlight that the legacy package repositories have been frozen.

We need to cherry-pick this PR along with #42022 and other relevant PRs to all release branches up to at least v1.25 (ideally v1.24 as well).

/assign @cpanato @saschagrunert @jeremyrickard 
cc @kubernetes/release-engineering 