### PR TITLE
Fix spelling mistake in kube scheduler

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/api-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/api-eviction.md
@@ -11,11 +11,11 @@ using a client of the {{<glossary_tooltip term_id="kube-apiserver" text="API ser
 creates an `Eviction` object, which causes the API server to terminate the Pod.
 
 API-initiated evictions respect your configured [`PodDisruptionBudgets`](/docs/tasks/run-application/configure-pdb/)
-and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination). 
+and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination).
 
 Using the API to create an Eviction object for a Pod is like performing a
 policy-controlled [`DELETE` operation](/docs/reference/kubernetes-api/workload-resources/pod-v1/#delete-delete-a-pod)
-on the Pod. 
+on the Pod.
 
 ## Calling the Eviction API
 
@@ -75,13 +75,13 @@ checks and responds in one of the following ways:
 * `429 Too Many Requests`: the eviction is not currently allowed because of the
   configured {{<glossary_tooltip term_id="pod-disruption-budget" text="PodDisruptionBudget">}}.
   You may be able to attempt the eviction again later. You might also see this
-  response because of API rate limiting. 
+  response because of API rate limiting.
 * `500 Internal Server Error`: the eviction is not allowed because there is a
   misconfiguration, like if multiple PodDisruptionBudgets reference the same Pod.
 
 If the Pod you want to evict isn't part of a workload that has a
 PodDisruptionBudget, the API server always returns `200 OK` and allows the
-eviction. 
+eviction.
 
 If the API server allows the eviction, the Pod is deleted as follows:
 
@@ -103,12 +103,12 @@ If the API server allows the eviction, the Pod is deleted as follows:
 ## Troubleshooting stuck evictions
 
 In some cases, your applications may enter a broken state, where the Eviction
-API will only return `429` or `500` responses until you intervene. This can 
-happen if, for example, a ReplicaSet creates pods for your application but new 
+API will only return `429` or `500` responses until you intervene. This can
+happen if, for example, a ReplicaSet creates pods for your application but new
 pods do not enter a `Ready` state. You may also notice this behavior in cases
 where the last evicted Pod had a long termination grace period.
 
-If you notice stuck evictions, try one of the following solutions: 
+If you notice stuck evictions, try one of the following solutions:
 
 * Abort or pause the automated operation causing the issue. Investigate the stuck
   application before you restart the operation.

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -254,13 +254,13 @@ the node label that the system uses to denote the domain. For examples, see
 [Well-Known Labels, Annotations and Taints](/docs/reference/labels-annotations-taints/).
 
 {{< note >}}
-Inter-pod affinity and anti-affinity require substantial amount of
+Inter-pod affinity and anti-affinity require substantial amounts of
 processing which can slow down scheduling in large clusters significantly. We do
 not recommend using them in clusters larger than several hundred nodes.
 {{< /note >}}
 
 {{< note >}}
-Pod anti-affinity requires nodes to be consistently labelled, in other words,
+Pod anti-affinity requires nodes to be consistently labeled, in other words,
 every node in the cluster must have an appropriate label matching `topologyKey`.
 If some or all nodes are missing the specified `topologyKey` label, it can lead
 to unintended behavior.
@@ -364,7 +364,7 @@ null `namespaceSelector` matches the namespace of the Pod where the rule is defi
 
 {{< note >}}
 <!-- UPDATE THIS WHEN PROMOTING TO BETA -->
-The `matchLabelKeys` field is a alpha-level field and is disabled by default in
+The `matchLabelKeys` field is an alpha-level field and is disabled by default in
 Kubernetes {{< skew currentVersion >}}.
 When you want to use it, you have to enable it via the
 `MatchLabelKeysInPodAffinity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
@@ -415,7 +415,7 @@ spec:
 
 {{< note >}}
 <!-- UPDATE THIS WHEN PROMOTING TO BETA -->
-The `mismatchLabelKeys` field is a alpha-level field and is disabled by default in
+The `mismatchLabelKeys` field is an alpha-level field and is disabled by default in
 Kubernetes {{< skew currentVersion >}}.
 When you want to use it, you have to enable it via the
 `MatchLabelKeysInPodAffinity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
@@ -561,7 +561,7 @@ where each web server is co-located with a cache, on three separate nodes.
 | *webserver-1* | *webserver-2* | *webserver-3* |
 |   *cache-1*   |   *cache-2*   |   *cache-3*   |
 
-The overall effect is that each cache instance is likely to be accessed by a single client, that
+The overall effect is that each cache instance is likely to be accessed by a single client that
 is running on the same node. This approach aims to minimize both skew (imbalanced load) and latency.
 
 You might have other reasons to use Pod anti-affinity.
@@ -589,7 +589,7 @@ Some of the limitations of using `nodeName` to select nodes are:
 {{< note >}}
 `nodeName` is intended for use by custom schedulers or advanced use cases where
 you need to bypass any configured schedulers. Bypassing the schedulers might lead to
-failed Pods if the assigned Nodes get oversubscribed. You can use [node affinity](#node-affinity) or a the [`nodeselector` field](#nodeselector) to assign a Pod to a specific Node without bypassing the schedulers.
+failed Pods if the assigned Nodes get oversubscribed. You can use the [node affinity](#node-affinity) or the [`nodeselector` field](#nodeselector) to assign a Pod to a specific Node without bypassing the schedulers.
 {{</ note >}}
 
 Here is an example of a Pod spec using the `nodeName` field:

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -96,7 +96,7 @@ define. Some of the benefits of affinity and anti-affinity include:
 The affinity feature consists of two types of affinity:
 
 - *Node affinity* functions like the `nodeSelector` field but is more expressive and
-  allows you to specify soft rules. 
+  allows you to specify soft rules.
 - *Inter-pod affinity/anti-affinity* allows you to constrain Pods against labels
   on other Pods.
 
@@ -305,22 +305,22 @@ Pod affinity rule uses the "hard"
 `requiredDuringSchedulingIgnoredDuringExecution`, while the anti-affinity rule
 uses the "soft" `preferredDuringSchedulingIgnoredDuringExecution`.
 
-The affinity rule specifies that the scheduler is allowed to place the example Pod 
+The affinity rule specifies that the scheduler is allowed to place the example Pod
 on a node only if that node belongs to a specific [zone](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
-where other Pods have been labeled with `security=S1`. 
-For instance, if we have a cluster with a designated zone, let's call it "Zone V," 
-consisting of nodes labeled with `topology.kubernetes.io/zone=V`, the scheduler can 
-assign the Pod to any node within Zone V, as long as there is at least one Pod within 
-Zone V already labeled with `security=S1`. Conversely, if there are no Pods with `security=S1` 
+where other Pods have been labeled with `security=S1`.
+For instance, if we have a cluster with a designated zone, let's call it "Zone V,"
+consisting of nodes labeled with `topology.kubernetes.io/zone=V`, the scheduler can
+assign the Pod to any node within Zone V, as long as there is at least one Pod within
+Zone V already labeled with `security=S1`. Conversely, if there are no Pods with `security=S1`
 labels in Zone V, the scheduler will not assign the example Pod to any node in that zone.
 
-The anti-affinity rule specifies that the scheduler should try to avoid scheduling the Pod 
+The anti-affinity rule specifies that the scheduler should try to avoid scheduling the Pod
 on a node if that node belongs to a specific [zone](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
-where other Pods have been labeled with `security=S2`. 
-For instance, if we have a cluster with a designated zone, let's call it "Zone R," 
-consisting of nodes labeled with `topology.kubernetes.io/zone=R`, the scheduler should avoid 
-assigning the Pod to any node within Zone R, as long as there is at least one Pod within 
-Zone R already labeled with `security=S2`. Conversely, the anti-affinity rule does not impact 
+where other Pods have been labeled with `security=S2`.
+For instance, if we have a cluster with a designated zone, let's call it "Zone R,"
+consisting of nodes labeled with `topology.kubernetes.io/zone=R`, the scheduler should avoid
+assigning the Pod to any node within Zone R, as long as there is at least one Pod within
+Zone R already labeled with `security=S2`. Conversely, the anti-affinity rule does not impact
 scheduling into Zone R if there are no Pods with `security=S2` labels.
 
 To get yourself more familiar with the examples of Pod affinity and anti-affinity,
@@ -371,12 +371,12 @@ When you want to use it, you have to enable it via the
 {{< /note >}}
 
 Kubernetes includes an optional `matchLabelKeys` field for Pod affinity
-or anti-affinity. The field specifies keys for the labels that should  match with the incoming Pod's labels, 
+or anti-affinity. The field specifies keys for the labels that should  match with the incoming Pod's labels,
 when satisfying the Pod (anti)affinity.
 
 The keys are used to look up values from the pod labels; those key-value labels are combined
 (using `AND`) with the match restrictions defined using the `labelSelector` field. The combined
-filtering selects the set of existing pods that will be taken into Pod (anti)affinity calculation. 
+filtering selects the set of existing pods that will be taken into Pod (anti)affinity calculation.
 
 A common use case is to use `matchLabelKeys` with `pod-template-hash` (set on Pods
 managed as part of a Deployment, where the value is unique for each revision).
@@ -405,7 +405,7 @@ spec:
             # Only Pods from a given rollout are taken into consideration when calculating pod affinity.
             # If you update the Deployment, the replacement Pods follow their own affinity rules
             # (if there are any defined in the new Pod template)
-            matchLabelKeys: 
+            matchLabelKeys:
             - pod-template-hash
 ```
 
@@ -422,7 +422,7 @@ When you want to use it, you have to enable it via the
 {{< /note >}}
 
 Kubernetes includes an optional `mismatchLabelKeys` field for Pod affinity
-or anti-affinity. The field specifies keys for the labels that should **not** match with the incoming Pod's labels, 
+or anti-affinity. The field specifies keys for the labels that should **not** match with the incoming Pod's labels,
 when satisfying the Pod (anti)affinity.
 
 One example use case is to ensure Pods go to the topology domain (node, zone, etc) where only Pods from the same tenant or team are scheduled in.
@@ -438,22 +438,22 @@ metadata:
 ...
 spec:
   affinity:
-    podAffinity:      
+    podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
       # ensure that pods associated with this tenant land on the correct node pool
       - matchLabelKeys:
           - tenant
         topologyKey: node-pool
-    podAntiAffinity:  
+    podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
       # ensure that pods associated with this tenant can't schedule to nodes used for another tenant
       - mismatchLabelKeys:
-        - tenant # whatever the value of the "tenant" label for this Pod, prevent  
+        - tenant # whatever the value of the "tenant" label for this Pod, prevent
                  # scheduling to nodes in any pool where any Pod from a different
                  # tenant is running.
         labelSelector:
           # We have to have the labelSelector which selects only Pods with the tenant label,
-          # otherwise this Pod would hate Pods from daemonsets as well, for example, 
+          # otherwise this Pod would hate Pods from daemonsets as well, for example,
           # which aren't supposed to have the tenant label.
           matchExpressions:
           - key: tenant
@@ -633,13 +633,13 @@ The following operators can only be used with `nodeAffinity`.
 
 |    Operator    |    Behaviour    |
 | :------------: | :-------------: |
-| `Gt` | The supplied value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector | 
-| `Lt` | The supplied value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector | 
+| `Gt` | The supplied value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
+| `Lt` | The supplied value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
 
 
 {{<note>}}
-`Gt` and `Lt` operators will not work with non-integer values. If the given value 
-doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt` 
+`Gt` and `Lt` operators will not work with non-integer values. If the given value
+doesn't parse as an integer, the pod will fail to get scheduled. Also, `Gt` and `Lt`
 are not available for `podAffinity`.
 {{</note>}}
 

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -41,14 +41,14 @@ ResourceClass
   driver.
 
 ResourceClaim
-: Defines a particular resource instances that is required by a
+: Defines a particular resource instance that is required by a
   workload. Created by a user (lifecycle managed manually, can be shared
   between different Pods) or for individual Pods by the control plane based on
   a ResourceClaimTemplate (automatic lifecycle, typically used by just one
   Pod).
 
 ResourceClaimTemplate
-: Defines the spec and some meta data for creating
+: Defines the spec and some metadata for creating
   ResourceClaims. Created by a user when deploying a workload.
 
 PodSchedulingContext

--- a/content/en/docs/concepts/scheduling-eviction/kube-scheduler.md
+++ b/content/en/docs/concepts/scheduling-eviction/kube-scheduler.md
@@ -62,7 +62,7 @@ kube-scheduler selects a node for the pod in a 2-step operation:
 
 The _filtering_ step finds the set of Nodes where it's feasible to
 schedule the Pod. For example, the PodFitsResources filter checks whether a
-candidate Node has enough available resource to meet a Pod's specific
+candidate Node has enough available resources to meet a Pod's specific
 resource requests. After this step, the node list contains any suitable
 Nodes; often, there will be more than one. If the list is empty, that
 Pod isn't (yet) schedulable.

--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -171,7 +171,7 @@ The kubelet has the following default hard eviction thresholds:
 - `nodefs.inodesFree<5%` (Linux nodes)
 
 These default values of hard eviction thresholds will only be set if none
-of the parameters is changed. If you changed the value of any parameter,
+of the parameters is changed. If you change the value of any parameter,
 then the values of other parameters will not be inherited as the default
 values and will be set to zero. In order to provide custom values, you
 should provide all the thresholds respectively.

--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -64,7 +64,7 @@ and it cannot be prefixed with `system-`.
 
 A PriorityClass object can have any 32-bit integer value smaller than or equal
 to 1 billion. This means that the range of values for a PriorityClass object is
-from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for 
+from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for
 built-in PriorityClasses that represent critical system Pods. A cluster
 admin should create one PriorityClass object for each such mapping that they want.
 
@@ -256,9 +256,9 @@ the Node is not considered for preemption.
 
 If a pending Pod has inter-pod {{< glossary_tooltip text="affinity" term_id="affinity" >}}
 to one or more of the lower-priority Pods on the Node, the inter-Pod affinity
-rule cannot be satisfied in the absence of those lower-priority Pods. In this case, 
+rule cannot be satisfied in the absence of those lower-priority Pods. In this case,
 the scheduler does not preempt any Pods on the Node. Instead, it looks for another
-Node. The scheduler might find a suitable Node or it might not. There is no 
+Node. The scheduler might find a suitable Node or it might not. There is no
 guarantee that the pending Pod can be scheduled.
 
 Our recommended solution for this problem is to create inter-Pod affinity only
@@ -361,7 +361,7 @@ to get evicted. The kubelet ranks pods for eviction based on the following facto
 
   1. Whether the starved resource usage exceeds requests
   1. Pod Priority
-  1. Amount of resource usage relative to requests 
+  1. Amount of resource usage relative to requests
 
 See [Pod selection for kubelet eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction)
 for more details.

--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -182,8 +182,8 @@ When Pod priority is enabled, the scheduler orders pending Pods by
 their priority and a pending Pod is placed ahead of other pending Pods
 with lower priority in the scheduling queue. As a result, the higher
 priority Pod may be scheduled sooner than Pods with lower priority if
-its scheduling requirements are met. If such Pod cannot be scheduled,
-scheduler will continue and tries to schedule other lower priority Pods.
+its scheduling requirements are met. If such Pod cannot be scheduled, the
+scheduler will continue and try to schedule other lower priority Pods.
 
 ## Preemption
 
@@ -199,7 +199,7 @@ the Pods are gone, P can be scheduled on the Node.
 ### User exposed information
 
 When Pod P preempts one or more Pods on Node N, `nominatedNodeName` field of Pod
-P's status is set to the name of Node N. This field helps scheduler track
+P's status is set to the name of Node N. This field helps the scheduler track
 resources reserved for Pod P and also gives users information about preemptions
 in their clusters.
 
@@ -209,8 +209,8 @@ After victim Pods are preempted, they get their graceful termination period. If
 another node becomes available while scheduler is waiting for the victim Pods to
 terminate, scheduler may use the other node to schedule Pod P. As a result
 `nominatedNodeName` and `nodeName` of Pod spec are not always the same. Also, if
-scheduler preempts Pods on Node N, but then a higher priority Pod than Pod P
-arrives, scheduler may give Node N to the new higher priority Pod. In such a
+the scheduler preempts Pods on Node N, but then a higher priority Pod than Pod P
+arrives, the scheduler may give Node N to the new higher priority Pod. In such a
 case, scheduler clears `nominatedNodeName` of Pod P. By doing this, scheduler
 makes Pod P eligible to preempt Pods on another Node.
 
@@ -288,7 +288,7 @@ enough demand and if we find an algorithm with reasonable performance.
 
 ## Troubleshooting
 
-Pod priority and pre-emption can have unwanted side effects. Here are some
+Pod priority and preemption can have unwanted side effects. Here are some
 examples of potential problems and ways to deal with them.
 
 ### Pods are preempted unnecessarily

--- a/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -59,7 +59,7 @@ The output is:
 ```
 
 To inform scheduler this Pod is ready for scheduling, you can remove its `schedulingGates` entirely
-by re-applying a modified manifest:
+by reapplying a modified manifest:
 
 {{% code_sample file="pods/pod-without-scheduling-gates.yaml" %}}
 

--- a/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -9,7 +9,7 @@ weight: 40
 {{< feature-state for_k8s_version="v1.27" state="beta" >}}
 
 Pods were considered ready for scheduling once created. Kubernetes scheduler
-does its due diligence to find nodes to place all pending Pods. However, in a 
+does its due diligence to find nodes to place all pending Pods. However, in a
 real-world case, some Pods may stay in a "miss-essential-resources" state for a long period.
 These Pods actually churn the scheduler (and downstream integrators like Cluster AutoScaler)
 in an unnecessary manner.
@@ -79,7 +79,7 @@ Given the test-pod doesn't request any CPU/memory resources, it's expected that 
 transited from previous `SchedulingGated` to `Running`:
 
 ```none
-NAME       READY   STATUS    RESTARTS   AGE   IP         NODE  
+NAME       READY   STATUS    RESTARTS   AGE   IP         NODE
 test-pod   1/1     Running   0          15s   10.0.0.4   node-2
 ```
 
@@ -94,8 +94,8 @@ scheduling. You can use `scheduler_pending_pods{queue="gated"}` to check the met
 {{< feature-state for_k8s_version="v1.27" state="beta" >}}
 
 You can mutate scheduling directives of Pods while they have scheduling gates, with certain constraints.
-At a high level, you can only tighten the scheduling directives of a Pod. In other words, the updated 
-directives would cause the Pods to only be able to be scheduled on a subset of the nodes that it would 
+At a high level, you can only tighten the scheduling directives of a Pod. In other words, the updated
+directives would cause the Pods to only be able to be scheduled on a subset of the nodes that it would
 previously match. More concretely, the rules for updating a Pod's scheduling directives are as follows:
 
 1. For `.spec.nodeSelector`, only additions are allowed. If absent, it will be allowed to be set.
@@ -107,8 +107,8 @@ previously match. More concretely, the rules for updating a Pod's scheduling dir
    or `fieldExpressions` are allowed, and no changes to existing `matchExpressions`
    and `fieldExpressions` will be allowed. This is because the terms in
    `.requiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms`, are ORed
-   while the expressions in `nodeSelectorTerms[].matchExpressions` and 
-   `nodeSelectorTerms[].fieldExpressions` are ANDed. 
+   while the expressions in `nodeSelectorTerms[].matchExpressions` and
+   `nodeSelectorTerms[].fieldExpressions` are ANDed.
 
 4. For `.preferredDuringSchedulingIgnoredDuringExecution`, all updates are allowed.
    This is because preferred terms are not authoritative, and so policy controllers

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -57,9 +57,9 @@ the `NodeResourcesFit` score function can be controlled by the
 Within the `scoringStrategy` field, you can configure two parameters: `requestedToCapacityRatio` and
 `resources`. The `shape` in the `requestedToCapacityRatio`
 parameter allows the user to tune the function as least requested or most
-requested based on `utilization` and `score` values. The `resources` parameter
-consists of `name` of the resource to be considered during scoring and `weight`
-specify the weight of each resource.
+requested based on `utilization` and `score` values. The `resources` parameter 
+comprises both the `name` of the resource to be considered during scoring and 
+its corresponding `weight`, which specifies the weight of each resource.
 
 Below is an example configuration that sets
 the bin packing behavior for extended resources `intel.com/foo` and `intel.com/bar`

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -57,8 +57,8 @@ the `NodeResourcesFit` score function can be controlled by the
 Within the `scoringStrategy` field, you can configure two parameters: `requestedToCapacityRatio` and
 `resources`. The `shape` in the `requestedToCapacityRatio`
 parameter allows the user to tune the function as least requested or most
-requested based on `utilization` and `score` values. The `resources` parameter 
-comprises both the `name` of the resource to be considered during scoring and 
+requested based on `utilization` and `score` values. The `resources` parameter
+comprises both the `name` of the resource to be considered during scoring and
 its corresponding `weight`, which specifies the weight of each resource.
 
 Below is an example configuration that sets

--- a/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -77,7 +77,7 @@ If you don't specify a threshold, Kubernetes calculates a figure using a
 linear formula that yields 50% for a 100-node cluster and yields 10%
 for a 5000-node cluster. The lower bound for the automatic value is 5%.
 
-This means that, the kube-scheduler always scores at least 5% of your cluster no
+This means that the kube-scheduler always scores at least 5% of your cluster no
 matter how large the cluster is, unless you have explicitly set
 `percentageOfNodesToScore` to be smaller than 5.
 

--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -83,7 +83,7 @@ the Pod is put into the active queue or the backoff queue
 so that the scheduler will retry the scheduling of the Pod.
 
 {{< note >}}
-QueueingHint evaluation during scheduling is a beta-level feature. 
+QueueingHint evaluation during scheduling is a beta-level feature.
 The v1.28 release series initially enabled the associated feature gate; however, after the
 discovery of an excessive memory footprint, the Kubernetes project set that feature gate
 to be disabled by default. In Kubernetes {{< skew currentVersion >}}, this feature gate is

--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -113,7 +113,7 @@ called for that node. Nodes may be evaluated concurrently.
 
 ### PostFilter {#post-filter}
 
-These plugins are called after Filter phase, but only when no feasible nodes
+These plugins are called after the Filter phase, but only when no feasible nodes
 were found for the pod. Plugins are called in their configured order. If
 any postFilter plugin marks the node as `Schedulable`, the remaining plugins
 will not be called. A typical PostFilter implementation is preemption, which

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -84,7 +84,7 @@ An empty `effect` matches all effects with key `key1`.
 
 {{< /note >}}
 
-The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.
+The above example used the `effect` of `NoSchedule`. Alternatively, you can use the `effect` of `PreferNoSchedule`.
 
 
 The allowed values for the `effect` field are:
@@ -227,7 +227,7 @@ are true. The following taints are built in:
  * `node.kubernetes.io/network-unavailable`: Node's network is unavailable.
  * `node.kubernetes.io/unschedulable`: Node is unschedulable.
  * `node.cloudprovider.kubernetes.io/uninitialized`: When the kubelet is started
-    with "external" cloud provider, this taint is set on a node to mark it
+    with an "external" cloud provider, this taint is set on a node to mark it
     as unusable. After a controller from the cloud-controller-manager initializes
     this node, the kubelet removes this taint.
 

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -71,7 +71,7 @@ spec:
 ```
 
 You can read more about this field by running `kubectl explain Pod.spec.topologySpreadConstraints` or
-refer to [scheduling](/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) section of the API reference for Pod.
+refer to the [scheduling](/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) section of the API reference for Pod.
 
 ### Spread constraint definition
 
@@ -254,7 +254,7 @@ follows the API definition of the field; however, the behavior is more likely to
 confusing and troubleshooting is less straightforward.
 
 You need a mechanism to ensure that all the nodes in a topology domain (such as a
-cloud provider region) are labelled consistently.
+cloud provider region) are labeled consistently.
 To avoid you needing to manually label nodes, most clusters automatically
 populate well-known labels such as `kubernetes.io/hostname`. Check whether
 your cluster supports this.
@@ -263,7 +263,7 @@ your cluster supports this.
 
 ### Example: one topology spread constraint {#example-one-topologyspreadconstraint}
 
-Suppose you have a 4-node cluster where 3 Pods labelled `foo: bar` are located in
+Suppose you have a 4-node cluster where 3 Pods labeled `foo: bar` are located in
 node1, node2 and node3 respectively:
 
 {{<mermaid>}}
@@ -290,7 +290,7 @@ can use a manifest similar to:
 {{% code_sample file="pods/topology-spread-constraints/one-constraint.yaml" %}}
 
 From that manifest, `topologyKey: zone` implies the even distribution will only be applied
-to nodes that are labelled `zone: <any value>` (nodes that don't have a `zone` label
+to nodes that are labeled `zone: <any value>` (nodes that don't have a `zone` label
 are skipped). The field `whenUnsatisfiable: DoNotSchedule` tells the scheduler to let the
 incoming Pod stay pending if the scheduler can't find a way to satisfy the constraint.
 
@@ -494,7 +494,7 @@ There are some implicit conventions worth noting here:
   above example, if you remove the incoming Pod's labels, it can still be placed onto
   nodes in zone `B`, since the constraints are still satisfied. However, after that
   placement, the degree of imbalance of the cluster remains unchanged - it's still zone `A`
-  having 2 Pods labelled as `foo: bar`, and zone `B` having 1 Pod labelled as
+  having 2 Pods labeled as `foo: bar`, and zone `B` having 1 Pod labeled as
   `foo: bar`. If this is not what you expect, update the workload's
   `topologySpreadConstraints[*].labelSelector` to match the labels in the pod template.
 
@@ -618,7 +618,7 @@ section of the enhancement proposal about Pod topology spread constraints.
   because, in this case, those topology domains won't be considered until there is
   at least one node in them.
 
-  You can work around this by using an cluster autoscaling tool that is aware of
+  You can work around this by using a cluster autoscaling tool that is aware of
   Pod topology spread constraints and is also aware of the overall set of topology
   domains.
 

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -99,7 +99,7 @@ your cluster. Those fields are:
   {{< note >}}
   The `MinDomainsInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
   enables `minDomains` for pod topology spread. Starting from v1.28,
-  the `MinDomainsInPodTopologySpread` gate 
+  the `MinDomainsInPodTopologySpread` gate
   is enabled by default. In older Kubernetes clusters it might be explicitly
   disabled or the field might not be available.
   {{< /note >}}


### PR DESCRIPTION
This PR aims to fix a spelling mistake in the Kubernetes Scheduler documentation.

An 's' was missing. I checked the rest of the file and did not find any other spelling mistake. No broken link found.

Link to doc: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/