### PR TITLE
Fix 'skew' shortcode to determine patch version accurately

### DIFF
--- a/layouts/shortcodes/skew.html
+++ b/layouts/shortcodes/skew.html
@@ -92,7 +92,7 @@
     {{- end -}}
     {{- if eq $seenPatchVersionInfoCount 0 -}}
         <!-- fallback patch version to .0 -->
-        {{- printf "%.2f.0" $currentVersion -}}
+        {{- printf "%s.0" $currentVersion -}}
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
This PR address issue #44370. I fixed skew helper to correctly handle case if .0 release created and there are no patch releases yet

How to test:
- Add fake release to `data/releases/schedule.yaml`
- Update hugo.toml with fake release
- Preview docs

Fake release example (We need to create release without previousPatches field)
```
- release: 1.30
  releaseDate: 2023-12-13
  next:
    release: 1.29.2
    cherryPickDeadline: 2024-02-09
    targetDate: 2024-02-14
  maintenanceModeStartDate: 2024-12-28
  endOfLifeDate: 2025-02-28
```

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
