### PR TITLE
fix: Fix offline build errors in CVE feed

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,6 +17,9 @@ disableBrowserError = true
 
 disableKinds = ["taxonomy"]
 
+# For offline build we need to ignore getJson error and handle nil returned instead. All getJson usages should be covered with warns
+ignoreErrors = ["error-remote-getjson"]
+
 ignoreFiles = [ "(?:^|/)OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
 timeout = "180s"
@@ -348,7 +351,7 @@ languageNameLatinScript = "Deutsch"
 
 [languages.hi]
 title = "Kubernetes"
-languageName = "हिन्दी (Hindi)"  
+languageName = "हिन्दी (Hindi)"
 weight = 5
 contentDir = "content/hi"
 languagedirection = "ltr"

--- a/layouts/_default/cve-feed.json
+++ b/layouts/_default/cve-feed.json
@@ -1,1 +1,10 @@
-{{ getJSON .Site.Params.cveFeedBucket | jsonify }}
+{{ $response := getJSON .Site.Params.cveFeedBucket }}
+{{ if eq $response nil }}
+  {{- if eq hugo.Environment "production" }}
+    {{ errorf "Unable to load CVE Feed. Aborting build." }}
+  {{- else -}}
+    {{ warnf "Cannot load CVE Feed." }}
+  {{- end -}}
+{{ end }}
+
+{{ $response | jsonify }}

--- a/layouts/_default/cve-feed.rss.xml
+++ b/layouts/_default/cve-feed.rss.xml
@@ -1,4 +1,7 @@
 {{ $feed := getJSON .Site.Params.cveFeedBucket -}}
+{{ if eq $feed nil }}
+  {{ warnf "Cannot load CVE feed." }}
+{{ end }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ $feed.title }}</title>
@@ -7,7 +10,10 @@
     <generator>Hugo -- gohugo.io</generator>
     <language>en-US</language>
 	<copyright>{{ .Site.Params.Copyright_k8s }}</copyright>
+    <!-- Handle case if CVE feed is not available. For example for offline build -->
+    {{ if ne $feed nil }}
     <lastBuildDate>{{ time.Format "Mon, 02 Jan 2006 15:04:05 -0700" $feed._kubernetes_io.updated_at | safeHTML }}</lastBuildDate>
+    {{ end -}}
     {{ with .OutputFormats.Get "RSS" -}}
 	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end -}}

--- a/layouts/_default/cve-feed.rss.xml
+++ b/layouts/_default/cve-feed.rss.xml
@@ -1,6 +1,10 @@
 {{ $feed := getJSON .Site.Params.cveFeedBucket -}}
 {{ if eq $feed nil }}
-  {{ warnf "Cannot load CVE feed." }}
+  {{- if eq hugo.Environment "production" }}
+    {{ errorf "Unable to load CVE feed. Aborting build." }}
+  {{- else -}}
+    {{ warnf "Cannot load CVE feed." }}
+  {{- end -}}
 {{ end }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>

--- a/layouts/shortcodes/cve-feed.html
+++ b/layouts/shortcodes/cve-feed.html
@@ -1,6 +1,10 @@
 {{ $feed := getJSON .Site.Params.cveFeedBucket }}
 {{ if eq $feed nil }}
-  {{ warnf "Cannot load CVE feed." }}
+  {{- if eq hugo.Environment "production" }}
+    {{ errorf "Unable to load CVE feed. Aborting build." }}
+  {{- else -}}
+    {{ warnf "Cannot load CVE feed." }}
+  {{- end -}}
 {{ end }}
 {{ if ne $feed.version "https://jsonfeed.org/version/1.1" }}
   {{ warnf "CVE feed shortcode. KEP-3203: CVE feed does not comply with JSON feed v1.1." }}

--- a/layouts/shortcodes/cve-feed.html
+++ b/layouts/shortcodes/cve-feed.html
@@ -1,9 +1,15 @@
 {{ $feed := getJSON .Site.Params.cveFeedBucket }}
+{{ if eq $feed nil }}
+  {{ warnf "Cannot load CVE feed." }}
+{{ end }}
 {{ if ne $feed.version "https://jsonfeed.org/version/1.1" }}
   {{ warnf "CVE feed shortcode. KEP-3203: CVE feed does not comply with JSON feed v1.1." }}
 {{ end }}
 <table class="security-cves">
+  <!-- Handle case if CVE feed is not available. For example for offline build -->
+  {{ if ne $feed nil }}
   <caption style="caption-side: top;">{{ T "cve_table" }} {{ printf (T "cve_table_date_format_string") ($feed._kubernetes_io.updated_at | time.Format (T "cve_table_date_format")) }}</caption>
+  {{ end }}
   <thead>
   <tr>
     <th>{{ T "cve_id" }}</th>

--- a/layouts/shortcodes/release-binaries.html
+++ b/layouts/shortcodes/release-binaries.html
@@ -1,5 +1,13 @@
 <!-- Fetch release_binaries.json from kubernetes-sigs/downloadkubernetes to render in table -->
 {{ $response := getJSON "https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/dist/release_binaries.json" }}
+{{ if eq $response nil }}
+  {{- if eq hugo.Environment "production" }}
+    {{ errorf "Unable to load release_binaries.json. Aborting build." }}
+  {{- else -}}
+    {{ warnf "Cannot load release_binaries.json." }}
+  {{- end -}}
+{{ end }}
+
 
 {{ $currentVersion := site.Params.version }}
 
@@ -21,7 +29,7 @@
 {{ end }}
 
 
-<!-- The below <div> defines an alternate content to be displayed only 
+<!-- The below <div> defines an alternate content to be displayed only
      when Javascript is disabled or when user's browser doesn't support Javascript -->
 <div class="downloadbinaries-nojs">
         <p>{{ T "release_binary_alternate_links" | markdownify }}</p>
@@ -38,10 +46,10 @@
     <div class="alert alert-info note callout" role="alert">
         <strong>{{ T "note" }}</strong>
         {{ $releaseBinarySectionNote := T "release_binary_section_note" }}
-        {{ $releaseBinarySectionNote = replace $releaseBinarySectionNote "<current-changelog-url>" (replace $currentVersion "v" "") }}    
+        {{ $releaseBinarySectionNote = replace $releaseBinarySectionNote "<current-changelog-url>" (replace $currentVersion "v" "") }}
         {{ $releaseBinarySectionNote = replace $releaseBinarySectionNote "<current-version>" $currentVersion }}
         {{ $releaseBinarySectionNote | markdownify }}
-    </div>    
+    </div>
     <details>
         <summary>{{ T "release_binary_options" }}</summary>
         <div class="text-center w-100">


### PR DESCRIPTION
Hello! This PR addresses issue #44223. I added checks for nil in getJson shortcode usage and now the website can be built without internet access if all required images already exist on the machine. 

How to check:
- run `make container-serve` locally
- wait until build will be completed and stop it (you will pull all required images)
- disable internet access on your machine
- run `make container-serve` again. It should be completed with warnings about CVE feed missing

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
