### PR TITLE
[fr] translate tasks from the Managing Secrets section

### DIFF
--- a/content/fr/docs/tasks/configmap-secret/_index.md
+++ b/content/fr/docs/tasks/configmap-secret/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Gestion des Secrets"
+weight: 60
+description: Gérer des données confidentielles avec les Secrets.
+---
+

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -1,0 +1,248 @@
+---
+title: Gestion des Secrets avec un fichier de configuration
+content_type: task
+weight: 20
+description: Créer des Secrets en utilisant un fichier de configuration de ressources.
+---
+
+<!-- overview -->
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+## Créer le Secret {#create-the-config-file}
+
+Vous pouvez d'abord définir l'objet `Secret` dans un fichier, au format JSON ou YAML,
+puis créer cet objet. La ressource
+[Secret](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#secret-v1-core)
+contient deux clé : `data` et `stringData`.
+Le champ `data` est utilisé pour stocker des données encodées en base64. Le
+champ `stringData` est fourni par commodité et permet de fournir
+les mêmes données sous forme de texte non encodé.
+Les valeurs de `data` et `stringData` doivent être composées de caractères alphanumériques,
+`-`, `_` ou `.`.
+
+L'exemple suivant stocke deux chaînes de caractères dans un Secret en utilisant le champ `data`.
+
+1. Convertissez le texte en base64 :
+
+   ```shell
+   echo -n 'admin' | base64
+   echo -n '1f2d1e2e67df' | base64
+   ```
+
+   {{< note >}}
+   Les valeurs JSON et YAML sérialisées des données du Secret sont encodées en base64. Les sauts de ligne ne sont pas valides à l'intérieur de ces chaînes et doivent être omis. Lors de l'utilisation de l'utilitaire `base64` sur Darwin/macOS, les utilisateurs doivent éviter d'utiliser l'option `-b` pour diviser les lignes longues. En revanche, les utilisateurs Linux *doivent* ajouter l'option `-w 0` à la commande `base64` ou alors utiliser `base64 | tr -d '\n'` si l'option `-w` n'est pas disponible.
+   {{< /note >}}
+
+   Le résultat sera similaire à :
+
+   ```
+   YWRtaW4=
+   MWYyZDFlMmU2N2Rm
+   ```
+
+1. Créez le manifeste :
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: mysecret
+   type: Opaque
+   data:
+     username: YWRtaW4=
+     password: MWYyZDFlMmU2N2Rm
+   ```
+
+   Notez que le nom d'un objet Secret doit être un
+   [nom de sous-domaine DNS valide](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+
+1. Créez le Secret en utilisant [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
+
+   ```shell
+   kubectl apply -f ./secret.yaml
+   ```
+
+   Le résultat sera similaire à :
+
+   ```
+   secret/mysecret created
+   ```
+
+Pour vérifier que le Secret a été créé et pour décoder les données du Secret, référez-vous à la page sur la 
+[Gestion des secrets à l'aide de kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
+
+### Spécifier des données non encodées lors de la création d'un Secret
+
+Pour certains cas, vous pouvez
+utiliser le champ `stringData` à la place. Ce
+champ vous permet d'ajouter du texte non encodé directement dans le Secret,
+et il sera encodée pour vous lors de la création ou de la mise à jour du Secret.
+
+Un exemple pratique de ce besoin pourrait être lorsque vous déployez une application
+qui utilise un Secret pour stocker un fichier de configuration, et vous voulez configurer
+certaines parties de ce fichier de configuration pendant votre processus de déploiement.
+
+Par exemple, si votre application utilise le fichier de configuration suivant :
+
+```yaml
+apiUrl: "https://my.api.com/api/v1"
+username: "<user>"
+password: "<password>"
+```
+
+Vous pourriez le stocker dans un Secret en utilisant la définition suivante :
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+stringData:
+  config.yaml: |
+    apiUrl: "https://my.api.com/api/v1"
+    username: <user>
+    password: <password>
+```
+
+{{< note >}}
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur (Server Side Apply).
+{{< /note >}}
+
+Lorsque vous récupérez les données du Secret, la commande retourne les valeurs encodées,
+et non les valeurs en texte brut que vous avez fournies dans `stringData`.
+
+Par exemple, si vous exécutez la commande suivante :
+
+```shell
+kubectl get secret mysecret -o yaml
+```
+
+Le résultat sera similaire à :
+
+```yaml
+apiVersion: v1
+data:
+  config.yaml: YXBpVXJsOiAiaHR0cHM6Ly9teS5hcGkuY29tL2FwaS92MSIKdXNlcm5hbWU6IHt7dXNlcm5hbWV9fQpwYXNzd29yZDoge3twYXNzd29yZH19
+kind: Secret
+metadata:
+  creationTimestamp: 2018-11-15T20:40:59Z
+  name: mysecret
+  namespace: default
+  resourceVersion: "7225"
+  uid: c280ad2e-e916-11e8-98f2-025000000001
+type: Opaque
+```
+
+### Spécifier à la fois `data` et `stringData`
+
+Si vous spécifiez un champ à la fois dans `data` et `stringData`, la valeur de `stringData` sera utilisée.
+
+Par exemple, si vous définissez le Secret suivant :
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  username: YWRtaW4=
+stringData:
+  username: administrator
+```
+
+{{< note >}}
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur (Server Side Apply).
+{{< /note >}}
+
+L'objet `Secret` sera créé comme ceci :
+
+```yaml
+apiVersion: v1
+data:
+  username: YWRtaW5pc3RyYXRvcg==
+kind: Secret
+metadata:
+  creationTimestamp: 2018-11-15T20:46:46Z
+  name: mysecret
+  namespace: default
+  resourceVersion: "7579"
+  uid: 91460ecb-e917-11e8-98f2-025000000001
+type: Opaque
+```
+
+`YWRtaW5pc3RyYXRvcg==` décodé devient `administrator`.
+
+## Modifier un Secret {#edit-secret}
+
+Pour éditer les données du Secret que vous avez créé à l'aide d'un manifeste, modifiez le champ `data`
+ou `stringData` dans votre manifeste et appliquez le fichier à votre
+cluster. Vous pouvez éditer un objet Secret existant à moins qu'il ne soit
+[immuable](/docs/concepts/configuration/secret/#secret-immutable).
+
+Par exemple, si vous souhaitez changer le mot de passe de l'exemple précédent pour 
+`birdsarentreal`, procédez comme suit :
+
+1. Encodez le nouveau mot de passe:
+
+   ```shell
+   echo -n 'birdsarentreal' | base64
+   ```
+
+   Le résultat sera similaire à :
+
+   ```
+   YmlyZHNhcmVudHJlYWw=
+   ```
+
+1. Mettre à jour le champ `data` avec votre nouvelle valeur :
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: mysecret
+   type: Opaque
+   data:
+     username: YWRtaW4=
+     password: YmlyZHNhcmVudHJlYWw=
+   ```
+
+1. Appliquer la configuration sur votre cluster :
+
+   ```shell
+   kubectl apply -f ./secret.yaml
+   ```
+
+   Le résultat sera similaire à :
+
+   ```
+   secret/mysecret configured
+   ```
+
+Kubernetes met à jour l'objet Secret existant. Pour être précis, l'outil `kubectl`
+remarque qu'il existe déja un `Secret` existant avec le même nom. `kubectl`
+récupère l'objet existant, planifie les modifications dessus et soumet le `Secret` modifié au plan de contrôle du cluster.
+
+Si vous utilisez `kubectl apply --server-side`, `kubectl` utilisera plutôt
+[le traitement coté serveur (Server Side Apply)](/docs/reference/using-api/server-side-apply/).
+
+## Nettoyage
+
+Pour supprimer le Secret que vous venez de créer :
+
+```shell
+kubectl delete secret mysecret
+```
+
+## {{% heading "whatsnext" %}}
+
+- En savoir plus sur les [Secrets](/docs/concepts/configuration/secret/)
+- Apprendre comment [gérer les Secrets avec kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- Apprendre à [gérer les Secrets avec kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -35,7 +35,7 @@ L'exemple suivant stocke deux chaînes de caractères dans un Secret en utilisan
    ```
 
    {{< note >}}
-   Les valeurs JSON et YAML sérialisées des données du Secret sont encodées en base64. Les sauts de ligne ne sont pas valides à l'intérieur de ces chaînes et doivent être omis. Lors de l'utilisation de l'utilitaire `base64` sur Darwin/macOS, les utilisateurs doivent éviter d'utiliser l'option `-b` pour diviser les lignes longues. En revanche, les utilisateurs Linux *doivent* ajouter l'option `-w 0` à la commande `base64` ou alors utiliser `base64 | tr -d '\n'` si l'option `-w` n'est pas disponible.
+   Les valeurs JSON et YAML du Secret sont sérialisées puis encodées en base64. Les sauts de ligne ne sont pas valides à l'intérieur de ces chaînes et doivent être omis. Lors de l'utilisation de l'utilitaire `base64` sur Darwin/macOS, les utilisateurs doivent éviter d'utiliser l'option `-b` pour diviser les lignes longues. En revanche, les utilisateurs Linux *doivent* ajouter l'option `-w 0` à la commande `base64` ou alors utiliser `base64 | tr -d '\n'` si l'option `-w` n'est pas disponible.
    {{< /note >}}
 
    Le résultat sera similaire à :

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -81,7 +81,7 @@ Pour vérifier que le Secret a été créé et pour décoder les données du Sec
 Pour certains cas, vous pouvez
 utiliser le champ `stringData` à la place. Ce
 champ vous permet d'ajouter du texte non encodé directement dans le Secret,
-et il sera encodée pour vous lors de la création ou de la mise à jour du Secret.
+et il sera encodé pour vous lors de la création ou de la mise à jour du Secret.
 
 Un exemple pratique de ce besoin pourrait être lorsque vous déployez une application
 qui utilise un Secret pour stocker un fichier de configuration, et vous voulez configurer

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -243,6 +243,6 @@ kubectl delete secret mysecret
 
 ## {{% heading "whatsnext" %}}
 
-- En savoir plus sur les [Secrets](/docs/concepts/configuration/secret/)
-- Apprendre comment [gérer les Secrets avec kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
-- Apprendre à [gérer les Secrets avec kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
+- En savoir plus sur les [Secrets](/fr/docs/concepts/configuration/secret/)
+- Apprendre comment [gérer les Secrets avec kubectl](/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- Apprendre à [gérer les Secrets avec kustomize](/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize/)

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -111,7 +111,7 @@ stringData:
 ```
 
 {{< note >}}
-Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur (Server Side Apply).
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement des modifications coté serveur (Server Side Apply).
 {{< /note >}}
 
 Lorsque vous récupérez les données du Secret, la commande retourne les valeurs encodées,
@@ -158,7 +158,7 @@ stringData:
 ```
 
 {{< note >}}
-Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur (Server Side Apply).
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement des modifications coté serveur (Server Side Apply).
 {{< /note >}}
 
 L'objet `Secret` sera créé comme ceci :

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -84,7 +84,7 @@ champ vous permet d'ajouter du texte non encodé directement dans le Secret,
 et il sera encodé pour vous lors de la création ou de la mise à jour du Secret.
 
 Un exemple pratique de ce besoin pourrait être lorsque vous déployez une application
-qui utilise un Secret pour stocker un fichier de configuration, et vous voulez configurer
+qui utilise un Secret pour stocker un fichier de configuration, et que vous voulez configurer
 certaines parties de ce fichier de configuration pendant votre processus de déploiement.
 
 Par exemple, si votre application utilise le fichier de configuration suivant :

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -74,7 +74,7 @@ L'exemple suivant stocke deux chaînes de caractères dans un Secret en utilisan
    ```
 
 Pour vérifier que le Secret a été créé et pour décoder les données du Secret, référez-vous à la page sur la 
-[Gestion des secrets à l'aide de kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
+[Gestion des secrets à l'aide de kubectl](/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
 ### Spécifier des données non encodées lors de la création d'un Secret
 

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -41,7 +41,7 @@ Vous devez utiliser des guillemets simples `''` pour échapper les caractères s
 interprétera ces caractères.
 
 {{< note >}}
-Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur (Server Side Apply).
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement des modifications coté serveur (Server Side Apply).
 {{< /note >}}
 
 ### Utiliser des fichiers sources

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -201,6 +201,6 @@ kubectl delete secret db-user-pass
 
 ## {{% heading "whatsnext" %}}
 
-- En savoir plus sur le [concept de Secret](/docs/concepts/configuration/secret/)
-- Apprendre comment [gérer les Secrets avec des fichiers de configuration](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
-- Apprendre à [gérer les Secrets avec kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
+- En savoir plus sur le [concept de Secret](/fr/docs/concepts/configuration/secret/)
+- Apprendre comment [gérer les Secrets avec des fichiers de configuration](/fr/docs/tasks/configmap-secret/managing-secret-using-config-file/)
+- Apprendre à [gérer les Secrets avec kustomize](/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize/)

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -1,0 +1,206 @@
+---
+title: Gestion des secrets avec kubectl
+content_type: task
+weight: 10
+description: Créer des Secrets via la ligne de commande kubectl.
+---
+
+<!-- overview -->
+
+Cette page vous montre comment créer, éditer, gérer et supprimer des
+{{<glossary_tooltip text="Secrets" term_id="secret">}} Kubernetes en utilisant l'outil de ligne de commande `kubectl`.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+## Créer un Secret
+
+Un objet `Secret` stocke des données sensibles telles que des informations d'identification
+utilisées par des Pods pour accéder à des services. Par exemple, vous pourriez avoir besoin d'un Secret pour stocker
+le nom d'utilisateur et le mot de passe nécessaires pour accéder à une base de données.
+
+Vous pouvez créer le Secret en passant les données brutes dans la commande, ou en stockant
+les informations d'identification dans des fichiers que vous transmettez à la commande. Les commandes suivantes
+créent un Secret qui stocke le nom d'utilisateur `admin` et le mot de passe `S!B\*d$zDsb=`.
+
+### Utiliser des données brutes
+
+Exécutez la commande suivante :
+
+```shell
+kubectl create secret generic db-user-pass \
+    --from-literal=username=admin \
+    --from-literal=password='S!B\*d$zDsb='
+```
+
+Vous devez utiliser des guillemets simples `''` pour échapper les caractères spéciaux tels que `$`, `\`,
+`*`, `=`, et `!` dans vos chaînes de caractères. Sinon, votre shell 
+interprétera ces caractères.
+
+{{< note >}}
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur (Server Side Apply).
+{{< /note >}}
+
+### Utiliser des fichiers sources
+
+1. Stockez les informations d'identification dans des fichiers :
+
+   ```shell
+   echo -n 'admin' > ./username.txt
+   echo -n 'S!B\*d$zDsb=' > ./password.txt
+   ```
+
+   L'argument `-n` garantit que les fichiers générés n'ont pas de saut de ligne supplémentaire
+   à la fin du texte. C'est important car lorsque `kubectl` lit un fichier et encode le contenu dans une chaîne base64, le saut de ligne supplémentaire
+   sera également encodé. Vous n'avez pas besoin d'échapper les caractères spéciaux
+   dans les chaînes que vous incluez dans un fichier.
+
+1. Passez les chemins des fichiers dans la commande `kubectl` :
+
+   ```shell
+   kubectl create secret generic db-user-pass \
+       --from-file=./username.txt \
+       --from-file=./password.txt
+   ```
+
+   Par défaut, le nom de la clé sera le nom du fichier. Vous pouvez éventuellement définir le nom de la clé
+   en utilisant `--from-file=[key=]source`. Par exemple :
+
+   ```shell
+   kubectl create secret generic db-user-pass \
+       --from-file=username=./username.txt \
+       --from-file=password=./password.txt
+   ```
+
+Avec l'une ou l'autre méthode, le résultat est similaire à :
+
+```
+secret/db-user-pass created
+```
+
+### Vérifier le Secret {#verify-the-secret}
+
+Vérifiez que le Secret a été créé :
+
+```shell
+kubectl get secrets
+```
+
+Le résultat est similaire à :
+
+```
+NAME              TYPE       DATA      AGE
+db-user-pass      Opaque     2         51s
+```
+
+Affichez les détails du Secret :
+
+```shell
+kubectl describe secret db-user-pass
+```
+
+Le résultat est similaire à :
+
+```
+Name:            db-user-pass
+Namespace:       default
+Labels:          <none>
+Annotations:     <none>
+
+Type:            Opaque
+
+Data
+====
+password:    12 bytes
+username:    5 bytes
+```
+
+Les commandes `kubectl get` et `kubectl describe` n'affichent pas le contenu
+d'un `Secret` par défaut. Cela protège le `Secret` contre une exposition
+accidentelle, ou d'être stocké dans un historique de terminal.
+
+### Décoder le Secret {#decoding-secret}
+
+1. Affichez le contenu du Secret que vous avez créé :
+
+   ```shell
+   kubectl get secret db-user-pass -o jsonpath='{.data}'
+   ```
+
+   Le résultat est similaire à :
+
+   ```json
+   { "password": "UyFCXCpkJHpEc2I9", "username": "YWRtaW4=" }
+   ```
+
+1. Décodez les données de `password` :
+
+   ```shell
+   echo 'UyFCXCpkJHpEc2I9' | base64 --decode
+   ```
+
+   Le résultat est similaire à :
+
+   ```
+   S!B\*d$zDsb=
+   ```
+
+   {{< caution >}}
+   Ceci est un exemple à des fins de documentation. En pratique,
+   cette méthode pourrait entraîner l'enregistrement de la commande avec les données encodées
+   dans l'historique de votre shell. Toute personne ayant accès à votre ordinateur pourrait trouver la
+   commande et décoder le secret. Une meilleure approche consiste à combiner les commandes d'affichage et de décodage.
+   {{< /caution >}}
+
+   ```shell
+   kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
+   ```
+
+## Modifier un Secret {#edit-secret}
+
+Vous pouvez éditer un objet `Secret` existant sauf s'il est
+[immuable](/docs/concepts/configuration/secret/#secret-immutable). Pour éditer un
+Secret, exécutez la commande suivante :
+
+```shell
+kubectl edit secrets <secret-name>
+```
+
+Cela ouvre votre éditeur par défaut et vous permet de mettre à jour les valeurs base64 encodées
+du Secret dans le champ `data`, comme dans l'exemple suivant :
+
+```yaml
+# Éditez l'objet ci-dessous. Les lignes commençant par '#' seront ignorées,
+# et un fichier vide interrompra l'édition. Si une erreur se produit lors de l'enregistrement du fichier, il sera
+# re ouvert en affichant les erreurs.
+#
+apiVersion: v1
+data:
+  password: UyFCXCpkJHpEc2I9
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  creationTimestamp: "2022-06-28T17:44:13Z"
+  name: db-user-pass
+  namespace: default
+  resourceVersion: "12708504"
+  uid: 91becd59-78fa-4c85-823f-6d44436242ac
+type: Opaque
+```
+
+## Nettoyer
+
+Pour supprimer un Secret, exécutez la commande suivante :
+
+```shell
+kubectl delete secret db-user-pass
+```
+
+## {{% heading "whatsnext" %}}
+
+- En savoir plus sur le [concept de Secret](/docs/concepts/configuration/secret/)
+- Apprendre comment [gérer les Secrets avec des fichiers de configuration](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
+- Apprendre à [gérer les Secrets avec kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -148,6 +148,6 @@ kubectl delete secret db-user-pass
 
 ## {{% heading "whatsnext" %}}
 
-- En savoir plus sur le [concept de Secret](/docs/concepts/configuration/secret/)
+- En savoir plus sur le [concept de Secret](/fr/docs/concepts/configuration/secret/)
 - Apprendre comment [gérer les Secrets avec kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
 - Apprendre à [gérer les Secrets avec un fichier de configuration](/docs/tasks/configmap-secret/managing-secret-using-config-file/)

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -25,7 +25,7 @@ des valeurs littérales. Par exemple, les instructions suivantes créent un fich
 pour le nom d'utilisateur `admin` et le mot de passe `1f2d1e2e67df`.
 
 {{< note >}}
-Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur.
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement des modifications coté serveur (Server Side Apply).
 {{< /note >}}
 
 ### Créer le fichier Kustomization

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -149,5 +149,5 @@ kubectl delete secret db-user-pass
 ## {{% heading "whatsnext" %}}
 
 - En savoir plus sur le [concept de Secret](/fr/docs/concepts/configuration/secret/)
-- Apprendre comment [gérer les Secrets avec kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
-- Apprendre à [gérer les Secrets avec un fichier de configuration](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
+- Apprendre comment [gérer les Secrets avec kubectl](/fr/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- Apprendre à [gérer les Secrets avec un fichier de configuration](/fr/docs/tasks/configmap-secret/managing-secret-using-config-file/)

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -109,7 +109,7 @@ Le résutat est similaire à :
 echo 'UyFCXCpkJHpEc2I9' | base64 --decode
 ```
 
-Le résutat est similaire à :
+Le résultat est similaire à :
 
 ```
 S!B\*d$zDsb=

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -122,7 +122,7 @@ Pour en savor plus, consultez
 ## Modifier un Secret {#edit-secret}
 
 1.  Dans votre fichier `kustomization.yaml`, modifiez les données, par exemple `password`.
-1.  Appliquez le dossier contenant le fichier kustomization :
+2.  Appliquez le dossier contenant le fichier kustomization :
 
     ```shell
     kubectl apply -k <directory-path>

--- a/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/fr/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -1,0 +1,153 @@
+---
+title: Gestion des secrets avec Kustomize
+content_type: task
+weight: 30
+description: Créer des Secrets à l'aide du fichier kustomization.yaml.
+---
+
+<!-- overview -->
+
+`kubectl` prend en charge l'utilisation de l'outil de gestion des objets [Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/) pour gérer les Secrets
+et ConfigMaps. Vous créez un *générateur de ressources* avec Kustomize, qui
+génère un Secret que vous pouvez appliquer au serveur API à l'aide de `kubectl`.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+## Créer un Secret
+
+Vous pouvez générer un Secret en définissant un `secretGenerator` dans un
+fichier `kustomization.yaml` qui référence d'autres fichiers existants, des fichiers `.env`, ou
+des valeurs littérales. Par exemple, les instructions suivantes créent un fichier Kustomization
+pour le nom d'utilisateur `admin` et le mot de passe `1f2d1e2e67df`.
+
+{{< note >}}
+Le champ `stringData` pour un Secret ne fonctionne pas bien avec le traitement coté serveur.
+{{< /note >}}
+
+### Créer le fichier Kustomization
+
+{{< tabs name="Secret data" >}}
+{{< tab name="Données brutes" codelang="yaml" >}}
+secretGenerator:
+- name: database-creds
+  literals:
+  - username=admin
+  - password=1f2d1e2e67df
+{{< /tab >}}
+{{% tab name="Fichiers" %}}
+1.  Stockez les informations d'identification dans des fichiers. Les noms de fichiers sont les clés du secret :
+
+    ```shell
+    echo -n 'admin' > ./username.txt
+    echo -n '1f2d1e2e67df' > ./password.txt
+    ```
+    L'argument `-n` garantit qu'il n'y a pas de saut de ligne supplémentaire
+    à la fin de vos fichiers.
+
+1.  Créez le fichier `kustomization.yaml` :
+
+    ```yaml
+    secretGenerator:
+    - name: database-creds
+      files:
+      - username.txt
+      - password.txt
+    ```
+{{% /tab %}}
+{{% tab name="Fichiers .env" %}}
+Vous pouvez également définir le générateur de secret dans le fichier `kustomization.yaml` en
+fournissant des fichiers `.env`. Par exemple, le fichier `kustomization.yaml` suivant
+récupère les données du fichier `.env.secret` :
+
+```yaml
+secretGenerator:
+- name: db-user-pass
+  envs:
+  - .env.secret
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Dans tous les cas, vous n'avez pas besoin d'encoder les valeurs en base64. Le nom du fichier YAML
+**doit** être `kustomization.yaml` ou `kustomization.yml`.
+
+### Appliquer le fichier kustomization
+
+Pour créer le Secret, appliquez le répertoire contenant le fichier kustomization :
+
+```shell
+kubectl apply -k <directory-path>
+```
+
+Le résutat est similaire à :
+
+```
+secret/database-creds-5hdh7hhgfk created
+```
+
+Lorsqu'un Secret est généré, le nom du Secret est créé en hashant
+les données du Secret et en ajoutant la valeur de hachage au nom. Cela garantit qu'un 
+nouveau Secret sera généré à chaque fois que les données sont modifiées.
+
+Pour vérifier que le Secret a été créé et décoder les données du Secret, 
+
+```shell
+kubectl get -k <directory-path> -o jsonpath='{.data}' 
+```
+
+Le résutat est similaire à :
+
+```
+{ "password": "UyFCXCpkJHpEc2I9", "username": "YWRtaW4=" }
+```
+
+```
+echo 'UyFCXCpkJHpEc2I9' | base64 --decode
+```
+
+Le résutat est similaire à :
+
+```
+S!B\*d$zDsb=
+```
+
+Pour en savor plus, consultez
+[la gestion des secrets avec kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret) et la
+[Gestion déclarative des objets Kubernetes avec Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/).
+
+## Modifier un Secret {#edit-secret}
+
+1.  Dans votre fichier `kustomization.yaml`, modifiez les données, par exemple `password`.
+1.  Appliquez le dossier contenant le fichier kustomization :
+
+    ```shell
+    kubectl apply -k <directory-path>
+    ```
+
+    Le résultat sera similaire à :
+
+    ```
+    secret/db-user-pass-6f24b56cc8 created
+    ```
+
+Le Secret modifié est créé en tant que nouvel objet `Secret`, au lieu de mettre à jour 
+le `Secret` existant. Il sera peut-être nécessaire de 
+mettre à jour les références au Secret dans vos Pods.
+
+## Nettoyage
+
+Pour supprimer un Secret, utilisez `kubectl` :
+
+```shell
+kubectl delete secret db-user-pass
+```
+
+## {{% heading "whatsnext" %}}
+
+- En savoir plus sur le [concept de Secret](/docs/concepts/configuration/secret/)
+- Apprendre comment [gérer les Secrets avec kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- Apprendre à [gérer les Secrets avec un fichier de configuration](/docs/tasks/configmap-secret/managing-secret-using-config-file/)


### PR DESCRIPTION
Hi,

This adds the French translation for the 3 tasks from the "Managing Secrets" section: https://kubernetes.io/docs/tasks/configmap-secret/.

There is one thing where I'm not quite sure how to translate properly. A few notes talk about the Server Side Apply concept:
`Note: The stringData field for a Secret does not work well with server-side apply.`

Translating literally  "server-side apply" would be "Application coté serveur", which is not "wrong", but IMO it's confusing, as it could be understood as an actual application hosted on a server. I've used "traitement coté serveur", which I think is closer to the reference term, but there might be a better translation.