### PR TITLE
Fix broken link for "Weave Net" documentation in "Installing Addons" page

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -82,7 +82,7 @@ installation instructions. The list does not try to be exhaustive.
 * [Spiderpool](https://github.com/spidernet-io/spiderpool) is an underlay and RDMA
   networking solution for Kubernetes. Spiderpool is supported on bare metal, virtual machines,
   and public cloud environments.
-* [Weave Net](https://github.com/weaveworks/weave )
+* [Weave Net](https://github.com/weaveworks/weave)
   provides networking and network policy, will carry on working on both sides
   of a network partition, and does not require an external database.
 

--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -82,7 +82,7 @@ installation instructions. The list does not try to be exhaustive.
 * [Spiderpool](https://github.com/spidernet-io/spiderpool) is an underlay and RDMA
   networking solution for Kubernetes. Spiderpool is supported on bare metal, virtual machines,
   and public cloud environments.
-* [Weave Net](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/)
+* [Weave Net](https://github.com/weaveworks/weave )
   provides networking and network policy, will carry on working on both sides
   of a network partition, and does not require an external database.
 


### PR DESCRIPTION
Updated the link to "Weave Net" documentation to https://github.com/weaveworks/weave  as suggested in https://github.com/kubernetes/website/issues/45201#issue-2141231774


Closes https://github.com/kubernetes/website/issues/45201