### PR TITLE
[zh] Localize part2 of /feature-gates/k*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kube-proxy-draining-terminating-nodes.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kube-proxy-draining-terminating-nodes.md
@@ -1,0 +1,18 @@
+---
+title: KubeProxyDrainingTerminatingNodes
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.28"
+---
+
+<!--
+Implement connection draining for
+terminating nodes for `externalTrafficPolicy: Cluster` services.
+-->
+为 `externalTrafficPolicy: Cluster` 服务实现终止节点的连接排空。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-plugins-watcher.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-plugins-watcher.md
@@ -1,0 +1,32 @@
+---
+# Removed from Kubernetes
+title: KubeletPluginsWatcher
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.11"
+    toVersion: "1.11"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.12"
+    toVersion: "1.12"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.13"
+    toVersion: "1.16"
+
+removed: true
+---
+
+<!--
+Enable probe-based plugin watcher utility to enable kubelet
+to discover plugins such as [CSI volume drivers](/docs/concepts/storage/volumes/#csi).
+-->
+启用基于探针的插件监视程序，使 kubelet 能够发现
+[CSI 卷驱动程序](/zh-cn/docs/concepts/storage/volumes/#csi)这类插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamic-resources.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamic-resources.md
@@ -1,0 +1,24 @@
+---
+title: KubeletPodResourcesDynamicResources
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+  
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.27"  
+---
+
+<!--
+Extend the kubelet's pod resources gRPC endpoint to
+to include resources allocated in `ResourceClaims` via `DynamicResourceAllocation` API.
+See [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources) for more details.
+with informations about the allocatable resources, enabling clients to properly
+track the free compute resources on a node.
+-->
+扩展 kubelet 的 Pod 资源 gRPC 端点以包括通过
+`DynamicResourceAllocation` API 在 `ResourceClaims` 中分配的资源。
+详情参见[资源分配报告](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)。
+包含有关可分配资源的信息，使客户端能够正确跟踪节点上的可用计算资源。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-get-allocatable.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-get-allocatable.md
@@ -1,0 +1,28 @@
+---
+title: KubeletPodResourcesGetAllocatable
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.22"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.23"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28" 
+---
+
+<!--
+Enable the kubelet's pod resources
+`GetAllocatableResources` functionality. This API augments the
+[resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)
+-->
+启用 kubelet 的 Pod 资源的 `GetAllocatableResources` 功能。
+此 API 增强了[资源分配报告](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-get.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-get.md
@@ -1,0 +1,19 @@
+---
+title: KubeletPodResourcesGet
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.27"
+---
+
+<!--
+Enable the `Get` gRPC endpoint on kubelet's for Pod resources.
+This API augments the [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources).
+-->
+在 kubelet 上为 Pod 资源启用 `Get` gRPC 端点。
+此 API 增强了[资源分配报告](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources.md
@@ -1,0 +1,28 @@
+---
+title: KubeletPodResources
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.13"
+    toVersion: "1.14"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.15"  
+    toVersion: "1.27" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28"  
+---
+
+<!--
+Enable the kubelet's pod resources gRPC endpoint. See
+[Support Device Monitoring](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/606-compute-device-assignment/README.md)
+for more details.
+-->
+启用 kubelet 上 Pod 资源 gRPC 端点。
+详情参见[支持设备监控](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/606-compute-device-assignment/README.md)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-separate-disk-gc.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-separate-disk-gc.md
@@ -1,0 +1,18 @@
+---
+title: KubeletSeparateDiskGC
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+
+<!--
+Enable kubelet to garbage collect container images and containers
+even when those are on a separate filesystem.
+-->
+启用 kubelet，即使在容器镜像和容器位于独立文件系统的情况下，也能进行垃圾回收。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-tracing.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-tracing.md
@@ -1,0 +1,26 @@
+---
+title: KubeletTracing
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
+---
+
+<!--
+Add support for distributed tracing in the kubelet.
+When enabled, kubelet CRI interface and authenticated http servers are instrumented to generate
+OpenTelemetry trace spans.
+See [Traces for Kubernetes System Components](/docs/concepts/cluster-administration/system-traces) for more details.
+-->
+新增在 kubelet 中对分布式追踪的支持。
+启用时，kubelet CRI 接口和经身份验证的 http 服务器被插桩以生成 OpenTelemetry 追踪 span。
+详情参见[追踪 Kubernetes 系统组件](/zh-cn/docs/concepts/cluster-administration/system-traces/)。


### PR DESCRIPTION
Related to issue #44410. Localized these files:

1.  kube-proxy-draining-terminating-nodes.md       
2.  kubelet-plugins-watcher.md
3.  kubelet-pod-resources-dynamic-resources.md     
4.  kubelet-pod-resources-get-allocatable.md       
5.  kubelet-pod-resources-get.md
6.  kubelet-pod-resources.md
7.  kubelet-separate-disk-gc.md
8.  kubelet-tracing.md


