### PR TITLE
[hi] Fix title mismatch in docs home for "Kubernetes Download"

### DIFF
--- a/content/hi/docs/home/_index.md
+++ b/content/hi/docs/home/_index.md
@@ -55,7 +55,7 @@ cards:
   button: प्रलेखन में योगदान करें 
   button_path: /docs/contribute
 - name: release-notes
-  title: कुबेरनेट्स रिलीज नोट्स 
+  title: कुबेरनेट्स डाउनलोड करें
   description: यदि आप कुबेरनेट्स इंस्टॉल कर रहे हैं या नवीनतम संस्करण में अपग्रेड कर रहे हैं, तो वर्तमान रिलीज़ नोट्स देखें।
   button: कुबेरनेट्स डाउनलोड करें
   button_path: "/docs/setup/release/notes"

--- a/content/hi/docs/home/_index.md
+++ b/content/hi/docs/home/_index.md
@@ -58,7 +58,7 @@ cards:
   title: कुबेरनेट्स डाउनलोड करें
   description: यदि आप कुबेरनेट्स इंस्टॉल कर रहे हैं या नवीनतम संस्करण में अपग्रेड कर रहे हैं, तो वर्तमान रिलीज़ नोट्स देखें।
   button: कुबेरनेट्स डाउनलोड करें
-  button_path: "/docs/setup/release/notes"
+  button_path: "https://kubernetes.io/releases/download/"
 - name: about
   title: प्रलेखन के बारे में
   description: इस वेबसाइट में कुबेरनेट्स के वर्तमान और पिछले 4 संस्करणों के लिए प्रलेखन हैं।

--- a/content/hi/docs/home/_index.md
+++ b/content/hi/docs/home/_index.md
@@ -58,7 +58,7 @@ cards:
   title: कुबेरनेट्स डाउनलोड करें
   description: यदि आप कुबेरनेट्स इंस्टॉल कर रहे हैं या नवीनतम संस्करण में अपग्रेड कर रहे हैं, तो वर्तमान रिलीज़ नोट्स देखें।
   button: कुबेरनेट्स डाउनलोड करें
-  button_path: "https://kubernetes.io/releases/download/"
+  button_path: "/releases/download"
 - name: about
   title: प्रलेखन के बारे में
   description: इस वेबसाइट में कुबेरनेट्स के वर्तमान और पिछले 4 संस्करणों के लिए प्रलेखन हैं।


### PR DESCRIPTION
This PR fixes the issue #45456  where the Hindi localization home page had an incorrect title. 
Changed the title from **कुबेरनेट्स रिलीज नोट्स** to **कुबेरनेट्स डाउनलोड करें** to match the section's content about downloading Kubernetes.

Why This Change:

The old title suggested it was about release notes, which was misleading. The update ensures the title reflects the content accurately, making it easier for users to find the download information.