### PR TITLE
Modified storage access for zone and deleted PersistentVolumeLabel since its deprecated

### DIFF
--- a/content/en/docs/setup/best-practices/multiple-zones.md
+++ b/content/en/docs/setup/best-practices/multiple-zones.md
@@ -95,12 +95,15 @@ such as Deployment, StatefulSet, or Job.
 
 ## Storage access for zones
 
-When persistent volumes are created, the `PersistentVolumeLabel`
-[admission controller](/docs/reference/access-authn-authz/admission-controllers/)
-automatically adds zone labels to any PersistentVolumes that are linked to a specific
-zone. The {{< glossary_tooltip text="scheduler" term_id="kube-scheduler" >}} then ensures,
+When persistent volumes are created, Kubernetes automatically adds zone labels 
+to any PersistentVolumes that are linked to a specific zone.
+The {{< glossary_tooltip text="scheduler" term_id="kube-scheduler" >}} then ensures,
 through its `NoVolumeZoneConflict` predicate, that pods which claim a given PersistentVolume
 are only placed into the same zone as that volume.
+
+Please note that the method of adding zone labels can depend on your 
+cloud provider and the storage provisioner you’re using. Always refer to the specific 
+documentation for your environment to ensure correct configuration.
 
 You can specify a {{< glossary_tooltip text="StorageClass" term_id="storage-class" >}}
 for PersistentVolumeClaims that specifies the failure domains (zones) that the


### PR DESCRIPTION
I just updated the "storage access" section in this page:
https://kubernetes.io/docs/setup/best-practices/multiple-zones/

So that dosen't contain "PersistentVolumeLabel" because its deprecated and added little text explain that zone labels are managed by the cloud provider or storage provisioner now