### PR TITLE
Revise body of patch request in StatefulSet tutorial

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -884,7 +884,7 @@ You select this update strategy for a StatefulSet by setting the
 Patch the `web` StatefulSet to use the `OnDelete` update strategy:
 
 ```shell
-kubectl patch statefulset web -p '{"spec":{"updateStrategy":{"type":"OnDelete"}}}'
+kubectl patch statefulset web -p '{"spec":{"updateStrategy":{"type":"OnDelete","rollingUpdate":null}}}'
 ```
 ```
 statefulset.apps/web patched


### PR DESCRIPTION
fixed body of patch request in StatefulSet tutorial
which was
kubectl patch statefulset web -p '{"spec":{"updateStrategy":{"type":"OnDelete"}}}'
To
kubectl patch statefulset web -p '{"spec":{"updateStrategy":{"type":"OnDelete","rollingUpdate":null}}}'
because most newbie of k8s will use minikube