### PR TITLE
Fix grammatical error regarding setup scripts in Kubernetes Components documentation

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -31,7 +31,7 @@ as well as detecting and responding to cluster events (for example, starting up 
 `{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
 
 Control plane components can be run on any machine in the cluster. However,
-for simplicity, set up scripts typically start all control plane components on
+for simplicity, setup scripts typically start all control plane components on
 the same machine, and do not run user containers on this machine. See
 [Creating Highly Available clusters with kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/)
 for an example control plane setup that runs across multiple machines.


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This Pull Request aims to correct a typo in the documentation by updating instances of "set up scripts" to the correct "setup scripts." According to the Microsoft Style Guide for documentation (https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/set-up-setup), "setup" should be one word when it is used as an adjective or noun.
