### PR TITLE
Update upgrade guides to clarify that legacy repos are frozen

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -163,19 +163,12 @@ For more information on version skews, see:
 * Kubernetes [version and version-skew policy](/docs/setup/release/version-skew-policy/)
 * Kubeadm-specific [version skew policy](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#version-skew-policy)
 
-{{< note >}}
-Kubernetes has [new package repositories hosted at `pkgs.k8s.io`](/blog/2023/08/15/pkgs-k8s-io-introduction/)
-starting from August 2023. The legacy package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`)
-have been frozen starting from September 13, 2023. Please read our
-[deprecation and freezing announcement](/blog/2023/08/31/legacy-package-repository-deprecation/)
-for more details.
-{{< /note >}}
+{{% legacy-repos-deprecation %}}
 
 {{< note >}}
 There's a dedicated package repository for each Kubernetes minor version. If you want to install
 a minor version other than {{< skew currentVersion >}}, please see the installation guide for
-your desired minor version. The official Kubernetes package repositories provide downloads for
-Kubernetes versions starting with v1.24.0. 
+your desired minor version.
 {{< /note >}}
 
 {{< tabs name="k8s_install" >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -19,6 +19,8 @@ package repositories (`pkgs.k8s.io`). If that's not the case, it's strongly
 recommended to migrate to the community-owned package repositories as described
 in the [official announcement](/blog/2023/08/15/pkgs-k8s-io-introduction/).
 
+{{% legacy-repos-deprecation %}}
+
 ### Verifying if the Kubernetes package repositories are used
 
 If you're unsure whether you're using the community-owned package repositories or the

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -59,6 +59,8 @@ enable the package repository for the desired Kubernetes minor release. This is 
 [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
 document.
 
+{{% legacy-repos-deprecation %}}
+
 ## Determine which version to upgrade to
 
 Find the latest patch release for Kubernetes {{< skew currentVersion >}} using the OS package manager:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -24,6 +24,8 @@ enable the package repository for the desired Kubernetes minor release. This is 
 [Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
 document.
 
+{{% legacy-repos-deprecation %}}
+
 ## Upgrading worker nodes
 
 ### Upgrade kubeadm

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -280,13 +280,12 @@ other = "Thanks for the feedback. If you have a specific, answerable question ab
 other = "Fetching results..."
 
 [legacy_repos_message]
-other = """Kubernetes has [new package repositories hosted at `pkgs.k8s.io`](/blog/2023/08/15/pkgs-k8s-io-introduction/)
-starting from August 2023. The legacy package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`) have been
-deprecated and frozen starting from September 13, 2023. To install Kubernetes versions released **after**
-September 13, 2023, you need to use the community-owned package repositories.
-Please read the [deprecation and freezing announcement](/blog/2023/08/31/legacy-package-repository-deprecation/)
-for more details. The new Kubernetes package repositories provide downloads for Kubernetes versions
-starting with v1.24.0."""
+other = """The legacy package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`) have been
+[deprecated and frozen starting from September 13, 2023](/blog/2023/08/31/legacy-package-repository-deprecation/).
+**Using the [new package repositories hosted at `pkgs.k8s.io`](/blog/2023/08/15/pkgs-k8s-io-introduction/)
+is strongly recommended and required in order to install Kubernetes versions released after September 13, 2023.**
+The deprecated legacy repositories, and their contents, might be removed at any time in the future and without
+a further notice period. The new package repositories provide downloads for Kubernetes versions starting with v1.24.0."""
 
 [main_by]
 other = "by"

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -279,6 +279,15 @@ other = "Thanks for the feedback. If you have a specific, answerable question ab
 [layouts_docs_search_fetching]
 other = "Fetching results..."
 
+[legacy_repos_message]
+other = """Kubernetes has [new package repositories hosted at `pkgs.k8s.io`](/blog/2023/08/15/pkgs-k8s-io-introduction/)
+starting from August 2023. The legacy package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`) have been
+deprecated and frozen starting from September 13, 2023. To install Kubernetes versions released **after**
+September 13, 2023, you need to use the community-owned package repositories.
+Please read the [deprecation and freezing announcement](/blog/2023/08/31/legacy-package-repository-deprecation/)
+for more details. The new Kubernetes package repositories provide downloads for Kubernetes versions
+starting with v1.24.0."""
+
 [main_by]
 other = "by"
 

--- a/layouts/shortcodes/legacy-repos-deprecation.html
+++ b/layouts/shortcodes/legacy-repos-deprecation.html
@@ -1,0 +1,3 @@
+<div class="alert alert-secondary callout note" role="alert">
+  <strong>{{ T "note" | safeHTML }}</strong> {{ T "legacy_repos_message" | markdownify }}
+</div>


### PR DESCRIPTION
This PR updates relevant upgrade guides to clarify that legacy repos are frozen and that you need to switch to the new Kubernetes repositories to installs versions released after September 13, 2023.

/assign @sftim @tengqm @Affan-7 @saschagrunert @cpanato 
cc @kubernetes/release-engineering 