### PR TITLE
Fixes to address Hugo deprecation warnings during build

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -15,7 +15,7 @@ timeZone = "UTC"
 enableRobotsTXT = true
 disableBrowserError = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 
 ignoreFiles = [ "(?:^|/)OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
@@ -296,18 +296,18 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 [languages]
 [languages.en]
 title = "Kubernetes"
-description = "Production-Grade Container Orchestration"
 languageName = "English"
 # Weight used for sorting.
 weight = 1
 languagedirection = "ltr"
 i18nDir = "./data/i18n"
 
+[languages.en.params]
+description = "Production-Grade Container Orchestration"
+
 [languages.zh-cn]
 title = "Kubernetes"
-description = "生产级别的容器编排系统"
 languageName = "中文 (Chinese)"
-languageNameLatinScript = "Chinese"
 weight = 2
 contentDir = "content/zh-cn"
 languagedirection = "ltr"
@@ -315,12 +315,12 @@ languagedirection = "ltr"
 [languages.zh-cn.params]
 time_format_blog = "2006.01.02"
 language_alternatives = ["en"]
+languageNameLatinScript = "Chinese"
+description = "生产级别的容器编排系统"
 
 [languages.ko]
 title = "Kubernetes"
-description = "운영 수준의 컨테이너 오케스트레이션"
 languageName = "한국어 (Korean)"
-languageNameLatinScript = "Korean"
 weight = 3
 contentDir = "content/ko"
 languagedirection = "ltr"
@@ -328,12 +328,12 @@ languagedirection = "ltr"
 [languages.ko.params]
 time_format_blog = "2006.01.02"
 language_alternatives = ["en"]
+description = "운영 수준의 컨테이너 오케스트레이션"
+languageNameLatinScript = "Korean"
 
 [languages.ja]
 title = "Kubernetes"
-description = "プロダクショングレードのコンテナ管理基盤"
 languageName = "日本語 (Japanese)"
-languageNameLatinScript = "Japanese"
 weight = 4
 contentDir = "content/ja"
 languagedirection = "ltr"
@@ -341,12 +341,12 @@ languagedirection = "ltr"
 [languages.ja.params]
 time_format_blog = "2006.01.02"
 language_alternatives = ["en"]
+languageNameLatinScript = "Japanese"
+description = "プロダクショングレードのコンテナ管理基盤"
 
 [languages.fr]
 title = "Kubernetes"
-description = "Solution professionnelle d’orchestration de conteneurs"
 languageName = "Français (French)"
-languageNameLatinScript = "Français"
 weight = 5
 contentDir = "content/fr"
 languagedirection = "ltr"
@@ -355,12 +355,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Solution professionnelle d’orchestration de conteneurs"
+languageNameLatinScript = "Français"
 
 [languages.it]
 title = "Kubernetes"
-description = "Orchestrazione di Container in produzione"
 languageName = "Italiano (Italian)"
-languageNameLatinScript = "Italiano"
 weight = 6
 contentDir = "content/it"
 languagedirection = "ltr"
@@ -369,12 +369,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Orchestrazione di Container in produzione"
+languageNameLatinScript = "Italiano"
 
 [languages.no]
 title = "Kubernetes"
-description = "Production-Grade Container Orchestration"
 languageName = "Norsk (Norwegian)"
-languageNameLatinScript = "Norsk"
 weight = 7
 contentDir = "content/no"
 languagedirection = "ltr"
@@ -383,12 +383,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Production-Grade Container Orchestration"
+languageNameLatinScript = "Norsk"
 
 [languages.de]
 title = "Kubernetes"
-description = "Produktionsreife Container-Orchestrierung"
 languageName = "Deutsch (German)"
-languageNameLatinScript = "Deutsch"
 weight = 8
 contentDir = "content/de"
 languagedirection = "ltr"
@@ -397,12 +397,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Produktionsreife Container-Orchestrierung"
+languageNameLatinScript = "Deutsch"
 
 [languages.es]
 title = "Kubernetes"
-description = "Orquestación de contenedores para producción"
 languageName = "Español (Spanish)"
-languageNameLatinScript = "Español"
 weight = 9
 contentDir = "content/es"
 languagedirection = "ltr"
@@ -411,12 +411,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Orquestación de contenedores para producción"
+languageNameLatinScript = "Español"
 
 [languages.pt-br]
 title = "Kubernetes"
-description = "Orquestração de contêineres em nível de produção"
 languageName = "Português (Portuguese)"
-languageNameLatinScript = "Português"
 weight = 10
 
 contentDir = "content/pt-br"
@@ -426,12 +426,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Orquestração de contêineres em nível de produção"
+languageNameLatinScript = "Português"
 
 [languages.id]
 title = "Kubernetes"
-description = "Orkestrasi Kontainer dengan Skala Produksi"
 languageName ="Bahasa Indonesia"
-languageNameLatinScript = "Bahasa Indonesia"
 weight = 11
 contentDir = "content/id"
 languagedirection = "ltr"
@@ -440,12 +440,13 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Orkestrasi Kontainer dengan Skala Produksi"
+languageNameLatinScript = "Bahasa Indonesia"
 
 [languages.hi]
 title = "Kubernetes"
 description = "प्रोडक्शन-ग्रेड कंटेनर ऑर्केस्ट्रेशन"
 languageName = "हिन्दी (Hindi)"  
-languageNameLatinScript = "Hindi"
 weight = 12
 contentDir = "content/hi"
 languagedirection = "ltr"
@@ -454,21 +455,22 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+languageNameLatinScript = "Hindi"
 
 [languages.vi]
 title = "Kubernetes"
-description = "Giải pháp điều phối container trong môi trường production"
 languageName = "Tiếng Việt (Vietnamese)"
-languageNameLatinScript = "Tiếng Việt"
 contentDir = "content/vi"
 weight = 13
 languagedirection = "ltr"
 
+[languages.vi.params]
+languageNameLatinScript = "Tiếng Việt"
+description = "Giải pháp điều phối container trong môi trường production"
+
 [languages.ru]
 title = "Kubernetes"
-description = "Первоклассная оркестрация контейнеров"
 languageName = "Русский (Russian)"
-languageNameLatinScript = "Russian"
 weight = 14
 contentDir = "content/ru"
 languagedirection = "ltr"
@@ -477,12 +479,12 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Первоклассная оркестрация контейнеров"
+languageNameLatinScript = "Russian"
 
 [languages.pl]
 title = "Kubernetes"
-description = "Produkcyjny system zarządzania kontenerami"
 languageName = "Polski (Polish)"
-languageNameLatinScript = "Polski"
 weight = 15
 contentDir = "content/pl"
 languagedirection = "ltr"
@@ -491,12 +493,12 @@ languagedirection = "ltr"
 time_format_blog = "01.02.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Produkcyjny system zarządzania kontenerami"
+languageNameLatinScript = "Polski"
 
 [languages.uk]
 title = "Kubernetes"
-description = "Довершена система оркестрації контейнерів"
 languageName = "Українська (Ukrainian)"
-languageNameLatinScript = "Ukrainian"
 weight = 16
 contentDir = "content/uk"
 languagedirection = "ltr"
@@ -505,3 +507,5 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "Довершена система оркестрації контейнерів"
+languageNameLatinScript = "Ukrainian"

--- a/hugo.toml
+++ b/hugo.toml
@@ -445,7 +445,6 @@ languageNameLatinScript = "Bahasa Indonesia"
 
 [languages.hi]
 title = "Kubernetes"
-description = "प्रोडक्शन-ग्रेड कंटेनर ऑर्केस्ट्रेशन"
 languageName = "हिन्दी (Hindi)"  
 weight = 12
 contentDir = "content/hi"
@@ -455,6 +454,7 @@ languagedirection = "ltr"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+description = "प्रोडक्शन-ग्रेड कंटेनर ऑर्केस्ट्रेशन"
 languageNameLatinScript = "Hindi"
 
 [languages.vi]


### PR DESCRIPTION
This Pr address the issue https://github.com/kubernetes/website/issues/44603 to remove deprecation warnings during build.

I made change to remove following warning as request in https://github.com/kubernetes/website/pull/43672#pullrequestreview-1696117277:

a) Removed "taxonomyterm" to fix the below error:
"2:48:45 PM: WARN DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead."

b) Shifted "languages.description" and "languagenamelatinscript" feilds to be under language.params

```
2:48:45 PM: WARN config: languages.id.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.id.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
2:48:45 PM: WARN config: languages.id.languagenamelatinscript: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.id.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```

This will fix #44603
