### PR TITLE
Fix missing whitespace in thirdparty-content.html

### DIFF
--- a/layouts/shortcodes/thirdparty-content.html
+++ b/layouts/shortcodes/thirdparty-content.html
@@ -2,7 +2,7 @@
 {{- $vendor_message := .Get "vendor" | default "false" -}}
 <div class="alert alert-secondary callout third-party-content" role="alert">
 {{- if not (eq $single "true" ) -}}
-  <strong>{{ T "note" | safeHTML }}</strong>
+  <strong>{{ T "note" | safeHTML }}</strong>&puncsp;
   {{- if (eq $vendor_message "true" ) -}}
     {{ T "thirdparty_message_vendor" | safeHTML }}
   {{- else -}}


### PR DESCRIPTION
This PR fixes an issue with missing `whitespace` char in the Note box.

Before | After
-- | --
<img width="2794" alt="Monosnap Image 2024-02-28 11-20-31" src="https://github.com/kubernetes/website/assets/369696/c02a8971-5913-4d3f-ac96-a08aa8fbff7e"> |  <img width="2794" alt="Monosnap Image 2024-02-28 11-21-23" src="https://github.com/kubernetes/website/assets/369696/ef1cadac-c759-4063-8e5b-d11c61438f28">
