### PR TITLE
fixed installation guide in using CoreDNS for Service Discovery page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -32,7 +32,7 @@ that will deploy and upgrade the cluster for you.
 ## Installing CoreDNS
 
 For manual deployment or replacement of kube-dns, see the documentation at the
-[CoreDNS GitHub project.](https://github.com/coredns/deployment/tree/master/kubernetes)
+[CoreDNS GitHub project.](https://github.com/coredns/coredns.io/blob/master/content/manual/installation.md)
 
 ## Migrating to CoreDNS
 

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -32,7 +32,7 @@ that will deploy and upgrade the cluster for you.
 ## Installing CoreDNS
 
 For manual deployment or replacement of kube-dns, see the documentation at the
-[CoreDNS GitHub project.](https://github.com/coredns/coredns.io/blob/master/content/manual/installation.md)
+[CoreDNS website](https://coredns.io/manual/installation/).
 
 ## Migrating to CoreDNS
 


### PR DESCRIPTION
Fixed installation guide in "using CoreDNS for Service Discovery" page which was leading to https://github.com/coredns/deployment/tree/master/kubernetes