### PR TITLE
Revert misleading link from deprecation notice

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -67,9 +67,6 @@ other = "You are viewing documentation for Kubernetes version:"
 [deprecation_warning]
 other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date information, see the "
 
-[deprecation_warning_page_link]
-other = "For the most up-to-date information of this page, check out the "
-
 [deprecation_file_warning]
 other = "Deprecated"
 

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -5,10 +5,7 @@
       {{ T "deprecation_title" }} {{ .Param "version" }}
     </h3>
     <p> Kubernetes {{ .Param "version" }} {{ T "deprecation_warning" }}
-     <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
-    </p>
-    <p> {{ T "deprecation_warning_page_link" }} 
-     <a href="{{ .Permalink }}">{{ T "latest_version" }}</a>
+      <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
This addresses part of issue https://github.com/kubernetes/website/issues/44196 which deals revert of https://github.com/kubernetes/website/pull/44173/files

The second part of re-opening the issue#29704 can be done once we get this revert in the repo via this PR