### PR TITLE
Adds new explanations to kuberentes tutorial expose section to make it clear what are the assumption about the service of the deployment

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -31,7 +31,10 @@ description: |-
             <p>If you haven't worked through the earlier sections, start from <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/">Using minikube to create a cluster</a>.</p>
 
             <p><em>Scaling</em> is accomplished by changing the number of replicas in a Deployment</p>
-            <p> <b> NOTE </b> If you are trying this after <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/">the previous section </a>, you may need to start from <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/">creating a cluster</a> as the services may have been deleted </p>
+            <p> <b> NOTE </b> If you are trying this after <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/">the previous section </a>, you either have deleted the service you created or the type of the node you have created is NodePort. In this section, it is assumed that a service with type LoadBalancer is created for the kubernetes-bootcamp deployment.</p>
+            <p>If you have not deleted the service created in <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro">the previous section</a>. Then, first delete the service and then run the following command to create a service of type LoadBalancer.</p>
+            <p><code><b>kubectl expose deployment/kubernetes-bootcamp --type="LoadBalancer" --port 8080</b></code></p>
+            <br />
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_lined">


### PR DESCRIPTION
In this tutorial section, it is assumed that the kubernetes-bootcamp service of type "LoadBalancer" exists. However, in previous section of the tutorial, a service of type "NodePort" is created and at end that section it is deleted. It can make users confused about what kind of service is currently created in this section of the document.

I added these lines to make it clear that we have to create a service of type "LoadBalancer" and I also added the command to make this happen.