### PR TITLE
Device Plugins: add info about GA graduation

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -160,7 +160,7 @@ The general workflow of a device plugin includes the following steps:
    The processing of the fully-qualified CDI device names by the Device Manager requires
    that the `DevicePluginCDIDevices` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
    is enabled for both the kubelet and the kube-apiserver. This was added as an alpha feature in Kubernetes
-   v1.28 and graduated to beta in v1.29.
+   v1.28, graduated to beta in v1.29 and to GA in v1.31.
    {{< /note >}}
 
 ### Handling kubelet restarts

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/device-plugin-cdi-devices.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/device-plugin-cdi-devices.md
@@ -13,6 +13,10 @@ stages:
   - stage: beta 
     defaultValue: true
     fromVersion: "1.29"
+    toVersion: "1.30"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.31"
     
 ---
 Enable support to CDI device IDs in the


### PR DESCRIPTION
This is a documentation update for the [Add CDI devices to device plugin API](https://github.com/kubernetes/enhancements/issues/4009) feature. The feature is planned for GA graduation in 1.31.

The documentation update was explicitly requested in [this comment](https://github.com/kubernetes/enhancements/issues/4009#issuecomment-1943582878)