### PR TITLE
[zh] Sync feature-gates/m*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/match-label-keys-in-pod-affinity.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/match-label-keys-in-pod-affinity.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.29"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/match-label-keys-in-pod-topology-spread.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/match-label-keys-in-pod-topology-spread.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/max-unavailable-stateful-set.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/max-unavailable-stateful-set.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.24"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/memory-manager.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/memory-manager.md
@@ -4,6 +4,15 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.22"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/memory-qos.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/memory-qos.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.22"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/min-domains-in-pod-topology-spread.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/min-domains-in-pod-topology-spread.md
@@ -4,6 +4,19 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.24"
+    toVersion: "1.24"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/minimize-ip-tables-restore.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/minimize-ip-tables-restore.md
@@ -4,6 +4,19 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.26"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28" 
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/mixed-protocol-lb-service.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/mixed-protocol-lb-service.md
@@ -4,6 +4,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.23"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.26"
+    toVersion: "1.27"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/mount-containers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/mount-containers.md
@@ -6,6 +6,18 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.9"
+    toVersion: "1.16"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.17"
+    toVersion: "1.17"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/mount-propagation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/mount-propagation.md
@@ -6,6 +6,22 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.8"
+    toVersion: "1.9"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.10"
+    toVersion: "1.11"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.12"
+    toVersion: "1.14"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/multi-cidr-range-allocator.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/multi-cidr-range-allocator.md
@@ -4,6 +4,14 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.28"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/multi-cidr-service-allocator.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/multi-cidr-service-allocator.md
@@ -4,6 +4,11 @@ content_type: feature_gate
 _build:
   list: never
   render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.27"
 ---
 
 <!--


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/website/issues/44410

Add the new 'stages' metadata in the front matter of all zh feature gate filename prefixed with "m" in
```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
```
1. match-label-keys-in-pod-affinity
2. match-label-keys-in-pod-topology-spread
3. max-unavailable-stateful-set
4. memory-manager
5. memory-qos
6. min-domains-in-pod-topology-spread
7. minimize-ip-tables-restore
8. mixed-protocol-lb-service
9. mount-containers
10. mount-propagation
11. multi-cidr-range-allocator
12. multi-cidr-service-allocator