### PR TITLE
fix: responseObject error [zh]

### DIFF
--- a/content/zh-cn/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/zh-cn/docs/reference/config-api/apiserver-audit.v1.md
@@ -234,7 +234,7 @@ Note: All but the last IP can be arbitrarily set by the client.
    to the external type, and serialized as JSON.  Omitted for non-resource requests.  Only logged
    at Response Level.
    -->
-   响应中包含的 API 对象，以 JSON 格式呈现。requestObject 是在被转换为外部类型
+   响应中包含的 API 对象，以 JSON 格式呈现。responseObject 是在被转换为外部类型
    并序列化为 JSON 格式之后才被记录的。
    对于非资源请求，此字段会被忽略。
    只有审计级别为 Response 时才会记录。


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
[EN]
API object returned in the response, in JSON. The ResponseObject is recorded after conversion to the external type, and serialized as JSON. Omitted for non-resource requests. Only logged at Response Level.
[ZH]
响应中包含的 API 对象，以 JSON 格式呈现。requestObject 是在被转换为外部类型 并序列化为 JSON 格式之后才被记录的。 对于非资源请求，此字段会被忽略。 只有审计级别为 Response 时才会记录。