### PR TITLE
[de] German localization of further glossary files

### DIFF
--- a/content/de/docs/reference/glossary/kubeadm.md
+++ b/content/de/docs/reference/glossary/kubeadm.md
@@ -1,0 +1,19 @@
+---
+title: Kubeadm
+id: kubeadm
+date: 2018-04-12
+full_link: /docs/reference/setup-tools/kubeadm/
+short_description: >
+  Ein Werkzeug um schnell Kubernetes zu installieren und ein sicheres Cluster zu erstellen.
+
+aka: 
+tags:
+- tool
+- operation
+---
+ Ein Werkzeug um schnell Kubernetes zu installieren und ein sicheres Cluster zu erstellen.
+
+<!--more--> 
+
+Man kann kubeadm verwenden, um sowohl die Control Plane, als auch die {{< glossary_tooltip text="Worker Node" term_id="node" >}} Komponenten zu installieren.
+

--- a/content/de/docs/reference/glossary/label.md
+++ b/content/de/docs/reference/glossary/label.md
@@ -1,0 +1,18 @@
+---
+title: Label
+id: label
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/labels
+short_description: >
+  Kennzeichnet Objekte mit identifizierenden Attributen, die sinnvoll und relevant für die Nutzer sind.
+
+aka: 
+tags:
+- fundamental
+---
+ Kennzeichnet Objekte mit identifizierenden Attributen, die sinnvoll und relevant für die Nutzer sind.
+
+<!--more--> 
+
+Labels sind Key-Value Paare, die an Objekte gebunden sind, zum Beispiel {{< glossary_tooltip text="Pods" term_id="pod" >}}. Sie werden verwendet, um eine Untermenge Objekte zu organisieren und auszuwählen.
+

--- a/content/de/docs/reference/glossary/master.md
+++ b/content/de/docs/reference/glossary/master.md
@@ -1,0 +1,15 @@
+---
+title: Master
+id: master
+date: 2020-04-16
+short_description: >
+  Veralteter Begriff, verwendet als Synonym für die Knoten auf denen die Control Plane läuft. 
+
+aka:
+tags:
+- fundamental
+---
+ Veralteter Begriff, verwendet als Synonym für die {{< glossary_tooltip text="Knoten" term_id="node" >}} auf denen die {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} läuft.
+
+<!--more-->
+Dieser Begriff wird noch durch einige Provisionierungswerkzeuge verwendet, wie zum Beispiel {{< glossary_tooltip text="kubeadm" term_id="kubeadm" >}}, und gemanagte Dienste, um {{< glossary_tooltip text="Knoten" term_id="node" >}} mit dem `kubernetes.io/role` {{< glossary_tooltip text="Label" term_id="label" >}} zu kennzeichnen, und {{< glossary_tooltip text="Pods" term_id="pod" >}} auf der {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} zu platzieren.

--- a/content/de/docs/reference/glossary/node.md
+++ b/content/de/docs/reference/glossary/node.md
@@ -1,0 +1,19 @@
+---
+title: Knoten
+id: node
+date: 2018-04-12
+full_link: /docs/concepts/architecture/nodes/
+short_description: >
+  Ein Knoten ist eine Arbietermaschine in Kubernetes.
+
+aka:
+tags:
+- fundamental
+---
+ Ein Knoten ist eine Arbietermaschine in Kubernetes.
+
+<!--more-->
+
+Ein Arbeiterknoten kann eine virtuelle Maschine oder physische Maschine sein, abhängig vom Cluster. Es hat lokale Daemons und Dienste, die nötig sind um {{< glossary_tooltip text="Pods" term_id="pod" >}} auszuführen, und wird von der Control Plane administriert. Die Daemonen auf einem Knoten beinhalten auch das {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}, {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}, und eine Container Runtime, die ein {{< glossary_tooltip text="CRI" term_id="cri" >}}, wie zum Beispiel {{< glossary_tooltip term_id="docker" >}}. implementieren.
+
+In älteren Kubernetes Versionen wurden Knoten "Minions" genannt.

--- a/content/de/docs/reference/glossary/object.md
+++ b/content/de/docs/reference/glossary/object.md
@@ -1,0 +1,15 @@
+---
+title: Objekt
+id: object
+date: 2020-10-12
+full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
+short_description: >
+   Eine Einheit im Kubernetessystem, die ein Teil des Zustands Ihres Clusters darstellt.
+aka: 
+tags:
+- fundamental
+---
+Eine Einheit im Kubernetessystem. Die Kubernetes API verwendet diese Einheiten um den Zustand Ihres Clusters darzustellen.
+<!--more-->
+Ein Kubernetes Objekt ist typischerweise ein "Datenstatz der Absicht"—sobald Sie das Objekt erstellen, arbeitet die Kubernetes {{< glossary_tooltip text="Control Plane" term_id="control-plane" >}} ständig, um zu versichern, dass das Element, welches es darstellt, auch existiert.
+Durch erstellen eines Objekts, erzählen Sie grundsätzlich dem Kubernetessystem wie dieser Teil der Arbeitslast Ihres Clusters aussehen soll; das ist der Wunschzustand Ihres Clusters.

