### PR TITLE
Add details in kubeadm-reconfigure.md for etcd

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
@@ -99,11 +99,14 @@ kubeadm init phase certs <component-name> --config <config-file>
 To write new manifest files in `/etc/kubernetes/manifests` you can use:
 
 ```shell
+# For Kubernetes control plane components
 kubeadm init phase control-plane <component-name> --config <config-file>
+# For local etcd
+kubeadm init phase etcd local --config <config-file>
 ```
 
 The `<config-file>` contents must match the updated `ClusterConfiguration`.
-The `<component-name>` value must be the name of the component.
+The `<component-name>` value must be a name of a Kubernetes control plane component (`apiserver`, `controller-manager` or `scheduler`).
 
 {{< note >}}
 Updating a file in `/etc/kubernetes/manifests` will tell the kubelet to restart the static Pod for the corresponding component.


### PR DESCRIPTION
The kubeadm init phase doesn't permit to reconfigure the etcd yaml manifest (when etcd is in local mode)

Adding a little more infos and the right command when etcd needs to be reconfigured