### PR TITLE
[zh-cn]sync kubeadm_config_print_join-defaults kubeadm_init_phase_certs_etcd-healthcheck-client

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
@@ -37,21 +37,6 @@ kubeadm config print join-defaults [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--component-configs strings/td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-A comma-separated list for component config API objects to print the default values for. Available values: [KubeProxyConfiguration KubeletConfiguration]. If this flag is not set, no component configs will be printed.
--->
-<p>
-以逗号分隔的组件配置 API 对象的列表，打印其默认值。可用值：[KubeProxyConfiguration KubeletConfiguration]。
-如果未设置此参数，则不会打印任何组件配置。
-</p>
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
@@ -18,11 +18,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令当前为 Alpha 功能。
-
 ```
 kubeadm init phase certs etcd-healthcheck-client [flags]
 ```


### PR DESCRIPTION
```
M       content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
M       content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
```