### PR TITLE
[de] German localization of more glossary entries

### DIFF
--- a/content/de/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/de/docs/reference/glossary/cloud-controller-manager.md
@@ -1,0 +1,19 @@
+---
+title: Cloud Controller Manager
+id: cloud-controller-manager
+date: 2018-04-12
+full_link: /docs/concepts/architecture/cloud-controller/
+short_description: >
+  Control Plane Komponente, die Kubernetes mit Drittanbieter Cloud Provider integriert.
+aka: 
+tags:
+- core-object
+- architecture
+- operation
+---
+ Eine Kubernetes {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} Komponente, die Cloud spezifische Kontrolllogik einbettet. Der [Cloud Controller Manager](/docs/concepts/architecture/cloud-controller/) lässt Sie Ihr Cluster in die Cloud Provider API einbinden, und trennt die Komponenten die mit der Cloud Platform interagieren von Komponenten, die nur mit Ihrem Cluster interagieren.
+
+<!--more-->
+
+Durch Entkopplung der Interoperabilitätslogik zwischen Kubernetes und der darunterliegenden Cloud Infrastruktur, ermöglicht der Cloud Controller Manager den Cloud Providern das Freigeben neuer Features in einem anderen Tempo als das Kubernetes Projekt.
+

--- a/content/de/docs/reference/glossary/cluster.md
+++ b/content/de/docs/reference/glossary/cluster.md
@@ -1,0 +1,17 @@
+---
+title: Cluster
+id: cluster
+date: 2019-06-15
+full_link: 
+short_description: >
+   Ein Satz Arbeitermaschinen, genannt Knoten, die containerisierte Anwendungen ausführen. Jedes Cluster hat mindestens einen Arbeiterknoten.
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+Ein Satz Arbeitermaschinen, gennant {{< glossary_tooltip text="Knoten" term_id="node" >}}, die containerisierte Anwendungen ausführen. Jedes Cluster hat mindestens einen Arbeiterknoten.
+
+<!--more-->
+Die Arbeiterknoten bringen die {{< glossary_tooltip text="Pods" term_id="pod" >}} unter, die die Komponenten der Applikationslast sind. Die {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} verwaltet die Arbeiterknoten und Pods im Cluster. In Produktionsumgebungen läuft die Control Plane meistens über mehrere Computer, und ein Cluster hat meistens mehrere Knoten, um Fehlertoleranz und Hochverfügbarkeit zu ermöglichen.

--- a/content/de/docs/reference/glossary/container.md
+++ b/content/de/docs/reference/glossary/container.md
@@ -1,0 +1,19 @@
+---
+title: Container
+id: container
+date: 2018-04-12
+full_link: /docs/concepts/containers/
+short_description: >
+  Ein kleines und portierbares ausführbares Image, dass eine Software und all seine Abhängigkeiten enthält.
+
+aka: 
+tags:
+- fundamental
+- workload
+---
+ Ein kleines und portierbares ausführbares Image, dass eine Software und all seine Abhängigkeiten enthält.
+
+<!--more--> 
+
+Container entkuppeln Anwendungen von der darunterliegenden Rechner Infrastruktur, um den Einsatz in verschiedenen Cloud- oder Betriebssystemumgebungen zu vereinfachen.
+Die Anwendungen in Container nennt man Containerisierte Anwendungen. Der Prozess des Bündelns dieser Anwendungen und ihrer Abhängigkeiten in einem Container Image nennt man Containerisierung.

--- a/content/de/docs/reference/glossary/control-plane.md
+++ b/content/de/docs/reference/glossary/control-plane.md
@@ -1,0 +1,25 @@
+---
+title: Control Plane
+id: control-plane
+date: 2019-05-12
+full_link:
+short_description: >
+  Die Container Orchestrierungsschicht, die die API und Schnittstellen exponiert, um den Lebenszyklus von Container zu definieren, bereitzustellen, und zu verwalten.
+
+aka:
+tags:
+- fundamental
+---
+ Die Container Orchestrierungsschicht, die die API und Schnittstellen exponiert, um den Lebenszyklus von Container zu definieren, bereitzustellen, und zu verwalten.
+
+ <!--more--> 
+ 
+ Diese Schicht besteht aus vielen verschiedenen Komponenten, zum Beispiel (aber nicht begranzt auf):
+
+ * {{< glossary_tooltip text="etcd" term_id="etcd" >}}
+ * {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}
+ * {{< glossary_tooltip text="Scheduler" term_id="kube-scheduler" >}}
+ * {{< glossary_tooltip text="Controller Manager" term_id="kube-controller-manager" >}}
+ * {{< glossary_tooltip text="Cloud Controller Manager" term_id="cloud-controller-manager" >}}
+
+ Diese Komponenten können als traditionelle Betriebssystemdienste (daemons) oder als Container laufen. Die Hosts auf denen diese Komponenten laufen, hießen früher {{< glossary_tooltip text="Master" term_id="master" >}}.

--- a/content/de/docs/reference/glossary/deployment.md
+++ b/content/de/docs/reference/glossary/deployment.md
@@ -1,0 +1,19 @@
+---
+title: Deployment
+id: deployment
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/deployment/
+short_description: >
+  Verwaltet eine replizierte Anwendung in Ihrem Cluster.
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ Ein API Object, das eine replizierte Anwendung verwaltet, typischerweise durch laufende Pods ohne lokalem Zustand.
+
+<!--more--> 
+
+Jedes Replikat wird durch ein {{< glossary_tooltip text="Pod" term_id="pod" >}} repräsentiert, und die Pods werden auf den {{< glossary_tooltip text="Knoten" term_id="node" >}} eines Clusters verteilt. Für Arbeitslasten, die einen lokalen Zustand benötigen, sollten Sie einen {{< glossary_tooltip term_id="StatefulSet" >}} verwenden.

--- a/content/de/docs/reference/glossary/docker.md
+++ b/content/de/docs/reference/glossary/docker.md
@@ -1,0 +1,17 @@
+---
+title: Docker
+id: docker
+date: 2018-04-12
+full_link: https://docs.docker.com/engine/
+short_description: >
+  Docker ist eine Software Technologie, die Virtualisierung auf Betriebssystemebene (auch bekannt als Container) bereitstellt.
+
+aka:
+tags:
+- fundamental
+---
+Docker (genauer gesagt, Docker Engine) ist eine Software Technologie, die Virtualisierung auf Betriebssystemebene (auch bekannt als {{< glossary_tooltip text="Container" term_id="container" >}}) bereitstellt.
+
+<!--more-->
+
+Docker verwendet die Ressourcenisolierungsfunktionen des Linux Kernels, wie cgroups und Kernel Namespaces, und ein Unionsfähiges Dateisystem wie OverlayFS (unter anderem), um unabhängige Container auf einer einzigen Linux Instanz auszuführen. Dies vermeidet den Mehraufwand des Starten und Verwalten virtueller Maschinen (VMs).


### PR DESCRIPTION
[de] This PR is to add  the German localization of the following files:

/content/de/doc/reference/glossary/cloud-controller-manager.md
/content/de/doc/reference/glossary/cluster.md
/content/de/doc/reference/glossary/container.md
/content/de/doc/reference/glossary/control-plane.md
/content/de/doc/reference/glossary/deployment.md
/content/de/doc/reference/glossary/docker.md