### PR TITLE
[zh] Sync feature-gates/g*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/gce-regional-persistent-disk.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/gce-regional-persistent-disk.md
@@ -6,6 +6,18 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.10"
+    toVersion: "1.12"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.13"
+    toVersion: "1.16"
+
+removed: true 
 ---
 <!--
 Enable the regional PD feature on GCE.

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/generic-ephemeral-volume.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/generic-ephemeral-volume.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.19"
+    toVersion: "1.20"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.22"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.23"
+    toVersion: "1.24"    
+
+removed: true
 ---
 <!--
 Enables ephemeral, inline volumes that support all features

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/graceful-node-shutdown-based-on-pod-priority.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/graceful-node-shutdown-based-on-pod-priority.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+  
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.23"
+    toVersion: "1.23"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.24"
 ---
 <!--
 Enables the kubelet to check Pod priorities

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/graceful-node-shutdown.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/graceful-node-shutdown.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.20"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.21"
 ---
 <!--
 Enables support for graceful shutdown in kubelet.

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/grpc-container-probe.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/grpc-container-probe.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.23"
+    toVersion: "1.23"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.26"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.27"
+    toVersion: "1.28"    
+
+removed: true 
 ---
 <!--
 Enables the gRPC probe method for {Liveness,Readiness,Startup}Probe.


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/website/issues/44410

Add the new 'stages' metadata to all zh feature gate filename prefixed with "g" in

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
```

1. gce-regional-persistent-disk.md
2. generic-ephemeral-volume.md
3. graceful-node-shutdown-based-on-pod-priority.md
4. graceful-node-shutdown.md
5. grpc-container-probe.md