### PR TITLE
Disable line wrapping instead of removing new lines

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -524,7 +524,7 @@ Some points to note:
   You can get the content using this command: 
 
   ```shell
-  cat myuser.csr | base64 | tr -d "\n"
+  cat myuser.csr | base64 -w 0
   ```
 
 


### PR DESCRIPTION
When encoding a file using base64 it's simpler to just use the w flag to remove the line wrapping instead of removing new lines.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
