### PR TITLE
add a doc for QueueingHint

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -222,6 +222,25 @@ This is an informational extension point. Post-bind plugins are called after a
 Pod is successfully bound. This is the end of a binding cycle, and can be used
 to clean up associated resources.
 
+### EnqueueExtension
+
+EnqueueExtension is the interface where the plugin can have control how the scheduling of Pods rejected by this plugin are retried.
+PreEnqueue, PreFilter, Filter, Reserve and Permit plugins are supposed to implement this interface.
+
+{{< feature-state for_k8s_version="v1.28" state="beta" >}}
+
+QueueingHint is a part of EnqueueExtension. 
+It's callback functions to decide if a Pod can be requeued to activeQ/backoffQ. 
+It's executed every time certain kind of events happens, 
+and when the QueueingHint finds that the event might make the Pod schedulable, 
+the scheduling queue requeues the Pod into activeQ/backoffQ so that the scheduler will retry the scheduling of the Pod.
+
+{{< note >}}
+QueueingHint is a beta-level field and enabled by default in 1.28. 
+You can disable it via the
+`SchedulerQueueingHints` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
+{{< /note >}}
+
 ## Plugin API
 
 There are two steps to the plugin API. First, plugins must register and get

--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -46,13 +46,12 @@ the queue and retried.
 ## Interfaces
 
 The following picture shows the scheduling context of a Pod and the interfaces
-that the scheduling framework exposes. In this picture "Filter" is
-equivalent to "Predicate" and "Scoring" is equivalent to "Priority function".
+that the scheduling framework exposes.
 
 One plugin may implement multiple interfaces to perform more complex or
 stateful tasks.
 
-Some interfaces are called as extension points which can be controled through 
+Some interfaces match the scheduler extension points which can be configured through 
 [Scheduler Configuration](/docs/reference/scheduling/config/#extension-points).
 
 {{< figure src="/images/docs/scheduling-framework-extensions.png" title="Scheduling framework extension points" class="diagram-large">}}
@@ -79,13 +78,13 @@ Plugins that implement PreEnqueue, PreFilter, Filter, Reserve or Permit should i
 {{< feature-state for_k8s_version="v1.28" state="beta" >}}
 
 QueueingHint is a callback function for deciding whether a Pod can be requeued to the active queue or backoff queue. 
-It's executed every time a certain kind of events happen,
-and when the QueueingHint finds that the event might make the Pod schedulable, 
+It's executed every time a certain kind of event or change happens in the cluster.
+When the QueueingHint finds that the event might make the Pod schedulable, 
 the Pod is put into the active queue or the backoff queue
 so that the scheduler will retry the scheduling of the Pod.
 
 {{< note >}}
-QueueingHint is a beta-level field and is enabled by default in 1.28. 
+QueueingHint evaluation during scheduling is a beta-level feature and is enabled by default in 1.28. 
 You can disable it via the
 `SchedulerQueueingHints` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 {{< /note >}}

--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -230,13 +230,14 @@ PreEnqueue, PreFilter, Filter, Reserve and Permit plugins are supposed to implem
 {{< feature-state for_k8s_version="v1.28" state="beta" >}}
 
 QueueingHint is a part of EnqueueExtension. 
-It's callback functions to decide if a Pod can be requeued to activeQ/backoffQ. 
-It's executed every time certain kind of events happens, 
+It's a callback function for deciding whether a Pod can be requeued to the active queue or backoff queue. 
+It's executed every time a certain kind of events happen,
 and when the QueueingHint finds that the event might make the Pod schedulable, 
-the scheduling queue requeues the Pod into activeQ/backoffQ so that the scheduler will retry the scheduling of the Pod.
+the Pod is put into the active queue or the backoff queue
+so that the scheduler will retry the scheduling of the Pod.
 
 {{< note >}}
-QueueingHint is a beta-level field and enabled by default in 1.28. 
+QueueingHint is a beta-level field and is enabled by default in 1.28. 
 You can disable it via the
 `SchedulerQueueingHints` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 {{< /note >}}


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4247-queueinghint

It's not a mistake that I try to push this to main branch, not to v1.29 branch.
This KEP is under a unique situation where we assume this feature has been existing as beta since v1.28.