### PR TITLE
[zh] Fix typo in instruction for Kubernetes repository configuration on CentOS/RHEL/Fedora 

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -284,10 +284,10 @@ version.
    ```
    [kubernetes]
    name=Kubernetes
-   baseurl=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< skew currentVersionAddMinor -1 "." >}}/rpm/
    enabled=1
    gpgcheck=1
-   gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< skew currentVersionAddMinor -1 "." >}}/rpm/repodata/repomd.xml.key
    exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
    ```
 
@@ -299,10 +299,10 @@ version.
    ```
    [kubernetes]
    name=Kubernetes
-   baseurl=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
    enabled=1
    gpgcheck=1
-   gpgkey=https://pkgs.k8s.io/core:/stable:/v{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
    exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
    ```
 


### PR DESCRIPTION
I made the fix to ENglish page as part of https://github.com/kubernetes/website/pull/44439/files. Submitted same fix for Chinese language.