### PR TITLE
[zh-cn]fix a localization typo: download kubectl checksum file command

### DIFF
--- a/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh-cn/docs/tasks/tools/install-kubectl-linux.md
@@ -100,10 +100,10 @@ The following methods exist for installing kubectl on Linux:
 
    {{< tabs name="download_checksum_linux" >}} 
    {{< tab name="x86-64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
    {{< /tab >}}
    {{< tab name="ARM64" codelang="bash" >}}
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
    {{< /tab >}}
    {{< /tabs >}}
 


### PR DESCRIPTION
the checksum file command is to download kubectl checksum file rather than kubectl binary file. 
Related PR: https://github.com/kubernetes/website/pull/43543. This pr contributed to the wrong checksum file command
