### PR TITLE
Update kompose go installation, go get is deprecated for executables

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -46,10 +46,10 @@ Alternatively, you can download the [tarball](https://github.com/kubernetes/komp
 {{% /tab %}}
 {{% tab name="Build from source" %}}
 
-Installing using `go get` pulls from the master branch with the latest development changes.
+Installing using `go install` pulls from the master branch with the latest development changes.
 
 ```sh
-go get -u github.com/kubernetes/kompose
+go install github.com/kubernetes/kompose@latest
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
[Go get is deprecated for installing executables](https://go.dev/doc/go-get-install-deprecation) switching to `go install` with the `@latest` "version" specification at the end allows global installing from anywhere (without `@latest` requires it be installed in a go module)