### PR TITLE
[ko] Fix typo in 'DNS for Services and Pods' page

### DIFF
--- a/content/ko/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/ko/docs/concepts/services-networking/dns-pod-service.md
@@ -156,7 +156,7 @@ metadata:
     name: busybox
 spec:
   hostname: busybox-1
-  subdomain: busy-subdomain
+  subdomain: busybox-subdomain
   containers:
   - image: busybox:1.28
     command:
@@ -172,7 +172,7 @@ metadata:
     name: busybox
 spec:
   hostname: busybox-2
-  subdomain: busy-subdomain
+  subdomain: busybox-subdomain
   containers:
   - image: busybox:1.28
     command:
@@ -276,9 +276,9 @@ spec:
 
 사용자들은 파드의 DNS 설정을 통해서 직접 파드의 DNS를 세팅할 수 있다.
 
-`dnsConfig` 필드는 선택적이고, `dnsPolicy` 세팅과 함께 동작한다.
-이때, 파드의 `dnsPolicy`의 값이 "`None`"으로 설정되어 있어야
-`dnsConfig` 필드를 지정할 수 있다.
+`dnsConfig` 필드는 선택적이며, 모든 `dnsPolicy` 설정값에 대해 동작할 수 있다.
+이때, 파드의 `dnsPolicy`의 값이 "`None`"으로 설정되어 있으면
+`dnsConfig` 필드를 필수로 지정해야 한다.
 
 사용자는 `dnsConfig` 필드에서 다음과 같은 속성들을 지정할 수 있다.
 


### PR DESCRIPTION
# modify spec.subdomain example
busy-subdomain -> busybox-subdomain

en-page: https://kubernetes.io/ko/docs/concepts/services-networking/dns-pod-service/#%ED%8C%8C%EB%93%9C%EC%9D%98-hostname-%EB%B0%8F-subdomain-%ED%95%84%EB%93%9C
ko-page: https://kubernetes.io/ko/docs/concepts/services-networking/dns-pod-service/#%ED%8C%8C%EB%93%9C%EC%9D%98-hostname-%EB%B0%8F-subdomain-%ED%95%84%EB%93%9C


# mistranslation change

en-page: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
```
The dnsConfig field is optional and it can work with any dnsPolicy settings. 
However, when a Pod's dnsPolicy is set to "None", the dnsConfig field has to be specified.
```
ko-page: https://kubernetes.io/ko/docs/concepts/services-networking/dns-pod-service/#pod-dns-config

### old
```dnsConfig``` 필드는 선택적이~~고~~, ```dnsPolicy``` ~~세팅과~~ ~~함께~~ 동작~~한다~~. 이때, 파드의 ```dnsPolicy```의 값이 "```None```"으로 설정되어 ~~있어야~~ ```dnsConfig``` ~~필드를~~ ~~지정할~~ ~~수~~ ~~있다~~.
### new
```dnsConfig``` 필드는 선택적이며, 모든 ```dnsPolicy``` 설정값에 대해 동작할 수 있다. 이때, 파드의 ```dnsPolicy```의 값이 "```None```"으로 설정되어 있으면 ```dnsConfig``` 필드는 필수로 지정해야 한다.