### PR TITLE
Demo generating feature gates table

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -980,6 +980,37 @@ div.alert > em.javascript-required {
     background: #326de6;
 }
 
+.td-content > table.feature-gates-table tbody tr.table-item-odd {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #000000;
+}
+
+.td-content > table.feature-gates-table tbody tr.table-item-even {
+  background: #ffffff;
+  color: #000000;
+}
+
+//Feature gate spanned cells
+td.feature-gate-name, .td-content > table td.feature-gate-name {
+  vertical-align: middle;
+
+  > *:first-child {
+    display: inline-block;
+    font-family: monospace;
+    border-bottom: 1px dotted #000;
+  }
+}
+
+.td-content > table.feature-gates-table tbody + tbody tr {
+  background: #ffffff;
+  color: #222222;
+}
+
+.td-content > table.feature-gates-table tbody + tbody tr + tr {
+  background: #ffffff;
+  color: #dd0000;
+}
+
 // Adjust Bing search result page
 #bing-results-container {
     padding: 1em;

--- a/layouts/shortcodes/feature-gate-table.html
+++ b/layouts/shortcodes/feature-gate-table.html
@@ -1,114 +1,77 @@
-{{- $featureDataFiles := .Site.GetPage "page" "docs/reference/command-line-tools-reference/feature-gates" -}}
+<table class="sortable-table feature-gates-table">
+  <caption style="display:none">
+    {{ .Get "caption" }}
+  </caption>
 
-<!-- Check if 'show-removed' is passed to the shortcode to display only 'removed' feature gates -->
-{{- $removedFeatureGateRequested := .Get "show-removed" -}}
-
-<!-- Extract value for the 'include' parameter passed to the shortcode  -->
-{{- $includeValues := .Get "include" -}} 
-
-<!-- Sort Feature gate pages list -->
-{{- $sortedFeatureGates := sort ($featureDataFiles.Resources.ByType "page") -}}
-
-<table class="sortable-table">
-    <caption style="display:none">
-        {{- .Get "caption" -}}
-    </caption>
-    <thead>
-      <tr>
-          <th>{{- T "feature_gate_table_header_feature" -}}</th>
-          <th>{{- T "feature_gate_table_header_default" -}}</th>
-          <th>{{- T "feature_gate_table_header_stage" -}}</th>
-          <th>
-          {{- if $removedFeatureGateRequested -}}
-               {{- T "feature_gate_table_header_from" -}}
-            {{- else -}}
-               {{- T "feature_gate_table_header_since" -}}
-            {{- end -}}
-          </th>
-          <th>
-            {{- if $removedFeatureGateRequested -}}
-                 {{- T "feature_gate_table_header_to" -}}
-              {{- else -}}
-                 {{- T "feature_gate_table_header_until" -}}
-              {{- end -}}
-            </th>
+  <thead>
+    <tr>
+        <!-- demo - not localized -->
+        <th>Feature</th>
+        <th>Default</th>
+        <th>Stage</th>
+        <th>Since</th>
+        <th>Until</th>
       </tr>
-    </thead>
-    <tbody>
-    {{- range $featureGateFile := $sortedFeatureGates -}}
+  </thead>
 
-        <!-- Extract the feature gate name from the "Title" parameter in file -->
-        {{- $featureGateName := $featureGateFile.Params.Title -}}
+  {{- $featureGatesBundle := site.GetPage "page" "docs/reference/command-line-tools-reference/feature-gates" -}}
+  {{- $featureCount := 0 -}}
+  <tbody>
+    {{- range $featureGatesBundle.Resources.ByType "page" -}}
+     {{- $bundle := . }}
 
-        <!-- Extract the feature gate status (i.e. removed or not) from the "Removed" parameter in file -->
-        {{- $removedStatusForFeature := index $featureGateFile.Params.Removed -}}
+     {{- if not (isSet $bundle.Params "stages") -}}
+      {{- continue -}}
+     {{- end -}}
 
