### PR TITLE
Enhance 'feature-state' shortcode to utilize feature gate description files

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -139,7 +139,7 @@ until disk usage reaches the `LowThresholdPercent` value.
 
 #### Garbage collection for unused container images {#image-maximum-age-gc}
 
-{{< feature-state for_k8s_version="v1.29" state="alpha" >}}
+{{< feature-state feature_gate_name="ImageMaximumGCAge" >}}
 
 As an alpha feature, you can specify the maximum time a local image can be unused for,
 regardless of disk usage. This is a kubelet setting that you configure for each node.

--- a/content/en/docs/concepts/architecture/leases.md
+++ b/content/en/docs/concepts/architecture/leases.md
@@ -33,7 +33,7 @@ instances are on stand-by.
 
 ## API server identity
 
-{{< feature-state for_k8s_version="v1.26" state="beta" >}}
+{{< feature-state feature_gate_name="APIServerIdentity" >}}
 
 Starting in Kubernetes v1.26, each `kube-apiserver` uses the Lease API to publish its identity to the
 rest of the system. While not particularly useful on its own, this provides a mechanism for clients to

--- a/content/en/docs/concepts/architecture/mixed-version-proxy.md
+++ b/content/en/docs/concepts/architecture/mixed-version-proxy.md
@@ -8,7 +8,7 @@ weight: 220
 
 <!-- overview -->
 
-{{< feature-state state="alpha" for_k8s_version="v1.28" >}}
+{{< feature-state feature_gate_name="UnknownVersionInteroperabilityProxy" >}}
 
 Kubernetes {{< skew currentVersion >}} includes an alpha feature that lets an
 {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}

--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -280,7 +280,7 @@ If you want to explicitly reserve resources for non-Pod processes, see
 
 ## Node topology
 
-{{< feature-state state="stable" for_k8s_version="v1.27" >}}
+{{< feature-state feature_gate_name="TopologyManager" >}}
 
 If you have enabled the `TopologyManager`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/), then
@@ -290,7 +290,7 @@ for more information.
 
 ## Graceful node shutdown {#graceful-node-shutdown}
 
-{{< feature-state state="beta" for_k8s_version="v1.21" >}}
+{{< feature-state feature_gate_name="GracefulNodeShutdown" >}}
 
 The kubelet attempts to detect node system shutdown and terminates pods running on the node.
 
@@ -374,7 +374,7 @@ Message:        Pod was terminated in response to imminent node shutdown.
 
 ### Pod Priority based graceful node shutdown {#pod-priority-graceful-node-shutdown}
 
-{{< feature-state state="beta" for_k8s_version="v1.24" >}}
+{{< feature-state feature_gate_name="GracefulNodeShutdownBasedOnPodPriority" >}}
 
 To provide more flexibility during graceful node shutdown around the ordering
 of pods during shutdown, graceful node shutdown honors the PriorityClass for
@@ -471,7 +471,7 @@ are emitted under the kubelet subsystem to monitor node shutdowns.
 
 ## Non-graceful node shutdown handling {#non-graceful-node-shutdown}
 
-{{< feature-state state="stable" for_k8s_version="v1.28" >}}
+{{< feature-state feature_gate_name="NodeOutOfServiceVolumeDetach" >}}
 
 A node shutdown action may not be detected by kubelet's Node Shutdown Manager,
 either because the command does not trigger the inhibitor locks mechanism used by
@@ -515,7 +515,7 @@ During a non-graceful shutdown, Pods are terminated in the two phases:
 
 ## Swap memory management {#swap-memory}
 
-{{< feature-state state="beta" for_k8s_version="v1.28" >}}
+{{< feature-state feature_gate_name="NodeSwap" >}}
 
 To enable swap on a node, the `NodeSwap` feature gate must be enabled on
 the kubelet, and the `--fail-swap-on` command line flag or `failSwapOn`

--- a/content/en/docs/concepts/cluster-administration/system-logs.md
+++ b/content/en/docs/concepts/cluster-administration/system-logs.md
@@ -238,7 +238,7 @@ The `logrotate` tool rotates logs daily, or once the log size is greater than 10
 
 ## Log query
 
