### PR TITLE
fix: List of removed feature gates shows feature removed in future release (TopologyManager)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed.md
@@ -393,9 +393,6 @@ In the following table:
 | `TokenRequestProjection` | `false` | Alpha | 1.11 | 1.11 |
 | `TokenRequestProjection` | `true` | Beta | 1.12 | 1.19 |
 | `TokenRequestProjection` | `true` | GA | 1.20 | 1.21 |
-| `TopologyManager` | `false` | Alpha | 1.16 | 1.17 |	
-| `TopologyManager` | `true` | Beta | 1.18 | 1.26 |	
-| `TopologyManager` | `true` | GA | 1.27 | 1.28 |
 | `UserNamespacesStatelessPodsSupport` | `false` | Alpha | 1.25 | 1.27 |
 | `ValidateProxyRedirects` | `false` | Alpha | 1.12 | 1.13 |
 | `ValidateProxyRedirects` | `true` | Beta | 1.14 | 1.21 |
@@ -922,10 +919,6 @@ In the following table:
 
 - `TokenRequestProjection`: Enable the injection of service account tokens into a Pod through a
   [`projected` volume](/docs/concepts/storage/volumes/#projected).
-
-- `TopologyManager`: Enable a mechanism to coordinate fine-grained hardware resource	
-  assignments for different components in Kubernetes. See	
-  [Control Topology Management Policies on a node](/docs/tasks/administer-cluster/topology-manager/).
 
 - `UserNamespacesStatelessPodsSupport`: Enable user namespace support for stateless Pods. This flag was renamed on newer releases to `UserNamespacesSupport`.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -322,6 +322,9 @@ For a reference to old feature gates that are removed, please refer to
 | `ServerSideFieldValidation` | `false` | Alpha | 1.23 | 1.24 |
 | `ServerSideFieldValidation` | `true` | Beta | 1.25 | 1.26 |
 | `ServerSideFieldValidation` | `true` | GA | 1.27 | - |
+| `TopologyManager` | `false` | Alpha | 1.16 | 1.17 |
+| `TopologyManager` | `true` | Beta | 1.18 | 1.26 |
+| `TopologyManager` | `true` | GA | 1.27 | - |
 | `WatchBookmark` | `false` | Alpha | 1.15 | 1.15 |
 | `WatchBookmark` | `true` | Beta | 1.16 | 1.16 |
 | `WatchBookmark` | `true` | GA | 1.17 | - |
@@ -735,6 +738,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
   in EndpointSlices. See [Topology Aware
   Hints](/docs/concepts/services-networking/topology-aware-hints/) for more
   details.
+- `TopologyManager`: Enable a mechanism to coordinate fine-grained hardware resource
+  assignments for different components in Kubernetes. See
+  [Control Topology Management Policies on a node](/docs/tasks/administer-cluster/topology-manager/).
 - `TopologyManagerPolicyAlphaOptions`: Allow fine-tuning of topology manager policies,
   experimental, Alpha-quality options.
   This feature gate guards *a group* of topology manager options whose quality level is alpha.


### PR DESCRIPTION
Corrected information about the removal of the TopologyManager feature gate.

Updated the pages:
- https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
- https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/

The list of removed feature gates incorrectly stated that the last release to include the TopologyManager feature gate was v1.28. However, until the v1.29 release comes out, it is not confirmed. The correction reflects the uncertainty regarding the removal in future releases.
#43613 