### PR TITLE
Add configuration block for Arabic to hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -509,3 +509,18 @@ time_format_blog = "02.01.2006"
 language_alternatives = ["en"]
 description = "Довершена система оркестрації контейнерів"
 languageNameLatinScript = "Ukrainian"
+
+[languages.ar]
+title = "كوبرنيتيز"
+languageName = "العربية (Arabic)"
+weight = 17
+contentDir = "content/ar"
+languagedirection = "rtl"
+
+[languages.ar.params]
+time_format_blog = "02.01.2006"
+# A list of language codes to look for untranslated content, ordered from left to right.
+language_alternatives = ["en"]
+description = "إدارة الحاويات لبيئات الإنتاج"
+languageNameLatinScript = "Arabic"
+


### PR DESCRIPTION
This commit will modify `hugo.toml` to have a new configuration block for the Arabic localization. Arabic is an RTL language.

This commit is part of a larger effort to initiate an Arabic localization of the
Kubernetes documentation. It contributes to achieving step 8 of the plan detailed in #44682:

> 8. Open a PR to configure a localization environment
> Note: base and target branches of the PR should be the dev branch of AR.
> [TODO] Add a configuration block for the new language to hugo.toml
> https://kubernetes.io/docs/contribute/localization/#modify-the-site-configuration

Note that this PR introduces the first spelling of "Kubernetes" in Arabic,
and as such, sets the standard for how the word should be spelled throughout
the documentation.