### PR TITLE
note about kustomize embeded version

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -24,7 +24,9 @@ To apply those Resources, run `kubectl apply` with `--kustomize` or `-k` flag:
 kubectl apply -k <kustomization_directory>
 ```
 
-Note, that Kubectl embeds Kustomize, that's why, whenever something is not working, you should check it with Kustomize alone, to verify if it is version related or not, there is a chance that your Kubectl has old version of Kustomize embeded.
+{{< note >}}
+Note, that Kubectl embeds Kustomize, that's why, whenever something is not working, you should check it with Kustomize alone, to verify if it is version related or not, there is a chance that your Kubectl has an old version of Kustomize embedded.
+{{</ note >}}
 
 ## {{% heading "prerequisites" %}}
 

--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -25,7 +25,7 @@ kubectl apply -k <kustomization_directory>
 ```
 
 {{< note >}}
-Note, that Kubectl embeds Kustomize, that's why, whenever something is not working, you should check it with Kustomize alone, to verify if it is version related or not, there is a chance that your Kubectl has an old version of Kustomize embedded.
+Kubectl embeds Kustomize, that's why, whenever something is not working, you should check it with Kustomize alone, to verify if it is version related or not, there is a chance that your Kubectl has an old version of Kustomize embedded.
 {{</ note >}}
 
 ## {{% heading "prerequisites" %}}

--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -24,7 +24,7 @@ To apply those Resources, run `kubectl apply` with `--kustomize` or `-k` flag:
 kubectl apply -k <kustomization_directory>
 ```
 
-
+Note, that Kubectl embeds Kustomize, that's why, whenever something is not working, you should check it with Kustomize alone, to verify if it is version related or not, there is a chance that your Kubectl has old version of Kustomize embeded.
 
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
in rare cases there are situations when you are trying to do something

according to docs, everything should work

but in reality - does not

the reason - older version of kustomize embeded in kubectl

with this change we want to notify users about such possibility to avoid wtfs

more detailed discussion here:

https://github.com/kubernetes-sigs/kustomize/issues/5248