### PR TITLE
Remove references to bridge-nf-call-iptables

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -54,19 +54,6 @@ that plugin or [networking provider](/docs/concepts/cluster-administration/netwo
 
 ## Network Plugin Requirements
 
-For plugin developers and users who regularly build or deploy Kubernetes, the plugin may also need
-specific configuration to support kube-proxy. The iptables proxy depends on iptables, and the
-plugin may need to ensure that container traffic is made available to iptables. For example, if
-the plugin connects containers to a Linux bridge, the plugin must set the
-`net/bridge/bridge-nf-call-iptables` sysctl to `1` to ensure that the iptables proxy functions
-correctly. If the plugin does not use a Linux bridge, but uses something like Open vSwitch or
-some other mechanism instead, it should ensure container traffic is appropriately routed for the
-proxy.
-
-By default, if no kubelet network plugin is specified, the `noop` plugin is used, which sets
-`net/bridge/bridge-nf-call-iptables=1` to ensure simple configurations (like Docker with a bridge)
-work correctly with the iptables proxy.
-
 ### Loopback CNI
 
 In addition to the CNI plugin installed on the nodes for implementing the Kubernetes network

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -109,8 +109,6 @@ The user can skip specific preflight checks or all of them with the `--ignore-pr
 - [warning] if firewalld is active
 - [error] if API server bindPort or ports 10250/10251/10252 are used
 - [Error] if `/etc/kubernetes/manifest` folder already exists and it is not empty
-- [Error] if `/proc/sys/net/bridge/bridge-nf-call-iptables` file does not exist/does not contain 1
-- [Error] if advertise address is ipv6 and `/proc/sys/net/bridge/bridge-nf-call-ip6tables` does not exist/does not contain 1.
 - [Error] if swap is on
 - [Error] if `conntrack`, `ip`, `iptables`, `mount`, `nsenter` commands are not present in the command path
 - [warning] if `ebtables`, `ethtool`, `socat`, `tc`, `touch`, `crictl` commands are not present in the command path

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -47,50 +47,33 @@ check the documentation for that version.
 <!-- body -->
 ## Install and configure prerequisites
 
-The following steps apply common settings for Kubernetes nodes on Linux.
+### Network configuration
 
-You can skip a particular setting if you're certain you don't need it.
+By default, the Linux kernel does not allow IPv4 packets to be routed
+between interfaces. Most Kubernetes cluster networking implementations
+will change this setting (if needed), but some might expect the
+administrator to do it for them. (Some might also expect other sysctl
+parameters to be set, kernel modules to be loaded, etc; consult the
+documentation for your specific network implementation.)
 
-For more information, see
-[Network Plugin Requirements](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements)
-or the documentation for your specific container runtime.
+### Enable IPv4 packet forwarding {#prerequisite-ipv4-forwarding-optional}
 
-### Forwarding IPv4 and letting iptables see bridged traffic
-
-Execute the below mentioned instructions:
+To manually enable IPv4 packet forwarding:
 
 ```bash
-cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
-overlay
-br_netfilter
-EOF
-
-sudo modprobe overlay
-sudo modprobe br_netfilter
-
 # sysctl params required by setup, params persist across reboots
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
-net.bridge.bridge-nf-call-iptables  = 1
-net.bridge.bridge-nf-call-ip6tables = 1
-net.ipv4.ip_forward                 = 1
+net.ipv4.ip_forward = 1
 EOF
 
 # Apply sysctl params without reboot
 sudo sysctl --system
 ```
 
-Verify that the `br_netfilter`, `overlay` modules are loaded by running the following commands:
+Verify that `net.ipv4.ip_forward` is set to 1 with:
 
 ```bash
-lsmod | grep br_netfilter
-lsmod | grep overlay
-```
-
-Verify that the `net.bridge.bridge-nf-call-iptables`, `net.bridge.bridge-nf-call-ip6tables`, and
-`net.ipv4.ip_forward` system variables are set to `1` in your `sysctl` config by running the following command:
-
-```bash
-sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward
+sysctl net.ipv4.ip_forward
 ```
 
 ## cgroup drivers


### PR DESCRIPTION
Telling users to set `bridge-nf-call-iptables` themselves was supposed to have been a temporary thing after kube-proxy's behavior changed between kubernetes 1.1 and 1.2. We can stop doing that now.

(kubeadm checks removed in https://github.com/kubernetes/kubernetes/pull/123464)