### PR TITLE
fix filename in kubectl installation page

### DIFF
--- a/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
@@ -56,10 +56,10 @@ The following methods exist for installing kubectl on Linux:
 
    {{< tabs name="download_binary_linux" >}}
    {{< tab name="x86-64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
    {{< /tab >}}
    {{< tab name="ARM64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
    {{< /tab >}}
    {{< /tabs >}}
 


### PR DESCRIPTION
### Renamed `kubectl` download url in zh-lang page.
1. It was `kubectl.sha256` instead of `kubectl`.
2. It will be wrong after next step - downloading the sha256sum txt then overwrite previous *`kubectl`*