### PR TITLE
[dev-1.29] Address review comment for KEP 4216 doc

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -159,7 +159,7 @@ that Kubernetes will keep trying to pull the image, with an increasing back-off 
 Kubernetes raises the delay between each attempt until it reaches a compiled-in limit,
 which is 300 seconds (5 minutes).
 
-## Image pull per runtime class
+### Image pull per runtime class
 
 {{< feature-state for_k8s_version="v1.29" state="alpha" >}}
 Kubernetes includes alpha support for performing image pulls based on the RuntimeClass of a Pod.


### PR DESCRIPTION
Add docs for KEP 4216: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4216-image-pull-per-runtime-class which has been accepted for k8s 1.29

This PR mainly addresses the review comment here https://github.com/kubernetes/website/pull/44028#discussion_r1406194376 from @sftim 