### PR TITLE
[zh] Sync feature-gates/i*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/image-maximum-gc-age.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/image-maximum-gc-age.md
@@ -1,0 +1,17 @@
+---
+title: ImageMaximumGCAge
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"   
+---
+
+<!--
+Enables the kubelet configuration field `imageMaximumGCAge`, allowing an administrator to specify the age after which an image will be garbage collected.
+-->
+启用 kubelet 配置字段 `imageMaximumGCAge`，允许管理员指定多久之后镜像将被垃圾收集。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-aws-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-aws-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-azure-disk-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-azure-disk-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-azure-file-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-azure-file-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+ 
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21" 
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-gce-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-gce-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21"  
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-openstack-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-openstack-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-portworx-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-portworx-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.23"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-rbd-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-rbd-unregister.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.23"
+    toVersion: "1.27"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.28"  
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-vsphere-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-vsphere-unregister.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/indexed-job.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/indexed-job.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.23"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"    
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ingress-class-namespaced-params.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ingress-class-namespaced-params.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.22"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.23"
+    toVersion: "1.24"    
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/initializers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/initializers.md
@@ -6,6 +6,17 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.7"
+    toVersion: "1.13"
+  - stage: deprecated
+    fromVersion: "1.14"
+    toVersion: "1.14"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ip-tables-ownership-cleanup.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ip-tables-ownership-cleanup.md
@@ -4,6 +4,19 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28" 
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ipv6-dual-stack.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ipv6-dual-stack.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.15"
+    toVersion: "1.20"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.22"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.23"
+    toVersion: "1.24"    
+
+removed: true 
 ---
 
 <!--


### PR DESCRIPTION
Related to issue #44410.  Mostly updated the front matters:

1. in-tree-plugin-aws-unregister.md
2. in-tree-plugin-azure-disk-unregister.md
3. in-tree-plugin-azure-file-unregister.md
4. in-tree-plugin-gce-unregister.md
5. in-tree-plugin-openstack-unregister.md
6. in-tree-plugin-portworx-unregister.md
7. in-tree-plugin-rbd-unregister.md
8. in-tree-plugin-vsphere-unregister.md
9. indexed-job.md
10. ingress-class-namespaced-params.md
11. initializers.md
12. ip-tables-ownership-cleanup.md
13. ipv6-dual-stack.md
14. image-maximum-gc-age.md