### PR TITLE
Update container-runtimes.md

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -57,17 +57,33 @@ or the documentation for your specific container runtime.
 
 ### Forwarding IPv4 and letting iptables see bridged traffic
 
-Execute the below mentioned instructions:
+The `br_netfilter` and `overlay` modules must be loaded. Verify by running the following commands:
 
 ```bash
+lsmod | grep br_netfilter
+lsmod | grep overlay
+```
+
+And load them if they aren't already:
+```
 cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
 EOF
-
 sudo modprobe overlay
 sudo modprobe br_netfilter
+```
 
+Verify that the `net.bridge.bridge-nf-call-iptables`, `net.bridge.bridge-nf-call-ip6tables`, and
+`net.ipv4.ip_forward` system variables are set to `1` in your `sysctl` config by running the following command:
+
+```bash
+sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
+```
+
+And run this if they aren't:
+
+```bash
 # sysctl params required by setup, params persist across reboots
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 net.bridge.bridge-nf-call-iptables  = 1
@@ -77,20 +93,6 @@ EOF
 
 # Apply sysctl params without reboot
 sudo sysctl --system
-```
-
-Verify that the `br_netfilter`, `overlay` modules are loaded by running the following commands:
-
-```bash
-lsmod | grep br_netfilter
-lsmod | grep overlay
-```
-
-Verify that the `net.bridge.bridge-nf-call-iptables`, `net.bridge.bridge-nf-call-ip6tables`, and
-`net.ipv4.ip_forward` system variables are set to `1` in your `sysctl` config by running the following command:
-
-```bash
-sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
 ```
 
 ## cgroup drivers


### PR DESCRIPTION
There is no point in changing some configurations to enable things that might be enabled already. I ran the commands to check the sysctl params and the modules and they were already correct in Ubuntu 22.04.3 LTS.