### PR TITLE
[zh] Sync feature-gates/d*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/daemon-set-update-surge.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/daemon-set-update-surge.md
@@ -5,6 +5,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.24"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.25"
+    toVersion: "1.28"
+
+removed: true 
 ---
 <!--
 Enables the DaemonSet workloads to maintain

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-host-network-ports-in-pod-templates.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-host-network-ports-in-pod-templates.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.28"  
 ---
 <!--
 Changes when the default value of

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-pod-topology-spread.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/default-pod-topology-spread.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.19"
+    toVersion: "1.19"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.23"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"    
+
+removed: true 
 ---
 <!--
 Enables the use of `PodTopologySpread` scheduling plugin to do

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/delegate-fs-group-to-csi-driver.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/delegate-fs-group-to-csi-driver.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.22"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.23"
+    toVersion: "1.25"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.26"
+    toVersion: "1.27"    
+
+removed: true 
 ---
 <!--
 If supported by the CSI driver, delegates the

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugin-cdi-devices.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugin-cdi-devices.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.28"
+    toVersion: "1.28"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.29"
 ---
 <!--
 Enable support to CDI device IDs in the

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugins.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/device-plugins.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.8"
+    toVersion: "1.9"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.10"
+    toVersion: "1.25"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.26"
+    toVersion: "1.27"    
+
+removed: true
 ---
 <!--
 Enable the [device-plugins](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-accelerator-usage-metrics.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-accelerator-usage-metrics.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.19"
+    toVersion: "1.19"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.24"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.25"
+    toVersion: "1.27"    
+
+removed: true  
 ---
 <!--
 [Disable accelerator metrics collected by the kubelet](/docs/concepts/cluster-administration/system-metrics/#disable-accelerator-metrics).

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-cloud-providers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-cloud-providers.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.28"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.29" 
 ---
 <!--
 Disables any functionality in `kube-apiserver`,

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-kubelet-cloud-credential-providers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-kubelet-cloud-credential-providers.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.23"
+    toVersion: "1.28"    
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.29" 
 ---
 <!--
 Disable the in-tree functionality in kubelet

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-node-kube-proxy-version.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/disable-node-kube-proxy-version.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.29"
 ---
 <!--
 Disable setting the `kubeProxyVersion` field of the Node.

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/downward-api-huge-pages.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/downward-api-huge-pages.md
@@ -4,6 +4,26 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.20"
+  - stage: beta 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"    
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.26"      
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.27"
+    toVersion: "1.28"    
+
+removed: true  
 ---
 <!--
 Enables usage of hugepages in

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dry-run.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dry-run.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.12"
+    toVersion: "1.12"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.13"
+    toVersion: "1.18"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.19"
+    toVersion: "1.27"    
+
+removed: true  
 ---
 <!--
 Enable server-side [dry run](/docs/reference/using-api/api-concepts/#dry-run) requests

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-auditing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-auditing.md
@@ -6,6 +6,17 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.13"
+    toVersion: "1.18"
+  - stage: deprecated
+    fromVersion: "1.19"
+    toVersion: "1.19"
+
+removed: true 
 ---
 <!--
 Used to enable dynamic auditing before v1.19.

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-kubelet-config.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-kubelet-config.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.4"
+    toVersion: "1.10"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.11"
+    toVersion: "1.21"    
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.25"    
+
+removed: true  
 ---
 <!--
 Enable the dynamic configuration of kubelet. The

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-provisioning-scheduling.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-provisioning-scheduling.md
@@ -6,6 +6,16 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.11"
+    toVersion: "1.11"
+  - stage: deprecated
+    fromVersion: "1.12"
+
+removed: true  
 ---
 <!--
 Extend the default scheduler to be aware of

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-resource-allocation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-resource-allocation.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.26"
 ---
 <!--
 Enables support for resources with custom parameters and a lifecycle

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-volume-provisioning.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/dynamic-volume-provisioning.md
@@ -6,6 +6,18 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: true
+    fromVersion: "1.3"
+    toVersion: "1.7"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.8"
+    toVersion: "1.12"    
+
+removed: true 
 ---
 <!--
 Enable the


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/website/issues/44410

Add the new 'stages' metadata in the **_front matter_** of all zh feature gate filename prefixed with "d" in

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
```

1. daemon-set-update-surge.md
2. default-host-network-ports-in-pod-templates.md
3. default-pod-topology-spread.md
4. delegate-fs-group-to-csi-driver.md
5. device-plugin-cdi-devices.md
6. device-plugins.md
7. disable-accelerator-usage-metrics.md
8. disable-cloud-providers.md
9. disable-kubelet-cloud-credential-providers.md
10. disable-node-kube-proxy-version.md
11. downward-api-huge-pages.md
12. dry-run.md
13. dynamic-auditing.md
14. dynamic-kubelet-config.md
15. dynamic-provisioning-scheduling.md
16. dynamic-resource-allocation.md
17. dynamic-volume-provisioning.md