### PR TITLE
Fix typo in 'replicalimit-param.yaml' example YAML

### DIFF
--- a/content/en/examples/validatingadmissionpolicy/replicalimit-param.yaml
+++ b/content/en/examples/validatingadmissionpolicy/replicalimit-param.yaml
@@ -2,5 +2,5 @@ apiVersion: rules.example.com/v1
 kind: ReplicaLimit
 metadata:
   name: "replica-limit-test.example.com"
-  namesapce: "default"
+  namespace: "default"
 maxReplicas: 3


### PR DESCRIPTION
Fix wording of `namespace` in validatingadmissionpolicy/replicalimit-param sample