### PR TITLE
Update kubelet-integration.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -163,7 +163,7 @@ Note that the kubeadm CLI command never touches this drop-in file.
 
 This configuration file installed by the `kubeadm`
 [package](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf) is written to
-`/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` and is used by systemd.
+`/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf` and is used by systemd.
 It augments the basic
 [`kubelet.service`](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubelet/kubelet.service):
 


### PR DESCRIPTION
https://github.com/kubernetes/release/blob/2e6dd4a8e1d8d76b4c19ad8b315665c9d22ea5ca/cmd/krel/templates/latest/kubeadm/kubeadm.spec#L50
https://github.com/kubernetes/release/issues/3392  
Kubeadm changed drop-in location for 10-kubeadm.conf from /etc/systemd/system/kubelet.service.d to /usr/lib/systemd/system/kubelet.service.d
