### PR TITLE
Added a note to specify only AMD64 compatibility for example image.

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -50,7 +50,7 @@ IP of requests it receives through an HTTP header. You can create it as follows:
 
 {{< note >}}
 The example image works only with AMD64 architecture.
-{{< note >}}
+{{< /note >}}
 
 ```shell
 kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.4

--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -48,6 +48,10 @@ the target localization.
 The examples use a small nginx webserver that echoes back the source
 IP of requests it receives through an HTTP header. You can create it as follows:
 
+{{< note >}}
+The example image works only with AMD64 architecture.
+{{< note >}}
+
 ```shell
 kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.4
 ```
@@ -55,8 +59,6 @@ The output is:
 ```
 deployment.apps/source-ip-app created
 ```
-
-
 
 ## {{% heading "objectives" %}}
 


### PR DESCRIPTION
As per requirement i have added **note** section above [kubectl](https://kubernetes.io/docs/tutorials/services/source-ip/)  command. #44241 