### PR TITLE
[kr-ko] Fix `configmap` to `configMap` in configmap.md

### DIFF
--- a/content/ko/docs/concepts/configuration/configmap.md
+++ b/content/ko/docs/concepts/configuration/configmap.md
@@ -174,7 +174,7 @@ spec:
       readOnly: true
   volumes:
   - name: foo
-    configmap:
+    configMap:
       name: myconfigmap
 ```
 


### PR DESCRIPTION
#### Why
'configmap' is an invalid field, correct to 'configMap'

#### Changes
* Fix `configmap` field in example to `configMap`

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
