### PR TITLE
Adds a new concept page for autoscaling

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -1,11 +1,9 @@
 ---
-reviewers: []
 title: Autoscaling Workloads
 description: >-
-  With Autoscaling, you can automatically update your workloads or infrastructure in one way or another. This allows your cluster to react to changes in resource demand more elastically and efficiently.
+  With autoscaling, you can automatically update your workloads in one way or another. This allows your cluster to react to changes in resource demand more elastically and efficiently.
 content_type: concept
 weight: 40
-hide_summary: true # Listed separately in section index
 ---
 
 <!-- overview -->
@@ -25,22 +23,20 @@ The first option is referred to as _horizontal scaling_, while the second is ref
 
 <!-- body -->
 
-## Scaling Workloads Horizontally
+## Scaling workloads horizontally
 
 In Kubernetes, you can scale a workload horizontally using a _HorizontalPodAutoscaler_ (HPA).
 It is implemented as a Kubernetes API resource and a {{< glossary_tooltip text="controller" term_id="controller" >}}
 and periodically adjusts the number of {{< glossary_tooltip text="replicas" term_id="replica" >}}
 in a workload to match observed resource utilization such as CPU or memory usage.
 
-There is a [walkthrough example](../../../tasks/run-application/horizontal-pod-autoscale-walkthrough.md) of configuring a HorizontalPodAutoscaler for a Deployment.
+There is a [walkthrough example](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough) of configuring a HorizontalPodAutoscaler for a Deployment.
 
-## Scaling Workloads Vertically
+## Scaling workloads vertically
 
 _tba_ about VerticalPodAutoscaler
 
-## Scaling the Cluster
-
-_tba_ about Cluster Autoscaler and Karpenter
+##
 
 ## Advanced Scenarios
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -11,38 +11,39 @@ weight: 40
 In Kubernetes, you can _scale_ a workload depending on the current demand of resources.
 This allows your cluster to react to changes in resource demand more elastically and efficiently.
 
+When you scale a workload, you can either increase or decrease the number of replicas managed by
+the workload, or adjust the resources available to the replicas in-place.
+
+The first approach is referred to as _horizontal scaling_, while the second is referred to as
+_vertical scaling_.
+
 There are manual and automatic ways to scale your workloads, depending on your use case.
 
 <!-- body -->
 
 ## Scaling workloads manually
 
-Kubernetes supports _manual scaling_ of workloads, either by changing the number of
-{{< glossary_tooltip text="replicas" term_id="replica">}} defined for an object that manages a set of
-{{< glossary_tooltip text="Pods" term_id="pod" >}} (for example a {{< glossary_tooltip text="Deployment" term_id="deployment" >}}),
-or by adjusting the resource requests and limits of the replicas managed by the workload
-(for example CPU or memory):
+Kubernetes supports _manual scaling_ of workloads. Horizontal scaling can be done
+using the `kubectl` CLI.
+For vertical scaling, you need to _patch_ the resource definition of your workload.
 
-- [Running multiple instances of your app](/docs/tutorials/kubernetes-basics/scale/scale-intro/)
-- [Resizing CPU and memory resources assigned to containers](/docs/tasks/configure-pod-container/resize-container-resources)
+See below for examples of both strategies.
+
+- **Horizontal scaling**: [Running multiple instances of your app](/docs/tutorials/kubernetes-basics/scale/scale-intro/)
+- **Vertical scaling**: [Resizing CPU and memory resources assigned to containers](/docs/tasks/configure-pod-container/resize-container-resources)
 
 {{< note >}}
-Resizing a workload in-place **without** restarting the Pods or its Containers requires Kubernetes version 1.27 or later.
+Resizing a workload in-place **without** restarting the {{< glossary_tooltip text="Pods" term_id="pod" >}}
+or its {{< glossary_tooltip text="Containers" term_id="container" >}} requires Kubernetes version 1.27 or later.
 {{< /note >}}
 
 ## Scaling workloads automatically
 
 Kubernetes also supports _automatic scaling_ of workloads, which is the focus of this page.
 
