### PR TITLE
Switch to newer kindest/node version

### DIFF
--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -482,7 +482,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.28.0
+    image: kindest/node:v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -490,7 +490,7 @@ nodes:
           kubeletExtraArgs:
             seccomp-default: "true"
   - role: worker
-    image: kindest/node:v1.28.0
+    image: kindest/node:v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration

--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -482,7 +482,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+    image: kindest/node:v1.28.0
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -490,7 +490,7 @@ nodes:
           kubeletExtraArgs:
             seccomp-default: "true"
   - role: worker
-    image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+    image: kindest/node:v1.28.0
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration


### PR DESCRIPTION
This PR fixes the 👁️  kind cluster added in [Enable the use of RuntimeDefault as the default seccomp profile for all workloads](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads) 👁️ 

# What was the issue?
* Impossible to make it run the second kind-worker node
  * You can check more detailed logs [here](https://github.com/kubernetes-sigs/kind/issues/3402#issue-1967064032) and also about the issue reported in kind
![image](https://github.com/kubernetes/website/assets/39351487/66dac759-0fe1-4c2a-a411-37f2902bb4da)


# What has been done?
* Update the "kindest/node" versions to v1.28.0
  * [RecommendedInKubernetesSigsKindIssue](https://github.com/kubernetes-sigs/kind/issues/3402#issuecomment-1785532845)
  * [kindest/node tags](https://hub.docker.com/r/kindest/node/tags)

# How to review?
* Prerequisiites
  * kubernetes v1.28 
* `kind create cluster --config=FileWithTheCurrentKindCustomCluster.yaml`

# Notes:
* Screenshots executed locally working fine now
![image](https://github.com/kubernetes/website/assets/39351487/c91eca98-3dde-4816-b7e2-f3328b8c13d3)




