### PR TITLE
Delay December patch releases for 2023-12-13

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,15 +78,10 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| November 2023         | N/A                  | N/A         |
-| December 2023         | 2023-12-01           | 2023-12-06  |
+| December 2023         | 2023-12-08           | 2023-12-13  |
 | January 2024          | 2024-01-12           | 2024-01-17  |
 | February 2024         | 2024-02-09           | 2024-02-14  |
 | March 2024            | 2024-03-08           | 2024-03-13  |
-
-**Note:** Due to overlap with KubeCon NA 2023 and the resulting lack of
-availability of Release Managers, it has been decided to skip patch releases
-in November. Instead, we'll have patch releases early in December.
 
 ## Detailed Release History for Active Branches
 


### PR DESCRIPTION
This PR updates the patch releases calendar to:

- Remove November patch releases given we had out-of-band releases already
- Delay December patch releases for 2023-12-13 (cherry-pick deadline 2023-12-08) to give more time for PRs to get merged after code freeze

Slack discussion: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1701097256703869

/assign @jeremyrickard @saschagrunert @cpanato @Verolop 
cc @kubernetes/release-engineering 