### PR TITLE
Fix typo in feature gates page

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/logging-alpha-options.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/logging-alpha-options.md
@@ -10,4 +10,4 @@ stages:
     defaultValue: false
     fromVersion: "1.24"
 ---
-Allow fine-tuing of experimental, alpha-quality logging options.
+Allow fine-tuning of experimental, alpha-quality logging options.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/logging-beta-options.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/logging-beta-options.md
@@ -10,4 +10,4 @@ stages:
     defaultValue: true
     fromVersion: "1.24"
 ---
-Allow fine-tuing of experimental, beta-quality logging options.
+Allow fine-tuning of experimental, beta-quality logging options.


### PR DESCRIPTION
As reported in issue 44625, found the files within content/en/docs/reference/command-line-tools-reference/feature-gates/ that contain the typo and fixed it.

Closes https://github.com/kubernetes/website/issues/44625