### PR TITLE
Update Kubectl Taint Documentation

### DIFF
--- a/content/en/docs/reference/kubectl/generated/kubectl_taint/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_taint/_index.md
@@ -30,6 +30,7 @@ Update the taints on one or more nodes.
   *  The value is optional. If given, it must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to 63 characters.
   *  The effect must be NoSchedule, PreferNoSchedule or NoExecute.
   *  Currently taint can only apply to node.
+  *  Note that if you manually schedule a pod by defining a node name in your workload yaml spec file like a pod, deployments, etc. it will override the usual scheduling mechanism, hence, bypassing the taint.
 
 ```
 kubectl taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N


### PR DESCRIPTION
# New Synopsis

*  Note that if you manually schedule a pod by defining a node name in your workload yaml spec file like a pod, deployments, etc. it will override the usual scheduling mechanism, hence, bypassing the taint.

# Issues in the Original Synopsis

* It didn't let developers know about another feature that can override a taint configuration.

# Conclusion 

In summary, developers should be mindful that manually scheduling pods with node names in YAML spec files can override standard scheduling mechanisms and bypass taint configurations, impacting deployment behaviour in their Kubernetes cluster.