### PR TITLE
 Fix cleanup instruction in macOS kubectl installation page

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -123,10 +123,10 @@ The following methods exist for installing kubectl on macOS:
    kubectl version --client --output=yaml
    ```
 
-1. After installing the plugin, clean up the installation files:
+1. After installling and validating kubectl, delete the checksum file:
 
    ```bash
-   rm kubectl kubectl.sha256
+   rm kkubectl.sha256
    ```
 
 ### Install with Homebrew on macOS

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -123,7 +123,7 @@ The following methods exist for installing kubectl on macOS:
    kubectl version --client --output=yaml
    ```
 
-1. After installling and validating kubectl, delete the checksum file:
+1. After installing and validating kubectl, delete the checksum file:
 
    ```bash
    rm kkubectl.sha256

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -126,7 +126,7 @@ The following methods exist for installing kubectl on macOS:
 1. After installing and validating kubectl, delete the checksum file:
 
    ```bash
-   rm kkubectl.sha256
+   rm kubectl.sha256
    ```
 
 ### Install with Homebrew on macOS


### PR DESCRIPTION
Sumary of cahnges:

Step 4 of the  https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#install-kubectl-binary-with-curl-on-macos,  tells users to move kubectl binary to a file location on your system PATH but then Step 6 ask the user to delete kubectl along with kubectl.sha256 file, but kubectl is already moved in Step 4. Also, there is section to remove kubectl below in the same page so I change the Step 6 to remove the sha file only now.

This will fix https://github.com/kubernetes/website/issues/44019