### PR TITLE
Add documentation for disable-force-detach-on-timeout

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -513,6 +513,29 @@ During a non-graceful shutdown, Pods are terminated in the two phases:
   recovered since the user was the one who originally added the taint.
 {{< /note >}}
 
+### Disable force detach on timeout {#disable-force-detach-on-timeout}
+
+With the advent of the "Non-graceful node shutdown" feature, users might opt
+to disable force detach on timeout in
+[kube controller manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
+
+Force detach on timeout can be disabled by setting the `disable-force-detach-on-timeout`
+flag in `kube controller manager`; this means that a volume that is hosted on a node that
+is unhealthy for more than 6 minutes will not have its associated
+[Volume Attachment](/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1/)
+deleted.
+
+If this behavior is disabled, then data corruption might be avoided in certain cases.
+
+However, manual mitigations might be required to repair the pod in question:
+* The user might opt to manually taint the underlying node via the
+[Non-Graceful Node Shutdown](#non-graceful-node-shutdown) procedure mentioned above if the node is
+truly detached.
+* If using the `Non-Graceful Node Shutdown` procedure is not an option, the user might opt to
+manually delete the necessary
+[Volume Attachment](/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1/)
+objects after manually unmounting and unstaging the volumes in question.
+
 ## Swap memory management {#swap-memory}
 
 {{< feature-state state="beta" for_k8s_version="v1.28" >}}

--- a/static/_redirects
+++ b/static/_redirects
@@ -79,6 +79,7 @@
 /docs/concepts/jobs/run-to-completion-finite-workloads/      /docs/concepts/workloads/controllers/job/ 301
 /id/docs/concepts/jobs/run-to-completion-finite-workloads/      /id/docs/concepts/workloads/controllers/job/ 301
 /docs/concepts/nodes/node/     /docs/concepts/architecture/nodes/ 301
+/docs/node-disable-force-detach-on-timeout/ /docs/concepts/architecture/nodes/#disable-force-detach-on-timeout 301
 /docs/concepts/services-networking/connect-applications-service/    /docs/tutorials/services/connect-applications-service/   301
 /docs/concepts/object-metadata/annotations/     /docs/concepts/overview/working-with-objects/annotations/ 301
 /docs/concepts/overview/     /docs/concepts/overview/what-is-kubernetes/ 301


### PR DESCRIPTION
Adding documentation for the new `disable-force-detach-on-timeout` flag.

The associated k8s PR can be found here: https://github.com/kubernetes/kubernetes/pull/120344

This is a new flag that is being added to disable force detach behavior when the 6 minute node unhealthy timer expires in kube-controller-manager in favor of [non-graceful node-shutdown](https://kubernetes.io/docs/concepts/architecture/nodes/#non-graceful-node-shutdown).

While I was able to test out most of this change by running `make serve`, I wasn't able to get any of the  static redirects working as a part of my local testing (including testing redirects I didn't add without my change). Is this expected?