### PR TITLE
Update redirects for kubectl reference page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -169,7 +169,7 @@
 
 /docs/reference/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
 
-/docs/reference/generated/kubectl/kubectl_commands/     docs/reference/kubectl/ 301
+/docs/reference/generated/kubectl/kubectl-commands/     /docs/reference/kubectl/ 301
 /docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-tools-reference/cloud-controller-manager/ 301
 /docs/reference/generated/kubelet/     /docs/reference/command-line-tools-reference/kubelet/ 301
 /docs/reference/generated/kube-apiserver/     /docs/reference/command-line-tools-reference/kube-apiserver/ 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -169,6 +169,7 @@
 
 /docs/reference/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
 
+/docs/reference/generated/kubectl/kubectl_commands/     docs/reference/kubectl/ 301
 /docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-tools-reference/cloud-controller-manager/ 301
 /docs/reference/generated/kubelet/     /docs/reference/command-line-tools-reference/kubelet/ 301
 /docs/reference/generated/kube-apiserver/     /docs/reference/command-line-tools-reference/kube-apiserver/ 301


### PR DESCRIPTION
As requeested in https://github.com/kubernetes/website/issues/44635 in this PR I have replaced https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands with a redirect to https://kubernetes.io/docs/reference/kubectl


This will fix https://github.com/kubernetes/website/issues/44635