### PR TITLE
[KEP-4006] Docs for Transitioning from SPDY to WebSockets (Beta)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/port-forward-websockets.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/port-forward-websockets.md
@@ -1,0 +1,15 @@
+---
+title: PortForwardWebsockets
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+Allow WebSocket streaming of the
+portforward sub-protocol (`port-forward`) from clients requesting
+version v2 (`v2.portforward.k8s.io`) of the sub-protocol.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/translate-stream-close-websocket-requests.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/translate-stream-close-websocket-requests.md
@@ -6,9 +6,9 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
-    defaultValue: false
-    fromVersion: "1.29"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.30"
 ---
 Allow WebSocket streaming of the
 remote command sub-protocol (`exec`, `cp`, `attach`) from clients requesting

--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -370,6 +370,14 @@ kubectl [flags]
 </tr>
 
 <tr>
+<td colspan="2">KUBECTL_PORT_FORWARD_WEBSOCKETS</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, the kubectl port-forward command will attempt to stream using the websockets protocol. If the upgrade to websockets fails, the commands will fallback to use the current SPDY protocol.
+</td>
+</tr>
+
+<tr>
 <td colspan="2">KUBECTL_REMOTE_COMMAND_WEBSOCKETS</td>
 </tr>
 <tr>


### PR DESCRIPTION
* Updates control plane feature flag: `TranslateStreamCloseWebsocketRequests` to Beta
* Adds new control plane feature flag: `PortForwardWebsockets` as Alpha
* Adds new `kubectl` feature flag: `KUBECTL_PORT_FORWARD_WEBSOCKETS`

https://github.com/kubernetes/enhancements/issues/4006