### PR TITLE
Introduce of the deprecated FG: MergeCLIArgumentsWithConfig

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -189,6 +189,7 @@ List of deprecated feature gates:
 Feature | Default 
 :-------|:--------
 `UpgradeAddonsBeforeControlPlane` | `false`
+`MergeCLIArgumentsWithConfig` | `false`
 {{< /table >}}
 
 Feature gate descriptions:
@@ -207,7 +208,13 @@ instance is upgraded. The deprecated `UpgradeAddonsBeforeControlPlane` feature g
 behavior. You should not need this old behavior; if you do, you should consider changing your cluster or upgrade processes, as this
 feature gate will be removed in a future release.
 
-List of removed feature gates:
+
+`MergeCLIArgumentsWithConfig`
+: This feature gate was introduced for Kubernetes v1.29, turn on this feature gate will merge the value passed by the flag `--ignore-preflight-errors`
+with the value of `ignorePreflightErrors` defined in the config file, which is the default behavior in 1.28 and eariler release.
+The feature gate is set to `false` by default, which means if the flag `--ignore-preflight-errors` is set and `ignorePreflightErrors` is configured in the config file as well,
+then the value defined in the config file will be ignored, this will be taken as the default when the feature gate is removed in 1.30 release cycle.
+
 
 {{< table caption="kubeadm removed feature gates" >}}
 Feature | Alpha | Beta | GA | Removed


### PR DESCRIPTION
The feature gate is added by this change: https://github.com/kubernetes/kubernetes/pull/119946

Also see the link for the comments: https://github.com/kubernetes/kubernetes/pull/119946#discussion_r1360184126

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
