### PR TITLE
[zh-cn] sync controllers/_index.md job.md pods/_index.md

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/controllers/_index.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/_index.md
@@ -1,10 +1,10 @@
 ---
-title: "工作负载资源"
+title: "工作负载管理"
 weight: 20
 simple_list: true
 ---
 <!--
-title: "Workload Resources"
+title: "Workload Management"
 weight: 20
 simple_list: true
 -->

--- a/content/zh-cn/docs/concepts/workloads/controllers/job.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/job.md
@@ -673,7 +673,7 @@ per index.
 为此，可以设置 `.spec.backoffLimitPerIndex` 来指定每个索引的最大 Pod 失败次数。
 
 <!--
-When the per-index backoff limit is exceeded for an index, Kuberentes considers the index as failed and adds it to the
+When the per-index backoff limit is exceeded for an index, Kubernetes considers the index as failed and adds it to the
 `.status.failedIndexes` field. The succeeded indexes, those with a successfully
 executed pods, are recorded in the `.status.completedIndexes` field, regardless of whether you set
 the `backoffLimitPerIndex` field.
@@ -1617,7 +1617,7 @@ the Job status, allowing the Pod to be removed by other controllers or users.
 {{< note >}}
 <!--
 See [My pod stays terminating](/docs/tasks/debug/debug-application/debug-pods/) if you
-observe that pods from a Job are stucked with the tracking finalizer.
+observe that pods from a Job are stuck with the tracking finalizer.
 -->
 如果你发现来自 Job 的某些 Pod 因存在负责跟踪的 Finalizer 而无法正常终止，
 请参阅[我的 Pod 一直处于终止状态](/zh-cn/docs/tasks/debug/debug-application/debug-pods/)。

--- a/content/zh-cn/docs/concepts/workloads/pods/_index.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/_index.md
@@ -213,17 +213,17 @@ Init containers run and complete before the app containers are started.
 {{< glossary_tooltip text="应用容器" term_id="app-container" >}}。
 Init 容器会在启动应用容器之前运行并完成。
 
-{{< feature-state for_k8s_version="v1.28" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.29" state="beta" >}}
 
 <!--
-Enabling the `SidecarContainers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+Enabled by default, the `SidecarContainers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 allows you to specify `restartPolicy: Always` for init containers.
 Setting the `Always` restart policy ensures that the init containers where you set it are
 kept running during the entire lifetime of the Pod.
 See [Sidecar containers and restartPolicy](/docs/concepts/workloads/pods/init-containers/#sidecar-containers-and-restartpolicy)
 for more details.
 -->
-启用 `SidecarContainers` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)允许你为
+启用 `SidecarContainers` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)（默认启用）允许你为
 Init 容器指定 `restartPolicy: Always`。设置重启策略为 `Always` 会确保 Init 容器在 Pod 的整个生命周期内保持运行。
 更多细节参阅[边车容器和重启策略](/zh-cn/docs/concepts/workloads/pods/init-containers/#sidecar-containers-and-restartpolicy)
 


### PR DESCRIPTION
content/zh-cn/docs/concepts/workloads/controllers/_index.md
content/zh-cn/docs/concepts/workloads/controllers/job.md
content/zh-cn/docs/concepts/workloads/pods/_index.md