### PR TITLE
Update wording in API deprecation guide for v1.27 and v1.29

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -35,11 +35,11 @@ The **flowcontrol.apiserver.k8s.io/v1beta3** API version of FlowSchema and Prior
 
 ### v1.29
 
-The **v1.29** release will stop serving the following deprecated API versions:
+The **v1.29** release stopped serving the following deprecated API versions:
 
 #### Flow control resources {#flowcontrol-resources-v129}
 
-The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and PriorityLevelConfiguration will no longer be served in v1.29.
+The **flowcontrol.apiserver.k8s.io/v1beta2** API version of FlowSchema and PriorityLevelConfiguration is no longer served as of v1.29.
 
 * Migrate manifests and API clients to use the **flowcontrol.apiserver.k8s.io/v1** API version, available since v1.29, or the **flowcontrol.apiserver.k8s.io/v1beta3** API version, available since v1.26.
 * All existing persisted objects are accessible via the new API
@@ -54,7 +54,7 @@ The **v1.27** release stopped serving the following deprecated API versions:
 
 #### CSIStorageCapacity {#csistoragecapacity-v127}
 
-The **storage.k8s.io/v1beta1** API version of CSIStorageCapacity will no longer be served in v1.27.
+The **storage.k8s.io/v1beta1** API version of CSIStorageCapacity is no longer served as of v1.27.
 
 * Migrate manifests and API clients to use the **storage.k8s.io/v1** API version, available since v1.24.
 * All existing persisted objects are accessible via the new API


### PR DESCRIPTION
This PR updates the wording in the v1.27 and v1.29 sections of the deprecated API migration guide to reflect the fact that these releases have already been shipped.