### PR TITLE
[de] German localization of further glossary items

### DIFF
--- a/content/de/docs/reference/glossary/addons.md
+++ b/content/de/docs/reference/glossary/addons.md
@@ -1,0 +1,16 @@
+---
+title: Add-ons
+id: addons
+date: 2019-12-15
+full_link: /docs/concepts/cluster-administration/addons/
+short_description: >
+  Ressourcen, die die Funktionalität von Kubernetes erweitern.
+
+aka:
+tags:
+- tool
+---
+  Ressourcen, die die Funktionalität von Kubernetes erweitern.
+
+<!--more-->
+[Add-Ons installieren](/docs/concepts/cluster-administration/addons/) erklärt mehr über die Verwendung von Add-Ons in Ihrem Cluster, und listet einige populäre Add-Ons auf.

--- a/content/de/docs/reference/glossary/admission-controller.md
+++ b/content/de/docs/reference/glossary/admission-controller.md
@@ -1,0 +1,20 @@
+---
+title: Zugangscontroller
+id: admission-controller
+date: 2019-06-28
+full_link: /docs/reference/access-authn-authz/admission-controllers/
+short_description: >
+  Ein Teil Code, das Anfragen an den Kubernetes API Server abfängt, vor der Persistenz eines Objekts.
+
+aka:
+tags:
+- extension
+- security
+---
+Ein Teil Code, das Anfragen an den Kubernetes API Server abfängt, vor der Persistenz eines Objekts.
+
+<!--more-->
+
+Zugangscontroller für den Kubernetes API Server sind konfigurierbar, und können "validierend", "verändernd", oder beides sein. Jeder Zugangscontroller kann die Anfrage ablehnen. Verändernde Controller können die Objekte ändern, die sie zulassen; validierende Controller dürfen das nicht.
+
+* [Zugangscontroller in der Kubernetes Dokumentation](/docs/reference/access-authn-authz/admission-controllers/)

