### PR TITLE
Simplify description for IdentifyPodOS

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/identify-pod-os.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/identify-pod-os.md
@@ -25,5 +25,3 @@ removed: true
 ---
 Allows the Pod OS field to be specified. This helps in identifying
 the OS of the pod authoritatively during the API server admission time.
-In Kubernetes {{< skew currentVersion >}}, the allowed values for the `pod.spec.os.name`
-are `windows` and `linux`.


### PR DESCRIPTION
Now that the `IdentifyPodOS` feature gate is removed, we can rely on the main Pod documentation to explain what operating systems Kubernetes can support for Pods.
As a result, we can have a simpler description.

[preview](https://deploy-preview-44623--kubernetes-io-main-staging.netlify.app//docs/reference/command-line-tools-reference/feature-gates-removed/)

/sig node
/kind cleanup