### PR TITLE
[zh-cn]fix: Correction of document example parameters

### DIFF
--- a/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
+++ b/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
@@ -2098,7 +2098,7 @@ resource without a class specified will be assigned this default class.
 
 类别：注解
 
-例子：`ingressclass.kubernetes.io/is-default-class: "true"`
+例子：`storageclass.kubernetes.io/is-default-class: "true"`
 
 用于：StorageClass
 


### PR DESCRIPTION
The example of `storageclass. kubernetes. io/is-default-class` should be written as `storageclass. kubernetes. io/is-default-class: "true"` , but it is written as `ingressclass.kubernetes.io/is-default-class: "true"`.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
