### PR TITLE
Replace scheduling plugins list with a table

### DIFF
--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -112,73 +112,30 @@ desired.
 The following plugins, enabled by default, implement one or more of these
 extension points:
 
-- `ImageLocality`: Favors nodes that already have the container images that the
-  Pod runs.
-  Extension points: `score`.
-- `TaintToleration`: Implements
-  [taints and tolerations](/docs/concepts/scheduling-eviction/taint-and-toleration/).
-  Implements extension points: `filter`, `preScore`, `score`.
-- `NodeName`: Checks if a Pod spec node name matches the current node.
-  Extension points: `filter`.
-- `NodePorts`: Checks if a node has free ports for the requested Pod ports.
-  Extension points: `preFilter`, `filter`.
-- `NodeAffinity`: Implements
-  [node selectors](/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
-  and [node affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).
-  Extension points: `filter`, `score`.
-- `PodTopologySpread`: Implements
-  [Pod topology spread](/docs/concepts/scheduling-eviction/topology-spread-constraints/).
-  Extension points: `preFilter`, `filter`, `preScore`, `score`.
-- `NodeUnschedulable`: Filters out nodes that have `.spec.unschedulable` set to
-  true.
-  Extension points: `filter`.
-- `NodeResourcesFit`: Checks if the node has all the resources that the Pod is
-  requesting. The score can use one of three strategies: `LeastAllocated`
-  (default), `MostAllocated` and `RequestedToCapacityRatio`.
-  Extension points: `preFilter`, `filter`, `score`.
-- `NodeResourcesBalancedAllocation`: Favors nodes that would obtain a more
-  balanced resource usage if the Pod is scheduled there.
-  Extension points: `score`.
-- `VolumeBinding`: Checks if the node has or if it can bind the requested
-  {{< glossary_tooltip text="volumes" term_id="volume" >}}.
-  Extension points: `preFilter`, `filter`, `reserve`, `preBind`, `score`.
-  {{< note >}}
-  `score` extension point is enabled when `VolumeCapacityPriority` feature is
-  enabled. It prioritizes the smallest PVs that can fit the requested volume
-  size.
-  {{< /note >}}
-- `VolumeRestrictions`: Checks that volumes mounted in the node satisfy
-  restrictions that are specific to the volume provider.
-  Extension points: `filter`.
-- `VolumeZone`: Checks that volumes requested satisfy any zone requirements they
-  might have.
-  Extension points: `filter`.
-- `NodeVolumeLimits`: Checks that CSI volume limits can be satisfied for the
-  node.
-  Extension points: `filter`.
-- `EBSLimits`: Checks that AWS EBS volume limits can be satisfied for the node.
-  Extension points: `filter`.
-- `GCEPDLimits`: Checks that GCP-PD volume limits can be satisfied for the node.
-  Extension points: `filter`.
-- `AzureDiskLimits`: Checks that Azure disk volume limits can be satisfied for
-  the node.
-  Extension points: `filter`.
-- `InterPodAffinity`: Implements
-  [inter-Pod affinity and anti-affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity).
-  Extension points: `preFilter`, `filter`, `preScore`, `score`.
-- `PrioritySort`: Provides the default priority based sorting.
-  Extension points: `queueSort`.
-- `DefaultBinder`: Provides the default binding mechanism.
-  Extension points: `bind`.
-- `DefaultPreemption`: Provides the default preemption mechanism.
-  Extension points: `postFilter`.
+|Plugin|Description|Extension Points|
+|---|---|---|
+|`AzureDiskLimits`|Checks that Azure disk volume limits can be satisfied for the node.|`filter`|
+|`CinderLimits`|Checks that [OpenStack Cinder](https://docs.openstack.org/cinder/) volume limits can be satisfied for the node.|`filter`|
+|`DefaultBinder`|Provides the default binding mechanism.|`bind`|
+|`DefaultPreemption`| Provides the default preemption mechanism.|`postFilter`|
+|`EBSLimits`| Checks that AWS EBS volume limits can be satisfied for the node.|`filter`|
+|`GCEPDLimits`| Checks that GCP-PD volume limits can be satisfied for the node.|`filter`|
+|`ImageLocality`|Favors nodes that already have the container images that the Pod runs.|`score`|
+|`InterPodAffinity`| Implements [inter-Pod affinity and anti-affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity).|`preFilter`, `filter`, `preScore`, `score`|
+|`NodeAffinity`|Implements [node selectors](/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) and [node affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).|`filter`, `score`|
+|`NodeName`|Checks if a Pod spec node name matches the current node.|`filter`|
+|`NodePorts`|Checks if a node has free ports for the requested Pod ports.|`preFilter`, `filter`|
+|`NodeResourcesBalancedAllocation`|Favors nodes that would obtain a more balanced resource usage if the Pod is scheduled there.|`score`|
+|`NodeResourcesFit`|Checks if the node has all the resources that the Pod is requesting. The score can use one of three strategies: `LeastAllocated` (default), `MostAllocated` and `RequestedToCapacityRatio`.|`preFilter`, `filter`, `score`.|
+|`NodeUnschedulable`|Filters out nodes that have `.spec.unschedulable` set to true. |`filter`|
+|`NodeVolumeLimits`| Checks that CSI volume limits can be satisfied for the node.|`filter`|
+|`PodTopologySpread`|Implements [Pod topology spread](/docs/concepts/scheduling-eviction/topology-spread-constraints/).|`preFilter`, `filter`, `preScore`, `score`|
+|`PrioritySort`|Provides the default priority based sorting.|`queueSort`|
+|`TaintToleration`|Implements [taints and tolerations](/docs/concepts/scheduling-eviction/taint-and-toleration/).|`filter`, `preScore`, `score`|
+|`VolumeBinding`|Checks if the node has or if it can bind the requested {{< glossary_tooltip text="volumes" term_id="volume" >}}. The `score` extension point is enabled when `VolumeCapacityPriority` feature is enabled. It prioritizes the smallest PVs that can fit the requested volume size.|`preFilter`, `filter`, `reserve`, `preBind`, `score`|
+|`VolumeRestrictions`|Checks that volumes mounted in the node satisfy restrictions that are specific to the volume provider.|`filter`|
+|`VolumeZone`|Checks that volumes requested satisfy any zone requirements they might have.|`filter`|
 
-You can also enable the following plugins, through the component config APIs,
-that are not enabled by default:
-
-- `CinderLimits`: Checks that [OpenStack Cinder](https://docs.openstack.org/cinder/)
-  volume limits can be satisfied for the node.
-  Extension points: `filter`.
 
 ### Multiple profiles
 


### PR DESCRIPTION
A proposal to move the Scheduler plugin list on document https://kubernetes.io/docs/reference/scheduling/config/ into a table

Current
![Screenshot 2024-01-22 at 16 10 50](https://github.com/kubernetes/website/assets/1822548/cc40b448-292b-4813-b1be-d1259863548b)

Proposal
![Screenshot 2024-01-22 at 16 12 13](https://github.com/kubernetes/website/assets/1822548/711670c6-40e9-44c6-86e7-180076d6a90d)
