### PR TITLE
Update container-lifecycle-hooks.md

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -50,7 +50,7 @@ A more detailed description of the termination behavior can be found in
 ### Hook handler implementations
 
 Containers can access a hook by implementing and registering a handler for that hook.
-There are two types of hook handlers that can be implemented for Containers:
+There are threetypes of hook handlers that can be implemented for Containers:
 
 * Exec - Executes a specific command, such as `pre-stop.sh`, inside the cgroups and namespaces of the Container.
 Resources consumed by the command are counted against the Container.

--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -50,7 +50,7 @@ A more detailed description of the termination behavior can be found in
 ### Hook handler implementations
 
 Containers can access a hook by implementing and registering a handler for that hook.
-There are threetypes of hook handlers that can be implemented for Containers:
+There are three types of hook handlers that can be implemented for Containers:
 
 * Exec - Executes a specific command, such as `pre-stop.sh`, inside the cgroups and namespaces of the Container.
 Resources consumed by the command are counted against the Container.


### PR DESCRIPTION
In the issue https://github.com/kubernetes/website/issues/44498 it is reported the section https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations, referrs as just 2 possible types of hook handlers for containers, but afterwards 3 are enumerated. Fixed the typo.


This will fix https://github.com/kubernetes/website/issues/44498