### PR TITLE
Fix broken GitHub Learning link in _index.md

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -47,8 +47,8 @@ pull request (PR) to the
 [`kubernetes/website` GitHub repository](https://github.com/kubernetes/website).
 You need to be comfortable with
 [git](https://git-scm.com/) and
-[GitHub](https://lab.github.com/)
-to work effectively in the Kubernetes community.
+[GitHub](https://skills.github.com/)
+to work effectively in the Kubernetes community. 
 
 To get involved with documentation:
 


### PR DESCRIPTION

**Page Updated:** https://kubernetes.io/docs/contribute/#getting-started

Update broken GitHub Learning link to (https://skills.github.com/)

![image](https://github.com/kubernetes/website/assets/76515568/604eb0a5-505b-4552-af6e-280f606e15e5)

