### PR TITLE
Update Bing Search to use Bing APIs not Cognitive Services

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -997,6 +997,16 @@ div.alert > em.javascript-required {
 #bing-results-container {
     padding: 1em;
 }
+.bing-result {
+  margin-bottom: 1em;
+}
+.bing-result-url {
+  font-size: 14px;
+}
+.bing-result-snippet {
+  color: #666666;
+  font-size: 14px;
+}
 #bing-pagination-container {
     padding: 1em;
     margin-bottom: 1em;

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -24,7 +24,7 @@
             </form>
           </div>
           <div class="col-12 col-md-8 offset-md-2">
-              <h2 class="ml-4">{{ .Title }}</h2>
+              <h2 class="search-title ml-3">{{ .Title }}</h2>
           {{ if .Site.Params.gcs_engine_id }}
           <script>
             (function() {


### PR DESCRIPTION
**Reason for this PR:**

- Bing Custom Search has transistioned from Azure Cognitive Services to Microsoft Bing API’s via Azure Marketplace. This happened in 2020, and now support for Cognitive Services will be disabled on 31 October 2023.
- This PR keeps Bing Custom Search working for users who do not use the Google Site Search (predominantly users from China or those behind firewalls where Google is blocked)

**What has been done:**

- Created a serverless function to act as a proxy to run the Bing search. This protects our API key and enables us to restrict access to the API via CORS (Kubernetes.io and localhost are included).
- Updated styling of Bing results
- Improved search page experience if no query has been passed
- Tidied up some CSS

**Notes:** 
- Bing search previously used https://www.customsearch.ai to set a customConfig - I did not have access to this original custom config so unable to see the settings it applied. customConfig is no longer part of Bing Search API V7, so any additional customisation required will need to be done via Bing Search API. The search seems to be operating without the need for a custom config, but perhaps there were some prioritisations or sorting of content that may need to be reapplied. 

**Why have I done this**
- I work for CNCF - who pays for the custom Bing search facility. I have been asked by Taylor Waggoner, Program Manager at CNCF to update this API so we can continue to use it beyond Tuesday. 

**Testing:**

- [Netlify search URL](https://deploy-preview-43731--kubernetes-io-main-staging.netlify.app/search/?q=contribute)
- Edit local storage cookies `is_china` = true
- For the netlify instance to work I have added netlify.app to CORS but I would like to remove this

![Screenshot-2023-10-29 --16 13 40](https://github.com/kubernetes/website/assets/10615884/4bc44357-f7e5-4653-aca4-d45cc76f04b3)