### PR TITLE
Additional clarifications for changing package repository

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -6,11 +6,28 @@ weight: 120
 
 <!-- overview -->
 
-This page explains how to enable a package repository for a new Kubernetes minor release
+This page explains how to enable a package repository for the desired
+Kubernetes minor release upon upgrading a cluster. This is only needed 
 for users of the community-owned package repositories hosted at `pkgs.k8s.io`.
-Unlike the legacy package repositories, the community-owned package repositories are
-structured in a way that there's a dedicated package repository for each Kubernetes
-minor version.
+Unlike the legacy package repositories, the community-owned package
+repositories are structured in a way that there's a dedicated package
+repository for each Kubernetes minor version.
+
+{{< note >}}
+This guide only covers a part of the Kubernetes upgrade process. Please see the
+[upgrade guide](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) for
+more information about upgrading Kubernetes clusters.
+{{</ note >}}
+
+{{< note >}}
+This step is only needed upon upgrading a cluster to another **minor** release.
+If you're upgrading to another patch release within the same minor release (e.g.
+v{{< skew currentVersion >}}.5 to v{{< skew currentVersion >}}.7), you don't
+need to follow this guide. However, if you're still using the legacy package
+repositories, you'll need to migrate to the new community-owned package
+repositories before upgrading (see the next section for more details on how to
+do this).
+{{</ note >}}
 
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
@sftim left some feedback on backports for docs for new package repositories:

- https://github.com/kubernetes/website/pull/43522
- https://github.com/kubernetes/website/pull/43523
- https://github.com/kubernetes/website/pull/43524
- https://github.com/kubernetes/website/pull/43525

This PR is supposed to address those concerns by:

- Clarifying that changing the package repository is meant to be used only when upgrading to another minor release
- Clarifying that changing the package repository document is only one part of the upgrade process

Fixes #43666