### PR TITLE
Moved the ready state information from the beta section to the job section.

### DIFF
--- a/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -325,16 +325,9 @@ JobStatus represents the current state of a Job.
     
     succeeded holds UIDs of succeeded Pods.
 
-
-
-### Beta level
-
-
 - **ready** (int32)
 
   The number of pods which have a Ready condition.
-  
-  This field is beta-level. The job controller populates the field when the feature gate JobReadyPods is enabled (enabled by default).
 
 ### Alpha level
 


### PR DESCRIPTION
fixes #44632 

As suggested in issue #44632, ready pod status is still listed as a beta feature and it should moved under the job section.
I moved the content to that section. 
 
![image](https://github.com/kubernetes/website/assets/76243309/172b74be-28c5-47a1-8f63-5af9f1add2d4)
