### PR TITLE
Change HorizontalPodAutoscaler walkthrough to use autoscaling/v2 API group

### DIFF
--- a/content/en/examples/application/hpa/php-apache.yaml
+++ b/content/en/examples/application/hpa/php-apache.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
@@ -9,4 +9,10 @@ spec:
     name: php-apache
   minReplicas: 1
   maxReplicas: 10
-  targetCPUUtilizationPercentage: 50
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50


### PR DESCRIPTION
Horizontal Pod Autoscaler API version autoscaling/v2 , and it provides more features than autoscaling/v1.
#43685 