### PR TITLE
[release-1.24] Update docs to use pkgs.k8s.io instead of legacy repos

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -76,9 +76,8 @@ Install a {{< glossary_tooltip term_id="container-runtime" text="container runti
 For detailed instructions and other prerequisites, see [Installing kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
 
 {{< note >}}
-If you have already installed kubeadm, run
-`apt-get update && apt-get upgrade` or
-`yum update` to get the latest version of kubeadm.
+If you have already installed kubeadm, see the first two steps of the
+[Upgrading Linux nodes](/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes) document for instructions on how to upgrade kubeadm.
 
 When you upgrade, the kubelet restarts every few seconds as it waits in a crashloop for
 kubeadm to tell it what to do. This crashloop is expected and normal.

--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -1,0 +1,189 @@
+---
+title: Changing The Kubernetes Package Repository
+content_type: task
+weight: 120
+---
+
+<!-- overview -->
+
+This page explains how to enable a package repository for a new Kubernetes minor release
+for users of the community-owned package repositories hosted at `pkgs.k8s.io`.
+Unlike the legacy package repositories, the community-owned package repositories are
+structured in a way that there's a dedicated package repository for each Kubernetes
+minor version.
+
+## {{% heading "prerequisites" %}}
+
+This document assumes that you're already using the community-owned
+package repositories (`pkgs.k8s.io`). If that's not the case, it's strongly
+recommended to migrate to the community-owned package repositories as described
+in the [official announcement](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/).
+
+{{% legacy-repos-deprecation %}}
+
+### Verifying if the Kubernetes package repositories are used
+
+If you're unsure whether you're using the community-owned package repositories or the
+legacy package repositories, take the following steps to verify:
+
+{{< tabs name="k8s_install_versions" >}}
+{{% tab name="Ubuntu, Debian or HypriotOS" %}}
+
+Print the contents of the file that defines the Kubernetes `apt` repository:
+
+```shell
+# On your system, this configuration file could have a different name
+pager /etc/apt/sources.list.d/kubernetes.list
+```
+
+If you see a line similar to:
+
+```
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
+```
+
+**You're using the Kubernetes package repositories and this guide applies to you.**
+Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories
+as described in the [official announcement](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/).
+
+{{% /tab %}}
+{{% tab name="CentOS, RHEL or Fedora" %}}
+
+Print the contents of the file that defines the Kubernetes `yum` repository:
+
+```shell
+# On your system, this configuration file could have a different name
+cat /etc/yum.repos.d/kubernetes.repo
+```
+
+If you see a `baseurl` similar to the `baseurl` in the output below:
+
+```
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl
+```
+
+**You're using the Kubernetes package repositories and this guide applies to you.**
+Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories
+as described in the [official announcement](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/).
+
+{{% /tab %}}
+
+{{% tab name="openSUSE or SLES" %}}
+
+Print the contents of the file that defines the Kubernetes `zypper` repository:
+
+```shell
+# On your system, this configuration file could have a different name
+cat /etc/zypp/repos.d/kubernetes.repo
+```
+
+If you see a `baseurl` similar to the `baseurl` in the output below:
+
+```
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl
+```
+
+**You're using the Kubernetes package repositories and this guide applies to you.**
+Otherwise, it's strongly recommended to migrate to the Kubernetes package repositories
+as described in the [official announcement](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< note >}}
+The URL used for the Kubernetes package repositories is not limited to `pkgs.k8s.io`,
+it can also be one of:
+
+- `pkgs.k8s.io`
+- `pkgs.kubernetes.io`
+- `packages.kubernetes.io`
+{{</ note >}}
+
+<!-- steps -->
+
+## Switching to another Kubernetes package repository
+
+This step should be done upon upgrading from one to another Kubernetes minor
+release in order to get access to the packages of the desired Kubernetes minor
+version.
+
+{{< tabs name="k8s_install_versions" >}}
+{{% tab name="Ubuntu, Debian or HypriotOS" %}}
+
+1. Open the file that defines the Kubernetes `apt` repository using a text editor of your choice:
+
+   ```shell
+   nano /etc/apt/sources.list.d/kubernetes.list
+   ```
+
+   You should see a single line with the URL that contains your current Kubernetes
+   minor version. For example, if you're using v{{< skew currentVersionAddMinor -1 "." >}},
+   you should see this:
+
+   ```
+   deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/deb/ /
+   ```
+
+1. Change the version in the URL to **the next available minor release**, for example:
+
+   ```
+   deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /
+   ```
+
+1. Save the file and exit your text editor. Continue following the relevant upgrade instructions.
+
+{{% /tab %}}
+{{% tab name="CentOS, RHEL or Fedora" %}}
+
+1. Open the file that defines the Kubernetes `yum` repository using a text editor of your choice:
+
+   ```shell
+   nano /etc/yum.repos.d/kubernetes.repo
+   ```
+
+   You should see a file with two URLs that contain your current Kubernetes
+   minor version. For example, if you're using v{{< skew currentVersionAddMinor -1 "." >}},
+   you should see this:
+
+   ```
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
+   exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
+   ```
+
+1. Change the version in these URLs to **the next available minor release**, for example:
+
+   ```
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
+   ```
+
+1. Save the file and exit your text editor. Continue following the relevant upgrade instructions.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## {{% heading "whatsnext" %}}
+
+* See how to [Upgrade kubeadm cluster](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -52,6 +52,15 @@ with the purpose of reconfiguring the cluster is not recommended and can have un
 
 <!-- steps -->
 
+## Changing the package repository
+
+If you're using the community-owned package repositories (`pkgs.k8s.io`), you need to 
+enable the package repository for the desired Kubernetes minor release. This is explained in
+[Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
+document.
+
+{{% legacy-repos-deprecation %}}
+
 ## Determine which version to upgrade to
 
 Find the latest patch release for Kubernetes {{< skew currentVersion >}} using the OS package manager:
@@ -61,12 +70,12 @@ Find the latest patch release for Kubernetes {{< skew currentVersion >}} using t
     apt update
     apt-cache madison kubeadm
     # find the latest {{< skew currentVersion >}} version in the list
-    # it should look like {{< skew currentVersion >}}.x-00, where x is the latest patch
+    # it should look like {{< skew currentVersion >}}.x-*, where x is the latest patch
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     yum list --showduplicates kubeadm --disableexcludes=kubernetes
     # find the latest {{< skew currentVersion >}} version in the list
-    # it should look like {{< skew currentVersion >}}.x-0, where x is the latest patch
+    # it should look like {{< skew currentVersion >}}.x-*, where x is the latest patch
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -84,16 +93,16 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
   {{< tabs name="k8s_install_kubeadm_first_cp" >}}
   {{% tab name="Ubuntu, Debian or HypriotOS" %}}
   ```shell
-   # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    apt-mark unhold kubeadm && \
-   apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
+   apt-get update && apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
    apt-mark hold kubeadm
    ```
   {{% /tab %}}
   {{% tab name="CentOS, RHEL or Fedora" %}}
   ```shell
-  # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
-  yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+  # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+  yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
   ```
   {{% /tab %}}
   {{< /tabs >}}
@@ -181,16 +190,16 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
   {{< tabs name="k8s_install_kubelet" >}}
   {{% tab name="Ubuntu, Debian or HypriotOS" %}}
   ```shell
-  # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
+  # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
   apt-mark unhold kubelet kubectl && \
-  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+  apt-get update && apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
   apt-mark hold kubelet kubectl
   ```
   {{% /tab %}}
   {{% tab name="CentOS, RHEL or Fedora" %}}
   ```shell
-  # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
-  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+  # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+  yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
   ```
   {{% /tab %}}
   {{< /tabs >}}

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -110,26 +110,29 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y ca-certificates curl
-   ```
-   If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
-   ```shell
-   sudo apt-get install -y apt-transport-https
+   # apt-transport-https may be a dummy package; if so, you can skip that package
+   sudo apt-get install -y apt-transport-https ca-certificates curl
    ```
 
-2. Download the Google Cloud public signing key:
+2. Download the public signing key for the Kubernetes package repositories. The same signing key is used for all repositories so you can disregard the version in the URL:
 
    ```shell
-   sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
-3. Add the Kubernetes `apt` repository:
+3. Add the appropriate Kubernetes `apt` repository. If you want to use Kubernetes version different than {{< param "version" >}},
+   replace {{< param "version" >}} with the desired minor version in the command below:
 
    ```shell
-   echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   # This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-4. Update `apt` package index with the new repository and install kubectl:
+{{< note >}}
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and `apt-get upgrade`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+{{< /note >}}
+
+1. Update `apt` package index, then install kubectl:
 
    ```shell
    sudo apt-get update
@@ -139,17 +142,32 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 {{% /tab %}}
 
 {{% tab name="Red Hat-based distributions" %}}
-```bash
-cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-sudo yum install -y kubectl
-```
+
+1. Add the Kubernetes `yum` repository. If you want to use Kubernetes version
+   different than {{< param "version" >}}, replace {{< param "version" >}} with
+   the desired minor version in the command below.
+
+   ```bash
+   # This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
+   cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   EOF
+   ```
+
+{{< note >}}
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+{{< /note >}}
+
+2. Install kubectl using `yum`:
+
+   ```bash
+   sudo yum install -y kubectl
+   ```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -51,6 +51,9 @@ other = "I AM..."
 [docs_label_users]
 other = "Users"
 
+[docs_page_versions]
+other = "This %s is for Kubernetes %s. If you want to use a different Kubernetes version, please refer to the following pages instead:"
+
 [docs_version_current]
 other = "(this documentation)"
 
@@ -149,6 +152,14 @@ other = "Thanks for the feedback. If you have a specific, answerable question ab
 
 [layouts_docs_search_fetching]
 other = "Fetching results..."
+
+[legacy_repos_message]
+other = """The legacy package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`) have been
+[deprecated and frozen starting from September 13, 2023](https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/).
+**Using the [new package repositories hosted at `pkgs.k8s.io`](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/)
+is strongly recommended and required in order to install Kubernetes versions released after September 13, 2023.**
+The deprecated legacy repositories, and their contents, might be removed at any time in the future and without
+a further notice period. The new package repositories provide downloads for Kubernetes versions starting with v1.24.0."""
 
 [main_by]
 other = "by"

--- a/layouts/shortcodes/doc-versions-list.html
+++ b/layouts/shortcodes/doc-versions-list.html
@@ -1,0 +1,20 @@
+{{ $versions := .Page.Param "versions" }}
+{{ $thisPageRelUri := .Page.RelPermalink }}
+{{ $thisPageTitle := .Page.Title }}
+{{ $thisVersionArray := split (.Page.Param "version") "." }}
+{{ $itemName := .Get 0 }}
+
+<div class="version-list">
+    <p>
+        {{ printf (T "docs_page_versions") $itemName (delimit $thisVersionArray ".") }}
+    </p>
+    <ul>
+        {{ range $index, $version := $versions }}
+            {{ if ne .version ( delimit $thisVersionArray "." ) }}
+            <li>
+                <a href="{{ .url }}{{ $thisPageRelUri }}">{{ $thisPageTitle }} (Kubernetes {{ .version }})</a>
+            </li>
+            {{ end }}
+        {{ end }}
+    </ul>
+</div>

--- a/layouts/shortcodes/legacy-repos-deprecation.html
+++ b/layouts/shortcodes/legacy-repos-deprecation.html
@@ -1,0 +1,3 @@
+<div class="alert alert-secondary callout note" role="alert">
+    <strong>{{ T "note" | safeHTML }}</strong> {{ T "legacy_repos_message" | markdownify }}
+</div>


### PR DESCRIPTION
The legacy package repositories (`apt.kubernetes.io` and `yum.kuberentes.io`) are deprecated and frozen. All Kubernetes versions released after September 13, 2023 are published only to the new package repositories hosted at pkgs.k8s.io. Because of that, I think we should update legacy docs to replace legacy repos with the new Kubernetes package repositories.

This is a manual cherry-pick of the followings PRs:

- #42022
- #43407
- #43458
- #43472
- #43478

Note: there might be some other updates included in this PR such as:

- https://github.com/kubernetes/website/pull/43524#discussion_r1362227256

/assign @saschagrunert @cpanato @jeremyrickard 
cc @kubernetes/release-engineering 