### PR TITLE
Clarify in the documentation what we mean with "allocated to MongoDB on the internet"

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -110,7 +110,7 @@ for database debugging.
    27017
    ```
 
-   27017 is the TCP port allocated to MongoDB on the internet.
+   27017 is the official TCP port for MongoDB.
 
 ## Forward a local port to a port on the Pod
 


### PR DESCRIPTION
The phrase "allocated to MongoDB on the internet" is confusing. One could read that the MongoDB pod in this example is being exposed to the internet, which is not the case.

I think the original author meant to say that `27017` is the official TCP port assigned to MongoDB by IANA, so I rephrased this sentence.