### PR TITLE
[zh-cn] Typo fix /config-api/kubeadm-config.v1beta3.md

### DIFF
--- a/content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/zh-cn/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -843,7 +843,7 @@ uploaded in a Secret in the cluster during the <code>uploadcerts init</code> pha
 The list of phases can be obtained with the <code>kubeadm init --help</code> command.
 The flag &quot;--skip-phases&quot; takes precedence over this field.</p>
    -->
-   <p><code>skipPhases</code> 是命令执行过程中药略过的阶段（Phases）。
+   <p><code>skipPhases</code> 是命令执行过程中要略过的阶段（Phases）。
 通过执行命令 <code>kubeadm init --help</code> 可以获得阶段的列表。
 参数标志 &quot;--skip-phases&quot; 优先于此字段的设置。</p>
 </td>


### PR DESCRIPTION
Fix typo in [InitConfiguration](https://kubernetes.io/zh-cn/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-InitConfiguration) 

/language zh
fix: #43796
