### PR TITLE
Improved reading comprehension in the 'Assigning Pods to Nodes' page.

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -123,7 +123,7 @@ your Pod spec.
 
 For example, consider the following Pod spec:
 
-{{% code_sample file="pods/pod-with-node-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-node-affinity-1.yaml" %}}
 
 In this example, the following rules apply:
 
@@ -173,7 +173,7 @@ scheduling decision for the Pod.
 
 For example, consider the following Pod spec:
 
-{{% code_sample file="pods/pod-with-affinity-anti-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-node-affinity-2.yaml" %}}
 
 If there are two possible nodes that match the
 `preferredDuringSchedulingIgnoredDuringExecution` rule, one with the

--- a/content/en/examples/pods/pod-with-node-affinity-1.yaml
+++ b/content/en/examples/pods/pod-with-node-affinity-1.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: with-node-affinity
+  name: with-node-affinity-1
 spec:
   affinity:
     nodeAffinity:
@@ -22,5 +22,5 @@ spec:
             values:
             - another-node-label-value
   containers:
-  - name: with-node-affinity
+  - name: with-node-affinity-1
     image: registry.k8s.io/pause:2.0

--- a/content/en/examples/pods/pod-with-node-affinity-2.yaml
+++ b/content/en/examples/pods/pod-with-node-affinity-2.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: with-affinity-anti-affinity
+  name: with-node-affinity-2
 spec:
   affinity:
     nodeAffinity:
@@ -28,5 +28,5 @@ spec:
             values:
             - key-2
   containers:
-  - name: with-node-affinity
+  - name: with-node-affinity-2
     image: registry.k8s.io/pause:2.0


### PR DESCRIPTION
## Existing Issue 1
The code example doesn't properly describe 'node affinity' rather, it uses 'anti-affinity' which is a pod concept and not a node concept. To express anti-affinity, we ought to use podAntiAffinity instead of nodeAffinity. Hence, this renders the example confusing to users.

Even though the below example expresses an 'anti-affinity' concept where the pod is not scheduled to a node, a node with the _lowest total score (rule that the node satisfies + weight)_ as used here, it doesn't express a requirement that an existing pod with a _label_ should already exist in the node as indicated in the [documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity). Rather, it expresses using weight as a form of anti-affinity.
While the word 'anti-affinity' may be used here in similar application, since no other part of the existing documentation defines 'anti-affinity' as related to weights, it is used wrongly here.
Another suggestion could be to define that an 'anti-affinity' can also be classified under a`spec.affinity. nodeAffinity` though not literally as it is used in `spec.affinity. podAntiAffinity` but as a concept in regards to [Node affinity weight](url), before introducing the example.

`pods/pod-with-affinity-anti-affinity.yaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: with-affinity-anti-affinity
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: label-1
            operator: In
            values:
            - key-1
      - weight: 50
        preference:
          matchExpressions:
          - key: label-2
            operator: In
            values:
            - key-2
  containers:
  - name: with-node-affinity
    image: registry.k8s.io/pause:2.0
```

## Fix 1
Change the naming.
- Use `pod-with-node-affinity-2` as the filename.
- Use `with-node-affinity-2` as the metadata value.
- Use `with-node-affinity-2` as the container name value.
> Note: this is the **second** example under the 'Node affinity' section.
`pods/pod-with-node-affinity-2.yaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: with-node-affinity-2
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: label-1
            operator: In
            values:
            - key-1
      - weight: 50
        preference:
          matchExpressions:
          - key: label-2
            operator: In
            values:
            - key-2
  containers:
  - name: with-node-affinity-2
    image: registry.k8s.io/pause:2.0
```

## Existing Issue 2
This is a minor issue that originated due to `Fix 1`. The user gets confused due to inconsistency in naming convention.
`pods/pod-with-node-affinity.yaml` 
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: with-node-affinity
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - antarctica-east1
            - antarctica-west1
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: another-node-label-key
            operator: In
            values:
            - another-node-label-value
  containers:
  - name: with-node-affinity
    image: registry.k8s.io/pause:2.0
```

## Fix 2
Change the naming so the reader understands this is the second example describing node-affinity.
- Use `pod-with-node-affinity-1` as the filename.
- Use `with-node-affinity-1` as the metadata value.
- Use `with-node-affinity-1` as the container name value.
> Note: this is the first example under the 'Node affinity' section.
`pods/pod-with-node-affinity-1.yaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: with-node-affinity-1
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: label-1
            operator: In
            values:
            - key-1
      - weight: 50
        preference:
          matchExpressions:
          - key: label-2
            operator: In
            values:
            - key-2
  containers:
  - name: with-node-affinity-1
    image: registry.k8s.io/pause:2.0
```

## Final words
I struggled with the documentation a lot while studying for my CKA. It'a why I thought this PR might be helpful.