### PR TITLE
[zh] Sync /kubectl/kubectl.md

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/kubectl.md
+++ b/content/zh-cn/docs/reference/kubectl/kubectl.md
@@ -17,11 +17,11 @@ kubectl controls the Kubernetes cluster manager.
 kubectl 管理控制 Kubernetes 集群。
 
 <!--
-Find more information at: https://kubernetes.io/docs/reference/kubectl/
+Find more information in [Command line tool](/docs/reference/kubectl/) (`kubectl`).
 -->
-获取更多信息，请访问 [kubectl 概述](/zh-cn/docs/reference/kubectl/)。
+更多信息请查阅[命令行工具](/zh-cn/docs/kubectl/)（`kubectl`）。
 
-```
+```shell
 kubectl [flags]
 ```
 
@@ -321,7 +321,9 @@ kubectl [flags]
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">
-      <!--If true, only write logs to their native severity level (vs also writing to each lower severity level-->
+      <!--
+      If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      -->
       如果为 true，则只将日志写入初始严重级别（而不是同时写入所有较低的严重级别）。
       </td>
     </tr>
@@ -560,104 +562,111 @@ When set to true, the kubectl exec, cp, and attach commands will attempt to stre
 ## {{% heading "seealso" %}}
 
 <!--
-* [kubectl annotate](/docs/reference/generated/kubectl/kubectl-commands#annotate)	 - Update the annotations on a resource
-* [kubectl api-resources](/docs/reference/generated/kubectl/kubectl-commands#api-resources)	 - Print the supported API resources on the server
-* [kubectl api-versions](/docs/reference/generated/kubectl/kubectl-commands#api-versions)	 - Print the supported API versions on the server, in the form of "group/version"
-* [kubectl apply](/docs/reference/generated/kubectl/kubectl-commands#apply)	 - Apply a configuration to a resource by filename or stdin
-* [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands#attach)	 - Attach to a running container
+* [kubectl annotate](/docs/reference/kubectl/generated/kubectl_annotate/) - Update the annotations on a resource
+* [kubectl api-resources](/docs/reference/kubectl/generated/kubectl_api-resources/) - Print the supported API resources on the server
+* [kubectl api-versions](/docs/reference/kubectl/generated/kubectl_api-versions/) - Print the supported API versions on the server,
+  in the form of "group/version"
+* [kubectl apply](/docs/reference/kubectl/generated/kubectl_apply/) - Apply a configuration to a resource by filename or stdin
+* [kubectl attach](/docs/reference/kubectl/generated/kubectl_attach/) - Attach to a running container
 -->
-* [kubectl annotate](/docs/reference/generated/kubectl/kubectl-commands#annotate)	 - 更新资源所关联的注解
-* [kubectl api-resources](/docs/reference/generated/kubectl/kubectl-commands#api-resources)	 - 打印服务器上所支持的 API 资源
-* [kubectl api-versions](/docs/reference/generated/kubectl/kubectl-commands#api-versions)	 - 以“组/版本”的格式输出服务端所支持的 API 版本
-* [kubectl apply](/docs/reference/generated/kubectl/kubectl-commands#apply)	 - 基于文件名或标准输入，将新的配置应用到资源上
-* [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands#attach)	 - 连接到一个正在运行的容器
+* [kubectl annotate](/zh-cn/docs/reference/kubectl/generated/kubectl_annotate/) - 更新资源所关联的注解
+* [kubectl api-resources](/docs/reference/kubectl/generated/kubectl_api-resources/) - 打印服务器上所支持的 API 资源
+* [kubectl api-versions](/docs/reference/kubectl/generated/kubectl_api-versions/) - 以“组/版本”的格式输出服务端所支持的 API 版本
+* [kubectl apply](/docs/reference/kubectl/generated/kubectl_apply/) - 基于文件名或标准输入，将新的配置应用到资源上
+* [kubectl attach](/docs/reference/kubectl/generated/kubectl_attach/) - 挂接到一个正在运行的容器
 <!--
-* [kubectl auth](/docs/reference/generated/kubectl/kubectl-commands#auth)	 - Inspect authorization
-* [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands#autoscale)	 - Auto-scale a Deployment, ReplicaSet, or ReplicationController
-* [kubectl certificate](/docs/reference/generated/kubectl/kubectl-commands#certificate)	 - Modify certificate resources.
-* [kubectl cluster-info](/docs/reference/generated/kubectl/kubectl-commands#cluster-info)	 - Display cluster info
-* [kubectl completion](/docs/reference/generated/kubectl/kubectl-commands#completion)	 - Output shell completion code for the specified shell (bash or zsh)
-* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands#config)	 - Modify kubeconfig files
+* [kubectl auth](/docs/reference/kubectl/generated/kubectl_auth/) - Inspect authorization
+* [kubectl autoscale](/docs/reference/kubectl/generated/kubectl_autoscale/) - Auto-scale a Deployment, ReplicaSet, or ReplicationController
+* [kubectl certificate](/docs/reference/kubectl/generated/kubectl_certificate/) - Modify certificate resources.
+* [kubectl cluster-info](/docs/reference/kubectl/generated/kubectl_cluster-info/) - Display cluster info
+* [kubectl completion](/docs/reference/kubectl/generated/kubectl_completion/) - Output shell completion code for the specified shell (bash or zsh)
+* [kubectl config](/docs/reference/kubectl/generated/kubectl_config/) - Modify kubeconfig files
 -->
-* [kubectl auth](/docs/reference/generated/kubectl/kubectl-commands#auth)	 - 检查授权信息
-* [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands#autoscale)	 - 对一个资源对象（Deployment、ReplicaSet 或 ReplicationController ）进行扩缩
-* [kubectl certificate](/docs/reference/generated/kubectl/kubectl-commands#certificate)	 - 修改证书资源
-* [kubectl cluster-info](/docs/reference/generated/kubectl/kubectl-commands#cluster-info)	 - 显示集群信息
-* [kubectl completion](/docs/reference/generated/kubectl/kubectl-commands#completion)	 - 根据已经给出的 Shell（bash 或 zsh），输出 Shell 补全后的代码
-* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands#config)	 - 修改 kubeconfig 配置文件
+* [kubectl auth](/docs/reference/kubectl/generated/kubectl_auth/) - 检查授权信息
+* [kubectl autoscale](/docs/reference/kubectl/generated/kubectl_autoscale/) - 对一个资源对象
+  （Deployment、ReplicaSet 或 ReplicationController）进行自动扩缩
+* [kubectl certificate](/docs/reference/kubectl/generated/kubectl_certificate/) - 修改证书资源
+* [kubectl cluster-info](/docs/reference/kubectl/generated/kubectl_cluster-info/) - 显示集群信息
+* [kubectl completion](/docs/reference/kubectl/generated/kubectl_completion/) - 根据已经给出的 Shell（bash 或 zsh），
+  输出 Shell 补全后的代码
+* [kubectl config](/docs/reference/kubectl/generated/kubectl_config/) - 修改 kubeconfig 配置文件
 <!--
-* [kubectl convert](/docs/reference/generated/kubectl/kubectl-commands#convert)	 - Convert config files between different API versions
-* [kubectl cordon](/docs/reference/generated/kubectl/kubectl-commands#cordon)	 - Mark node as unschedulable
-* [kubectl cp](/docs/reference/generated/kubectl/kubectl-commands#cp)	 - Copy files and directories to and from containers.
-* [kubectl create](/docs/reference/generated/kubectl/kubectl-commands#create)	 - Create a resource from a file or from stdin.
-* [kubectl debug](/docs/reference/generated/kubectl/kubectl-commands#debug)	 - Create debugging sessions for troubleshooting workloads and nodes
-* [kubectl delete](/docs/reference/generated/kubectl/kubectl-commands#delete)	 - Delete resources by filenames, stdin, resources and names, or by resources and label selector
+* [kubectl cordon](/docs/reference/kubectl/generated/kubectl_cordon/) - Mark node as unschedulable
+* [kubectl cp](/docs/reference/kubectl/generated/kubectl_cp/) - Copy files and directories to and from containers.
+* [kubectl create](/docs/reference/kubectl/generated/kubectl_create/) - Create a resource from a file or from stdin.
+* [kubectl debug](/docs/reference/kubectl/generated/kubectl_debug/) - Create debugging sessions for troubleshooting workloads and nodes
+* [kubectl delete](/docs/reference/kubectl/generated/kubectl_delete/) - Delete resources by filenames,
+  stdin, resources and names, or by resources and label selector
 -->
-* [kubectl convert](/docs/reference/generated/kubectl/kubectl-commands#convert)	 - 在不同的 API 版本之间转换配置文件
-* [kubectl cordon](/docs/reference/generated/kubectl/kubectl-commands#cordon)	 - 标记节点为不可调度的
-* [kubectl cp](/docs/reference/generated/kubectl/kubectl-commands#cp)	 - 将文件和目录拷入/拷出容器
-* [kubectl create](/docs/reference/generated/kubectl/kubectl-commands#create)	 - 通过文件或标准输入来创建资源
-* [kubectl debug](/docs/reference/generated/kubectl/kubectl-commands#debug)	 - 创建用于排查工作负载和节点故障的调试会话
-* [kubectl delete](/docs/reference/generated/kubectl/kubectl-commands#delete)	 - 通过文件名、标准输入、资源和名字删除资源，或者通过资源和标签选择算符来删除资源
+* [kubectl cordon](/docs/reference/kubectl/generated/kubectl_cordon/) - 标记节点为不可调度的
+* [kubectl cp](/docs/reference/kubectl/generated/kubectl_cp/) - 将文件和目录拷入/拷出容器
+* [kubectl create](/docs/reference/kubectl/generated/kubectl_create/) - 通过文件或标准输入来创建资源
+* [kubectl debug](/docs/reference/kubectl/generated/kubectl_debug/) - 创建用于排查工作负载和节点故障的调试会话
+* [kubectl delete](/docs/reference/kubectl/generated/kubectl_delete/) - 通过文件名、标准输入、资源和名字删除资源，
+  或者通过资源和标签选择算符来删除资源
 <!--
-* [kubectl describe](/docs/reference/generated/kubectl/kubectl-commands#describe)	 - Show details of a specific resource or group of resources
-* [kubectl diff](/docs/reference/generated/kubectl/kubectl-commands#diff)	 - Diff live version against would-be applied version
-* [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands#drain)	 - Drain node in preparation for maintenance
-* [kubectl edit](/docs/reference/generated/kubectl/kubectl-commands#edit)	 - Edit a resource on the server
-* [kubectl events](/docs/reference/generated/kubectl/kubectl-commands#events)  - List events
-* [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands#exec)	 - Execute a command in a container
-* [kubectl explain](/docs/reference/generated/kubectl/kubectl-commands#explain)	 - Documentation of resources
-* [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands#expose)	 - Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
+* [kubectl describe](/docs/reference/kubectl/generated/kubectl_describe/) - Show details of a specific resource or group of resources
+* [kubectl diff](/docs/reference/kubectl/generated/kubectl_diff/) - Diff live version against would-be applied version
+* [kubectl drain](/docs/reference/kubectl/generated/kubectl_drain/) - Drain node in preparation for maintenance
+* [kubectl edit](/docs/reference/kubectl/generated/kubectl_edit/) - Edit a resource on the server
+* [kubectl events](/docs/reference/kubectl/generated/kubectl_events/)  - List events
+* [kubectl exec](/docs/reference/kubectl/generated/kubectl_exec/) - Execute a command in a container
+* [kubectl explain](/docs/reference/kubectl/generated/kubectl_explain/) - Documentation of resources
+* [kubectl expose](/docs/reference/kubectl/generated/kubectl_expose/) - Take a replication controller,
+  service, deployment or pod and expose it as a new Kubernetes Service
 -->
-* [kubectl describe](/docs/reference/generated/kubectl/kubectl-commands#describe)	 - 显示某个资源或某组资源的详细信息
-* [kubectl diff](/docs/reference/generated/kubectl/kubectl-commands#diff)	 - 显示目前版本与将要应用的版本之间的差异
-* [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands#drain)	 - 腾空节点，准备维护
-* [kubectl edit](/docs/reference/generated/kubectl/kubectl-commands#edit)	 - 修改服务器上的某资源
-* [kubectl events](/docs/reference/generated/kubectl/kubectl-commands#events)  - 列举事件
-* [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands#exec)	 - 在容器中执行相关命令
-* [kubectl explain](/docs/reference/generated/kubectl/kubectl-commands#explain)	 - 显示资源文档说明
-* [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands#expose)	 - 给定副本控制器、服务、Deployment 或 Pod，将其暴露为新的 kubernetes Service
+* [kubectl describe](/docs/reference/kubectl/generated/kubectl_describe/) - 显示某个资源或某组资源的详细信息
+* [kubectl diff](/docs/reference/kubectl/generated/kubectl_diff/) - 显示目前版本与将要应用的版本之间的差异
+* [kubectl drain](/docs/reference/kubectl/generated/kubectl_drain/) - 腾空节点，准备维护
+* [kubectl edit](/docs/reference/kubectl/generated/kubectl_edit/) - 修改服务器上的某资源
+* [kubectl events](/docs/reference/kubectl/generated/kubectl_events/)  - 列举事件
+* [kubectl exec](/docs/reference/kubectl/generated/kubectl_exec/) - 在容器中执行相关命令
+* [kubectl explain](/docs/reference/kubectl/generated/kubectl_explain/) - 显示资源文档说明
+* [kubectl expose](/docs/reference/kubectl/generated/kubectl_expose/) - 给定副本控制器、服务、Deployment 或 Pod，
+  将其暴露为新的 kubernetes Service
 <!--
-* [kubectl get](/docs/reference/generated/kubectl/kubectl-commands#get)	 - Display one or many resources
-* [kubectl kustomize](/docs/reference/generated/kubectl/kubectl-commands#kustomize)	 - Build a kustomization target from a directory or a remote url.
-* [kubectl label](/docs/reference/generated/kubectl/kubectl-commands#label)	 - Update the labels on a resource
-* [kubectl logs](/docs/reference/generated/kubectl/kubectl-commands#logs)	 - Print the logs for a container in a pod
-* [kubectl options](/docs/reference/generated/kubectl/kubectl-commands#options)	 - Print the list of flags inherited by all commands
-* [kubectl patch](/docs/reference/generated/kubectl/kubectl-commands#patch)	 - Update field(s) of a resource
+* [kubectl get](/docs/reference/kubectl/generated/kubectl_get/) - Display one or many resources
+* [kubectl kustomize](/docs/reference/kubectl/generated/kubectl_kustomize/) - Build a kustomization
+  target from a directory or a remote url.
+* [kubectl label](/docs/reference/kubectl/generated/kubectl_label/) - Update the labels on a resource
+* [kubectl logs](/docs/reference/kubectl/generated/kubectl_logs/) - Print the logs for a container in a pod
+* [kubectl options](/docs/reference/kubectl/generated/kubectl_options/) - Print the list of flags inherited by all commands
+* [kubectl patch](/docs/reference/kubectl/generated/kubectl_patch/) - Update field(s) of a resource
 -->
-* [kubectl get](/docs/reference/generated/kubectl/kubectl-commands#get)	 - 显示一个或者多个资源信息
-* [kubectl kustomize](/docs/reference/generated/kubectl/kubectl-commands#kustomize)	 - 从目录或远程 URL 中构建 kustomization
-* [kubectl label](/docs/reference/generated/kubectl/kubectl-commands#label)	 - 更新资源的标签
-* [kubectl logs](/docs/reference/generated/kubectl/kubectl-commands#logs)	 - 输出 Pod 中某容器的日志
-* [kubectl options](/docs/reference/generated/kubectl/kubectl-commands#options)	 - 打印所有命令都支持的共有参数列表
-* [kubectl patch](/docs/reference/generated/kubectl/kubectl-commands#patch)	 - 基于策略性合并修补（Stategic Merge Patch）规则更新某资源中的字段
+* [kubectl get](/docs/reference/kubectl/generated/kubectl_get/) - 显示一个或者多个资源信息
+* [kubectl kustomize](/docs/reference/kubectl/generated/kubectl_kustomize/) - 从目录或远程 URL 中构建 kustomization
+* [kubectl label](/docs/reference/kubectl/generated/kubectl_label/) - 更新资源的标签
+* [kubectl logs](/docs/reference/kubectl/generated/kubectl_logs/) - 输出 Pod 中某容器的日志
+* [kubectl options](/docs/reference/kubectl/generated/kubectl_options/) - 打印所有命令都支持的共有参数列表
+* [kubectl patch](/docs/reference/kubectl/generated/kubectl_patch/) - 更新某资源中的字段
 <!--
-* [kubectl plugin](/docs/reference/generated/kubectl/kubectl-commands#plugin)	 - Provides utilities for interacting with plugins.
-* [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands#port-forward)	 - Forward one or more local ports to a pod
-* [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands#proxy)	 - Run a proxy to the Kubernetes API server
-* [kubectl replace](/docs/reference/generated/kubectl/kubectl-commands#replace)	 - Replace a resource by filename or stdin
-* [kubectl rollout](/docs/reference/generated/kubectl/kubectl-commands#rollout)	 - Manage the rollout of a resource
-* [kubectl run](/docs/reference/generated/kubectl/kubectl-commands#run)	 - Run a particular image on the cluster
+* [kubectl plugin](/docs/reference/kubectl/generated/kubectl_plugin/) - Provides utilities for interacting with plugins.
+* [kubectl port-forward](/docs/reference/kubectl/generated/kubectl_port-forward/) - Forward one or more local ports to a pod
+* [kubectl proxy](/docs/reference/kubectl/generated/kubectl_proxy/) - Run a proxy to the Kubernetes API server
+* [kubectl replace](/docs/reference/kubectl/generated/kubectl_replace/) - Replace a resource by filename or stdin
+* [kubectl rollout](/docs/reference/kubectl/generated/kubectl_rollout/) - Manage the rollout of a resource
+* [kubectl run](/docs/reference/kubectl/generated/kubectl_run/) - Run a particular image on the cluster
 -->
-* [kubectl plugin](/docs/reference/generated/kubectl/kubectl-commands#plugin)	 - 运行命令行插件
-* [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands#port-forward)	 - 将一个或者多个本地端口转发到 Pod
-* [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands#proxy)	 - 运行一个 kubernetes API 服务器代理
-* [kubectl replace](/docs/reference/generated/kubectl/kubectl-commands#replace)	 - 基于文件名或标准输入替换资源
-* [kubectl rollout](/docs/reference/generated/kubectl/kubectl-commands#rollout)	 - 管理资源的上线
-* [kubectl run](/docs/reference/generated/kubectl/kubectl-commands#run)	 - 在集群中使用指定镜像启动容器
+* [kubectl plugin](/docs/reference/kubectl/generated/kubectl_plugin/) - 运行命令行插件
+* [kubectl port-forward](/docs/reference/kubectl/generated/kubectl_port-forward/) - 将一个或者多个本地端口转发到 Pod
+* [kubectl proxy](/docs/reference/kubectl/generated/kubectl_proxy/) - 运行一个 kubernetes API 服务器代理
+* [kubectl replace](/docs/reference/kubectl/generated/kubectl_replace/) - 基于文件名或标准输入替换资源
+* [kubectl rollout](/docs/reference/kubectl/generated/kubectl_rollout/) - 管理资源的上线
+* [kubectl run](/docs/reference/kubectl/generated/kubectl_run/) - 在集群中使用指定镜像启动容器
 <!--
-* [kubectl scale](/docs/reference/generated/kubectl/kubectl-commands#scale)	 - Set a new size for a Deployment, ReplicaSet or Replication Controller
-* [kubectl set](/docs/reference/generated/kubectl/kubectl-commands#set)	 - Set specific features on objects
-* [kubectl taint](/docs/reference/generated/kubectl/kubectl-commands#taint)	 - Update the taints on one or more nodes
-* [kubectl top](/docs/reference/generated/kubectl/kubectl-commands#top)	 - Display Resource (CPU/Memory/Storage) usage.
-* [kubectl uncordon](/docs/reference/generated/kubectl/kubectl-commands#uncordon)	 - Mark node as schedulable
-* [kubectl version](/docs/reference/generated/kubectl/kubectl-commands#version)	 - Print the client and server version information
-* [kubectl wait](/docs/reference/generated/kubectl/kubectl-commands#wait)	 - Experimental: Wait for a specific condition on one or many resources.
+* [kubectl scale](/docs/reference/kubectl/generated/kubectl_scale/) - Set a new size for a Deployment, ReplicaSet or Replication Controller
+* [kubectl set](/docs/reference/kubectl/generated/kubectl_set/) - Set specific features on objects
+* [kubectl taint](/docs/reference/kubectl/generated/kubectl_taint/) - Update the taints on one or more nodes
+* [kubectl top](/docs/reference/kubectl/generated/kubectl_top/) - Display Resource (CPU/Memory/Storage) usage.
+* [kubectl uncordon](/docs/reference/kubectl/generated/kubectl_uncordon/) - Mark node as schedulable
+* [kubectl version](/docs/reference/kubectl/generated/kubectl_version/) - Print the client and server version information
+* [kubectl wait](/docs/reference/kubectl/generated/kubectl_wait/) - Experimental: Wait for a specific condition on one or many resources.
 -->
-* [kubectl scale](/docs/reference/generated/kubectl/kubectl-commands#scale)	 - 为一个 Deployment、ReplicaSet 或 ReplicationController 设置一个新的规模值
-* [kubectl set](/docs/reference/generated/kubectl/kubectl-commands#set)	 - 为对象设置功能特性
-* [kubectl taint](/docs/reference/generated/kubectl/kubectl-commands#taint)	 - 在一个或者多个节点上更新污点配置
-* [kubectl top](/docs/reference/generated/kubectl/kubectl-commands#top)	 - 显示资源（CPU/内存/存储）使用率
-* [kubectl uncordon](/docs/reference/generated/kubectl/kubectl-commands#uncordon)	 - 标记节点为可调度的
-* [kubectl version](/docs/reference/generated/kubectl/kubectl-commands#version)	 - 打印客户端和服务器的版本信息
-* [kubectl wait](/docs/reference/generated/kubectl/kubectl-commands#wait)	 - 实验级特性：等待一个或多个资源达到某种状态
+* [kubectl scale](/docs/reference/kubectl/generated/kubectl_scale/) - 为一个 Deployment、ReplicaSet 或
+  ReplicationController 设置一个新的规模值
+* [kubectl set](/docs/reference/kubectl/generated/kubectl_set/) - 为对象设置功能特性
+* [kubectl taint](/docs/reference/kubectl/generated/kubectl_taint/) - 在一个或者多个节点上更新污点配置
+* [kubectl top](/docs/reference/kubectl/generated/kubectl_top/) - 显示资源（CPU/内存/存储）使用率
+* [kubectl uncordon](/docs/reference/kubectl/generated/kubectl_uncordon/) - 标记节点为可调度的
+* [kubectl version](/docs/reference/kubectl/generated/kubectl_version/) - 打印客户端和服务器的版本信息
+* [kubectl wait](/docs/reference/kubectl/generated/kubectl_wait/) - 实验级特性：等待一个或多个资源达到某种状态


### PR DESCRIPTION
Sync with en #45235 

```
content/zh-cn/docs/reference/kubectl/kubectl.md
```
The bottom referenced docs may require additional time to localize due to their size, so only the first one (kubectl_annotate) has been added with the `/zh-cn` prefix.

See [preview](https://deploy-preview-45300--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubectl/kubectl/).