### PR TITLE
Fix broken link of content/ja/docs/contribute/_index.md

### DIFF
--- a/content/ja/docs/contribute/_index.md
+++ b/content/ja/docs/contribute/_index.md
@@ -130,7 +130,7 @@ class first,second white
 {{</ mermaid >}}
 図2. はじめての貢献のための準備。
 
-- 貢献のための複数の方法について学ぶために[貢献の概要](/ja/docs/contribute/new-content/overview/)を読んでください。
+- 貢献のための複数の方法について学ぶために[貢献の概要](/ja/docs/contribute/new-content/)を読んでください。
 - 良い開始地点を探すために[`kubernetes/website` issueリスト](https://github.com/kubernetes/website/issues/)を確認してください。
 - 既存のドキュメントに対して[GitHubを使ってプルリクエストをオープン](/docs/contribute/new-content/open-a-pr/#changes-using-github)し、GitHubへのissueの登録について学んでください。
 - 正確さと言語の校正のため、他のKubernetesコミュニティメンバーから[プルリクエストのレビュー](/docs/contribute/review/reviewing-prs/)を受けてください。


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->


`tag: release-1.26` has [content/ja/docs/contribute/new-content/overview.md](https://github.com/kubernetes/website/blob/release-1.26/content/ja/docs/contribute/new-content/overview.md),
But `tag: main` has no [content/ja/docs/contribute/new-content/overview.md](https://github.com/kubernetes/website/blob/main/content/ja/docs/contribute/new-content/overview.md)

Close:https://github.com/kubernetes/website/issues/44645