### PR TITLE
Try PageFind for search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ build-preview: module-check ## Build site with drafts and future posts enabled
 
 deploy-preview: ## Deploy preview site via netlify
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --buildFuture --environment preview -b $(DEPLOY_PRIME_URL)
-	npx -y pagefind --site public
 
 functions-build:
 	$(NETLIFY_FUNC) build functions-src
@@ -52,11 +51,9 @@ check-headers-file:
 production-build: module-check ## Build the production site and ensure that noindex headers aren't added
 	GOMAXPROCS=1 hugo --cleanDestinationDir --minify --environment production
 	HUGO_ENV=production $(MAKE) check-headers-file
-	npx -y pagefind --site public
 
 non-production-build: module-check ## Build the non-production site, which adds noindex headers to prevent indexing
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --environment nonprod
-	npx -y pagefind --site public
 
 serve: module-check ## Boot the development server.
 	hugo server --buildFuture --environment development

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ build-preview: module-check ## Build site with drafts and future posts enabled
 
 deploy-preview: ## Deploy preview site via netlify
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --buildFuture --environment preview -b $(DEPLOY_PRIME_URL)
+	npx -y pagefind --site public
 
 functions-build:
 	$(NETLIFY_FUNC) build functions-src

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,11 @@ check-headers-file:
 production-build: module-check ## Build the production site and ensure that noindex headers aren't added
 	GOMAXPROCS=1 hugo --cleanDestinationDir --minify --environment production
 	HUGO_ENV=production $(MAKE) check-headers-file
+	npx -y pagefind --site public
 
 non-production-build: module-check ## Build the non-production site, which adds noindex headers to prevent indexing
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --environment nonprod
+	npx -y pagefind --site public
 
 serve: module-check ## Boot the development server.
 	hugo server --buildFuture --environment development

--- a/hugo.toml
+++ b/hugo.toml
@@ -158,7 +158,7 @@ githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 github_repo = "https://github.com/kubernetes/website"
 
 # Searching
-k8s_search = true
+k8s_search = false
 
 # The following search parameters are specific to Docsy's implementation. Kubernetes implementes its own search-related partials and scripts.
 

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -27,4 +27,15 @@
     aria-label="{{ T "ui_search_placeholder" }}"
     autocomplete="off"
   >
+{{ else }}
+
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+<script src="/pagefind/pagefind-ui.js"></script>
+<div id="search"></div>
+<script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+        new PagefindUI({ element: "#search", showSubResults: true });
+    });
+</script>
+
 {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 # DO NOT REMOVE THIS (contact @kubernetes/sig-docs-leads)
 publish = "public"
 functions = "functions"
-command = "git submodule update --init --recursive --depth 1 && make non-production-build"
+command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"
 
 [build.environment]
 NODE_VERSION = "10.20.0"
@@ -16,13 +16,13 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
-command = "git submodule update --init --recursive --depth 1 && make deploy-preview"
+command = "git submodule update --init --recursive --depth 1 && make deploy-preview && npx -y pagefind --site public"
 
 [context.branch-deploy]
-command = "git submodule update --init --recursive --depth 1 && make non-production-build"
+command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"
 
 [context.main]
 # This context is triggered by the `main` branch and allows search indexing
 # DO NOT REMOVE THIS (contact @kubernetes/sig-docs-leads)
 publish = "public"
-command = "git submodule update --init --recursive --depth 1 && make production-build"
+command = "git submodule update --init --recursive --depth 1 && make production-build && npx -y pagefind --site public"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
-command = "git submodule update --init --recursive --depth 1 && make deploy-preview && npx -y pagefind --site public"
+command = "git submodule update --init --recursive --depth 1 && make deploy-preview && npx -v"
 
 [context.branch-deploy]
 command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"
 
 [build.environment]
-NODE_VERSION = "10.20.0"
+NODE_VERSION = "20.5.0"
 HUGO_VERSION = "0.111.3"
 
 [context.production.environment]
@@ -16,7 +16,7 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
-command = "git submodule update --init --recursive --depth 1 && make deploy-preview && npx -v"
+command = "git submodule update --init --recursive --depth 1 && make deploy-preview && npx -v && npx -y pagefind --site public"
 
 [context.branch-deploy]
 command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"


### PR DESCRIPTION
This PR tests out using [pagefind](https://pagefind.app/docs/) for site search as per [this issue](https://github.com/kubernetes/website/issues/44475).

Note, I had to upgrade the `NODE_VERSION = "20.5.0"` since the `npx -y pagefind --site public` command wasn't working on the existing node version. I'm not sure if there are any negative repercussions to this.