### PR TITLE
Write headings in sentence case for StatefulSet tutorial

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -116,7 +116,7 @@ NAME      DESIRED   CURRENT   AGE
 web       2         1         20s
 ```
 
-### Ordered Pod Creation
+### Ordered Pod creation
 
 For a StatefulSet with _n_ replicas, when Pods are being deployed, they are
 created sequentially, ordered from _{0..n-1}_. Examine the output of the
@@ -479,7 +479,7 @@ created each Pod sequentially with respect to its ordinal index, and it
 waited for each Pod's predecessor to be Running and Ready before launching the
 subsequent Pod.
 
-### Scaling Down
+### Scaling down
 
 In one terminal, watch the StatefulSet's Pods:
 


### PR DESCRIPTION
Update the [tutorial](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/) for StatefulSets to write headings in sentence case, per the [style guide](https://kubernetes.io/docs/contribute/style/style-guide/#headings).

Part of PR #42767

/kind cleanup