### PR TITLE
Add release 1.29 to previousPatches in the schedule.yaml

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -10,6 +10,9 @@ schedules:
     targetDate: 2024-01-17
   maintenanceModeStartDate: 2024-12-28
   endOfLifeDate: 2025-02-28
+  previousPatches:
+    - release: 1.29.0
+      targetDate: 2023-12-13 
 - release: 1.28
   releaseDate: 2023-08-15
   next:


### PR DESCRIPTION
Resolves https://github.com/kubernetes/website/issues/44330


#### Additional Context:

Despite being reported for a [single page](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/), this is a broader site-wide issue affecting multiple pages using `{{< skew currentPatchVersion >}}`. 

The shortcode "`{{< skew currentPatchVersion >}}`" seems to be struggling to determine the latest patch version with new 1.29 release. The current output from shortcode is `%!f(string=1.).0.` ([see here](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#install-kubectl-binary-with-curl-on-windows)). The quick fix involves updating the schedule.yaml to incorporate the latest version, v1.29.0, ensuring the shortcode displays the expected value.


[Fixed Preview Page](https://deploy-preview-44344--kubernetes-io-main-staging.netlify.app/docs/tasks/tools/install-kubectl-windows/#install-kubectl-binary-with-curl-on-windows) | [Current Broken Website Page](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#install-kubectl-binary-with-curl-on-windows)