### PR TITLE
Remove grpc container probe feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
@@ -203,6 +203,9 @@ In the following table:
 | `ExternalPolicyForExternalIP` | `true` | GA | 1.18 | 1.22 |
 | `GCERegionalPersistentDisk` | `true` | Beta | 1.10 | 1.12 |
 | `GCERegionalPersistentDisk` | `true` | GA | 1.13 | 1.16 |
+| `GRPCContainerProbe` | `false` | Alpha | 1.23 | 1.23 |
+| `GRPCContainerProbe` | `true` | Beta | 1.24 | 1.26 |
+| `GRPCContainerProbe` | `true` | GA | 1.27 | 1.28 |
 | `GenericEphemeralVolume` | `false` | Alpha | 1.19 | 1.20 |
 | `GenericEphemeralVolume` | `true` | Beta | 1.21 | 1.22 |
 | `GenericEphemeralVolume` | `true` | GA | 1.23 | 1.24 |
@@ -703,6 +706,9 @@ In the following table:
   applied to Service ExternalIPs.
 
 - `GCERegionalPersistentDisk`: Enable the regional PD feature on GCE.
+
+- `GRPCContainerProbe`: Enables the gRPC probe method for {Liveness,Readiness,Startup}Probe.
+  See [Configure Liveness, Readiness and Startup Probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe).
 
 - `GenericEphemeralVolume`: Enables ephemeral, inline volumes that support all features
   of normal volumes (can be provided by third-party storage vendors, storage capacity tracking,

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -263,9 +263,6 @@ For a reference to old feature gates that are removed, please refer to
 | `ExpandedDNSConfig` | `true` | GA | 1.28 | |
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | 1.27 |
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Deprecated | 1.28 | |
-| `GRPCContainerProbe` | `false` | Alpha | 1.23 | 1.23 |
-| `GRPCContainerProbe` | `true` | Beta | 1.24 | 1.26 |
-| `GRPCContainerProbe` | `true` | GA | 1.27 | |
 | `IPTablesOwnershipCleanup` | `false` | Alpha | 1.25 | 1.26 |
 | `IPTablesOwnershipCleanup` | `true` | Beta | 1.27 | 1.27 |
 | `IPTablesOwnershipCleanup` | `true` | GA | 1.28 | |
@@ -515,8 +512,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
   for more details.
 - `GracefulNodeShutdownBasedOnPodPriority`: Enables the kubelet to check Pod priorities
   when shutting down a node gracefully.
-- `GRPCContainerProbe`: Enables the gRPC probe method for {Liveness,Readiness,Startup}Probe.
-  See [Configure Liveness, Readiness and Startup Probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe).
 - `HonorPVReclaimPolicy`: Honor persistent volume reclaim policy when it is `Delete` irrespective of PV-PVC deletion ordering.
   For more details, check the
   [PersistentVolume deletion protection finalizer](/docs/concepts/storage/persistent-volumes/#persistentvolume-deletion-protection-finalizer)


### PR DESCRIPTION
Since https://github.com/kubernetes/kubernetes/pull/120248 was merged for v1.29.

https://github.com/kubernetes/website/blob/63b39839b87d4dea04624d8fbbadd1ac55f28ff2/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md#L73-L76
- should we remove this part as well?old blog may not need to be updated.