### PR TITLE
[zh] Fix page formatting at https://k8s.io/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm

### DIFF
--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -340,13 +340,13 @@ These instructions are for Kubernetes {{< skew currentVersion >}}.
    curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
-   {{< note >}}
-   <!--
-   In releases older than Debian 12 and Ubuntu 22.04, folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command.
-   -->
-   在低于 Debian 12 和 Ubuntu 22.04 的发行版本中，`/etc/apt/keyrings` 默认不存在。
-   应在 curl 命令之前创建它。
-   {{< /note >}}
+{{< note >}}
+<!--
+In releases older than Debian 12 and Ubuntu 22.04, folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command.
+-->
+在低于 Debian 12 和 Ubuntu 22.04 的发行版本中，`/etc/apt/keyrings` 默认不存在。
+应在 curl 命令之前创建它。
+{{< /note >}}
 
 <!--
 3. Add the appropriate Kubernetes `apt` repository. Please note that this repository have packages


### PR DESCRIPTION
Fix the page formatting of https://k8s.io/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm, which is mentioned in #44848 

Links:
- [Current page](https://k8s.io/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm)
- [Preview](https://deploy-preview-44853--kubernetes-io-main-staging.netlify.app/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
