### PR TITLE
Update logging.md: Log rotation of kubelet

### DIFF
--- a/content/en/docs/concepts/cluster-administration/logging.md
+++ b/content/en/docs/concepts/cluster-administration/logging.md
@@ -97,15 +97,13 @@ The usual way to access this is by running `kubectl logs`.
 
 {{< feature-state for_k8s_version="v1.21" state="stable" >}}
 
-You can configure the kubelet to rotate logs automatically.
-
-If you configure rotation, the kubelet is responsible for rotating container logs and managing the
+The kubelet is responsible for rotating container logs and managing the
 logging directory structure.
 The kubelet sends this information to the container runtime (using CRI),
 and the runtime writes the container logs to the given location.
 
 You can configure two kubelet [configuration settings](/docs/reference/config-api/kubelet-config.v1beta1/),
-`containerLogMaxSize` and `containerLogMaxFiles`,
+`containerLogMaxSize` (default 10Mi) and `containerLogMaxFiles` (default 5),
 using the [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/).
 These settings let you configure the maximum size for each log file and the maximum number of
 files allowed for each container respectively.


### PR DESCRIPTION
close  https://github.com/kubernetes/website/issues/44550

Since the "Log rotation" feature is stable and [enabled by default from v1.21](https://github.com/kubernetes/kubernetes/blob/1b6b3ba013025c1914f6a992b7223e99c185599c/CHANGELOG/CHANGELOG-1.22.md?plain=1#L2642C1-L2642C281),
we can remove the words "You can configure" and "If you configure rotation".

Also, it would be good to mention defaults for kubelet configuration, refer to https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

