### PR TITLE
Add issue link info to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,5 @@
 <!--
-
  Hello!
-
- Remember to ADD A DESCRIPTION and delete this note before submitting
- your pull request. The description should explain what will change,
- and why.
 
  PLEASE title the FIRST commit appropriately, so that if you squash all
  your commits into one, the combined commit message makes sense.
@@ -20,5 +15,24 @@
 
  If you're documenting a feature that will be part of a future release, see
  https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-
 -->
+### Description
+
+<!--
+ Remember to ADD A DESCRIPTION and delete this note before submitting
+ your pull request. The description should explain what will change,
+ and why.
+-->
+
+### Issue
+
+<!--
+ If this pull request resolves an open issue, please link the issue in the PR
+ description so it will automatically close when the PR is merged.
+
+ See the GitHub documentation for more details and other options:
+
+ https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+-->
+
+Closes: #


### PR DESCRIPTION
While reviewing pull requests I noticed there are a lot of PRs that are addressing open issues, but the PRs are not properly linked. This results in a lot of issues being left open, even after the fix has been merged.

This updates the PR template to give a short instruction on adding the expected line in the PR description so that the issue and PR can be linked automatically and closed on merge.