### PR TITLE
update SkipReadOnlyValidationGCE status to Deprecated

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -191,7 +191,6 @@ For a reference to old feature gates that are removed, please refer to
 | `SidecarContainers` | `false` | Alpha | 1.28 | |
 | `SizeMemoryBackedVolumes` | `false` | Alpha | 1.20 | 1.21 |
 | `SizeMemoryBackedVolumes` | `true` | Beta | 1.22 | |
-| `SkipReadOnlyValidationGCE` | `false` | Alpha | 1.28 | |
 | `StableLoadBalancerNodeSet` | `true` | Beta | 1.27 | |
 | `StatefulSetAutoDeletePVC` | `false` | Alpha | 1.23 | 1.26 |
 | `StatefulSetAutoDeletePVC` | `false` | Beta | 1.27 | |
@@ -318,6 +317,8 @@ For a reference to old feature gates that are removed, please refer to
 | `ServiceNodePortStaticSubrange` | `false` | Alpha | 1.27 | 1.27 |
 | `ServiceNodePortStaticSubrange` | `true` | Beta | 1.28 | 1.28 |
 | `ServiceNodePortStaticSubrange` | `true` | GA | 1.29 | - |
+| `SkipReadOnlyValidationGCE` | `false` | Alpha | 1.28 | 1.28 |
+| `SkipReadOnlyValidationGCE` | `true` | Deprecated | 1.29 | |
 | `TopologyManager` | `false` | Alpha | 1.16 | 1.17 |
 | `TopologyManager` | `true` | Beta | 1.18 | 1.26 |
 | `TopologyManager` | `true` | GA | 1.27 | - |


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/121083
