### PR TITLE
[zh] Localize part3 of feature-gates/p*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-ready-to-start-containers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-ready-to-start-containers.md
@@ -1,0 +1,29 @@
+---
+title: PodReadyToStartContainersCondition
+former_titles:
+  - PodHasNetworkCondition
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.28"
+    toVersion: "1.28"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.29"
+---
+
+<!--
+Enable the kubelet to mark the [PodReadyToStartContainers](/docs/concepts/workloads/pods/pod-lifecycle/#pod-has-network) condition on pods.
+
+This feature gate was previously known as `PodHasNetworkCondition`, and the associated condition was
+named `PodHasNetwork`.
+-->
+使得 kubelet 能在 Pod 上标记
+[PodReadyToStartContainers](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-has-network) 状况。
+
+此特性门控先前称为 `PodHasNetworkCondition`，关联的状况称为 `PodHasNetwork`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-scheduling-readiness.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-scheduling-readiness.md
@@ -1,0 +1,22 @@
+---
+title: PodSchedulingReadiness
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.26"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
+---
+
+<!--
+Enable setting `schedulingGates` field to control a Pod's [scheduling readiness](/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
+-->
+允许设置 `schedulingGates` 字段以控制 Pod
+的[调度就绪状态](/zh-cn/docs/concepts/scheduling-eviction/pod-scheduling-readiness)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-security.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-security.md
@@ -1,0 +1,29 @@
+---
+# Removed from Kubernetes
+title: PodSecurity
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.22"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.23"
+    toVersion: "1.24"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.25"
+    toVersion: "1.27"
+
+removed: true
+---
+
+<!--
+Enables the `PodSecurity` admission plugin.
+-->
+启用 `PodSecurity` 准入插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-share-process-namespace.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pod-share-process-namespace.md
@@ -1,0 +1,34 @@
+---
+# Removed from Kubernetes
+title: PodShareProcessNamespace
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.10"
+    toVersion: "1.11"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.12"
+    toVersion: "1.16"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.17"
+    toVersion: "1.19"
+
+removed: true
+---
+
+<!--
+Enable the setting of `shareProcessNamespace` in a Pod for sharing
+a single process namespace between containers running in a pod.  More details can be found in
+[Share Process Namespace between Containers in a Pod](/docs/tasks/configure-pod-container/share-process-namespace/).
+-->
+在 Pod 中启用 `shareProcessNamespace` 的设置，
+以便在 Pod 中运行的容器之间共享同一进程名字空间。
+更多细节请参见[在 Pod 中的容器间共享同一进程名字空间](/zh-cn/docs/tasks/configure-pod-container/share-process-namespace/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/prefer-nominated-node.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/prefer-nominated-node.md
@@ -1,0 +1,32 @@
+---
+# Removed from Kubernetes
+title: PreferNominatedNode
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.23"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"
+
+removed: true
+---
+
+<!--
+This flag tells the scheduler whether the nominated
+nodes will be checked first before looping through all the other nodes in
+the cluster.
+-->
+这个标志告诉调度器在循环遍历集群中的所有其他节点之前是否先检查指定的节点。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/probe-termination-grace-period.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/probe-termination-grace-period.md
@@ -1,0 +1,36 @@
+---
+title: ProbeTerminationGracePeriod
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.22"  
+    toVersion: "1.24" 
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.25"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28"
+    toVersion: "1.28"     
+
+removed: true
+---
+
+<!--
+Enable [setting probe-level
+`terminationGracePeriodSeconds`](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#probe-level-terminationgraceperiodseconds)
+on pods. See the [enhancement proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2238-liveness-probe-grace-period)
+for more details.
+-->
+在 Pod 上启用[设置探针级别 `terminationGracePeriodSeconds`](/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#probe-level-terminationgraceperiodseconds)。
+更多细节请参见[增强提案](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2238-liveness-probe-grace-period)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/proc-mount-type.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/proc-mount-type.md
@@ -1,0 +1,19 @@
+---
+title: ProcMountType
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.12"
+---
+
+<!--
+Enables control over the type proc mounts for containers
+by setting the `procMount` field of a SecurityContext.
+-->
+允许容器通过设置 SecurityContext 的 `procMount` 字段来控制对
+proc 类型的挂载方式。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/proxy-terminating-endpoints.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/proxy-terminating-endpoints.md
@@ -1,0 +1,26 @@
+---
+title: ProxyTerminatingEndpoints
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.25"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.26"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28"  
+---
+
+<!--
+Enable the kube-proxy to handle terminating
+endpoints when `ExternalTrafficPolicy=Local`.
+-->
+当 `ExternalTrafficPolicy=Local` 时，允许 kube-proxy 处理终止过程中的端点。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pvc-protection.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/pvc-protection.md
@@ -1,0 +1,26 @@
+---
+# Removed from Kubernetes
+title: PVCProtection
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.9"
+    toVersion: "1.9"
+  - stage: deprecated
+    fromVersion: "1.10"
+    toVersion: "1.10"
+
+removed: true
+---
+
+<!--
+Enable the prevention of a PersistentVolumeClaim (PVC) from
+being deleted when it is still used by any Pod.
+-->
+启用后，可预防仍然有 Pod 正使用的 PersistentVolumeClaim (PVC) 被删除。


### PR DESCRIPTION
Related to issue #44410. Localize these fiels:

1. pod-ready-to-start-containers.md
2. pod-scheduling-readiness.md
3. pod-security.md
4. pod-share-process-namespace.md
5. prefer-nominated-node.md
6. probe-termination-grace-period.md
7. proc-mount-type.md
8. proxy-terminating-endpoints.md
9. pvc-protection.md