### PR TITLE
Fix the links

### DIFF
--- a/content/zh-cn/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/zh-cn/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -37,7 +37,7 @@ API or the `kube-*` components from the upstream code, see the following instruc
 <!--
 You need to have these tools installed:
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Golang](https://golang.org/doc/install) version 1.13+
+  - [Golang](https://go.dev/doc/install) version 1.13+
   - [Docker](https://docs.docker.com/engine/installation/)
   - [etcd](https://github.com/coreos/etcd/)
   - [make](https://www.gnu.org/software/make/)
@@ -46,7 +46,7 @@ You need to have these tools installed:
 - 你需要安装以下工具：
 
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Golang](https://golang.org/doc/install) 的 1.13 版本或更高
+  - [Golang](https://go.dev/doc/install) 的 1.13 版本或更高
   - [Docker](https://docs.docker.com/engine/installation/)
   - [etcd](https://github.com/coreos/etcd/)
   - [make](https://www.gnu.org/software/make/)


### PR DESCRIPTION
The old link cannot be accessed,update the link.
https://golang.org/doc/install ——> https://go.dev/doc/install
