### PR TITLE
Document on the probes page that redirects are not followed to 

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -488,7 +488,9 @@ startupProbe:
 ```
 
 {{< note >}}
-HTTP probes will not follow redirects. It will succeed on redirect response like `302`, but will report the warning as shown below:
+When the kubelet probes a Pod using HTTP, the default behavior is only to follows redirects if the redirect  
+is to the same host. If the kubelet receives 11 or more redirects during probing, the probe is considered a  
+warning and a related Event is created:  
 
 ```none
 Events:
@@ -499,9 +501,11 @@ Events:
   Normal   Pulled        24m                     kubelet            Successfully pulled image "docker.io/kennethreitz/httpbin" in 5m12.402735213s
   Normal   Created       24m                     kubelet            Created container httpbin
   Normal   Started       24m                     kubelet            Started container httpbin
-  Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: <body>
+ Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects  
 ```
 
+If the kubelet receives a redirect where the hostname is different from the request, the outcome of the probe  
+is a warning and the kubelet creates an event to report this.
 {{< /note >}}
 
 ### TCP probes

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -488,9 +488,9 @@ startupProbe:
 ```
 
 {{< note >}}
-When the kubelet probes a Pod using HTTP, the default behavior is only to follows redirects if the redirect  
-is to the same host. If the kubelet receives 11 or more redirects during probing, the probe is considered a  
-warning and a related Event is created:  
+When the kubelet probes a Pod using HTTP, it only follows redirects if the redirect   
+is to the same host. If the kubelet receives 11 or more redirects during probing, the probe is considered successful
+and a related Event is created:  
 
 ```none
 Events:
@@ -504,8 +504,7 @@ Events:
  Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects  
 ```
 
-If the kubelet receives a redirect where the hostname is different from the request, the outcome of the probe  
-is a warning and the kubelet creates an event to report this.
+If the kubelet receives a redirect where the hostname is different from the request, the outcome of the probe is treated as successful and kubelet creates an event to report the redirect failure.
 {{< /note >}}
 
 ### TCP probes

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -487,6 +487,23 @@ startupProbe:
         value: ""
 ```
 
+{{< note >}}
+HTTP probes will not follow redirects. It will succeed on redirect response like `302`, but will report the warning as shown below:
+
+```none
+Events:
+  Type     Reason        Age                     From               Message
+  ----     ------        ----                    ----               -------
+  Normal   Scheduled     29m                     default-scheduler  Successfully assigned default/httpbin-7b8bc9cb85-bjzwn to daocloud
+  Normal   Pulling       29m                     kubelet            Pulling image "docker.io/kennethreitz/httpbin"
+  Normal   Pulled        24m                     kubelet            Successfully pulled image "docker.io/kennethreitz/httpbin" in 5m12.402735213s
+  Normal   Created       24m                     kubelet            Created container httpbin
+  Normal   Started       24m                     kubelet            Started container httpbin
+  Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: <body>
+```
+
+{{< /note >}}
+
 ### TCP probes
 
 For a TCP probe, the kubelet makes the probe connection at the node, not in the Pod, which


### PR DESCRIPTION
What type of PR is this?
/sig node

Which issue(s) this PR fixes:
This PR fixes issue #30849.

The changes are done on this page -> https://deploy-preview-44098--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

![Screenshot 2023-11-27 114113](https://github.com/kubernetes/website/assets/108334168/e58b84f9-6bb1-41ce-9317-46b09bb43147)
