### PR TITLE
RFC 1035 vs RFC 1123: clarify the difference

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -67,6 +67,11 @@ This means the name must:
 - start with an alphabetic character
 - end with an alphanumeric character
 
+The only difference between the RFC 1035 and RFC 1123
+label standards is that RFC 1123 labels are allowed to
+start with a digit, whereas RFC 1035 labels can start
+with a lowercase alphabetic character only.
+
 ### Path Segment Names
 
 Some resource types require their names to be able to be safely encoded as a

--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -67,10 +67,12 @@ This means the name must:
 - start with an alphabetic character
 - end with an alphanumeric character
 
+{{< note >}}
 The only difference between the RFC 1035 and RFC 1123
 label standards is that RFC 1123 labels are allowed to
 start with a digit, whereas RFC 1035 labels can start
 with a lowercase alphabetic character only.
+{{< /note >}}
 
 ### Path Segment Names
 


### PR DESCRIPTION
Add a paragraph explaining what is the difference between RFC 1035
and RFC 1123 labels.

Before this change, the documentation just listed the requirements for
each type of label, which meant the reader had to use their brain to
work out for themselves what the difference actually is. This takes time
and mental load. It is better that the documentation explicitly state
what the actual difference is, so the reader doesn't have to do that.

It will also hopefully reduce the future incidence of people logging
issues due to being confused about the difference between them,
see for example: https://github.com/kubernetes/kubernetes/issues/116964