### PR TITLE
Fix path for example yaml in 'Coarse Parallel Processing Using a Work Queue' task page

### DIFF
--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -48,7 +48,7 @@ Start RabbitMQ as follows:
 
 ```shell
 # make a Service for the StatefulSet to use
-kubectl create -f https://kubernetes.io/examples/application/job/rabbitmq//rabbitmq-service.yaml
+kubectl create -f https://kubernetes.io/examples/application/job/rabbitmq/rabbitmq-service.yaml
 ```
 ```
 service "rabbitmq-service" created

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -48,14 +48,14 @@ Start RabbitMQ as follows:
 
 ```shell
 # make a Service for the StatefulSet to use
-kubectl create -f https://kubernetes.io/examples/application/job/rabbitmq-service.yaml
+kubectl create -f https://kubernetes.io/examples/application/job/rabbitmq//rabbitmq-service.yaml
 ```
 ```
 service "rabbitmq-service" created
 ```
 
 ```shell
-kubectl create -f https://kubernetes.io/examples/application/job/rabbitmq-statefulset.yaml
+kubectl create -f https://kubernetes.io/examples/application/job/rabbitmq/rabbitmq-statefulset.yaml
 ```
 ```
 statefulset "rabbitmq" created


### PR DESCRIPTION
This PR updates the link to the example yaml in the task page. Currently, the link is incorrect as it has missing 'rabbitmq' dir in the path. 

Fixes https://github.com/kubernetes/website/issues/45020