### PR TITLE
Revise explanation for DefaultHostNetworkHostPortsInPodTemplates

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/default-host-network-ports-in-pod-templates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/default-host-network-ports-in-pod-templates.md
@@ -10,9 +10,12 @@ stages:
     defaultValue: false
     fromVersion: "1.28"  
 ---
-Changes when the default value of
-`PodSpec.containers[*].ports[*].hostPort`
-is assigned. The default is to only set a default value in Pods.
+This feature gate controls the point at which a default value for
+`.spec.containers[*].ports[*].hostPort`
+is assigned, for Pods using `hostNetwork: true`. The default since Kubernetes v1.28 is to only set a default
+value in Pods.
 
-Enabling this means a default will be assigned even to embedded
-PodSpecs (e.g. in a Deployment), which is the historical default.
+Enabling this means a default will be assigned even to the `.spec` of an embedded
+[PodTemplate](/docs/concepts/workloads/pods/#pod-templates) (for example, in a Deployment),
+which is the way that older releases of Kubernetes worked.
+You should migrate your code so that it does not rely on the legacy behavior.


### PR DESCRIPTION
Reword the explanation for the `DefaultHostNetworkHostPortsInPodTemplates` feature gate.


[preview](https://deploy-preview-44626--kubernetes-io-main-staging.netlify.app//docs/reference/command-line-tools-reference/feature-gates/)


/sig network
/language en