### PR TITLE
Clean up OWNERS_ALIASES English groups

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,6 +24,7 @@ aliases:
     - rlenferink
   sig-docs-en-owners: # Admins for English content
     - celestehorgan
+    - dipesh-rawat
     - divya-mohan0209
     - drewhagen # RT 1.30 Docs Lead
     - katcosgrove # RT 1.30 Lead
@@ -33,12 +34,12 @@ aliases:
     - sftim
     - tengqm
   sig-docs-en-reviews: # PR reviews for English content
-    - bradtopol
+    - celestehorgan
     - dipesh-rawat
     - divya-mohan0209
     - kbhawkey
-    - mehabhalodiya
     - mengjiao-liu
+    - mickeyboxell
     - natalisucks
     - nate-double-u
     - reylejano


### PR DESCRIPTION
In conversation with SIG Docs leadership, we've cleaned up some of our membership to the reviewers and approvers group for English docs, and welcome @dipesh-rawat to our approvers group and PR Wrangling schedule

/assign @divya-mohan0209, @reylejano