### PR TITLE
Adjust the title level of "Validation rules" on custom-resource-definitions.md

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -769,7 +769,7 @@ validations are not supported by ratcheting under the implementation in Kubernet
   ratcheted.
 
 
-## Validation rules
+### Validation rules
 
 {{< feature-state state="beta" for_k8s_version="v1.25" >}}
 


### PR DESCRIPTION
Adjusted the title level of "Validation rules" from h2 to h3 to align with the "Advanced topics" section it belongs to.




<img width="365" alt="Screenshot 2023-10-22 at 22 19 06" src="https://github.com/kubernetes/website/assets/26692080/243b2a92-41de-47c6-91c7-d5c37117da3b">

---
<img width="265" alt="Screenshot 2023-10-22 at 22 24 37" src="https://github.com/kubernetes/website/assets/26692080/20ac7925-d701-41c5-bb6b-98b64948bd9c">





