### PR TITLE
Topology manager remove

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
@@ -393,6 +393,9 @@ In the following table:
 | `TokenRequestProjection` | `false` | Alpha | 1.11 | 1.11 |
 | `TokenRequestProjection` | `true` | Beta | 1.12 | 1.19 |
 | `TokenRequestProjection` | `true` | GA | 1.20 | 1.21 |
+| `TopologyManager` | `false` | Alpha | 1.16 | 1.17 |	
+| `TopologyManager` | `true` | Beta | 1.18 | 1.26 |	
+| `TopologyManager` | `true` | GA | 1.27 | 1.28 |
 | `UserNamespacesStatelessPodsSupport` | `false` | Alpha | 1.25 | 1.27 |
 | `ValidateProxyRedirects` | `false` | Alpha | 1.12 | 1.13 |
 | `ValidateProxyRedirects` | `true` | Beta | 1.14 | 1.21 |
@@ -919,6 +922,10 @@ In the following table:
 
 - `TokenRequestProjection`: Enable the injection of service account tokens into a Pod through a
   [`projected` volume](/docs/concepts/storage/volumes/#projected).
+
+- `TopologyManager`: Enable a mechanism to coordinate fine-grained hardware resource	
+  assignments for different components in Kubernetes. See	
+  [Control Topology Management Policies on a node](/docs/tasks/administer-cluster/topology-manager/).
 
 - `UserNamespacesStatelessPodsSupport`: Enable user namespace support for stateless Pods. This flag was renamed on newer releases to `UserNamespacesSupport`.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -322,9 +322,6 @@ For a reference to old feature gates that are removed, please refer to
 | `ServerSideFieldValidation` | `false` | Alpha | 1.23 | 1.24 |
 | `ServerSideFieldValidation` | `true` | Beta | 1.25 | 1.26 |
 | `ServerSideFieldValidation` | `true` | GA | 1.27 | - |
-| `TopologyManager` | `false` | Alpha | 1.16 | 1.17 |
-| `TopologyManager` | `true` | Beta | 1.18 | 1.26 |
-| `TopologyManager` | `true` | GA | 1.27 | - |
 | `WatchBookmark` | `false` | Alpha | 1.15 | 1.15 |
 | `WatchBookmark` | `true` | Beta | 1.16 | 1.16 |
 | `WatchBookmark` | `true` | GA | 1.17 | - |
@@ -738,9 +735,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
   in EndpointSlices. See [Topology Aware
   Hints](/docs/concepts/services-networking/topology-aware-hints/) for more
   details.
-- `TopologyManager`: Enable a mechanism to coordinate fine-grained hardware resource
-  assignments for different components in Kubernetes. See
-  [Control Topology Management Policies on a node](/docs/tasks/administer-cluster/topology-manager/).
 - `TopologyManagerPolicyAlphaOptions`: Allow fine-tuning of topology manager policies,
   experimental, Alpha-quality options.
   This feature gate guards *a group* of topology manager options whose quality level is alpha.


### PR DESCRIPTION
Move feature gates TopologyManager to  feature-gates-removed page
Ref: https://github.com/kubernetes/kubernetes/pull/121252