### PR TITLE
Fix GRPC route link in Kubernetes Gateway API blog

### DIFF
--- a/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
+++ b/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
@@ -169,7 +169,7 @@ If there's something on this list you want to get involved in, or there's
 something not on this list that you want to advocate for to get on the roadmap
 please join us in the #sig-network-gateway-api channel on Kubernetes Slack or our weekly [community calls](https://gateway-api.sigs.k8s.io/contributing/community/#meetings).
 
-[gep1016]:https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-1016.md
+[gep1016]:https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-1016.md
 [grpc]:https://grpc.io/
 [pr1085]:https://github.com/kubernetes-sigs/gateway-api/pull/1085
 [tcpr]:https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1alpha2/tcproute_types.go


### PR DESCRIPTION
Fix broken link