### PR TITLE
Add docs for KEP 4216: Image pull per runtime class

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -182,6 +182,7 @@ For a reference to old feature gates that are removed, please refer to
 | `RemainingItemCount` | `true` | Beta | 1.16 | |
 | `RotateKubeletServerCertificate` | `false` | Alpha | 1.7 | 1.11 |
 | `RotateKubeletServerCertificate` | `true` | Beta | 1.12 | |
+| `RuntimeClassInImageCriApi` | `false` | Alpha | 1.29 | |
 | `SELinuxMountReadWriteOncePod` | `false` | Alpha | 1.25 | 1.26 |
 | `SELinuxMountReadWriteOncePod` | `false` | Beta | 1.27 | 1.27 |
 | `SELinuxMountReadWriteOncePod` | `true` | Beta | 1.28 | |
@@ -713,6 +714,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `RotateKubeletServerCertificate`: Enable the rotation of the server TLS certificate on the kubelet.
   See [kubelet configuration](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)
   for more details.
+- `RuntimeClassInImageCriApi` : Enables images to be pulled based on runtime class.
+  This feature gate is currently off by default in v1.29 Alpha.
 - `SELinuxMountReadWriteOncePod`: Speeds up container startup by allowing kubelet to mount volumes
   for a Pod directly with the correct SELinux label instead of changing each file on the volumes
   recursively. The initial implementation focused on ReadWriteOncePod volumes.


### PR DESCRIPTION
Add docs for KEP 4216: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4216-image-pull-per-runtime-class which has been accepted for k8s 1.29

P.S. : Opened this PR against dev-1.29 branch based on review comment here https://github.com/kubernetes/website/pull/43541#issuecomment-1820057245 