### PR TITLE
Instructions to access Service and Ingress Resource through a minikube tunnel

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -20,6 +20,13 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 This tutorial assumes that you are using `minikube` to run a local Kubernetes cluster.
 Visit [Install tools](/docs/tasks/tools/#minikube) to learn how to install `minikube`.
 
+{{< note >}}
+This tutorial uses a container that requires the AMD64 architecture. 
+If you are using minikube on a computer with a different CPU architecture,
+you could try using minikube with a driver that can emulate AMD64.
+For example, the Docker Desktop driver can do this.
+{{< /note >}}
+
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 If you are using an older Kubernetes version, switch to the documentation for that version.
 
@@ -70,6 +77,21 @@ If you haven't already set up a cluster locally, run `minikube start` to create 
    ```none
    deployment.apps/web created
    ```
+   
+   Verify that the Deployment is in a Ready state:
+   
+   ```shell
+   kubectl get deployment web 
+   ```  
+
+   The output should be similar to:
+
+   ```none
+   NAME   READY   UP-TO-DATE   AVAILABLE   AGE
+   web    1/1     1            1           53s
+   ``` 
+    
+    
 
 1. Expose the Deployment:
 
@@ -96,22 +118,40 @@ If you haven't already set up a cluster locally, run `minikube start` to create 
    web       NodePort   10.104.133.249   <none>        8080:31637/TCP   12m
    ```
 
-1. Visit the Service via NodePort:
+1. Visit the Service via NodePort, using the [`minikube service`](https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-service-with-tunnel) command. Follow the instructions for your platform:
 
+   {{< tabs name="minikube_service" >}}
+   {{% tab name="Linux" %}}
+   
    ```shell
    minikube service web --url
    ```
-
    The output is similar to:
-
    ```none
    http://172.17.0.15:31637
    ```
-
+   Invoke the URL obtained in the output of the previous step:
    ```shell
    curl http://172.17.0.15:31637 
    ```
-
+   {{% /tab %}}
+   {{% tab name="MacOS" %}}
+   ```shell
+   # The command must be run in a separate terminal.
+   minikube service web --url 
+   ```
+   The output is similar to:
+   ```none
+   http://127.0.0.1:62445
+   ! Because you are using a Docker driver on darwin, the terminal needs to be open to run it.
+   ```
+   From a different terminal, invoke the URL obtained in the output of the previous step:
+   ```shell
+   curl http://127.0.0.1:62445 
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
+   <br>
    The output is similar to:
 
    ```none
@@ -162,12 +202,46 @@ The following manifest defines an Ingress that sends traffic to your Service via
    ```
 
 
-1. Verify that the Ingress controller is directing traffic:
+1. Verify that the Ingress controller is directing traffic, by following the instructions for your platform:
+
+   {{< note >}}
+   The network is limited if using the Docker driver on MacOS (Darwin) and the Node IP is not reachable directly. To get ingress to work you’ll need to open a new terminal and run `minikube tunnel`.  
+   `sudo` permission is required for it, so provide the password when prompted. 
+   {{< /note >}}    
+
+
+   {{< tabs name="ingress" >}}
+   {{% tab name="Linux" %}}
 
    ```shell
    curl --resolve "hello-world.info:80:$( minikube ip )" -i http://hello-world.info
    ```
+   {{% /tab %}}
+   {{% tab name="MacOS" %}}
 
+   ```shell
+   minikube tunnel
+   ```
+   The output is similar to:
+
+   ```none
+   Tunnel successfully started
+
+   NOTE: Please do not close this terminal as this process must stay alive for the tunnel to be accessible ...
+
+   The service/ingress example-ingress requires privileged ports to be exposed: [80 443]
+   sudo permission will be asked for it.
+   Starting tunnel for service example-ingress.
+   ```
+
+   From within a new terminal, invoke the following command:
+   ```shell
+   curl --resolve "hello-world.info:80:127.0.0.1" -i http://hello-world.info
+   ```
+
+   {{% /tab %}}
+  {{< /tabs >}}
+   <br>
    You should see:
 
    ```none
@@ -176,25 +250,36 @@ The following manifest defines an Ingress that sends traffic to your Service via
    Hostname: web-55b8c6998d-8k564
    ```
 
-   You can also visit `hello-world.info` from your browser.
+1. Optionally, you can also visit `hello-world.info` from your browser.
 
-   * **Optionally**
-     Look up the external IP address as reported by minikube:
-     ```shell
-     minikube ip
-     ```
-
-     Add line similar to the following one to the bottom of the `/etc/hosts` file on
+   Add a line to the bottom of the `/etc/hosts` file on
      your computer (you will need administrator access):
 
-     ```none
+     {{< tabs name="hosts" >}}
+     {{% tab name="Linux" %}}
+   Look up the external IP address as reported by minikube
+   ```none
+     minikube ip 
+   ``` 
+   <br>
+
+   ```none
      172.17.0.15 hello-world.info
-     ```
-
-     {{< note >}}
-     Change the IP address to match the output from `minikube ip`.
-     {{< /note >}}
-
+   ```
+   
+   {{< note >}}
+   Change the IP address to match the output from `minikube ip`.
+   {{< /note >}}
+   {{% /tab %}}
+     {{% tab name="MacOS" %}} 
+   ```none
+   127.0.0.1 hello-world.info
+   ```
+     {{% /tab %}}
+     {{< /tabs >}}
+   
+     <br>
+   
      After you make this change, your web browser sends requests for
      `hello-world.info` URLs to Minikube.
 
@@ -211,6 +296,18 @@ The following manifest defines an Ingress that sends traffic to your Service via
    ```none
    deployment.apps/web2 created
    ```
+   Verify that the Deployment is in a Ready state:
+
+   ```shell
+   kubectl get deployment web2 
+   ```  
+
+   The output should be similar to:
+
+   ```none
+   NAME   READY   UP-TO-DATE   AVAILABLE   AGE
+   web2   1/1     1            1           16s
+   ``` 
 
 1. Expose the second Deployment:
 
@@ -255,9 +352,38 @@ The following manifest defines an Ingress that sends traffic to your Service via
 
 1. Access the 1st version of the Hello World app.
 
+   {{< tabs name="ingress2-v1" >}}
+   {{% tab name="Linux" %}}
+
    ```shell
    curl --resolve "hello-world.info:80:$( minikube ip )" -i http://hello-world.info
    ```
+   {{% /tab %}}
+   {{% tab name="MacOS" %}}
+
+   ```shell
+   minikube tunnel
+   ```
+   The output is similar to:
+
+   ```none
+   Tunnel successfully started
+
+   NOTE: Please do not close this terminal as this process must stay alive for the tunnel to be accessible ...
+
+   The service/ingress example-ingress requires privileged ports to be exposed: [80 443]
+   sudo permission will be asked for it.
+   Starting tunnel for service example-ingress.
+   ```
+
+   From within a new terminal, invoke the following command:
+   ```shell
+   curl --resolve "hello-world.info:80:127.0.0.1" -i http://hello-world.info
+   ```
+
+   {{% /tab %}}
+   {{< /tabs >}}
+   <br>
 
    The output is similar to:
 
@@ -269,9 +395,37 @@ The following manifest defines an Ingress that sends traffic to your Service via
 
 1. Access the 2nd version of the Hello World app.
 
+   {{< tabs name="ingress2-v2" >}}
+   {{% tab name="Linux" %}}
+
    ```shell
    curl --resolve "hello-world.info:80:$( minikube ip )" -i http://hello-world.info/v2
    ```
+   {{% /tab %}}
+   {{% tab name="MacOS" %}}
+
+   ```shell
+   minikube tunnel
+   ```
+   The output is similar to:
+
+   ```none
+   Tunnel successfully started
+
+   NOTE: Please do not close this terminal as this process must stay alive for the tunnel to be accessible ...
+
+   The service/ingress example-ingress requires privileged ports to be exposed: [80 443]
+   sudo permission will be asked for it.
+   Starting tunnel for service example-ingress.
+   ```
+
+   From within a new terminal, invoke the following command:
+   ```shell
+   curl --resolve "hello-world.info:80:127.0.0.1" -i http://hello-world.info/v2
+   ```
+
+   {{% /tab %}}
+   {{< /tabs >}}
 
    The output is similar to:
 


### PR DESCRIPTION
Fixes #44651
Fixes #45027

This PR adds instructions specific to MacOS and Windows to the [ingress-minikube](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/) page. These instructions are needed in order to access a Service or an Ingress Resource deployed in minikube via a minikube tunnel.

This change is necessary as several readers have reported that the existing page does not provide this information and users on MacOS or Windows are unable to successfully complete this tutorial due to this gap.

**NOTE:**
I have successfully tested the proposed changes on a MacOS M* series machine. I am unable to test these changes on a Windows machine as I do not have access to one. I would really appreciate if a person having a Windows laptop would help me validate the instructions on Windows and report any necessary changes to the documentation.

**Preview Page:** is available [here](https://deploy-preview-45071--kubernetes-io-main-staging.netlify.app/docs/tasks/access-application-cluster/ingress-minikube/)

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
