### PR TITLE
Fix typo in deprecation-guide.md at v1.26

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -53,7 +53,7 @@ The **v1.26** release stopped serving the following deprecated API versions:
 
 The **flowcontrol.apiserver.k8s.io/v1beta1** API version of FlowSchema and PriorityLevelConfiguration is no longer served as of v1.26.
 
-* Migrate manifests and API clients to use the **flowcontrol.apiserver.k8s.io/v1beta3** API version, available since v1.26.
+* Migrate manifests and API clients to use the **flowcontrol.apiserver.k8s.io/v1beta2** API version.
 * All existing persisted objects are accessible via the new API
 * No notable changes
 


### PR DESCRIPTION
This seems to have been erroneously copy-pasted from the v1.29 paragraph. It should be `v1beta2` and that's available since before `1.0.0`. I did not check for the exact version because I think no one cares.