### PR TITLE
Update basic-stateful-set.md

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -637,13 +637,13 @@ Get the Pods to view their container images:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0.8
+gcr.io/google_containers/nginx-slim:0.8
+gcr.io/google_containers/nginx-slim:0.8
+gcr.io/google_containers/nginx-slim:0.8
 
 ```
 
-All the Pods in the StatefulSet are now running the previous container image.
+All the Pods in the StatefulSet are now running the updated container image.
 
 {{< note >}}
 You can also use `kubectl rollout status sts/<name>` to view


### PR DESCRIPTION
Prior to this stage in the tutorial, we had scaled the statefulset down to 3 pods and patched its container image to reference `gcr.io/google_containers/nginx-slim:0.8`. This change is to keep the tutorial consistent. Great job btw