### PR TITLE
[zh-cn]sync persistent-volume-v1 mutating-webhook-configuration-v1 validating-webhook-configuration-v1

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -1767,6 +1767,25 @@ PersistentVolumeStatus 是持久卷的当前状态。
 <hr>
 
 <!--
+- **lastPhaseTransitionTime** (Time)
+
+  lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically
+  resets to current time everytime a volume phase transitions. This is an alpha field and requires
+  enabling PersistentVolumeLastPhaseTransitionTime feature.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.
+  Wrappers are provided for many of the factory methods that the time package offers.*
+-->
+- **lastPhaseTransitionTime** (Time)
+
+  lastPhaseTransitionTime 是从一个阶段转换到另一个阶段的时间，每次卷阶段转换时都会自动重置为当前时间。
+  这是一个 Alpha 字段，需要启用 PersistentVolumeLastPhaseTransitionTime 特性。
+
+  <a name="Time"></a>
+  **Time 是 time.Time 的包装器，支持正确编组为 YAML 和 JSON，它为 time 包提供的许多工厂方法提供了包装器。**
+
+<!--
 - **message** (string)
   message is a human-readable message indicating details about why the volume is in this state.
 

--- a/content/zh-cn/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
@@ -272,13 +272,13 @@ MutatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可接
        - 如果 failurePolicy=Ignore，忽略错误并跳过该 webhook。
 
     <!--
-    This is an alpha feature and managed by the AdmissionWebhookMatchConditions feature gate.
+    This is an beta feature and managed by the AdmissionWebhookMatchConditions feature gate.
   
     <a name="MatchCondition"></a>
     *MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.*
     -->
     
-    这是一个 Alpha 功能特性，由 AdmissionWebhookMatchConditions 特性门控管理。
+    这是一个 Beta 功能特性，由 AdmissionWebhookMatchConditions 特性门控管理。
 
     <a name="MatchCondition"></a>
     **MatchCondition 表示将请求发送到 Webhook 之前必须满足的条件。**

--- a/content/zh-cn/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
@@ -266,12 +266,12 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
      - 如果 failurePolicy=Ignore，忽略错误并跳过该 webhook。
 
   <!--
-  This is an alpha feature and managed by the AdmissionWebhookMatchConditions feature gate.
+  This is an beta feature and managed by the AdmissionWebhookMatchConditions feature gate.
   
   <a name="MatchCondition"></a>
   *MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.*
   -->
-  这是一个 Alpha 功能特性，由 AdmissionWebhookMatchConditions 特性门控管理。
+  这是一个 Beta 功能特性，由 AdmissionWebhookMatchConditions 特性门控管理。
 
   <a name="MatchCondition"></a>
   **MatchCondition 表示将请求发送到 Webhook 之前必须满足的条件。**


### PR DESCRIPTION

```
# Changes to be committed:
#       modified:   content/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md

```