### PR TITLE
[zh] Localize feature-gates/d*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/daemon-set-update-surge.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/daemon-set-update-surge.md
@@ -1,0 +1,15 @@
+---
+title: DaemonSetUpdateSurge
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables the DaemonSet workloads to maintain
+availability during update per node.
+See [Perform a Rolling Update on a DaemonSet](/docs/tasks/manage-daemon/update-daemon-set/).
+-->
+使 DaemonSet 工作负载在每个节点的更新期间保持可用性。
+参阅[对 DaemonSet 执行滚动更新](/zh-cn/docs/tasks/manage-daemon/update-daemon-set/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-host-network-ports-in-pod-templates.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-host-network-ports-in-pod-templates.md
@@ -1,0 +1,20 @@
+---
+title: DefaultHostNetworkHostPortsInPodTemplates
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Changes when the default value of
+`PodSpec.containers[*].ports[*].hostPort`
+is assigned. The default is to only set a default value in Pods.
+
+Enabling this means a default will be assigned even to embedded
+PodSpecs (e.g. in a Deployment), which is the historical default.
+-->
+更改何时设置 `PodSpec.containers[*].ports[*].hostPort` 的默认值。
+默认仅在 Pod 中设置默认值。
+
+启用此特性意味着即使在嵌套的 PodSpec（例如 Deployment 中）中也会设置默认值，
+这是以前的默认行为。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-pod-topology-spread.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-pod-topology-spread.md
@@ -1,0 +1,15 @@
+---
+# Removed from Kubernetes
+title: DefaultPodTopologySpread
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables the use of `PodTopologySpread` scheduling plugin to do
+[default spreading](/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints).
+-->
+启用 `PodTopologySpread` 调度插件以执行
+[默认分布](/zh-cn/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/delegate-fs-group-to-csi-driver.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/delegate-fs-group-to-csi-driver.md
@@ -1,0 +1,15 @@
+---
+title: DelegateFSGroupToCSIDriver
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+If supported by the CSI driver, delegates the
+role of applying `fsGroup` from a Pod's `securityContext` to the driver by
+passing `fsGroup` through the NodeStageVolume and NodePublishVolume CSI calls.
+-->
+如果 CSI 驱动程序支持，则通过 NodeStageVolume
+和 NodePublishVolume CSI 调用传递 `fsGroup`，
+委托驱动来应用 Pod 的 `securityContext` 中的 `fsGroup`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugin-cdi-devices.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugin-cdi-devices.md
@@ -1,0 +1,13 @@
+---
+title: DevicePluginCDIDevices
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable support to CDI device IDs in the
+[Device Plugin](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) API.
+-->
+启用[设备插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+API 对 CDI 设备 ID 的支持。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugins.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugins.md
@@ -1,0 +1,12 @@
+---
+title: DevicePlugins
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable the [device-plugins](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+based resource provisioning on nodes.
+-->
+在节点上启用基于[设备插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)的资源制备。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-accelerator-usage-metrics.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-accelerator-usage-metrics.md
@@ -1,0 +1,12 @@
+---
+title: DisableAcceleratorUsageMetrics
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+[Disable accelerator metrics collected by the kubelet](/docs/concepts/cluster-administration/system-metrics/#disable-accelerator-metrics).
+-->
+[禁用 kubelet 收集的加速器指标](/zh-cn/docs/concepts/cluster-administration/system-metrics/#disable-accelerator-metrics)。
+

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-cloud-providers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-cloud-providers.md
@@ -1,0 +1,14 @@
+---
+title: DisableCloudProviders
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Disables any functionality in `kube-apiserver`,
+`kube-controller-manager` and `kubelet` related to the `--cloud-provider`
+component flag.
+-->
+禁用 `kube-apiserver`、`kube-controller-manager`
+和 `kubelet` 中与 `--cloud-provider` 组件标志相关的所有功能。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-kubelet-cloud-credential-providers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-kubelet-cloud-credential-providers.md
@@ -1,0 +1,13 @@
+---
+title: DisableKubeletCloudCredentialProviders
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Disable the in-tree functionality in kubelet
+to authenticate to a cloud provider container registry for image pull credentials.
+-->
+禁用 kubelet 中为拉取镜像内置的凭据机制，
+该凭据用于向云提供商的容器镜像仓库进行身份认证。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-node-kube-proxy-version.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-node-kube-proxy-version.md
@@ -1,0 +1,11 @@
+---
+title: DisableNodeKubeProxyVersion
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Disable setting the `kubeProxyVersion` field of the Node.
+-->
+禁止设置 Node 的 `kubeProxyVersion` 字段。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/downward-api-huge-pages.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/downward-api-huge-pages.md
@@ -1,0 +1,14 @@
+---
+title: DownwardAPIHugePages
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables usage of hugepages in
+[downward API](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information).
+-->
+允许在[下行（Downward）API](/zh-cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information)
+中使用巨页信息。
+

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dry-run.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dry-run.md
@@ -1,0 +1,15 @@
+---
+title: DryRun
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable server-side [dry run](/docs/reference/using-api/api-concepts/#dry-run) requests
+so that validation, merging, and mutation can be tested without committing.
+-->
+启用在服务器端对请求进行
+[试运行（Dry Run）](/zh-cn/docs/reference/using-api/api-concepts/#dry-run)，
+以便在不提交的情况下测试验证、合并和变更。
+

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-auditing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-auditing.md
@@ -1,0 +1,13 @@
+---
+# Removed from Kubernetes
+title: DynamicAuditing
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Used to enable dynamic auditing before v1.19.
+-->
+在 v1.19 版本前用于启用动态审计。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-kubelet-config.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-kubelet-config.md
@@ -1,0 +1,17 @@
+---
+# Removed from Kubernetes
+title: DynamicKubeletConfig
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable the dynamic configuration of kubelet. The
+feature is no longer supported outside of supported skew policy. The feature
+gate was removed from kubelet in 1.24.
+-->
+启用 kubelet 的动态配置。
+除偏差策略场景外，不再支持该功能。
+该特性门控在 kubelet 1.24 版本中已被移除。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-provisioning-scheduling.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-provisioning-scheduling.md
@@ -1,0 +1,16 @@
+---
+# Removed from Kubernetes
+title: DynamicProvisioningScheduling
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Extend the default scheduler to be aware of
+volume topology and handle PV provisioning.
+This feature was superseded by the `VolumeScheduling` feature  in v1.12.
+-->
+扩展默认调度器以了解卷拓扑并处理 PV 制备。
+此特性已在 v1.12 中完全被 `VolumeScheduling` 特性取代。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-resource-allocation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-resource-allocation.md
@@ -1,0 +1,12 @@
+---
+title: DynamicResourceAllocation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+---
+<!--
+Enables support for resources with custom parameters and a lifecycle
+that is independent of a Pod.
+-->
+启用对具有自定义参数和独立于 Pod 生命周期的资源的支持。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-volume-provisioning.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-volume-provisioning.md
@@ -1,0 +1,15 @@
+---
+# Removed from Kubernetes
+title: DynamicVolumeProvisioning
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+<!--
+Enable the
+[dynamic provisioning](/docs/concepts/storage/dynamic-provisioning/) of persistent volumes to Pods.
+-->
+启用持久化卷到 Pod
+的[动态制备](/zh-cn/docs/concepts/storage/dynamic-provisioning/)。


### PR DESCRIPTION
Related to issue #44410 

Localize feature-gates/d*.md

  1. daemon-set-update-surge.md
  2. default-host-network-ports-in-pod-templates.md
  3. default-pod-topology-spread.md
  4. delegate-fs-group-to-csi-driver.md
  5. device-plugin-cdi-devices.md
  6. device-plugins.md
  7. disable-accelerator-usage-metrics.md
  8. disable-cloud-providers.md
  9. disable-kubelet-cloud-credential-providers.md
  10. disable-node-kube-proxy-version.md
  11. downward-api-huge-pages.md
  12. dry-run.md
  13. dynamic-auditing.md
  14. dynamic-kubelet-config.md
  15. dynamic-provisioning-scheduling.md
  16. dynamic-resource-allocation.md
  17. dynamic-volume-provisioning.md