### PR TITLE
Containerized the reference documentation generation script

### DIFF
--- a/update-imported-docs/Dockerfile
+++ b/update-imported-docs/Dockerfile
@@ -1,0 +1,32 @@
+# Use Ubuntu as the base image
+FROM ubuntu:20.04
+
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# copy go & brodocs
+COPY --from=golang:latest /usr/local/go /usr/local/go
+COPY --from=gauravpadam/brodocs:latest / /app/brodocs
+
+
+# Install necessary packages and dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.7 \
+    python3-pip \
+    git \
+    sudo \
+    make \
+    gcc \
+    && apt install --reinstall build-essential -y
+
+# Upgrade pip and install PyYAML
+RUN pip3 install --upgrade pip
+RUN pip3 install pyyaml
+
+# Set the GOPATH & NODEPATH environment variable
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV PATH="/app/brodocs/usr/local/bin:${PATH}"
+


### PR DESCRIPTION
Closes the long-standing #28037 (closes #28037)

**I've done a couple of things here:**
- Added a dockerfile which lets us build an image for generation of k8s documentation
- The minor edits in the script itself ensures the script works _both_ in local and containerized environments
- Tested the script in both local and containerized environments; Both yield the same results
<br/>

**How can we test the docker environment?**
cd into your `update-imported-docs` directory
Run the following commands to build and run the image:
<br/>

```
docker build -t refdocsgen .
docker run -it  -v <path-to-website-root-directory>:/website" -v /tempvol refdocsgen /bin/bash -c "./update-imported-docs.py reference.yml <release-version>"
```

We can remove the volume by deleting the container

Edit: #44055 adds the documentation for the same
Edit: PR https://github.com/kubernetes-sigs/reference-docs/pull/345 opened against reference-docs which makes some changes to the makefile; We need not use docker socket anymore
