### PR TITLE
Move Feature Gate RetroactiveDefaultStorageClass to Feature Gates (removed) Page

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
@@ -303,6 +303,9 @@ In the following table:
 | `ResourceQuotaScopeSelectors` | `false` | Alpha | 1.11 | 1.11 |
 | `ResourceQuotaScopeSelectors` | `true` | Beta | 1.12 | 1.16 |
 | `ResourceQuotaScopeSelectors` | `true` | GA | 1.17 | 1.18 |
+| `RetroactiveDefaultStorageClass` | `false` | Alpha | 1.25 | 1.25 |
+| `RetroactiveDefaultStorageClass` | `true` | Beta | 1.26 | 1.27 |
+| `RetroactiveDefaultStorageClass` | `true` | GA | 1.28 | 1.28 |
 | `RootCAConfigMap` | `false` | Alpha | 1.13 | 1.19 |
 | `RootCAConfigMap` | `true` | Beta | 1.20 | 1.20 |
 | `RootCAConfigMap` | `true` | GA | 1.21 | 1.22 |
@@ -817,6 +820,8 @@ In the following table:
   nodes with same scores.
 
 - `ResourceQuotaScopeSelectors`: Enable resource quota scope selectors.
+
+- `RetroactiveDefaultStorageClass`: Allow assigning StorageClass to unbound PVCs retroactively.
 
 - `RootCAConfigMap`: Configure the `kube-controller-manager` to publish a
   {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} named `kube-root-ca.crt`

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -310,9 +310,6 @@ For a reference to old feature gates that are removed, please refer to
 | `RemoveSelfLink` | `false` | Alpha | 1.16 | 1.19 |
 | `RemoveSelfLink` | `true` | Beta | 1.20 | 1.23 |
 | `RemoveSelfLink` | `true` | GA | 1.24 | |
-| `RetroactiveDefaultStorageClass` | `false` | Alpha | 1.25 | 1.25 |
-| `RetroactiveDefaultStorageClass` | `true` | Beta | 1.26 | 1.27 |
-| `RetroactiveDefaultStorageClass` | `true` | GA | 1.28 | |
 | `SeccompDefault` | `false` | Alpha | 1.22 | 1.24 |
 | `SeccompDefault` | `true` | Beta | 1.25 | 1.26 |
 | `SeccompDefault` | `true` | GA | 1.27 | - |
@@ -703,7 +700,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
   objects and collections. This field has been deprecated since the Kubernetes v1.16
   release. When this feature is enabled, the `.metadata.selfLink` field remains part of
   the Kubernetes API, but is always unset.
-- `RetroactiveDefaultStorageClass`: Allow assigning StorageClass to unbound PVCs retroactively.
 - `RotateKubeletServerCertificate`: Enable the rotation of the server TLS certificate on the kubelet.
   See [kubelet configuration](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)
   for more details.


### PR DESCRIPTION
The `RetroactiveDefaultStorageClass` feature gate was graduated to GA in 1.28 and it has been removed in k8s v1.29 by the following PR: https://github.com/kubernetes/kubernetes/pull/120861, with the reference to it, this PR moves the `RetroactiveDefaultStorageClass` feature gate from **Feature Gates** to **Feature Gates (removed)** docs for the k8s v1.29.