### PR TITLE
[zh]: delete removed kubeadm subcommand

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_controller-manager.conf.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_controller-manager.conf.md
@@ -30,7 +30,7 @@ After renewal, in order to make changes effective, is is required to restart con
 续订后，为了使更改生效，需要重新启动控制平面组件，并最终重新分发更新的证书，以防文件在其他地方使用。
 
 ```
-kubeadm alpha renew controller-manager.conf [flags]
+kubeadm certs renew controller-manager.conf [flags]
 ```
 
 <!--

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_kubeconfig_user.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_kubeconfig_user.md
@@ -12,7 +12,7 @@ Output a kubeconfig file for an additional user.
 为其他用户输出一个 kubeconfig 文件。
 
 ```
-kubeadm alpha kubeconfig user [flags]
+kubeadm kubeconfig user [flags]
 ```
 
 <!--

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset.md
@@ -20,7 +20,6 @@ The "reset" command executes the following phases:
 
 ```
 preflight              Run reset pre-flight checks
-update-cluster-status  Remove this node from the ClusterStatus object.
 remove-etcd-member     Remove a local etcd member.
 cleanup-node           Run cleanup node.
 ```


### PR DESCRIPTION
…in docs.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
fix: delete deprecated command `kubeadm` in docs.