### PR TITLE
Correct image version typo

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -161,7 +161,7 @@ description: |-
             <div class="col-md-12">
                <h3>Roll back an update</h3>
                <p>Let’s perform another update, and try to deploy an image tagged with <code>v10</code>:</p>
-               <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=gcr.io/google-samples/kubernetes-bootcamp:v10</b></code></p>
+               <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=gcr.io/google-samples/kubernetes-bootcamp:v1</b></code></p>
                <p>Use <code>get deployments</code> to see the status of the deployment:</p>
                <p><code><b>kubectl get deployments</b></code></p>
                <p>Notice that the output doesn't list the desired number of available Pods. Run the <code>get pods</code> subcommand to list all Pods:</p>


### PR DESCRIPTION
This should be a rollback to v1. 

There is no v10 of the gcr.io/google-samples/kubernetes-bootcamp image, so it throws an error and the rollback fails.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
