### PR TITLE
Add kube-proxy non-privileged blog post

### DIFF
--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -1,0 +1,101 @@
+---
+layout: blog
+title: "Non-privileged kube-proxy container"
+date: 0000-00-00
+slug: kube-proxy-non-privileged
+---
+
+**Author**: Lars Ekman
+
+This post describes how the `--init-only` flag added in K8s v1.29 can
+be used to perform configuration that requires privileged mode in an
+initContainer, while the main `kube-proxy` container may run with a
+stricter securityContext.
+
+Please note that `kube-proxy` can be installed in different ways, but
+installers that installs `kube-proxy` as a POD, like `kubeadm`, can
+now use this function for improved security.
+
+
+## Background
+
+It is undesirable to run a server container like `kube-proxy` in
+privileged mode. Security aware users wants to [use capabilities instead](
+https://github.com/kubernetes/kubernetes/issues/112171).
+
+If `kube-proxy` is installed as a POD, the initialization requires
+"privileged" mode, mostly for setting sysctl's. However, for some time
+now `kube-proxy` doesn't alter sysctl's and other settings that
+already have the desired value. In theory this can be used to do all
+privileged configuration in an initContainer.
+
+The problem is to know *what* to setup. Until now the only option has
+been to read the source, but with `--init-only` the setup is done
+*exactly* as on a normal start, and then `kube-proxy` exits.
+
+
+## Kube-proxy initialization in an initContainer
+
+Traditionally `kube-proxy` runs in "privileged mode (manifests
+narrowed):
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-proxy
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-proxy
+        command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy/config.conf
+        - --hostname-override=$(NODE_NAME)
+        securityContext:
+          privileged: true
+```
+
+But now it is possible to use:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-proxy
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: kube-proxy-init
+        command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy/config.conf
+        - --init-only
+        securityContext:
+          privileged: true
+      containers:
+      - name: kube-proxy
+        command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy/config.conf
+        - --hostname-override=$(NODE_NAME)
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
+```
+
+
+## Improve security even more
+
+
+
+## Summary
+
+The `--init-only` flag can be used to perform privileged
+initialization in an initContainer and run the main container with
+"NET_ADMIN" capabilities only. Installers like `kubeadm` may be
+altered to use this feature.

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -7,7 +7,7 @@ slug: kube-proxy-non-privileged
 
 **Author**: Lars Ekman
 
-This post describes how the `--init-only` flag added in K8s v1.29 can
+This post describes how the `--init-only` flag to `kube-proxy`, added in K8s v1.29, can
 be used to perform configuration that requires privileged mode in an
 initContainer, while the main `kube-proxy` container may run with a
 stricter securityContext.

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -27,7 +27,7 @@ If `kube-proxy` is installed as a POD, the initialization requires
 "privileged" mode, mostly for setting sysctl's. However, for some time
 now `kube-proxy` doesn't alter sysctl's and other settings that
 already have the desired value. In theory this can be used to do all
-privileged configuration in an initContainer.
+privileged configuration in an [init container](/docs/concepts/workloads/pods/init-containers/).
 
 The problem is to know *what* to setup. Until now the only option has
 been to read the source, but with `--init-only` the setup is done

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -10,7 +10,10 @@ slug: kube-proxy-non-privileged
 This post describes how the `--init-only` flag to `kube-proxy` can be
 used to run the main kube-proxy container in a stricter
 `securityContext` by performing the configuration that requires
-privileged mode in a separate [init container](/docs/concepts/workloads/pods/init-containers/).
+privileged mode in a separate [init container](
+/docs/concepts/workloads/pods/init-containers/). Since
+Windows doesn't have the equivalent of `capabilities`, this only works
+on Linux.
 
 The `kube-proxy` Pod still only meets the *privileged* [Pod Security
 Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/),but there is still an improvement because the running container doesn't

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -12,9 +12,9 @@ be used to perform configuration that requires privileged mode in an
 initContainer, while the main `kube-proxy` container may run with a
 stricter securityContext.
 
-Please note that `kube-proxy` can be installed in different ways. For
-installers such as `kubeadm` that install `kube-proxy` to run as a Pod, the new
-functionality can help you improve security.
+Please note that `kube-proxy` can be installed in different ways. The
+examples below assume that kube-proxy is run from a pod, but similar
+changes could be made in clusters where it is run as a system service.
 
 
 ## Background

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -34,7 +34,7 @@ been to read the source, but with `--init-only` the setup is done
 *exactly* as on a normal start, and then `kube-proxy` exits.
 
 
-## Kube-proxy initialization in an initContainer
+## Initializing kube-proxy in an init container
 
 Traditionally `kube-proxy` runs in "privileged mode (manifests
 narrowed):

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -31,8 +31,9 @@ set the sysctls to the right values, then `kube-proxy` could run
 unprivileged.
 
 The problem is to know *what* to setup. Until now the only option has
-been to read the source, but with `--init-only` the setup is done
-*exactly* as on a normal start, and then `kube-proxy` exits.
+been to read the source to see what changes `kube-proxy` would have
+made, but with `--init-only` you can have `kube-proxy` itself do the setup
+*exactly* as on a normal start, and then exit.
 
 
 ## Initializing kube-proxy in an init container

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -12,9 +12,9 @@ be used to perform configuration that requires privileged mode in an
 initContainer, while the main `kube-proxy` container may run with a
 stricter securityContext.
 
