### PR TITLE
[zh] Sync access-application-cluster/*.md and relative linked files.

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/quick-reference.md
+++ b/content/zh-cn/docs/reference/kubectl/quick-reference.md
@@ -1,5 +1,5 @@
 ---
-title: kubectl 备忘单
+title: kubectl 快速参考
 content_type: concept
 weight: 10
 card:
@@ -7,7 +7,7 @@ card:
   weight: 10
 ---
 <!--
-title: kubectl Cheat Sheet
+title: kubectl Quick Reference
 reviewers:
 - erictune
 - krousey

--- a/content/zh-cn/docs/tasks/access-application-cluster/access-cluster-services.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/access-cluster-services.md
@@ -252,7 +252,8 @@ You may be able to put an apiserver proxy URL into the address bar of a browser.
 你或许能够将 API 服务器代理的 URL 放入浏览器的地址栏，然而：
 
 <!--
-- Web browsers cannot usually pass tokens, so you may need to use basic (password) auth. Apiserver can be configured to accept basic auth,
+- Web browsers cannot usually pass tokens, so you may need to use basic (password) auth.
+  Apiserver can be configured to accept basic auth,
   but your cluster may not be configured to accept basic auth.
 - Some web apps may not work, particularly those with client side javascript that construct URLs in a
   way that is unaware of the proxy path prefix.

--- a/content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
@@ -48,11 +48,11 @@ kubectl config view
 ```
 
 <!--
-Many of the [examples](/docs/reference/kubectl/cheatsheet/) provide an introduction to using
+Many of the [examples](/docs/reference/kubectl/quick-reference/) provide an introduction to using
 `kubectl`, and complete documentation is found in the
 [kubectl reference](/docs/reference/kubectl/).
 -->
-有许多[例子](/zh-cn/docs/reference/kubectl/cheatsheet/)介绍了如何使用 kubectl，
+有许多[例子](/zh-cn/docs/reference/kubectl/quick-reference/)介绍了如何使用 kubectl，
 可以在 [kubectl 参考](/zh-cn/docs/reference/kubectl/)中找到更完整的文档。
 
 <!--


### PR DESCRIPTION
1. Sync `access-application-cluster/*.md`
2. Rename and sync `cheatsheet.md` to `quick-reference.md`

Depends on PR #44669 link anchor fixes of file:

```
content/zh-cn/docs/tasks/administer-cluster/access-cluster-api.md
```