### PR TITLE
Rename concept section “Workload resources”

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/_index.md
+++ b/content/en/docs/concepts/workloads/controllers/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Workload Resources"
+title: "Workload Management"
 weight: 20
 simple_list: true
 ---


### PR DESCRIPTION
The term “resource“ is much used and often misleads readers, so I propose changing “Workload Resources” to “Workload Management”.

This section is really about the concepts in Kubernetes that let you manage your applications / workloads.