### PR TITLE
Add a note about minikube tunnel for Docker Desktop

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -156,6 +156,14 @@ kubernetes-bootcamp   1/1     1            1           11m
                <p>Next, we’ll do a <code>curl</code> to the exposed IP address and port. Execute the command multiple times:</p>
                <p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></b></b></code></p>
                <p>We hit a different Pod with every request. This demonstrates that the load-balancing is working.</p>
+               {{< note >}}<p>If you're running minikube with Docker Desktop as the container driver, a minikube tunnel is needed. This is because containers inside Docker Desktop are isolated from your host computer.<br>
+                <p>In a separate terminal window, execute:<br>
+                  <code><b>minikube service kubernetes-bootcamp --url</b></code></p>
+                <p>The output looks like this:
+                  <pre><b>http://127.0.0.1:51082<br>!  Because you are using a Docker driver on darwin, the terminal needs to be open to run it.</b></pre></p>
+                <p>Then use the given URL to access the app:<br>
+                  <code><b>curl 127.0.0.1:51082</b></code></p>
+               {{< /note >}}
             </div>
         </div>
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This PR tries to fix #40645 

When using Docker Desktop as the container driver for minikube, a minikube tunnel is needed. This is because containers inside Docker Desktop are isolated from your host computer.
This is explained very well as a note in [Using a Service to Expose Your App](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/).

In this PR, I added the same section to [Running Multiple Instances of Your App](https://kubernetes.io/docs/tutorials/kubernetes-basics/scale/scale-intro/).

Suggestions and feedback are welcome.

Best Regards,
Aditya