### PR TITLE
Add a link to sample-controller repository on Controllers page

### DIFF
--- a/content/en/docs/concepts/architecture/controller.md
+++ b/content/en/docs/concepts/architecture/controller.md
@@ -165,6 +165,6 @@ controller does.
 * Discover some of the basic [Kubernetes objects](/docs/concepts/overview/working-with-objects/)
 * Learn more about the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * If you want to write your own controller, see
-  [Extension Patterns](/docs/concepts/extend-kubernetes/#extension-patterns)
-  in Extending Kubernetes.
+  [Kubernetes extension patterns](/docs/concepts/extend-kubernetes/#extension-patterns)
+  and the [sample-controller](https://github.com/kubernetes/sample-controller) repository.
 


### PR DESCRIPTION
The [sample-controller](https://github.com/kubernetes/sample-controller) repository would be helpful if you want to write your own controller.

See [Preview](https://deploy-preview-43774--kubernetes-io-main-staging.netlify.app/docs/concepts/architecture/controller/)


