### PR TITLE
Fix KinD typos in en docs

### DIFF
--- a/content/en/blog/_posts/2020-08-26-kubernetes-release-1.19.md
+++ b/content/en/blog/_posts/2020-08-26-kubernetes-release-1.19.md
@@ -77,7 +77,7 @@ Check out the full details of the Kubernetes 1.19 release in our [release notes]
 
 ## Availability
 
-Kubernetes 1.19 is available for download on [GitHub](https://github.com/kubernetes/kubernetes/releases/tag/v1.19.0). To get started with Kubernetes, check out these [interactive tutorials](https://kubernetes.io/docs/tutorials/) or run local Kubernetes clusters using Docker container “nodes” with [KinD](https://kind.sigs.k8s.io/) (Kubernetes in Docker). You can also easily install 1.19 using [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/).
+Kubernetes 1.19 is available for download on [GitHub](https://github.com/kubernetes/kubernetes/releases/tag/v1.19.0). To get started with Kubernetes, check out these [interactive tutorials](https://kubernetes.io/docs/tutorials/) or run local Kubernetes clusters using Docker container “nodes” with [kind](https://kind.sigs.k8s.io/) (Kubernetes in Docker). You can also easily install 1.19 using [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/).
 
 ## Release Team
 This release is made possible through the efforts of hundreds of individuals who contributed both technical and non-technical content. Special thanks to the [release team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.19/release_team.md) led by Taylor Dolezal, Senior Developer Advocate at HashiCorp. The 34 release team members coordinated many aspects of the release, from documentation to testing, validation, and feature completeness.

--- a/content/en/docs/tutorials/security/ns-level-pss.md
+++ b/content/en/docs/tutorials/security/ns-level-pss.md
@@ -22,12 +22,12 @@ level. For instructions, refer to
 
 Install the following on your workstation:
 
-- [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 - [kubectl](/docs/tasks/tools/)
 
 ## Create cluster
 
-1. Create a `KinD` cluster as follows:
+1. Create a `kind` cluster as follows:
 
    ```shell
    kind create cluster --name psa-ns-level
@@ -150,7 +150,7 @@ kind delete cluster --name psa-ns-level
   [shell script](/examples/security/kind-with-namespace-level-baseline-pod-security.sh)
   to perform all the preceding steps all at once.
 
-  1. Create KinD cluster
+  1. Create kind cluster
   2. Create new namespace
   3. Apply `baseline` Pod Security Standard in `enforce` mode while applying
      `restricted` Pod Security Standard also in `warn` and `audit` mode.


### PR DESCRIPTION
Fix ```KinD``` typos in en docs.
There are somes show Kind , and somes show KinD.
Review the website of kind [kind quick start](https://kind.sigs.k8s.io/docs/user/quick-start/). 

It is maybe Kind is rightness.