### PR TITLE
[zh] Add missing link anchor of configure probe

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -369,7 +369,7 @@ kubectl describe pod goproxy
 <!--
 ## Define a gRPC liveness probe
 -->
-## 定义 gRPC 存活探针
+## 定义 gRPC 存活探针 {#define-a-grpc-liveness-probe}
 
 {{< feature-state for_k8s_version="v1.27" state="stable" >}}
 


### PR DESCRIPTION
Related to PR #44477

The configure probe doc missing link anchor: https://github.com/kubernetes/website/pull/44477/files#diff-67c0aa7eef1f10a118f3befbb8c8cd13377a94db42466814d582be75f49f68eaR13

---

See the preview of link anchor: https://deploy-preview-44492--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe
