### PR TITLE
[ko] Translate /docs/tasks/administer-cluster/quota-api-object into Korean

### DIFF
--- a/content/ko/docs/tasks/administer-cluster/quota-api-object.md
+++ b/content/ko/docs/tasks/administer-cluster/quota-api-object.md
@@ -1,0 +1,178 @@
+---
+title: API 오브젝트에 대한 쿼터 구성
+content_type: task
+weight: 130
+---
+
+
+<!-- overview -->
+
+이 페이지에서는 퍼시스턴트볼륨클레임(PersistentVolumeClaim) 및 
+서비스를 포함한 API 오브젝트에 대한 쿼터를 구성하는 방법을 설명한다.
+쿼터는 네임스페이스에 생성할 수 있는 
+특정 유형의 오브젝트 수를 제한한다.
+쿼터는 [리소스쿼터(ResourceQuota)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#resourcequota-v1-core) 
+오브젝트에서 지정한다.
+
+
+
+
+## {{% heading "prerequisites" %}}
+
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+
+
+
+<!-- steps -->
+
+## 네임스페이스 생성
+
+이 예제에서 생성하는 리소스가 클러스터의 나머지 부분과 격리되도록  
+네임스페이스를 생성한다.
+
+```shell
+kubectl create namespace quota-object-example
+```
+
+## 리소스쿼터 생성
+
+리소스쿼터 오브젝트의 구성 파일은 다음과 같다.
+
+{{% codenew file="admin/resource/quota-objects.yaml" %}}
+
+리소스쿼터를 생성한다.
+
+```shell
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-objects.yaml --namespace=quota-object-example
+```
+
+리소스쿼터에 대한 자세한 정보를 살펴본다.
+
+```shell
+kubectl get resourcequota object-quota-demo --namespace=quota-object-example --output=yaml
+```
+
+출력에 따르면 quota-object-example 네임스페이스가 
+최대 하나의 퍼시스턴트볼륨클레임, 최대 두 개의 로드밸런서 유형의 서비스를 가질 수 있으며, NodePort 유형의 서비스는 
+가질 수 없다.
+
+```yaml
+status:
+  hard:
+    persistentvolumeclaims: "1"
+    services.loadbalancers: "2"
+    services.nodeports: "0"
+  used:
+    persistentvolumeclaims: "0"
+    services.loadbalancers: "0"
+    services.nodeports: "0"
+```
+
+## 퍼시스턴트볼륨클레임 생성
+
+퍼시스턴트볼륨클레임 오브젝트에 대한 구성 파일은 다음과 같다.
+
+{{% codenew file="admin/resource/quota-objects-pvc.yaml" %}}
+
+퍼시스턴트볼륨클레임을 생성한다.
+
+```shell
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-objects-pvc.yaml --namespace=quota-object-example
+```
+
+퍼시스턴트볼륨클레임이 생성되었는지 확인한다.
+
+```shell
+kubectl get persistentvolumeclaims --namespace=quota-object-example
+```
+
+출력에 따르면 퍼시스턴트볼륨클레임이 존재하고 Pending 상태이다.
+
+```
+NAME             STATUS
+pvc-quota-demo   Pending
+```
+
+## 두 번째 퍼시스턴트볼륨클레임 생성 시도
+
+두 번째 퍼시스턴트볼륨클레임 오브젝트의 구성 파일은 다음과 같다.
+
+{{% codenew file="admin/resource/quota-objects-pvc-2.yaml" %}}
+
+두 번째 퍼시스턴트볼륨클레임 생성을 시도한다.
+
+```shell
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-objects-pvc-2.yaml --namespace=quota-object-example
+```
+
+출력에 따르면 두 번째 퍼시스턴트볼륨클레임이 네임스페이스의 쿼터를 초과했기 때문에 생성되지 않았다.
+
+
+```
+persistentvolumeclaims "pvc-quota-demo-2" is forbidden:
+exceeded quota: object-quota-demo, requested: persistentvolumeclaims=1,
+used: persistentvolumeclaims=1, limited: persistentvolumeclaims=1
+```
+
+## 참고 사항
+
+쿼터로 제한할 수 있는 API 리소스를 확인하는 데 사용되는 문자열은 
+다음과 같다.
+
+<table>
+<tr><th>문자열</th><th>API 오브젝트</th></tr>
+<tr><td>"pods"</td><td>파드</td></tr>
+<tr><td>"services"</td><td>서비스</td></tr>
+<tr><td>"replicationcontrollers"</td><td>레플리케이션컨트롤러(ReplicationController)</td></tr>
+<tr><td>"resourcequotas"</td><td>리소스쿼터</td></tr>
+<tr><td>"secrets"</td><td>시크릿(Secret)</td></tr>
+<tr><td>"configmaps"</td><td>컨피그맵(ConfigMap)</td></tr>
+<tr><td>"persistentvolumeclaims"</td><td>퍼시스턴트볼륨클레임</td></tr>
+<tr><td>"services.nodeports"</td><td>NodePort 유형의 서비스</td></tr>
+<tr><td>"services.loadbalancers"</td><td>로드밸런서 유형의 서비스</td></tr>
+</table>
+
+## 정리
+
+네임스페이스를 삭제한다.
+
+```shell
+kubectl delete namespace quota-object-example
+```
+
+
+
+## {{% heading "whatsnext" %}}
+
+
+### 클러스터 관리자의 경우
+
+* [네임스페이스에 대한 기본 메모리 요청량과 상한 구성](/ko/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
+
+* [네임스페이스에 대한 기본 CPU 요청량과 상한 구성](/ko/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
+
+* [네임스페이스에 대한 메모리의 최소 및 최대 제약 조건 구성](/ko/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/)
+
+* [네임스페이스에 대한 CPU의 최소 및 최대 제약 조건 구성](/ko/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)
+
+* [네임스페이스에 대한 메모리 및 CPU 쿼터 구성](/ko/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
+
+* [네임스페이스에 대한 파드 쿼터 구성](/ko/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace/)
+
+### 앱 개발자의 경우
+
+* [컨테이너 및 파드 메모리 리소스 할당](/ko/docs/tasks/configure-pod-container/assign-memory-resource/)
+
+* [컨테이너 및 파드 CPU 리소스 할당](/ko/docs/tasks/configure-pod-container/assign-cpu-resource/)
+
+* [파드에 대한 서비스 품질(QoS) 구성](/ko/docs/tasks/configure-pod-container/quality-service-pod/)
+
+
+
+
+
+
+
+

--- a/content/ko/examples/admin/resource/quota-objects-pvc-2.yaml
+++ b/content/ko/examples/admin/resource/quota-objects-pvc-2.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-quota-demo-2
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi

--- a/content/ko/examples/admin/resource/quota-objects-pvc.yaml
+++ b/content/ko/examples/admin/resource/quota-objects-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-quota-demo
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi

--- a/content/ko/examples/admin/resource/quota-objects.yaml
+++ b/content/ko/examples/admin/resource/quota-objects.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: object-quota-demo
+spec:
+  hard:
+    persistentvolumeclaims: "1"
+    services.loadbalancers: "2"
+    services.nodeports: "0"


### PR DESCRIPTION
#44507 
위 이슈를 번역하였습니다.

추가적으로 한글화하면서 약간의 질문이 있어서 도움을 받고 싶습니다.

1. 57번째 줄의 각 유형들(PersistentVolumeClaim, LoadBalancer)을 한글로 표기해야하는지, 원문으로 표기해야하는지를 잘 모르겠습니다.
중국버전을 확인해보니  영문 그대로 표현하던데, 그에 대한 근거를 잘 모르겠어서 우선 한글로 표기하였습니다! 
134번째 줄의 LoadBalancer도 같은 상황입니다!

2. 75번째 줄에서 "Here is the configuration file for a PersistentVolumeClaim object:"문장을 "퍼시스턴트볼륨클레임 오브젝트에 대한 설정 파일은 다음과 같다."와 같이 번역하였습니다.
밑에 100번째 줄에서 "Here is the configuration file for a second PersistentVolumeClaim:" 과 같은 문장이 있어서, "두 번째 퍼시스턴트볼륨클레임 오브젝트의 설정 파일은 다음과 같다." 와 같이 번역하였는데, 사실 두 문장의 의미가 거의 동일하다고 봐도 무방하여 통일성을 위해 100번째 줄의 번역에 "오브젝트"라는 단어를 원문과 다르게 추가하였습니다. 이런 식으로 진행해도 괜찮은지, 원문을 따라 "두 번째 퍼시스턴트볼륨클레임의 설정 파일은 다음과 같다." 정도로 번역하면 되는지 궁금합니다.


리뷰어의 의견에 따라 필요시 수정하겠습니다! 항상 감사합니다!