### PR TITLE
[dev-1.30] KEP-3857: Recursive Read-only (RRO) mounts

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/recursive-read-only-mounts.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/recursive-read-only-mounts.md
@@ -1,0 +1,14 @@
+---
+title: RecursiveReadOnlyMounts
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+Enables support for recursive read-only mounts.
+For more details, see [read-only mounts](/docs/concepts/storage/volumes/#read-only-mounts).

--- a/content/en/examples/storage/rro.yaml
+++ b/content/en/examples/storage/rro.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rro
+spec:
+  volumes:
+    - name: mnt
+      hostPath:
+        # tmpfs is mounted on /mnt/tmpfs
+        path: /mnt
+  containers:
+    - name: busybox
+      image: busybox
+      args: ["sleep", "infinity"]
+      volumeMounts:
+        # /mnt-rro/tmpfs is not writable
+        - name: mnt
+          mountPath: /mnt-rro
+          readOnly: true
+          mountPropagation: None
+          recursiveReadOnly: Enabled
+        # /mnt-ro/tmpfs is writable
+        - name: mnt
+          mountPath: /mnt-ro
+          readOnly: true
+        # /mnt-rw/tmpfs is writable
+        - name: mnt
+          mountPath: /mnt-rw


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
For:
- https://github.com/kubernetes/enhancements/issues/3857 (alpha in v1.30)

Depends on:
- [x] https://github.com/kubernetes/kubernetes/pull/123180


- - -

Preview: https://deploy-preview-45159--kubernetes-io-vnext-staging.netlify.app/docs/concepts/storage/volumes/#recursive-read-only-mounts