### PR TITLE
[es] localize content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md to Spanish

### DIFF
--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -1,6 +1,6 @@
 ---
 title: "autocompletado con fish"
-description: "Configuracion Opcional para habilitar el autocompletado en la shell fish."
+description: "Configuración opcional para habilitar el autocompletado en la shell fish."
 headless: true
 _build:
   list: never
@@ -12,13 +12,13 @@ _build:
 El autocompletado para Fish necesita de kubectl versión 1.23 o superior.
 {{< /note >}}
 
-El script de autocompletado de Fish para kubectl puede ser generado con el comando `kubectl completion fish`. Ejecutando este comando en su shell habilitará el autocompletado de kubectl para fish.
+El script de autocompletado de Fish para kubectl puede ser generado con el comando `kubectl completion fish`. Ejecutando este comando en tu shell habilitará el autocompletado de kubectl para Fish.
 
-Para qué funcione en sus futuras sesiones shell, debe agregar la siguiente línea al archivo `~/.config/fish/config.fish`:
+Para qué funcione en sus futuras sesiones shell, debes agregar la siguiente línea al archivo `~/.config/fish/config.fish`:
 
 ```shell
 kubectl completion fish | source
 ```
 
-Después de recargar su shell el autocompletado para kubectl estará funcionando automáticamente.
+Después de recargar tu shell, el autocompletado para kubectl estará funcionando automáticamente.
 

--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -1,0 +1,24 @@
+---
+title: "autocompletado con fish"
+description: "Configuracion Opcional para habilitar el autocompletado en la shell fish."
+headless: true
+_build:
+  list: never
+  render: never
+  publishResources: false
+---
+
+{{< note >}}
+El autocompletado para Fish necesita de kubectl versión 1.23 o superior.
+{{< /note >}}
+
+El script de autocompletado de Fish para kubectl puede ser generado con el comando `kubectl completion fish`. Ejecutando este comando en su shell habilitará el autocompletado de kubectl para fish.
+
+Para qué funcione en sus futuras sesiones shell, debe agregar la siguiente línea al archivo `~/.config/fish/config.fish`:
+
+```shell
+kubectl completion fish | source
+```
+
+Después de recargar su shell el autocompletado para kubectl estará funcionando automáticamente.
+


### PR DESCRIPTION
This is a Feature Request closes https://github.com/kubernetes/website/issues/44380

What would you like to be added
Localize content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md to Spanish

Why is this needed
There is no Spanish localization for this file.

/assign @ramrodo