### PR TITLE
Add "Limitations of Linux Capabilities for Non-Root Containers" Section

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -385,7 +385,7 @@ omit the `CAP_` portion of the constant.
 For example, to add `CAP_SYS_TIME`, include `SYS_TIME` in your list of capabilities.
 {{< /note >}}
 
-### Limitations of Linux Capabilities for Non-Root Containers
+### Limitations of Linux capabilities for non-root containers
 
 When running containers as non-root users, it's important to be aware that Linux capabilities might not be fully granted due to the security model of Linux. This limitation can prevent non-root containers from performing operations that require specific capabilities, even if those capabilities are explicitly granted in the container's security context.
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -389,7 +389,7 @@ For example, to add `CAP_SYS_TIME`, include `SYS_TIME` in your list of capabilit
 
 When running containers as non-root users, it's important to be aware that Linux capabilities might not be fully granted due to the security model of Linux. This limitation can prevent non-root containers from performing operations that require specific capabilities, even if those capabilities are explicitly granted in the container's security context.
 
-One workaround for this limitation involves setting capabilities directly on the binary within the container image. However, this approach is not ideal and may have security implications. Kubernetes is actively working on better solutions to support ambient capabilities, allowing for a more secure and straightforward way to grant necessary privileges to containers. For more information on this effort, refer to [KEP-2763: Support Ambient Capabilities](https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/2763-ambient-capabilities/README.md).
+One workaround for this limitation involves setting capabilities directly on the binary within the container image. However, this approach is not ideal and may have security implications.
 
 ## Set the Seccomp Profile for a Container
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -385,6 +385,12 @@ omit the `CAP_` portion of the constant.
 For example, to add `CAP_SYS_TIME`, include `SYS_TIME` in your list of capabilities.
 {{< /note >}}
 
+### Limitations of Linux Capabilities for Non-Root Containers
+
+When running containers as non-root users, it's important to be aware that Linux capabilities might not be fully granted due to the security model of Linux. This limitation can prevent non-root containers from performing operations that require specific capabilities, even if those capabilities are explicitly granted in the container's security context.
+
+One workaround for this limitation involves setting capabilities directly on the binary within the container image. However, this approach is not ideal and may have security implications. Kubernetes is actively working on better solutions to support ambient capabilities, allowing for a more secure and straightforward way to grant necessary privileges to containers. For more information on this effort, refer to [KEP-2763: Support Ambient Capabilities](https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/2763-ambient-capabilities/README.md).
+
 ## Set the Seccomp Profile for a Container
 
 To set the Seccomp profile for a Container, include the `seccompProfile` field


### PR DESCRIPTION
This pull request introduces a new section titled "Limitations of Linux Capabilities for Non-Root Containers" to the Kubernetes documentation under the "Configure a Security Context for a Pod or Container" page. The addition follows the note on Linux capability constants, providing a natural transition to a discussion on the practical limitations of applying these capabilities to non-root containers.

Motivation:

While the existing documentation provides detailed insights into security contexts and Linux capabilities, it does not fully address the peculiar behavior observed when certain capabilities are granted to non-root users. Specifically, the surprise came when, after configuring additional capabilities for a non-root user, the process capabilities (CapPrm and CapEff) were inspected and found to be zero (0000000000000000), indicating no permitted or effective capabilities. This observation underscores a gap in the documentation regarding the effective scope and limitations of Linux capabilities in non-root contexts.

The proposed section aims to shed light on this behavior, offering explanations and guidance to avoid confusion and misconfigurations.