### PR TITLE
[zh] localize feature-gates 55 c*.md files

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cloud-controller-manager-webhook.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cloud-controller-manager-webhook.md
@@ -1,0 +1,12 @@
+---
+title: CloudControllerManagerWebhook
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+Enable webhooks in cloud controller manager.
+-->
+启用在云控制器管理器中的 Webhook。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cloud-dual-stack-node-ips.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cloud-dual-stack-node-ips.md
@@ -1,0 +1,14 @@
+---
+title: CloudDualStackNodeIPs
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables dual-stack `kubelet --node-ip` with external cloud providers.
+See [Configure IPv4/IPv6 dual-stack](/docs/concepts/services-networking/dual-stack/#configure-ipv4-ipv6-dual-stack)
+for more details.
+-->
+允许在外部云驱动中通过 `kubelet --node-ip` 设置双协议栈。
+有关更多详细信息，请参阅[配置 IPv4/IPv6 双栈](/zh-cn/docs/concepts/services-networking/dual-stack/#configure-ipv4-ipv6-dual-stack)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cluster-trust-bundle-projection.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cluster-trust-bundle-projection.md
@@ -1,0 +1,12 @@
+---
+title: ClusterTrustBundleProjection
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+
+<!--
+[`clusterTrustBundle` projected volume sources](/docs/concepts/storage/projected-volumes#clustertrustbundle).
+-->
+[`clusterTrustBundle` 投射卷源](/zh-cn/docs/concepts/storage/projected-volumes#clustertrustbundle)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cluster-trust-bundle.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cluster-trust-bundle.md
@@ -1,0 +1,11 @@
+---
+title: ClusterTrustBundle
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable ClusterTrustBundle objects and kubelet integration.
+-->
+启用 ClusterTrustBundle 对象和 kubelet 集成。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/component-slis.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/component-slis.md
@@ -1,0 +1,14 @@
+---
+title: ComponentSLIs
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable the `/metrics/slis` endpoint on Kubernetes components like
+kubelet, kube-scheduler, kube-proxy, kube-controller-manager, cloud-controller-manager
+allowing you to scrape health check metrics.
+-->
+在 kubelet、kube-scheduler、kube-proxy、kube-controller-manager、cloud-controller-manager
+等 Kubernetes 组件上启用 `/metrics/slis` 端点，从而允许你抓取健康检查指标。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/configurable-fs-group-policy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/configurable-fs-group-policy.md
@@ -1,0 +1,17 @@
+---
+# Removed from Kubernetes
+title: ConfigurableFSGroupPolicy
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Allows user to configure volume permission change policy
+for fsGroups when mounting a volume in a Pod. See
+[Configure volume permission and ownership change policy for Pods](/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods)
+for more details.
+-->
+在 Pod 中挂载卷时，允许用户为 fsGroup 配置卷访问权限和属主变更策略。
+请参见[为 Pod 配置卷访问权限和属主变更策略](/zh-cn/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/consistent-http-get-handlers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/consistent-http-get-handlers.md
@@ -1,0 +1,12 @@
+---
+title: ConsistentHTTPGetHandlers
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Normalize HTTP get URL and Header passing for lifecycle
+handlers with probers.
+-->
+使用探测器为生命周期处理程序规范化 HTTP get URL 和标头传递。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/consistent-list-from-cache.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/consistent-list-from-cache.md
@@ -1,0 +1,11 @@
+---
+title: ConsistentListFromCache
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Allow the API server to serve consistent lists from cache.
+-->
+允许 API 服务器从缓存中提供一致的 list 操作。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/container-checkpoint.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/container-checkpoint.md
@@ -1,0 +1,13 @@
+---
+title: ContainerCheckpoint
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables the kubelet `checkpoint` API.
+See [Kubelet Checkpoint API](/docs/reference/node/kubelet-checkpoint-api/) for more details.
+-->
+启用 kubelet `checkpoint` API。
+详情见 [Kubelet Checkpoint API](/zh-cn/docs/reference/node/kubelet-checkpoint-api/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/contextual-logging.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/contextual-logging.md
@@ -1,0 +1,13 @@
+---
+title: ContextualLogging
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+When you enable this feature gate, Kubernetes components that support
+ contextual logging add extra detail to log output.
+-->
+当你启用这个特性门控，支持日志上下文记录的 Kubernetes
+组件会为日志输出添加额外的详细内容。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/controller-manager-leader-migration.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/controller-manager-leader-migration.md
@@ -1,0 +1,21 @@
+---
+# Removed from Kubernetes
+title: ControllerManagerLeaderMigration
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables Leader Migration for
+[kube-controller-manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/#initial-leader-migration-configuration) and
+[cloud-controller-manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/#deploy-cloud-controller-manager)
+which allows a cluster operator to live migrate
+controllers from the kube-controller-manager into an external controller-manager
+(e.g. the cloud-controller-manager) in an HA cluster without downtime.
+-->
+为 [kube-controller-manager](/zh-cn/docs/tasks/administer-cluster/controller-manager-leader-migration/#initial-leader-migration-configuration)
+和 [cloud-controller-manager](/zh-cn/docs/tasks/administer-cluster/controller-manager-leader-migration/#deploy-cloud-controller-manager)
+启用 Leader 迁移，它允许集群管理者在没有停机的高可用集群环境下，实时把 kube-controller-manager
+迁移到外部的 controller-manager (例如 cloud-controller-manager) 中。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager-policy-alpha-options.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager-policy-alpha-options.md
@@ -1,0 +1,16 @@
+---
+title: CPUManagerPolicyAlphaOptions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+This allows fine-tuning of CPUManager policies,
+experimental, Alpha-quality options
+This feature gate guards *a group* of CPUManager options whose quality level is alpha.
+This feature gate will never graduate to beta or stable.
+-->
+允许对 CPU 管理器策略进行微调，针对试验性的、Alpha 质量级别的选项。
+此特性门控用来保护一组质量级别为 Alpha 的 CPU 管理器选项。
+此特性门控永远不会被升级为 Beta 或者稳定版本。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager-policy-beta-options.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager-policy-beta-options.md
@@ -1,0 +1,16 @@
+---
+title: CPUManagerPolicyBetaOptions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+This allows fine-tuning of CPUManager policies,
+experimental, Beta-quality options
+This feature gate guards *a group* of CPUManager options whose quality level is beta.
+This feature gate will never graduate to stable.
+-->
+允许对 CPU 管理器策略进行微调，针对试验性的、Beta 质量级别的选项。
+此特性门控用来保护一组质量级别为 Beta 的 CPU 管理器选项。
+此特性门控永远不会被升级为稳定版本。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager-policy-options.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager-policy-options.md
@@ -1,0 +1,11 @@
+---
+title: CPUManagerPolicyOptions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Allow fine-tuning of CPUManager policies.
+-->
+允许微调 CPU 管理器策略。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cpu-manager.md
@@ -1,0 +1,13 @@
+---
+title: CPUManager
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable container level CPU affinity support, see
+[CPU Management Policies](/docs/tasks/administer-cluster/cpu-management-policies/).
+-->
+启用容器级别的 CPU 亲和性支持，有关更多详细信息，请参见
+[CPU 管理策略](/zh-cn/docs/tasks/administer-cluster/cpu-management-policies/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/crd-validation-ratcheting.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/crd-validation-ratcheting.md
@@ -1,0 +1,14 @@
+---
+title: CRDValidationRatcheting
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable updates to custom resources to contain
+violations of their OpenAPI schema if the offending portions of the resource
+update did not change. See [Validation Ratcheting](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting) for more details.
+-->
+如果资源更新的冲突部分未发生变化，则启用对自定义资源的更新以包含对 OpenAPI 模式的违规条目。
+详情参见[验证递进](/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cri-container-log-rotation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cri-container-log-rotation.md
@@ -1,0 +1,20 @@
+---
+# Removed from Kubernetes
+title: CRIContainerLogRotation
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable container log rotation for CRI container runtime.
+The default max size of a log file is 10MB and the default max number of
+log files allowed for a container is 5.
+These values can be configured in the kubelet config.
+See [logging at node level](/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)
+for more details.
+-->
+为 CRI 容器运行时启用容器日志轮换。日志文件的默认最大大小为 10MB，
+缺省情况下，一个容器允许的最大日志文件数为 5。这些值可以在 kubelet 配置中配置。
+更多细节请参见[日志架构](/zh-cn/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cron-job-controller-v2.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cron-job-controller-v2.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CronJobControllerV2
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Use an alternative implementation of the
+{{< glossary_tooltip text="CronJob" term_id="cronjob" >}} controller. Otherwise,
+version 1 of the same controller is selected.
+-->
+使用 {{< glossary_tooltip text="CronJob" term_id="cronjob" >}}
+控制器的一种替代实现。否则，系统会选择同一控制器的 v1 版本。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cron-job-time-zone.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cron-job-time-zone.md
@@ -1,0 +1,12 @@
+---
+title: CronJobTimeZone
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Allow the use of the `timeZone` optional field in [CronJobs](/docs/concepts/workloads/controllers/cron-jobs/)
+-->
+允许在 [CronJobs](/zh-cn/docs/concepts/workloads/controllers/cron-jobs/)
+中使用 `timeZone` 可选字段。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cron-jobs-scheduled-annotation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cron-jobs-scheduled-annotation.md
@@ -1,0 +1,14 @@
+---
+title: CronJobsScheduledAnnotation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Set the scheduled job time as an
+{{< glossary_tooltip text="annotation" term_id="annotation" >}} on Jobs that were created
+on behalf of a CronJob.
+-->
+将调度作业的时间设置为代表 CronJob 创建的作业上的一个
+  {{< glossary_tooltip text="注解" term_id="annotation" >}}。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cross-namespace-volume-data-source.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/cross-namespace-volume-data-source.md
@@ -1,0 +1,14 @@
+---
+title: CrossNamespaceVolumeDataSource
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable the usage of cross namespace volume data source
+ to allow you to specify a source namespace in the `dataSourceRef` field of a
+ PersistentVolumeClaim.
+-->
+启用跨名字空间卷数据源，以允许你在 PersistentVolumeClaim
+的 `dataSourceRef` 字段中指定一个源名字空间。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-block-volume.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-block-volume.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CSIBlockVolume
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable external CSI volume drivers to support block storage.
+See [`csi` raw block volume support](/docs/concepts/storage/volumes/#csi-raw-block-volume-support)
+for more details.
+-->
+启用外部 CSI 卷驱动程序用于支持块存储。有关更多详细信息，请参见
+[`csi` 原始块卷支持](/zh-cn/docs/concepts/storage/volumes/#csi-raw-block-volume-support)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-driver-registry.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-driver-registry.md
@@ -1,0 +1,14 @@
+---
+# Removed from Kubernetes
+title: CSIDriverRegistry
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable all logic related to the CSIDriver API object in
+`csi.storage.k8s.io`.
+-->
+在 `csi.storage.k8s.io` 中启用与 CSIDriver API 对象有关的所有逻辑。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-inline-volume.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-inline-volume.md
@@ -1,0 +1,13 @@
+---
+# Removed from Kubernetes
+title: CSIInlineVolume
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable CSI Inline volumes support for pods.
+-->
+为 Pod 启用 CSI 内联卷支持。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-aws-complete.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-aws-complete.md
@@ -1,0 +1,23 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationAWSComplete
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Stops registering the EBS in-tree plugin in
+kubelet and volume controllers and enables shims and translation logic to
+route volume operations from the AWS-EBS in-tree plugin to EBS CSI plugin.
+Requires CSIMigration and CSIMigrationAWS feature flags enabled and EBS CSI
+plugin installed and configured on all nodes in the cluster. This flag has
+been deprecated in favor of the `InTreePluginAWSUnregister` feature flag
+which prevents the registration of in-tree EBS plugin.
+-->
+停止在 kubelet 和卷控制器中注册 EBS 内嵌插件，
+并启用封装和转换逻辑，将卷操作从 AWS-EBS 内嵌插件路由到 EBS CSI 插件。
+这需要启用 CSIMigration 和 CSIMigrationAWS 特性标志，并在集群中的所有节点上安装和配置
+EBS CSI 插件。该特性标志已被废弃，取而代之的是 `InTreePluginAWSUnregister`，
+后者会阻止注册 EBS 内嵌插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-aws.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-aws.md
@@ -1,0 +1,20 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationAWS
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from the AWS-EBS in-tree plugin to EBS CSI plugin. Supports
+falling back to in-tree EBS plugin for mount operations to nodes that have
+the feature disabled or that do not have EBS CSI plugin installed and
+configured. Does not support falling back for provision operations, for those
+the CSI plugin must be installed and configured.
+-->
+启用封装和转换逻辑，将卷操作从 AWS-EBS 内嵌插件路由到 EBS CSI 插件。
+如果节点禁用了此特性门控或者未安装和配置 EBS CSI 插件，支持回退到内嵌 EBS 插件来执行卷挂载操作。
+不支持回退到这些插件来执行卷制备操作，因为需要安装并配置 CSI 插件

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-disk-complete.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-disk-complete.md
@@ -1,0 +1,24 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationAzureDiskComplete
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Stops registering the Azure-Disk in-tree
+plugin in kubelet and volume controllers and enables shims and translation
+logic to route volume operations from the Azure-Disk in-tree plugin to
+AzureDisk CSI plugin. Requires CSIMigration and CSIMigrationAzureDisk feature
+flags enabled and AzureDisk CSI plugin installed and configured on all nodes
+in the cluster. This flag has been deprecated in favor of the
+`InTreePluginAzureDiskUnregister` feature flag which prevents the registration
+of in-tree AzureDisk plugin.
+-->
+停止在 kubelet 和卷控制器中注册 Azure 磁盘内嵌插件，
+并启用封装和转换逻辑，将卷操作从 Azure 磁盘内嵌插件路由到 AzureDisk CSI 插件。
+这需要启用 CSIMigration 和 CSIMigrationAzureDisk 特性标志，
+并在集群中的所有节点上安装和配置 AzureDisk CSI 插件。该特性标志已被废弃，
+取而代之的是能防止注册内嵌 AzureDisk 插件的 `InTreePluginAzureDiskUnregister` 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-disk.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-disk.md
@@ -1,0 +1,23 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationAzureDisk
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from the Azure-Disk in-tree plugin to AzureDisk CSI plugin.
+Supports falling back to in-tree AzureDisk plugin for mount operations to
+nodes that have the feature disabled or that do not have AzureDisk CSI plugin
+installed and configured. Does not support falling back for provision
+operations, for those the CSI plugin must be installed and configured.
+Requires CSIMigration feature flag enabled.
+-->
+启用封装和转换逻辑，将卷操作从 AzureDisk 内嵌插件路由到 Azure 磁盘 CSI 插件。
+对于禁用了此特性的节点或者没有安装并配置 AzureDisk CSI 插件的节点，
+支持回退到内嵌（in-tree）AzureDisk 插件来执行磁盘挂载操作。
+不支持回退到内嵌插件来执行磁盘制备操作，因为对应的 CSI 插件必须已安装且正确配置。
+此特性需要启用 CSIMigration 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-file-complete.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-file-complete.md
@@ -1,0 +1,24 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationAzureFileComplete
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Stops registering the Azure-File in-tree
+plugin in kubelet and volume controllers and enables shims and translation
+logic to route volume operations from the Azure-File in-tree plugin to
+AzureFile CSI plugin. Requires CSIMigration and CSIMigrationAzureFile feature
+flags  enabled and AzureFile CSI plugin installed and configured on all nodes
+in the cluster. This flag has been deprecated in favor of the
+`InTreePluginAzureFileUnregister` feature flag which prevents the registration
+ of in-tree AzureFile plugin.
+-->
+停止在 kubelet 和卷控制器中注册 Azure-File 内嵌插件，
+并启用封装和转换逻辑，将卷操作从 Azure-File 内嵌插件路由到 AzureFile CSI 插件。
+这需要启用 CSIMigration 和 CSIMigrationAzureFile 特性标志，
+并在集群中的所有节点上安装和配置 AzureFile CSI 插件。该特性标志已被废弃，
+取而代之的是能防止注册内嵌 AzureDisk 插件的 `InTreePluginAzureFileUnregister` 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-file.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-file.md
@@ -1,0 +1,21 @@
+---
+title: CSIMigrationAzureFile
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from the Azure-File in-tree plugin to AzureFile CSI plugin.
+Supports falling back to in-tree AzureFile plugin for mount operations to
+nodes that have the feature disabled or that do not have AzureFile CSI plugin
+installed and configured. Does not support falling back for provision
+operations, for those the CSI plugin must be installed and configured.
+Requires CSIMigration feature flag enabled.
+-->
+启用封装和转换逻辑，将卷操作从 AzureFile 内嵌插件路由到
+AzureFile CSI 插件。对于禁用了此特性的节点或者没有安装并配置 AzureFile CSI
+插件的节点，支持回退到内嵌（in-tree）AzureFile 插件来执行卷挂载操作。
+不支持回退到内嵌插件来执行卷制备操作，因为对应的 CSI 插件必须已安装且正确配置。
+此特性需要启用 CSIMigration 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-gce-complete.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-gce-complete.md
@@ -1,0 +1,24 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationGCEComplete
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Stops registering the GCE-PD in-tree plugin in
+kubelet and volume controllers and enables shims and translation logic to
+route volume operations from the GCE-PD in-tree plugin to PD CSI plugin.
+Requires CSIMigration and CSIMigrationGCE feature flags enabled and PD CSI
+plugin installed and configured on all nodes in the cluster. This flag has
+been deprecated in favor of the `InTreePluginGCEUnregister` feature flag which
+prevents the registration of in-tree GCE PD plugin.
+-->
+停止在 kubelet 和卷控制器中注册 GCE-PD 内嵌插件，
+并启用封装和转换逻辑，将卷操作从 GCE-PD 内嵌插件路由到 PD CSI 插件。
+这需要启用 CSIMigration 和 CSIMigrationGCE 特性标志，并在集群中的所有节点上安装和配置
+PD CSI 插件。该特性标志已被废弃，取而代之的是能防止注册内嵌 GCE PD 插件的
+`InTreePluginGCEUnregister` 特性标志。
+

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-gce.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-gce.md
@@ -1,0 +1,21 @@
+---
+title: CSIMigrationGCE
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from the GCE-PD in-tree plugin to PD CSI plugin. Supports falling
+back to in-tree GCE plugin for mount operations to nodes that have the
+feature disabled or that do not have PD CSI plugin installed and configured.
+Does not support falling back for provision operations, for those the CSI
+plugin must be installed and configured. Requires CSIMigration feature flag
+enabled.
+-->
+启用封装和转换逻辑，将卷操作从 GCE-PD 内嵌插件路由到 PD CSI 插件。
+对于禁用了此特性的节点或者没有安装并配置 PD CSI 插件的节点，
+支持回退到内嵌GCE 插件来执行卷挂载操作。
+不支持回退到内嵌插件来执行卷制备操作，因为对应的 CSI 插件必须已安装且正确配置。
+此特性需要启用 CSIMigration 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-open-stack-complete.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-open-stack-complete.md
@@ -1,0 +1,24 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationOpenStackComplete
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Stops registering the Cinder in-tree plugin in
+kubelet and volume controllers and enables shims and translation logic to route
+volume operations from the Cinder in-tree plugin to Cinder CSI plugin.
+Requires CSIMigration and CSIMigrationOpenStack feature flags enabled and Cinder
+CSI plugin installed and configured on all nodes in the cluster. This flag has
+been deprecated in favor of the `InTreePluginOpenStackUnregister` feature flag
+which prevents the registration of in-tree openstack cinder plugin.
+-->
+停止在 kubelet 和卷控制器中注册 Cinder 内嵌插件，
+并启用封装和转换逻辑，将卷操作从 Cinder 内嵌插件路由到 Cinder CSI 插件。
+这需要启用 CSIMigration 和 CSIMigrationOpenStack 特性标志，
+并在集群中的所有节点上安装和配置 Cinder CSI 插件。
+该特性标志已被弃用，取而代之的是能防止注册内嵌 OpenStack Cinder 插件的
+`InTreePluginOpenStackUnregister` 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-open-stack.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-open-stack.md
@@ -1,0 +1,23 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationOpenStack
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from the Cinder in-tree plugin to Cinder CSI plugin. Supports
+falling back to in-tree Cinder plugin for mount operations to nodes that have
+the feature disabled or that do not have Cinder CSI plugin installed and
+configured. Does not support falling back for provision operations, for those
+the CSI plugin must be installed and configured. Requires CSIMigration
+feature flag enabled.
+-->
+启用封装和转换逻辑，将卷操作从 Cinder 内嵌插件路由到 Cinder CSI 插件。
+对于禁用了此特性的节点或者没有安装并配置 Cinder CSI 插件的节点，
+支持回退到内嵌 Cinder 插件来执行挂载操作。
+不支持回退到内嵌插件来执行制备操作，因为对应的 CSI 插件必须已安装且正确配置。
+此特性需要启用 CSIMigration 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-portworx.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-portworx.md
@@ -1,0 +1,14 @@
+---
+title: CSIMigrationPortworx
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume operations
+from the Portworx in-tree plugin to Portworx CSI plugin.
+Requires Portworx CSI driver to be installed and configured in the cluster.
+-->
+启用封装和转换逻辑，将卷操作从 Portworx 内嵌插件路由到
+Portworx CSI 插件。需要在集群中安装并配置 Portworx CSI 插件.

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-rbd.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-rbd.md
@@ -1,0 +1,20 @@
+---
+title: CSIMigrationRBD
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from the RBD in-tree plugin to Ceph RBD CSI plugin. Requires
+CSIMigration and csiMigrationRBD feature flags enabled and Ceph CSI plugin
+installed and configured in the cluster. This flag has been deprecated in
+favor of the `InTreePluginRBDUnregister` feature flag which prevents the registration of
+in-tree RBD plugin.
+-->
+启用封装和转换逻辑，将卷操作从 RBD 的内嵌插件路由到 Ceph RBD CSI 插件。
+此特性要求 CSIMigration 和 csiMigrationRBD 特性标志均被启用，
+且集群中安装并配置了 Ceph CSI 插件。
+此标志已被弃用，以鼓励使用 `InTreePluginRBDUnregister` 特性标志。
+后者会禁止注册内嵌的 RBD 插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration.md
@@ -1,0 +1,14 @@
+---
+# Removed from Kubernetes
+title: CSIMigration
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume
+operations from in-tree plugins to corresponding pre-installed CSI plugins
+-->
+启用封装和转换逻辑，将卷操作从内嵌插件路由到对应的预安装 CSI 插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migrationv-sphere-complete.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migrationv-sphere-complete.md
@@ -1,0 +1,24 @@
+---
+# Removed from Kubernetes
+title: CSIMigrationvSphereComplete
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Stops registering the vSphere in-tree plugin in kubelet
+and volume controllers and enables shims and translation logic to route volume operations
+from the vSphere in-tree plugin to vSphere CSI plugin. Requires CSIMigration and
+CSIMigrationvSphere feature flags enabled and vSphere CSI plugin installed and
+configured on all nodes in the cluster. This flag has been deprecated in favor
+of the `InTreePluginvSphereUnregister` feature flag which prevents the
+registration of in-tree vsphere plugin.
+-->
+停止在 kubelet 和卷控制器中注册 vSphere 内嵌插件，
+并启用封装和转换逻辑，将卷操作从 vSphere 内嵌插件路由到 vSphere CSI 插件。
+这需要启用 CSIMigration 和 CSIMigrationvSphere 特性标志，
+并在集群中的所有节点上安装和配置 vSphere CSI 插件。
+该特性标志已被废弃，取而代之的是能防止注册内嵌 vSphere 插件的
+`InTreePluginvSphereUnregister` 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migrationv-sphere.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migrationv-sphere.md
@@ -1,0 +1,21 @@
+---
+title: CSIMigrationvSphere
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables shims and translation logic to route volume operations
+from the vSphere in-tree plugin to vSphere CSI plugin. Supports falling back
+to in-tree vSphere plugin for mount operations to nodes that have the feature
+disabled or that do not have vSphere CSI plugin installed and configured.
+Does not support falling back for provision operations, for those the CSI
+plugin must be installed and configured. Requires CSIMigration feature flag
+enabled.
+-->
+启用封装和转换逻辑，将卷操作从 vSphere 内嵌插件路由到 vSphere CSI 插件。
+如果节点禁用了此特性门控或者未安装和配置 vSphere CSI 插件，
+则支持回退到 vSphere 内嵌插件来执行挂载操作。
+不支持回退到内嵌插件来执行制备操作，因为对应的 CSI 插件必须已安装且正确配置。
+这需要启用 CSIMigration 特性标志。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-node-expand-secret.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-node-expand-secret.md
@@ -1,0 +1,13 @@
+---
+title: CSINodeExpandSecret
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable passing secret authentication data to a CSI driver for use
+ during a `NodeExpandVolume` CSI operation.
+-->
+允许在 `NodeExpandVolume` CSI 操作期间，
+将保密的身份验证数据传递到 CSI 驱动以供后者使用。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-node-info.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-node-info.md
@@ -1,0 +1,13 @@
+---
+# Removed from Kubernetes
+title: CSINodeInfo
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable all logic related to the CSINodeInfo API object in `csi.storage.k8s.io`.
+-->
+在 `csi.storage.k8s.io` 中启用与 CSINodeInfo API 对象有关的所有逻辑。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-persistent-volume.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-persistent-volume.md
@@ -1,0 +1,17 @@
+---
+# Removed from Kubernetes
+title: CSIPersistentVolume
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable discovering and mounting volumes provisioned through a
+[CSI (Container Storage Interface)](https://git.k8s.io/design-proposals-archive/storage/container-storage-interface.md)
+compatible volume plugin.
+-->
+启用发现和挂载通过
+[CSI（容器存储接口）](https://git.k8s.io/design-proposals-archive/storage/container-storage-interface.md)
+兼容卷插件配置的卷。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-service-account-token.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-service-account-token.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CSIServiceAccountToken
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable CSI drivers to receive the pods' service account token
+that they mount volumes for. See
+[Token Requests](https://kubernetes-csi.github.io/docs/token-requests.html).
+-->
+允许 CSI 驱动接收挂载卷目标 Pods 的服务账号令牌。
+参阅[令牌请求（Token Requests）](https://kubernetes-csi.github.io/docs/token-requests.html)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-storage-capacity.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-storage-capacity.md
@@ -1,0 +1,18 @@
+---
+title: CSIStorageCapacity
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables CSI drivers to publish storage capacity information
+and the Kubernetes scheduler to use that information when scheduling pods. See
+[Storage Capacity](/docs/concepts/storage/storage-capacity/).
+Check the [`csi` volume type](/docs/concepts/storage/volumes/#csi) documentation for more details.
+-->
+启用 CSI 驱动发布存储容量信息，
+以及 Kubernetes 调度器在调度 Pods 时使用该信息。
+详情见[存储容量](/zh-cn/docs/concepts/storage/storage-capacity/)。
+更多详情请参阅 [`csi` 卷类型](/zh-cn/docs/concepts/storage/volumes/#csi)文档。
+

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-volume-fs-group-policy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-volume-fs-group-policy.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CSIVolumeFSGroupPolicy
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Allows CSIDrivers to use the `fsGroupPolicy` field.
+This field controls whether volumes created by a CSIDriver support volume ownership
+and permission modifications when these volumes are mounted.
+-->
+允许 CSIDriver 使用 `fsGroupPolicy` 字段。
+该字段能控制由 CSIDriver 创建的卷在挂载这些卷时是否支持卷所有权和权限修改。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-volume-health.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-volume-health.md
@@ -1,0 +1,11 @@
+---
+title: CSIVolumeHealth
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable support for CSI volume health monitoring on node.
+-->
+启用对节点上的 CSI 卷运行状况监控的支持。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csr-duration.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csr-duration.md
@@ -1,0 +1,14 @@
+---
+# Removed from Kubernetes
+title: CSRDuration
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Allows clients to request a duration for certificates issued
+via the Kubernetes CSR API.
+-->
+允许客户端为通过 Kubernetes CSR API 签署的证书申请有效期限。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-cpu-cfs-quota-period.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-cpu-cfs-quota-period.md
@@ -1,0 +1,14 @@
+---
+title: CustomCPUCFSQuotaPeriod
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable nodes to change `cpuCFSQuotaPeriod` in
+[kubelet config](/docs/tasks/administer-cluster/kubelet-config-file/).
+-->
+使节点能够更改
+[kubelet 配置](/zh-cn/docs/tasks/administer-cluster/kubelet-config-file/)
+中的 `cpuCFSQuotaPeriod`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-pod-dns.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-pod-dns.md
@@ -1,0 +1,17 @@
+---
+# Removed from Kubernetes
+title: CustomPodDNS
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable customizing the DNS settings for a Pod using its `dnsConfig` property.
+Check [Pod's DNS Config](/docs/concepts/services-networking/dns-pod-service/#pods-dns-config)
+for more details.
+-->
+允许使用 Pod 的 `dnsConfig` 属性自定义其 DNS 设置。
+更多详细信息，请参见
+[Pod 的 DNS 配置](/zh-cn/docs/concepts/services-networking/dns-pod-service/#pods-dns-config)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-defaulting.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-defaulting.md
@@ -1,0 +1,13 @@
+---
+# Removed from Kubernetes
+title: CustomResourceDefaulting
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable CRD support for default values in OpenAPI v3 validation schemas.
+-->
+为 CRD 启用在其 OpenAPI v3 验证模式中提供默认值的支持。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-publish-open-api.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-publish-open-api.md
@@ -1,0 +1,13 @@
+---
+# Removed from Kubernetes
+title: CustomResourcePublishOpenAPI
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables publishing of CRD OpenAPI specs.
+-->
+启用 CustomResourceDefinition OpenAPI 规范的发布。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-subresources.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-subresources.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CustomResourceSubresources
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable `/status` and `/scale` subresources
+on resources created from [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+-->
+对于用
+[CustomResourceDefinition](/zh-cn/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+创建的资源启用其 `/status` 和 `/scale` 子资源。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-validation-expressions.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-validation-expressions.md
@@ -1,0 +1,14 @@
+---
+title: CustomResourceValidationExpressions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable expression language validation in CRD
+which will validate customer resource based on validation rules written in
+the `x-kubernetes-validations` extension.
+-->
+启用 CRD 中的表达式语言合法性检查，
+基于 `x-kubernetes-validations` 扩展中所书写的合法性检查规则来验证定制资源。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-validation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-validation.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CustomResourceValidation
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable schema based validation on resources created from
+[CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+-->
+对于用
+[CustomResourceDefinition](/zh-cn/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+创建的资源启用基于模式的验证。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-webhook-conversion.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-webhook-conversion.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: CustomResourceWebhookConversion
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable webhook-based conversion
+on resources created from [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+-->
+对于用
+[CustomResourceDefinition](/zh-cn/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+创建的资源启用基于 Webhook 的转换。


### PR DESCRIPTION
Related to issue #44410

* Localize 55 files with filename prefixed with `c`

Seems it cannot compile succeed before all the content of `feature-gates-description` in `features-gate/index.md` has been localized.