### PR TITLE
Fixed: Unable to deploy and test the kubernetes documentation site locally in windows 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd website
 The Kubernetes website uses the [Docsy Hugo theme](https://github.com/google/docsy#readme). Even if you plan to run the website in a container, we strongly recommend pulling in the submodule and other development dependencies by running the following:
 
 ### Windows
-```command prompt
+```powershell
 # fetch submodule dependencies
 git submodule update --init --recursive --depth 1
 ```
@@ -66,11 +66,11 @@ To install dependencies, deploy and test the site locally, run:
   npm ci
   make serve
   ```
-- For Windows (Command Prompt)
+- For Windows (PowerShell)
   
-  ```command prompt
-  rmdir /s /q i18n
-  for /f %A in ('cd') do mklink /J "%A\i18n" "%A\data\i18n" 
+  ```powershell
+  Remove-Item -Path "i18n" -Recurse -Force
+  $CD = Get-Location; New-Item -ItemType Junction -Path "$CD\i18n" -Value "$CD\data\i18n" 
   npm ci
   hugo.exe server --buildFuture --environment development
   ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd website
 The Kubernetes website uses the [Docsy Hugo theme](https://github.com/google/docsy#readme). Even if you plan to run the website in a container, we strongly recommend pulling in the submodule and other development dependencies by running the following:
 
 ### Windows
-```powershell
+```command prompt
 # fetch submodule dependencies
 git submodule update --init --recursive --depth 1
 ```
@@ -62,11 +62,15 @@ To install dependencies, deploy and test the site locally, run:
 
 - For macOS and Linux
   ```bash
+  
   npm ci
   make serve
   ```
-- For Windows (PowerShell)
-  ```powershell
+- For Windows (Command Prompt)
+  
+  ```command prompt
+  rmdir /s /q i18n
+  for /f %A in ('cd') do mklink /J "%A\i18n" "%A\data\i18n" 
   npm ci
   hugo.exe server --buildFuture --environment development
   ```

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Make sure to install the Hugo extended version specified by the `HUGO_VERSION` e
 To install dependencies, deploy and test the site locally, run:
 
 - For macOS and Linux
-  ```bash
   
+  ```bash
   npm ci
   make serve
   ```


### PR DESCRIPTION
**ISSUE DETAILS**
Windows commands are not mentioned properly in the README.md file to deploy and test the site locally. Even i found out that previously many users also have issue with windows and many contributors are continuously asking the maintainers the same question that how to deploy the site and test in windows locally.

refer #43401 
I have changed the approach that i used in the above pr.

**WHAT I HAVE CHANGED?**

All the commands should be written in command prompt while deploying the site locally.
Added the following commands:

rmdir /s /q i18n  ->  _This command will first remove the i18n directory_

for /f %A in ('cd') do mklink /J "%A\i18n" "%A\data\i18n"   -> _This command will make symbolic link in windows._
