### PR TITLE
Add doc-versions-list shortcode

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -15,13 +15,7 @@ This page shows how to install the `kubeadm` toolbox.
 For information on how to create a cluster with kubeadm once you have performed this installation process,
 see the [Creating a cluster with kubeadm](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) page.
 
-This installation guide is for Kubernetes {{< skew currentVersion >}}. If you want to use a different
-Kubernetes version, please refer to the following pages instead:
-
-- [Installing kubeadm for Kubernetes {{< skew currentVersionAddMinor -1 "." >}}](https://v{{< skew currentVersionAddMinor -1 "-" >}}.docs.kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
-- [Installing kubeadm for Kubernetes {{< skew currentVersionAddMinor -2 "." >}}](https://v{{< skew currentVersionAddMinor -2 "-" >}}.docs.kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
-- [Installing kubeadm for Kubernetes {{< skew currentVersionAddMinor -3 "." >}}](https://v{{< skew currentVersionAddMinor -3 "-" >}}.docs.kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
-- [Installing kubeadm for Kubernetes {{< skew currentVersionAddMinor -4 "." >}}](https://v{{< skew currentVersionAddMinor -4 "-" >}}.docs.kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
+{{< doc-versions-list "installation guide" >}}
 
 ## {{% heading "prerequisites" %}}
 

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -91,6 +91,9 @@ other = "I AM..."
 [docs_label_users]
 other = "Users"
 
+[docs_page_versions]
+other = "This %s is for Kubernetes %s. If you want to use a different Kubernetes version, please refer to the following pages instead:"
+
 [docs_version_current]
 other = "(this documentation)"
 

--- a/layouts/shortcodes/doc-versions-list.html
+++ b/layouts/shortcodes/doc-versions-list.html
@@ -1,0 +1,20 @@
+{{ $versions := .Page.Param "versions" }}
+{{ $thisPageRelUri := .Page.RelPermalink }}
+{{ $thisPageTitle := .Page.Title }}
+{{ $thisVersionArray := split (.Page.Param "version") "." }}
+{{ $itemName := .Get 0 }}
+
+<div class="version-list">
+    <p>
+        {{ printf (T "docs_page_versions") $itemName (delimit $thisVersionArray ".") }}
+    </p>
+    <ul>
+        {{ range $index, $version := $versions }}
+            {{ if ne .version ( delimit $thisVersionArray "." ) }}
+            <li>
+                <a href="{{ .url }}{{ $thisPageRelUri }}">{{ $thisPageTitle }} (Kubernetes {{ .version }})</a>
+            </li>
+            {{ end }}
+        {{ end }}
+    </ul>
+</div>


### PR DESCRIPTION
This is a proposal to add `doc-versions-list` shortcode. This is supposed to be replacement for deprecated `versions-other` shortcode. This shortcode generates links to other versions of the given document, like this:

![image](https://github.com/kubernetes/website/assets/18719127/51e646cf-e7fb-4fc2-b5a4-d80382aecd71)

The new shortcode brings some improvements over the old `versions-other` shortcode:

- Links to the given page instead of the home page
- Brings some improvements from the new `supported-versions` layout

I decided to create a new shortcode because the old shortcode is still being used by some translations.

/assign @sftim 