### PR TITLE
Fix links related to projection of keys and file permissions in the ConfigMap documentation

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -728,10 +728,8 @@ kubectl delete pod dapi-test-pod --now
 
 ### Project keys to specific paths and file permissions
 
-You can project keys to specific paths and specific permissions on a per-file
-basis. The
-[Secrets](/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod)
-guide explains the syntax.
+You can project keys to specific paths. Refer to the corresponding section in the [Secrets](/docs/tasks/inject-data-application/distribute-credentials-secure/#project-secret-keys-to-specific-file-paths) guide for the syntax.  
+You can set POSIX permissions for keys. Refer to the corresponding section in the [Secrets](/docs/tasks/inject-data-application/distribute-credentials-secure/#set-posix-permissions-for-secret-keys) guide for the syntax.
 
 ### Optional references
 


### PR DESCRIPTION
Fixes #44728 

The [Configure a Pod to Use a ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) page contains a section called [Project keys to specific paths and file permissions](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#project-keys-to-specific-paths-and-file-permissions).
This section contains a link to a corresponding section in the Secrets guide. The link does not take the user to the precise location.

This PR improves the reader's experience while navigating through this section, by redirecting to the exact locations in the Secrets guide.


Regards,
Aditya

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
