### PR TITLE
[ja] Translate reference/glossary/admission-controller.md & affinity.md & aggregation-layer.md & annotation.md & api-group.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/admission-controller.md
+++ b/content/ja/docs/reference/glossary/admission-controller.md
@@ -1,0 +1,20 @@
+---
+title: アドミッションコントローラー
+id: admission-controller
+date: 2019-06-28
+full_link: /docs/reference/access-authn-authz/admission-controllers/
+short_description: >
+  オブジェクトを永続化する前に、Kubernetes APIサーバーへのリクエストをインターセプトするコード。
+
+aka:
+tags:
+- extension
+- security
+---
+  オブジェクトを永続化する前に、Kubernetes APIサーバーへのリクエストをインターセプトするコード。
+
+<!--more-->
+
+アドミッションコントローラーはKubernetes APIサーバー用に構成可能で、検証・変更、またはその両方を行うことができます。アドミッションコントローラーはリクエストを拒否する可能性があります。変更コントローラーは、許可するオブジェクトを変更する可能性があります。コントローラーの検証ではできない場合があります。
+
+* [Admission controllers in the Kubernetes documentation](/docs/reference/access-authn-authz/admission-controllers/)

--- a/content/ja/docs/reference/glossary/affinity.md
+++ b/content/ja/docs/reference/glossary/affinity.md
@@ -1,0 +1,19 @@
+---
+title: アフィニティ
+id: affinity
+date: 2019-01-11
+full_link: /ja/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+short_description: >
+     ポッドを配置する場所を決定するためにスケジューラによって使用されるルール
+aka:
+tags:
+- fundamental
+---
+
+Kubernetesでは、_affinity_ はポッドを配置する場所に関するヒントをスケジューラに与える一連のルールです。
+<!--more-->
+アフィニティには次の2種類があります:
+* Nodeアフィニティ](/ja/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+* [Pod間のアフィニティとアンチアフィニティ](/ja/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
+
+ルールは、Kubernetes{{< glossary_tooltip term_id="label" text="ラベル">}}と{{< glossary_tooltip term_id="pod" text="ポッド" >}}で指定された{{< glossary_tooltip term_id="selector" text="セレクター">}}を使用して定義され、スケジューラにどれだけ厳密にルールを適用するかに応じて、必須または優先のいずれかにすることができます。

--- a/content/ja/docs/reference/glossary/aggregation-layer.md
+++ b/content/ja/docs/reference/glossary/aggregation-layer.md
@@ -1,0 +1,19 @@
+---
+title: アグリゲーションレイヤー
+id: aggregation-layer
+date: 2018-10-08
+full_link: /docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
+short_description: >
+  アグリゲーションレイヤーを使用すると、追加のKubernetesスタイルのAPIをクラスターにインストールできます。
+
+aka: 
+tags:
+- architecture
+- extension
+- operation
+---
+ アグリゲーションレイヤーを使用すると、追加のKubernetesスタイルのAPIをクラスターにインストールできます。
+
+<!--more-->
+
+{{< glossary_tooltip text="Kubernetes API Server" term_id="kube-apiserver" >}}を[support additional APIs](/docs/tasks/extend-kubernetes/configure-aggregation-layer/)に設定すると, `APIService`オブジェクトを追加してKubernetes APIのパスを要求できます。

--- a/content/ja/docs/reference/glossary/annotation.md
+++ b/content/ja/docs/reference/glossary/annotation.md
@@ -1,0 +1,15 @@
+---
+title: アノテーション
+id: annotation
+date: 2018-04-12
+full_link: /ja/docs/concepts/overview/working-with-objects/annotations
+short_description: >
+  任意の非識別メタデータをオブジェクトにアタッチするために使用されるキーと値のペア。
+aka: 
+tags:
+- fundamental
+---
+ 任意の非識別メタデータをオブジェクトにアタッチするために使用されるキーと値のペア。
+<!--more--> 
+
+アノテーション内のメタデータには、大小、構造化、非構造化があり、{{< glossary_tooltip text="labels" term_id="label" >}}で許可されていない文字を含めることができます。ツールやライブラリなどのクライアントは、このメタデータを取得できます。

--- a/content/ja/docs/reference/glossary/api-group.md
+++ b/content/ja/docs/reference/glossary/api-group.md
@@ -1,0 +1,17 @@
+---
+title: APIグループ
+id: api-group
+date: 2019-09-02
+full_link: /ja/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
+short_description: >
+  Kubernetes APIの関連するパスのセット。
+aka:
+tags:
+- fundamental
+- architecture
+---
+Kubernetes APIの関連するパスのセット。
+<!--more-->
+APIサーバーの構成を変更することで、各APIグループを有効または無効にできます。特定のリソースへのパスを無効または有効にすることもできます。APIグループを使用すると、Kubernetes APIを簡単に拡張できます。APIグループは、RESTパスとシリアル化されたオブジェクトの`apiVersion`フィールドで指定されます。
+
+* 詳しくは [APIグループ](/ja/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning)をご覧ください。


### PR DESCRIPTION
This is a Feature Request

What would you like to be added

Translate following files into Japanese.
https://kubernetes.io/docs/reference/glossary/?all=true#term-admission-controller
https://kubernetes.io/docs/reference/glossary/?all=true#term-affinity
https://kubernetes.io/docs/reference/glossary/?all=true#term-aggregation-layer
https://kubernetes.io/docs/reference/glossary/?all=true#term-annotation
https://kubernetes.io/docs/reference/glossary/?all=true#term-api-group

Why is this needed
This page has not been translated.

Comments

/language ja
/assign