### PR TITLE
Document Kubernetes' use of WebSockets (replacement for SPDY / KEP 4006)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -205,6 +205,7 @@ For a reference to old feature gates that are removed, please refer to
 | `TopologyManagerPolicyBetaOptions` | `true` | Beta | 1.28 | |
 | `TopologyManagerPolicyOptions` | `false` | Alpha | 1.26 | 1.27 |
 | `TopologyManagerPolicyOptions` | `true` | Beta | 1.28 | |
+| `TranslateStreamCloseWebsocketRequests` | `false` | Alpha | 1.29 | |
 | `UnknownVersionInteroperabilityProxy` | `false` | Alpha | 1.28 | |
 | `UserNamespacesSupport` | `false` | Alpha | 1.28 | |
 | `ValidatingAdmissionPolicy` | `false` | Alpha | 1.26 | 1.27 |
@@ -739,6 +740,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
   This feature gate guards *a group* of topology manager options whose quality level is beta.
   This feature gate will never graduate to stable.
 - `TopologyManagerPolicyOptions`: Allow fine-tuning of topology manager policies,
+- `TranslateStreamCloseWebsocketRequests`: Allow WebSocket streaming of the
+  remote command sub-protocol (`exec`, `cp`, `attach`) from clients requesting
+  version 5 (v5) of the sub-protocol.
 - `UnknownVersionInteroperabilityProxy`: Proxy resource requests to the correct peer kube-apiserver when
   multiple kube-apiservers exist at varied versions.
   See [Mixed version proxy](/docs/concepts/architecture/mixed-version-proxy/) for more information.

--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -369,6 +369,14 @@ kubectl [flags]
 </td>
 </tr>
 
+<tr>
+<td colspan="2">KUBECTL_REMOTE_COMMAND_WEBSOCKETS</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, the kubectl exec, cp, and attach commands will attempt to stream using the websockets protocol. If the upgrade to websockets fails, the commands will fallback to use the current SPDY protocol.
+</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
* Adds documentation for new alpha `TranslateStreamCloseWebsocketRequests` feature flag, allowing the control plane to accept WebSockets/V5 upgrade requests.
* Adds documentation for new alpha kubectl  environment variable `KUBECTL_REMOTE_COMMAND_WEBSOCKETS` feature flag, which attempts to use the WebSockets protocol for `kubectl exec`, `kubectl cp`, and `kubectl attach` when it is set.