### PR TITLE
Update KubeCon dates for NA 2023/EU 2024

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -47,12 +47,12 @@ To download Kubernetes, visit the [download](/releases/download/) section.
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on April 18-21, 2023</a>
-        <br>
-        <br>
-        <br>
-        <br>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 6-9, 2023</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on March 19-22, 2024</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Seeing #43565 made me realise that the KubeCon 2023 dates, currently displayed at https://kubernetes.io/, are outdated. This tiny PR puts the upcoming KubeCon 2023 NA first and adds KubeCon 2024 EU.
