### PR TITLE
Update configure-redis-using-configmap.md

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -61,7 +61,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/conte
 Examine the contents of the Redis pod manifest and note the following:
 
 * A volume named `config` is created by `spec.volumes[1]`
-* The `key` and `path` under `spec.volumes[1].items[0]` exposes the `redis-config` key from the 
+* The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the 
   `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
 * The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
 


### PR DESCRIPTION
Fix missing configMap middle key

BEFORE
======
Using the original description gives a null value

cat redis-pod.yaml| yq .spec.volumes[1].items[0]
```
null
```

AFTER
=====
After adding the missing middle key, it shows the correct value

cat redis-pod.yaml| yq .spec.volumes[1].configMap.items[0]
```
key: redis-config
path: redis.conf
```

