### PR TITLE
fix: container not sandbox

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/crictl.md
+++ b/content/en/docs/tasks/debug/debug-cluster/crictl.md
@@ -274,7 +274,7 @@ deleted by the Kubelet.
 ### Create a container
 
 Using `crictl` to create a container is useful for debugging container runtimes.
-On a running Kubernetes cluster, the sandbox will eventually be stopped and
+On a running Kubernetes cluster, the container will eventually be stopped and
 deleted by the Kubelet.
 
 1. Pull a busybox image


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Using crictl to create a container is useful for debugging container runtimes. On a running Kubernetes cluster, the sandbox will eventually be stopped and deleted by the Kubelet.
the  container not the sandbox.