### PR TITLE
Add new warning for kubernetes deb/RPM packages migration

### DIFF
--- a/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
+++ b/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
@@ -100,10 +100,12 @@ community-owned repositories (`pkgs.k8s.io`).
 
 ## Can I continue to use the legacy package repositories?
 
-The existing packages in the legacy repositories will be available for the foreseeable
+~~The existing packages in the legacy repositories will be available for the foreseeable
 future. However, the Kubernetes project can't provide _any_ guarantees on how long
 is that going to be. The deprecated legacy repositories, and their contents, might
-be removed at any time in the future and without a further notice period.
+be removed at any time in the future and without a further notice period.~~
+
+**UPDATE**: The legacy packages are expected to go away in January 2024.
 
 The Kubernetes project **strongly recommends** migrating to the new community-owned
 repositories **as soon as possible**.

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -207,3 +207,13 @@ announcements:
   message: |
     4 days of incredible opportunities to collaborate, learn + share with the entire community!<br />
     November 6 - November 9, 2023.
+
+- name: Legacy package repositories shutdown
+  startTime: 2023-11-27T00:00:00
+  endTime: 2024-02-01T00:00:00
+  style: "background: #d95e00"
+  title: Changes to the location of Linux packages for Kubernetes
+  message: |
+    The legacy Linux package repositories (`apt.kubernetes.io` and `yum.kubernetes.io` AKA `packages.cloud.google.com`)<br/>
+    have been frozen starting from September 13, 2023 **and are going away in January 2024**, users *must* migrate.<br/>
+    Please read our [announcement](/blog/2023/08/31/legacy-package-repository-deprecation/) for more details.


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Previously we only had a vague warning that users should migrate as soon as possible. We now have a more concrete (though technically approximate) timeline that they _must_ migrate before January 2024 and should re-emphasize this change.

Technically the project could redirect these old apt.kubernetes.io and yum.kubernetes.io endpoints to a static snapshot but that will take time, effort, and resources and it's not clear as a project that we should continue to do this versus moving forward with the new community managed host, so in the meantime we should warn that the endpoints as-is will stop working.