### PR TITLE
Updated (zh-cn) Set up kubectl on Linux docs

### DIFF
--- a/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
@@ -56,10 +56,10 @@ The following methods exist for installing kubectl on Linux:
 
    {{< tabs name="download_binary_linux" >}}
    {{< tab name="x86-64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
    {{< /tab >}}
    {{< tab name="ARM64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
    {{< /tab >}}
    {{< /tabs >}}
 
@@ -100,10 +100,10 @@ The following methods exist for installing kubectl on Linux:
 
    {{< tabs name="download_checksum_linux" >}} 
    {{< tab name="x86-64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
    {{< /tab >}}
    {{< tab name="ARM64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
    {{< /tab >}}
    {{< /tabs >}}
 
@@ -239,17 +239,17 @@ Or use this for detailed view of version:
    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-   {{< note >}}
+{{< note >}}
    <!--
    To upgrade kubectl to another minor release, you'll need to bump the version in
    `/etc/apt/sources.list.d/kubernetes.list` before running `apt-get update` and
    `apt-get upgrade`. This procedure is described in more detail in
    [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
    -->
-   要升级 kubectl 到别的次要版本，你需要先升级 `/etc/apt/sources.list.d/kubernetes.list` 中的版本，
-   再运行 `apt-get update` 和 `apt-get upgrade`。
-   更详细的步骤可以在[更改 Kubernetes 软件包仓库](/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository/)中找到。
-   {{< /note >}}
+要升级 kubectl 到别的次要版本，你需要先升级 `/etc/apt/sources.list.d/kubernetes.list` 中的版本，
+再运行 `apt-get update` 和 `apt-get upgrade`。
+更详细的步骤可以在[更改 Kubernetes 软件包仓库](/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository/)中找到。
+{{< /note >}}
 
 <!--
 4. Update `apt` package index, then install kubectl:
@@ -326,6 +326,51 @@ To upgrade kubectl to another minor release, you'll need to bump the version in 
    ```
 
 {{% /tab %}}
+
+{{% tab name="基于 SUSE 的发行版" %}}
+<!-- 
+Add the Kubernetes zypper repository. If you want to use Kubernetes version different than {{< param "version" >}}, replace {{< param "version" >}} with the desired minor version in the command below.
+ -->
+
+1. 添加 Kubernetes `zypper` 软件源。如果您想使用不同于 {{< param "version" >}} 的 Kubernetes 版本，请在下面的命令中将 {{< param "version" >}} 替换为所需的次要版本。
+
+<!-- 
+# This overwrites any existing configuration in /etc/zypp/repos.d/kubernetes.repo
+cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+EOF
+ -->
+```shell
+# 这将覆盖 /etc/zypp/repos.d/kubernetes.repo 中的任何现有配置。
+cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+EOF
+```
+{{< note >}}
+   <!--
+   To upgrade kubectl to another minor release, you'll need to bump the version in /etc/zypp/repos.d/kubernetes.repo before running zypper update. This procedure is described in more detail in
+   [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+   -->
+要升级 kubectl 到另一个小版本，您需要在运行 `zypper update` 之前提升 `/etc/zypp/repos.d/kubernetes.repo`中的版本。此过程在《更改 Kubernetes 软件包存储库》中有更详细的描述。
+{{< /note >}}
+
+2. 使用 `zypper` 安装 kubectl:
+   ```bash
+   sudo zypper install -y kubectl
+
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 <!--

--- a/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
@@ -329,45 +329,53 @@ To upgrade kubectl to another minor release, you'll need to bump the version in 
 
 {{% tab name="基于 SUSE 的发行版" %}}
 <!-- 
-Add the Kubernetes zypper repository. If you want to use Kubernetes version different than {{< param "version" >}}, replace {{< param "version" >}} with the desired minor version in the command below.
- -->
+1. Add the Kubernetes `zypper` repository. If you want to use Kubernetes version
+different than {{< param "version" >}}, replace {{< param "version" >}} with
+the desired minor version in the command below.
+-->
 
 1. 添加 Kubernetes `zypper` 软件源。如果您想使用不同于 {{< param "version" >}} 的 Kubernetes 版本，请在下面的命令中将 {{< param "version" >}} 替换为所需的次要版本。
 
 <!-- 
+```bash
 # This overwrites any existing configuration in /etc/zypp/repos.d/kubernetes.repo
 cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
 EOF
+```
  -->
-```shell
+```bash
 # 这将覆盖 /etc/zypp/repos.d/kubernetes.repo 中的任何现有配置。
 cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
 EOF
 ```
 {{< note >}}
-   <!--
-   To upgrade kubectl to another minor release, you'll need to bump the version in /etc/zypp/repos.d/kubernetes.repo before running zypper update. This procedure is described in more detail in
+<!--
+   To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/zypp/repos.d/kubernetes.repo` before running `zypper update`. This procedure is described in more detail in
    [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
-   -->
-要升级 kubectl 到另一个小版本，您需要在运行 `zypper update` 之前提升 `/etc/zypp/repos.d/kubernetes.repo`中的版本。此过程在《更改 Kubernetes 软件包存储库》中有更详细的描述。
+-->
+要升级 kubectl 到另一个小版本，你需要先更新 `/etc/zypp/repos.d/kubernetes.repo` 的版本，
+再运行 `zypper update`。此过程在[更改 Kubernetes 软件包仓库](/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository/) 中有更详细的描述。
 {{< /note >}}
 
+<!--
+	2. Install kubectl using `zypper`:
+-->
 2. 使用 `zypper` 安装 kubectl:
    ```bash
    sudo zypper install -y kubectl
-
+   ```
 
 {{% /tab %}}
 


### PR DESCRIPTION
Subject: New PR (zn-cn) for 'Install and Set Up kubectl on Linux' Documentation Fixes
Solves the issue : https://github.com/kubernetes/website/issues/43366

Dear Reviewers and Maintainers,
I sincerely apologize for the confusion caused by the creation and subsequent closure of multiple Pull Requests (PRs) for the same issue , and I deeply regret any inconvenience this may have caused.
Related PR:#43393 #43481
I have made the relevant changes to the (zh-cn) kubectl installation documentation.

Fix 1:
fixed the typo error in the zn-ch docs for Installation and Setting Up kubectl on Linux

![1](https://github.com/kubernetes/website/assets/76515568/e657b563-ec93-4c5e-b214-1194562652d1)


Fix 2:
Translated the new tab about SUSE-based distributions (zn-ch)

![2](https://github.com/kubernetes/website/assets/76515568/c36f2982-350c-450c-a3d4-05e168d57622)

image

Fix 3:

Fixed the content merging of two tabs in Install using native package management

![3](https://github.com/kubernetes/website/assets/76515568/10220478-d536-4b20-8425-b0995bd50b2a)

