### PR TITLE
[zh] should be container not sandbox for `tasks/debug/debug-cluster/crictl`

### DIFF
--- a/content/zh-cn/docs/tasks/debug/debug-cluster/crictl.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/crictl.md
@@ -429,7 +429,7 @@ deleted by the Kubelet.
 ### 创建容器 {#create-a-container}
 
 用 `crictl` 创建容器对容器运行时排错很有帮助。
-在运行的 Kubernetes 集群中，沙盒会随机地被 kubelet 停止和删除。
+在运行的 Kubernetes 集群中，容器会随机地被 kubelet 停止和删除。
 
 <!--
 1. Pull a busybox image


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
用 crictl 创建容器对容器运行时排错很有帮助。 在运行的 Kubernetes 集群中，沙盒会随机地被 kubelet 停止和删除
应改成 
用 crictl 创建容器对容器运行时排错很有帮助。 在运行的 Kubernetes 集群中，容器会随机地被 kubelet 停止和删除
