### PR TITLE
Update deployment.md to remove containerPort

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -1222,8 +1222,6 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.14.2
-        ports:
-        - containerPort: 80
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1253,8 +1251,6 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.14.2
-        ports:
-        - containerPort: 80
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1284,8 +1280,6 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.14.2
-        ports:
-        - containerPort: 80
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Removes `containerPort` from the example specs as it is not explained nor required.