### PR TITLE
[pt-br] Update linkTitle for docs home page

### DIFF
--- a/content/pt-br/docs/home/_index.md
+++ b/content/pt-br/docs/home/_index.md
@@ -6,7 +6,7 @@ noedit: true
 cid: docsHome
 layout: docsportal_home
 class: gridPage gridPageHome
-linkTitle: "Home"
+linkTitle: "Documentação"
 main_menu: true
 weight: 10
 hide_feedback: true


### PR DESCRIPTION
This PR fixes the footer string that was changed in PR #42962, as explained in issue #43068.