### PR TITLE
Avoid two <h1> elements for blog section

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -680,6 +680,11 @@ main.content {
   }
 }
 
+.td-blog .header-hero h1, .td-blog .header-hero h2 {
+  font-size: 2.25rem; // match rest of site, even if it is actually h2
+  margin-bottom: 20px;
+}
+
 /* CASE-STUDIES */
 
 // Many of the case studies have small variations in markup and styles;
@@ -819,7 +824,8 @@ body.td-documentation {
   }
 }
 
-#announcement + .header-hero.filler {
+/* don't display the hero header for some pages when there is a banner active */
+#announcement + .header-hero.filler, .td-page.td-blog #announcement + .header-hero {
   display: none;
 }
 

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -13,12 +13,12 @@
       {{ partial "announcement.html" . }}
       {{ block "hero" . }}
       <section class="header-hero text-center text-white font-bold pb-4">
-        <h1>
+        {{ if .IsSection }}<h1>{{ else }}<h2>{{ end }}
           {{ $sectionHeading := .Site.GetPage "section" .Section }}
           {{ with $sectionHeading }}
             {{ .Title }}
           {{ end }}
-        </h1>
+        {{ if .IsSection }}</h1>{{ else }}</h2>{{ end }}
       </section>
          {{ block "hero-more" . }}{{ end }}
       {{ end }}


### PR DESCRIPTION
Change our customizations to Docsy, so that pages in the [blog](https://blog.k8s.io/) section don't have two `<h1>` elements.
This snag showed up when we were testing PageFind for search.

/area web-development