-        <!-- Check if 'stages' parameter is missing in the front matter -->
-        {{- if not (isSet $featureGateFile.Params "stages") -}}
-            {{- warnf "Stages parameter is missing in the front matter for %s in %s" $featureGateName (print $featureGateFile.File.Lang "/" $featureGateFile.File.Path) -}}
+     {{- $featureIsGraduatedOrDeprecated := false -}}
 
-        {{- else -}}
-            {{- if not $removedFeatureGateRequested -}}
-                <!-- Check if the feature gate should be included based on the 'include' parameter -->
+     {{- range $stage := $bundle.Params.stages -}}
+      {{- if or (eq ($stage).stage "stable") (eq ($stage).stage "deprecated") -}}
+       {{- $featureIsGraduatedOrDeprecated = true -}}
+      {{- end -}}
+     {{- end -}}
+     {{- if $featureIsGraduatedOrDeprecated -}}
+      {{- continue -}}
+     {{- end -}}
 
-                {{- if $removedStatusForFeature -}}
-                    {{- continue -}}
-                {{- end -}}
+     {{- $featureRowCount := 0 -}}
 
-                <!-- Check if 'alpha' or 'beta' is specified in 'include' values, set flag accordingly -->
-                {{- $onlyDisplayAlphaBetaFeature := or (in $includeValues "alpha") (in $includeValues "beta") -}}
-                {{- $graduatedOrDeprecatedFlag := false -}}
+     {{- range $stage := $bundle.Params.stages -}}
+       {{- if or (eq ($stage).stage "alpha") (eq ($stage).stage "beta") -}}
+         {{- $featureRowCount = add $featureRowCount 1 -}}
+       {{- end }}
+     {{- end }}
 
-                <!-- Iterate through stages for current Feature gate to check for "stable" or "deprecated" stage -->
-                {{- range $stage := $featureGateFile.Params.stages -}}
-                    {{- if or (eq ($stage).stage "stable") (eq ($stage).stage "deprecated") -}}
-                        {{- $graduatedOrDeprecatedFlag = true -}}
-                    {{- end -}}
-                {{- end -}}
+     {{- $featurePhaseRow := 0 -}}
 
-                {{- if eq $onlyDisplayAlphaBetaFeature $graduatedOrDeprecatedFlag -}}
-                    {{- continue -}}
-                {{- end -}}
-
-            {{- else -}}
-            <!-- Check if 'removed' parameter is not specified, continue to the next iteration -->
-            {{- if not $removedStatusForFeature -}}
-                {{- continue -}}
-            {{- end -}}
+     {{- range $stage := $bundle.Params.stages -}}
+      {{- if or (eq ($stage).stage "alpha") (eq ($stage).stage "beta") -}}
+       {{- if or (ne (printf "%T" ($stage).fromVersion) "string") (and (isSet $stage "toVersion") (ne (printf "%T" ($stage).toVersion) "string")) -}}
+        {{- errorf "Feature gate stage version has invalid type for feature gate %s, stage \"%s\" (should be string)" $bundle.Title ($stage).stage -}}
+       {{- end -}}
+       {{- if not (isSet $stage "featureGateDefault") -}}
+        {{- warnf "Feature gate does not have default value for feature gate %s, stage \"%s\"" $bundle.Title ($stage).stage -}}
+       {{- end -}}
+       <tr class="table-item-{{if (modBool $featureCount 2)}}odd{{else}}even{{end}}">
+        <!-- one cell for the feature gate name, no matter how many rows -->
+        {{- if eq $featurePhaseRow 0 -}}
+        <td class="feature-gate-name" rowspan="{{ $featureRowCount }}"><span title="{{ $bundle.Content | plainify }}">{{- $bundle.Title -}}</span></td>
         {{- end -}}
