### PR TITLE
Update deprecated API migration guidance of HorizontalPodAutoscaler for v1.25 and v1.26

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -78,8 +78,7 @@ The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler is no longer 
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
 * Notable changes:
-  * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type=Utilization`. See [Metric Target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling).
-
+  * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type: Utilization`. See [Autoscaling on multiple metrics and custom metrics](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 ### v1.25
 
 The **v1.25** release stopped serving the following deprecated API versions:
@@ -131,7 +130,7 @@ The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler is no longer 
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
 * Notable changes:
-  * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type=Utilization`. See [Metric Target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling).
+  * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type: Utilization`. See [Autoscaling on multiple metrics and custom metrics](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 
 #### PodDisruptionBudget {#poddisruptionbudget-v125}
 

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -77,6 +77,7 @@ The **flowcontrol.apiserver.k8s.io/v1beta1** API version of FlowSchema and Prior
 The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler is no longer served as of v1.26.
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
+* All existing persisted objects are accessible via the new API
 * Notable changes:
   * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type: Utilization`. See [Autoscaling on multiple metrics and custom metrics](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 ### v1.25
@@ -129,6 +130,7 @@ The **events.k8s.io/v1beta1** API version of Event is no longer served as of v1.
 The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler is no longer served as of v1.25.
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
+* All existing persisted objects are accessible via the new API
 * Notable changes:
   * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type: Utilization`. See [Autoscaling on multiple metrics and custom metrics](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -77,8 +77,8 @@ The **flowcontrol.apiserver.k8s.io/v1beta1** API version of FlowSchema and Prior
 The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler is no longer served as of v1.26.
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
-* Notable changes in **autoscaling/v2**
-  * **targetAverageUtilization** field is no longer supported. Use [target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling) object instead. Check [Resource metrics](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics) for more details
+* Notable changes:
+  * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type=Utilization`. See [Metric Target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling).
 
 ### v1.25
 
@@ -130,8 +130,8 @@ The **events.k8s.io/v1beta1** API version of Event is no longer served as of v1.
 The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler is no longer served as of v1.25.
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
-* Notable changes in **autoscaling/v2**
-  * **targetAverageUtilization** field is no longer supported. Use [target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling) object instead. Check [Resource metrics](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics) for more details
+* Notable changes:
+  * `targetAverageUtilization` is replaced with `target.averageUtilization` and `target.type=Utilization`. See [Metric Target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling).
 
 #### PodDisruptionBudget {#poddisruptionbudget-v125}
 

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -77,7 +77,22 @@ The **flowcontrol.apiserver.k8s.io/v1beta1** API version of FlowSchema and Prior
 The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler is no longer served as of v1.26.
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
-* All existing persisted objects are accessible via the new API
+* Notable changes in **autoscaling/v2**
+  * **targetAverageUtilization** field is no longer supported. Use `target` object instead
+    * From this 
+      ```yaml
+          - resource:
+            name: memory
+            targetAverageUtilization: 75
+      ```
+    * Change to this
+      ```yaml
+          - resource:
+            name: memory
+            target:
+              averageUtilization: 75
+              type: Utilization
+      ```
 
 ### v1.25
 
@@ -129,7 +144,22 @@ The **events.k8s.io/v1beta1** API version of Event is no longer served as of v1.
 The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler is no longer served as of v1.25.
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
-* All existing persisted objects are accessible via the new API
+* Notable changes in **autoscaling/v2**
+  * **targetAverageUtilization** field is no longer supported. Use `target` object instead
+    * From this 
+      ```yaml
+          - resource:
+            name: memory
+            targetAverageUtilization: 75
+      ```
+    * Change to this
+      ```yaml
+          - resource:
+            name: memory
+            target:
+              averageUtilization: 75
+              type: Utilization
+      ```
 
 #### PodDisruptionBudget {#poddisruptionbudget-v125}
 

--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -78,21 +78,7 @@ The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler is no longer 
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
 * Notable changes in **autoscaling/v2**
-  * **targetAverageUtilization** field is no longer supported. Use `target` object instead
-    * From this 
-      ```yaml
-          - resource:
-            name: memory
-            targetAverageUtilization: 75
-      ```
-    * Change to this
-      ```yaml
-          - resource:
-            name: memory
-            target:
-              averageUtilization: 75
-              type: Utilization
-      ```
+  * **targetAverageUtilization** field is no longer supported. Use [target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling) object instead. Check [Resource metrics](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics) for more details
 
 ### v1.25
 
@@ -145,21 +131,7 @@ The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler is no longer 
 
 * Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
 * Notable changes in **autoscaling/v2**
-  * **targetAverageUtilization** field is no longer supported. Use `target` object instead
-    * From this 
-      ```yaml
-          - resource:
-            name: memory
-            targetAverageUtilization: 75
-      ```
-    * Change to this
-      ```yaml
-          - resource:
-            name: memory
-            target:
-              averageUtilization: 75
-              type: Utilization
-      ```
+  * **targetAverageUtilization** field is no longer supported. Use [target](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#metrictarget-v2-autoscaling) object instead. Check [Resource metrics](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics) for more details
 
 #### PodDisruptionBudget {#poddisruptionbudget-v125}
 


### PR DESCRIPTION
Fix deprecated API migration guidance of HorizontalPodAutoscaler. Because **targetAverageUtilization** is replaced with **target** object in **autoscaling/v2**. Also add example for migration
