### PR TITLE
Removed outdated information for SA and Added the Note for Manually created Secret API objects.

### DIFF
--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -340,30 +340,6 @@ Then, delete the Secret you now know the name of:
 kubectl -n examplens delete secret/example-automated-thing-token-zyxwv
 ```
 
-The control plane spots that the ServiceAccount is missing its Secret,
-and creates a replacement:
-
-```shell
-kubectl -n examplens get serviceaccount/example-automated-thing -o yaml
-```
-
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{},"name":"example-automated-thing","namespace":"examplens"}}
-  creationTimestamp: "2019-07-21T07:07:07Z"
-  name: example-automated-thing
-  namespace: examplens
-  resourceVersion: "1026"
-  selfLink: /api/v1/namespaces/examplens/serviceaccounts/example-automated-thing
-  uid: f23fd170-66f2-4697-b049-e1e266b7f835
-secrets:
-  - name: example-automated-thing-token-4rdrh
-```
-
 ## Clean up
 
 If you created a namespace `examplens` to experiment with, you can remove it:

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -269,8 +269,7 @@ If you view the ServiceAccount using:
 
 You can't see the `build-robot-secret` Secret in the ServiceAccount API objects
 [`.secrets`](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/) field
-because manually created Secret API objects do not appear in the ServiceAccount API object's
-`.secrets` field. That field is only populated with auto-generated Secrets.
+because that field is only populated with auto-generated Secrets.
 {{< /note >}}
 
 ## Add ImagePullSecrets to a service account

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -262,6 +262,11 @@ Secret somewhere that your terminal / computer screen could be seen by an onlook
 When you delete a ServiceAccount that has an associated Secret, the Kubernetes
 control plane automatically cleans up the long-lived token from that Secret.
 
+{{< note >}}
+Manually created Secret API objects do not appear in the service account API object's
+`.secrets` field. That field is only populated with auto-generated secrets.
+{{< /note >}}
+
 ## Add ImagePullSecrets to a service account
 
 First, [create an imagePullSecret](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -263,8 +263,14 @@ When you delete a ServiceAccount that has an associated Secret, the Kubernetes
 control plane automatically cleans up the long-lived token from that Secret.
 
 {{< note >}}
-Manually created Secret API objects do not appear in the service account API object's
-`.secrets` field. That field is only populated with auto-generated secrets.
+If you view the ServiceAccount using:
+
+` kubectl get serviceaccount build-robot -o yaml`
+
+You can't see the `build-robot-secret` Secret in the ServiceAccount API objects
+[`.secrets`](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/) field
+because manually created Secret API objects do not appear in the ServiceAccount API object's
+`.secrets` field. That field is only populated with auto-generated Secrets.
 {{< /note >}}
 
 ## Add ImagePullSecrets to a service account


### PR DESCRIPTION
This PR removed the inaccurate information about SA from the [Managing Service Accounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#delete-token) docs and also added the for Manually created Secret API objects under the [Manually create a long-lived API token for a ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount) in the [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) task page.

Fixes #43111
