### PR TITLE
Update analytics dashboard and change link on site

### DIFF
--- a/content/en/docs/contribute/analytics.md
+++ b/content/en/docs/contribute/analytics.md
@@ -14,9 +14,9 @@ This page contains information about the kubernetes.io analytics dashboard.
 
 <!-- body -->
 
-[View the dashboard](https://datastudio.google.com/reporting/fede2672-b2fd-402a-91d2-7473bdb10f04).
+[View the dashboard](https://lookerstudio.google.com/u/0/reporting/fe615dc5-59b0-4db5-8504-ef9eacb663a9/page/4VDGB/).
 
-This dashboard is built using Google Data Studio and shows information collected on kubernetes.io using Google Analytics.
+This dashboard is built using [Google Looker Studio](https://lookerstudio.google.com/overview) and shows information collected on kubernetes.io using Google Analytics 4 since August 2022. 
 
 ### Using the dashboard
 


### PR DESCRIPTION
This PR updates the link to the new analytics dashboard. The dashboard is very similar to the old analytics dashboard.

* page one: User over view page
* page 2: top 50 pages by page views
* page 3: top 50 search terms
* page 4: top blogs

One thing to note is that there are still permission issues which @divya-mohan0209 calls out in https://github.com/kubernetes/website/issues/44292. I'm not sure the best way to make this more sustainable. There can only be one set of credentials to pull the data from GA4 into the dashboard, right now I have it set up to use mine.  @natalisucks @reylejano @divya-mohan0209 if you have any suggestions on who this should be, please let me know and I can update it.  

fixes https://github.com/kubernetes/website/issues/43281