### PR TITLE
Add link to Minikube in "Install and Set Up kubectl on macOS"

### DIFF
--- a/content/en/docs/tasks/tools/included/verify-kubectl.md
+++ b/content/en/docs/tasks/tools/included/verify-kubectl.md
@@ -12,7 +12,7 @@ In order for kubectl to find and access a Kubernetes cluster, it needs a
 [kubeconfig file](/docs/concepts/configuration/organize-cluster-access-kubeconfig/),
 which is created automatically when you create a cluster using
 [kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh)
-or successfully deploy a Minikube cluster.
+or successfully deploy a [Minikube](https://minikube.sigs.k8s.io/docs/start/) cluster.
 By default, kubectl configuration is located at `~/.kube/config`.
 
 Check that kubectl is properly configured by getting the cluster state:

--- a/content/en/docs/tasks/tools/included/verify-kubectl.md
+++ b/content/en/docs/tasks/tools/included/verify-kubectl.md
@@ -12,7 +12,7 @@ In order for kubectl to find and access a Kubernetes cluster, it needs a
 [kubeconfig file](/docs/concepts/configuration/organize-cluster-access-kubeconfig/),
 which is created automatically when you create a cluster using
 [kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh)
-or successfully deploy a [Minikube](https://minikube.sigs.k8s.io/docs/start/) cluster.
+or successfully deploy a {{<glossary_tooltip text="Minikube" term_id="minikube" >}} cluster.
 By default, kubectl configuration is located at `~/.kube/config`.
 
 Check that kubectl is properly configured by getting the cluster state:


### PR DESCRIPTION
Linking directly to the Minikube installation guide when it is first
mentioned ensures the user has immediate access at the point
in the kubectl installation when it becomes relevant.
