### PR TITLE
Feature gate SchedulerQueueingHints is disabled by default

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -84,8 +84,10 @@ the Pod is put into the active queue or the backoff queue
 so that the scheduler will retry the scheduling of the Pod.
 
 {{< note >}}
-QueueingHint evaluation during scheduling is a beta-level feature and is enabled by default in 1.28. 
-You can disable it via the
+QueueingHint evaluation during scheduling is a beta-level feature. 
+It's enabled by default in 1.28.0 - 1.28.5, 
+but is disabled by default in 1.29 because of excessive memory footprint.
+You can enable it via the
 `SchedulerQueueingHints` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 {{< /note >}}
 

--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -85,8 +85,10 @@ so that the scheduler will retry the scheduling of the Pod.
 
 {{< note >}}
 QueueingHint evaluation during scheduling is a beta-level feature. 
-It's enabled by default in 1.28.0 - 1.28.5, 
-but is disabled by default in 1.29 because of excessive memory footprint.
+The v1.28 release series initially enabled the associated feature gate; however, after the
+discovery of an excessive memory footprint, the Kubernetes project set that feature gate
+to be disabled by default. In Kubernetes {{< skew currentVersion >}}, this feature gate is
+disabled and you need to enable it manually.
 You can enable it via the
 `SchedulerQueueingHints` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 {{< /note >}}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -184,7 +184,7 @@ For a reference to old feature gates that are removed, please refer to
 | `SELinuxMountReadWriteOncePod` | `false` | Alpha | 1.25 | 1.26 |
 | `SELinuxMountReadWriteOncePod` | `false` | Beta | 1.27 | 1.27 |
 | `SELinuxMountReadWriteOncePod` | `true` | Beta | 1.28 | |
-| `SchedulerQueueingHints` | `true` | Beta | 1.28.0 | 1.28.5 |
+| `SchedulerQueueingHints` | `true` | Beta | 1.28 | 1.28 |
 | `SchedulerQueueingHints` | `false` | Beta | 1.29 | |
 | `SecurityContextDeny` | `false` | Alpha | 1.27 | |
 | `SeparateTaintEvictionController` | `true` | Beta | 1.29 | |

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -184,7 +184,8 @@ For a reference to old feature gates that are removed, please refer to
 | `SELinuxMountReadWriteOncePod` | `false` | Alpha | 1.25 | 1.26 |
 | `SELinuxMountReadWriteOncePod` | `false` | Beta | 1.27 | 1.27 |
 | `SELinuxMountReadWriteOncePod` | `true` | Beta | 1.28 | |
-| `SchedulerQueueingHints` | `true` | Beta | 1.28 | |
+| `SchedulerQueueingHints` | `true` | Beta | 1.28.0 | 1.28.5 |
+| `SchedulerQueueingHints` | `false` | Beta | 1.29 | |
 | `SecurityContextDeny` | `false` | Alpha | 1.27 | |
 | `SeparateTaintEvictionController` | `true` | Beta | 1.29 | |
 | `ServiceAccountTokenJTI` | `false` | Alpha | 1.29 | |


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Feature gate SchedulerQueueingHints is disabled by default.
https://github.com/kubernetes/kubernetes/pull/122289

This PR reflects it on the doc.