### PR TITLE
[fr]: Removing old CSS includes from tutorials and fix html href

### DIFF
--- a/content/fr/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/_index.html
@@ -8,13 +8,12 @@ card:
   title: Pas à pas des bases
 ---
 
+
 <!DOCTYPE html>
 
 <html lang="fr">
 
 <body>
-
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
 
 <div class="layout" id="top">
 
@@ -67,9 +66,9 @@ card:
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
+                <a href="/fr/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. Explorez votre application</h5></a>
+                  <a href="/fr/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. Explorez votre application</h5></a>
                 </div>
               </div>
             </div>
@@ -79,25 +78,25 @@ card:
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
+                <a href="/fr/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. Exposez votre application publiquement</h5></a>
+                  <a href="/fr/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. Exposez votre application publiquement</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
+                <a href="/fr/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. Mettre à l'échelle votre application</h5></a>
+                  <a href="/fr/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. Mettre à l'échelle votre application</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
+                <a href="/fr/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. Mettre à jour votre application</h5></a>
+                  <a href="/fr/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. Mettre à jour votre application</h5></a>
                 </div>
               </div>
             </div>
@@ -108,7 +107,7 @@ card:
 
     <div class="row">
       <div class="col-md-12">
-        <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button">Lancer le tutoriel<span class="btn__next">›</span></a>
+        <a class="btn btn-lg btn-success" href="/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button">Lancer le tutoriel<span class="btn__next">›</span></a>
       </div>
     </div>
 

--- a/content/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -9,8 +9,6 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/content/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -9,7 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
 
 <div class="layout" id="top">
 
@@ -96,7 +95,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/" role="button">Lancer le didacticiel interactif <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/" role="button">Lancer le didacticiel interactif <span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/fr/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -9,8 +9,7 @@ weight: 20
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
-<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
+
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">
@@ -29,7 +28,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continuer au module 3<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/fr/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continuer au module 3<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/fr/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -9,7 +9,6 @@ weight: 10
 
 <body>
 
-<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
 
 <div class="layout" id="top">
 
@@ -71,7 +70,7 @@ weight: 10
                 <p>Vous pouvez créer et gérer un déploiement à l'aide de l'interface de ligne de commande, <b>Kubectl</b>.</p>
                 <p>Kubectl utilise l'API Kubernetes pour interagir avec le cluster. Dans ce module, vous apprendrez les commandes Kubectl les plus courantes nécessaires à la création de déploiements exécutant vos applications sur un cluster Kubernetes.</p>
 
-                <p>Lorsque vous créez un déploiement, vous devez spécifier l'image de conteneur de votre application et le nombre de réplicas que vous souhaitez exécuter. Vous pouvez modifier ces informations ultérieurement en mettant à jour votre déploiement.; Modules <a href="/docs/tutorials/kubernetes-basics/scale-intro/">5</a> et <a href="/docs/tutorials/kubernetes-basics/update-intro/">6</a> du bootcamp, expliquez comment vous pouvez faire évoluer et mettre à jour vos déploiements.</p>
+                <p>Lorsque vous créez un déploiement, vous devez spécifier l'image de conteneur de votre application et le nombre de réplicas que vous souhaitez exécuter. Vous pouvez modifier ces informations ultérieurement en mettant à jour votre déploiement.; Modules <a href="/fr/docs/tutorials/kubernetes-basics/scale-intro/">5</a> et <a href="/fr/docs/tutorials/kubernetes-basics/update-intro/">6</a> du bootcamp, expliquez comment vous pouvez faire évoluer et mettre à jour vos déploiements.</p>
 
 
 
@@ -99,7 +98,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/" role="button">Lancer le didacticiel interactif <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/fr/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/" role="button">Lancer le didacticiel interactif <span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/fr/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -105,7 +105,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <h2>Dépannage avec kubectl</h2>
-                <p>Dans le module <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>, vous avez utilisé l'interface de ligne de commande Kubectl. Vous continuerez à l'utiliser dans le module 3 pour obtenir des informations sur les applications déployées et leurs environnements. Les opérations les plus courantes peuvent être effectuées avec les commandes kubectl suivantes:</p>
+                <p>Dans le module <a href="/fr/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>, vous avez utilisé l'interface de ligne de commande Kubectl. Vous continuerez à l'utiliser dans le module 3 pour obtenir des informations sur les applications déployées et leurs environnements. Les opérations les plus courantes peuvent être effectuées avec les commandes kubectl suivantes:</p>
                 <ul>
                     <li><b>kubectl get</b> - liste les ressources</li>
                     <li><b>kubectl describe</b> - affiche des informations détaillées sur une ressource</li>
@@ -128,7 +128,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button">Démarrer le didacticiel interactif <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/fr/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button">Démarrer le didacticiel interactif <span class="btn__next">›</span></a>
             </div>
         </div>
 


### PR DESCRIPTION
[French tutorials](https://kubernetes.io/fr/docs/tutorials/kubernetes-basics/) still include old CSS files. However, if you visit these pages, the browser will try to access them and return 404 ([e.g.](https://kubernetes.io/docs/tutorials/kubernetes-basics/public/css/styles.css)). 

They were removed from the English tutorials in https://github.com/kubernetes/website/pull/34188. This PR removes them from the French localisation.


PS: Not directly related to this PR,  even though `https://katacoda.com/embed.js` was included on those pages next to the CSS files I did not remove them.

I also wanted to let you know that all `Katacoda-related` pieces should be removed from the localisation since these interactive tutorials are not supported anymore and need replacing. Here is an umbrella issue for this task #41496 

To get rid of Katacoda, many texts need corrections, which I can't do without French team knowledge.

fixes #45327

/sig docs
/language fr
/area localization