-{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+{{< feature-state feature_gate_name="NodeLogQuery" >}}
 
 To help with debugging issues on nodes, Kubernetes v1.27 introduced a feature that allows viewing logs of services
 running on the node. To use the feature, ensure that the `NodeLogQuery`

--- a/content/en/docs/concepts/cluster-administration/system-traces.md
+++ b/content/en/docs/concepts/cluster-administration/system-traces.md
@@ -76,7 +76,7 @@ For more information about the `TracingConfiguration` struct, see
 
 ### kubelet traces
 
-{{< feature-state for_k8s_version="v1.27" state="beta" >}}
+{{< feature-state feature_gate_name="KubeletTracing" >}}
 
 The kubelet CRI interface and authenticated http servers are instrumented to generate
 trace spans. As with the apiserver, the endpoint and sampling rate are configurable.

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -161,7 +161,7 @@ which is 300 seconds (5 minutes).
 
 ### Image pull per runtime class
 
-{{< feature-state for_k8s_version="v1.29" state="alpha" >}}
+{{< feature-state feature_gate_name="RuntimeClassInImageCriApi" >}}
 Kubernetes includes alpha support for performing image pulls based on the RuntimeClass of a Pod.
 
 If you enable the `RuntimeClassInImageCriApi` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -360,7 +360,7 @@ null `namespaceSelector` matches the namespace of the Pod where the rule is defi
 
 #### matchLabelKeys
 
-{{< feature-state for_k8s_version="v1.29" state="alpha" >}}
+{{< feature-state feature_gate_name="MatchLabelKeysInPodAffinity" >}}
 
 {{< note >}}
 <!-- UPDATE THIS WHEN PROMOTING TO BETA -->
@@ -410,7 +410,7 @@ spec:
 
 #### mismatchLabelKeys
 
-{{< feature-state for_k8s_version="v1.29" state="alpha" >}}
+{{< feature-state feature_gate_name="MatchLabelKeysInPodAffinity" >}}
 
 {{< note >}}
 <!-- UPDATE THIS WHEN PROMOTING TO BETA -->

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -621,7 +621,7 @@ can define your own (provider specific) annotations on the Service that specify 
 
 #### Load balancers with mixed protocol types
 
-{{< feature-state for_k8s_version="v1.26" state="stable" >}}
+{{< feature-state feature_gate_name="MixedProtocolLBService" >}}
 
 By default, for LoadBalancer type of Services, when there is more than one port defined, all
 ports must have the same protocol, and the protocol must be one which is supported
@@ -670,7 +670,7 @@ Unprefixed names are reserved for end-users.
 
 #### Specifying IPMode of load balancer status {#load-balancer-ip-mode}
 
-{{< feature-state for_k8s_version="v1.29" state="alpha" >}}
+{{< feature-state feature_gate_name="LoadBalancerIPMode" >}}
 
 Starting as Alpha in Kubernetes 1.29, 
 a [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) 

--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -49,6 +49,21 @@ Renders to:
 
 {{< feature-state for_k8s_version="v1.10" state="beta" >}}
 
+### Feature state retrieval from description file
+
+To dynamically determine the state of the feature, make use of the `feature_gate_name`
+shortcode parameter. The feature state details will be extracted from the corresponding feature gate 
+description file located in `content/en/docs/reference/command-line-tools-reference/feature-gates/`.
+For example:
+
+```
+{{</* feature-state feature_gate_name="NodeSwap" */>}}
+```
+
+Renders to:
+
+{{< feature-state feature_gate_name="NodeSwap" >}}
+
 ## Feature gate description
 
 In a Markdown page (`.md` file) on this site, you can add a shortcode to

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -151,6 +151,12 @@ other = "Until"
 [feature_state]
 other = "FEATURE STATE:"
 
+[feature_state_kubernetes_label]
+other = "Kubernetes"
+
+[feature_state_feature_gate_tooltip]
+other = "Feature Gate:"
+
 [feedback_heading]
 other = "Feedback"
 

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -2,10 +2,56 @@
 {{ $state := .Get "state" }}
 {{ $for_k8s_version := .Get "for_k8s_version" | default (.Page.Param "version")}}
 {{ $is_valid := strings.Contains $valid_states $state }}
-{{ if not $is_valid }}
-{{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
-{{ else }}
-<div style="margin-top: 10px; margin-bottom: 10px;">
-  <b>{{ T "feature_state" }}</b> <code>Kubernetes {{ $for_k8s_version }} [{{ $state }}]</code>
-</div>
+{{ $feature_gate_name := .Get "feature_gate_name" }}
+
+ <!-- When 'feature_gate_name' parameter is not specified, continue with the values provided. -->
+{{ if not $feature_gate_name }}
+  {{ if not $is_valid }}
+    {{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
+  {{ else }}
+    <div class="my-2 feature-state-notice feature-{{ $state }}">
+      <b>{{ T "feature_state" }}</b> <code>{{T "feature_state_kubernetes_label" }} {{ $for_k8s_version }} [{{ $state }}]</code>
+    </div>
+  {{ end }}
+
+{{- else -}}
+  <!-- When 'feature_gate_name' is specified, the following code block extracts the status of the feature gate from the description file. -->
+
+  <!-- Set the path for feature gate description files -->
+  {{- $featureGateDescriptionFilesPath := "/docs/reference/command-line-tools-reference/feature-gates" -}}
+
+  <!-- Access the 'English' site and get the feature gate description pages -->
+  {{- with index (where .Site.Sites "Language.Lang" "eq" "en") 0 -}}
+    {{- with .GetPage $featureGateDescriptionFilesPath -}}
+
+      <!-- Sort Feature gate pages list -->
+      {{- $sortedFeatureGates := sort (.Resources.ByType "page") -}}
+      {{- $featureGateFound := false -}}
+
+      <!-- Iterate through feature gate files -->
+      {{- range $featureGateFile := $sortedFeatureGates -}}
+        {{- $featureGateNameFromFile := $featureGateFile.Params.Title -}}
+        
+        {{- if eq $featureGateNameFromFile $feature_gate_name -}}
+          <!-- Extract information from the final stage of the feature gate -->
+          {{- $currentStage := index $featureGateFile.Params.stages (sub (len $featureGateFile.Params.stages) 1) -}}
+          {{- with $currentStage -}}  
+           
+          <!-- Display feature state information  -->
+            <div class="my-2 feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
+              <b>{{ T "feature_state" }}</b> <code>{{T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
+            </div>       
+
+            {{- $featureGateFound = true -}}        
+          {{- end -}}        
+        {{- end -}}
+      {{- end -}}
+
+      <!-- Check if specified feature gate is not found -->
+      {{- if not $featureGateFound -}}
+        {{- errorf "Invalid feature gate: '%s' is not recognized or lacks a matching description file in '%s'" $feature_gate_name  (print "en" $featureGateDescriptionFilesPath) -}}
+      {{- end -}}
+
+    {{- end -}}
+  {{- end -}}
 {{ end }}


### PR DESCRIPTION
#### Description
This PR builds on top of PR https://github.com/kubernetes/website/pull/44478 to enhance the `feature-state` shortcode functionality to dynamically display the version and state of the documented feature by extracting details from the feature gate description files.

#### Motivation
With the introduction of feature gate description files containing metadata (such as stages, default values, versions), leveraging this information to render the feature state becomes feasible. Consequently, as a feature gate progresses through stages, the corresponding changes will automatically reflect on pages utilizing the `feature-state` shortcode.

#### Summary of Changes
- Introduced a new parameter `feature_gate_name` in the shortcode to specify the feature gate name.
- Implemented logic to retrieve feature gate state exclusively from **_English_** files, providing localization teams benefits without additional efforts. Changes in the main site's (English language) description file will seamlessly propagate feature state to other languages.
- Replaced existing inline CSS styling with Docsy spacing classes for similar rendering of output.
- Added documentation regarding the `feature-gate-name` option of the `feature-state` shortcode.
- Updated the _feature-state_ shortcode usage on select pages to utilize the new option. 

Following merge, other pages can gradually transition to using this option where applicable. Additionally, synchronization with the dev-1.30 branch could facilitate contributors to adopt the new format in the ongoing release.


#### Verification of Changes
The output from the modified shortcode aligns with the current website content.

[Preview Link 1](https://deploy-preview-45032--kubernetes-io-main-staging.netlify.app/docs/concepts/architecture/garbage-collection/) | [Current Doc 1](https://kubernetes.io/docs/concepts/architecture/garbage-collection/)
[Preview Link 2](https://deploy-preview-45032--kubernetes-io-main-staging.netlify.app/docs/concepts/architecture/leases/) | [Current Doc 2](https://kubernetes.io/docs/concepts/architecture/leases/)
[Preview Link 3](https://deploy-preview-45032--kubernetes-io-main-staging.netlify.app/docs/concepts/architecture/mixed-version-proxy) | [Current Doc 3](https://k8s.io/docs/concepts/architecture/mixed-version-proxy)
[Preview Link 4](https://deploy-preview-45032--kubernetes-io-main-staging.netlify.app/docs/concepts/architecture/nodes/) | [Current Doc 4](https://k8s.io/docs/concepts/architecture/nodes/)
[Preview Link for doc](https://deploy-preview-45032--kubernetes-io-main-staging.netlify.app/docs/contribute/style/hugo-shortcodes/)


/area web-development