### PR TITLE
Define new well-known annotation: kubernetes.io/display-name

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -539,6 +539,19 @@ Used on: All Objects
 
 This annotation is used for describing specific behaviour of given object.
 
+### kubernetes.io/display-name {#display-name}
+
+Type: Annotation
+
+Example: `kubernetes.io/display-name: "Display name of K8s object."`
+
+Used on: All Objects
+
+This annotation is used for applying a human-readable name to a given object.
+Unlike an [object name](/docs/concepts/overview/working-with-objects/names/),
+the value for this annotation is mutable and does not need to comply with a DNS
+sub-domain.
+
 ### kubernetes.io/enforce-mountable-secrets {#enforce-mountable-secrets}
 
 Type: Annotation


### PR DESCRIPTION
This patch introduces a new, well-known annotation, `kubernetes.io/display-name`. Please refer to https://github.com/kubernetes/kubernetes/issues/121514 for the background, goals, and non-goals. Thanks!