### PR TITLE
[WIP] Add blog post "Managing Cluster API with Kluctl"

### DIFF
--- a/content/en/blog/_posts/2024-02-xx-cluster-api-kluctl.md
+++ b/content/en/blog/_posts/2024-02-xx-cluster-api-kluctl.md
@@ -1,0 +1,11 @@
+---
+layout: blog
+title: "Managing Cluster API with Kluctl"
+date: 2024-02-xx
+slug: cluster-api-kluctl
+---
+
+**Author:** Alexander Block (codablock)
+
+This is placeholder. The review is currently performed at https://hackmd.io/@codablock/Hyv13tQna
+When the initial review is done, I will replace this placeholder with the content of the blog.


### PR DESCRIPTION
Hello,

as discussed in Slack (#sig-docs-blog), here is the proposed blog post about "Managing Cluster API with Kluctl". It's a tutorial that shows an alternative way on how to manage Cluster API workload clusters. It got quite long, I hope this is still ok for blog.kubernetes.io.

I could also split the tutorial up into two parts, but that would have the risk that part 1 would leave the reader with a sense of "ok...and why is this useful?", simply because the powerful stuff comes with part 2.

I started with a placeholder commit that only points to HackMD. It was suggested to do initial review there. Here is the link: https://hackmd.io/@codablock/Hyv13tQna. When initial review is done, I will force-push with the latest draft.