### PR TITLE
[ja] sync k8s.io/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure/#次の項目 with en docs

### DIFF
--- a/content/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
+++ b/content/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
@@ -90,11 +90,12 @@ spec:
 
 ## {{% heading "whatsnext" %}}
 
-
 * [コンテナ](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)の`terminationMessagePath`フィールド参照
-* [ログ取得](/docs/concepts/cluster-administration/logging/)について
+* [イメージ](/ja/docs/concepts/containers/images/)の[ImagePullBackOff](/ja/docs/concepts/containers/images/#imagepullbackoff)参照
+* [ログ取得](/ja/docs/concepts/cluster-administration/logging/)について
 * [Goテンプレート](https://pkg.go.dev/text/template)について
-
+* [Podのステータス](/ja/docs/tasks/debug/debug-application/debug-init-containers/#understanding-pod-status)と[Podのフェーズ](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)について
+* [コンテナのステータス](/ja/docs/concepts/workloads/pods/pod-lifecycle/#container-states)について
 
 
 

--- a/content/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
+++ b/content/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure.md
@@ -91,7 +91,7 @@ spec:
 ## {{% heading "whatsnext" %}}
 
 * [コンテナ](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)の`terminationMessagePath`フィールド参照
-* [イメージ](/ja/docs/concepts/containers/images/)の[ImagePullBackOff](/ja/docs/concepts/containers/images/#imagepullbackoff)参照
+* [イメージ](/ja/docs/concepts/containers/images/)の[ImagePullBackOff](/ja/docs/concepts/containers/images/#imagepullbackoff)を参照
 * [ログ取得](/ja/docs/concepts/cluster-administration/logging/)について
 * [Goテンプレート](https://pkg.go.dev/text/template)について
 * [Podのステータス](/ja/docs/tasks/debug/debug-application/debug-init-containers/#understanding-pod-status)と[Podのフェーズ](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)について


### PR DESCRIPTION
Syncs ja docs page with a newer en page.

Links:
- [Japanese docs](https://kubernetes.io/ja/docs/tasks/debug/debug-application/determine-reason-pod-failure/#%E6%AC%A1%E3%81%AE%E9%A0%85%E7%9B%AE)
- [English docs](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/#what-s-next)
