### PR TITLE
[zh] Fix link anchor in configure-service-account.md

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
@@ -794,7 +794,7 @@ often good enough for the application to load the token on a schedule
 <!--
 ## Service Account Issuer Discovery
 -->
-## 发现服务账号分发者
+## 发现服务账号分发者 {#service-account-issuer-discovery}
 
 {{< feature-state for_k8s_version="v1.21" state="stable" >}}
 


### PR DESCRIPTION
The feature-gate `ServiceAccountIssuerDiscovery` is referring this link anchor:
```
/zh-cn/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
```

---

See preview link anchor: https://deploy-preview-44591--kubernetes-io-main-staging.netlify.app/zh-cn/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery