### PR TITLE
[ja]Update kubeadm installation instructions in Japanese documentation

### DIFF
--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -126,19 +126,27 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
 
    ```shell
    sudo apt-get update
+   # apt-transport-httpsはダミーパッケージの可能性があります。その場合、そのパッケージはスキップできます
    sudo apt-get install -y apt-transport-https ca-certificates curl gpg
    ```
 
-2. Google Cloudの公開鍵をダウンロードします:
+2. Kubernetesパッケージリポジトリの公開署名キーをダウンロードします。すべてのリポジトリに同じ署名キーが使用されるため、URL内のバージョンは無視できます:
 
    ```shell
-   curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+   # `/etc/apt/keyrings`フォルダーが存在しない場合は、curlコマンドの前に作成する必要があります。下記の備考を参照してください。
+   # sudo mkdir -p -m 755 /etc/apt/keyrings
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
-3. Kubernetesの`apt`リポジトリを追加します:
+{{< note >}}
+Debian 12とUbuntu 22.04より古いリリースでは、`/etc/apt/keyrings`フォルダーはデフォルトでは存在しないため、curlコマンドの前に作成する必要があります。
+{{< /note >}}
+
+3. 適切なKubernetes `apt`リポジトリを追加します。このリポジトリには、Kubernetes {{< skew currentVersion >}}用のパッケージのみがあることに注意してください。他のKubernetesマイナーバージョンの場合は、目的のマイナーバージョンに一致するようにURL内のKubernetesマイナーバージョンを変更する必要があります(インストールする予定のKubernetesバージョンのドキュメントも読んでください):
 
    ```shell
-   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   # これにより、/etc/apt/sources.list.d/kubernetes.listにある既存の設定が上書きされます
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
 4. `apt`のパッケージ一覧を更新し、kubelet、kubeadm、kubectlをインストールします。そしてバージョンを固定します:

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -156,10 +156,6 @@ Debian 12とUbuntu 22.04より古いリリースでは、`/etc/apt/keyrings`フ�
    sudo apt-get install -y kubelet kubeadm kubectl
    sudo apt-mark hold kubelet kubeadm kubectl
    ```
-{{< note >}}
-Debian 12やUbuntu 22.04より古いリリースでは、`/etc/apt/keyrings`はデフォルトでは存在しません。
-必要に応じてこのディレクトリを作成し、誰でも読み取り可能で、管理者のみ書き込み可能にすることができます。
-{{< /note >}}
 
 {{% /tab %}}
 {{% tab name="CentOS、RHEL、またはFedora" %}}

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -122,7 +122,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
 
 {{< tabs name="k8s_install" >}}
 {{% tab name="Ubuntu、Debian、またはHypriotOS" %}}
-1. `apt`のパッケージ一覧を更新し、Kubernetesの`apt`リポジトリを利用するのに必要なパッケージをインストールします:
+1. `apt`のパッケージ一覧を更新し、Kubernetesの`apt`リポジトリーを利用するのに必要なパッケージをインストールします:
 
    ```shell
    sudo apt-get update
@@ -130,7 +130,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
    sudo apt-get install -y apt-transport-https ca-certificates curl gpg
    ```
 
-2. Kubernetesパッケージリポジトリの公開署名キーをダウンロードします。すべてのリポジトリに同じ署名キーが使用されるため、URL内のバージョンは無視できます:
+2. Kubernetesパッケージリポジトリーの公開署名キーをダウンロードします。すべてのリポジトリーに同じ署名キーが使用されるため、URL内のバージョンは無視できます:
 
    ```shell
    # `/etc/apt/keyrings`フォルダーが存在しない場合は、curlコマンドの前に作成する必要があります。下記の備考を参照してください。
@@ -142,7 +142,7 @@ kubeadmは`kubelet`や`kubectl`をインストールまたは管理**しない**
 Debian 12とUbuntu 22.04より古いリリースでは、`/etc/apt/keyrings`フォルダーはデフォルトでは存在しないため、curlコマンドの前に作成する必要があります。
 {{< /note >}}
 
-3. 適切なKubernetes `apt`リポジトリを追加します。このリポジトリには、Kubernetes {{< skew currentVersion >}}用のパッケージのみがあることに注意してください。他のKubernetesマイナーバージョンの場合は、目的のマイナーバージョンに一致するようにURL内のKubernetesマイナーバージョンを変更する必要があります(インストールする予定のKubernetesバージョンのドキュメントも読んでください):
+3. 適切なKubernetes `apt`リポジトリーを追加します。このリポジトリーには、Kubernetes {{< skew currentVersion >}}用のパッケージのみがあることに注意してください。他のKubernetesマイナーバージョンの場合は、目的のマイナーバージョンに一致するようにURL内のKubernetesマイナーバージョンを変更する必要があります(インストールする予定のKubernetesバージョンのドキュメントも読んでください):
 
    ```shell
    # これにより、/etc/apt/sources.list.d/kubernetes.listにある既存の設定が上書きされます


### PR DESCRIPTION
issue: #44495.
Due to operational errors in the previous PR, it ended up in an awkward state. So I re-created the PR.
The original PR is PR: #44496.

As suggested in the previous PR, I have made updates beyond fixing the problem, specifically revising the entire section related to Debian-based distributions.