### PR TITLE
Remove rapture reference for build admins

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -16,7 +16,6 @@ The responsibilities of each role are described below.
   - [Becoming a Release Manager](#becoming-a-release-manager)
 - [Release Manager Associates](#release-manager-associates)
   - [Becoming a Release Manager Associate](#becoming-a-release-manager-associate)
-- [Build Admins](#build-admins)
 - [SIG Release Leads](#sig-release-leads)
   - [Chairs](#chairs)
   - [Technical Leads](#technical-leads)
@@ -25,7 +24,7 @@ The responsibilities of each role are described below.
 
 | Mailing List | Slack | Visibility | Usage | Membership |
 | --- | --- | --- | --- | --- |
-| [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (including Associates, Build Admins, and SIG Chairs) |
+| [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (including Associates, and SIG Chairs) |
 | [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) | N/A | Private | Private discussion for privileged Release Managers | Release Managers, SIG Release leadership |
 | [security-release-team@kubernetes.io](mailto:security-release-team@kubernetes.io) | [#security-release-team](https://kubernetes.slack.com/archives/G0162T1RYHG) (channel) / @security-rel-team (user group) | Private | Security release coordination with the Security Response Committee | [security-discuss-private@kubernetes.io](mailto:security-discuss-private@kubernetes.io), [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) |
 
@@ -42,7 +41,6 @@ for more information.
 
 - [Patch Release Team][handbook-patch-release]
 - [Branch Managers][handbook-branch-mgmt]
-- [Build Admins][handbook-packaging]
 
 ## Release Managers
 
@@ -158,22 +156,6 @@ Contributors can become Associates by demonstrating the following:
   - these efforts require interacting and pairing with Release Managers and
     Associates
 
-## Build Admins
-
-Build Admins are (currently) Google employees with the requisite access to
-Google build systems/tooling to publish deb/rpm packages on behalf of the
-Kubernetes project. They are responsible for:
-
-- Building, signing, and publishing the deb/rpm packages
-- Being the interlock with Release Managers (and Associates) on the final steps
-of each minor (1.Y) and patch (1.Y.Z) release
-
-GitHub team: [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins)
-
-- Aaron Crickenberger ([@spiffxp](https://github.com/spiffxp))
-- Ben Kazemi ([@BenjaminKazemi](https://github.com/BenjaminKazemi))
-- Grant McCloskey ([@MushuEE](https://github.com/MushuEE))
-
 ## SIG Release Leads
 
 SIG Release Chairs and Technical Leads are responsible for:
@@ -211,7 +193,6 @@ Example: [1.15 Release Team](https://git.k8s.io/sig-release/releases/release-1.1
 
 [community-membership]: https://git.k8s.io/community/community-membership.md#member
 [handbook-branch-mgmt]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md
-[handbook-packaging]: https://git.k8s.io/release/hack/rapture/README.md
 [handbook-patch-release]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/patch-release-team.md
 [k-sig-release-releases]: https://git.k8s.io/sig-release/releases
 [patches]: /releases/patch-releases/


### PR DESCRIPTION
Package builds are now integrated into `krel obs`, means we do not have to reference rapture any more. It also got removed in https://github.com/kubernetes/release/pull/3313.

/cc @kubernetes/release-managers 