### PR TITLE
Bump Hugo to v0.120.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = "git submodule update --init --recursive --depth 1 && make non-product
 
 [build.environment]
 NODE_VERSION = "10.20.0"
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.3"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
Closes #43671

The change is tested locally, Website container builds on v0.120.3 now