-The concept of _Autoscaling_ in Kubernetes refers to the ability to automatically update the workloads of your cluster. This can be either an object that manages a set of Pods (for example a
-{{< glossary_tooltip text="Deployment" term_id="deployment" >}} or Pods or PodTemplates themselves.
-
-Depending on _what_ is being scaled, there are also different options for _how_ to scale:
-
-- scale the number of available instances (such as Replicas in a Deployment)
-- scale the available resources on existing instances themselves (such as CPU or memory of a {{< glossary_tooltip text="Container" term_id="container" >}} in a Pod)
-
-The first option is referred to as _horizontal scaling_, while the second is referred to as _vertical scaling_.
+The concept of _Autoscaling_ in Kubernetes refers to the ability to automatically update an
+object that manages a set of Pods (for example a
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}}.
 
 ### Scaling workloads horizontally
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -90,12 +90,21 @@ Additionally, the `InPlaceVerticalScaling` feature gate needs to be enabled.
 ### Autoscaling based on cluster size
 
 For workloads that need to be scaled based on the size of the cluster (for example
-`cluster-dns` or other system components), you can use the _Cluster Proportional Autoscaler_.<br />
-Just like the VPA, it is not part of the Kubernetes core, but hosted in its
-own repository [on GitHub](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler).
+`cluster-dns` or other system components), you can use the
+[_Cluster Proportional Autoscaler_](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler).<br />
+Just like the VPA, it is not part of the Kubernetes core, but hosted as its
+own project on GitHub.
 
 The Cluster Proportional Autoscaler watches the number of schedulable {{< glossary_tooltip text="nodes" term_id="node" >}}
 and cores and scales the number of replicas of the target workload accordingly.
+
+If the number of replicas should stay the same, you can scale your workloads vertically according to the cluster size using
+the [_Cluster Proportional Vertical Autoscaler_](https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler).
+The project is **currently in beta** and can be found on GitHub.
+
+While the Cluster Proportional Autoscaler scales the number of replicas of a workload, the Cluster Proportional Vertical Autoscaler
+adjusts the resource requests for a workload (for example a Deployment or DaemonSet) based on the number of nodes and/or cores
+in the cluster.
 
 ### Event driven Autoscaling
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -1,0 +1,55 @@
+---
+reviewers: []
+title: Autoscaling Workloads
+description: >-
+  With Autoscaling, you can automatically update your workloads or infrastructure in one way or another. This allows your cluster to react to changes in resource demand more elastically and efficiently.
+content_type: concept
+weight: 40
+hide_summary: true # Listed separately in section index
+---
+
+<!-- overview -->
+
+The concept of _Autoscaling_ in Kubernetes refers to the ability to automatically update the available
+resources of your cluster. This can be either a replication controller (for example a
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}} or
+{{< glossary_tooltip text="ReplicaSet" term_id="replica-set" >}}), or the cluster infrastructure
+itself (for example the number of {{< glossary_tooltip text="Nodes" term_id="node" >}}).
+
+Besides the differentiation in _what_ is being scaled, there are also different options for _how_ to scale:
+
+- scale the number of available instances (such as Pods or Nodes)
+- scale the available resources on existing instances themselves (such as CPU or memory)
+
+The first option is referred to as _horizontal scaling_, while the second is referred to as _vertical scaling_.
+
+<!-- body -->
+
+## Scaling Workloads Horizontally
+
+In Kubernetes, you can scale a workload horizontally using a _HorizontalPodAutoscaler_ (HPA).
+It is implemented as a Kubernetes API resource and a {{< glossary_tooltip text="controller" term_id="controller" >}}
+and periodically adjusts the number of {{< glossary_tooltip text="replicas" term_id="replica" >}}
+in a workload to match observed resource utilization such as CPU or memory usage.
+
+There is a [walkthrough example](../../../tasks/run-application/horizontal-pod-autoscale-walkthrough.md) of configuring a HorizontalPodAutoscaler for a Deployment.
+
+## Scaling Workloads Vertically
+
+_tba_ about VerticalPodAutoscaler
+
+## Scaling the Cluster
+
+_tba_ about Cluster Autoscaler and Karpenter
+
+## Advanced Scenarios
+
+_tba_ about Cluster Proportional Autoscaler, KEDA, and KNative Autoscaler
+
+## {{% heading "whatsnext" %}}
+
+- item 1
+- item 2
+  - subitem 1
+  - subitem 2
+- item 3

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -83,11 +83,12 @@ Mode | Description
 
 ### Event driven Autoscaling
 
