### PR TITLE
Switch to newer image for hashicorp/http-echo in examples

### DIFF
--- a/content/en/examples/pods/security/seccomp/ga/audit-pod.yaml
+++ b/content/en/examples/pods/security/seccomp/ga/audit-pod.yaml
@@ -11,7 +11,7 @@ spec:
       localhostProfile: profiles/audit.json
   containers:
   - name: test-container
-    image: hashicorp/http-echo:0.2.3
+    image: hashicorp/http-echo:1.0
     args:
     - "-text=just made some syscalls!"
     securityContext:

--- a/content/en/examples/pods/security/seccomp/ga/default-pod.yaml
+++ b/content/en/examples/pods/security/seccomp/ga/default-pod.yaml
@@ -10,7 +10,7 @@ spec:
       type: RuntimeDefault
   containers:
   - name: test-container
-    image: hashicorp/http-echo:0.2.3
+    image: hashicorp/http-echo:1.0
     args:
     - "-text=just made some more syscalls!"
     securityContext:

--- a/content/en/examples/pods/security/seccomp/ga/fine-pod.yaml
+++ b/content/en/examples/pods/security/seccomp/ga/fine-pod.yaml
@@ -11,7 +11,7 @@ spec:
       localhostProfile: profiles/fine-grained.json
   containers:
   - name: test-container
-    image: hashicorp/http-echo:0.2.3
+    image: hashicorp/http-echo:1.0
     args:
     - "-text=just made some syscalls!"
     securityContext:

--- a/content/en/examples/pods/security/seccomp/ga/violation-pod.yaml
+++ b/content/en/examples/pods/security/seccomp/ga/violation-pod.yaml
@@ -11,7 +11,7 @@ spec:
       localhostProfile: profiles/violation.json
   containers:
   - name: test-container
-    image: hashicorp/http-echo:0.2.3
+    image: hashicorp/http-echo:1.0
     args:
     - "-text=just made some syscalls!"
     securityContext:


### PR DESCRIPTION
This PR is part of #42286

# What has been done?
* Update the "hashicorp/http-echo" versions to v1.0, which supports ARM64 arhictecture
  * [DockerHubReferenceLink](https://hub.docker.com/r/hashicorp/http-echo/tags)
  * [HashiCorpHttpEchoPRAdded](https://github.com/hashicorp/http-echo/pull/3) 

# How to review?
* Pre requisites
  * ARM64 architecture
  * kind
  * kubectl
* Follow the steps indicated in the SecComp page for creating a pod
  * [RunTime default seccomp profile](https://kubernetes.io/docs/tutorials/security/seccomp/#create-a-pod-that-uses-the-container-runtime-default-seccomp-profile)
  * [SecComp profile specified in the audit.json](https://kubernetes.io/docs/tutorials/security/seccomp/#create-a-pod-with-a-seccomp-profile-for-syscall-auditing)  

# Notes:
* Screenshots executed locally in my local setUp (macOs Ventura v.13.1 arm164, kind v0.20.0)
![image](https://github.com/kubernetes/website/assets/39351487/334d90ed-172d-4595-9722-4a4949767d8d)


