### PR TITLE
[dev-1.29] Add docs for KEP 4216: Image pull per runtime class

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -159,6 +159,17 @@ that Kubernetes will keep trying to pull the image, with an increasing back-off 
 Kubernetes raises the delay between each attempt until it reaches a compiled-in limit,
 which is 300 seconds (5 minutes).
 
+## Image pull per runtime class
+
+{{< feature-state for_k8s_version="v1.29" state="alpha" >}}
+Kubernetes includes alpha support for performing image pulls based on the RuntimeClass of a Pod.
+
+If you enable the `RuntimeClassInImageCriApi` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
+the kubelet references container images by a tuple of (image name, runtime handler) rather than just the
+image name or digest. Your {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
+may adapt its behavior based on the selected runtime handler.
+Pulling images based on runtime class will be helpful for VM based containers like windows hyperV containers.
+
 ## Serial and parallel image pulls
 
 By default, kubelet pulls images serially. In other words, kubelet sends only

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -182,6 +182,7 @@ For a reference to old feature gates that are removed, please refer to
 | `RemainingItemCount` | `true` | Beta | 1.16 | |
 | `RotateKubeletServerCertificate` | `false` | Alpha | 1.7 | 1.11 |
 | `RotateKubeletServerCertificate` | `true` | Beta | 1.12 | |
+| `RuntimeClassInImageCriApi` | `false` | Alpha | 1.29 | |
 | `SELinuxMountReadWriteOncePod` | `false` | Alpha | 1.25 | 1.26 |
 | `SELinuxMountReadWriteOncePod` | `false` | Beta | 1.27 | 1.27 |
 | `SELinuxMountReadWriteOncePod` | `true` | Beta | 1.28 | |
@@ -695,6 +696,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `RotateKubeletServerCertificate`: Enable the rotation of the server TLS certificate on the kubelet.
   See [kubelet configuration](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)
   for more details.
+- `RuntimeClassInImageCriApi` : Enables images to be pulled based on the [runtime class]
+  (/docs/concepts/containers/runtime-class/) of the pods that reference them.
 - `SELinuxMountReadWriteOncePod`: Speeds up container startup by allowing kubelet to mount volumes
   for a Pod directly with the correct SELinux label instead of changing each file on the volumes
   recursively. The initial implementation focused on ReadWriteOncePod volumes.


### PR DESCRIPTION
Add docs for KEP 4216: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4216-image-pull-per-runtime-class which has been accepted for k8s 1.29

P.S. : Opened this PR against dev-1.29 branch based on review comment here https://github.com/kubernetes/website/pull/43541#issuecomment-1820057245