-_tbd_
+It is also possible to scale workloads based on events, for example using the
+[_Kubernetes Event Driven Autoscaler_ (**KEDA**)](https://keda.sh/).
 
-### Autoscaling based on cluster size
-
-_tbd_
+KEDA is a CNCF graduated enabling you to scale your workloads based on the number
+of events to be processed, for example the amount of messages in a queue. There exists
+a wide range of adapters for different event sources to choose from.
 
 ### Autoscaling based on schedules
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -81,6 +81,15 @@ Mode | Description
 `Off` | The VPA does not automatically change the resource requirements of the pods. The recommendations are calculated and can be inspected in the VPA object.
 {{< /table >}}
 
+### Autoscaling based on cluster size
+
+For workloads that need to be scaled based on the size of the cluster (for example
+`cluster-dns` or other system components), you can use the _Cluster Proportional Autoscaler_.<br />
+Just like the VPA, it is not part of the Kubernetes core, but hosted in its
+own repository [on GitHub](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler).
+
+The Cluster Proportional Autoscaler watches the number of schedulable {{< glossary_tooltip text="nodes" term_id="node" >}} and cores and scales the number of replicas of the target workload accordingly.
+
 ### Event driven Autoscaling
 
 It is also possible to scale workloads based on events, for example using the

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -57,7 +57,29 @@ There is a [walkthrough tutorial](/docs/tasks/run-application/horizontal-pod-aut
 
 ### Scaling workloads vertically
 
-_tbd_
+You can automatically scale a workload vertically using a _VerticalPodAutoscaler_ (VPA).
+Different to the HPA, the VPA doesn't come with Kubernetes by default, but is a separate project
+that can be found [on GitHub](https://github.com/kubernetes/autoscaler/tree/9f87b78df0f1d6e142234bb32e8acbd71295585a/vertical-pod-autoscaler).
+
+Once installed, it allows you to create {{< glossary_tooltip text="CustomResourceDefinitions" term_id="customresourcedefinition" >}}
+(CRDs) for your workloads which define _how_ and _when_ to scale the resources of the managed replicas.
+
+{{< note >}}
+The current default version of the HPA (**v0.14.0**) requires **Kubernetes version 1.25** or later.
+You will also need to have the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
+installed to your cluster.
+{{< /note >}}
+
+At the moment, the VPA operates can operate in four different modes:
+
+{{< table caption="Different modes of the VPA" >}}
+Mode | Description
+:----|:-----------
+`Auto` | Currently `Recreate`, might change to in-place updates in the future
+`Recreate` | The VPA assigns resource requests on pod creation as well as updates them on existing pods by evicting them when the requested resources differ significantly from the new recommendation
+`Initial` | The VPA only assigns resource requests on pod creation and never changes them later.
+`Off` | The VPA does not automatically change the resource requirements of the pods. The recommendations are calculated and can be inspected in the VPA object.
+{{< /table >}}
 
 ### Event driven Autoscaling
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -18,32 +18,32 @@ There are manual and automatic ways to scale your workloads, depending on your u
 ## Scaling workloads manually
 
 Kubernetes supports _manual scaling_ of workloads, either by changing the number of
-{{< glossary_tooltip text="Replicas" term_id="replica">}} of an object that manages a set of
+{{< glossary_tooltip text="replicas" term_id="replica">}} defined for an object that manages a set of
 {{< glossary_tooltip text="Pods" term_id="pod" >}} (for example a {{< glossary_tooltip text="Deployment" term_id="deployment" >}}),
 or by adjusting the provided resources of each Replica (for example CPU or memory).
 
-### Scaling the number of Replicas of a workload
+### Manual changes to replica count
 
-You can use the `kubectl scale` command to increase or decrease the number of Replicas of a workload:
+You can use the `kubectl scale` command to increase or decrease the number of replicas for a workload:
 
 ```shell
-kubectl scale deployment <deployment-name> --replicas=<desired-replicas>
+kubectl scale deployment <deployment-name> --replicas=<desired-count>
 ```
 
 See also this [example of scaling a Deployment](/docs/concepts/workloads/controllers/deployment/#scaling-a-deployment) in the `Deployment` documentation.
 
 ### Resizing workloads in-place
 
-Instead of scaling the number of Replicas of a workload, you can also adjust the provided resources
-of each Replica, in-place. You do this by patching the entries in one or both of the following
-fields of the `Pod` or [PodTemplate](/docs/concepts/workloads/pods/#pod-templates) you want to resize:
+Instead of scaling the number of replicas of a workload, you can also adjust the provided resources
+for a particular pod or set of pods, in-place. You do this by patching the entries in one or both of the following
+fields of the `Pod` or [pod template](/docs/concepts/workloads/pods/#pod-templates) you want to resize:
 
 - `spec.containers[*].resources.requests`
 - `spec.containers[*].resources.limits`
 
-{{< caution >}}
+{{< note >}}
 Resizing a workload in-place **without** restarting the Pods or its Containers requires Kubernetes version 1.27 or later.
-{{< /caution >}}
+{{< /note >}}
 
 See also this task about [resizing CPU and memory resources](/docs/tasks/configure-pod-container/resize-container-resources) assigned to Containers.
 
@@ -66,10 +66,10 @@ The first option is referred to as _horizontal scaling_, while the second is ref
 In Kubernetes, you can automatically scale a workload horizontally using a _HorizontalPodAutoscaler_ (HPA).
 
 It is implemented as a Kubernetes API resource and a {{< glossary_tooltip text="controller" term_id="controller" >}}
-and periodically adjusts the number of {{< glossary_tooltip text="Replicas" term_id="replica" >}}
+and periodically adjusts the number of {{< glossary_tooltip text="replicas" term_id="replica" >}}
 in a workload to match observed resource utilization such as CPU or memory usage.
 
-There is a [walkthrough example](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough) of configuring a HorizontalPodAutoscaler for a Deployment.
+There is a [walkthrough tutorial](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough) of configuring a HorizontalPodAutoscaler for a Deployment.
 
 ### Scaling workloads vertically
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -20,32 +20,15 @@ There are manual and automatic ways to scale your workloads, depending on your u
 Kubernetes supports _manual scaling_ of workloads, either by changing the number of
 {{< glossary_tooltip text="replicas" term_id="replica">}} defined for an object that manages a set of
 {{< glossary_tooltip text="Pods" term_id="pod" >}} (for example a {{< glossary_tooltip text="Deployment" term_id="deployment" >}}),
-or by adjusting the provided resources of each Replica (for example CPU or memory).
+or by adjusting the resource requests and limits of the replicas managed by the workload
+(for example CPU or memory):
 
-### Manual changes to replica count
-
-You can use the `kubectl scale` command to increase or decrease the number of replicas for a workload:
-
-```shell
-kubectl scale deployment <deployment-name> --replicas=<desired-count>
-```
-
-See also this [example of scaling a Deployment](/docs/concepts/workloads/controllers/deployment/#scaling-a-deployment) in the `Deployment` documentation.
-
-### Resizing workloads in-place
-
-Instead of scaling the number of replicas of a workload, you can also adjust the provided resources
-for a particular pod or set of pods, in-place. You do this by patching the entries in one or both of the following
-fields of the `Pod` or [pod template](/docs/concepts/workloads/pods/#pod-templates) you want to resize:
-
-- `spec.containers[*].resources.requests`
-- `spec.containers[*].resources.limits`
+- [Running multiple instances of your app](/docs/tutorials/kubernetes-basics/scale/scale-intro/)
+- [Resizing CPU and memory resources assigned to containers](/docs/tasks/configure-pod-container/resize-container-resources)
 
 {{< note >}}
 Resizing a workload in-place **without** restarting the Pods or its Containers requires Kubernetes version 1.27 or later.
 {{< /note >}}
-
-See also this task about [resizing CPU and memory resources](/docs/tasks/configure-pod-container/resize-container-resources) assigned to Containers.
 
 ## Scaling workloads automatically
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -8,39 +8,92 @@ weight: 40
 
 <!-- overview -->
 
-The concept of _Autoscaling_ in Kubernetes refers to the ability to automatically update the available
-resources of your cluster. This can be either a replication controller (for example a
-{{< glossary_tooltip text="Deployment" term_id="deployment" >}} or
-{{< glossary_tooltip text="ReplicaSet" term_id="replica-set" >}}), or the cluster infrastructure
-itself (for example the number of {{< glossary_tooltip text="Nodes" term_id="node" >}}).
+In Kubernetes, you can _scale_ a workload depending on the current demand of resources.
+This allows your cluster to react to changes in resource demand more elastically and efficiently.
 
-Besides the differentiation in _what_ is being scaled, there are also different options for _how_ to scale:
-
-- scale the number of available instances (such as Pods or Nodes)
-- scale the available resources on existing instances themselves (such as CPU or memory)
-
-The first option is referred to as _horizontal scaling_, while the second is referred to as _vertical scaling_.
+There are manual and automatic ways to scale your workloads, depending on your use case.
 
 <!-- body -->
 
-## Scaling workloads horizontally
+## Scaling workloads manually
 
-In Kubernetes, you can scale a workload horizontally using a _HorizontalPodAutoscaler_ (HPA).
+Kubernetes supports _manual scaling_ of workloads, either by changing the number of
+{{< glossary_tooltip text="Replicas" term_id="replica">}} of an object that manages a set of
+{{< glossary_tooltip text="Pods" term_id="pod" >}} (for example a {{< glossary_tooltip text="Deployment" term_id="deployment" >}}),
+or by adjusting the provided resources of each Replica (for example CPU or memory).
+
+### Scaling the number of Replicas of a workload
+
+You can use the `kubectl scale` command to increase or decrease the number of Replicas of a workload:
+
+```shell
+kubectl scale deployment <deployment-name> --replicas=<desired-replicas>
+```
+
+See also this [example of scaling a Deployment](/docs/concepts/workloads/controllers/deployment/#scaling-a-deployment) in the `Deployment` documentation.
+
+### Resizing workloads in-place
+
+Instead of scaling the number of Replicas of a workload, you can also adjust the provided resources
+of each Replica, in-place. You do this by patching the entries in one or both of the following
+fields of the `Pod` or [PodTemplate](/docs/concepts/workloads/pods/#pod-templates) you want to resize:
+
+- `spec.containers[*].resources.requests`
+- `spec.containers[*].resources.limits`
+
+{{< caution >}}
+Resizing a workload in-place **without** restarting the Pods or its Containers requires Kubernetes version 1.27 or later.
+{{< /caution >}}
+
+See also this task about [resizing CPU and memory resources](/docs/tasks/configure-pod-container/resize-container-resources) assigned to Containers.
+
+## Scaling workloads automatically
+
+Kubernetes also supports _automatic scaling_ of workloads, which is the focus of this page.
+
+The concept of _Autoscaling_ in Kubernetes refers to the ability to automatically update the workloads of your cluster. This can be either an object that manages a set of Pods (for example a
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}} or Pods or PodTemplates themselves.
+
+Depending on _what_ is being scaled, there are also different options for _how_ to scale:
+
+- scale the number of available instances (such as Replicas in a Deployment)
+- scale the available resources on existing instances themselves (such as CPU or memory of a {{< glossary_tooltip text="Container" term_id="container" >}} in a Pod)
+
+The first option is referred to as _horizontal scaling_, while the second is referred to as _vertical scaling_.
+
+### Scaling workloads horizontally
+
+In Kubernetes, you can automatically scale a workload horizontally using a _HorizontalPodAutoscaler_ (HPA).
+
 It is implemented as a Kubernetes API resource and a {{< glossary_tooltip text="controller" term_id="controller" >}}
-and periodically adjusts the number of {{< glossary_tooltip text="replicas" term_id="replica" >}}
+and periodically adjusts the number of {{< glossary_tooltip text="Replicas" term_id="replica" >}}
 in a workload to match observed resource utilization such as CPU or memory usage.
 
 There is a [walkthrough example](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough) of configuring a HorizontalPodAutoscaler for a Deployment.
 
-## Scaling workloads vertically
+### Scaling workloads vertically
 
-_tba_ about VerticalPodAutoscaler
+_tbd_
 
-##
+### Event driven Autoscaling
 
-## Advanced Scenarios
+_tbd_
 
-_tba_ about Cluster Proportional Autoscaler, KEDA, and KNative Autoscaler
+### Autoscaling based on cluster size
+
+_tbd_
+
+### Autoscaling based on schedules
+
+_tbd_
+
+## Scaling cluster infrastructure
+
+_tbd_, short summary
+
+## Third-party Autoscalers
+
+_tbd_, short summary of KEDA and KNative autoscalers
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -32,11 +32,6 @@ See below for examples of both strategies.
 - **Horizontal scaling**: [Running multiple instances of your app](/docs/tutorials/kubernetes-basics/scale/scale-intro/)
 - **Vertical scaling**: [Resizing CPU and memory resources assigned to containers](/docs/tasks/configure-pod-container/resize-container-resources)
 
-{{< note >}}
-Resizing a workload in-place **without** restarting the {{< glossary_tooltip text="Pods" term_id="pod" >}}
-or its {{< glossary_tooltip text="Containers" term_id="container" >}} requires Kubernetes version 1.27 or later.
-{{< /note >}}
-
 ## Scaling workloads automatically
 
 Kubernetes also supports _automatic scaling_ of workloads, which is the focus of this page.
@@ -57,6 +52,8 @@ There is a [walkthrough tutorial](/docs/tasks/run-application/horizontal-pod-aut
 
 ### Scaling workloads vertically
 
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
+
 You can automatically scale a workload vertically using a _VerticalPodAutoscaler_ (VPA).
 Different to the HPA, the VPA doesn't come with Kubernetes by default, but is a separate project
 that can be found [on GitHub](https://github.com/kubernetes/autoscaler/tree/9f87b78df0f1d6e142234bb32e8acbd71295585a/vertical-pod-autoscaler).
@@ -65,12 +62,11 @@ Once installed, it allows you to create {{< glossary_tooltip text="CustomResourc
 (CRDs) for your workloads which define _how_ and _when_ to scale the resources of the managed replicas.
 
 {{< note >}}
-The current default version of the HPA (**v0.14.0**) requires **Kubernetes version 1.25** or later.
-You will also need to have the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
-installed to your cluster.
+You will need to have the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
+installed to your cluster for the HPA to work.
 {{< /note >}}
 
-At the moment, the VPA operates can operate in four different modes:
+At the moment, the VPA can operate in four different modes:
 
 {{< table caption="Different modes of the VPA" >}}
 Mode | Description
@@ -81,6 +77,16 @@ Mode | Description
 `Off` | The VPA does not automatically change the resource requirements of the pods. The recommendations are calculated and can be inspected in the VPA object.
 {{< /table >}}
 
+#### Requirements for in-place resizing
+
+{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+
+Resizing a workload in-place **without** restarting the {{< glossary_tooltip text="Pods" term_id="pod" >}}
+or its {{< glossary_tooltip text="Containers" term_id="container" >}} requires Kubernetes version 1.27 or later.<br />
+Additionally, the `InPlaceVerticalScaling` feature gate needs to be enabled.
+
+{{< feature-gate-description name="InPlacePodVerticalScaling" >}}
+
 ### Autoscaling based on cluster size
 
 For workloads that need to be scaled based on the size of the cluster (for example
@@ -88,7 +94,8 @@ For workloads that need to be scaled based on the size of the cluster (for examp
 Just like the VPA, it is not part of the Kubernetes core, but hosted in its
 own repository [on GitHub](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler).
 
-The Cluster Proportional Autoscaler watches the number of schedulable {{< glossary_tooltip text="nodes" term_id="node" >}} and cores and scales the number of replicas of the target workload accordingly.
+The Cluster Proportional Autoscaler watches the number of schedulable {{< glossary_tooltip text="nodes" term_id="node" >}}
+and cores and scales the number of replicas of the target workload accordingly.
 
 ### Event driven Autoscaling
 
@@ -101,20 +108,30 @@ a wide range of adapters for different event sources to choose from.
 
 ### Autoscaling based on schedules
 
-_tbd_
+Another strategy for scaling your workloads is to **schedule** the scaling operations, for example in order to
+reduce resource consumption during off-peak hours.
+
+Similar to event driven autoscaling, such behavior can be achieved using KEDA in conjunction with
+its [`Cron` scaler](https://keda.sh/docs/2.13/scalers/cron/). The `Cron` scaler allows you to define schedules
+(and time zones) for scaling your workloads in or out.
 
 ## Scaling cluster infrastructure
 
-_tbd_, short summary
+If scaling workloads isn't enough to meet your needs, you can also scale your cluster infrastructure itself.
 
-## Third-party Autoscalers
+Scaling the cluster infrastructure normally means adding or removing {{< glossary_tooltip text="nodes" term_id="node" >}}.
+This can be done using one of two available autoscalers:
 
-_tbd_, short summary of KEDA and KNative autoscalers
+- [**Cluster Autoscaler**](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
+- [**Karpenter**](https://github.com/kubernetes-sigs/karpenter?tab=readme-ov-file)
+
+Both scalers work by watching for pods marked as _unschedulable_ or _underutilized_ nodes and then adding or
+removing nodes as needed.
 
 ## {{% heading "whatsnext" %}}
 
-- item 1
-- item 2
-  - subitem 1
-  - subitem 2
-- item 3
+- Learn more about scaling horizontally
+  - [Scale a StatefulSet](/docs/tasks/run-application/scale-stateful-set/)
+  - [HorizontalPodAutoscaler Walkthrough](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/)
+- [Resize Container Resources In-Place](/docs/tasks/configure-pod-container/resize-container-resources/)
+- [Autoscale the DNS Service in a Cluster](/docs/tasks/administer-cluster/dns-horizontal-autoscaling/)


### PR DESCRIPTION
This PR introduces a new Concept page Autoscaling, providing an overview of the different options available. It fixes #44084.

I plan to add to the skeleton currently pushed to the PR over the next days.

Some questions for now:

- Is the overall style acceptable? I read the [style guide](https://kubernetes.io/docs/contribute/style/style-guide/), but finding a balance of formatting too much/too little is hard
- Is a single file `concepts/workloads/autoscaling.md` fine or should it rather go into a new directory, e.g. `concepts/workloads/autoscaling/_index.md`?
- How detailed should the overview be? For example, the [Horizontal Pod Autoscaling Task](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) is incredibly detailed - should I link there **OR** copy bits and pieces **OR** will content be moved over in the future? The HPA overview is one paragraph + a link to the corresponding task for now

---
[Preview](https://deploy-preview-44959--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/autoscaling/)