### PR TITLE
Add docs for Restarting sidecar containers during Pod termination

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -84,6 +84,21 @@ Here's an example of a Job with two containers, one of which is a sidecar:
 
 {{% code_sample language="yaml" file="application/job/job-sidecar.yaml" %}}
 
+### Restarting sidecar containers during Pod termination
+
+{{< feature-state for_k8s_version="v1.31" state="alpha" >}}
+
+Normally during Pod termination, all activities supporting containers are
+disabled. This includes ConfigMaps and Secrets refreshes, probes and
+restarts.
+
+With the feature gate `RestartContainerDuringTermination` you can enable
+these activities for init containers with `restartPolicy: Always` set, allowing
+them to restart during Pod termination.
+
+This ensures that the sidecar containers are continuously running and provide
+their support to main application containers until the Pod is deleted.
+
 ## Differences from application containers
 
 Sidecar containers run alongside _app containers_ in the same pod. However, they do not

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/restart-container-during-termination.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/restart-container-during-termination.md
@@ -1,0 +1,16 @@
+---
+title: RestartContainerDuringTermination
+content_type: feature_gate
+_build:
+list: never
+render: false
+
+stages:
+- stage: alpha
+  defaultValue: false
+  fromVersion: "1.31"
+---
+Allow restarting containers during termination.
+In alpha, this feature is limited to restartable init containers.
+See [Sidecar containers and restartPolicy](/docs/concepts/workloads/pods/sidecar-containers/)
+for more details.


### PR DESCRIPTION
Documentation changes for KEP 4438: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4438-sidecar-restart-termination
KEP issue: https://github.com/kubernetes/enhancements/issues/4438