### PR TITLE
Add user guidance comment for executing drain and uncordon on control plane

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -62,6 +62,7 @@ sudo kubeadm upgrade node
 Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
 
 ```shell
+# execute this command on a control plane node
 # replace <node-to-drain> with the name of your node you are draining
 kubectl drain <node-to-drain> --ignore-daemonsets
 ```
@@ -99,6 +100,7 @@ kubectl drain <node-to-drain> --ignore-daemonsets
 Bring the node back online by marking it schedulable:
 
 ```shell
+# execute this command on a control plane node
 # replace <node-to-uncordon> with the name of your node
 kubectl uncordon <node-to-uncordon>
 ```


### PR DESCRIPTION
Fixes #44321

Added clear comments to specify that the `kubectl drain` and `kubectl uncordon` commands must be executed on the controlplane node.

Suggestions and feedback are welcome.

Best Regards,
Aditya

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
