### PR TITLE
[zh] Localize feature-gates/s*.md part 1

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/schedule-daemon-set-pods.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/schedule-daemon-set-pods.md
@@ -1,0 +1,30 @@
+---
+# Removed from Kubernetes
+title: ScheduleDaemonSetPods
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.11"
+    toVersion: "1.11"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.12"
+    toVersion: "1.16"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.17"
+    toVersion: "1.18"
+
+removed: true
+---
+<!--
+Enable DaemonSet Pods to be scheduled by the default scheduler instead
+of the DaemonSet controller.
+-->
+启用 DaemonSet Pod 由默认调度器而不是 DaemonSet 控制器进行调度。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/scheduler-queueing-hints.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/scheduler-queueing-hints.md
@@ -1,0 +1,28 @@
+---
+title: SchedulerQueueingHints
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.28"
+    toVersion: "1.28"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Enables [the scheduler's _queueing hints_ enhancement](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md),
+which benefits to reduce the useless requeueing.
+The scheduler retries scheduling pods if something changes in the cluster that could make the pod scheduled.
+Queueing hints are internal signals that allow the scheduler to filter the changes in the cluster
+that are relevant to the unscheduled pod, based on previous scheduling attempts.
+-->
+启用[调度器的**排队提示**增强功能](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md)，
+有助于减少无效的重新排队。
+调度器会在集群中发生可能导致 Pod 被重新调度的变化时，尝试重新进行 Pod 的调度。
+排队提示是一些内部信号，
+用于帮助调度器基于先前的调度尝试来筛选集群中与未调度的 Pod 相关的变化。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/sctp-support.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/sctp-support.md
@@ -1,0 +1,31 @@
+---
+# Removed from Kubernetes
+title: SCTPSupport
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.12"
+    toVersion: "1.18"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.19"
+    toVersion: "1.19"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.22"
+
+removed: true
+---
+<!--
+Enables the _SCTP_ `protocol` value in Pod, Service, Endpoints, EndpointSlice,
+and NetworkPolicy definitions.
+-->
+在 Pod、Service、Endpoints、NetworkPolicy 定义中允许将 **SCTP**
+用作 `protocol` 值。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/seccomp-default.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/seccomp-default.md
@@ -1,0 +1,30 @@
+---
+title: SeccompDefault
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.24"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.25"  
+    toVersion: "1.26" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.27"
+    toVersion: "1.28"     
+
+removed: true
+---
+<!--
+Enables the use of `RuntimeDefault` as the default seccomp profile
+for all workloads.
+The seccomp profile is specified in the `securityContext` of a Pod and/or a Container.
+-->
+启用 `RuntimeDefault` 作为所有工作负载的默认 seccomp 配置文件。
+此 seccomp 配置文件在 Pod 和/或 Container 的 `securityContext` 中被指定。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/security-context-deny.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/security-context-deny.md
@@ -1,0 +1,16 @@
+---
+title: SecurityContextDeny
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.27"
+---
+<!--
+This gate signals that the `SecurityContextDeny` admission controller is deprecated.
+-->
+此门控表示 `SecurityContextDeny` 准入控制器已弃用。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selector-index.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selector-index.md
@@ -1,0 +1,30 @@
+---
+# Removed from Kubernetes
+title: SelectorIndex
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.18"
+    toVersion: "1.18"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.19"
+    toVersion: "1.19"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.25"
+
+removed: true  
+---
+<!--
+Allows label and field based indexes in API server watch cache to accelerate
+list operations.
+-->
+允许使用 API 服务器的 watch 缓存中基于标签和字段的索引来加速 list 操作。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selinux-mount-read-write-once-pod.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selinux-mount-read-write-once-pod.md
@@ -1,0 +1,28 @@
+---
+title: SELinuxMountReadWriteOncePod
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.27"
+    toVersion: "1.27"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.28"
+---
+<!--
+Speeds up container startup by allowing kubelet to mount volumes
+for a Pod directly with the correct SELinux label instead of changing each file on the volumes
+recursively. The initial implementation focused on ReadWriteOncePod volumes.
+-->
+通过允许 kubelet 直接用正确的 SELinux
+标签为 Pod 挂载卷而不是以递归方式更改这些卷上的每个文件来加速容器启动。
+最初的实现侧重 ReadWriteOncePod 卷。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/separate-taint-eviction-controller.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/separate-taint-eviction-controller.md
@@ -1,0 +1,24 @@
+---
+title: SeparateTaintEvictionController
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.29"
+---
+<!--
+Enables running `TaintEvictionController`,
+that performs [Taint-based Evictions](/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions),
+in a controller separated from `NodeLifecycleController`. When this feature is
+enabled, users can optionally disable Taint-based Eviction setting the
+`--controllers=-taint-eviction-controller` flag on the `kube-controller-manager`.
+-->
+允许运行 `TaintEvictionController`，该控制器可在 `NodeLifecycleController`
+之外执行[基于污点的驱逐](/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions)。
+此特性启用时，用户可以在 `kube-controller-manager`
+上设置 `--controllers=-taint-eviction-controller` 标志，
+可选择禁用基于污点的驱逐。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/server-side-apply.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/server-side-apply.md
@@ -1,0 +1,25 @@
+---
+title: ServerSideApply
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.14"
+    toVersion: "1.15"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.16"  
+    toVersion: "1.21" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.22"  
+---
+<!--
+Enables the [Sever Side Apply (SSA)](/docs/reference/using-api/server-side-apply/)
+feature on the API Server.
+-->
+在 API 服务器上启用[服务器端应用（SSA）](/zh-cn/docs/reference/using-api/server-side-apply/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/server-side-field-validation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/server-side-field-validation.md
@@ -1,0 +1,27 @@
+---
+title: ServerSideFieldValidation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.23"
+    toVersion: "1.24"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.25"  
+    toVersion: "1.26" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.27"  
+---
+<!--
+Enables server-side field validation. This means the validation
+of resource schema is performed at the API server side rather than the client side
+(for example, the `kubectl create` or `kubectl apply` command line).
+-->
+启用服务器端字段验证。这意味着资源模式的验证发生在 API 服务器端而不是客户端
+（例如，`kubectl create` 或 `kubectl apply` 命令行）。


### PR DESCRIPTION
Related to issue #44410 

Localize part 1 10 files of feature-gates/s*.md:

1. schedule-daemon-set-pods.md
1. scheduler-queueing-hints.md
1. sctp-support.md
1. seccomp-default.md
1. security-context-deny.md
1. selector-index.md
1. selinux-mount-read-write-once-pod.md
1. separate-taint-eviction-controller.md
1. server-side-apply.md
1. server-side-field-validation.md