### PR TITLE
Hyperlinking client-go and clarifying a sentence

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -45,7 +45,7 @@ value for this field is `600`, i.e. ten minutes.
 Once created, a CertificateSigningRequest must be approved before it can be signed.
 Depending on the signer selected, a CertificateSigningRequest may be automatically approved
 by a {{< glossary_tooltip text="controller" term_id="controller" >}}.
-Otherwise, a CertificateSigningRequest must be manually approved either via the REST API - the most common
+Otherwise, a CertificateSigningRequest must be manually approved via the REST API - the most common
 methods for making these API requests include kubectl (by running `kubectl certificate approve`)
 and the Kubernetes go client library [client-go](https://github.com/kubernetes/client-go). Likewise, a CertificateSigningRequest may also be denied,
 which tells the configured signer that it must not sign the request.

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -45,7 +45,9 @@ value for this field is `600`, i.e. ten minutes.
 Once created, a CertificateSigningRequest must be approved before it can be signed.
 Depending on the signer selected, a CertificateSigningRequest may be automatically approved
 by a {{< glossary_tooltip text="controller" term_id="controller" >}}.
-Otherwise, a CertificateSigningRequest must be manually approved either via the REST API - the most common methods for making these API requests include kubectl (by running `kubectl certificate approve`) and the Kubernetes go client library [client-go](https://github.com/kubernetes/client-go). Likewise, a CertificateSigningRequest may also be denied,
+Otherwise, a CertificateSigningRequest must be manually approved either via the REST API - the most common
+methods for making these API requests include kubectl (by running `kubectl certificate approve`)
+and the Kubernetes go client library [client-go](https://github.com/kubernetes/client-go). Likewise, a CertificateSigningRequest may also be denied,
 which tells the configured signer that it must not sign the request.
 
 For certificates that have been approved, the next step is signing. The relevant signing controller

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -45,8 +45,7 @@ value for this field is `600`, i.e. ten minutes.
 Once created, a CertificateSigningRequest must be approved before it can be signed.
 Depending on the signer selected, a CertificateSigningRequest may be automatically approved
 by a {{< glossary_tooltip text="controller" term_id="controller" >}}.
-Otherwise, a CertificateSigningRequest must be manually approved either via the REST API (or client-go)
-or by running `kubectl certificate approve`. Likewise, a CertificateSigningRequest may also be denied,
+Otherwise, a CertificateSigningRequest must be manually approved either via the REST API - the most common methods for making these API requests include kubectl (by running `kubectl certificate approve`) and the Kubernetes go client library [client-go](https://github.com/kubernetes/client-go). Likewise, a CertificateSigningRequest may also be denied,
 which tells the configured signer that it must not sign the request.
 
 For certificates that have been approved, the next step is signing. The relevant signing controller


### PR DESCRIPTION
- Adding a hyperlink for client-go appears helpful.
- Clarifying that client-go and kubectl are still functioning via calls to the Kubernetes API.

I'm totally open to rejection here if it seems like the hyperlink isn't necessary.