### PR TITLE
typo fix: "claimPolicy" to "persistentVolumeReclaimPolicy"

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -358,7 +358,7 @@ spec:
   ...
 ```
 
-This is useful if you want to consume PersistentVolumes that have their `claimPolicy` set
+This is useful if you want to consume PersistentVolumes that have their `persistentVolumeReclaimPolicy` set
 to `Retain`, including cases where you are reusing an existing PV.
 
 ### Expanding Persistent Volumes Claims


### PR DESCRIPTION
just renamed  "claimPolicy" to "persistentVolumeReclaimPolicy"
this will fix this page: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims

because PVC's dont have "claimPolicy" field but instead "persistentVolumeReclaimPolicy"
