### PR TITLE
[zh] Localize 16 files with filename prefixed with 'a' in feature-gates

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/accelerators.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/accelerators.md
@@ -1,0 +1,27 @@
+---
+# 已从 Kubernetes 中移除
+title: Accelerators
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+# Removed from Kubernetes
+title: Accelerators
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+-->
+
+<!--
+Provided an early form of plugin to enable Nvidia GPU support when using
+Docker Engine; no longer available. See
+[Device Plugins](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) for
+an alternative.
+-->
+使用 Docker Engine 时启用 Nvidia GPU 支持。这一特性不再提供。
+关于替代方案，请参阅[设备插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/admission-webhook-match-conditions.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/admission-webhook-match-conditions.md
@@ -1,0 +1,14 @@
+---
+title: AdmissionWebhookMatchConditions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable [match conditions](/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions)
+on mutating & validating admission webhooks.
+-->
+在变更性质和合法性检查的准入 Webhook
+上启用[匹配状况](/zh-cn/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/advanced-auditing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/advanced-auditing.md
@@ -1,0 +1,12 @@
+---
+title: AdvancedAuditing
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable [advanced auditing](/docs/tasks/debug/debug-cluster/audit/#advanced-audit)
+-->
+启用[高级审计](/zh-cn/docs/tasks/debug/debug-cluster/audit/#advanced-audit)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/affinity-in-annotations.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/affinity-in-annotations.md
@@ -1,0 +1,25 @@
+---
+# 已从 Kubernetes 中移除
+title: AffinityInAnnotations
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+# Removed from Kubernetes
+title: AffinityInAnnotations
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+-->
+
+<!--
+Enable setting
+[Pod affinity or anti-affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
+-->
+启用
+[Pod 亲和性或反亲和性](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)设置。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/aggregated-discovery-endpoint.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/aggregated-discovery-endpoint.md
@@ -1,0 +1,14 @@
+---
+title: AggregatedDiscoveryEndpoint
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable a single HTTP endpoint `/discovery/<version>` which
+supports native HTTP caching with ETags containing all APIResources known to the API server.
+-->
+启用单个 HTTP 端点 `/discovery/<version>`，
+支持用 ETag 进行原生 HTTP 缓存，包含 API 服务器已知的所有 APIResource。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-ext-traffic-local-endpoints.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-ext-traffic-local-endpoints.md
@@ -1,0 +1,23 @@
+---
+# 已从 Kubernetes 中移除
+title: AllowExtTrafficLocalEndpoints
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+# Removed from Kubernetes
+title: AllowExtTrafficLocalEndpoints
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+-->
+
+<!--
+Enable a service to route external requests to node local endpoints.
+-->
+启用服务用于将外部请求路由到节点本地端点。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-backend-proxy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-backend-proxy.md
@@ -1,0 +1,24 @@
+---
+# 已从 Kubernetes 中移除
+title: AllowInsecureBackendProxy
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+# Removed from Kubernetes
+title: AllowInsecureBackendProxy
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+-->
+
+<!--
+Enable the users to skip TLS verification of
+kubelets on Pod log requests.
+-->
+允许用户在请求 Pod 日志时跳过 kubelet 的 TLS 验证。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/any-volume-data-source.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/any-volume-data-source.md
@@ -1,0 +1,14 @@
+---
+title: AnyVolumeDataSource
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable use of any custom resource as the `DataSource` of a
+{{< glossary_tooltip text="PVC" term_id="persistent-volume-claim" >}}.
+-->
+允许使用任何自定义的资源来作为
+{{< glossary_tooltip text="PVC" term_id="persistent-volume-claim" >}} 中的 `DataSource`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-list-chunking.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-list-chunking.md
@@ -1,0 +1,13 @@
+---
+title: APIListChunking
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable the API clients to retrieve (`LIST` or `GET`)
+resources from API server in chunks.
+-->
+启用 API 客户端以块的形式从 API 服务器检索（`LIST` 或 `GET`）资源。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
@@ -1,0 +1,13 @@
+---
+title: APIPriorityAndFairness
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable managing request concurrency with
+prioritization and fairness at each server. (Renamed from `RequestManagement`)
+-->
+在每个服务器上启用优先级和公平性来管理请求并发（由 `RequestManagement` 重命名而来）。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-response-compression.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-response-compression.md
@@ -1,0 +1,12 @@
+---
+title: APIResponseCompression
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Compress the API responses for `LIST` or `GET` requests.
+-->
+压缩 `LIST` 或 `GET` 请求的 API 响应。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
@@ -1,0 +1,16 @@
+---
+title: APISelfSubjectReview
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Activate the `SelfSubjectReview` API which allows users
+to see the requesting subject's authentication information.
+See [API access to authentication information for a client](/docs/reference/access-authn-authz/authentication/#self-subject-review)
+for more details.
+-->
+激活 `SelfSubjectReview` API，允许用户查看请求主体的身份验证信息。
+更多细节请参阅 [API 访问客户端的身份验证信息](/zh-cn/docs/reference/access-authn-authz/authentication/#self-subject-review)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-identity.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-identity.md
@@ -1,0 +1,13 @@
+---
+title: APIServerIdentity
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Assign each API server an ID in a cluster, using a [Lease](/docs/concepts/architecture/leases).
+-->
+使用[租约](/zh-cn/docs/concepts/architecture/leases)为集群中的每个
+API 服务器赋予一个 ID。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-tracing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-tracing.md
@@ -1,0 +1,14 @@
+---
+title: APIServerTracing
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Add support for distributed tracing in the API server.
+See [Traces for Kubernetes System Components](/docs/concepts/cluster-administration/system-traces) for more details.
+-->
+在 API 服务器中添加对分布式跟踪的支持。
+更多细节参阅[针对 Kubernetes 系统组件的追踪](/zh-cn/docs/concepts/cluster-administration/system-traces/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/apparmor.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/apparmor.md
@@ -1,0 +1,14 @@
+---
+title: AppArmor
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable use of AppArmor mandatory access control for Pods running on Linux nodes.
+See [AppArmor Tutorial](/docs/tutorials/security/apparmor/) for more details.
+-->
+在 Linux 节点上为 Pod 启用 AppArmor 机制的强制访问控制。
+更多细节参阅 [AppArmor 教程](/zh-cn/docs/tutorials/security/apparmor/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/attach-volume-limit.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/attach-volume-limit.md
@@ -1,0 +1,27 @@
+---
+# 已从 Kubernetes 中移除
+title: AttachVolumeLimit
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+# Removed from Kubernetes
+title: AttachVolumeLimit
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+-->
+
+<!--
+Enable volume plugins to report limits on number of volumes
+that can be attached to a node.
+See [dynamic volume limits](/docs/concepts/storage/storage-limits/#dynamic-volume-limits)
+for more details.
+-->
+启用卷插件用于报告可连接到节点的卷数限制。
+更多细节参阅[动态卷限制](/zh-cn/docs/concepts/storage/storage-limits/#dynamic-volume-limits)。


### PR DESCRIPTION
Related to issue #44410 and need wait for #44409 

Add zh text to all filename prefixed with "a" in

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
```

1. accelerators.md
2. admission-webhook-match-conditions.md
3. advanced-auditing.md
4. affinity-in-annotations.md
5. aggregated-discovery-endpoint.md
6. allow-ext-traffic-local-endpoints.md
7. allow-insecure-backend-proxy.md
8. any-volume-data-source.md
9. api-list-chunking.md
10. api-priority-and-fairness.md
11. api-response-compression.md
12. api-self-subject-review.md
13. api-server-identity.md
14. api-server-tracing.md
15. apparmor.md
16. attach-volume-limit.md
