### PR TITLE
Update container-runtimes.md

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -233,6 +233,11 @@ To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc`,
 The `systemd` cgroup driver is recommended if you use [cgroup v2](/docs/concepts/architecture/cgroups).
 
 {{< note >}}
+The elipses above indicate that config.toml should already have these sections. If you
+find yourself having to create these entries (instead of just changing `SystemdCgroup`
+to `true`, then you definitely need to run the `containerd config` command referenced
+below.
+
 If you installed containerd from a package (for example, RPM or `.deb`), you may find
 that the CRI integration plugin is disabled by default.
 


### PR DESCRIPTION
Added a clarification on setting systemd as the cgroup driver. Many folks setting up kubernetes for the first time are not going to understand what a crash loop is or if they're having one.

There is a lot I don't know, so maybe it's not always the case that your config.toml should already be populated. But... if it's acceptable to run the `containerd config defaults` command, it makes sense to suggest that from the start to keep people from wasting time when their kubeapi isn't up after the `kubeadm init` command.
