### PR TITLE
Add missing space in Pod Lifecycle concept page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -161,7 +161,7 @@ the Pod level `restartPolicy` is either `OnFailure` or `Always`.
 When the kubelet is handling container restarts according to the configured restart
 policy, that only applies to restarts that make replacement containers inside the
 same Pod and running on the same node. After containers in a Pod exit, the kubelet
-restarts them with an exponential back-off delay (10s, 20s,40s, …), that is capped at
+restarts them with an exponential back-off delay (10s, 20s, 40s, …), that is capped at
 five minutes. Once a container has executed for 10 minutes without any problems, the
 kubelet resets the restart backoff timer for that container.
 [Sidecar containers and Pod lifecycle](/docs/concepts/workloads/pods/sidecar-containers/#sidecar-containers-and-pod-lifecycle)


### PR DESCRIPTION
No actual content change, just a missing space after a `,`.

No other issues have been found with `git grep -E ',[0-9]+s'`.