### PR TITLE
Fix broken link on issue-wrangler.md

### DIFF
--- a/content/en/docs/contribute/participate/issue-wrangler.md
+++ b/content/en/docs/contribute/participate/issue-wrangler.md
@@ -8,7 +8,7 @@ weight: 20
 
 Alongside the [PR Wrangler](/docs/contribute/participate/pr-wranglers), formal approvers,
 reviewers and members of SIG Docs take week-long shifts
-[triaging and categorising issues](/docs/contribute/review/for-approvers.md/#triage-and-categorize-issues)
+[triaging and categorising issues](/docs/contribute/review/for-approvers/#triage-and-categorize-issues)
 for the repository.
 
 <!-- body -->
@@ -18,7 +18,7 @@ for the repository.
 Each day in a week-long shift the Issue Wrangler will be responsible for:
 
 - Triaging and tagging incoming issues daily. See
-  [Triage and categorize issues](/docs/contribute/review/for-approvers.md/#triage-and-categorize-issues)
+  [Triage and categorize issues](/docs/contribute/review/for-approvers/#triage-and-categorize-issues)
   for guidelines on how SIG Docs uses metadata.
 - Keeping an eye on stale & rotten issues within the kubernetes/website repository.
 - Maintenance of the [Issues board](https://github.com/orgs/kubernetes/projects/72/views/1).


### PR DESCRIPTION
The correct link is https://kubernetes.io/docs/contribute/review/for-approvers/#triage-and-categorize-issues