### PR TITLE
[es] localize content/en/docs/tasks/tools/install-kubectl-macos.md to Spanish

### DIFF
--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -1,6 +1,6 @@
 ---
-title: "autocompletado con fish"
-description: "Configuración opcional para habilitar el autocompletado en la shell fish."
+title: "Autocompletado con Fish"
+description: "Configuración opcional para habilitar el autocompletado de la shell Fish"
 headless: true
 _build:
   list: never
@@ -9,12 +9,12 @@ _build:
 ---
 
 {{< note >}}
-El autocompletado para Fish necesita de kubectl versión 1.23 o superior.
+Se requiere kubectl 1.23 o superior para utilizar el autocompletado de Fish.
 {{< /note >}}
 
-El script de autocompletado de Fish para kubectl puede ser generado con el comando `kubectl completion fish`. Ejecutando este comando en tu shell habilitará el autocompletado de kubectl para Fish.
+El script de autocompletado de Fish puede ser generado con el comando `kubectl completion fish`. Leyendo este archivo en su Shell habilita el autocompletado de kubectl.
 
-Para qué funcione en sus futuras sesiones shell, debes agregar la siguiente línea al archivo `~/.config/fish/config.fish`:
+Para hacer esto en todas sus sesiones agregue la siguiente linea a su archivo `~/.config/fish/config.fish`:
 
 ```shell
 kubectl completion fish | source

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -6,8 +6,8 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-Se debe utilizar la versión de kubectl con la menor versión de diferencia con
-su cluster. Por ejemplo, un cliente con versión v{{< skew currentVersion >}} se puede comunicar
+Se debe utilizar la versión de kubectl con la menor diferencia de versión de respecto de 
+su clúster. Por ejemplo, un cliente con versión v{{< skew currentVersion >}} se puede comunicar
 con los siguientes versiones de plano de control v{{< skew currentVersionAddMinor -1 >}}, 
 v{{< skew currentVersionAddMinor 0 >}}, and v{{< skew currentVersionAddMinor 1 >}}.
 Utilizar la última versión compatible de kubectl evita posibles errores.

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -150,36 +150,36 @@ puede instalar kubectl con Homebrew.
    kubectl version --client
    ```
 
-### Install with Macports on macOS
+### Instalar con Macports en macOS
 
