### PR TITLE
Update fr docs outdated link

### DIFF
--- a/content/fr/docs/concepts/storage/volumes.md
+++ b/content/fr/docs/concepts/storage/volumes.md
@@ -857,7 +857,7 @@ Vous devez créer un secret dans l'API Kubernetes avant de pouvoir l'utiliser.
 Un conteneur utilisant un secret en tant que point de montage de volume [subPath](#using-subpath) ne recevra pas les mises à jour des secrets.
 {{< /note >}}
 
-Les secrets sont décrits plus en détails [ici](/docs/user-guide/secrets).
+Les secrets sont décrits plus en détails [ici](/docs/concepts/configuration/secret/).
 
 ### storageOS {#storageos}
 


### PR DESCRIPTION
# The issue
The link to the page about secrets in the volume is broken in the French documentation.

# The fix
This commit addresses the broken link on the volume page.
