### PR TITLE
Fix broken page layout for "Install and Set Up kubectl on Linux"

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -210,17 +210,19 @@ To upgrade kubectl to another minor release, you'll need to bump the version in 
    gpgcheck=1
    gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
    EOF
+   ```
 
-   {{< note >}}
-   To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/zypp/repos.d/kubernetes.repo`
-   before running `zypper update`. This procedure is described in more detail in
-   [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
-   {{< /note >}}
+{{< note >}}
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/zypp/repos.d/kubernetes.repo`
+before running `zypper update`. This procedure is described in more detail in
+[Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+{{< /note >}}
 
-1. Install kubectl using `zypper`:
+   2. Install kubectl using `zypper`:
 
-   ```bash
-   sudo zypper install -y kubectl
+      ```bash
+      sudo zypper install -y kubectl
+      ```
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
I experimented with various combinations of indentations in an attempt to resolve the issue, but none of them produced the desired result except for the one I'm proposing here. I copied the spacings from the "Red Hat-based" tab that displays correctly on the website.

This will fix https://github.com/kubernetes/website/issues/43431