### PR TITLE
Fix `matchLabelKeys` example yaml 

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -391,21 +391,22 @@ metadata:
 ...
 spec:
   template:
-    affinity:
-      podAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - database
-          topologyKey: topology.kubernetes.io/zone
-          # Only Pods from a given rollout are taken into consideration when calculating pod affinity.
-          # If you update the Deployment, the replacement Pods follow their own affinity rules
-          # (if there are any defined in the new Pod template)
-          matchLabelKeys: 
-          - pod-template-hash
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - database
+            topologyKey: topology.kubernetes.io/zone
+            # Only Pods from a given rollout are taken into consideration when calculating pod affinity.
+            # If you update the Deployment, the replacement Pods follow their own affinity rules
+            # (if there are any defined in the new Pod template)
+            matchLabelKeys: 
+            - pod-template-hash
 ```
 
 #### mismatchLabelKeys


### PR DESCRIPTION
The `spec.template` of `Deployment` YAML is a `PodTemplateSpec`, so it should be `spec.template.spec.affinity` instead of `spec.template.affinity`.


```
$ k explain deploy.spec.template.affinity
GROUP:      apps
KIND:       Deployment
VERSION:    v1

error: field "affinity" does not exist
```

```
$ explain deploy.spec.template.spec.affinity
GROUP:      apps
KIND:       Deployment
VERSION:    v1

FIELD: affinity <Affinity>

...
```

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

