### PR TITLE
Update pod-scheduling-readiness.md to beta

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -6,7 +6,7 @@ weight: 40
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.26" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.27" state="beta" >}}
 
 Pods were considered ready for scheduling once created. Kubernetes scheduler
 does its due diligence to find nodes to place all pending Pods. However, in a 


### PR DESCRIPTION
Pod Scheduling Readiness graduated to beta in 1.27, this update reflects that feature state.
