### PR TITLE
update documentation for component-slis

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -85,8 +85,6 @@ For a reference to old feature gates that are removed, please refer to
 | `CloudDualStackNodeIPs` | false | Alpha | 1.27 | 1.28 |
 | `CloudDualStackNodeIPs` | true | Beta | 1.29 | |
 | `ClusterTrustBundle` | false | Alpha | 1.27 | |
-| `ComponentSLIs` | `false` | Alpha | 1.26 | 1.26 |
-| `ComponentSLIs` | `true` | Beta | 1.27 | |
 | `ConsistentListFromCache` | `false` | Alpha | 1.28 |
 | `ContainerCheckpoint` | `false` | Alpha | 1.25 | |
 | `ContextualLogging` | `false` | Alpha | 1.24 | |
@@ -245,6 +243,9 @@ For a reference to old feature gates that are removed, please refer to
 | `CSIMigrationvSphere` | `false` | Beta | 1.19 | 1.24 |
 | `CSIMigrationvSphere` | `true` | Beta | 1.25 | 1.25 |
 | `CSIMigrationvSphere` | `true` | GA | 1.26 | - |
+| `ComponentSLIs` | `false` | Alpha | 1.26 | 1.26 |
+| `ComponentSLIs` | `true` | Beta | 1.27 | 1.28|
+| `ComponentSLIs` | `true` | GA | 1.29 | - |
 | `ConsistentHTTPGetHandlers` | `true` | GA | 1.25 | - |
 | `DaemonSetUpdateSurge` | `false` | Alpha | 1.21 | 1.21 |
 | `DaemonSetUpdateSurge` | `true` | Beta | 1.22 | 1.24 |

--- a/content/en/docs/reference/instrumentation/slis.md
+++ b/content/en/docs/reference/instrumentation/slis.md
@@ -9,7 +9,7 @@ weight: 20
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.27" state="beta" >}}
+{{< feature-state for_k8s_version="v1.29" state="stable" >}}
 
 By default, Kubernetes {{< skew currentVersion >}} publishes Service Level Indicator (SLI) metrics 
 for each Kubernetes component binary. This metric endpoint is exposed on the serving 


### PR DESCRIPTION
Component SLIs is graduating to GA. This updates the documentation accordingly.