### PR TITLE
docs : changed "an RBAC" to "a RBAC"

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -42,7 +42,7 @@ to understand how those restrictions can prevent you making some changes.
 
 ### Role and ClusterRole
 
-An RBAC _Role_ or _ClusterRole_ contains rules that represent a set of permissions.
+A RBAC _Role_ or _ClusterRole_ contains rules that represent a set of permissions.
 Permissions are purely additive (there are no "deny" rules).
 
 A Role always sets permissions within a particular {{< glossary_tooltip text="namespace" term_id="namespace" >}};
@@ -240,7 +240,7 @@ GET /api/v1/namespaces/{namespace}/pods/{name}/log
 ```
 
 In this case, `pods` is the namespaced resource for Pod resources, and `log` is a
-subresource of `pods`. To represent this in an RBAC role, use a slash (`/`) to
+subresource of `pods`. To represent this in a RBAC role, use a slash (`/`) to
 delimit the resource and subresource. To allow a subject to read `pods` and
 also access the `log` subresource for each of those Pods, you write:
 


### PR DESCRIPTION
changed from "an RBAC" to "a RBAC"

See issue at https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole

<img width="493" alt="Screenshot 2023-11-12 051618" src="https://github.com/kubernetes/website/assets/102309095/b8ab2c4c-55cd-4d48-9341-5ebf67b40d1c">
