### PR TITLE
Add description for "StatefulSetAutoDeletePVC" feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
@@ -518,6 +518,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - {{< feature-gate-description name="SizeMemoryBackedVolumes" >}}
 - {{< feature-gate-description name="SkipReadOnlyValidationGCE" >}}
 - {{< feature-gate-description name="StableLoadBalancerNodeSet" >}}
+- {{< feature-gate-description name="StatefulSetAutoDeletePVC" >}}
 - {{< feature-gate-description name="StatefulSetStartOrdinal" >}}
 - {{< feature-gate-description name="StorageVersionAPI" >}}
 - {{< feature-gate-description name="StorageVersionHash" >}}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/stateful-set-auto-delete-pvc.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/stateful-set-auto-delete-pvc.md
@@ -1,0 +1,13 @@
+---
+title: StatefulSetAutoDeletePVC
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+---
+Allows the use of the optional `.spec.persistentVolumeClaimRetentionPolicy` field, 
+providing control over the deletion of PVCs in a StatefulSet's lifecycle.
+See
+[PersistentVolumeClaim retention](/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
+for more details.


### PR DESCRIPTION
This pull request addresses the missing description for the `StatefulSetAutoDeletePVC` feature gate, which despite being listed in the table on the [documentation page](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features), lacks a brief description.

[Preview Page](https://deploy-preview-44465--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates/)