### PR TITLE
Fix misleading advice about sharing of environment variables

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -81,9 +81,9 @@ throughout the lifecycle of the pod and can be started and stopped independently
 main container. Unlike [init containers](/docs/concepts/workloads/pods/init-containers/),
 sidecar containers support [probes](/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe) to control their lifecycle.
 
-These containers can interact directly with the main application containers, sharing
-the same network namespace, filesystem, and environment variables. They work closely
-together to provide additional functionality.
+Sidecar containers can interact directly with the main application containers, sharing
+the same network namespace, and filesystem. They work closely together to
+provide additional functionality.
 
 ## Resource sharing within containers
 

--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -81,9 +81,13 @@ throughout the lifecycle of the pod and can be started and stopped independently
 main container. Unlike [init containers](/docs/concepts/workloads/pods/init-containers/),
 sidecar containers support [probes](/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe) to control their lifecycle.
 
-Sidecar containers can interact directly with the main application containers, sharing
-the same network namespace, and filesystem. They work closely together to
-provide additional functionality.
+Sidecar containers can interact directly with the main application containers, because
+like init containers they always share the same network, and can optionally also share
+volumes (filesystems).
+
+Init containers stop before the main containers start up, so init containers cannot
+exchange messages with the app container in a Pod. Any data passing is one-way
+(for example, an init container can put information inside an `emptyDir` volume).
 
 ## Resource sharing within containers
 


### PR DESCRIPTION
Hello!

This PR aims to address an issue in the current [documentation](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#differences-from-init-containers) regarding the interaction of containers within a Pod, specifically about the sharing of environment variables.

In the current documentation, there's a statement suggesting that sidecar containers and main application containers within a Pod can share environment variables. This information could potentially lead to confusion, as environment variables are defined per container in Kubernetes and are not shared by default across containers within a Pod.

To clarify this and provide accurate information to users, I have removed the misleading reference to the sharing of environment variables from this statement -

> These containers can interact directly with the main application containers, sharing the same network namespace, filesystem, and environment variables.

This change is intended to enhance the clarity and accuracy of the documentation, ensuring that it correctly reflects the behavior of Kubernetes Pods and containers without leading to misunderstandings about environment variable sharing.

I have also replaced "this" with "sidecar" as this line is the starting point of a new paragraph and hence could be the  cause of a potential confusion.

I look forward to your feedback and any further discussions on this PR.



