### PR TITLE
Improve wording around Kata containers and OCI runtime spec

### DIFF
--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -291,7 +291,7 @@ sandboxing implementations are available:
 
 * [gVisor](https://gvisor.dev/) intercepts syscalls from containers and runs them through a
   userspace kernel, written in Go, with limited access to the underlying host.
-* [Kata Containers](https://katacontainers.io/) is an OCI compliant runtime that allows you to run
+* [Kata Containers](https://katacontainers.io/) provide a secure container runtime that allows you to run
   containers in a VM. The hardware virtualization available in Kata offers an added layer of
   security for containers running untrusted code.
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fixes #40114 

From the Kubernetes documentation standpoint, a minor change in the wording should help clear the ambiguity specified in issue #40114. Instead of stating that Kata Containers is an OCI _"compliant"_ runtime, I'm proposing a change to state that Kata containers _"support"_ the OCI Runtime Specification (from v3.0.2 and above).