-
-        {{- range $featureGate := $featureGateFile.Params.stages -}}
-            <!-- Check if the 'stage' value is valid -->
-            {{- $validStages := slice "alpha" "beta" "stable" "deprecated" -}}
-            {{- $isValidStage := in $validStages $featureGate.stage -}}
-            {{- if not $isValidStage -}}
-                {{- errorf "Invalid 'stage' value '%s' specified for feature gate '%s' in %s (Valid values are: %s)" $featureGate.stage $featureGateName (print $featureGateFile.File.Lang "/" $featureGateFile.File.Path) $validStages -}}
-            {{- end -}}
-
-            <!-- Parse and extract the numeric values in format x.y or x.y.z for comparison -->
-            {{- $formattedFromVersion := printf "%s" $featureGate.fromVersion | replaceRE "(\\d+\\.\\d+(?:\\.\\d+)?)?.*" "$1" -}}
-            {{- $formattedToVersion := printf "%s" $featureGate.toVersion | replaceRE "(\\d+\\.\\d+(?:\\.\\d+)?)?.*" "$1" -}}
-
-            <!-- Check for invalid 'fromVersion' value -->
-            {{- if not (eq (printf "%s" $featureGate.fromVersion) $formattedFromVersion) -}}
-                {{- errorf "Invalid 'fromVersion' value '%s' specified for feature gate '%s' in %s" $featureGate.fromVersion $featureGateName (print $featureGateFile.File.Lang "/" $featureGateFile.File.Path) -}}
-            {{- end -}}
-
-            <!-- Check for invalid 'toVersion' value -->
-            {{- if and $featureGate.toVersion (not (eq (printf "%s" $featureGate.toVersion) $formattedToVersion)) -}}
-                {{- errorf "Invalid 'toVersion' value '%s' specified for feature gate '%s' in %s" $featureGate.toVersion $featureGateName (print $featureGateFile.File.Lang "/" $featureGateFile.File.Path) -}}
-            {{- end -}}
-
-            <!-- Display feature gate information in table rows -->
-            <tr>
-                <td><code>{{- $featureGateName -}}</code></td>
-                <td>{{- if isSet $featureGate "defaultValue" -}}<code>{{- $featureGate.defaultValue -}}</code>{{- else -}}–{{- end -}}</td>
-                <td>{{- T (printf "feature_gate_stage_%s" $featureGate.stage) -}}</td>
-                <td>{{- $featureGate.fromVersion -}}</td>
-                <td>{{- if isSet $featureGate "toVersion" -}}{{- $featureGate.toVersion -}}{{- else -}}–{{- end -}}</td>
-            </tr>
-            {{- end -}}
-        {{- end -}}
+        <td><code>{{- ($stage).featureGateDefault -}}</code></td>
+        <td>{{- ($stage).stage | title }}</td>
+        <td>{{- if isSet $stage "fromVersion" -}}{{- ($stage).fromVersion -}}{{- else -}}–{{- end -}}</td>
+        <td>{{- if isSet $stage "toVersion" -}}{{- ($stage).toVersion -}}{{- else -}}–{{- end -}}</td>
+       </tr>
+       {{- $featurePhaseRow = add $featurePhaseRow 1 -}}
+      {{- end -}}
+     {{- end -}}
+     {{- $featureCount = add $featureCount 1 -}}
     {{- end -}}
-</tbody>
+  </tbody>
+  <tbody>
+    <tr><td colspan="5" rowspan="2" style="text-align: right;"><em>&hellip;more rows</em></td></tr>
+    <tr></tr>
+    <tr><td colspan="5" rowspan="1"><strong>This is only a demo.</strong><br />If all the rows were here, you could sort the table too.</td></tr>
+  </tbody>
 </table>


### PR DESCRIPTION
This is a demo for how we could build on PR #41793 to also render tables of feature gates. The final two commits add the changes; everything else is part of #41793, or was when I opened the PR.
([preview](https://deploy-preview-43491--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates/#overview) - or see [below](https://github.com/kubernetes/website/pull/43491#issuecomment-1764061580) for a screenshot)

I only updated the front matter for a few feature gates to demo how it might work. If someone wants to do the rest, you're welcome to - maybe check that this is the approach we want first, though.

You can now hover over the feature gate name in the lefthand column to see a description of the feature.

/hold
I don't plan to merge this; it's a demonstration.