### PR TITLE
Update pkgs.k8s.io blog post with information about removing legacy repos

### DIFF
--- a/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
+++ b/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
@@ -18,38 +18,38 @@ This blog post contains information about these new package repositories,
 what does it mean to you as an end user, and how to migrate to the new
 repositories.
 
-**ℹ️  Update (August 31, 2023):** the _**legacy Google-hosted repositories are deprecated
-and will be frozen starting with September 13, 2023.**_
+**ℹ️  Update (January 12, 2024):** the _**legacy Google-hosted repositories are going
+away in January 2024.**_
 Check out [the deprecation announcement](/blog/2023/08/31/legacy-package-repository-deprecation/)
 for more details about this change.
 
 ## What you need to know about the new package repositories?
 
-_(updated on August 31, 2023)_
+_(updated on January 12, 2024)_
 
 - This is an **opt-in change**; you're required to manually migrate from the
   Google-hosted repository to the Kubernetes community-owned repositories.
   See [how to migrate](#how-to-migrate) later in this announcement for migration information
   and instructions.
-- The legacy Google-hosted repositories are **deprecated as of August 31, 2023**,
-  and will be **frozen approximately as of September 13, 2023**. The freeze will happen
-  immediately following the patch releases that are scheduled for September 2023.
-  Freezing the legacy repositories means that we will publish packages for the Kubernetes
-  project only to the community-owned repositories as of the September 13, 2023 cut-off point.
+- **The legacy Google-hosted package repositories are going away in January 2024.** These repositories
+  have been **deprecated as of August 31, 2023**, and **frozen as of September 13, 2023**.
   Check out the [deprecation announcement](/blog/2023/08/31/legacy-package-repository-deprecation/)
   for more details about this change.
-- The existing packages in the legacy repositories will be available for the foreseeable future.
+- ~~The existing packages in the legacy repositories will be available for the foreseeable future.
   However, the Kubernetes project can't provide any guarantees on how long is that going to be.
   The deprecated legacy repositories, and their contents, might be removed at any time in the future
-  and without a further notice period.
+  and without a further notice period.~~ **The legacy package repositories are going away in
+  January 2024.**
 - Given that no new releases will be published to the legacy repositories after
   the September 13, 2023 cut-off point, you will not be able to upgrade to any patch or minor
   release made from that date onwards if you don't migrate to the new Kubernetes package repositories.
   That said, we recommend migrating to the new Kubernetes package repositories **as soon as possible**.
 - The new Kubernetes package repositories contain packages beginning with those
   Kubernetes versions that were still under support when the community took
-  over the package builds. This means that anything before v1.24.0 will only be
-  available in the Google-hosted repository.
+  over the package builds. This means that the new package repositories have Linux packages for all
+  Kubernetes releases starting with v1.24.0.
+- Kubernetes does not have official Linux packages available for earlier releases of Kubernetes;
+  however, your Linux distribution may provide its own packages.
 - There's a dedicated package repository for each Kubernetes minor version.
   When upgrading to a different minor release, you must bear in mind that
   the package repository details also change.


### PR DESCRIPTION
This PR updates the original announcement blog post for `pkgs.k8s.io` to highlight that the legacy repositories are going away in January 2024 and to make it explicit that the new package repositories have releases starting with v1.24.0.

Relevant to https://github.com/kubernetes/website/pull/44719