### PR TITLE
Fix typos in Feature gates tables

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates-removed/index.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates-removed/index.md
@@ -385,7 +385,7 @@ In the following table:
 | `ServiceTopology` | `false` | Deprecated | 1.20 | 1.22 |
 | `SetHostnameAsFQDN` | `false` | Alpha | 1.19 | 1.19 |
 | `SetHostnameAsFQDN` | `true` | Beta | 1.20 | 1.21 |
-| `SetHostnameAsFQDN` | `true` | GA | 1.22 | 1,24 |
+| `SetHostnameAsFQDN` | `true` | GA | 1.22 | 1.24 |
 | `StartupProbe` | `false` | Alpha | 1.16 | 1.17 |
 | `StartupProbe` | `true` | Beta | 1.18 | 1.19 |
 | `StartupProbe` | `true` | GA | 1.20 | 1.23 |

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
@@ -163,8 +163,8 @@ For a reference to old feature gates that are removed, please refer to
 | `OpenAPIEnums` | `true` | Beta | 1.24 | |
 | `PDBUnhealthyPodEvictionPolicy` | `false` | Alpha | 1.26 | 1.26 |
 | `PDBUnhealthyPodEvictionPolicy` | `true` | Beta | 1.27 | |
-| `PersistentVolumeLastPhaseTransistionTime` | `false` | Alpha | 1.28  | 1.28 |
-| `PersistentVolumeLastPhaseTransistionTime` | `true`  | Beta  | 1.29  | |
+| `PersistentVolumeLastPhaseTransitionTime` | `false` | Alpha | 1.28  | 1.28 |
+| `PersistentVolumeLastPhaseTransitionTime` | `true`  | Beta  | 1.29  | |
 | `PodAndContainerStatsFromCRI` | `false` | Alpha | 1.23 | |
 | `PodDeletionCost` | `false` | Alpha | 1.21 | 1.21 |
 | `PodDeletionCost` | `true` | Beta | 1.22 | |
@@ -232,7 +232,7 @@ For a reference to old feature gates that are removed, please refer to
 | `WinOverlay` | `false` | Alpha | 1.14 | 1.19 |
 | `WinOverlay` | `true` | Beta | 1.20 | |
 | `WindowsHostNetwork` | `true` | Alpha | 1.26 | |
-| `ZeroLimitedNominalConcurrencyShares` | `false` | Beta | v1.29 | |
+| `ZeroLimitedNominalConcurrencyShares` | `false` | Beta | 1.29 | |
 
 {{< /table >}}
 


### PR DESCRIPTION
#### Summary of changes

-  Fixed Typo in Feature Name `PersistentVolumeLastPhaseTransitionTime`
    - **_Reference_**: [kubernetes/pkg/features/kube_features.go](https://github.com/kubernetes/kubernetes/blob/f68a965e5ae7a954b567c6162de0e2d17606d680/pkg/features/kube_features.go#L590) or [enhancements/KEP-3762](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3762-persistent-volume-last-phase-transition-time/README.md)

- Correct Minor Typo in version format for `ZeroLimitedNominalConcurrencyShares`
   -  All version values in the table follow a consistent format without 'v'.
   
-  Update Punctuation in Removed Feature Gates table for `SetHostnameAsFQDN`
     - ',' _(comma)_ was used instead of '.' _(dot)_ for separation.
     
[Preview Page  1 ](https://deploy-preview-44469--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features)

[Preview Page 2](https://deploy-preview-44469--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates-removed/#feature-gates-that-are-removed)   