### PR TITLE
Switch more feature-state shortcodes to be data driven

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -229,7 +229,7 @@ the API server will send any `BOOKMARK` event even when requested.
 
 ## Streaming lists
 
-{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+{{< feature-state feature_gate_name="WatchList" >}}
 
 On large clusters, retrieving the collection of some resource types may result in
 a significant increase of resource usage (primarily RAM) on the control plane.
@@ -287,7 +287,7 @@ Content-Type: application/json
 
 ## Response compression
 
-{{< feature-state for_k8s_version="v1.16" state="beta" >}}
+{{< feature-state feature_gate_name="APIResponseCompression" >}}
 
 `APIResponseCompression` is an option that allows the API server to compress the responses for **get**
 and **list** requests, reducing the network bandwidth and improving the performance of large-scale clusters.
@@ -317,7 +317,7 @@ The `content-encoding` header indicates that the response is compressed with `gz
 
 ## Retrieving large results sets in chunks
 
-{{< feature-state for_k8s_version="v1.29" state="stable" >}}
+{{< feature-state feature_gate_name="APIListChunking" >}}
 
 On large clusters, retrieving the collection of some resource types may result in
 very large responses that can impact the server and client. For instance, a cluster
@@ -787,7 +787,7 @@ These situations are:
 
 ### Validation for unrecognized or duplicate fields {#setting-the-field-validation-level}
 
-{{< feature-state for_k8s_version="v1.27" state="stable" >}}
+{{< feature-state feature_gate_name="ServerSideFieldValidation" >}}
 
 From 1.25 onward, unrecognized or duplicate fields in an object are detected via
 validation on the server when you use HTTP verbs that can submit data (`POST`, `PUT`, and `PATCH`). Possible levels of
@@ -846,7 +846,7 @@ a boolean flag.
 
 ## Dry-run
 
- {{< feature-state for_k8s_version="v1.18" state="stable" >}}
+{{< feature-state feature_gate_name="DryRun" >}}
 
 When you use HTTP verbs that can modify resources (`POST`, `PUT`, `PATCH`, and
 `DELETE`), you can submit your request in a _dry run_ mode. Dry run mode helps to

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -11,7 +11,7 @@ weight: 25
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.22" state="stable" >}}
+{{< feature-state feature_gate_name="ServerSideApply" >}}
 
 Kubernetes supports multiple appliers collaborating to manage the fields
 of a single [object](/docs/concepts/overview/working-with-objects/).

--- a/content/en/docs/tasks/administer-cluster/memory-manager.md
+++ b/content/en/docs/tasks/administer-cluster/memory-manager.md
@@ -12,7 +12,7 @@ weight: 410
 
 <!-- overview -->
 
-{{< feature-state state="beta" for_k8s_version="v1.22" >}}
+{{< feature-state feature_gate_name="MemoryManager" >}}
 
 The Kubernetes *Memory Manager* enables the feature of guaranteed memory (and hugepages)
 allocation for pods in the `Guaranteed` {{< glossary_tooltip text="QoS class" term_id="qos-class" >}}.

--- a/content/en/docs/tasks/administer-cluster/switch-to-evented-pleg.md
+++ b/content/en/docs/tasks/administer-cluster/switch-to-evented-pleg.md
@@ -5,7 +5,7 @@ content_type: task
 weight: 90
 ---
 
-{{< feature-state for_k8s_version="v1.27" state="beta" >}}
+{{< feature-state feature_gate_name="EventedPLEG" >}}
 
 <!-- overview -->
 

--- a/content/en/docs/tasks/configure-pod-container/resize-container-resources.md
+++ b/content/en/docs/tasks/configure-pod-container/resize-container-resources.md
@@ -8,7 +8,7 @@ min-kubernetes-server-version: 1.27
 
 <!-- overview -->
 
-{{< feature-state state="alpha" for_k8s_version="v1.27" >}}
+{{< feature-state feature_gate_name="InPlacePodVerticalScaling" >}}
 
 This page assumes that you are familiar with [Quality of Service](/docs/tasks/configure-pod-container/quality-service-pod/)
 for Kubernetes Pods.

--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -7,7 +7,7 @@ min-kubernetes-server-version: v1.25
 ---
 
 <!-- overview -->
-{{< feature-state for_k8s_version="v1.30" state="beta" >}}
+{{< feature-state feature_gate_name="UserNamespacesSupport" >}}
 
 This page shows how to configure a user namespace for pods. This allows you to
 isolate the user running inside the container from the one in the host.

--- a/content/en/docs/tasks/job/pod-failure-policy.md
+++ b/content/en/docs/tasks/job/pod-failure-policy.md
@@ -5,7 +5,7 @@ min-kubernetes-server-version: v1.25
 weight: 60
 ---
 
-{{< feature-state for_k8s_version="v1.26" state="beta" >}}
+{{< feature-state feature_gate_name="JobPodFailurePolicy" >}}
 
 <!-- overview -->
 

--- a/content/en/docs/tasks/network/extend-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/extend-service-ip-ranges.md
@@ -8,7 +8,7 @@ content_type: task
 ---
 
 <!-- overview -->
-{{< feature-state state="alpha" for_k8s_version="v1.29" >}}
+{{< feature-state feature_gate_name="MultiCIDRServiceAllocator" >}}
 
 This document shares how to extend the existing Service IP range assigned to a cluster.
 

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -241,7 +241,7 @@ These pods are tracked via `.status.currentHealthy` field in the PDB status.
 
 ## Unhealthy Pod Eviction Policy
 
-{{< feature-state for_k8s_version="v1.27" state="beta" >}}
+{{< feature-state feature_gate_name="PDBUnhealthyPodEvictionPolicy" >}}
 
 {{< note >}}
 This feature is enabled by default. You can disable it by disabling the `PDBUnhealthyPodEvictionPolicy`


### PR DESCRIPTION
Switch some feature-state shortcodes to be data driven, using the behavior added in https://github.com/kubernetes/website/pull/45032.
When the relevant feature gates graduate (or get deprecated), the associated shortcode will render the changed data automatically.

Follows #45166