### PR TITLE
[zh] Localize kubeadm_init_phase_kubeconfig_super-admin.md

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_super-admin.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_super-admin.md
@@ -1,0 +1,170 @@
+<!--
+Generate a kubeconfig file for the super-admin
+-->
+为 super-admin 生成一个 kubeconfig 文件。
+
+<!--
+### Synopsis
+-->
+### 概要
+
+<!--
+Generate a kubeconfig file for the super-admin, and save it to super-admin.conf file.
+-->
+为 super-admin 生成一个 kubeconfig 文件，并将其保存到 super-admin.conf 文件中。
+
+```
+kubeadm init phase kubeconfig super-admin [flags]
+```
+
+<!--
+### Options
+-->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--apiserver-advertise-address string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
+-->
+<p>API 服务器所公布其监听的 IP 地址。如果未设置，则使用默认的网络接口。</p></td>
+</tr>
+
+<tr>
+<!--
+--apiserver-bind-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 6443
+-->
+<td colspan="2">--apiserver-bind-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值：6443</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+Port for the API Server to bind to.
+-->
+<p>API 服务器绑定的端口。</p></td>
+</tr>
+
+<tr>
+<!--
+--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"
+-->
+<td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："/etc/kubernetes/pki"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+The path where to save and store the certificates.
+-->
+<p>保存和存储证书的路径。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+Path to a kubeadm configuration file.
+-->
+<p>kubeadm 配置文件的路径。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--control-plane-endpoint string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+Specify a stable IP address or DNS name for the control plane.
+-->
+<p>为控制平面指定一个稳定的 IP 地址或 DNS 名称。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--dry-run</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+Don't apply any changes; just output what would be done.
+-->
+<p>不做任何更改；只输出将要执行的操作。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+help for super-admin
+-->
+<p>super-admin 的帮助信息。</p></td>
+</tr>
+
+<tr>
+<!--
+--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes"
+-->
+<td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："/etc/kubernetes"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+The path where to save the kubeconfig file.
+-->
+<p>保存 kubeconfig 文件的路径。</p></td>
+</tr>
+
+<tr>
+<!--
+--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "stable-1"
+-->
+<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："stable-1"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+Choose a specific Kubernetes version for the control plane.
+-->
+<p>为控制平面指定一个特定的 Kubernetes 版本。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+<!--
+### Options inherited from parent commands
+-->
+### 从父命令继承的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
+-->
+<p>[实验性功能] 指向‘真实’宿主根文件系统的路径。</p></td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
Add zh text to this new page:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_super-admin.md
```
See [preview](https://deploy-preview-44361--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_super-admin/) please.