### PR TITLE
blog: Update expected end date for legacy package repos

### DIFF
--- a/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
+++ b/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
@@ -112,7 +112,7 @@ future. However, the Kubernetes project can't provide _any_ guarantees on how lo
 is that going to be. The deprecated legacy repositories, and their contents, might
 be removed at any time in the future and without a further notice period.~~
 
-**UPDATE**: The legacy packages are expected to go away in January 2024.
+**UPDATE**: The legacy packages are expected to go away by the end of February 2024.
 
 The Kubernetes project **strongly recommends** migrating to the new community-owned
 repositories **as soon as possible**.


### PR DESCRIPTION
This is a minor update to the expected end date for the legacy package repos. It was original targeted for January 2024, but current progress looks like it will be any time in the next week, placing it by the end of February. This is a quick update just to make things more accurate for current and historical purposes.