### PR TITLE
Fix feature-gates/z*.md content format

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
@@ -11,5 +11,5 @@ stages:
     fromVersion: "1.29"
 ---
 Allow [Priority & Fairness](/docs/concepts/cluster-administration/flow-control/)
-in the API server to use a zero value for the `nominalConcurrencyShares field of
+in the API server to use a zero value for the `nominalConcurrencyShares` field of
 the `limited` section of a priority level.


### PR DESCRIPTION
Update file:

```
content/en/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
```

Fix missing backtick of field `nominalConcurrencyShares`.

---

See [preview](https://deploy-preview-44563--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates/#feature-gates).