### PR TITLE
Edit docker-specific image  name

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -133,7 +133,7 @@ description: |-
                and look for the <code>Image</code> field:</p>
                <p><code><b>kubectl describe pods</b></code></p>
                <p>To update the image of the application to version 2, use the <code>set image</code> subcommand, followed by the deployment name and the new image version:</p>
-               <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=jocatalin/kubernetes-bootcamp:v2</b></code></p>
+               <p><code><b>kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=docker.io/jocatalin/kubernetes-bootcamp:v2</b></code></p>
                <p>The command notified the Deployment to use a different image for your app and initiated a rolling update. Check the status of the new Pods, and view the old one terminating with the <code>get pods</code> subcommand:</p>
                <p><code><b>kubectl get pods</b></code></p>
             </div>


### PR DESCRIPTION
Hi K8s maintainers!

This documentation failed for me because I was running Minikube on Podman Desktop, and the image name `jocatalin/kubernetes-bootcamp` assumed that the registry was `docker.io`.

I think this slight modification would work for Docker and Podman alike. Let me know if you agree!