### PR TITLE
Update cheatsheet.md - fish completions

### DIFF
--- a/content/en/docs/reference/kubectl/quick-reference.md
+++ b/content/en/docs/reference/kubectl/quick-reference.md
@@ -45,10 +45,12 @@ echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc 
 
 ### FISH
 
-Require kubectl version 1.23 or above.
+{{< note >}}
+Requires kubectl version 1.23 or above.
+{{< /note >}}
 
 ```bash
-echo 'kubectl completion fish | source' >> ~/.config/fish/config.fish  # add kubectl autocompletion permanently to your fish shell 
+echo 'kubectl completion fish | source' > ~/.config/fish/completions/kubectl.fish && source ~/.config/fish/completions/kubectl.fish
 ```
 
 ### A note on `--all-namespaces`


### PR DESCRIPTION
put fish completion config in its own conventional place

I almost dumped the completions out directly but then I realized this updates regularly as kubectl updates and adds new functionality.

This is also an improvement over the previous version as it sources the completions immediately.