### PR TITLE
Add patch release dates for January, February, and March 2024

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -80,6 +80,9 @@ releases may also occur in between these.
 | --------------------- | -------------------- | ----------- |
 | November 2023         | N/A                  | N/A         |
 | December 2023         | 2023-12-01           | 2023-12-06  |
+| January 2024          | 2024-01-12           | 2024-01-17  |
+| February 2024         | 2024-02-09           | 2024-02-14  |
+| March 2024            | 2024-03-08           | 2024-03-13  |
 
 **Note:** Due to overlap with KubeCon NA 2023 and the resulting lack of
 availability of Release Managers, it has been decided to skip patch releases


### PR DESCRIPTION
This PR adds patch release dates for January, February, and March 2024. The patch release dates were selected with the following in mind:

- December patch releases being very in December
- KubeCon EU being around mid-March

/assign @saschagrunert @cpanato @Verolop
cc @kubernetes/release-engineering 