### PR TITLE
[zh-cn] Fix volume-snapshot-classes broken-links

### DIFF
--- a/content/zh-cn/docs/concepts/storage/volume-snapshot-classes.md
+++ b/content/zh-cn/docs/concepts/storage/volume-snapshot-classes.md
@@ -116,7 +116,7 @@ then both the underlying snapshot and VolumeSnapshotContent remain.
 -->
 ### 删除策略 {#deletion-policy}
 
-卷快照类具有 [deletionPolicy] 属性(/zh-cn/docs/concepts/storage/volume-snapshots/#delete)。
+卷快照类具有 [deletionPolicy](/zh-cn/docs/concepts/storage/volume-snapshots/#delete) 属性。
 用户可以配置当所绑定的 VolumeSnapshot 对象将被删除时，如何处理 VolumeSnapshotContent 对象。
 卷快照类的这个策略可以是 `Retain` 或者 `Delete`。这个策略字段必须指定。
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->


## Description

There is a broken link in **zh-cn** [volume-snapshot-classes.md](https://kubernetes.io/zh-cn/docs/concepts/storage/volume-snapshot-classes/#deletion-policy).

This PR is used to fix the issue mentioned above.

Thanks. 