### PR TITLE
[zh] Localize feature-gates/s*.md part 2

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-issuer-discovery.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-issuer-discovery.md
@@ -1,0 +1,33 @@
+---
+# Removed from Kubernetes
+title: ServiceAccountIssuerDiscovery
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.18"
+    toVersion: "1.19"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.20"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.23"
+
+removed: true
+---
+<!--
+Enable OIDC discovery endpoints (issuer and JWKS URLs) for the
+service account issuer in the API server. See
+[Configure Service Accounts for Pods](/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery)
+for more details.
+-->
+在 API 服务器中为服务账号颁发者启用 OIDC 发现端点（颁发者和 JWKS URL）。
+详情参见[为 Pod 配置服务账号](/zh-cn/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-jti.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-jti.md
@@ -1,0 +1,18 @@
+---
+title: ServiceAccountTokenJTI
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Controls whether JTIs (UUIDs) are embedded into generated service account tokens,
+and whether these JTIs are recorded into the Kubernetes audit log for future requests made by these tokens.
+-->
+控制是否将 JTI（UUID）嵌入到生成的服务账号令牌中，
+以及对于这些令牌未来的请求，是否将这些 JTI 记录到 Kubernetes 审计日志中。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-node-binding-validation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-node-binding-validation.md
@@ -1,0 +1,16 @@
+---
+title: ServiceAccountTokenNodeBindingValidation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Controls whether the apiserver will validate a Node reference in service account tokens.
+-->
+控制 API 服务器是否会验证服务账号令牌中的 Node 引用。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-node-binding.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-node-binding.md
@@ -1,0 +1,16 @@
+---
+title: ServiceAccountTokenNodeBinding
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Controls whether the apiserver allows binding service account tokens to Node objects.
+-->
+控制 API 服务器是否允许将服务账号令牌绑定到 Node 对象。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-pod-node-info.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-account-token-pod-node-info.md
@@ -1,0 +1,18 @@
+---
+title: ServiceAccountTokenPodNodeInfo
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Controls whether the apiserver embeds the node name and uid
+for the associated node when issuing service account tokens bound to Pod objects.
+-->
+控制 API 服务器在颁发绑定到 Pod 对象的服务账号令牌时，
+是否嵌入关联 Node 的名称和 `uid`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-app-protocol.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-app-protocol.md
@@ -1,0 +1,29 @@
+---
+# Removed from Kubernetes
+title: ServiceAppProtocol
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.18"
+    toVersion: "1.18"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.19"
+    toVersion: "1.19"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.22"    
+
+removed: true
+---
+<!--
+Enables the `appProtocol` field on Services and Endpoints.
+-->
+为 Service 和 Endpoints 启用 `appProtocol` 字段。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-internal-traffic-policy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-internal-traffic-policy.md
@@ -1,0 +1,27 @@
+---
+title: ServiceInternalTrafficPolicy
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.25"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.26"
+    toVersion: "1.27"    
+
+removed: true
+---
+<!--
+Enables the `internalTrafficPolicy` field on Services
+-->
+为 Service 启用 `internalTrafficPolicy` 字段。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-ip-static-subrange.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-ip-static-subrange.md
@@ -1,0 +1,35 @@
+---
+title: ServiceIPStaticSubrange
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.24"
+    toVersion: "1.24"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.25"
+    toVersion: "1.25"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.26"
+    toVersion: "1.27"    
+
+removed: true  
+---
+<!--
+Enables a strategy for Services ClusterIP allocations, whereby the
+ClusterIP range is subdivided. Dynamic allocated ClusterIP addresses will be allocated preferently
+from the upper range allowing users to assign static ClusterIPs from the lower range with a low
+risk of collision. See
+[Avoiding collisions](/docs/reference/networking/virtual-ips/#avoiding-collisions)
+for more details.
+-->
+启用 Service 的 ClusterIP 分配策略，从而细分 ClusterIP 范围。
+动态分配的 ClusterIP 地址将优先从较高范围分配，
+以允许用户从较低范围分配静态 ClusterIP，进而降低发生冲突的风险。
+更多详细信息请参阅[避免冲突](/zh-cn/docs/reference/networking/virtual-ips/#avoiding-collisions)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-lb-node-port-control.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-lb-node-port-control.md
@@ -1,0 +1,29 @@
+---
+# Removed from Kubernetes
+title: ServiceLBNodePortControl
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.23"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"    
+
+removed: true
+---
+<!--
+Enables the `allocateLoadBalancerNodePorts` field on Services.
+-->
+为 Service 启用 `allocateLoadBalancerNodePorts` 字段。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-load-balancer-class.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-load-balancer-class.md
@@ -1,0 +1,32 @@
+---
+# Removed from Kubernetes
+title: ServiceLoadBalancerClass
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.23"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"    
+
+removed: true
+---
+<!--
+Enables the `loadBalancerClass` field on Services. See
+[Specifying class of load balancer implementation](/docs/concepts/services-networking/service/#load-balancer-class)
+for more details.
+-->
+为 Service 启用 `loadBalancerClass` 字段。
+有关更多信息，请参见[设置负载均衡器实现的类别](/zh-cn/docs/concepts/services-networking/service/#load-balancer-class)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-load-balancer-finalizer.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-load-balancer-finalizer.md
@@ -1,0 +1,29 @@
+---
+# Removed from Kubernetes
+title: ServiceLoadBalancerFinalizer
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.15"
+    toVersion: "1.15"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.16"
+    toVersion: "1.16"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.17"
+    toVersion: "1.20"    
+
+removed: true
+---
+<!--
+Enable finalizer protection for Service load balancers.
+-->
+为 Service 负载均衡器启用终结器（finalizers）保护。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-node-exclusion.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-node-exclusion.md
@@ -1,0 +1,32 @@
+---
+# Removed from Kubernetes
+title: ServiceNodeExclusion
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.8"
+    toVersion: "1.18"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.19"
+    toVersion: "1.20"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.22"    
+
+removed: true
+---
+<!--
+Enable the exclusion of nodes from load balancers created by a cloud provider.
+A node is eligible for exclusion if labelled with "`node.kubernetes.io/exclude-from-external-load-balancers`".
+-->
+允许从云提供商创建的负载均衡器中排除节点。
+如果节点标记有 `node.kubernetes.io/exclude-from-external-load-balancers` 标签，
+则可以排除该节点。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-nodeport-static-subrange.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-nodeport-static-subrange.md
@@ -1,0 +1,28 @@
+---
+title: ServiceNodePortStaticSubrange
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.27"
+    toVersion: "1.27"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.28"  
+    toVersion: "1.28" 
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.29" 
+---
+<!--
+Enables the use of different port allocation
+strategies for NodePort Services. For more details, see
+[reserve NodePort ranges to avoid collisions](/docs/concepts/services-networking/service/#avoid-nodeport-collisions).
+-->
+允许对 NodePort Service 使用不同的端口分配策略。
+有关更多详细信息，
+请参阅[保留 NodePort 范围以避免冲突](/zh-cn/docs/concepts/services-networking/service/#avoid-nodeport-collisions)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-topology.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-topology.md
@@ -1,0 +1,25 @@
+---
+# Removed from Kubernetes
+title: ServiceTopology
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.17"
+    toVersion: "1.19"
+  - stage: deprecated 
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.22"
+
+removed: true
+---
+<!--
+Enable service to route traffic based upon the Node topology of the cluster.
+-->
+允许 Service 基于集群的节点拓扑进行流量路由。


### PR DESCRIPTION
Related to issue #44410 

Localize part 2 14 files of feature-gates/s*.md

1. service-account-issuer-discovery.md
1. service-account-token-jti.md
1. service-account-token-node-binding-validation.md
1. service-account-token-node-binding.md
1. service-account-token-pod-node-info.md
1. service-app-protocol.md
1. service-internal-traffic-policy.md
1. service-ip-static-subrange.md
1. service-lb-node-port-control.md
1. service-load-balancer-class.md
1. service-load-balancer-finalizer.md
1. service-node-exclusion.md
1. service-nodeport-static-subrange.md
1. service-topology.md