### PR TITLE
Fix a typo on blog 2023-10-23-pv-last-phase-transtition-time.md

### DIFF
--- a/content/en/blog/_posts/2023-10-23-pv-last-phase-transtition-time.md
+++ b/content/en/blog/_posts/2023-10-23-pv-last-phase-transtition-time.md
@@ -32,7 +32,6 @@ including manual cleanup based on the time a volume was last used or producing a
 
 Provided you've enabled the feature gate (see [How to use it](#how-to-use-it), the new `.status.lastPhaseTransitionTime` field of a PersistentVolume (PV)
 is updated every time that PV transitions from one phase to another.
-``
 Whether it's transitioning from `Pending` to `Bound`, `Bound` to `Released`, or any other phase transition, the `lastPhaseTransitionTime` will be recorded.
 For newly created PVs the phase will be set to `Pending` and the `lastPhaseTransitionTime` will be recorded as well.
 


### PR DESCRIPTION
Delete unexpected **``** on 
> phase to another. `` Whether it's transitioning

https://kubernetes.io/blog/2023/10/23/persistent-volume-last-phase-transition-time/#how-to-use-it
