### PR TITLE
Add information about how existing in-trees PVs and in-tree format yaml file will be handled after CSI migration is completed

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1104,7 +1104,12 @@ configuration changes to existing Storage Classes, PersistentVolumes or Persiste
 (referring to in-tree plugins) when transitioning to a CSI driver that supersedes an in-tree plugin.
 
 {{< note >}}
-* Existing PVs created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed and corresponing in-tree volume plugins are deleted.
+Existing PVs created by a in-tree volume plugin can still be used in the future without any configuration
+changes, even after the migration to CSI is completed for that volume type, and even after you upgrade to a
+version of Kubernetes that doesn't have compiled-in support for that kind of storage.
+ 
+As part of that migration, you - or another cluster administrator - **must** have installed and configured
+the appropriate CSI driver for that storage. The core of Kubernetes does not install that software for you.
 * New PVs in manifests referring to in-tree volume plugins can still be created, even after the in-tree volume plugins are removed from Kubernetes.
 {{< /note >}}
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -64,7 +64,7 @@ Below is a list of In-tree plugins that are supported by Kubernetes and the stat
 The Container Storage Interface (CSI) was designed to help Kubernetes replace its existing, in-tree storage driver mechanisms - especially vendor specific plugins. Kubernetes support for the Container Storage Interface has been generally available since Kubernetes v1.13. For more details on CSI Migration, please refer to [Out-of-tree volume plugins](#out-of-tree-volume-plugins).
 
 {{< note >}}
-When a Kubernetes cluster administrator updates a cluster to enable CSI migration, existing workloads that utilize PVCs which are backed by in-tree storage plugins will continue to function as they always have. Existing In trees PVs and In Tree format yaml file will still be used in the future even after the migration is completed, and will not be left unprocessed or deleted in the future. Users can still specify the following In-tree plugins in their yaml file. However, behind the scenes, Kubernetes hands control of all storage management operations (previously targeting in-tree drivers) to CSI drivers.
+When a Kubernetes cluster administrator updates a cluster to enable CSI migration, existing workloads that utilize PVCs which are backed by in-tree storage plugins will continue to function as they always have. Existing in-tree PVs and in-tree format yaml file will still be used in the future even after the migration is completed, and will not be left unprocessed or deleted in the future. Users can still specify the following in-tree plugins in their yaml file. However, behind the scenes, Kubernetes hands control of all storage management operations (previously targeting in-tree drivers) to CSI drivers.
 {{< /note >}}
 
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -60,7 +60,7 @@ a different volume.
 
 ## In-tree volume plugins and their CSI Migration progress {#volume-types}
 
-Below is a list of In-tree plugins that are supported by Kubernetes and the status of their respective CSI Migrations progress.
+Below is a list of in-tree plugins that are supported by Kubernetes and the status of their respective CSI Migrations progress.
 The Container Storage Interface (CSI) was designed to help Kubernetes replace its existing, in-tree storage driver mechanisms - especially vendor specific plugins. Kubernetes support for the Container Storage Interface has been generally available since Kubernetes v1.13. For more details on CSI Migration, please refer to [Out-of-tree volume plugins](#out-of-tree-volume-plugins).
 
 {{< note >}}

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1110,7 +1110,14 @@ version of Kubernetes that doesn't have compiled-in support for that kind of sto
  
 As part of that migration, you - or another cluster administrator - **must** have installed and configured
 the appropriate CSI driver for that storage. The core of Kubernetes does not install that software for you.
-* New PVs in manifests referring to in-tree volume plugins can still be created, even after the in-tree volume plugins are removed from Kubernetes.
+
+---
+
+After that migration, you can also define new PVCs and PVs that refer to the legacy, built-in
+storage integrations.
+Provided you have the appropriate CSI driver installed and configured, the PV creation continues
+to work, even for brand new volumes. The actual storage management now happens through
+the CSI driver.
 {{< /note >}}
 
 The operations and features that are supported include:

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1104,7 +1104,7 @@ configuration changes to existing Storage Classes, PersistentVolumes or Persiste
 (referring to in-tree plugins) when transitioning to a CSI driver that supersedes an in-tree plugin.
 
 {{< note >}}
-* The existing PV created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed. 
+* Existing PVs created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed and corresponing in-tree volume plugins are deleted.
 * A new PV with a manifest that uses in-tree volume plugins can still be created, even after the in-tree volume plugin is removed from Kubernetes.
 {{< /note >}}
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1105,7 +1105,7 @@ configuration changes to existing Storage Classes, PersistentVolumes or Persiste
 
 {{< note >}}
 * Existing PVs created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed and corresponing in-tree volume plugins are deleted.
-* New PVs with manifests that referring to in-tree volume plugins can still be created, even after the in-tree volume plugins are removed from Kubernetes.
+* New PVs in manifests referring to in-tree volume plugins can still be created, even after the in-tree volume plugins are removed from Kubernetes.
 {{< /note >}}
 
 The operations and features that are supported include:

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -58,9 +58,15 @@ Volumes cannot mount within other volumes (but see [Using subPath](#using-subpat
 for a related mechanism). Also, a volume cannot contain a hard link to anything in
 a different volume.
 
-## Types of volumes {#volume-types}
+## In-tree volume plugins and their CSI Migration progress {#volume-types}
 
-Kubernetes supports several types of volumes.
+Below is a list of In-tree plugins that are supported by Kubernetes and the status of their respective CSI Migrations progress.
+The Container Storage Interface (CSI) was designed to help Kubernetes replace its existing, in-tree storage driver mechanisms - especially vendor specific plugins.Kubernetes support for the Container Storage Interface has been generally available since Kubernetes v1.13. For more details on CSI Migration, please refer to [Out-of-tree volume plugins](#out-of-tree-volume-plugins).
+
+{{< note >}}
+When a Kubernetes cluster administrator updates a cluster to enable CSI migration, existing workloads that utilize PVCs which are backed by in-tree storage plugins will continue to function as they always have. Existing In trees PVs and In Tree format yaml file will still be used in the future even after the migration is completed, and will not be left unprocessed or deleted in the future. Users can still specify the following In-tree plugins in their yaml file. However, behind the scenes, Kubernetes hands control of all storage management operations (previously targeting in-tree drivers) to CSI drivers.
+{{< /note >}}
+
 
 ### awsElasticBlockStore (removed) {#awselasticblockstore}
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -58,15 +58,9 @@ Volumes cannot mount within other volumes (but see [Using subPath](#using-subpat
 for a related mechanism). Also, a volume cannot contain a hard link to anything in
 a different volume.
 
-## In-tree volume plugins and their CSI Migration progress {#volume-types}
+## Types of volumes {#volume-types}
 
-Below is a list of in-tree plugins that are supported by Kubernetes and the status of their respective CSI Migrations progress.
-The Container Storage Interface (CSI) was designed to help Kubernetes replace its existing, in-tree storage driver mechanisms - especially vendor specific plugins. Kubernetes support for the Container Storage Interface has been generally available since Kubernetes v1.13. For more details on CSI Migration, please refer to [Out-of-tree volume plugins](#out-of-tree-volume-plugins).
-
-{{< note >}}
-When a Kubernetes cluster administrator updates a cluster to enable CSI migration, existing workloads that utilize PVCs which are backed by in-tree storage plugins will continue to function as they always have. Existing in-tree PVs and in-tree format yaml file will still be used in the future even after the migration is completed, and will not be left unprocessed or deleted in the future. Users can still specify the following in-tree plugins in their yaml file. However, behind the scenes, Kubernetes hands control of all storage management operations (previously targeting in-tree drivers) to CSI drivers.
-{{< /note >}}
-
+Kubernetes supports several types of volumes.
 
 ### awsElasticBlockStore (removed) {#awselasticblockstore}
 
@@ -1108,6 +1102,12 @@ plugins to corresponding CSI plugins (which are expected to be installed and con
 As a result, operators do not have to make any
 configuration changes to existing Storage Classes, PersistentVolumes or PersistentVolumeClaims
 (referring to in-tree plugins) when transitioning to a CSI driver that supersedes an in-tree plugin.
+
+{{< note >}}
+* The existing PV created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed. 
+* Manifests that use in-tree volume plugins will also be used in the future without modifying.
+* A new PV with a manifest that uses in-tree volume plugins can still be created, even after the in-tree volume plugin is removed from Kubernetes.
+{{< /note >}}
 
 The operations and features that are supported include:
 provisioning/delete, attach/detach, mount/unmount and resizing of volumes.

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -61,7 +61,7 @@ a different volume.
 ## In-tree volume plugins and their CSI Migration progress {#volume-types}
 
 Below is a list of In-tree plugins that are supported by Kubernetes and the status of their respective CSI Migrations progress.
-The Container Storage Interface (CSI) was designed to help Kubernetes replace its existing, in-tree storage driver mechanisms - especially vendor specific plugins.Kubernetes support for the Container Storage Interface has been generally available since Kubernetes v1.13. For more details on CSI Migration, please refer to [Out-of-tree volume plugins](#out-of-tree-volume-plugins).
+The Container Storage Interface (CSI) was designed to help Kubernetes replace its existing, in-tree storage driver mechanisms - especially vendor specific plugins. Kubernetes support for the Container Storage Interface has been generally available since Kubernetes v1.13. For more details on CSI Migration, please refer to [Out-of-tree volume plugins](#out-of-tree-volume-plugins).
 
 {{< note >}}
 When a Kubernetes cluster administrator updates a cluster to enable CSI migration, existing workloads that utilize PVCs which are backed by in-tree storage plugins will continue to function as they always have. Existing In trees PVs and In Tree format yaml file will still be used in the future even after the migration is completed, and will not be left unprocessed or deleted in the future. Users can still specify the following In-tree plugins in their yaml file. However, behind the scenes, Kubernetes hands control of all storage management operations (previously targeting in-tree drivers) to CSI drivers.

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1105,7 +1105,6 @@ configuration changes to existing Storage Classes, PersistentVolumes or Persiste
 
 {{< note >}}
 * The existing PV created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed. 
-* Manifests that use in-tree volume plugins will also be used in the future without modifying.
 * A new PV with a manifest that uses in-tree volume plugins can still be created, even after the in-tree volume plugin is removed from Kubernetes.
 {{< /note >}}
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1105,7 +1105,7 @@ configuration changes to existing Storage Classes, PersistentVolumes or Persiste
 
 {{< note >}}
 * Existing PVs created by in-tree volume plugin can still be used in the future without any configuration changes even after the `CSIMigration` is completed and corresponing in-tree volume plugins are deleted.
-* A new PV with a manifest that uses in-tree volume plugins can still be created, even after the in-tree volume plugin is removed from Kubernetes.
+* New PVs with manifests that referring to in-tree volume plugins can still be created, even after the in-tree volume plugins are removed from Kubernetes.
 {{< /note >}}
 
 The operations and features that are supported include:


### PR DESCRIPTION
This PR added information about how existing in-trees PVs and in-tree format yaml file will be handled after CSI migration is completed to the "Migrating to CSI drivers from in-tree plugin" section at the volume page.
https://kubernetes.io/docs/concepts/storage/volumes/#migrating-to-csi-drivers-from-in-tree-plugins

I think these contents needs to be added for the following reason:
Our users might be confused as to whether their existing in-trees PVs and manifests that use in-tree volume plugins will still work after the CSI Migration is completed, but only the 2022 Blog states that the project will continue to run as usual, the documentation doesn't mention this matter. So I added some introduction about this.

The added content is all from the following blog and Issue:
・Issue [About the future of existing PV generated from the in-tree format yaml once the CSI migration is complete](https://github.com/kubernetes/kubernetes/issues/120907)

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