--- a/content/de/docs/reference/glossary/affinity.md
+++ b/content/de/docs/reference/glossary/affinity.md
@@ -1,0 +1,20 @@
+---
+title: Affinität
+id: affinity
+date: 2019-01-11
+full_link: /docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+short_description: >
+     Regeln, die vom Scheduler verwendet werden, um festzulegen wo Pods platziert werden.
+aka:
+tags:
+- fundamental
+---
+
+In Kubernetes, ist _Affinität_ ein Satz Regeln, die dem Scheduler Hinweise geben, wo er Pods platzieren soll.
+
+<!--more-->
+Es gibt zwei Arten Affinität:
+* [Knoten Affinität](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+* [Pod-zo-Pod Affinität](/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
+
+Die Regeln werden mithilfe der in {{< glossary_tooltip term_id="pod" text="Pods" >}} angegebenen {{< glossary_tooltip term_id="label" text="Label">}} und {{< glossary_tooltip term_id="selector" text="Selektoren">}} definiert, und sie können entweder erforderlich oder bevorzugt sein, je nachdem wie streng sie möchten, dass der Scheduler sie durchsetzen soll.

--- a/content/de/docs/reference/glossary/aggregation-layer.md
+++ b/content/de/docs/reference/glossary/aggregation-layer.md
@@ -1,0 +1,19 @@
+---
+title: Aggregationsschicht
+id: aggregation-layer
+date: 2018-10-08
+full_link: /docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
+short_description: >
+  Die Aggregationsschicht erlaubt Ihnen die Installation zusätzlicher Kubernetes-artiger APIs in Ihrem Cluster.
+
+aka: 
+tags:
+- architecture
+- extension
+- operation
+---
+ Die Aggregationsschicht erlaubt Ihnen die Installation zusätzlicher Kubernetes-artiger APIs in Ihrem Cluster.
+
+<!--more-->
+
+Wenn Sie den {{< glossary_tooltip text="Kubernetes API Server" term_id="kube-apiserver" >}} konfiguriert haben um [zusätzliche APIs zu unterstützen](/docs/tasks/extend-kubernetes/configure-aggregation-layer/), können Sie `APIService` Objekte hinzufügen, um einen URL Pfad in der Kubernetes API zu "belegen".

--- a/content/de/docs/reference/glossary/annotation.md
+++ b/content/de/docs/reference/glossary/annotation.md
@@ -1,0 +1,18 @@
+---
+title: Annotation
+id: annotation
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/annotations
+short_description: >
+  Ein Key-Value Paar, dass verwendet wird um willkürliche, nicht-identifizierende Metadaten an Objekte zu binden.
+
+aka: 
+tags:
+- fundamental
+---
+ Ein Key-Value Paar, dass verwendet wird um willkürliche, nicht-identifizierende Metadaten an Objekte zu binden.
+
+<!--more--> 
+
+Die Metadaten in einer Annotation können klein oder groß sein, strukturiert oder unstrukturiert, und können Zeichen enthalten, die nicht in {{< glossary_tooltip text="Label" term_id="label" >}} erlaubt sind. Clients wie Tools oder Libraries können diese Metadaten abfragen.
+

--- a/content/de/docs/reference/glossary/api-eviction.md
+++ b/content/de/docs/reference/glossary/api-eviction.md
@@ -1,0 +1,24 @@
+---
+title: API-initiierte Räumung
+id: api-eviction
+date: 2021-04-27
+full_link: /docs/concepts/scheduling-eviction/api-eviction/
+short_description: >
+  API-initiierte Räumung ist der Prozess, durch den Sie die Räumungs API verwenden, um ein Räumungsobjekt zu erstellen, dass eine geordnete Beendung des Pods auslöst.
+aka:
+tags:
+- operation
+---
+API-initiierte Räumung ist der Prozess, durch den Sie die [Räumungs API](/docs/reference/generated/kubernetes-api/{{<param "version">}}/#create-eviction-pod-v1-core) verwenden, um ein Räumungsobjekt zu erstellen, dass eine geordnete Beendung des Pods auslöst.
+
+
+<!--more-->
+
+Sie können Räumung anfragen, indem Sie direkt die Räumungs API verwenden, mithilfe eines Clients des kube-api-servers, wie der `kubectl drain` Befehl. Wenn ein `Räumungs` Objekt erstellt wird, beendet der API Server den Pod. 
+
+API-initiierte Räumungen respektieren Ihre konfigurierte [`PodDisruptionBudgets`](/docs/tasks/run-application/configure-pdb/)
+und [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination).
+
+API-initiierte Räumung ist nicht das gleiche wie [Knotendruck Räumung](/docs/concepts/scheduling-eviction/node-pressure-eviction/).
+
+* Siehe [API-initiierte Räumung](/docs/concepts/scheduling-eviction/api-eviction/) für mehr Informationen.

--- a/content/de/docs/reference/glossary/api-group.md
+++ b/content/de/docs/reference/glossary/api-group.md
@@ -1,0 +1,19 @@
+---
+title: API Gruppe
+id: api-group
+date: 2019-09-02
+full_link: /docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
+short_description: >
+  Ein Satz zugehöriger Pfade in der Kubernetes API.
+
+aka:
+tags:
+- fundamental
+- architecture
+---
+Ein Satz zugehöriger Pfade in der Kubernetes API. 
+
+<!--more-->
+Sie können jedeAPI Gruppe ein- oder ausschalten durch Änderung der Konfiguration Ihres API Servers. Sie können auch Pfade zu spezifischen Ressourcen ein- oder ausschalten. API Gruppe vereinfacht die Erweiterung der Kubernetes API. Die API Gruppe ist festgelegt durch einen REST Pfad und durch das `apiVersion` Feld eines serialisierten Objekts.
+
+* Siehe [API Gruppe](/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning) für mehr Informationen.

--- a/content/de/docs/reference/glossary/app-container.md
+++ b/content/de/docs/reference/glossary/app-container.md
@@ -1,0 +1,17 @@
+---
+title: App Container
+id: app-container
+date: 2019-02-12
+full_link:
+short_description: >
+  Ein Container, der verwendet wird um einen Teil einer Arbeitslast auszuführen. Vergleiche mit init Container.
+
+aka:
+tags:
+- workload
+---
+ Anwendungscontainer (oder App Container) sind die {{< glossary_tooltip text="Container" term_id="container" >}} in einem {{< glossary_tooltip text="Pod" term_id="pod" >}}, die gestartet werden, nachdem jegliche {{< glossary_tooltip text="Init Container" term_id="init-container" >}} abgeschlossen haben.
+
+<!--more-->
+
+Ein Init Container erlaubt es Ihnen Initialisierungsdetails, die wichtig sind für die gesamte {{< glossary_tooltip text="Arbeitslast" term_id="workload" >}}, und die nicht mehr weiter laufen müssen, sobald der Anwendungscontainer startet, sauber abzutrennen. Wenn ein Pod keine Init Container konfiguriert hat, sind alle Container in diesem Pod App Container.

--- a/content/de/docs/reference/glossary/application-architect.md
+++ b/content/de/docs/reference/glossary/application-architect.md
@@ -1,0 +1,18 @@
+---
+title: Anwendungsarchitekt
+id: application-architect
+date: 2018-04-12
+full_link: 
+short_description: >
+  Eine Person, die verantwortlich ist für das Highlevel-Design einer Anwendung.
+
+aka: 
+tags:
+- user-type
+---
+ Eine Person, die verantwortlich ist für das Highlevel-Design einer Anwendung.
+
+<!--more--> 
+
+Ein Architekt sorgt dafür, dass die Implementierung einer Anwendung eine skalierbare und verwaltbare Interaktion mit den umgebenden Komponenten ermöglicht. Umgebende Komponenten können Datenbanken, Logging-Infrastruktur und andere Microservices sein.
+

--- a/content/de/docs/reference/glossary/application-developer.md
+++ b/content/de/docs/reference/glossary/application-developer.md
@@ -1,0 +1,18 @@
+---
+title: Anwendungsentwickler
+id: application-developer
+date: 2018-04-12
+full_link: 
+short_description: >
+  Eine Person, die eine Anwendung entwickelt, die in einem Kubernetes Cluster läuft.
+
+aka: 
+tags:
+- user-type
+---
+ Eine Person, die eine Anwendung entwickelt, die in einem Kubernetes Cluster läuft.
+
+<!--more--> 
+
+Ein Anwendungsentwickler fokussiert auf einen Teil der Anwendung. Die Größe des Fokus kann significant variieren.
+

--- a/content/de/docs/reference/glossary/applications.md
+++ b/content/de/docs/reference/glossary/applications.md
@@ -1,0 +1,12 @@
+---
+title: Anwendungen
+id: applications
+date: 2019-05-12
+full_link:
+short_description: >
+  Die Schicht, in der verschiedene containerisierte Anwendungen laufen.
+aka:
+tags:
+- fundamental
+---
+ Die Schicht, in der verschiedene containerisierte Anwendungen laufen.

--- a/content/de/docs/reference/glossary/approver.md
+++ b/content/de/docs/reference/glossary/approver.md
@@ -1,0 +1,18 @@
+---
+title: Approver
+id: approver
+date: 2018-04-12
+full_link: 
+short_description: >
+  Eine Person, die Kubernetes Code Beiträge überprüfen und zulassen kann.
+
+aka: 
+tags:
+- community
+---
+ Eine Person, die Kubernetes Code Beiträge überprüfen und zulassen kann.
+
+<!--more--> 
+
+Während Code Review sich auf Qualität und Korrektheit des Codes konzentriert, ist das Genehmigen auf die holistische Akzeptanz eines Beitrags fokussiert. Holistische Akzeptanz achtet unter anderem auf Rückwärts- und Vorwärtskompatibilität, beachten der API und Flag Konventionen, subtile Performance- und Korrektheitsprobleme, und Interaktionen mit anderen Teilendes Systems. Approver Status ist begrenzt auf einen Teil des gesamten Codes (Codebase). Approver wurden früher Maintainer genannt.
+


### PR DESCRIPTION
This PR is for the German localization of the following glossary items:

content/de/docs/reference/glossary/addons.md
content/de/docs/reference/glossary/admission-controller.md
content/de/docs/reference/glossary/affinity.md
content/de/docs/reference/glossary/aggregation-layer.md
content/de/docs/reference/glossary/annotation.md
content/de/docs/reference/glossary/api-eviction.md
content/de/docs/reference/glossary/api-group.md
content/de/docs/reference/glossary/app-container.md
content/de/docs/reference/glossary/application-architect.md
content/de/docs/reference/glossary/application-developer.md
content/de/docs/reference/glossary/applications.md
content/de/docs/reference/glossary/approver.md