### PR TITLE
remove GA feature-gate APISelfSubjectReview

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed/index.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed/index.md
@@ -41,6 +41,9 @@ In the following table:
 | `AllowExtTrafficLocalEndpoints` | `true` | GA | 1.7 | 1.9 |
 | `AllowInsecureBackendProxy` | `true` | Beta | 1.17 | 1.20 |
 | `AllowInsecureBackendProxy` | `true` | GA | 1.21 | 1.25 |
+| `APISelfSubjectReview` | `false` | Alpha | 1.26 | 1.26 |
+| `APISelfSubjectReview` | `true` | Beta | 1.27 | 1.27 |
+| `APISelfSubjectReview` | `true` | GA | 1.28 | 1.29 |
 | `AttachVolumeLimit` | `false` | Alpha | 1.11 | 1.11 |
 | `AttachVolumeLimit` | `true` | Beta | 1.12 | 1.16 |
 | `AttachVolumeLimit` | `true` | GA | 1.17 | 1.21 |
@@ -454,6 +457,7 @@ In the following table:
 - {{< feature-gate-description name="AdvancedAuditing" >}}
 - {{< feature-gate-description name="AllowExtTrafficLocalEndpoints" >}}
 - {{< feature-gate-description name="AllowInsecureBackendProxy" >}}
+- {{< feature-gate-description name="APISelfSubjectReview" >}}
 - {{< feature-gate-description name="AttachVolumeLimit" >}}
 - {{< feature-gate-description name="BalanceAttachedNodeVolumes" >}}
 - {{< feature-gate-description name="BlockVolume" >}}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
@@ -1,4 +1,5 @@
 ---
+# Removed from Kubernetes
 title: APISelfSubjectReview
 content_type: feature_gate
 _build:

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
@@ -239,9 +239,6 @@ For a reference to old feature gates that are removed, please refer to
 | `APIListChunking` | `false` | Alpha | 1.8 | 1.8 |
 | `APIListChunking` | `true` | Beta | 1.9 | 1.28 |
 | `APIListChunking` | `true` | GA | 1.29 | - |
-| `APISelfSubjectReview` | `false` | Alpha | 1.26 | 1.26 |
-| `APISelfSubjectReview` | `true` | Beta | 1.27 | 1.27 |
-| `APISelfSubjectReview` | `true` | GA | 1.28 | - |
 | `CPUManager` | `false` | Alpha | 1.8 | 1.9 |
 | `CPUManager` | `true` | Beta | 1.10 | 1.25 |
 | `CPUManager` | `true` | GA | 1.26 | - |
@@ -403,7 +400,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - {{< feature-gate-description name="APIListChunking" >}}
 - {{< feature-gate-description name="APIPriorityAndFairness" >}}
 - {{< feature-gate-description name="APIResponseCompression" >}}
-- {{< feature-gate-description name="APISelfSubjectReview" >}}
 - {{< feature-gate-description name="APIServerIdentity" >}}
 - {{< feature-gate-description name="APIServerTracing" >}}
 - {{< feature-gate-description name="AppArmor" >}}


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/issues/120315
feature-gate was removed by https://github.com/kubernetes/kubernetes/pull/122032