### PR TITLE
Add 1.32 removal info for v1beta3 flowcontrol API

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -20,6 +20,19 @@ deprecated API versions to newer and more stable API versions.
 
 ## Removed APIs by release
 
+### v1.32
+
+The **v1.32** release will stop serving the following deprecated API versions:
+
+#### Flow control resources {#flowcontrol-resources-v132}
+
+The **flowcontrol.apiserver.k8s.io/v1beta3** API version of FlowSchema and PriorityLevelConfiguration will no longer be served in v1.32.
+
+* Migrate manifests and API clients to use the **flowcontrol.apiserver.k8s.io/v1** API version, available since v1.29.
+* All existing persisted objects are accessible via the new API
+* Notable changes in **flowcontrol.apiserver.k8s.io/v1**:
+  * The PriorityLevelConfiguration `spec.limited.nominalConcurrencyShares` field only defaults to 30 when unspecified, and an explicit value of 0 is not changed to 30.
+
 ### v1.29
 
 The **v1.29** release will stop serving the following deprecated API versions:

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -41,8 +41,10 @@ The **v1.29** release will stop serving the following deprecated API versions:
 
 The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and PriorityLevelConfiguration will no longer be served in v1.29.
 
-* Migrate manifests and API clients to use the **flowcontrol.apiserver.k8s.io/v1beta3** API version, available since v1.26.
+* Migrate manifests and API clients to use the **flowcontrol.apiserver.k8s.io/v1** API version, available since v1.29, or the **flowcontrol.apiserver.k8s.io/v1beta3** API version, available since v1.26.
 * All existing persisted objects are accessible via the new API
+* Notable changes in **flowcontrol.apiserver.k8s.io/v1**:
+  * The PriorityLevelConfiguration `spec.limited.assuredConcurrencyShares` field is renamed to `spec.limited.nominalConcurrencyShares` and only defaults to 30 when unspecified, and an explicit value of 0 is not changed to 30.
 * Notable changes in **flowcontrol.apiserver.k8s.io/v1beta3**:
   * The PriorityLevelConfiguration `spec.limited.assuredConcurrencyShares` field is renamed to `spec.limited.nominalConcurrencyShares`
 


### PR DESCRIPTION
Adding the deprecation / removal / replacement details for the last (!) default-on beta API

cc @deads2k @tkashem @MikeSpreitzer 

For [KEP 1040](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1040-priority-and-fairness) and [KEP-1635](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1635-prevent-permabeta)

/sig api-machinery architecture