### PR TITLE
Postpone December patch releases for 2023-12-19

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -78,7 +78,7 @@ releases may also occur in between these.
 
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
-| December 2023         | 2023-12-08           | 2023-12-13  |
+| December 2023         | 2023-12-15           | 2023-12-19  |
 | January 2024          | 2024-01-12           | 2024-01-17  |
 | February 2024         | 2024-02-09           | 2024-02-14  |
 | March 2024            | 2024-03-08           | 2024-03-13  |

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -6,8 +6,8 @@ schedules:
   releaseDate: 2023-08-15
   next:
     release: 1.28.5
-    cherryPickDeadline: 2023-12-01
-    targetDate: 2023-12-06
+    cherryPickDeadline: 2023-12-15
+    targetDate: 2023-12-19
   maintenanceModeStartDate: 2024-08-28
   endOfLifeDate: 2024-10-28
   previousPatches:
@@ -35,8 +35,8 @@ schedules:
   endOfLifeDate: 2024-06-28
   next:
     release: 1.27.9
-    cherryPickDeadline: 2023-12-01
-    targetDate: 2023-12-06
+    cherryPickDeadline: 2023-12-15
+    targetDate: 2023-12-19
   previousPatches:
     - release: 1.27.8
       cherryPickDeadline: ""
@@ -75,8 +75,8 @@ schedules:
   endOfLifeDate: 2024-02-28
   next:
     release: 1.26.12
-    cherryPickDeadline: 2023-12-01
-    targetDate: 2023-12-06
+    cherryPickDeadline: 2023-12-15
+    targetDate: 2023-12-19
   previousPatches:
     - release: 1.26.11
       cherryPickDeadline: ""


### PR DESCRIPTION
Following up with the docs update after the official announcement: https://groups.google.com/a/kubernetes.io/g/dev/c/OSAd6wvO3EQ/m/W6022Yo0AgAJ

The December patch releases are postponed for 2023-12-19 with the cherry-pick deadline being 2023-12-15.

/assign @saschagrunert @Verolop @cpanato @jeremyrickard 
cc @kubernetes/release-engineering 