### PR TITLE
fix: Create a static pod running argument [zh]

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/static-pod.md
@@ -166,7 +166,7 @@ For example, this is how to start a simple web server as a static Pod:
    `--pod-manifest-path=/etc/kubernetes/manifests/` argument.
    On Fedora, edit `/etc/kubernetes/kubelet` to include this line:
 -->
-3. 配置这个节点上的 kubelet，使用这个参数执行 `--pod-manifest-path=/etc/kubelet.d/`。
+3. 配置这个节点上的 kubelet，使用这个参数执行 `--pod-manifest-path=/etc/kubernetes/manifests/`。
    在 Fedora 上编辑 `/etc/kubernetes/kubelet` 以包含下面这行：
 
    ```


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
[EN]
Configure your kubelet on the node to use this directory by running it with --pod-manifest-path=/etc/kubernetes/manifests/ argument. On Fedora, edit /etc/kubernetes/kubelet to include this line:
[ZH]
配置这个节点上的 kubelet，使用这个参数执行 --pod-manifest-path=/etc/kubelet.d/。 在 Fedora 上编辑 /etc/kubernetes/kubelet 以包含下面这行：