### PR TITLE
Reflect CSI allowVolumeExpansion stable status

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -126,7 +126,7 @@ StorageClass has the field `allowVolumeExpansion` set to true.
 | Azure File           | 1.11                        |
 | Portworx             | 1.11                        |
 | FlexVolume           | 1.13                        |
-| CSI                  | 1.14 (alpha), 1.16 (beta)   |
+| CSI                  | 1.24                        |
 
 {{< /table >}}
 


### PR DESCRIPTION
The CSI support for `allowVolumeExpansion` went GA in the 1.24 release. This was reflected [in the Persistent Volume documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#csi-volume-expansion) (#36962), but there is also a reference in the Storage Class docs that had not been updated yet to show it was no longer in beta.