### PR TITLE
Fix "feature-state" shortcode rendering within "tab" shortcode

### DIFF
--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -9,9 +9,9 @@
   {{ if not $is_valid }}
     {{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
   {{ else }}
-    <div class="my-2 feature-state-notice feature-{{ $state }}">
-      <b>{{ T "feature_state" }}</b> <code>{{T "feature_state_kubernetes_label" }} {{ $for_k8s_version }} [{{ $state }}]</code>
-    </div>
+  <div class="my-2 feature-state-notice feature-{{ $state }}">
+    <b>{{ T "feature_state" }}</b> <code>{{T "feature_state_kubernetes_label" }} {{ $for_k8s_version }} [{{ $state }}]</code>
+  </div>
   {{ end }}
 
 {{- else -}}
@@ -38,9 +38,9 @@
           {{- with $currentStage -}}  
            
           <!-- Display feature state information  -->
-            <div class="my-2 feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
-              <b>{{ T "feature_state" }}</b> <code>{{T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
-            </div>       
+          <div class="my-2 feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
+            <b>{{ T "feature_state" }}</b> <code>{{T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
+          </div>       
 
             {{- $featureGateFound = true -}}        
           {{- end -}}        


### PR DESCRIPTION
This PR addresses the rendering issue encountered when using the `feature-state` shortcode within the `tab` shortcode.

**Problem**:  The `tab` shortcode struggles to render nested `feature-state` shortcode content correctly, resulting in raw HTML output as reported in https://github.com/kubernetes/website/issues/45191#issue-2140757972. This occurs due to spacing and indentation, which disrupt the tab layout _(The behavior is identical when employing the 'note' shortcode with indentation; it disrupts the tab layout)_.

**Changes**: Removal of indentation within the  `feature-state` shortcode output so that `tab` shortcode can function properly.

**Outcome**: The `feature-state` shortcode now renders accurately  within the tab layout and other contexts.


[Fixed Preview Page _(check "Namespaced" tab)_](https://deploy-preview-45203--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/ingress/#ingressclass-scope) | [Broken Current Page _(check "Namespaced" tab)_](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingressclass-scope)

Fixes https://github.com/kubernetes/website/issues/45191



/area web-development

