### PR TITLE
Fix Broken voyager link in ingress-controllers.md

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -64,7 +64,7 @@ Kubernetes as a project supports and maintains [AWS](https://github.com/kubernet
 * The [Traefik Kubernetes Ingress provider](https://doc.traefik.io/traefik/providers/kubernetes-ingress/) is an
   ingress controller for the [Traefik](https://traefik.io/traefik/) proxy.
 * [Tyk Operator](https://github.com/TykTechnologies/tyk-operator) extends Ingress with Custom Resources to bring API Management capabilities to Ingress. Tyk Operator works with the Open Source Tyk Gateway & Tyk Cloud control plane.
-* [Voyager](https://appscode.com/products/voyager) is an ingress controller for
+* [Voyager](https://voyagermesh.com) is an ingress controller for
   [HAProxy](https://www.haproxy.org/#desc).
 * [Wallarm Ingress Controller](https://www.wallarm.com/solutions/waf-for-kubernetes) is an Ingress Controller that provides WAAP (WAF) and API Security capabilities.
 


### PR DESCRIPTION
Fixed Broken Voyager link in Ingress controller page

**Page Changed:** https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#additional-controllers

Changed Link From (https://appscode.com/products/voyager) to (https://voyagermesh.com/)

![image](https://github.com/kubernetes/website/assets/76515568/8426efdb-6108-4d64-8ff2-a72654949f84)

**[OriginalPage](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#additional-controllers)  |  [PreviewPage](https://deploy-preview-44276--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/ingress-controllers/#additional-controllers)**
