### PR TITLE
Add integrity attribute to script used by CNCF Landscape shortcode 

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -91,6 +91,10 @@
 <script defer src="{{ "js/release_binaries.js" | relURL }}"></script>
 {{- end -}}
 
+{{- if .HasShortcode "cncf-landscape" -}}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js" integrity="sha384-hHTwgxzjpO1G1NI0wMHWQYUxnGtpWyDjVSZrFnDrlWa5OL+DFY57qnDWw/5WSJOl" crossorigin="anonymous"></script>
+{{- end -}}
+
 {{- if eq (lower .Params.cid) "community" -}}
 {{- if eq .Params.community_styles_migrated true -}}
 <link href="/css/community.css" rel="stylesheet"><!-- legacy styles -->

--- a/layouts/shortcodes/cncf-landscape.html
+++ b/layouts/shortcodes/cncf-landscape.html
@@ -57,7 +57,7 @@ document.addEventListener("DOMContentLoaded", function () {
 </script>
 {{- end -}}
 <div id="frameHolder">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js" intregrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" crossorigin="anonymous"></script>
   {{ if ( .Get "category" ) }}
   <iframe id="iframe-landscape" src="https://landscape.cncf.io/embed/embed.html?key={{ .Get "category" }}&headers=false&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 100%; min-height: 100px; border: 0;"></iframe>
   <script>

--- a/layouts/shortcodes/cncf-landscape.html
+++ b/layouts/shortcodes/cncf-landscape.html
@@ -57,7 +57,6 @@ document.addEventListener("DOMContentLoaded", function () {
 </script>
 {{- end -}}
 <div id="frameHolder">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js" intregrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" crossorigin="anonymous"></script>
   {{ if ( .Get "category" ) }}
   <iframe id="iframe-landscape" src="https://landscape.cncf.io/embed/embed.html?key={{ .Get "category" }}&headers=false&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 100%; min-height: 100px; border: 0;"></iframe>
   <script>


### PR DESCRIPTION
Add integrity attribute to script used by CNCF Landscape shortcode.

Fixes [#45404](https://github.com/kubernetes/website/issues/45404#issue-2163352174)