### PR TITLE
socks5-proxy-access-api.md: fix broken mermaid diagram

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/socks5-proxy-access-api.md
+++ b/content/en/docs/tasks/extend-kubernetes/socks5-proxy-access-api.md
@@ -39,7 +39,7 @@ Figure 1 represents what you're going to achieve in this task.
 graph LR;
 
   subgraph local[Local client machine]
-  client([client])-- local <br> traffic .->  local_ssh[Local SSH <br> SOCKS5 proxy];
+  client([client])-. local <br> traffic .->  local_ssh[Local SSH <br> SOCKS5 proxy];
   end
   local_ssh[SSH <br>SOCKS5 <br> proxy]-- SSH Tunnel -->sshd
   


### PR DESCRIPTION
## Description 
This PR fixes the mermaid syntax to properly render the diagram below:

![image](https://github.com/kubernetes/website/assets/5674762/51e95887-8fe4-448c-ad6a-0e66c69cb15b)

## Problem
In [Use a SOCKS5 Proxy to Access the Kubernetes API](https://kubernetes.io/docs/tasks/extend-kubernetes/socks5-proxy-access-api/#task-context) page
- `Figure 1. SOCKS5 tutorial components` diagram is broken due to mermaid syntax error as of version 10.6.1.

![image](https://github.com/kubernetes/website/assets/5674762/4042bd1a-c2b1-4fcc-90d5-62af1fecc94f)

## Steps to reproduce locally
```
> cat diagrams/socks5.mm
graph LR;

  subgraph local[Local client machine]
  client([client])-- local <br> traffic .->  local_ssh[Local SSH <br> SOCKS5 proxy];
  end
  local_ssh[SSH <br>SOCKS5 <br> proxy]-- SSH Tunnel -->sshd
  
  subgraph remote[Remote server]
  sshd[SSH <br> server]-- local traffic -->service1;
  end
  client([client])-. proxied HTTPs traffic <br> going through the proxy .->service1[Kubernetes API];

  classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
  classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
  classDef cluster fill:#fff,stroke:#bbb,stroke-width:2px,color:#326ce5;
  class ingress,service1,service2,pod1,pod2,pod3,pod4 k8s;
  class client plain;
  class cluster cluster;
```

```
> docker run --rm -v $PWD/diagrams:/data minlag/mermaid-cli:10.6.1 -i socks5.mm
Generating single mermaid chart

Error: Evaluation failed: Error: Lexical error on line 6. Unrecognized text.
...r>SOCKS5 <br> proxy]-- SSH Tunnel -->ssh
-----------------------^
    at Lh.parseError (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:98:21111)
    at Object.parseError (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:100:1277)
    at Object.next (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:102:1854)
    at Object.lex (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:103:92)
    at E2 (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:98:21739)
    at Lh.parse (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:98:21986)
    at PUt.parse (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:64:512)
    at new PUt (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:64:247)
    at GjA (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:64:824)
    at async Object.N2e [as render] (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/dist/index.html:87:1146)
    at ExecutionContext._ExecutionContext_evaluate (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/ExecutionContext.js:254:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ExecutionContext.evaluate (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/ExecutionContext.js:143:16)
    at async CDPJSHandle.evaluate (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/JSHandle.js:56:16)
    at async CDPElementHandle.$eval (file:///home/mermaidcli/node_modules/puppeteer-core/lib/esm/puppeteer/common/ElementHandle.js:86:24)
    at async renderMermaid (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/src/index.js:246:22)
    at async parseMMD (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/src/index.js:218:20)
    at async run (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/src/index.js:479:20)
    at async cli (file:///home/mermaidcli/node_modules/@mermaid-js/mermaid-cli/src/index.js:184:3)
```

Or use [Mermaid Live Editor v10.8.1](https://mermaid.live/)