### PR TITLE
Update KubeCon dates for 2024

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -47,12 +47,12 @@ To download Kubernetes, visit the [download](/releases/download/) section.
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 6-9, 2023</a>
-        <br>
-        <br>
-        <br>
-        <br>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on March 19-22, 2024</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 12-15, 2024</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Since KubeCon + CloudNativeCon NA 2024 has passed, it's time to update the dates & links of this event at the https://kubernetes.io/ main page. This PR does it.

Note: [new link](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/) to the next (i.e. 2024) NA event went live already but, currently, it features an intro splash only. I guess the full website will follow a bit later. We still