### PR TITLE
clarify nodes only update labels upon registration

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -117,7 +117,7 @@ As mentioned in the [Node name uniqueness](#node-name-uniqueness) section,
 when Node configuration needs to be updated, it is a good practice to re-register
 the node with the API server. For example, if the kubelet is being restarted with
 a new set of `--node-labels`, but the same Node name is used, the change will
-not take effect, as labels are only set (or reset) upon Node registration with the API server.
+not take effect, as labels are only set (or modified) upon Node registration with the API server.
 
 Pods already scheduled on the Node may misbehave or cause issues if the Node
 configuration will be changed on kubelet restart. For example, already running

--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -115,9 +115,9 @@ are enabled, kubelets are only authorized to create/modify their own Node resour
 {{< note >}}
 As mentioned in the [Node name uniqueness](#node-name-uniqueness) section,
 when Node configuration needs to be updated, it is a good practice to re-register
-the node with the API server. For example, if the kubelet being restarted with
-the new set of `--node-labels`, but the same Node name is used, the change will
-not take an effect, as labels are being set on the Node registration.
+the node with the API server. For example, if the kubelet is being restarted with
+a new set of `--node-labels`, but the same Node name is used, the change will
+not take effect, as labels are only set (or reset) upon Node registration with the API server.
 
 Pods already scheduled on the Node may misbehave or cause issues if the Node
 configuration will be changed on kubelet restart. For example, already running


### PR DESCRIPTION
A simple update to the nodes doc, which I thought might clarify that labels are **only** updated upon registration with the API server. 
