### PR TITLE
[zh] Sync network-policies.md and its yaml

### DIFF
--- a/content/zh-cn/examples/service/networking/networkpolicy.yaml
+++ b/content/zh-cn/examples/service/networking/networkpolicy.yaml
@@ -8,28 +8,28 @@ spec:
     matchLabels:
       role: db
   policyTypes:
-    - Ingress
-    - Egress
+  - Ingress
+  - Egress
   ingress:
-    - from:
-        - ipBlock:
-            cidr: 172.17.0.0/16
-            except:
-              - 172.17.1.0/24
-        - namespaceSelector:
-            matchLabels:
-              project: myproject
-        - podSelector:
-            matchLabels:
-              role: frontend
-      ports:
-        - protocol: TCP
-          port: 6379
+  - from:
+    - ipBlock:
+        cidr: 172.17.0.0/16
+        except:
+        - 172.17.1.0/24
+    - namespaceSelector:
+        matchLabels:
+          project: myproject
+    - podSelector:
+        matchLabels:
+          role: frontend
+    ports:
+    - protocol: TCP
+      port: 6379
   egress:
-    - to:
-        - ipBlock:
-            cidr: 10.0.0.0/24
-      ports:
-        - protocol: TCP
-          port: 5978
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/24
+    ports:
+    - protocol: TCP
+      port: 5978
 


### PR DESCRIPTION
Sync with en upstream

```
content/zh-cn/docs/concepts/services-networking/network-policies.md
```
See [preview](https://deploy-preview-44846--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/services-networking/network-policies/).