### PR TITLE
[pt-br] Update obsolete links in Portuguese locale

### DIFF
--- a/content/pt-br/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/_index.html
@@ -62,25 +62,25 @@ card:
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/pt/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
+                <a href="/pt-br/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/pt/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><h5>1. Criar um cluster Kubernetes</h5></a>
+                  <a href="/pt-br/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><h5>1. Criar um cluster Kubernetes</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/pt/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
+                <a href="/pt-br/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/pt/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><h5>2. Implantar um aplicativo</h5></a>
+                  <a href="/pt-br/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><h5>2. Implantar um aplicativo</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/pt/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
+                <a href="/pt-br/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/pt/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. Explore seu aplicativo</h5></a>
+                  <a href="/pt-br/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. Explore seu aplicativo</h5></a>
                 </div>
               </div>
             </div>
@@ -90,17 +90,17 @@ card:
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/pt/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
+                <a href="/pt-br/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/pt/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. Exponha seu aplicativo publicamente</h5></a>
+                  <a href="/pt-br/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. Exponha seu aplicativo publicamente</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/pt/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
+                <a href="/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/pt/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. Escale seu aplicativo</h5></a>
+                  <a href="/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. Escale seu aplicativo</h5></a>
                 </div>
               </div>
             </div>

--- a/content/pt-br/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -132,7 +132,7 @@ description: |-
           empacotado em um contêiner que utiliza o NGINX para repetir todas as requisições.
           (Se você ainda não tentou criar o aplicativo hello-node e implantá-lo
           usando um contêiner, você pode fazer isso primeiro seguindo as
-          instruções do <a href="/pt/docs/tutorials/hello-minikube/">tutorial Olá, Minikube!</a>).
+          instruções do <a href="/pt-br/docs/tutorials/hello-minikube/">tutorial Olá, Minikube!</a>).
         </p>
 
         <p>

--- a/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -109,7 +109,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/pt/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">Iniciar tutorial interativo<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/pt-br/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">Iniciar tutorial interativo<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -109,7 +109,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/pt-br/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">Iniciar tutorial interativo<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/pt/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">Iniciar tutorial interativo<span class="btn__next">›</span></a>
             </div>
         </div>
 


### PR DESCRIPTION
Update obsoleted links that were still pointing to `/pt/` instead of `/pt-br/`