-If you are on macOS and using [Macports](https://macports.org/) package manager,
-you can install kubectl with Macports.
+Si esta en macOS y utiliza [Macports](https://macports.org/),
+puede instalar kubectl con Macports.
 
-1. Run the installation command:
+1. Ejecute  el comando para instalar:
 
    ```bash
    sudo port selfupdate
    sudo port install kubectl
    ```
 
-1. Test to ensure the version you installed is up-to-date:
+1. Test para asegurar que la versión instalada está actualizada:
 
    ```bash
    kubectl version --client
    ```
 
-## Verify kubectl configuration
+## Verificar la configuración de kubectl
 
 {{< include "included/verify-kubectl.md" >}}
 
-## Optional kubectl configurations and plugins
+## Configuraciones opcionales y plugins de kubectl
 
-### Enable shell autocompletion
+### Habilitar el autocompletado en la shell
 
-kubectl provides autocompletion support for Bash, Zsh, Fish, and PowerShell
-which can save you a lot of typing.
+Kubectl tiene soporte para autocompletar en Bash, Zsh, Fish y Powershell,
+lo que puede agilizar el tipeo.
 
-Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
+A continuación están los procedimientos para configurarlo en Bash, Fisch y Zsh.
 
 {{< tabs name="kubectl_autocompletion" >}}
 {{< tab name="Bash" include="included/optional-kubectl-configs-bash-mac.md" />}}
@@ -187,11 +187,11 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
 
-### Install `kubectl convert` plugin
+### Instalar el plugin `kubectl convert`
 
 {{< include "included/kubectl-convert-overview.md" >}}
 
-1. Download the latest release with the command:
+1. Descargue la última versión con el siguiente comando:
 
    {{< tabs name="download_convert_binary_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}
@@ -202,9 +202,9 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    {{< /tab >}}
    {{< /tabs >}}
 
-1. Validate the binary (optional)
+1. Valide el binario (opcional)
 
-   Download the kubectl-convert checksum file:
+   Descargue el checksum de kubectl-convert:
 
    {{< tabs name="download_convert_checksum_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}
@@ -215,19 +215,19 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    {{< /tab >}}
    {{< /tabs >}}
 
-   Validate the kubectl-convert binary against the checksum file:
+   Ahora se puede validar el binario utilizando el checksum:
 
    ```bash
    echo "$(cat kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
    ```
 
-   If valid, the output is:
+   Si es válido, la salida será:
 
    ```console
    kubectl-convert: OK
    ```
 
-   If the check fails, `shasum` exits with nonzero status and prints output similar to:
+   En caso de falla, `sha256` terminará con un estado diferente a cero con una salida similar a esta:
 
    ```console
    kubectl-convert: FAILED
@@ -235,16 +235,16 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    ```
 
    {{< note >}}
-   Download the same version of the binary and checksum.
+   Descargue la misma versión del binario y del checksum.
    {{< /note >}}
 
-1. Make kubectl-convert binary executable
+1. Dar permisos de ejecución al binario.
 
    ```bash
    chmod +x ./kubectl-convert
    ```
 
-1. Move the kubectl-convert binary to a file location on your system `PATH`.
+1. Mover el binario de kubectl al `PATH` de su sistema.
 
    ```bash
    sudo mv ./kubectl-convert /usr/local/bin/kubectl-convert
@@ -252,45 +252,46 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    ```
 
    {{< note >}}
-   Make sure `/usr/local/bin` is in your PATH environment variable.
+   Asegúrese que el PATH `/usr/local/bin` forme parte de las variables de entorno.
    {{< /note >}}
 
-1. Verify plugin is successfully installed
+1. Verificar si el plugin fue instalado correctamente
 
    ```shell
    kubectl convert --help
    ```
 
-   If you do not see an error, it means the plugin is successfully installed.
+   Si no visualiza ningún error quiere decir que el plugin fue instalado correctamente.
 
-1. After installing the plugin, clean up the installation files:
+1. Después de instalar el plugin elimine los archivos de instalación:
 
    ```bash
    rm kubectl-convert kubectl-convert.sha256
    ```
 
-### Uninstall kubectl on macOS
+### Eliminar kubectl en macOS
 
-Depending on how you installed `kubectl`, use one of the following methods.
+Dependiendo de como haya instalado `kubectl` puede utilizar uno de los siguientes métodos.
 
-### Uninstall kubectl using the command-line
+### Eliminar kubectl usando la linea de comandos
 
-1.  Locate the `kubectl` binary on your system:
+1.  Ubique el binario de `kubectl` en su sistema:
 
     ```bash
     which kubectl
     ```
 
-1.  Remove the `kubectl` binary:
+1.  Elimine el binario de `kubectl`:
 
     ```bash
     sudo rm <path>
     ```
-    Replace `<path>` with the path to the `kubectl` binary from the previous step. For example, `sudo rm /usr/local/bin/kubectl`.
+    Reemplace `<path>` con el path que apunta al binario de `kubectl`
+    del paso anterior. Por ejemplo, `sudo rm /usr/local/bin/kubectl`
 
-### Uninstall kubectl using homebrew
+### Eliminar kubectl utilizando homebrew
 
-If you installed `kubectl` using Homebrew, run the following command:
+Si instaló `kubectl` utilizando Homebrew ejecute el siguiente comando:
 
 ```bash
 brew remove kubectl
@@ -299,5 +300,3 @@ brew remove kubectl
 ## {{% heading "whatsnext" %}}
 
 {{< include "included/kubectl-whats-next.md" >}}
-
-

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -16,14 +16,14 @@ Utilizar la última versión compatible de kubectl evita posibles errores.
 
 Existen los siguientes métodos para instalar kubectl en macOS:
 
-- [Instalar kubectl en macOS](#install-kubectl-on-macos)
-  - [Instalación del binario para macOS con Curl](#install-kubectl-binary-with-curl-on-macos)
-  - [Instalar con Homebrew en macOS](#install-with-homebrew-on-macos)
-  - [Instalar con Macports en macOS](#install-with-macports-on-macos)
-- [Verificar la configuración de kubectl](#verify-kubectl-configuration)
-- [Configuraciones y plugins opcionales para kubectl](#optional-kubectl-configurations-and-plugins)
-  - [Habilitar el autocompletado de la shell](#enable-shell-autocompletion)
-  - [Instalar el plugin `kubectl convert`](#install-kubectl-convert-plugin)
+- [Instalar kubectl en macOS](#instalar-kubectl-en-macos)
+  - [Instalación del binario para macOS con Curl](#instalación-del-binario-para-macos-de-kubectl-con-curl)
+  - [Instalar con Homebrew en macOS](#instalar-utilizando-homebrew-en-macos)
+  - [Instalar con Macports en macOS](#instalar-con-macports-en-macos)
+- [Verificar la configuración de kubectl](#verificar-la-configuración-de-kubectl)
+- [Configuraciones y plugins opcionales para kubectl](#configuraciones-opcionales-y-plugins-de-kubectl)
+  - [Habilitar el autocompletado de la shell](#instalar-bash-complete)
+  - [Instalar el plugin `kubectl convert`](#instalar-el-plugin-kubectl-convert)
 
 ### Instalación del binario para macOS de kubectl con Curl
 

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -22,7 +22,7 @@ Existen los siguientes métodos para instalar kubectl en macOS:
   - [Instalar con Macports en macOS](#instalar-con-macports-en-macos)
 - [Verificar la configuración de kubectl](#verificar-la-configuración-de-kubectl)
 - [Configuraciones y plugins opcionales para kubectl](#configuraciones-opcionales-y-plugins-de-kubectl)
-  - [Habilitar el autocompletado de la shell](#instalar-bash-complete)
+  - [Habilitar el autocompletado de la shell](#habilitar-el-autocompletado-en-la-shell)
   - [Instalar el plugin `kubectl convert`](#instalar-el-plugin-kubectl-convert)
 
 ### Instalación del binario para macOS de kubectl con Curl
@@ -39,8 +39,8 @@ Existen los siguientes métodos para instalar kubectl en macOS:
    {{< /tabs >}}
 
    {{< note >}}
-   Para Descargar una versión específica reemplazar la siguiente parte del comando con la 
-   versión que desea instalar `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
+   Para descargar una versión específica, reemplaza la siguiente parte del comando con la 
+   versión que deseas instalar `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
 
    Por ejemplo, para descargar la versión {{< skew currentPatchVersion >}} en macOS:
 
@@ -48,7 +48,7 @@ Existen los siguientes métodos para instalar kubectl en macOS:
    curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/amd64/kubectl"
    ```
 
-   Para macOS con procesador Apple Silicon, ejecute:
+   Para macOS con procesador Apple Silicon, ejecuta:
 
    ```bash
    curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/arm64/kubectl"
@@ -75,7 +75,7 @@ Existen los siguientes métodos para instalar kubectl en macOS:
    echo "$(cat kubectl.sha256)  kubectl" | shasum -a 256 --check
    ```
 
-   Si es válido va a obtener la siguiente respuesta:
+   Si es válido, vas a obtener la siguiente respuesta:
 
    ```console
    kubectl: OK
@@ -98,7 +98,7 @@ Existen los siguientes métodos para instalar kubectl en macOS:
    chmod +x ./kubectl
    ```
 
-1. Mover el binario de kubectl al `PATH` de su sistema.
+1. Mover el binario de kubectl al `PATH` de tu sistema.
 
    ```bash
    sudo mv ./kubectl /usr/local/bin/kubectl
@@ -106,7 +106,7 @@ Existen los siguientes métodos para instalar kubectl en macOS:
    ```
 
    {{< note >}}
-   Asegúrese que el PATH `/usr/local/bin` forme parte de las variables de entorno.
+   Asegúrate que el PATH `/usr/local/bin` forme parte de las variables de entorno.
    {{< /note >}}
 
 1. Test para asegurar que la versión instalada está actualizada:
@@ -153,7 +153,7 @@ puede instalar kubectl con Homebrew.
 ### Instalar con Macports en macOS
 
 Si esta en macOS y utiliza [Macports](https://macports.org/),
-puede instalar kubectl con Macports.
+puedes instalar kubectl con Macports.
 
 1. Ejecute  el comando para instalar:
 
@@ -191,7 +191,7 @@ A continuación están los procedimientos para configurarlo en Bash, Fisch y Zsh
 
 {{< include "included/kubectl-convert-overview.md" >}}
 
-1. Descargue la última versión con el siguiente comando:
+1. Descarga la última versión con el siguiente comando:
 
    {{< tabs name="download_convert_binary_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -1,0 +1,303 @@
+---
+title: Instalar y Configurar kubectl en macOS
+content_type: task
+weight: 10
+---
+
+## {{% heading "prerequisites" %}}
+
+Se debe utilizar la versión de kubectl con una minor versión de diferencia con
+su cluster. Por ejemplo, un cliente con versión v{{< skew currentVersion >}} se puede comunicar
+con los siguientes versiones de plano de control v{{< skew currentVersionAddMinor -1 >}}, 
+v{{< skew currentVersionAddMinor 0 >}}, and v{{< skew currentVersionAddMinor 1 >}}.
+Utilizar la última versión compatible de kubectl evita posibles errores.
+
+## Instalar kubectl en macOS
+
+Existen los siguientes métodos para instalar kubectl en macOS:
+
+- [Instalar kubectl en macOS](#install-kubectl-on-macos)
+  - [Instalación del binario para macOS con Curl](#install-kubectl-binary-with-curl-on-macos)
+  - [Instalar con Homebrew en macOS](#install-with-homebrew-on-macos)
+  - [Instalar con Macports en macOS](#install-with-macports-on-macos)
+- [Verificar la configuración de kubectl](#verify-kubectl-configuration)
+- [Configuraciones y plugins opcionales para kubectl](#optional-kubectl-configurations-and-plugins)
+  - [Habilitar el autocompletado de la shell](#enable-shell-autocompletion)
+  - [Instalar el plugin `kubectl convert`](#install-kubectl-convert-plugin)
+
+### Instalación del binario para macOS de kubectl con Curl
+
+1. Descargar la última versión con el siguiente comando:
+
+   {{< tabs name="download_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+   {{< note >}}
+   Para Descargar una versión específica reemplazar la siguiente parte del comando con la 
+   versión que desea instalar `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
+
+   Por ejemplo, para descargar la versión {{< skew currentPatchVersion >}} en macOS:
+
+   ```bash
+   curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/amd64/kubectl"
+   ```
+
+   Para macOS con procesador Apple Silicon, ejecute:
+
+   ```bash
+   curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/arm64/kubectl"
+   ```
+
+   {{< /note >}}
+
+1. Validación del binario (paso opcional)
+
+   Descargar el archivo checksum:
+
+   {{< tabs name="download_checksum_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
+  
+   Validar el binario de kubectl contra el archivo checksum:
+
+   ```bash
+   echo "$(cat kubectl.sha256)  kubectl" | shasum -a 256 --check
+   ```
+
+   Si es válido va a obtener la siguiente respuesta:
+
+   ```console
+   kubectl: OK
+   ```
+
+   En caso de falla, `sha256` terminará con un estado diferente a cero con una salida similar a:
+
+   ```console
+   kubectl: FAILED
+   shasum: WARNING: 1 computed checksum did NOT match
+   ```
+
+   {{< note >}}
+   Descargue la misma versión del binario y el checksum.
+   {{< /note >}}
+
+1. Dar permisos de ejecución al binario.
+
+   ```bash
+   chmod +x ./kubectl
+   ```
+
+1. Mover el binario de kubectl al `PATH` de su sistema.
+
+   ```bash
+   sudo mv ./kubectl /usr/local/bin/kubectl
+   sudo chown root: /usr/local/bin/kubectl
+   ```
+
+   {{< note >}}
+   Asegúrese que el PATH `/usr/local/bin` forme parte de las variables de entorno.
+   {{< /note >}}
+
+1. Test para asegurar que la versión instalada está actualizada:
+
+   ```bash
+   kubectl version --client
+   ```
+   
+   Se puede utilizar lo siguiente para una vista detallada de la versión:
+
+   ```cmd
+   kubectl version --client --output=yaml
+   ```
+
+1. Luego de instalar el plugin puede eliminar los archivos de instalación:
+
+   ```bash
+   rm kubectl kubectl.sha256
+   ```
+
+### Instalar utilizando Homebrew en macOS
+
+Si está utilizando [Homebrew](https://brew.sh/) en macOS,
+puede instalar kubectl con Homebrew.
+
+1. Ejecute el comando para instalar:
+
+   ```bash
+   brew install kubectl
+   ```
+
+   ó
+
+   ```bash
+   brew install kubernetes-cli
+   ```
+
+1. Test para asegurar que la versión instalada está actualizada:
+
+   ```bash
+   kubectl version --client
+   ```
+
+### Install with Macports on macOS
+
+If you are on macOS and using [Macports](https://macports.org/) package manager,
+you can install kubectl with Macports.
+
+1. Run the installation command:
+
+   ```bash
+   sudo port selfupdate
+   sudo port install kubectl
+   ```
+
+1. Test to ensure the version you installed is up-to-date:
+
+   ```bash
+   kubectl version --client
+   ```
+
+## Verify kubectl configuration
+
+{{< include "included/verify-kubectl.md" >}}
+
+## Optional kubectl configurations and plugins
+
+### Enable shell autocompletion
+
+kubectl provides autocompletion support for Bash, Zsh, Fish, and PowerShell
+which can save you a lot of typing.
+
+Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
+
+{{< tabs name="kubectl_autocompletion" >}}
+{{< tab name="Bash" include="included/optional-kubectl-configs-bash-mac.md" />}}
+{{< tab name="Fish" include="included/optional-kubectl-configs-fish.md" />}}
+{{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
+{{< /tabs >}}
+
+### Install `kubectl convert` plugin
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+1. Download the latest release with the command:
+
+   {{< tabs name="download_convert_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+1. Validate the binary (optional)
+
+   Download the kubectl-convert checksum file:
+
+   {{< tabs name="download_convert_checksum_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+   Validate the kubectl-convert binary against the checksum file:
+
+   ```bash
+   echo "$(cat kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
+   ```
+
+   If valid, the output is:
+
+   ```console
+   kubectl-convert: OK
+   ```
+
+   If the check fails, `shasum` exits with nonzero status and prints output similar to:
+
+   ```console
+   kubectl-convert: FAILED
+   shasum: WARNING: 1 computed checksum did NOT match
+   ```
+
+   {{< note >}}
+   Download the same version of the binary and checksum.
+   {{< /note >}}
+
+1. Make kubectl-convert binary executable
+
+   ```bash
+   chmod +x ./kubectl-convert
+   ```
+
+1. Move the kubectl-convert binary to a file location on your system `PATH`.
+
+   ```bash
+   sudo mv ./kubectl-convert /usr/local/bin/kubectl-convert
+   sudo chown root: /usr/local/bin/kubectl-convert
+   ```
+
+   {{< note >}}
+   Make sure `/usr/local/bin` is in your PATH environment variable.
+   {{< /note >}}
+
+1. Verify plugin is successfully installed
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   If you do not see an error, it means the plugin is successfully installed.
+
+1. After installing the plugin, clean up the installation files:
+
+   ```bash
+   rm kubectl-convert kubectl-convert.sha256
+   ```
+
+### Uninstall kubectl on macOS
+
+Depending on how you installed `kubectl`, use one of the following methods.
+
+### Uninstall kubectl using the command-line
+
+1.  Locate the `kubectl` binary on your system:
+
+    ```bash
+    which kubectl
+    ```
+
+1.  Remove the `kubectl` binary:
+
+    ```bash
+    sudo rm <path>
+    ```
+    Replace `<path>` with the path to the `kubectl` binary from the previous step. For example, `sudo rm /usr/local/bin/kubectl`.
+
+### Uninstall kubectl using homebrew
+
+If you installed `kubectl` using Homebrew, run the following command:
+
+```bash
+brew remove kubectl
+```
+  
+## {{% heading "whatsnext" %}}
+
+{{< include "included/kubectl-whats-next.md" >}}
+
+

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -6,7 +6,7 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-Se debe utilizar la versión de kubectl con una minor versión de diferencia con
+Se debe utilizar la versión de kubectl con la menor versión de diferencia con
 su cluster. Por ejemplo, un cliente con versión v{{< skew currentVersion >}} se puede comunicar
 con los siguientes versiones de plano de control v{{< skew currentVersionAddMinor -1 >}}, 
 v{{< skew currentVersionAddMinor 0 >}}, and v{{< skew currentVersionAddMinor 1 >}}.

--- a/content/es/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/install-kubectl-macos.md
@@ -286,8 +286,7 @@ Dependiendo de como haya instalado `kubectl` puede utilizar uno de los siguiente
     ```bash
     sudo rm <path>
     ```
-    Reemplace `<path>` con el path que apunta al binario de `kubectl`
-    del paso anterior. Por ejemplo, `sudo rm /usr/local/bin/kubectl`
+    Reemplace `<path>` con el path que apunta al binario de `kubectl` del paso anterior. Por ejemplo, `sudo rm /usr/local/bin/kubectl`
 
 ### Eliminar kubectl utilizando homebrew
 


### PR DESCRIPTION
This is a Feature Request closes https://github.com/kubernetes/website/issues/41883

What would you like to be added
Localize content/en/docs/tasks/tools/install-kubectl-macos.md to Spanish

Why is this needed
There is no Spanish localization for this file.

/assign @ramrodo 