### PR TITLE
[zh-cn]sync kubeadm_init_phase_certs_etcd-ca kubeadm_init_phase_certs_sa

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-ca.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-ca.md
@@ -19,11 +19,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令目前处于 Alpha 阶段。
-
 ```
 kubeadm init phase certs etcd-ca [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_sa.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_sa.md
@@ -9,15 +9,14 @@ Generate a private key for signing service account tokens along with its public 
 ### 概要
 
 <!--
-Generate the private key for signing service account tokens along with its public key, and save them into sa.key and sa.pub files. If both files already exist, kubeadm skips the generation step and existing files will be used.
+Generate the private key for signing service account tokens along with its public key, and save them into sa.key and sa.pub files.
 -->
 生成用来签署服务账号令牌的私钥及其公钥，并将其保存到 sa.key 和 sa.pub 文件中。
-如果两个文件都已存在，则 kubeadm 会跳过生成步骤，而将使用现有文件。
 
 <!--
-Alpha Disclaimer: this command is currently alpha.
+If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
-Alpha 免责声明：此命令当前为 Alpha 阶段。
+如果两个文件都已存在，则 kubeadm 会跳过生成步骤，而将使用现有文件。
 
 ```
 kubeadm init phase certs sa [flags]


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-ca.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_sa.md