### PR TITLE
[zh-cn] Update KubeCon dates and fix mismatched blocks

### DIFF
--- a/content/zh-cn/_index.html
+++ b/content/zh-cn/_index.html
@@ -34,7 +34,7 @@ Google 每周运行数十亿个容器，Kubernetes 基于与之相同的原则�
 {{% blocks/feature image="blocks" %}}
 
 <!-- #### Never Outgrow -->
-#### 处处适用
+#### 永不过时
 
 <!-- Whether testing locally or running a global enterprise, Kubernetes flexibility grows with you to deliver your applications
 consistently and easily no matter how complex your need is. -->
@@ -45,8 +45,8 @@ consistently and easily no matter how complex your need is. -->
 
 {{% blocks/feature image="suitcase" %}}
 
-<!-- #### Run Anywhere -->
-#### 永不过时
+<!-- #### Run K8s Anywhere -->
+#### 处处适用
 
 <!-- Kubernetes is open source giving you the freedom to take advantage of on-premises, 
 hybrid, or public cloud infrastructure, letting you effortlessly move workloads to where it matters to you.

--- a/content/zh-cn/_index.html
+++ b/content/zh-cn/_index.html
@@ -70,14 +70,14 @@ Kubernetes 是开源系统，可以自由地部署在企业内部，私有云、
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">观看视频</button>
         <br>
         <br>
-        <!-- <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on April 18-21, 2023</a> -->
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">参加 2023 年 4 月 18-21 日的欧洲 KubeCon + CloudNativeCon</a>
-        <br>
-        <br>
-        <br>
-        <br>
         <!-- <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 6-9, 2023</a> -->
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">参加 2023 年 11 月 6-9 日的北美 KubeCon + CloudNativeCon</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <!-- <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on March 19-22, 2024</a> -->
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">参加 2024 年 3 月 19-22 日的欧洲 KubeCon + CloudNativeCon</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
The Chinese translations of 'Run Anywhere' and 'Never Outgrow' on homepage are mixed up. Fix it.