### PR TITLE
Fix link to custom resources

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -29,7 +29,7 @@ The following principles shaped the design and architecture of Gateway API:
   * __Application Developer:__ Manages an application running in a cluster and is typically
     concerned with application-level configuration and [Service](/docs/concepts/services-networking/service/)
     composition.
-* __Portable:__ Gateway API specifications are defined as [custom resources](docs/concepts/extend-kubernetes/api-extension/custom-resources)
+* __Portable:__ Gateway API specifications are defined as [custom resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources)
   and are supported by many [implementations](https://gateway-api.sigs.k8s.io/implementations/).
 * __Expressive:__ Gateway API kinds support functionality for common traffic routing use cases
   such as header-based matching, traffic weighting, and others that were only possible in


### PR DESCRIPTION
The link to custom resources was broken due to a missing / at the beginning.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
