### PR TITLE
Add minimal systemd version about configuring cgroup driver docs

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -125,6 +125,10 @@ cgroup driver instead of `cgroupfs`.
 
 ### systemd cgroup driver {#systemd-cgroup-driver}
 
+{{< note >}}
+The minimum `systemd` version should be v228 and above, see [details](https://github.com/systemd/systemd/commit/17f62e9bd00f5fefd486475861b06d3ec6b7ee10)
+{{< /note >}}
+
 When [systemd](https://www.freedesktop.org/wiki/Software/systemd/) is chosen as the init
 system for a Linux distribution, the init process generates and consumes a root control group
 (`cgroup`) and acts as a cgroup manager.


### PR DESCRIPTION
try to fix https://github.com/kubernetes/website/issues/44904
add minimal systemd version about configuring cgroup driver docs