-Please note that `kube-proxy` can be installed in different ways, but
-installers that installs `kube-proxy` as a POD, like `kubeadm`, can
-now use this function for improved security.
+Please note that `kube-proxy` can be installed in different ways. For
+installers such as `kubeadm` that install `kube-proxy` to run as a Pod, the new
+functionality can help you improve security.
 
 
 ## Background

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -24,10 +24,11 @@ privileged mode. Security aware users wants to [use capabilities instead](
 https://github.com/kubernetes/kubernetes/issues/112171).
 
 If `kube-proxy` is installed as a POD, the initialization requires
-"privileged" mode, mostly for setting sysctl's. However, for some time
-now `kube-proxy` doesn't alter sysctl's and other settings that
-already have the desired value. In theory this can be used to do all
-privileged configuration in an [init container](/docs/concepts/workloads/pods/init-containers/).
+"privileged" mode, mostly for setting sysctl's. However, `kube-proxy`
+only tries to set the sysctl's if they don't already have the right
+values. In theory, then, if a privileged [init container](/docs/concepts/workloads/pods/init-containers/)
+set the sysctls to the right values, then `kube-proxy` could run
+unprivileged.
 
 The problem is to know *what* to setup. Until now the only option has
 been to read the source, but with `--init-only` the setup is done

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -7,10 +7,10 @@ slug: kube-proxy-non-privileged
 
 **Author**: Lars Ekman
 
-This post describes how the `--init-only` flag to `kube-proxy`, added in K8s v1.29, can
-be used to perform configuration that requires privileged mode in an
-initContainer, while the main `kube-proxy` container may run with a
-stricter securityContext.
+This post describes how the `--init-only` flag to `kube-proxy` can be
+used to run the main kube-proxy container in a stricter
+`securityContext` by performing the configuration that requires
+privileged mode in a separate initContainer.
 
 Please note that `kube-proxy` can be installed in different ways. The
 examples below assume that kube-proxy is run from a pod, but similar
@@ -20,8 +20,7 @@ changes could be made in clusters where it is run as a system service.
 ## Background
 
 It is undesirable to run a server container like `kube-proxy` in
-privileged mode. Security aware users wants to [use capabilities instead](
-https://github.com/kubernetes/kubernetes/issues/112171).
+privileged mode. Security aware users wants to use capabilities instead.
 
 If `kube-proxy` is installed as a POD, the initialization requires
 "privileged" mode, mostly for setting sysctl's. However, `kube-proxy`
@@ -76,6 +75,7 @@ spec:
         command:
         - /usr/local/bin/kube-proxy
         - --config=/var/lib/kube-proxy/config.conf
+        - --hostname-override=$(NODE_NAME)
         - --init-only
         securityContext:
           privileged: true
@@ -89,9 +89,6 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
 ```
-
-
-## Improve security even more
 
 
 

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -36,8 +36,8 @@ been to read the source, but with `--init-only` the setup is done
 
 ## Initializing kube-proxy in an init container
 
-Traditionally `kube-proxy` runs in "privileged mode (manifests
-narrowed):
+Usually, cluster operators run `kube-proxy` in a privileged security context. Here's a snippet of an
+example manifest:
 
 ```yaml
 apiVersion: apps/v1

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -102,6 +102,6 @@ spec:
 ## Summary
 
 The `--init-only` flag can be used to perform privileged
-initialization in an initContainer and run the main container with
+initialization in an init container and run the main container with
 `NET_ADMIN` capabilities only. Installers like `kubeadm` will likely be
 altered to use this feature in the future.

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -97,5 +97,5 @@ spec:
 
 The `--init-only` flag can be used to perform privileged
 initialization in an initContainer and run the main container with
-"NET_ADMIN" capabilities only. Installers like `kubeadm` may be
+`NET_ADMIN` capabilities only. Installers like `kubeadm` may be
 altered to use this feature.

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -44,8 +44,10 @@ made, but with `--init-only` you can have `kube-proxy` itself do the setup
 
 ## Initializing kube-proxy in an init container
 
-Usually, cluster operators run `kube-proxy` in a privileged security context. Here's a snippet of an
-example manifest:
+*The example manifests below are not complete, but narrowed down to what is
+essential to illustrate the function.*
+
+Usually, cluster operators run `kube-proxy` in a privileged security context.
 
 ```yaml
 apiVersion: apps/v1

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -10,7 +10,11 @@ slug: kube-proxy-non-privileged
 This post describes how the `--init-only` flag to `kube-proxy` can be
 used to run the main kube-proxy container in a stricter
 `securityContext` by performing the configuration that requires
-privileged mode in a separate initContainer.
+privileged mode in a separate [init container](/docs/concepts/workloads/pods/init-containers/).
+
+The `kube-proxy` Pod still only meets the *privileged* [Pod Security
+Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/),but there is still an improvement because the running container doesn't
+need to run privileged.
 
 Please note that `kube-proxy` can be installed in different ways. The
 examples below assume that kube-proxy is run from a pod, but similar
@@ -96,5 +100,5 @@ spec:
 
 The `--init-only` flag can be used to perform privileged
 initialization in an initContainer and run the main container with
-`NET_ADMIN` capabilities only. Installers like `kubeadm` may be
-altered to use this feature.
+`NET_ADMIN` capabilities only. Installers like `kubeadm` will likely be
+altered to use this feature in the future.

--- a/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
+++ b/content/en/blog/_posts/0000-00-00-kube-proxy-non-privileged.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Non-privileged kube-proxy container"
+title: "Kubernetes 1.29: Support for Running kube-proxy in a Non-privileged Container"
 date: 0000-00-00
 slug: kube-proxy-non-privileged
 ---


### PR DESCRIPTION
The post describes how the --init-only flag can be used to do privileged initialization in an initContainer, and run the main container with NET_ADMIN capabilities only
