### PR TITLE
fix: clarify day of the week in cron job documentation

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -55,9 +55,9 @@ The `.spec.schedule` field is required. The value of that field follows the [Cro
 # │ ┌───────────── hour (0 - 23)
 # │ │ ┌───────────── day of the month (1 - 31)
 # │ │ │ ┌───────────── month (1 - 12)
-# │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
-# │ │ │ │ │                                   7 is also Sunday on some systems)
+# │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
 # │ │ │ │ │                                   OR sun, mon, tue, wed, thu, fri, sat
+# │ │ │ │ │ 
 # │ │ │ │ │
 # * * * * *
 ```


### PR DESCRIPTION
The cron scheduling syntax documentation was copied from somewhere else, and included an optional part of the spec (sundays can be referenced as 0 or 7) that is not implemented by kubernetes. This is unnecessarily confusing.
