### PR TITLE
Changing the Image Specified in the ReplicaSet Documentation 

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -99,7 +99,7 @@ Pod Template:
   Labels:  tier=frontend
   Containers:
    nginx:
-    Image:        nginx
+    Image:        nginx:1.14.2
     Port:         <none>
     Host Port:    <none>
     Environment:  <none>

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -90,17 +90,16 @@ And you will see output similar to:
 Name:         frontend
 Namespace:    default
 Selector:     tier=frontend
-Labels:       app=guestbook
+Labels:       app=nginx
               tier=frontend
-Annotations:  kubectl.kubernetes.io/last-applied-configuration:
-                {"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"annotations":{},"labels":{"app":"guestbook","tier":"frontend"},"name":"frontend",...
+Annotations:  <none>
 Replicas:     3 current / 3 desired
 Pods Status:  3 Running / 0 Waiting / 0 Succeeded / 0 Failed
 Pod Template:
   Labels:  tier=frontend
   Containers:
-   php-redis:
-    Image:        gcr.io/google_samples/gb-frontend:v3
+   nginx:
+    Image:        nginx
     Port:         <none>
     Host Port:    <none>
     Environment:  <none>
@@ -109,9 +108,9 @@ Pod Template:
 Events:
   Type    Reason            Age   From                   Message
   ----    ------            ----  ----                   -------
-  Normal  SuccessfulCreate  117s  replicaset-controller  Created pod: frontend-wtsmm
-  Normal  SuccessfulCreate  116s  replicaset-controller  Created pod: frontend-b2zdv
-  Normal  SuccessfulCreate  116s  replicaset-controller  Created pod: frontend-vcmts
+  Normal  SuccessfulCreate  13s   replicaset-controller  Created pod: frontend-gbgfx
+  Normal  SuccessfulCreate  13s   replicaset-controller  Created pod: frontend-rwz57
+  Normal  SuccessfulCreate  13s   replicaset-controller  Created pod: frontend-wkl7w
 ```
 
 And lastly you can check for the Pods brought up:
@@ -124,16 +123,16 @@ You should see Pod information similar to:
 
 ```
 NAME             READY   STATUS    RESTARTS   AGE
-frontend-b2zdv   1/1     Running   0          6m36s
-frontend-vcmts   1/1     Running   0          6m36s
-frontend-wtsmm   1/1     Running   0          6m36s
+frontend-gbgfx   1/1     Running   0          10m
+frontend-rwz57   1/1     Running   0          10m
+frontend-wkl7w   1/1     Running   0          10m
 ```
 
 You can also verify that the owner reference of these pods is set to the frontend ReplicaSet.
 To do this, get the yaml of one of the Pods running:
 
 ```shell
-kubectl get pods frontend-b2zdv -o yaml
+kubectl get pods frontend-gbgfx -o yaml
 ```
 
 The output will look similar to this, with the frontend ReplicaSet's info set in the metadata's ownerReferences field:
@@ -142,11 +141,11 @@ The output will look similar to this, with the frontend ReplicaSet's info set in
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: "2020-02-12T07:06:16Z"
+  creationTimestamp: "2024-02-28T22:30:44Z"
   generateName: frontend-
   labels:
     tier: frontend
-  name: frontend-b2zdv
+  name: frontend-gbgfx
   namespace: default
   ownerReferences:
   - apiVersion: apps/v1
@@ -154,7 +153,7 @@ metadata:
     controller: true
     kind: ReplicaSet
     name: frontend
-    uid: f391f6db-bb9b-4c09-ae74-6a1f77f3d5cf
+    uid: e129deca-f864-481b-bb16-b27abfd92292
 ...
 ```
 

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -90,7 +90,7 @@ And you will see output similar to:
 Name:         frontend
 Namespace:    default
 Selector:     tier=frontend
-Labels:       app=nginx
+Labels:       app=guestbook
               tier=frontend
 Annotations:  <none>
 Replicas:     3 current / 3 desired
@@ -98,8 +98,8 @@ Pods Status:  3 Running / 0 Waiting / 0 Succeeded / 0 Failed
 Pod Template:
   Labels:  tier=frontend
   Containers:
-   nginx:
-    Image:        nginx:1.14.2
+   php-redis:
+    Image:        us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
     Port:         <none>
     Host Port:    <none>
     Environment:  <none>

--- a/content/en/examples/controllers/frontend.yaml
+++ b/content/en/examples/controllers/frontend.yaml
@@ -3,7 +3,7 @@ kind: ReplicaSet
 metadata:
   name: frontend
   labels:
-    app: guestbook
+    app: nginx
     tier: frontend
 spec:
   # modify replicas according to your case
@@ -17,5 +17,5 @@ spec:
         tier: frontend
     spec:
       containers:
-      - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v3
+      - name: nginx
+        image: nginx

--- a/content/en/examples/controllers/frontend.yaml
+++ b/content/en/examples/controllers/frontend.yaml
@@ -3,7 +3,7 @@ kind: ReplicaSet
 metadata:
   name: frontend
   labels:
-    app: nginx
+    app: guestbook
     tier: frontend
 spec:
   # modify replicas according to your case
@@ -17,5 +17,5 @@ spec:
         tier: frontend
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.2
+      - name: php-redis
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5

--- a/content/en/examples/controllers/frontend.yaml
+++ b/content/en/examples/controllers/frontend.yaml
@@ -18,4 +18,4 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: nginx:1.14.2


### PR DESCRIPTION
 Updated frontend.yaml in the Controllers File Path

A lot of developers have complained about the image `gcr.io/google_samples/gb-frontend:v3` failing. I was able to trace the image to [here](https://console.cloud.google.com/gcr/images/google-samples/global/gb-frontend).
I noticed that it doesn't work anymore, even when I do a `docker pull` and then a `docker run`
I also tried creating a `php:latest` container alone and it failed.
I initially used `nginx` image, but thanks to @adityasamant25 who pointed me to the latest php-redis image used which was referenced in this PR #44290 `us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5`

# Updated the Replicaset Page in the Concept File Path

The rest of the section had to reflect the new image created.
- A description of the Replicast
- New generated names of the running pods
- New details of the yaml output

# Referenced Issues

Fixes #45329 
Fixes #44415

# Referenced PR
PR #44290