### PR TITLE
[zh] Sync /feature-gates/a*.md 

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/accelerators.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/accelerators.md
@@ -6,6 +6,17 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.6"
+    toVersion: "1.10"
+  - stage: deprecated
+    fromVersion: "1.11"
+    toVersion: "1.11"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/admission-webhook-match-conditions.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/admission-webhook-match-conditions.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.27"
+    toVersion: "1.27"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.28"  
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/advanced-auditing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/advanced-auditing.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+  
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.7"
+    toVersion: "1.7"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.8"
+    toVersion: "1.11"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.12"
+    toVersion: "1.27"    
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/affinity-in-annotations.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/affinity-in-annotations.md
@@ -6,6 +6,17 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.6"
+    toVersion: "1.7"
+  - stage: deprecated
+    fromVersion: "1.8"
+    toVersion: "1.8"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/aggregated-discovery-endpoint.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/aggregated-discovery-endpoint.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.26"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-ext-traffic-local-endpoints.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-ext-traffic-local-endpoints.md
@@ -6,6 +6,18 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: beta 
+    defaultValue: false
+    fromVersion: "1.4"
+    toVersion: "1.6"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.7"
+    toVersion: "1.9"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-backend-proxy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-backend-proxy.md
@@ -6,6 +6,18 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.17"
+    toVersion: "1.20"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.25"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/any-volume-data-source.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/any-volume-data-source.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.18"
+    toVersion: "1.23"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.24"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-list-chunking.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-list-chunking.md
@@ -4,6 +4,19 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.8"
+    toVersion: "1.8"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.9"  
+    toVersion: "1.28" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.29"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
@@ -4,6 +4,19 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.18"
+    toVersion: "1.19"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.28"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.29" 
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-response-compression.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-response-compression.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: "alpha" 
+    defaultValue: false
+    fromVersion: "1.7"
+    toVersion: "1.15"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.16"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
@@ -4,6 +4,19 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.26"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28" 
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-identity.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-identity.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.25"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.26"  
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-tracing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-server-tracing.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"  
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/apparmor.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/apparmor.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.4"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/attach-volume-limit.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/attach-volume-limit.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.11"
+    toVersion: "1.11"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.12"
+    toVersion: "1.16"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.17"
+    toVersion: "1.21"
+
+removed: true
 ---
 
 <!--


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/website/issues/44410

Add the new 'stages' metadata to all zh feature gate filename prefixed with "a" in

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
```

1. accelerators.md
2. admission-webhook-match-conditions.md
3. advanced-auditing.md
4. affinity-in-annotations.md
5. aggregated-discovery-endpoint.md
6. allow-ext-traffic-local-endpoints.md
7. allow-insecure-backend-proxy.md
8. any-volume-data-source.md
9. api-list-chunking.md
10. api-priority-and-fairness.md
11. api-response-compression.md
12. api-self-subject-review.md
13. api-server-identity.md
14. api-server-tracing.md
15. apparmor.md
16. attach-volume-limit.md