### PR TITLE
[de] Localized controller.md, added needed glossaries, removed master refe…

### DIFF
--- a/content/de/docs/concepts/architecture/controller.md
+++ b/content/de/docs/concepts/architecture/controller.md
@@ -1,0 +1,103 @@
+---
+title: Controller
+content_type: concept
+weight: 30
+---
+
+<!-- overview -->
+
+In der Robotik und der Automatisierung ist eine _Kontrollschleife_ eine endlose Schleife, die den Zustand eines Systems regelt.
+
+Hier ist ein Beispiel einer Kontrollschleife: ein Thermostat in einem Zimmer.
+
+Wenn Sie die Temperatur einstellen, sagen Sie dem Thermostaten was der *Wunschzustand* ist. Die tatsächliche Raumtemperatur ist der *Istzustand*. Der Thermostat agiert um den Istzustand dem Wunschzustand anzunähern, indem er Geräte an oder ausschaltet.
+
+{{< glossary_definition text="Controller" term_id="controller" length="short">}}
+
+
+
+
+<!-- body -->
+
+## Controller Muster
+
+Ein Controller überwacht mindestens einen Kubernetes Ressourcentyp.
+Diese {{< glossary_tooltip text="Objekte" term_id="object" >}}
+haben ein Spezifikationsfeld, das den Wunschzustand darstellt. Der oder die Controller für diese Ressource sind dafür verantwortlich, dass sich der Istzustand dem Wunschzustand annähert.
+
+Der Controller könnte die Aktionen selbst ausführen; meistens jedoch sendet der Controller Nachrichten an den {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}, die nützliche Effekte haben. Unten sehen Sie Beispiele dafür.
+
+{{< comment >}}
+Manche eingebaute Controller, zum Beispiel der Namespace Controller, agieren auf Objekte die keine Spezifikation haben. Zur Vereinfachung lässt diese Seite die Erklärung zu diesem Detail aus.
+{{< /comment >}}
+
+### Kontrolle via API Server
+
+Der {{< glossary_tooltip text="Job" term_id="job" >}} Controller ist ein Beispiel eines eingebauten Kubernetes Controllers. Eingebaute Controller verwalten den Zustand durch Interaktion mit dem Cluster API Server.
+
+Ein Job ist eine Kubernetes Ressource, die einen {{< glossary_tooltip text="Pod" term_id="pod" >}}, oder vielleicht mehrere Pods, erstellt, um eine Tätigkeit auszuführen und dann zu beenden.
+
+(Sobald [geplant](/docs/concepts/scheduling-eviction/), werden Pod Objekte Teil des Wunschzustands eines Kubelets).
+
+Wenn der Job Controller eine neue Tätigkeit erkennt, versichert er, dass irgendwo in Ihrem Cluster, die Kubelets auf einem Satz Knoten, die korrekte Anzahl Pods laufen lässt, um die Tätigkeit auszuführen. Der Job Controller selbst lässt keine Pods oder Container laufen. Stattdessen sagt der Job Controller dem API Server, dass er Pods erstellen oder entfernen soll.
+Andere Komponenten in der {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} reagieren auf die neue Information (neue Pods müssen geplant werden und müssen laufen), und irgendwann ist die Arbeit beendet.
+
+Nachdem Sie einen neuen Job erstellen, ist der Wunschzustand, dass dieser Job beendet ist. Der Job Controller sorgt dafür, dass der Istzustand sich dem Wunschzustand annähert: Pods, die die Arbeit ausführen, werden erstellt, sodass der Job näher an seine Vollendung kommt.
+
+Controller aktualisieren auch die Objekte die sie konfigurieren. Zum Beispiel: sobald die Arbeit eines Jobs beendet ist, aktualisiert der Job Controller das Job Objekt und markiert es als `beendet`.
+
+(Das ist ungefähr wie ein Thermostat, der ein Licht ausschaltet, um anzuzeigen dass der Raum nun die Wunschtemperatur hat).
+
+### Direkte Kontrolle
+
+Im Gegensatz zum Job Controller, müssen manche Controller auch Sachen außerhalb Ihres Clusters ändern.
+
+Zum Beispiel, wenn Sie eine Kontrollschleife verwenden, um sicherzustellen dass es genug {{< glossary_tooltip text="Knoten" term_id="node" >}} in ihrem Cluster gibt, dann benötigt dieser Controller etwas außerhalb des jetztigen Clusters, um neue Knoten bei Bedarf zu erstellen.
+
+Controller die mit dem externen Status interagieren, erhalten den Wunschzustand vom API Server, und kommunizieren dann direkt mit einem externen System, um den Istzustand näher an den Wunschzustand zu bringen.
+
+(Es gibt tatsächlich einen [Controller](https://github.com/kubernetes/autoscaler/), der die Knoten in Ihrem Cluster horizontal skaliert.)
+
+Wichtig ist hier, dass der Controller Veränderungen vornimmt, um den Wunschzustand zu erreichen, und dann den Istzustand an den API Server Ihres Clusters meldet. Andere Kontrollschleifen können diese Daten beobachten und eigene Aktionen unternehmen.
+
+Im Beispiel des Thermostaten, wenn der Raum sehr kalt ist, könnte ein anderer Controller eine Frostschutzheizung einschalten. Bei Kubernetes Cluster arbeitet die Contol Plane indirekt mit IP Adressen Verwaltungstools, Speicherdienste, Cloud Provider APIs, und andere Dienste, um [Kubernetes zu erweitern](/docs/concepts/extend-kubernetes/) und das zu implementieren.
+
+## Wunschzustand gegen Istzustand {#desired-vs-current}
+
+Kubernetes hat eine Cloud-Native Sicht auf Systeme, und kann ständige Veränderungen verarbeiten.
+
+Ihr Cluster kann sich jederzeit verändern, während Arbeit erledigt wird und Kontrollschleifen automatisch Fehler reparieren. Das bedeutet, dass Ihr Cluster eventuell nie einen stabilen Zustand erreicht.
+
+Solange die Controller Ihres Clusters laufen, und sinnvolle Veränderungen vornehmen können, ist es egal ob der Gesamtzustand stabil ist oder nicht.
+
+## Design
+
+Als Grundlage seines Designs verwendet Kubernetes viele Controller, die alle einen bestimmten Aspekt des Clusterzustands verwalten. Meistens verwendet eine bestimmte Kontrollschleife (Controller) eine Sorte Ressourcen als seinen Wunschzustand, und hat eine andere Art Ressource, dass sie verwaltet um den Wunschzustand zu erreichen. Zum Beispiel, ein Controller für Jobs überwacht Job Objekte (um neue Arbeit zu finden), und Pod Objekte (um die Arbeit auszuführen, und um zu erkennen wann die Arbeit beendet ist). In diesem Fall erstellt etwas anderes die Jobs, während der Job Controller Pods erstellt.
+
+Es ist sinnvoll einfache Controller zu haben, statt eines monolithischen Satzes Kontrollschleifen, die miteinander verbunden sind. Controller können scheitern, also ist Kubernetes entworfen um das zu erlauben.
+
+{{< note >}}
+Es kann mehrere Controller geben, die die gleiche Art Objekte erstellen oder aktualisieren können. Im Hintergrund sorgen Kubernetes Controller dafür, dass sie nur auf die Ressourcen achten, die mit den kontrollierenden Ressourcen verbunden sind.
+
+Man kann zum Beispiel Deployments und Jobs haben; beide erstellen Pods.
+Der Job Controller löscht nicht die Pods die Ihr Deployment erstellt hat, weil es Informationen ({{< glossary_tooltip term_id="Label" text="Bezeichnungen" >}}) gibt, die der Controller verwenden kann, um die Pods voneinander zu unterscheiden.
+{{< /note >}}
+
+## Wege um Controller auszuführen {#running-controllers}
+
+Kubernetes enthält eingebaute Controller, die innerhalb des {{< glossary_tooltip text="Kube Controller Manager" term_id="kube-controller-manager" >}} laufen. Diese eingebaute Controller liefern wichtige grundsätzliche Verhalten.
+
+Der Deployment Controller und Job Controller sind Beispiele für Controller die Teil von Kubernetes selbst sind ("eingebaute" Controller).
+Kubernetes erlaubt die Verwendung von resilienten Control Planes, sodass bei Versagen eines eingebauten Controllers ein anderer Teil des Control Planes die Arbeit übernimmt.
+
+Sie finden auch Controller, die außerhalb des Control Planes laufen, um Kubernetes zu erweitern. Oder, wenn Sie möchten, können Sie auch selbst einen neuen Controller entwickeln.
+Sie können Ihren Controller als einen Satz Pods oder außerhalb von Kubernetes laufen lassen. Was am besten passt, hängt davon ab was der jeweilige Controller tut.
+
+## {{% heading "whatsnext" %}}
+
+* Lesen Sie über den [Kubernetes Control Plane](/docs/concepts/overview/components/#control-plane-components)
+* Entdecke einige der grundlegenden [Kubernetes Objekte](/docs/concepts/overview/working-with-objects/)
+* Lerne mehr über die [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
+* Wenn Sie ihren eigenen Controller entwickeln wollen, siehe [Kubernetes extension patterns](/docs/concepts/extend-kubernetes/#extension-patterns)
+  und das [sample-controller](https://github.com/kubernetes/sample-controller) Repository.
+

--- a/content/de/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/de/docs/reference/glossary/cloud-controller-manager.md
@@ -1,0 +1,19 @@
+---
+title: Cloud Controller Manager
+id: cloud-controller-manager
+date: 2018-04-12
+full_link: /docs/concepts/architecture/cloud-controller/
+short_description: >
+  Control Plane Komponente, die Kubernetes mit Drittanbieter Cloud Provider integriert.
+aka: 
+tags:
+- core-object
+- architecture
+- operation
+---
+ Eine Kubernetes {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} Komponente, die Cloud spezifische Kontrolllogik einbettet. Der [Cloud Controller Manager](/docs/concepts/architecture/cloud-controller/) lässt Sie Ihr Cluster in die Cloud Provider API einbinden, und trennt die Komponenten die mit der Cloud Platform interagieren von Komponenten, die nur mit Ihrem Cluster interagieren.
+
+<!--more-->
+
+Durch Entkopplung der Interoperabilitätslogik zwischen Kubernetes und der darunterliegenden Cloud Infrastruktur, ermöglicht der Cloud Controller Manager den Cloud Providern das Freigeben neuer Features in einem anderen Tempo als das Kubernetes Projekt.
+

--- a/content/de/docs/reference/glossary/cluster.md
+++ b/content/de/docs/reference/glossary/cluster.md
@@ -1,0 +1,17 @@
+---
+title: Cluster
+id: cluster
+date: 2019-06-15
+full_link: 
+short_description: >
+   Ein Satz Arbeitermaschinen, genannt Knoten, die containerisierte Anwendungen ausführen. Jedes Cluster hat mindestens einen Arbeiterknoten.
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+Ein Satz Arbeitermaschinen, gennant {{< glossary_tooltip text="Knoten" term_id="node" >}}, die containerisierte Anwendungen ausführen. Jedes Cluster hat mindestens einen Arbeiterknoten.
+
+<!--more-->
+Die Arbeiterknoten bringen die {{< glossary_tooltip text="Pods" term_id="pod" >}} unter, die die Komponenten der Applikationslast sind. Die {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} verwaltet die Arbeiterknoten und Pods im Cluster. In Produktionsumgebungen läuft die Control Plane meistens über mehrere Computer, und ein Cluster hat meistens mehrere Knoten, um Fehlertoleranz und Hochverfügbarkeit zu ermöglichen.

--- a/content/de/docs/reference/glossary/container.md
+++ b/content/de/docs/reference/glossary/container.md
@@ -1,0 +1,19 @@
+---
+title: Container
+id: container
+date: 2018-04-12
+full_link: /docs/concepts/containers/
+short_description: >
+  Ein kleines und portierbares ausführbares Image, dass eine Software und all seine Abhängigkeiten enthält.
+
+aka: 
+tags:
+- fundamental
+- workload
+---
+ Ein kleines und portierbares ausführbares Image, dass eine Software und all seine Abhängigkeiten enthält.
+
+<!--more--> 
+
+Container entkuppeln Anwendungen von der darunterliegenden Rechner Infrastruktur, um den Einsatz in verschiedenen Cloud- oder Betriebssystemumgebungen zu vereinfachen.
+Die Anwendungen in Container nennt man Containerisierte Anwendungen. Der Prozess des Bündelns dieser Anwendungen und ihrer Abhängigkeiten in einem Container Image nennt man Containerisierung.

--- a/content/de/docs/reference/glossary/control-plane.md
+++ b/content/de/docs/reference/glossary/control-plane.md
@@ -1,0 +1,25 @@
+---
+title: Control Plane
+id: control-plane
+date: 2019-05-12
+full_link:
+short_description: >
+  Die Container Orchestrierungsschicht, die die API und Schnittstellen exponiert, um den Lebenszyklus von Container zu definieren, bereitzustellen, und zu verwalten.
+
+aka:
+tags:
+- fundamental
+---
+ Die Container Orchestrierungsschicht, die die API und Schnittstellen exponiert, um den Lebenszyklus von Container zu definieren, bereitzustellen, und zu verwalten.
+
+ <!--more--> 
+ 
+ Diese Schicht besteht aus vielen verschiedenen Komponenten, zum Beispiel (aber nicht begranzt auf):
+
+ * {{< glossary_tooltip text="etcd" term_id="etcd" >}}
+ * {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}
+ * {{< glossary_tooltip text="Scheduler" term_id="kube-scheduler" >}}
+ * {{< glossary_tooltip text="Controller Manager" term_id="kube-controller-manager" >}}
+ * {{< glossary_tooltip text="Cloud Controller Manager" term_id="cloud-controller-manager" >}}
+
+ Diese Komponenten können als traditionelle Betriebssystemdienste (daemons) oder als Container laufen. Die Hosts auf denen diese Komponenten laufen, hießen früher {{< glossary_tooltip text="Master" term_id="master" >}}.

--- a/content/de/docs/reference/glossary/controller.md
+++ b/content/de/docs/reference/glossary/controller.md
@@ -1,0 +1,21 @@
+---
+title: Controller
+id: controller
+date: 2018-04-12
+full_link: /docs/concepts/architecture/controller/
+short_description: >
+  Eine Kontrollschleife, die den geteilten Zustand des Clusters über den Apiserver beobachtet, und Änderungen ausführt, um den aktuellen Zustand in Richtung des Wunschzustands zu bewegen.
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+In Kubernetes sind Controller Kontrollschleifen, die den Zustand des {{< glossary_tooltip term_id="cluster" text="Clusters">}} beobachten, und dann Änderungen ausführen oder anfragen, wenn benötigt.
+Jeder Controller versucht den aktuellen Clusterzustand in Richtung des Wunschzustands zu bewegen.
+
+<!--more-->
+
+Controller beobachten den geteilten Zustand des Clusters durch den {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}} (Teil der {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}}).
+
+Mache Controller, laufen auch im Control Plane, und stellen Kontrollschleifen zur Verfügung, die essentiell für die grundlegende Kubernetes Funktionalität sind. Zum Beispiel: der Deployment Controller, der Daemonset Controller, der Namespace Controller und der Persistent Volume Controller (unter anderem) laufen alle innerhalb des {{< glossary_tooltip text="Kube Controller Managers" term_id="kube-controller-manager" >}}.

--- a/content/de/docs/reference/glossary/deployment.md
+++ b/content/de/docs/reference/glossary/deployment.md
@@ -1,0 +1,19 @@
+---
+title: Deployment
+id: deployment
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/deployment/
+short_description: >
+  Verwaltet eine replizierte Anwendung in Ihrem Cluster.
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ Ein API Object, das eine replizierte Anwendung verwaltet, typischerweise durch laufende Pods ohne lokalem Zustand.
+
+<!--more--> 
+
+Jedes Replikat wird durch ein {{< glossary_tooltip text="Pod" term_id="pod" >}} repräsentiert, und die Pods werden auf den {{< glossary_tooltip text="Knoten" term_id="node" >}} eines Clusters verteilt. Für Arbeitslasten, die einen lokalen Zustand benötigen, sollten Sie einen {{< glossary_tooltip term_id="StatefulSet" >}} verwenden.

--- a/content/de/docs/reference/glossary/docker.md
+++ b/content/de/docs/reference/glossary/docker.md
@@ -1,0 +1,17 @@
+---
+title: Docker
+id: docker
+date: 2018-04-12
+full_link: https://docs.docker.com/engine/
+short_description: >
+  Docker ist eine Software Technologie, die Virtualisierung auf Betriebssystemebene (auch bekannt als Container) bereitstellt.
+
+aka:
+tags:
+- fundamental
+---
+Docker (genauer gesagt, Docker Engine) ist eine Software Technologie, die Virtualisierung auf Betriebssystemebene (auch bekannt als {{< glossary_tooltip text="Container" term_id="container" >}}) bereitstellt.
+
+<!--more-->
+
+Docker verwendet die Ressourcenisolierungsfunktionen des Linux Kernels, wie cgroups und Kernel Namespaces, und ein Unionsfähiges Dateisystem wie OverlayFS (unter anderem), um unabhängige Container auf einer einzigen Linux Instanz auszuführen. Dies vermeidet den Mehraufwand des Starten und Verwalten virtueller Maschinen (VMs).

--- a/content/de/docs/reference/glossary/job.md
+++ b/content/de/docs/reference/glossary/job.md
@@ -1,0 +1,20 @@
+---
+title: Job
+id: job
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/job/
+short_description: >
+  Ein endlicher oder batch Auftrag der bis zum Abschluss läuft.
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ Ein endlicher oder batch Auftrag der bis zum Abschluss läuft.
+
+<!--more--> 
+
+Erstellt ein oder mehrere {{< glossary_tooltip text="Pod" term_id="pod" >}} Objekte und versichert, dass eine angegebene Anzahl erfolgreich endet. Während Pods erfolgreich beenden, überwacht der Jub den erfolgreichen Abschluss.
+

--- a/content/de/docs/reference/glossary/kube-apiserver.md
+++ b/content/de/docs/reference/glossary/kube-apiserver.md
@@ -4,16 +4,16 @@ id: kube-apiserver
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
-  Komponente auf dem Master, der die Kubernetes-API verfügbar macht. Es ist das Frontend für die Kubernetes-Steuerebene.
+  Komponente auf der Control Plane, die die Kubernetes-API verfügbar macht. Es ist das Frontend für die Kubernetes-Steuerebene.
 
 aka:
 tags:
 - architecture
 - fundamental
 ---
- Komponente auf dem Master, der die Kubernetes-API verfügbar macht. Es ist das Frontend für die Kubernetes-Steuerebene.
+ Komponente auf der Control Plane, die die Kubernetes-API verfügbar macht. Es ist das Frontend für die Kubernetes-Steuerebene.
 
 <!--more-->
 
-Es ist für die horizontale Skalierung konzipiert, d. H. Es skaliert durch die Bereitstellung von mehr Instanzen. Mehr informationen finden Sie unter [Cluster mit hoher Verfügbarkeit erstellen](/docs/admin/high-availability/).
+Es ist für die horizontale Skalierung konzipiert, d.h. es skaliert durch die Bereitstellung von mehr Instanzen. Mehr informationen finden Sie unter [Cluster mit hoher Verfügbarkeit erstellen](/docs/admin/high-availability/).
 

--- a/content/de/docs/reference/glossary/kube-controller-manager.md
+++ b/content/de/docs/reference/glossary/kube-controller-manager.md
@@ -4,16 +4,16 @@ id: kube-controller-manager
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-controller-manager/
 short_description: >
-  Komponente auf dem Master, auf dem Controller ausgeführt werden.
+  Komponente auf der Control Plane, auf der Controller ausgeführt werden.
 
 aka:
 tags:
 - architecture
 - fundamental
 ---
- Komponente auf dem Master, auf dem {{< glossary_tooltip text="controllers" term_id="controller" >}} ausgeführt werden.
+ Komponente auf der Control Plane, auf der {{< glossary_tooltip text="Controller" term_id="controller" >}} ausgeführt werden.
 
 <!--more-->
 
-Logisch gesehen ist jeder {{< glossary_tooltip text="controller" term_id="controller" >}} ein separater Prozess, aber zur Vereinfachung der Komplexität werden sie alle zu einer einzigen Binärdatei zusammengefasst und in einem einzigen Prozess ausgeführt.
+Logisch gesehen ist jeder {{< glossary_tooltip text="Controller" term_id="controller" >}} ein separater Prozess, aber zur Vereinfachung der Komplexität werden sie alle zu einer einzigen Binärdatei zusammengefasst und in einem einzigen Prozess ausgeführt.
 

--- a/content/de/docs/reference/glossary/kube-proxy.md
+++ b/content/de/docs/reference/glossary/kube-proxy.md
@@ -1,0 +1,21 @@
+---
+title: kube-proxy
+id: kube-proxy
+date: 2018-04-12
+full_link: /docs/reference/command-line-tools-reference/kube-proxy/
+short_description: >
+  `kube-proxy` ist ein Netzwerkproxy, der auf jedem Knoten im Cluster läuft.
+
+aka:
+tags:
+- fundamental
+- networking
+---
+ kube-proxy ist ein Netwzwerkproxy, der auf jedem {{< glossary_tooltip text="Knoten" term_id="node" >}} in Ihrem Cluster läuft, und ein Teil des Kubernetes {{< glossary_tooltip text="Service" term_id="service">}} Konzepts implementiert.
+
+<!--more-->
+
+[kube-proxy](/docs/reference/command-line-tools-reference/kube-proxy/)
+pflegt Netzwerkregeln auf den Knoten. Diese Netzwerkregeln erlauben Nezwerkkommunikation zu Ihren Pods von Netzwerksitzungen innerhalb und außerhalb Ihres Clusters.
+
+kube-proxy verwendet die Paketfilterungsschicht des Betriebssystems, wenn eine existiert und verfügbar ist. Ansonsten leitet kube-proxy den Verkehr selbst weiter.

--- a/content/de/docs/reference/glossary/kube-scheduler.md
+++ b/content/de/docs/reference/glossary/kube-scheduler.md
@@ -4,13 +4,13 @@ id: kube-scheduler
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
-  Komponente auf dem Master, die neu erstellte Pods überwacht, denen kein Node zugewiesen ist. Sie wählt den Node aus, auf dem sie ausgeführt werden sollen.
+  Komponente auf der Control Plane, die neu erstellte Pods überwacht, denen kein Knoten zugewiesen ist. Sie wählt den Knoten aus, auf dem sie ausgeführt werden sollen.
 
 aka:
 tags:
 - architecture
 ---
- Komponente auf dem Master, die neu erstellte Pods überwacht, denen kein Node zugewiesen ist. Sie wählt den Node aus, auf dem sie ausgeführt werden sollen.
+ Komponente auf der Control Plane, die neu erstellte Pods überwacht, denen kein Knoten zugewiesen ist. Sie wählt den Knoten aus, auf dem sie ausgeführt werden sollen.
 
 <!--more-->
 

--- a/content/de/docs/reference/glossary/kubeadm.md
+++ b/content/de/docs/reference/glossary/kubeadm.md
@@ -1,0 +1,19 @@
+---
+title: Kubeadm
+id: kubeadm
+date: 2018-04-12
+full_link: /docs/reference/setup-tools/kubeadm/
+short_description: >
+  Ein Werkzeug um schnell Kubernetes zu installieren und ein sicheres Cluster zu erstellen.
+
+aka: 
+tags:
+- tool
+- operation
+---
+ Ein Werkzeug um schnell Kubernetes zu installieren und ein sicheres Cluster zu erstellen.
+
+<!--more--> 
+
+Man kann kubeadm verwenden, um sowohl die Control Plane, als auch die {{< glossary_tooltip text="Worker Node" term_id="node" >}} Komponenten zu installieren.
+

--- a/content/de/docs/reference/glossary/kubelet.md
+++ b/content/de/docs/reference/glossary/kubelet.md
@@ -4,14 +4,14 @@ id: kubelet
 date: 2018-04-12
 full_link: /docs/reference/generated/kubelet
 short_description: >
-  Ein Agent, der auf jedem Node im Cluster ausgeführt wird. Er stellt sicher, dass Container in einem Pod ausgeführt werden.
+  Ein Agent, der auf jedem Knoten im Cluster ausgeführt wird. Er stellt sicher, dass Container in einem Pod ausgeführt werden.
 
 aka:
 tags:
 - fundamental
 - core-object
 ---
- Ein Agent, der auf jedem Node im Cluster ausgeführt wird. Er stellt sicher, dass Container in einem Pod ausgeführt werden.
+ Ein Agent, der auf jedem Knoten im Cluster ausgeführt wird. Er stellt sicher, dass Container in einem Pod ausgeführt werden.
 
 <!--more-->
 

--- a/content/de/docs/reference/glossary/label.md
+++ b/content/de/docs/reference/glossary/label.md
@@ -1,0 +1,18 @@
+---
+title: Label
+id: label
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/labels
+short_description: >
+  Kennzeichnet Objekte mit identifizierenden Attributen, die sinnvoll und relevant für die Nutzer sind.
+
+aka: 
+tags:
+- fundamental
+---
+ Kennzeichnet Objekte mit identifizierenden Attributen, die sinnvoll und relevant für die Nutzer sind.
+
+<!--more--> 
+
+Labels sind Key-Value Paare, die an Objekte gebunden sind, zum Beispiel {{< glossary_tooltip text="Pods" term_id="pod" >}}. Sie werden verwendet, um eine Untermenge Objekte zu organisieren und auszuwählen.
+

--- a/content/de/docs/reference/glossary/master.md
+++ b/content/de/docs/reference/glossary/master.md
@@ -1,0 +1,15 @@
+---
+title: Master
+id: master
+date: 2020-04-16
+short_description: >
+  Veralteter Begriff, verwendet als Synonym für die Knoten auf denen die Control Plane läuft. 
+
+aka:
+tags:
+- fundamental
+---
+ Veralteter Begriff, verwendet als Synonym für die {{< glossary_tooltip text="Knoten" term_id="node" >}} auf denen die {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} läuft.
+
+<!--more-->
+Dieser Begriff wird noch durch einige Provisionierungswerkzeuge verwendet, wie zum Beispiel {{< glossary_tooltip text="kubeadm" term_id="kubeadm" >}}, und gemanagte Dienste, um {{< glossary_tooltip text="Knoten" term_id="node" >}} mit dem `kubernetes.io/role` {{< glossary_tooltip text="Label" term_id="label" >}} zu kennzeichnen, und {{< glossary_tooltip text="Pods" term_id="pod" >}} auf der {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} zu platzieren.

--- a/content/de/docs/reference/glossary/node.md
+++ b/content/de/docs/reference/glossary/node.md
@@ -1,0 +1,19 @@
+---
+title: Knoten
+id: node
+date: 2018-04-12
+full_link: /docs/concepts/architecture/nodes/
+short_description: >
+  Ein Knoten ist eine Arbietermaschine in Kubernetes.
+
+aka:
+tags:
+- fundamental
+---
+ Ein Knoten ist eine Arbietermaschine in Kubernetes.
+
+<!--more-->
+
+Ein Arbeiterknoten kann eine virtuelle Maschine oder physische Maschine sein, abhängig vom Cluster. Es hat lokale Daemons und Dienste, die nötig sind um {{< glossary_tooltip text="Pods" term_id="pod" >}} auszuführen, und wird von der Control Plane administriert. Die Daemonen auf einem Knoten beinhalten auch das {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}, {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}, und eine Container Runtime, die ein {{< glossary_tooltip text="CRI" term_id="cri" >}}, wie zum Beispiel {{< glossary_tooltip term_id="docker" >}}. implementieren.
+
+In älteren Kubernetes Versionen wurden Knoten "Minions" genannt.

--- a/content/de/docs/reference/glossary/object.md
+++ b/content/de/docs/reference/glossary/object.md
@@ -1,0 +1,15 @@
+---
+title: Objekt
+id: object
+date: 2020-10-12
+full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
+short_description: >
+   Eine Einheit im Kubernetessystem, die ein Teil des Zustands Ihres Clusters darstellt.
+aka: 
+tags:
+- fundamental
+---
+Eine Einheit im Kubernetessystem. Die Kubernetes API verwendet diese Einheiten um den Zustand Ihres Clusters darzustellen.
+<!--more-->
+Ein Kubernetes Objekt ist typischerweise ein "Datenstatz der Absicht"—sobald Sie das Objekt erstellen, arbeitet die Kubernetes {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} ständig, um zu versichern, dass das Element, welches es darstellt, auch existiert.
+Durch erstellen eines Objekts, erzählen Sie grundsätzlich dem Kubernetessystem wie dieser Teil der Arbeitslast Ihres Clusters aussehen soll; das ist der Wunschzustand Ihres Clusters.

--- a/content/de/docs/reference/glossary/pod.md
+++ b/content/de/docs/reference/glossary/pod.md
@@ -1,0 +1,18 @@
+---
+title: Pod
+id: pod
+date: 2018-04-12
+full_link: /docs/concepts/workloads/pods/
+short_description: >
+  Ein Pod stellt ein Satz laufender Container in Ihrem Cluster dar.
+
+aka: 
+tags:
+- core-object
+- fundamental
+---
+ Das kleinste und einfachste Kubernetesobjekt. Ein Pod stellt ein Satz laufender {{< glossary_tooltip text="Container" term_id="container" >}} in Ihrem Cluster dar.
+
+<!--more--> 
+
+Ein Pod wird typischerweise verwendet, um einen einzelnen primären Container laufen zu lassen. Es kann optional auch "sidecar" Container laufen lassen, die zusätzliche Features, wie logging, hinzufügen. Pods werden normalerweise durch ein {{< glossary_tooltip text="Deployment" term_id="deployment" >}} verwaltet.

--- a/content/de/docs/reference/glossary/selector.md
+++ b/content/de/docs/reference/glossary/selector.md
@@ -1,0 +1,18 @@
+---
+title: Selector
+id: selector
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/labels/
+short_description: >
+  Eralubt Benutzer das Filtern einer Liste Ressourcen basierend auf Label.
+
+aka: 
+tags:
+- fundamental
+---
+ Erlaubt Benutzer das Filtern einer Liste Ressourcen basierend auf {{< glossary_tooltip text="Label" term_id="label" >}}.
+
+<!--more--> 
+
+Selektoren werden verwendet beim Abfragen einer Liste Ressourcen, um Sie nach Label zu filtern.
+

--- a/content/de/docs/reference/glossary/service.md
+++ b/content/de/docs/reference/glossary/service.md
@@ -1,0 +1,20 @@
+---
+title: Service
+id: service
+date: 2018-04-12
+full_link: /docs/concepts/services-networking/service/
+short_description: >
+  Eine Methode um Anwendungen, die auf einem Satz Pods laufen, als Netzwerkdienst freizugeben.
+tags:
+- fundamental
+- core-object
+---
+Eine Methode um Netwzwerkanwendungen freizugeben, die als einen oder mehrere {{< glossary_tooltip text="Pods" term_id="pod" >}} in Ihrem Cluster laufen.
+
+<!--more-->
+
+Der Satz Pods, der von einem Servie anvisiert ist, wird durch einen {{< glossary_tooltip text="Selector" term_id="selector" >}} bestimmt. Wenn mehrere Pods hinzugefügt oder entfernt werden, ändert sich der Satz Pods die zum Selector passen. Der Service versichert, dass Netzwerkverkehr an den aktuellen Satz Pods für die Arbeitslast gelenkt werden kann.
+
+Kubernetes Services verwenden entweder IP Netzwerke (IPv4, IPv6, oder beide), oder referenzieren einen externen Namen im Domain Name System (DNS).
+
+Die Service Abstraktion ermöglicht andere Mechanismen, wie Ingress und Gateway.

--- a/content/de/docs/reference/glossary/statefulset.md
+++ b/content/de/docs/reference/glossary/statefulset.md
@@ -1,0 +1,22 @@
+---
+title: StatefulSet
+id: statefulset
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/statefulset/
+short_description: >
+  Ein StatefulSet verwaltet die Bereitstellung und die Skalierung eines Satzes Pods, mit langlebigem Speicher und persistenter Identifzierung für jeden Pod.
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+- storage
+---
+ Verwaltet die Bereitstellung und Skalierung eines Satzes {{< glossary_tooltip text="Pods" term_id="pod" >}}, *und stellt Garantieen zur Reihenfolge und Einzigartigkeit bereit* für diese Pods.
+
+<!--more--> 
+
+Wie ein {{< glossary_tooltip text="Deployment" term_id="deployment" >}}, verwaltet ein StatefulSet Pods basierend auf eine identische Container Spezifikation. Anders als ein Deployment, verwaltet ein StatefulSet eine persistente Identität für jeden seiner Pods. Diese Pods werden anhand der gleichen Spezifikation erstellt, sind aber nicht austauschbar&#58; Jeder hat eine persistente Identifizierung, die über jede Verschiebung erhalten bleibt.
+
+Wenn Sie Speichervolumen verwenden wollen, um Persistenz der Arbeitslast zu ermöglichen, können Sie einen StatefulSet as Teil der Lösung verwenden. Obwohl einzelne Pods in einem StatefulSet anfälling für Fehler sind, machen die persistente Podidentifizierungen es einfacher, existierende Volumen mit neuen Pods, die die fehlerhaften ersetzen, zu verbinden.


### PR DESCRIPTION
This PR adds the German localization for content/de/docs/concepts/architecture/controller.md and also localizes all the glossary entries referenced. Furthermore, the glossary entries "kube-apiserver", "kube-controller-manager", "kube-scheduler", and "kubelet" were modified to remove the "master/slave" terminology.
