### PR TITLE
certificates.md: add note about system:masters in apiserver cert

### DIFF
--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -95,6 +95,12 @@ Required certificates:
 | kube-apiserver-kubelet-client | kubernetes-ca             | system:masters | client           |                                                     |
 | front-proxy-client            | kubernetes-front-proxy-ca |                | client           |                                                     |
 
+{{< note >}}
+Instead of using the super-user group `system:masters` for `kube-apiserver-kubelet-client`
+a less privileged group can be used. kubeadm uses the `kubeadm:cluster-admins` group for
+that purpose.
+{{< /note >}}
+
 [1]: any other IP or DNS name you contact your cluster on (as used by [kubeadm](/docs/reference/setup-tools/kubeadm/)
 the load balancer stable IP and/or DNS name, `kubernetes`, `kubernetes.default`, `kubernetes.default.svc`,
 `kubernetes.default.svc.cluster`, `kubernetes.default.svc.cluster.local`)


### PR DESCRIPTION

The kube-apiserver flag --kubelet-client-certificate
accepts a client certificate (kube-apiserver-kubelet-client.crt)
to connect to the kubelet. There is no need for this certificate
to have "system:masters" as "O" in the Subject, instead it
can be a less privileged group like kubeadm's "kubeadm:cluster-admins".

k/k bugfix PR:
https://github.com/kubernetes/kubernetes/pull/121837
