### PR TITLE
Fix visibility of "Learn Kubernetes Basics" button on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,6 +41,6 @@
 
 {{ define "hero-more" }}
 {{ with site.GetPage "section" "docs/tutorials/kubernetes-basics" }}
-<a href="{{ .RelPermalink }}" id="quickstartButton" class="button">{{ .LinkTitle }}</a>
+<a href="{{ .RelPermalink }}"><button id="quickstartButton" class="button">{{ .LinkTitle }}</button></a>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Closes #43396

Changed the link into a button, Now our asset classes apply on it