### PR TITLE
Added link to netcat official site and '-v' key to netcat command example

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -49,10 +49,10 @@ route, we recommend you add IP route(s) so Kubernetes cluster addresses go via t
 ## Check required ports
 These [required ports](/docs/reference/networking/ports-and-protocols/)
 need to be open in order for Kubernetes components to communicate with each other.
-You can use tools like netcat to check if a port is open. For example:
+You can use tools like [netcat](https://netcat.sourceforge.net) to check if a port is open. For example:
 
 ```shell
-nc 127.0.0.1 6443
+nc 127.0.0.1 6443 -v
 ```
 
 The pod network plugin you use may also require certain ports to be


### PR DESCRIPTION
Hello!
I added link to `netcat` official site and a very useful key `-v` at example command.

Why did I add this?
1. My installation did not include netcat out of the box and I had to search for what was meant.
2. When running the example as is (without an additional key) - it is absolutely unclear what is happening.

Example output of the command without a key, if the port is unavailable:
```
$ nc 127.0.0.1 6443
```
Example of command output with key, if port is unavailable:
```
nc 127.0.0.1 6443 -v
nc: connectx to 127.0.0.1 port 6443 (tcp) failed: Connection refused
```