### PR TITLE
Add kubernetes.dev mirroring guidelines

### DIFF
--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -189,6 +189,17 @@ To submit a blog post follow these directions:
       - **Tutorials** that only apply to specific releases or versions and not all future versions
       - References to pre-GA APIs or features
 
+### Mirroring from the Kubernetes Contributor Blog
+
+To mirror a blog post from the [Kubernetes contributor blog](https://www.kubernetes.dev/blog/), follow these guidelines:
+
+- Keep the blog content the same. If there are changes, they should be made to the original article first, and then to the mirrored article.
+- The mirrored blog should have a `canonicalUrl`, that is, essentially the url of the original blog after it has been published.
+- [Kubernetes contributor blogs](https://kubernetes.dev/blog) have their authors mentioned in the YAML header, while the Kubernetes blog posts mention authors in the blog content itself. This should be changed when mirroring the content.
+- Publication dates stay the same as the original blog.
+
+All of the other guidelines and expectations detailed above apply as well.
+
 ## Submit a case study
 
 Case studies highlight how organizations are using Kubernetes to solve real-world problems. The


### PR DESCRIPTION
Based on comment in https://github.com/kubernetes/website/issues/44123#issuecomment-1831041912 and conversation in slack https://kubernetes.slack.com/archives/CJDHVD54J/p1706577613048429?thread_ts=1706544061.503169&cid=CJDHVD54J and offline conversation with @Gauravpadam , this change adds some guidelines for mirroring a blog post from kubernetes.dev to kubernetes.io

