### PR TITLE
Fix broken link in v1.29 Release Announcement blog

### DIFF
--- a/content/en/blog/_posts/2023-12-13-kubernetes-1.29.md
+++ b/content/en/blog/_posts/2023-12-13-kubernetes-1.29.md
@@ -5,7 +5,7 @@ date: 2023-12-13
 slug: kubernetes-v1-29-release
 ---
 
-**Authors:** [Kubernetes v1.29 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release_team.md)
+**Authors:** [Kubernetes v1.29 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release-team.md)
 
 **Editors:** Carol Valencia, Kristin Martin, Abigail McCarthy, James Quigley
 


### PR DESCRIPTION
 Go through the [release announcement](https://kubernetes.io/blog/2023/12/13/kubernetes-v1-29-release/) just identified a broken link to the Authors file of the release team members. This PR aims to fix the link.
 
