### PR TITLE
Update glossary.html by adding missing whitespace after colon for AKA list

### DIFF
--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -43,7 +43,7 @@
 		<div>
 			<div class="term-name"><b>{{ .Title }}</b><a href="{{ printf "#%s" $term_identifier }}" class="permalink hide">LINK</a></div>
 			{{ with .Params.aka }}
-			{{ T "layouts_docs_glossary_aka" }}:<i>{{ delimit . ", " }}</i>
+			{{ T "layouts_docs_glossary_aka" }}: <i>{{ delimit . ", " }}</i>
 			<br>
 			{{ end }}
 			<span class="preview-text">{{ .Summary }} <a href="javascript:void(0)" class="click-controller no-underline" data-target="{{ .Params.id }}">[+]</a></span>


### PR DESCRIPTION
This pull request implements miscellaneous changes to the layout of glossary pages by adding missing whitespace after the colon in the list of "also known as" values.