### PR TITLE
Fix 'auditAnnotations' example

### DIFF
--- a/content/en/examples/access/validating-admission-policy-audit-annotation.yaml
+++ b/content/en/examples/access/validating-admission-policy-audit-annotation.yaml
@@ -11,6 +11,8 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["deployments"]
   validations:
-    - key: "high-replica-count"
-      expression: "object.spec.replicas > 50"
+    - expression: "object.spec.replicas > 50"
       messageExpression: "'Deployment spec.replicas set to ' + string(object.spec.replicas)"
+  auditAnnotations:
+    - key: "high-replica-count"
+      valueExpression: "'Deployment spec.replicas set to ' + string(object.spec.replicas)"


### PR DESCRIPTION
The "[Audit annotations](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#audit-annotations)" section of the ValidatingAdmissionPolicies docs has an example that doesn't actually show how to use `auditAnnotations`.

This change adds the missing `auditAnnotations` property and removes the invalid `key` property from the `validations`.