### PR TITLE
Update configure-upgrade-etcd.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -344,13 +344,7 @@ Before starting the restore operation, a snapshot file must be present. It can
 either be a snapshot file from a previous backup operation, or from a remaining
 [data directory](https://etcd.io/docs/current/op-guide/configuration/#--data-dir).
 
-Here is an example:
-
-```shell
-ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshot.db
-```
-
-Another example for restoring using `etcdctl` options:
+When restoring the cluster, use the `--data-dir` option to specify to which folder the cluster should be restored:
 
 ```shell
 ETCDCTL_API=3 etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
@@ -363,6 +357,8 @@ Yet another example would be to first export the `ETCDCTL_API` environment varia
 export ETCDCTL_API=3
 etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
+
+If `<data-dir-location>` is the same folder as before, delete it and stop etcd process before restoring the cluster. Else change etcd configuration and restart the etcd process after restoration to make it use the new data directory.
 
 For more information and examples on restoring a cluster from a snapshot file, see
 [etcd disaster recovery documentation](https://etcd.io/docs/current/op-guide/recovery/#restoring-a-cluster).


### PR DESCRIPTION
Precision on --data-dir option when restoring etcd cluster

- Removed the command without `--data-dir` option. 
- Detailed the two options that we have with `--data-dir` : restoring to the same folder as before or to a different folder (which is generally the advised method to my knowledge)

More details:
I was never able to restore a cluster without `--data-dir` option. The lessons and tutorials out there tell you to use `--data-dir` to restore to a specific folder

You'd think that not specifying  `--data-dir` will restore to the same folder as before but it doesn't. It just doesn't work and doesn't give any error message. Maybe it's restoring to some default folder that is generally not the one configured. (tested on k8s 1.27.0 / etcd 3.5.7.0 : first delete `/var/lib/etcd`, then restore without `--data-dir` option :  `/var/lib/etcd` is still not present)

