### PR TITLE
Fix default status of StatefulsetAutoDeletePVC when beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/stateful-set-auto-delete-pvc.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/stateful-set-auto-delete-pvc.md
@@ -12,7 +12,7 @@ stages:
     fromVersion: "1.23"
     toVersion: "1.26"
   - stage: beta
-    defaultValue: false
+    defaultValue: true
     fromVersion: "1.27"
 ---
 Allows the use of the optional `.spec.persistentVolumeClaimRetentionPolicy` field, 


### PR DESCRIPTION
StatefulsetAutoDeletePVC has been on by default since it
graduated to Beta in 1.27

Fixes #43976


Signed-off-by: Naadir Jeewa <naadir.jeewa@broadcom.com>

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
