### PR TITLE
Document SELinuxMount feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/selinux-mount.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/selinux-mount.md
@@ -1,0 +1,20 @@
+---
+title: SELinuxMount
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+Speeds up container startup by allowing kubelet to mount volumes
+for a Pod directly with the correct SELinux label instead of changing each file on the volumes
+recursively.
+It widens the performance improvements behind the `SELinuxMountReadWriteOncePod`
+feature gate by extending the implementation to all volumes.
+
+Enabling the `SELinuxMount` feature gate requires the feature gate `SELinuxMountReadWriteOncePod` to
+be enabled.


### PR DESCRIPTION
Add documentation for SELinuxMount feature gate.

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
Issue: https://github.com/kubernetes/enhancements/issues/1710

~WIP:~

~needs the [implementation](https://github.com/kubernetes/kubernetes/pull/123157) merged first~
