### PR TITLE
Typo in replicalimit-param.yaml fixed. 

### DIFF
--- a/content/zh-cn/examples/validatingadmissionpolicy/replicalimit-param.yaml
+++ b/content/zh-cn/examples/validatingadmissionpolicy/replicalimit-param.yaml
@@ -2,5 +2,5 @@ apiVersion: rules.example.com/v1
 kind: ReplicaLimit
 metadata:
   name: "replica-limit-test.example.com"
-  namesapce: "default"
+  namespace: "default"
 maxReplicas: 3


### PR DESCRIPTION
Issue fixed: The word 'namspace' had a typo and its fixed now. 
