### PR TITLE
[ar]: Translate tutorials/kubernetes-basics/_index.html page to arabic

### DIFF
--- a/content/ar/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/ar/docs/tutorials/kubernetes-basics/_index.html
@@ -1,0 +1,115 @@
+---
+title: تعلم أساسيات كوبيرنيتيس.
+linkTitle: تعلم أساسيات كوبيرنيتيس.
+no_list: true
+weight: 10
+card:
+  name: tutorials
+  weight: 20
+  title: نبذة عن الأساسيات.
+
+
+
+<!DOCTYPE html>
+
+<html lang="ar">
+
+<body>
+
+<div class="layout" id="top">
+
+  <main class="content">
+    <div class="row">
+        <div class="col-md-9">
+            <h2>أساسيات كوبيرنيتيس</h2>
+            <p>نتناول في الدرس الآتي أساسيات كوبيرنيتيس، وهو نظام لإدارة العناقيد. ينقسم الدرس إلى عدة وحدات،
+              تحتوي كل منها على بضع المفاهيم بالإضافة إلى برنامج تفاعلي يجسد تلك المفاهيم.</p>
+            <p>يمكنك تعلم الآتي من خلال تلك البرامج:</p>
+            <ul>
+            <li>نشر تطبيق معبأ في حاوية على عنقود.</li>
+            <li>توسيع ذلك التطبيق.</li>
+            <li>تحديث التطبيق المعبأ في حاوية بإصدار جديد للبرنامج.</li>
+            <li>معالجة الأعطال في التطبيق.</li>
+            </ul>
+        </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+        <div class="col-md-9">
+            <h2>القيمة المضافة من استخدام كوبيرنيتيس</h2>
+            <p>في سياق تطبيقات الويب الحديثة، يتوقع المستخدمون توفر التطبيقات بشكل متواصل دون أعطال، وينشر المطورون إصدارات جديدة للتطبيقات بشكلٍ متاوصلً أيضاً. تساعد تحوية البرامج  على تحقيق تلك الأهداف، ذلك لتمكين إصدار وتحديث التطبيقات دون توقف. يساعد كوبيرنيتيس على ضمان عمل تلك التطبيقات المحزمة في المكان والوقت المرغوب، ويساعدها في العثور على الموارد والأدوات التي تحتاج إليها للعمل. كوبيرنيتيس هو مشروع جاهز للإنتاج، مفتوح المصدر، صُمِّمَ بخبرة جوجل المتراكمة في تنظيم الحاويات، بالإضافة إلى أفضل الأفكار من المجتمع.</p>
+        </div>
+    </div>
+
+    <br>
+
+    <div id="basics-modules" class="content__modules">
+      <h2>أساسيات كوبيرنيتيس</h2>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/ar/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/ar/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><h5>1. إنشاء عنقود كوبيرنيتيس</h5></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/ar/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/ar/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><h5>2. نشر التطبيق</h5></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/ar/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/ar/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. استكشاف التطبيق</h5></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/ar/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/ar/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. إتاحة التطبيق للعموم</h5></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/ar/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/ar/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. توسيع التطبيق</h5></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/ar/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/ar/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. تحديث التطبيق</h5></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </main>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds the translation related to the tutorials basics  `/docs/tutorials/kubernetes-basics`.

Part of https://github.com/kubernetes/website/issues/44682