### PR TITLE
feat: add priority class to glossary

### DIFF
--- a/content/en/docs/reference/glossary/priority-class.md
+++ b/content/en/docs/reference/glossary/priority-class.md
@@ -1,0 +1,18 @@
+---
+title: Priority Class
+id: priority-class
+date: 2023-11-20
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/
+short_description: >
+  An object that defines the importance of a Pod relative to other Pods. 
+
+tags:
+- operation
+---
+An object that defines the importance of a {{< glossary_tooltip text="Pod" term_id="pod" >}} relative to other Pods.
+
+<!--more-->
+
+A non-namespaced object that allows application owners to set different levels of importance to Pods. Pods with higher importance will be prioritized by the scheduler. For example, if a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the more important Pod possible.
+
+To learn more, read [Pod Priority and Preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/).

--- a/content/en/docs/reference/glossary/priority-class.md
+++ b/content/en/docs/reference/glossary/priority-class.md
@@ -13,6 +13,6 @@ An object that defines the importance of a {{< glossary_tooltip text="Pod" term_
 
 <!--more-->
 
-A non-namespaced object that allows application owners to set different levels of importance to Pods. Pods with higher importance will be prioritized by the scheduler. For example, if a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the more important Pod possible.
+A non-namespaced object that allows application owners to define a mapping from a priority class name to the integer value, creating levels of importance for Pods. Pods mapped to Priority Class objects with higher importance values will be prioritized by the scheduler. For example, if a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the more important Pod possible.
 
 To learn more, read [Pod Priority and Preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/).

--- a/content/en/docs/reference/glossary/priority-class.md
+++ b/content/en/docs/reference/glossary/priority-class.md
@@ -13,6 +13,6 @@ An object that defines the importance of a {{< glossary_tooltip text="Pod" term_
 
 <!--more-->
 
-A non-namespaced object that allows application owners to define a mapping from a priority class name to the integer value, creating levels of importance for Pods. Pods mapped to Priority Class objects with higher importance values will be prioritized by the scheduler. For example, if a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the more important Pod possible.
+A non-namespaced object that allows application owners to define a mapping from a priority class name to the integer value of the priority, creating levels of importance for Pods. Pods mapped to Priority Class objects with higher importance values will be prioritized by the scheduler. For example, if a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the more important Pod possible.
 
 To learn more, read [Pod Priority and Preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/).


### PR DESCRIPTION
Adds the feature mentioned in #41943 .

Added glossary entry for the PriorityClass resource. I mainly kept the content as close to the original link as possible. 

