### PR TITLE
Update kubeadm upgrade instructions

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -129,6 +129,15 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    kubeadm version
    ```
 
+1. Drain the node
+
+   Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
+
+   ```shell
+   # replace <node-to-drain> with the name of your node you are draining
+   kubectl drain <node-to-drain> --ignore-daemonsets
+   ```
+
 1. Verify the upgrade plan:
 
    ```shell
@@ -202,15 +211,6 @@ sudo kubeadm upgrade apply
 ```
 
 Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no longer needed.
-
-### Drain the node
-
-Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
-
-```shell
-# replace <node-to-drain> with the name of your node you are draining
-kubectl drain <node-to-drain> --ignore-daemonsets
-```
 
 ### Upgrade kubelet and kubectl
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -75,8 +75,8 @@ Find the latest patch release for Kubernetes {{< skew currentVersion >}} using t
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
 # It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
-apt update
-apt-cache madison kubeadm
+sudo apt update
+sudo apt-cache madison kubeadm
 ```
 
 {{% /tab %}}
@@ -107,9 +107,9 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
 
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   apt-mark unhold kubeadm && \
-   apt-get update && apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
-   apt-mark hold kubeadm
+   sudo apt-mark unhold kubeadm && \
+   sudo apt-get update && sudo apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
+   sudo apt-mark hold kubeadm
    ```
 
    {{% /tab %}}
@@ -221,9 +221,9 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   apt-mark unhold kubelet kubectl && \
-   apt-get update && apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
-   apt-mark hold kubelet kubectl
+   sudo apt-mark unhold kubelet kubectl && \
+   sudo apt-get update && sudo apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
+   sudo apt-mark hold kubelet kubectl
    ```
 
    {{% /tab %}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -75,8 +75,8 @@ Find the latest patch release for Kubernetes {{< skew currentVersion >}} using t
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
 # It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
-sudo apt update
-sudo apt-cache madison kubeadm
+apt update
+apt-cache madison kubeadm
 ```
 
 {{% /tab %}}
@@ -107,9 +107,9 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
 
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo apt-mark unhold kubeadm && \
-   sudo apt-get update && sudo apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
-   sudo apt-mark hold kubeadm
+   apt-mark unhold kubeadm && \
+   apt-get update && apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
+   apt-mark hold kubeadm
    ```
 
    {{% /tab %}}
@@ -221,9 +221,9 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo apt-mark unhold kubelet kubectl && \
-   sudo apt-get update && sudo apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
-   sudo apt-mark hold kubelet kubectl
+   apt-mark unhold kubelet kubectl && \
+   apt-get update && apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
+   apt-mark hold kubelet kubectl
    ```
 
    {{% /tab %}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -28,6 +28,16 @@ document.
 
 ## Upgrading worker nodes
 
+### Drain the node
+
+Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
+
+```shell
+# execute this command on a control plane node
+# replace <node-to-drain> with the name of your node you are draining
+kubectl drain <node-to-drain> --ignore-daemonsets
+```
+
 ### Upgrade kubeadm
 
 Upgrade kubeadm:
@@ -55,16 +65,6 @@ For worker nodes this upgrades the local kubelet configuration:
 
 ```shell
 sudo kubeadm upgrade node
-```
-
-### Drain the node
-
-Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
-
-```shell
-# execute this command on a control plane node
-# replace <node-to-drain> with the name of your node you are draining
-kubectl drain <node-to-drain> --ignore-daemonsets
 ```
 
 ### Upgrade kubelet and kubectl

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -22,15 +22,6 @@ upgrade the control plane nodes before upgrading your Windows nodes.
 
 ## Upgrading worker nodes
 
-### Upgrade kubeadm
-
-1.  From the Windows node, upgrade kubeadm:
-
-    ```powershell
-    # replace {{< skew currentPatchVersion >}} with your desired version
-    curl.exe -Lo <path-to-kubeadm.exe>  "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubeadm.exe"
-    ```
-
 ### Drain the node
 
 1.  From a machine with access to the Kubernetes API,
@@ -46,6 +37,15 @@ upgrade the control plane nodes before upgrading your Windows nodes.
     ```
     node/ip-172-31-85-18 cordoned
     node/ip-172-31-85-18 drained
+    ```
+
+### Upgrade kubeadm
+
+1.  From the Windows node, upgrade kubeadm:
+
+    ```powershell
+    # replace {{< skew currentPatchVersion >}} with your desired version
+    curl.exe -Lo <path-to-kubeadm.exe>  "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubeadm.exe"
     ```
 
 ### Upgrade the kubelet configuration


### PR DESCRIPTION
This PR moves `kubectl drain` instructions before `kubeadm upgrade plan` and `kubeadm upgrade apply`, because the node must be cordoned before upgrading (not after)
