### PR TITLE
Update enforce-standards-admission-controller.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -33,12 +33,12 @@ For v1.22, use [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-
 {{< /note >}}
 
 ```yaml
-apiVersion: apiserver.config.k8s.io/v1 # see compatibility note
+apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - name: PodSecurity
   configuration:
-    apiVersion: pod-security.admission.config.k8s.io/v1
+    apiVersion: pod-security.admission.config.k8s.io/v1 # see compatibility note
     kind: PodSecurityConfiguration
     # Defaults applied when a mode label is not set.
     #


### PR DESCRIPTION
It seems comment was set to a wrong field. There is no need to change apiserver.config.k8s.io/VERSION, we need to modify only pod-security.admission.config.k8s.io/VERSION

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
