### PR TITLE
Make sidebar show up when Javascript is disabled

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -52,5 +52,19 @@
   }
 </script>
 
+<!--for the side menu to show up on desktop even if JavaScript is turned off-->
+<noscript>
+  <style>
+    #sidebarnav {
+      width: calc(20% - 5px);
+    }
+    #maindoc{
+      width: calc(80% - 5px);
+    }
+    #td-sidebar-menu {
+      display: block !important;
+    }
+  </style>
+</noscript>
 
 {{ partial "hooks/body-end.html" . }}


### PR DESCRIPTION
Make sidebar of the documentation show up even if Javascript is turned off.

This will work only on the desktop size. But it's better than not having it.

Fixes: https://github.com/kubernetes/website/issues/43275