### PR TITLE
KEP-3705 CloudDualStackNodeIPs to GA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/cloud-dual-stack-node-ips.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/cloud-dual-stack-node-ips.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.29"
+    toVersion: "1.29"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.30"
+
 ---
 Enables dual-stack `kubelet --node-ip` with external cloud providers.
 See [Configure IPv4/IPv6 dual-stack](/docs/concepts/services-networking/dual-stack/#configure-ipv4-ipv6-dual-stack)


### PR DESCRIPTION
per https://github.com/kubernetes/enhancements/pull/4415 and https://github.com/kubernetes/kubernetes/pull/123134

I think this is right? First feature gate change since the new feature gate documentation system...

There were no outstanding references to the feature gate in the rest of the documentation. (They were written out when we went to beta.)