### PR TITLE
[zh] sync concepts/architecture/cgroups.md

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/cgroups.md
+++ b/content/zh-cn/docs/concepts/architecture/cgroups.md
@@ -195,8 +195,8 @@ cgroup v2 使用一个与 cgroup v1 不同的 API，因此如果有任何应用�
  DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
  * If you deploy Java applications, prefer to use versions which fully support cgroup v2:
     * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
-    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
-    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
+    * [IBM Semeru Runtimes](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.382.0, 11.0.20.0, 17.0.8.0, and later
+    * [IBM Java](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.8.6 and later
 * If you are using the [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) package, make sure
   the version you use is v1.5.1 or higher.
 -->
@@ -205,8 +205,8 @@ cgroup v2 使用一个与 cgroup v1 不同的 API，因此如果有任何应用�
   需将其更新到 v0.43.0 或更高版本。
 * 如果你部署 Java 应用程序，最好使用完全支持 cgroup v2 的版本：
     * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372、11.0.16、15 及更高的版本
-    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01、11.0.16.0、17.0.4.0、18.0.2.0 及更高的版本
-    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 及更高的版本
+    * [IBM Semeru Runtimes](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.382.0、11.0.20.0、17.0.8.0 及更高的版本
+    * [IBM Java](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.8.6 及更高的版本
 * 如果你正在使用 [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) 包，
   确保你使用的版本是 v1.5.1 或者更高。
 


### PR DESCRIPTION
## PR Summary

- **EN upstream**: `content/en/docs/concepts/architecture/cgroups.md`
- **Sync to**: `content/zh-cn/docs/concepts/architecture/cgroups.md`

Sync check by `scripts/lsync.sh` on `main` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/architecture/cgroups.md
diff --git a/content/en/docs/concepts/architecture/cgroups.md b/content/en/docs/concepts/architecture/cgroups.md
index b0a98af660..b96d89e0d6 100644
--- a/content/en/docs/concepts/architecture/cgroups.md
+++ b/content/en/docs/concepts/architecture/cgroups.md
@@ -104,8 +104,8 @@ updated to newer versions that support cgroup v2. For example:
  DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
 * If you deploy Java applications, prefer to use versions which fully support cgroup v2:
     * [OpenJDK / HotSpot](https://bugs.openjdk.org/browse/JDK-8230305): jdk8u372, 11.0.16, 15 and later
-    * [IBM Semeru Runtimes](https://www.eclipse.org/openj9/docs/version0.33/#control-groups-v2-support): jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
-    * [IBM Java](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=new-service-refresh-7#whatsnew_sr7__fp15): 8.0.7.15 and later
+    * [IBM Semeru Runtimes](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.382.0, 11.0.20.0, 17.0.8.0, and later
+    * [IBM Java](https://www.ibm.com/support/pages/apar/IJ46681): 8.0.8.6 and later
 * If you are using the [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) package, make sure
   the version you use is v1.5.1 or higher.

```
Sync check by`scripts/lsync.sh` on `sync/cgroup_20231022` branch:
```diff
$ scripts/lsync.sh content/zh-cn/docs/concepts/architecture/cgroups.md
content/zh-cn/docs/concepts/architecture/cgroups.md is still in sync
```

Thanks to the reviewers in advance.
Best Regards,

Kivinsae Fang