### PR TITLE
Use etcdutl instead of etcdctl for restoring an etcd cluster

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -347,16 +347,19 @@ either be a snapshot file from a previous backup operation, or from a remaining
 When restoring the cluster, use the `--data-dir` option to specify to which folder the cluster should be restored:
 
 ```shell
-ETCDCTL_API=3 etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
+etcdutl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
 where `<data-dir-location>` is a directory that will be created during the restore process.
 
-Yet another example would be to first export the `ETCDCTL_API` environment variable:
+Another example would be to first export the `ETCDCTL_API` environment variable:
 
 ```shell
 export ETCDCTL_API=3
 etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
+{{< note >}}
+Using etcdctl for restoring snapshots is deprecated since etcd v3.5.x
+{{< /note >}}
 
 If `<data-dir-location>` is the same folder as before, delete it and stop etcd process before restoring the cluster. Else change etcd configuration and restart the etcd process after restoration to make it use the new data directory.
 

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -351,15 +351,15 @@ etcdutl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
 where `<data-dir-location>` is a directory that will be created during the restore process.
 
-Another example would be to first export the `ETCDCTL_API` environment variable:
+The below example depicts the usage of the `etcdctl` tool for the restore operation:
+{{< note >}}
+The usage of `etcdctl` for restoring has been deprecated since etcd v3.5.x and may be removed from a future etcd release.
+{{< /note >}}
 
 ```shell
 export ETCDCTL_API=3
 etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
-{{< note >}}
-Using etcdctl for restoring snapshots is deprecated since etcd v3.5.x
-{{< /note >}}
 
 If `<data-dir-location>` is the same folder as before, delete it and stop etcd process before restoring the cluster. Else change etcd configuration and restart the etcd process after restoration to make it use the new data directory.
 


### PR DESCRIPTION
This PR refers to the page
Kubernetes Documentation > Tasks > Administer a Cluster > Operating etcd clusters for Kubernetes

In the section titled "Restoring an etcd cluster", the commands use the etcdctl utility to restore from an existing snapshot.
Using etcdctl for restoring snapshots is deprecated since etcd version 3.5.x
Usage of this command displays a deprecation warning and suggests to use etcdutl utility instead

This PR is to depict the use of the etcdutl utility for restoring from an existing snapshot.

Before submitting the PR, I have tested the changes on a local Kubernetes cluster for v1.28.0 and I can confirm everything works as expected.

I have kept a reference to the etcdctl command in the 3rd example and I have added a note highlighting the deprecation.

I feel this change is necessary as the etcd official documentation has already changed to reflect the use of the etcdutl utility, as can be seen in the etcd documentation referenced in this section - https://etcd.io/docs/v3.6/op-guide/recovery/#restoring-a-cluster.

This PR tries to fix #44216