### PR TITLE
Fix markup for tutorials

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -153,7 +153,7 @@ description: |-
       </div>
       <div class="row">
           <p>
-            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" title="Viewing Pods and Nodes">Viewing Pods and Nodes</a>.</p>
+            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" title="Viewing Pods and Nodes">Viewing Pods and Nodes</a>.
           </p>
       </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -189,7 +189,7 @@ description: |-
 
       <div class="row">
           <p>
-            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/" title="Using A Service To Expose Your App">Using A Service To Expose Your App</a>.</p>
+            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/" title="Using A Service To Expose Your App">Using A Service To Expose Your App</a>.
           </p>
       </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -128,7 +128,7 @@ description: |-
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Step 2: Using labels</h3>
+				<h3>Using labels</h3>
 				<div class="content">
 				<p>The Deployment created automatically a label for our Pod. With the <code>describe deployment</code> subcommand you can see the name (the <em>key</em>) of that label:</p>
 				<p><code><b>kubectl describe deployment</b></code></p>
@@ -166,7 +166,7 @@ description: |-
 		</div>
 				<div class="row">
 				<p>
-					Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" title="Running Multiple Instances of Your App">Running Multiple Instances of Your App</a>.</p>
+					Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" title="Running Multiple Instances of Your App">Running Multiple Instances of Your App</a>.
 				</p>
 				</div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -174,7 +174,7 @@ kubernetes-bootcamp   1/1     1            1           11m
 
       <div class="row">
           <p>
-            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/update/update-intro/" title="Performing a Rolling Update">Performing a Rolling Update</a>.</p>
+            Once you're ready, move on to <a href="/docs/tutorials/kubernetes-basics/update/update-intro/" title="Performing a Rolling Update">Performing a Rolling Update</a>.
           </p>
       </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -140,7 +140,7 @@ description: |-
         </div>
         <div class="row">
             <div class="col-md-12">
-               <h3>Step 2: Verify an update</h3>
+               <h3>Verify an update</h3>
                <p>First, check that the app is running. To find the exposed IP address and port, run the <code>describe service</code> command:</p>
                <p><code><b>kubectl describe services/kubernetes-bootcamp</b></code></p>
                <p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
@@ -183,7 +183,7 @@ description: |-
         <div class="row">
             <div class="col-md-12">
                 <p>Remember to clean up your local cluster</p>
-                <p><code><b>kubectl delete deployments/kubernetes-bootcamp services/kubernetes-bootcamp</b></code></p>
+                <p><code><b>kubectl delete deployments/kubernetes-bootcamp services/kubernetes-bootcamp</b></code>
             </div>
         </div>
 


### PR DESCRIPTION
Updated /content/en/docs/tutorials/kubernetes-basics/deploy-intro.html to update-intro.html

- Remove extra </p> tag from the docs

- Updated headings in expose-intro.html and update-intro.html 