### PR TITLE
Introduce of the deprecated FG: MergeCLIArgumentsWithConfig

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -189,6 +189,7 @@ List of deprecated feature gates:
 Feature | Default 
 :-------|:--------
 `UpgradeAddonsBeforeControlPlane` | `false`
+`MergeCLIArgumentsWithConfig` | `false`
 {{< /table >}}
 
 Feature gate descriptions:
@@ -206,6 +207,13 @@ other control plane instances have been upgraded completely, and the addons upgr
 instance is upgraded. The deprecated `UpgradeAddonsBeforeControlPlane` feature gate gives you a chance to keep the old upgrade
 behavior. You should not need this old behavior; if you do, you should consider changing your cluster or upgrade processes, as this
 feature gate will be removed in a future release.
+
+
+`MergeCLIArgumentsWithConfig`
+: This feature gate is introduced in Kubernetes v1.29 and defaults to `false`. Enabling this feature gate will merge the value passed
+by the `--ignore-preflight-errors` flag with the value of `ignorePreflightErrors` defined in the config file, which is the default behavior
+in v1.28 and earlier release. The default value `false` means that if the `--ignore-preflight-errors` flag is set and `ignorePreflightErrors`
+is specified in the config file, the value defined in the config file will be ignored.
 
 List of removed feature gates:
 


### PR DESCRIPTION
The feature gate is added by this change: https://github.com/kubernetes/kubernetes/pull/119946

Also see the link for the comments: https://github.com/kubernetes/kubernetes/pull/119946#discussion_r1360184126

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
