### PR TITLE
[zh] Localize feature-gates/s*.md part 3

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/set-hostname-as-fqdn.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/set-hostname-as-fqdn.md
@@ -1,0 +1,32 @@
+---
+# Removed from Kubernetes
+title: SetHostnameAsFQDN
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.19"
+    toVersion: "1.19"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.21"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.24"    
+
+removed: true
+---
+<!--
+Enable the ability of setting Fully Qualified Domain Name(FQDN) as the
+hostname of a pod. See
+[Pod's `setHostnameAsFQDN` field](/docs/concepts/services-networking/dns-pod-service/#pod-sethostnameasfqdn-field).
+-->
+启用将全限定域名（FQDN）设置为 Pod 主机名的功能。
+请参见 [Pod 的 `setHostnameAsFQDN` 字段](/zh-cn/docs/concepts/services-networking/dns-pod-service/#pod-sethostnameasfqdn-field)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/sidecar-containers.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/sidecar-containers.md
@@ -1,0 +1,25 @@
+---
+title: SidecarContainers
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.28"
+    toVersion: "1.28"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.29"
+---
+<!--
+Allow setting the `restartPolicy` of an init container to
+`Always` so that the container becomes a sidecar container (restartable init containers).
+See [Sidecar containers and restartPolicy](/docs/concepts/workloads/pods/sidecar-containers/)
+for more details.
+-->
+允许将 Init 容器的 `restartPolicy` 设置为 `Always`，
+以便该容器成为一个边车容器（可重启的 Init 容器）。
+详情参见[边车容器和 restartPolicy](/zh-cn/docs/concepts/workloads/pods/sidecar-containers/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/size-memory-backed-volumes.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/size-memory-backed-volumes.md
@@ -1,0 +1,21 @@
+---
+title: SizeMemoryBackedVolumes
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.20"
+    toVersion: "1.21"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.22"
+---
+<!--
+Enable kubelets to determine the size limit for
+memory-backed volumes (mainly `emptyDir` volumes).
+-->
+允许 kubelet 检查基于内存制备的卷的尺寸约束（目前主要针对 `emptyDir` 卷）。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/skip-read-only-validation-gce.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/skip-read-only-validation-gce.md
@@ -1,0 +1,21 @@
+---
+title: SkipReadOnlyValidationGCE
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.28"
+    toVersion: "1.28"
+  - stage: deprecated
+    defaultValue: true
+    fromVersion: "1.29"  
+---
+<!--
+Skip validation for GCE, will enable in the
+next version.
+-->
+跳过对 GCE 的验证，将在下个版本中启用。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stable-load-balancer-node-set.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stable-load-balancer-node-set.md
@@ -1,0 +1,17 @@
+---
+title: StableLoadBalancerNodeSet
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
+---
+<!--
+Enables less load balancer re-configurations by
+the service controller (KCCM) as an effect of changing node state.
+-->
+允许服务控制器（KCCM）减少根据节点状态变化来对负载均衡器作重新配置的操作。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/startup-probe.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/startup-probe.md
@@ -1,0 +1,30 @@
+---
+# Removed from Kubernetes
+title: StartupProbe
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.16"
+    toVersion: "1.17"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.18"
+    toVersion: "1.19"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.23"    
+
+removed: true
+---
+<!--
+Enable the [startup](/docs/concepts/workloads/pods/pod-lifecycle/#when-should-you-use-a-startup-probe)
+probe in the kubelet.
+-->
+在 kubelet 中启用[启动探针](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#when-should-you-use-a-startup-probe)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stateful-set-auto-delete-pvc.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stateful-set-auto-delete-pvc.md
@@ -1,0 +1,27 @@
+---
+title: StatefulSetAutoDeletePVC
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.23"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.27"
+---
+<!--
+Allows the use of the optional `.spec.persistentVolumeClaimRetentionPolicy` field, 
+providing control over the deletion of PVCs in a StatefulSet's lifecycle.
+See
+[PersistentVolumeClaim retention](/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
+for more details.
+-->
+允许使用可选字段 `.spec.persistentVolumeClaimRetentionPolicy`，
+以便根据 StatefulSet 的生命周期来控制 PVC 的删除。
+详情参见 [PersistentVolumeClaim 保留](/zh-cn/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stateful-set-min-ready-seconds.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stateful-set-min-ready-seconds.md
@@ -1,0 +1,30 @@
+---
+# Removed from Kubernetes
+title: StatefulSetMinReadySeconds
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.22"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.23"
+    toVersion: "1.24"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.25"
+    toVersion: "1.26"    
+
+removed: true
+---
+<!--
+Allows `minReadySeconds` to be respected by
+the StatefulSet controller.
+-->
+允许 StatefulSet 控制器遵守 `minReadySeconds`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stateful-set-start-ordinal.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/stateful-set-start-ordinal.md
@@ -1,0 +1,24 @@
+---
+title: StatefulSetStartOrdinal
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.26"
+    toVersion: "1.26"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.27"
+---
+<!--
+Allow configuration of the start ordinal in a
+StatefulSet. See
+[Start ordinal](/docs/concepts/workloads/controllers/statefulset/#start-ordinal)
+for more details.
+-->
+允许在 StatefulSet 中配置起始序号。
+详情参见[起始序号](/zh-cn/docs/concepts/workloads/controllers/statefulset/#start-ordinal)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-object-in-use-protection.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-object-in-use-protection.md
@@ -1,0 +1,27 @@
+---
+# Removed from Kubernetes
+title: StorageObjectInUseProtection
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.10"
+    toVersion: "1.10"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.11"
+    toVersion: "1.24"    
+
+removed: true   
+---
+<!--
+Postpone the deletion of PersistentVolume or
+PersistentVolumeClaim objects if they are still being used.
+-->
+如果仍在使用 PersistentVolume 或 PersistentVolumeClaim 对象，
+则将其删除操作推迟。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-api.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-api.md
@@ -1,0 +1,17 @@
+---
+title: StorageVersionAPI
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.20"
+---
+<!--
+Enable the
+[storage version API](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageversion-v1alpha1-internal-apiserver-k8s-io).
+-->
+启用[存储版本 API](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageversion-v1alpha1-internal-apiserver-k8s-io)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-hash.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-hash.md
@@ -1,0 +1,21 @@
+---
+title: StorageVersionHash
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.14"
+    toVersion: "1.14"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.15"
+---
+<!--
+Allow API servers to expose the storage version hash in the
+discovery.
+-->
+允许 API 服务器在版本发现中公开存储版本的哈希值。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/streaming-proxy-redirects.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/streaming-proxy-redirects.md
@@ -1,0 +1,36 @@
+---
+# Removed from Kubernetes
+title: StreamingProxyRedirects
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta 
+    defaultValue: false
+    fromVersion: "1.5"
+    toVersion: "1.5"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.6"
+    toVersion: "1.17"    
+  - stage: deprecated 
+    defaultValue: true
+    fromVersion: "1.18"
+    toVersion: "1.21"
+  - stage: deprecated 
+    defaultValue: false
+    fromVersion: "1.22"
+    toVersion: "1.24"
+
+removed: true
+---
+<!--
+Instructs the API server to intercept (and follow) redirects from the
+backend (kubelet) for streaming requests. Examples of streaming requests include the `exec`,
+`attach` and `port-forward` requests.
+-->
+指示 API 服务器拦截（并跟踪）后端（kubelet）的重定向以处理流请求。
+流请求的例子包括 `exec`、`attach` 和 `port-forward` 请求。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/structured-authentication-configuration.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/structured-authentication-configuration.md
@@ -1,0 +1,17 @@
+---
+title: StructuredAuthenticationConfiguration
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Enable [structured authentication configuration](/docs/reference/access-authn-authz/authentication/#configuring-the-api-server) 
+for the API server.
+-->
+为 API 服务器启用[结构化身份验证配置](/zh-cn/docs/reference/access-authn-authz/authentication/#configuring-the-api-server)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/structured-authorization-configuration.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/structured-authorization-configuration.md
@@ -1,0 +1,19 @@
+---
+title: StructuredAuthorizationConfiguration
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+<!--
+Enable structured authorization configuration, so that cluster administrators
+can specify more than one [authorization webhook](/docs/reference/access-authn-authz/webhook/)
+in the API server handler chain.
+-->
+启用结构化授权配置，以便集群管理员可以在 API
+服务器处理程序链中指定多个[授权 Webhook](/zh-cn/docs/reference/access-authn-authz/webhook/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/support-ipvs-proxy-mode.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/support-ipvs-proxy-mode.md
@@ -1,0 +1,35 @@
+---
+# Removed from Kubernetes
+title: SupportIPVSProxyMode
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.8"
+    toVersion: "1.8"
+  - stage: beta 
+    defaultValue: false
+    fromVersion: "1.9"
+    toVersion: "1.9"    
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.10"
+    toVersion: "1.10"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.11"
+    toVersion: "1.20"    
+
+removed: true
+---
+<!--
+Enable providing in-cluster service load balancing using IPVS.
+See [service proxies](/docs/reference/networking/virtual-ips/) for more details.
+-->
+启用使用 IPVS 提供集群内服务负载平衡。
+详情参见[服务代理](/zh-cn/docs/reference/networking/virtual-ips/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/support-node-pids-limit.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/support-node-pids-limit.md
@@ -1,0 +1,35 @@
+---
+# Removed from Kubernetes
+title: SupportNodePidsLimit
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.14"
+    toVersion: "1.14"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.15"
+    toVersion: "1.19"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.23"    
+
+removed: true
+---
+<!--
+Enable the support to limiting PIDs on the Node.  The parameter
+`pid=<number>` in the `--system-reserved` and `--kube-reserved` options can be specified to
+ensure that the specified number of process IDs will be reserved for the system as a whole and for
+ Kubernetes system daemons respectively.
+-->
+允许限制 Node 上的 PID 用量。
+`--system-reserved` 和 `--kube-reserved` 中的参数 `pid=<数值>`
+可以分别用来设定为整个系统所预留的进程 ID 个数，
+和为 Kubernetes 系统守护进程预留的进程 ID 个数。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/support-pod-pids-limit.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/support-pod-pids-limit.md
@@ -1,0 +1,29 @@
+---
+# Removed from Kubernetes
+title: SupportPodPidsLimit
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.10"
+    toVersion: "1.13"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.14"
+    toVersion: "1.19"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.23"    
+
+removed: true
+---
+<!--
+Enable the support to limiting PIDs in Pods.
+-->
+允许限制 Pod 中的 PID 用量。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/suspend-job.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/suspend-job.md
@@ -1,0 +1,31 @@
+---
+# Removed from Kubernetes
+title: SuspendJob
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.21"
+    toVersion: "1.21"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.22"
+    toVersion: "1.23"    
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.24"
+    toVersion: "1.25"    
+
+removed: true
+---
+<!--
+Enable support to suspend and resume Jobs. For more details, see
+ [the Jobs docs](/docs/concepts/workloads/controllers/job/).
+-->
+启用对挂起和恢复 Job 的支持。详情参见
+[Job 文档](/zh-cn/docs/concepts/workloads/controllers/job/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/sysctls.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/sysctls.md
@@ -1,0 +1,27 @@
+---
+# Removed from Kubernetes
+title: Sysctls
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.11"
+    toVersion: "1.20"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.22"    
+
+removed: true
+---
+<!--
+Enable support for namespaced kernel parameters (sysctls) that can be set for each
+pod. See [sysctls](/docs/tasks/administer-cluster/sysctl-cluster/) for more details.
+-->
+允许为每个 Pod 设置受命名空间约束的内核参数（sysctl）。详情参见
+[sysctl](/zh-cn/docs/tasks/administer-cluster/sysctl-cluster/)。


### PR DESCRIPTION
Related to issue #44410 

Localize part 3 20 files of feature-gates/s*.md

1. set-hostname-as-fqdn.md
1. sidecar-containers.md
1. size-memory-backed-volumes.md
1. skip-read-only-validation-gce.md
1. stable-load-balancer-node-set.md
1. startup-probe.md
1. stateful-set-auto-delete-pvc.md
1. stateful-set-min-ready-seconds.md
1. stateful-set-start-ordinal.md
1. storage-object-in-use-protection.md
1. storage-version-api.md
1. storage-version-hash.md
1. streaming-proxy-redirects.md
1. structured-authentication-configuration.md
1. structured-authorization-configuration.md
1. support-ipvs-proxy-mode.md
1. support-node-pids-limit.md
1. support-pod-pids-limit.md
1. suspend-job.md
1. sysctls.md