### PR TITLE
[zh] Sync /feature-gates/b*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/balance-attached-node-volumes.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/balance-attached-node-volumes.md
@@ -6,6 +6,18 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.11"
+    toVersion: "1.21"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.22"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/block-volume.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/block-volume.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.9"
+    toVersion: "1.12"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.13"
+    toVersion: "1.17"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.18"
+    toVersion: "1.21"    
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/bound-service-account-token-volume.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/bound-service-account-token-volume.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.13"
+    toVersion: "1.20"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.21"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.23"    
+
+removed: true
 ---
 
 <!--


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/website/issues/44410

Add the new 'stages' metadata to all zh feature gate filename prefixed with "b" in

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
```

1. balance-attached-node-volumes
2. block-volume
3. bound-service-account-token-volume