### PR TITLE
Update Taints and Tolerations Documentation

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -315,7 +315,11 @@ tolerations to all daemons, to prevent DaemonSets from breaking.
 Adding these tolerations ensures backward compatibility. You can also add
 arbitrary tolerations to DaemonSets.
 
-> **Note:** If you manually schedule a pod by defining a node name in your workload yaml spec file like a pod, deployments, etc. it will override the usual scheduling mechanism, hence, bypassing the taint.
+{{< note >}}
+If you manually schedule a pod by defining a node name in your workload yaml spec
+file like a pod, deployments, etc. it will override the usual scheduling mechanism,
+hence, bypassing the taint.
+{{< /note >}}
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -62,7 +62,15 @@ tolerations:
   effect: "NoSchedule"
 ```
 
-Here's an example of a pod that uses tolerations:
+The default Kubernetes scheduler takes taints and tolerations into account when
+selecting a node to run a particular Pod. However, if you manually specify the
+`.spec.nodeName` for a Pod, that action bypasses the scheduler; the Pod is then
+bound onto on the node where you assigned it, even if there are `NoSchedule`
+taints on that node that you selected.
+If this happens and the node also has a `NoExecute` taint set, the kubelet will
+eject the Pod unless there is an appropriate toleration set.
+
+Here's an example of a pod that has some tolerations defined:
 
 {{% code_sample file="pods/pod-with-toleration.yaml" %}}
 
@@ -314,10 +322,6 @@ tolerations to all daemons, to prevent DaemonSets from breaking.
 
 Adding these tolerations ensures backward compatibility. You can also add
 arbitrary tolerations to DaemonSets.
-
-{{< note >}}
-If the `nodeName` for a Pod manifest is manually specified, the scheduler will assign the Pod to the node specified, regardless of any taints or tolerations.
-{{< /note >}}
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -315,6 +315,8 @@ tolerations to all daemons, to prevent DaemonSets from breaking.
 Adding these tolerations ensures backward compatibility. You can also add
 arbitrary tolerations to DaemonSets.
 
+> **Note:** If you manually schedule a pod by defining a node name in your workload yaml spec file like a pod, deployments, etc. it will override the usual scheduling mechanism, hence, bypassing the taint.
+
 ## {{% heading "whatsnext" %}}
 
 * Read about [Node-pressure Eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/)

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -68,7 +68,7 @@ selecting a node to run a particular Pod. However, if you manually specify the
 bound onto on the node where you assigned it, even if there are `NoSchedule`
 taints on that node that you selected.
 If this happens and the node also has a `NoExecute` taint set, the kubelet will
-eject the Pod unless there is an appropriate toleration set.
+eject the Pod unless there is an appropriate tolerance set.
 
 Here's an example of a pod that has some tolerations defined:
 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -65,7 +65,7 @@ tolerations:
 The default Kubernetes scheduler takes taints and tolerations into account when
 selecting a node to run a particular Pod. However, if you manually specify the
 `.spec.nodeName` for a Pod, that action bypasses the scheduler; the Pod is then
-bound onto on the node where you assigned it, even if there are `NoSchedule`
+bound onto the node where you assigned it, even if there are `NoSchedule`
 taints on that node that you selected.
 If this happens and the node also has a `NoExecute` taint set, the kubelet will
 eject the Pod unless there is an appropriate tolerance set.

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -316,9 +316,7 @@ Adding these tolerations ensures backward compatibility. You can also add
 arbitrary tolerations to DaemonSets.
 
 {{< note >}}
-If you manually schedule a pod by defining a node name in your workload yaml spec
-file like a pod, deployments, etc. it will override the usual scheduling mechanism,
-hence, bypassing the taint.
+If the `nodeName` for a Pod manifest is manually specified, the scheduler will assign the Pod to the node specified, regardless of any taints or tolerations.
 {{< /note >}}
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
# Lack of Clarity in the Original 'Taints and Tolerations' Documentation

* It didn't let developers know about another feature that can override a taint configuration.

# Conclusion

Developers should be mindful that manually scheduling pods with node names in YAML spec files can override standard scheduling mechanisms and bypass taint configurations, impacting deployment behaviour in their Kubernetes cluster.

Thanks to @windsonsea and @tengqm who helped me align my contribution.