### PR TITLE
Changes to reflect the deprecation of pod-manifest-path argument

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -97,17 +97,16 @@ For example, this is how to start a simple web server as a static Pod:
    EOF
    ```
 
-1. Configure your kubelet on the node to use this directory by running it with
+1. Configure the kubelet on that node to set a `staticPodPath` value in the
+   [kubelet configuration file](/docs/reference/config-api/kubelet-config.v1beta1/).  
+   See [Set Kubelet Parameters Via A Configuration File](/docs/tasks/administer-cluster/kubelet-config-file/)
+   for more information.
+
+   An alternative and deprecated method is to configure the kubelet on that node
+   to look for static Pod manifests locally, using a command line argument.
+   To use the deprecated approach, start the kubelet with the  
    `--pod-manifest-path=/etc/kubernetes/manifests/` argument.
-   On Fedora, edit `/etc/kubernetes/kubelet` to include this line:
-
-   ```
-   KUBELET_ARGS="--cluster-dns=10.254.0.10 --cluster-domain=kube.local --pod-manifest-path=/etc/kubernetes/manifests/"
-   ```
-
-   or add the `staticPodPath: <the directory>` field in the
-   [kubelet configuration file](/docs/reference/config-api/kubelet-config.v1beta1/).
-
+      
 1. Restart the kubelet. On Fedora, you would run:
 
    ```shell


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This PR tries to fix #32835 

This PR contains the following changes:
1. Reflect the "staticPodPath" as the primary option to configure the directory holding the static pod manifests.
2. Specify in a note block that the option to configure this using an argument is now deprecated.

I am personally of the opinion that it is not necessary to mention the deprecated option anymore.
If reviewers agree, I could remove the reference to the deprecated option altogether.

Suggestions and feedback are welcome.

Best Regards,
Aditya
