### PR TITLE
Fix broken link in Gateway API v1.0 blog

### DIFF
--- a/content/en/blog/_posts/2023-10-31-Gateway-API-GA/index.md
+++ b/content/en/blog/_posts/2023-10-31-Gateway-API-GA/index.md
@@ -60,7 +60,7 @@ follow up blog post that will cover each of these new features in detail.
 ### Everything else
 For a full list of the changes included in this release, please refer to the
 [v1.0.0 release
-notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.1.0).
+notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0 ).
 
 ## How we got here
 

--- a/content/en/blog/_posts/2023-10-31-Gateway-API-GA/index.md
+++ b/content/en/blog/_posts/2023-10-31-Gateway-API-GA/index.md
@@ -60,7 +60,7 @@ follow up blog post that will cover each of these new features in detail.
 ### Everything else
 For a full list of the changes included in this release, please refer to the
 [v1.0.0 release
-notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0 ).
+notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0).
 
 ## How we got here
 


### PR DESCRIPTION
As requested in issue #43761 udpated the blog article to link to 1.0.0 not 0.1.0

This will fix #43761