### PR TITLE
Fix Kubeadm install layout break for mobile device

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -902,9 +902,16 @@ section#cncf {
   margin: 0;
 }
 
+//Table Content
+.tab-content table{
+  border-collapse: separate;
+  border-spacing: 6px;
+}
+
 .tab-pane {
   border-radius: 0.25rem;
   padding: 0 16px 16px;
+  overflow: auto;
 
   border: 1px solid #dee2e6;
   &:first-of-type.active {


### PR DESCRIPTION
Fix Issue: #43265
Issue: Code snippet layout at "Kubeadm install" page is causing layout break of page for mobile devices
**Changes made:**
Added some css  for making adjustment in table layout that are under tabs

![image](https://github.com/kubernetes/website/assets/76515568/db3f9960-9a2a-4cf1-a7fa-671efeebfb7b)
