### PR TITLE
Fix rendering issue in tab layout

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -136,7 +136,7 @@ This step should be done upon upgrading from one to another Kubernetes minor
 release in order to get access to the packages of the desired Kubernetes minor
 version.
 
-{{< tabs name="k8s_install_versions" >}}
+{{< tabs name="k8s_upgrade_versions" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 
 1. Open the file that defines the Kubernetes `apt` repository using a text editor of your choice:


### PR DESCRIPTION
Resolves https://github.com/kubernetes/website/issues/44166

#### Additional Context
The cause of the issue is the presence of two tab layouts with the same name, specifically _`k8s_install_versions`_ Consequently, when navigating the [second tab layout](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/change-package-repository/#switching-to-another-kubernetes-package-repository) and selecting different tabs, the content appeared static, while the first tab layout's content changed!
To resolve this issue, the pull request modifies the second tab layout name to ensure uniqueness.

[Preview Fix Tab Layout ](https://deploy-preview-44167--kubernetes-io-main-staging.netlify.app/docs/tasks/administer-cluster/kubeadm/change-package-repository/#switching-to-another-kubernetes-package-repository)| [Current Broken Tab Layout](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/change-package-repository/#switching-to-another-kubernetes-package-repository)