### PR TITLE
fix: Missing curl '<ip-addr>' command in ingress-minikube.md document

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -108,6 +108,10 @@ If you haven't already set up a cluster locally, run `minikube start` to create 
    http://172.17.0.15:31637
    ```
 
+   ```shell
+   curl http://172.17.0.15:31637 
+   ```
+
    The output is similar to:
 
    ```none


### PR DESCRIPTION
Added the command curl <ip-addr> which is missing between two outputs.
#43473 