### PR TITLE
Update legacy packages blog post with a note about available releases

### DIFF
--- a/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
+++ b/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
@@ -100,8 +100,10 @@ community-owned repositories (`pkgs.k8s.io`).
 
 ### What releases are available in the new community-owned package repositories?
 
-All releases starting from Kubernetes v1.24.0 are available in the 
-community-owned package repositories (`pkgs.k8s.io`).
+Linux packages for releases starting from Kubernetes v1.24.0 are available in the 
+Kubernetes package repositories (`pkgs.k8s.io`). Kubernetes does not have official
+Linux packages available for earlier releases of Kubernetes; however, your Linux
+distribution may provide its own packages.
 
 ## Can I continue to use the legacy package repositories?
 

--- a/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
+++ b/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
@@ -98,6 +98,11 @@ we'll only publish packages to the new package repositories (`pkgs.k8s.io`).
 Kubernetes 1.29 and onwards will have packages published **only** to the
 community-owned repositories (`pkgs.k8s.io`).
 
+### What releases are available in the new community-owned package repositories?
+
+All releases starting from Kubernetes v1.24.0 are available in the 
+community-owned package repositories (`pkgs.k8s.io`).
+
 ## Can I continue to use the legacy package repositories?
 
 ~~The existing packages in the legacy repositories will be available for the foreseeable


### PR DESCRIPTION
I have received feedback that it's not clear from the [legacy repositories deprecation announcement](https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/) what releases are available in the community-owned package repositories. Instead, the `Timeline of changes` section is giving a feeling that only v1.28.2, v1.27.6, v1.26.9, v1.25.14, and onwards are available.

This PR is supposed to address this feedback by adding a short section explaining that releases starting with v1.24.0 are available in the community-owned package repositories.