### PR TITLE
Change title and add redirects for kubectl cheatsheet

### DIFF
--- a/content/en/docs/reference/kubectl/quick-guide.md
+++ b/content/en/docs/reference/kubectl/quick-guide.md
@@ -1,5 +1,5 @@
 ---
-title: kubectl Cheat Sheet
+title: kubectl Quick Guide
 reviewers:
 - erictune
 - krousey

--- a/content/en/docs/reference/kubectl/quick-guide.md
+++ b/content/en/docs/reference/kubectl/quick-guide.md
@@ -1,5 +1,5 @@
 ---
-title: kubectl Quick Guide
+title: kubectl Quick Start Guide
 reviewers:
 - erictune
 - krousey

--- a/content/en/docs/reference/kubectl/quick-reference.md
+++ b/content/en/docs/reference/kubectl/quick-reference.md
@@ -1,5 +1,5 @@
 ---
-title: kubectl Quick Start Guide
+title: kubectl Quick Reference
 reviewers:
 - erictune
 - krousey

--- a/static/_redirects
+++ b/static/_redirects
@@ -30,6 +30,8 @@
 /docs/api-reference/labels-annotations-taints/     /docs/reference/labels-annotations-taints/ 301
 /docs/reference/using-api/api-overview/     /docs/reference/using-api/ 301
 /docs/reference/access-authn-authz/controlling-access/   /docs/concepts/security/controlling-access/ 301
+/docs/reference/kubectl/cheatsheet/   /docs/reference/kubectl/quick-guide/ 301
+/kubectlguide /docs/reference/kubectl/quick-guide/ 302
 
 /docs/concepts/abstractions/controllers/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
 /docs/concepts/abstractions/controllers/statefulsets/     /docs/concepts/workloads/controllers/statefulset/ 301
@@ -345,7 +347,7 @@
 /docs/tutorials/stateless-application/run-stateless-ap-replication-controller/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 /docs/tutorials/stateless-application/run-stateless-application-deployment/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 
-/cheatsheet /docs/reference/kubectl/cheatsheet/ 302
+/cheatsheet /docs/reference/kubectl/quick-guide/ 302
 
 /docs/whatisk8s/     /docs/concepts/overview/what-is-kubernetes/ 301
 /events/     /docs/community     301

--- a/static/_redirects
+++ b/static/_redirects
@@ -30,8 +30,8 @@
 /docs/api-reference/labels-annotations-taints/     /docs/reference/labels-annotations-taints/ 301
 /docs/reference/using-api/api-overview/     /docs/reference/using-api/ 301
 /docs/reference/access-authn-authz/controlling-access/   /docs/concepts/security/controlling-access/ 301
-/docs/reference/kubectl/cheatsheet/   /docs/reference/kubectl/quick-guide/ 301
-/kubectlguide /docs/reference/kubectl/quick-guide/ 302
+/docs/reference/kubectl/cheatsheet/   /docs/reference/kubectl/quick-reference/ 301
+/kubectlguide /docs/reference/kubectl/quick-reference/ 302
 
 /docs/concepts/abstractions/controllers/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
 /docs/concepts/abstractions/controllers/statefulsets/     /docs/concepts/workloads/controllers/statefulset/ 301
@@ -347,7 +347,7 @@
 /docs/tutorials/stateless-application/run-stateless-ap-replication-controller/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 /docs/tutorials/stateless-application/run-stateless-application-deployment/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 
-/cheatsheet /docs/reference/kubectl/quick-guide/ 302
+/cheatsheet /docs/reference/kubectl/quick-reference/ 302
 
 /docs/whatisk8s/     /docs/concepts/overview/what-is-kubernetes/ 301
 /events/     /docs/community     301


### PR DESCRIPTION
Summary of PR changes as requested in #43433

-   Changed the title and URL for kubectl/cheatsheet/ to kubectl/quick-reference
-   Added redirect from kubectl/cheatsheet/ to the new page
-   Set up a new short URL

I have gone through the previous commits in the website and come up with theses changes. Do review and feedback. Aplogies if changes are not as expected.

This will fix #43433