### PR TITLE
Mention how requests are inferred from limits

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
@@ -68,7 +68,6 @@ spec:
     stdin: true
     tty: true
     resources:
-      # Note: If only limits are specified, kubelet will deduce requests from those limits and set them to be the same as the limits.
       limits:
         cpu: 500m
         memory: 100Mi
@@ -97,6 +96,10 @@ The output is:
 ```
 map[cpu:250m memory:120Mi]
 ```
+
+{{< note >}}
+If only `limits` are specified, kubelet will deduce `requests` from those limits and set them to be the same as the defined `limits`.
+{{< /note >}}
 
 If a [ResourceQuota](/docs/concepts/policy/resource-quotas/) is defined, the sum of container requests as well as the
 `overhead` field are counted.

--- a/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
@@ -68,13 +68,14 @@ spec:
     stdin: true
     tty: true
     resources:
-      requests:
+      # Note: If only limits are specified, kubelet will deduce requests from those limits and set them to be the same as the limits.
+      limits:
         cpu: 500m
         memory: 100Mi
   - name: nginx-ctr
     image: nginx
     resources:
-      requests:
+      limits:
         cpu: 1500m
         memory: 100Mi
 ```

--- a/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
@@ -79,6 +79,10 @@ spec:
         memory: 100Mi
 ```
 
+{{< note >}}
+If only `limits` are specified in the pod definition, kubelet will deduce `requests` from those limits and set them to be the same as the defined `limits`.
+{{< /note >}}
+
 At admission time the RuntimeClass [admission controller](/docs/reference/access-authn-authz/admission-controllers/)
 updates the workload's PodSpec to include the `overhead` as described in the RuntimeClass. If the PodSpec already has this field defined,
 the Pod will be rejected. In the given example, since only the RuntimeClass name is specified, the admission controller mutates the Pod
@@ -96,10 +100,6 @@ The output is:
 ```
 map[cpu:250m memory:120Mi]
 ```
-
-{{< note >}}
-If only `limits` are specified, kubelet will deduce `requests` from those limits and set them to be the same as the defined `limits`.
-{{< /note >}}
 
 If a [ResourceQuota](/docs/concepts/policy/resource-quotas/) is defined, the sum of container requests as well as the
 `overhead` field are counted.

--- a/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
@@ -68,13 +68,13 @@ spec:
     stdin: true
     tty: true
     resources:
-      limits:
+      requests:
         cpu: 500m
         memory: 100Mi
   - name: nginx-ctr
     image: nginx
     resources:
-      limits:
+      requests:
         cpu: 1500m
         memory: 100Mi
 ```


### PR DESCRIPTION
In the example section for pod overhead - we need to have requests instead of limits. As sum of requests(not limits) is considered while admitting a pod with pod overhead