### PR TITLE
Dev 1.29 user namespaces pss update

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -485,6 +485,12 @@ Restrictions on the following controls are only required if `.spec.os.name` is n
 - Seccomp
 - Linux Capabilities
 
+## User namespaces
+
+User Namespaces are a Linux-only feature to run workloads with increased
+isolation. How they work together with Pod Security Standards is described in
+the [documentation](/docs/concepts/workloads/pods/user-namespaces#integration-with-pod-security-admission-checks) for Pods that use user namespaces.
+
 ## FAQ
 
 ### Why isn't there a profile between privileged and baseline?

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -811,7 +811,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `UserNamespacesPodSecurityStandards`: Enable Pod Security Standards policies relaxation for pods
   that run with namespaces. You must set the value of this feature gate consistently across all nodes in
   your cluster, and you must also enable `UserNamespacesSupport` to use this feature.
-  See [User Namespaces](/docs/concepts/workloads/pods/user-namespaces/#integration-with-pod-security-standards) for more details.
+  See [User Namespaces](/docs/concepts/workloads/pods/user-namespaces/#integration-with-pod-security-admission-checks) for more details.
 - `UserNamespacesSupport`: Enable user namespace support for Pods.
   Before Kubernetes v1.28, this feature gate was named `UserNamespacesStatelessPodsSupport`.
 - `ValidatingAdmissionPolicy`: Enable [ValidatingAdmissionPolicy](/docs/reference/access-authn-authz/validating-admission-policy/)


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/website/pull/43803

I think it would be best to rebase the PR on top of `master` once `dev-1.29` got integrated into it.