### PR TITLE
Fix access-cluster-services.md list indent

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/access-cluster-services.md
+++ b/content/en/docs/tasks/access-application-cluster/access-cluster-services.md
@@ -43,7 +43,7 @@ You have several options for connecting to nodes, pods and services from outside
   - Proxies may cause problems for some web applications.
   - Only works for HTTP/HTTPS.
   - Described [here](#manually-constructing-apiserver-proxy-urls).
-  - Access from a node or pod in the cluster.
+- Access from a node or pod in the cluster.
   - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
     Connect to other nodes, pods, and services from that shell.
   - Some clusters may allow you to ssh to a node in the cluster. From there you may be able to


### PR DESCRIPTION
Fix list indent in the section: [Ways to connect](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster-services/#ways-to-connect)

The correct list should have 3 method to connect nodes/pods/services:
* Public IP
* `kubectl proxy`
* From a pod/node in the cluster

--- 

See [preview](https://deploy-preview-44831--kubernetes-io-main-staging.netlify.app/docs/tasks/access-application-cluster/access-cluster-services/#ways-to-connect).