### PR TITLE
Fix search-icon when typing

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1003,3 +1003,32 @@ div.alert > em.javascript-required {
         margin: 0.25em;
     }
 }
+
+// Adjust Search-bar search-icon
+.search-bar {
+  display: flex;
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #4c4c4c;
+  border-radius: 20px; 
+  vertical-align: middle;
+  flex-grow: 1;
+  overflow-x: hidden;
+  width: auto;
+}
+
+.search-bar:focus-within {
+  border: 2.5px solid rgba(47, 135, 223, 0.7);
+}
+
+.search-bar i.search-icon {
+  padding: .5em .5em .5em .75em;
+  opacity: .75;
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  padding: .5em 0 .5em 0;
+}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,33 +1,3 @@
-<style>
-  .search-bar {
-    display: flex;
-    align-items: center;
-    background-color: #fff;
-    border: 1px solid #4c4c4c;
-    border-radius: 20px; 
-    vertical-align: middle;
-    flex-grow: 1;
-    overflow-x: hidden;
-    width: auto;
-  }
-
-  .search-bar:focus-within {
-    border: 2.5px solid rgba(47, 135, 223, 0.7);
-  }
-
-  .search-bar i.search-icon {
-    padding: .5em .5em .5em .75em;
-    opacity: .75;
-  }
-
-  .search-input {
-    flex: 1;
-    border: none;
-    outline: none;
-    padding: .5em 0 .5em 0;
-  }
-</style>
-
 {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
 <div class="search-bar">
   <i class="search-icon fas fa-search"></i>

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,41 +1,83 @@
-  <style> 
-    input[type=text] {
+<head>
+  <style>
+    .search-bar {
+      display: flex;
+      align-items: center;
+      background-color: #fff;
+      border: 1px solid #ccc;
+      border-radius: 20px; 
+      padding: 4px; 
+      width: 50vw;
+    }
+
+    .search-bar:focus-within {
+      border: 2.5px solid rgba(47, 135, 223, 0.7);
+    }
+
+    .search-bar i.fas {
+      margin-right: 10px; 
+    }
+
+    .td-search-input {
+      font-family: 'Your Preferred Font', sans-serif;
+    }
+
+    .search-input {
+      flex: 1;
       box-sizing: border-box;
-      background-color: white;
-      background-image: url('https://www.w3schools.com/css/searchicon.png');
-      background-position: 10px 10px; 
-      background-repeat: no-repeat;
-      padding: 12px 20px 12px 40px;
+      border: none;
+      outline: none;
+      padding: 8px;
+      font-size: 16px;
+      border-radius: 15px;
+    }
+
+    /* Adjust the placeholder font style */
+    .search-input::placeholder {
+      font-style: normal;
+      font-weight: normal;
+      font-size: 16px;
+      color: #aaa;
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+</head>
 
-{{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
-  <input
-    type="text"
-    class="form-control td-search-input"
-    placeholder=" {{ T "ui_search_placeholder" }}"
-    aria-label="{{ T "ui_search_placeholder" }}"
-    autocomplete="off"
-  >
-{{ else if .Site.Params.offlineSearch }}
-  <div id="search-nav-container">
+<body>
+  {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
+  <div class="search-bar">
+    <i class="fas fa-search"></i>
     <input
-      type="text"
-      id="search-input"
-      autocomplete="off"
-      class="form-control td-search-input"
-      placeholder=" {{ T "ui_search_placeholder" }}"
+      type="search"
+      class="search-input td-search-input" 
+      placeholder="{{ T "ui_search_placeholder" }}"
+      aria-label="{{ T "ui_search_placeholder" }}"
       autocomplete="off"
     >
-    <div id="search-results" class="container"></div>
   </div>
-{{ else if .Site.Params.k8s_search }}
-  <input
-    type="text"
-    class="form-control td-search-input"
-    name="q"
-    placeholder=" {{ T "ui_search_placeholder" }}"
-    aria-label="{{ T "ui_search_placeholder" }}"
-    autocomplete="off"
-  >
-{{ end }}
+  {{ else if .Site.Params.offlineSearch }}
+  <div class="search-bar" id="search-nav-container">
+    <i class="fas fa-search"></i>
+    <input
+      type="search"
+      class="search-input td-search-input" 
+      id="search-input"
+      placeholder="{{ T "ui_search_placeholder" }}"
+      aria-label="{{ T "ui_search_placeholder" }}"
+      autocomplete="off"
+    >
+  </div>
+  {{ else if .Site.Params.k8s_search }}
+  <div class="search-bar">
+    <i class="fas fa-search"></i>
+    <input
+      type="search"
+      name="q"
+      class="search-input td-search-input" 
+      placeholder="{{ T "ui_search_placeholder" }}"
+      aria-label="{{ T "ui_search_placeholder" }}"
+      autocomplete="off"
+    >
+  </div>
+  {{ end }}
+</body>

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,29 +1,40 @@
+  <style> 
+    input[type=text] {
+      box-sizing: border-box;
+      background-color: white;
+      background-image: url('https://www.w3schools.com/css/searchicon.png');
+      background-position: 10px 10px; 
+      background-repeat: no-repeat;
+      padding: 12px 20px 12px 40px;
+    }
+  </style>
+
 {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
   <input
-    type="search"
+    type="text"
     class="form-control td-search-input"
-    placeholder="&#xf002; {{ T "ui_search_placeholder" }}"
+    placeholder=" {{ T "ui_search_placeholder" }}"
     aria-label="{{ T "ui_search_placeholder" }}"
     autocomplete="off"
   >
 {{ else if .Site.Params.offlineSearch }}
   <div id="search-nav-container">
     <input
-      type="search"
+      type="text"
       id="search-input"
       autocomplete="off"
       class="form-control td-search-input"
-      placeholder="&#xf002 {{ T "ui_search_placeholder" }}"
+      placeholder=" {{ T "ui_search_placeholder" }}"
       autocomplete="off"
     >
     <div id="search-results" class="container"></div>
   </div>
 {{ else if .Site.Params.k8s_search }}
   <input
-    type="search"
+    type="text"
     class="form-control td-search-input"
     name="q"
-    placeholder="&#xf002 {{ T "ui_search_placeholder" }}"
+    placeholder=" {{ T "ui_search_placeholder" }}"
     aria-label="{{ T "ui_search_placeholder" }}"
     autocomplete="off"
   >

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,82 +1,66 @@
-<head>
-  <style>
-    .search-bar {
-      display: flex;
-      align-items: center;
-      background-color: #fff;
-      border: 1px solid #ccc;
-      border-radius: 20px; 
-      padding: 4px; 
-      width: 50vw;
-    }
+<style>
+  .search-bar {
+    display: flex;
+    align-items: center;
+    background-color: #fff;
+    border: 1px solid #4c4c4c;
+    border-radius: 20px; 
+    vertical-align: middle;
+    flex-grow: 1;
+    overflow-x: hidden;
+    width: auto;
+  }
 
-    .search-bar:focus-within {
-      border: 2.5px solid rgba(47, 135, 223, 0.7);
-    }
+  .search-bar:focus-within {
+    border: 2.5px solid rgba(47, 135, 223, 0.7);
+  }
 
-    .search-bar i.fas {
-      margin-right: 10px; 
-    }
+  .search-bar i.search-icon {
+    padding: .5em .5em .5em .75em;
+    opacity: .75;
+  }
 
-    .td-search-input {
-      font-family: sans-serif;
-    }
+  .search-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    padding: .5em 0 .5em 0;
+  }
+</style>
 
-    .search-input {
-      flex: 1;
-      box-sizing: border-box;
-      border: none;
-      outline: none;
-      padding: 8px;
-      font-size: 16px;
-      border-radius: 15px;
-    }
-
-    .search-input::placeholder {
-      font-style: normal;
-      font-weight: normal;
-      font-size: 16px;
-      color: #aaa;
-    }
-  </style>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-</head>
-
-<body>
-  {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
-  <div class="search-bar">
-    <i class="fas fa-search"></i>
-    <input
-      type="search"
-      class="search-input td-search-input" 
-      placeholder="{{ T "ui_search_placeholder" }}"
-      aria-label="{{ T "ui_search_placeholder" }}"
-      autocomplete="off"
-    >
-  </div>
-  {{ else if .Site.Params.offlineSearch }}
-  <div class="search-bar" id="search-nav-container">
-    <i class="fas fa-search"></i>
-    <input
-      type="search"
-      class="search-input td-search-input" 
-      id="search-input"
-      placeholder="{{ T "ui_search_placeholder" }}"
-      aria-label="{{ T "ui_search_placeholder" }}"
-      autocomplete="off"
-    >
-  </div>
-  {{ else if .Site.Params.k8s_search }}
-  <div class="search-bar">
-    <i class="fas fa-search"></i>
-    <input
-      type="search"
-      name="q"
-      class="search-input td-search-input" 
-      placeholder="{{ T "ui_search_placeholder" }}"
-      aria-label="{{ T "ui_search_placeholder" }}"
-      autocomplete="off"
-    >
-  </div>
-  {{ end }}
-</body>
+{{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
+<div class="search-bar">
+  <i class="search-icon fas fa-search"></i>
+  <input
+    type="search"
+    class="search-input td-search-input" 
+    placeholder="{{ T "ui_search_placeholder" }}"
+    aria-label="{{ T "ui_search_placeholder" }}"
+    autocomplete="off"
+  >
+</div>
+{{ else if .Site.Params.offlineSearch }}
+<div class="search-bar" id="search-nav-container">
+  <i class="search-icon fas fa-search"></i>
+  <input
+    type="search"
+    class="search-input td-search-input" 
+    id="search-input"
+    placeholder="{{ T "ui_search_placeholder" }}"
+    aria-label="{{ T "ui_search_placeholder" }}"
+    autocomplete="off"
+  >
+</div>
+{{ else if .Site.Params.k8s_search }}
+<div class="search-bar">
+  <i class="search-icon fas fa-search"></i>
+  <input
+    type="search"
+    name="q"
+    class="search-input td-search-input" 
+    placeholder="{{ T "ui_search_placeholder" }}"
+    aria-label="{{ T "ui_search_placeholder" }}"
+    autocomplete="off"
+  >
+</div>
+{{ end }}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -19,7 +19,7 @@
     }
 
     .td-search-input {
-      font-family: 'Your Preferred Font', sans-serif;
+      font-family: sans-serif;
     }
 
     .search-input {
@@ -32,7 +32,6 @@
       border-radius: 15px;
     }
 
-    /* Adjust the placeholder font style */
     .search-input::placeholder {
       font-style: normal;
       font-weight: normal;


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
This PR fixes the `Search-icon` disappearance issue when typing something in the search bar. Earlier the magnifying glass symbol was kept within the placeholder of the input form, so whenever something was typed the `Search-icon` would disappear too along with the placeholder comments `Search this site`. I have fixed that in this PR and now the magnifying glass `Search-icon` stays in place at the left-most side of the search bar. 
This is in the context of the issue #44416.