--- a/content/de/docs/reference/glossary/pod.md
+++ b/content/de/docs/reference/glossary/pod.md
@@ -1,0 +1,18 @@
+---
+title: Pod
+id: pod
+date: 2018-04-12
+full_link: /docs/concepts/workloads/pods/
+short_description: >
+  Ein Pod stellt ein Satz laufender Container in Ihrem Cluster dar.
+
+aka: 
+tags:
+- core-object
+- fundamental
+---
+ Das kleinste und einfachste Kubernetesobjekt. Ein Pod stellt ein Satz laufender {{< glossary_tooltip text="Container" term_id="container" >}} in Ihrem Cluster dar.
+
+<!--more--> 
+
+Ein Pod wird typischerweise verwendet, um einen einzelnen primären Container laufen zu lassen. Es kann optional auch "sidecar" Container laufen lassen, die zusätzliche Features, wie logging, hinzufügen. Pods werden normalerweise durch ein {{< glossary_tooltip text="Deployment" term_id="deployment" >}} verwaltet.

--- a/content/de/docs/reference/glossary/selector.md
+++ b/content/de/docs/reference/glossary/selector.md
@@ -1,0 +1,18 @@
+---
+title: Selector
+id: selector
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/labels/
+short_description: >
+  Eralubt Benutzer das Filtern einer Liste Ressourcen basierend auf Label.
+
+aka: 
+tags:
+- fundamental
+---
+ Erlaubt Benutzer das Filtern einer Liste Ressourcen basierend auf {{< glossary_tooltip text="Label" term_id="label" >}}.
+
+<!--more--> 
+
+Selektoren werden verwendet beim Abfragen einer Liste Ressourcen, um Sie nach Label zu filtern.
+

--- a/content/de/docs/reference/glossary/service.md
+++ b/content/de/docs/reference/glossary/service.md
@@ -1,0 +1,20 @@
+---
+title: Service
+id: service
+date: 2018-04-12
+full_link: /docs/concepts/services-networking/service/
+short_description: >
+  Eine Methode um Anwendungen, die auf einem Satz Pods laufen, als Netzwerkdienst freizugeben.
+tags:
+- fundamental
+- core-object
+---
+Eine Methode um Netwzwerkanwendungen freizugeben, die als einen oder mehrere {{< glossary_tooltip text="Pods" term_id="pod" >}} in Ihrem Cluster laufen.
+
+<!--more-->
+
+Der Satz Pods, der von einem Servie anvisiert ist, wird durch einen {{< glossary_tooltip text="Selector" term_id="selector" >}} bestimmt. Wenn mehrere Pods hinzugefügt oder entfernt werden, ändert sich der Satz Pods die zum Selector passen. Der Service versichert, dass Netzwerkverkehr an den aktuellen Satz Pods für die Arbeitslast gelenkt werden kann.
+
+Kubernetes Services verwenden entweder IP Netzwerke (IPv4, IPv6, oder beide), oder referenzieren einen externen Namen im Domain Name System (DNS).
+
+Die Service Abstraktion ermöglicht andere Mechanismen, wie Ingress und Gateway.

--- a/content/de/docs/reference/glossary/statefulset.md
+++ b/content/de/docs/reference/glossary/statefulset.md
@@ -1,0 +1,22 @@
+---
+title: StatefulSet
+id: statefulset
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/statefulset/
+short_description: >
+  Ein StatefulSet verwaltet die Bereitstellung und die Skalierung eines Satzes Pods, mit langlebigem Speicher und persistenter Identifzierung für jeden Pod.
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+- storage
+---
+ Verwaltet die Bereitstellung und Skalierung eines Satzes {{< glossary_tooltip text="Pods" term_id="pod" >}}, *und stellt Garantieen zur Reihenfolge und Einzigartigkeit bereit* für diese Pods.
+
+<!--more--> 
+
+Wie ein {{< glossary_tooltip text="Deployment" term_id="deployment" >}}, verwaltet ein StatefulSet Pods basierend auf eine identische Container Spezifikation. Anders als ein Deployment, verwaltet ein StatefulSet eine persistente Identität für jeden seiner Pods. Diese Pods werden anhand der gleichen Spezifikation erstellt, sind aber nicht austauschbar&#58; Jeder hat eine persistente Identifizierung, die über jede Verschiebung erhalten bleibt.
+
+Wenn Sie Speichervolumen verwenden wollen, um Persistenz der Arbeitslast zu ermöglichen, können Sie einen StatefulSet as Teil der Lösung verwenden. Obwohl einzelne Pods in einem StatefulSet anfälling für Fehler sind, machen die persistente Podidentifizierungen es einfacher, existierende Volumen mit neuen Pods, die die fehlerhaften ersetzen, zu verbinden.


### PR DESCRIPTION
[de] This PR is to add the German localization for the following glossary files:

/content/de/docs/reference/glossary/kubeadm.md
/content/de/docs/reference/glossary/label.md
/content/de/docs/reference/glossary/master.md
/content/de/docs/reference/glossary/node.md
/content/de/docs/reference/glossary/object.md
/content/de/docs/reference/glossary/pod.md
/content/de/docs/reference/glossary/selector.md
/content/de/docs/reference/glossary/service.md
/content/de/docs/reference/glossary/statefulset.md