### PR TITLE
Update define-command-argument-container.md

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -31,7 +31,7 @@ the `args` field in the configuration file. The command and arguments that
 you define cannot be changed after the Pod is created.
 
 The command and arguments that you define in the configuration file
-override the default command and arguments provided by the container image.
+override the default command and arguments provided by the container image.（which are CMD and ENTRYPOINT）
 If you define args, but do not define a command, the default command is used
 with your new arguments.
 

--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -31,7 +31,7 @@ the `args` field in the configuration file. The command and arguments that
 you define cannot be changed after the Pod is created.
 
 The command and arguments that you define in the configuration file
-override the default command and arguments provided by the container image.（which are CMD and ENTRYPOINT）
+override the default command and arguments provided by the container image.（which are CMD and ENTRYPOINT in Dockerfile image syntax.）
 If you define args, but do not define a command, the default command is used
 with your new arguments.
 

--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -31,7 +31,8 @@ the `args` field in the configuration file. The command and arguments that
 you define cannot be changed after the Pod is created.
 
 The command and arguments that you define in the configuration file
-override the default command and arguments provided by the container image.（which are CMD and ENTRYPOINT in Dockerfile image syntax.）
+override the default command and arguments provided by the container image
+(which are CMD and ENTRYPOINT in Dockerfile image syntax).
 If you define args, but do not define a command, the default command is used
 with your new arguments.
 


### PR DESCRIPTION
add "CMD and ENTRYPOINT" to explain image command and arguments.
When search CMD and command meantime，users will find that document