### PR TITLE
Add info on using the figure hugo shortcode

### DIFF
--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -124,6 +124,10 @@ Submissions need to be in Markdown format to be used by the [Hugo](https://gohug
 for the blog. There are [many resources available](https://gohugo.io/documentation/) on how to use
 this technology stack.
 
+For illustrations, diagrams or charts, the [figure shortcode](https://gohugo.io/content-management/shortcodes/#figure)
+can be used. For other images, we strongly encourage use of alt attributes; if an image doesn't
+need any alt attrribute, maybe it's not needed in the article at all.
+
 We recognize that this requirement makes the process more difficult for less-familiar folks to
 submit, and we're constantly looking at solutions to lower this bar. If you have ideas on how to
 lower the barrier, please volunteer to help out. 


### PR DESCRIPTION
This change adds some information about using the `figure` hugo shortcode for adding images to a blog article.
I've added it to the 'Technical Considerations for submitting a blog post' section just after where hugo is mentioned so that it flows logically for anyone reading the guide.

For related discussion, see https://kubernetes.slack.com/archives/CJDHVD54J/p1706544061503169