### PR TITLE
Update deprecation-guide.md

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -35,7 +35,7 @@ The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and Prior
 
 ### v1.27
 
-The **v1.27** release has stopped serving the following deprecated API versions post release:
+The **v1.27** release stopped serving the following deprecated API versions:
 
 #### CSIStorageCapacity {#csistoragecapacity-v127}
 

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -35,7 +35,7 @@ The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and Prior
 
 ### v1.27
 
-The v1.27 release stopped serving the following deprecated API versions(as release has already happened):
+The **v1.27** release has stopped serving the following deprecated API versions post release:
 
 #### CSIStorageCapacity {#csistoragecapacity-v127}
 

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -35,7 +35,7 @@ The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and Prior
 
 ### v1.27
 
-The **v1.27** release will stop serving the following deprecated API versions:
+The v1.27 release stopped serving the following deprecated API versions(as release has already happened):
 
 #### CSIStorageCapacity {#csistoragecapacity-v127}
 


### PR DESCRIPTION
Fixed the wrong tense in API deprecation page. Changed the line "The v1.27 release will stop serving the following deprecated API versions:"



<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
