### PR TITLE
Update description for the NetworkUnavailable condition

### DIFF
--- a/content/en/docs/reference/node/node-status.md
+++ b/content/en/docs/reference/node/node-status.md
@@ -47,7 +47,7 @@ The `conditions` field describes the status of all `Running` nodes. Examples of 
 | `DiskPressure`       | `True` if pressure exists on the disk size—that is, if the disk capacity is low; otherwise `False` |
 | `MemoryPressure`     | `True` if pressure exists on the node memory—that is, if the node memory is low; otherwise `False` |
 | `PIDPressure`        | `True` if pressure exists on the processes—that is, if there are too many processes on the node; otherwise `False` |
-| `NetworkUnavailable` | `True` if the network for the node is not correctly configured, otherwise `False` |
+| `NetworkUnavailable` | Reflects the network status as determined by the plugins; `True` if improperly configured, `False` for correct configuration and operational network. This value is plugin-dependent and not a Kubernetes standard. A network can be fully operational even if this condition does not exist. |
 {{< /table >}}
 
 {{< note >}}


### PR DESCRIPTION
## Why this PR?
In #42917 we found that the description for the `NetworkUnavailable` condition, when it's `False`, is not clear enough to understand how it should be interpreted. Also, the condition (`NetworkUnavailable`) is not something that's a k8s standard (managed by third-party libraries and plugins ) and the nodes can be fully functional even if that condition does not exist.

It is a result of a deeper issue which is being discussed in [#120486](https://github.com/kubernetes/kubernetes/issues/120486)

For this PR, we aim to clear the `NetworkUnavailable`'s description a bit.

## What was changed in this PR?
Update the description of `NetworkUnavailable` condition to:
- clarify what a `False` value means for this condition.
- clarify that it is not a k8s standard and is dependent on plugins.