### PR TITLE
Add missing syscalls in fine-grained profile of seccomp tutorial

### DIFF
--- a/content/en/examples/pods/security/seccomp/profiles/fine-grained.json
+++ b/content/en/examples/pods/security/seccomp/profiles/fine-grained.json
@@ -57,7 +57,11 @@
                 "sendto",
                 "set_tid_address",
                 "setitimer",
-                "writev"
+                "writev",
+                "fstatfs",
+                "getdents64",
+                "pipe2",
+                "getrlimit"
             ],
             "action": "SCMP_ACT_ALLOW"
         }


### PR DESCRIPTION
## Problem

If following steps in the *Restrict a Container's Syscalls with seccomp* tutorial, the [`fine-pod`](https://github.com/kubernetes/website/blob/63c3ee3a1e6771b1c4f5c16871dcc2d043e31937/content/en/docs/tutorials/security/seccomp.md#create-a-pod-with-a-seccomp-profile-that-only-allows-necessary-syscalls) will failed to start. The result is not expected as what described in the tutorial.

## Environment

*   OS: Ubuntu 22.04.2 LTS (in VirtualBox)
*   CPU architecture: x86-64
*   Kind version: 0.22.0

## Details

Following steps in the tutorial, I found the `fine-pod` failed to start with status `CrashLoopBackOff`:

```bash
NAME       READY   STATUS             RESTARTS     AGE
fine-pod   0/1     CrashLoopBackOff   1 (2s ago)   10s
```

So I looked into logs of the Pod to try to figure out what happened, and it shows:

```bash
ensure /proc/self/fd is on procfs: operation not permitted
```

It seems that some necessary syscalls are not allowed in the `fine-grained.json` profile. To understand which syscalls were missing in the profile, I changed `defaultAction` of the profile into `SCMP_ACT_LOG` and redid the steps again. Then, here is what I saw in my syslog:

```bash
Mar  7 18:23:04 my-machine kernel: [149402.823736] audit: type=1326 audit(1709806984.125:803): auid=4294967295 uid=65532 gid=65532 ses=4294967295 subj=unconfined pid=172134 comm="runc:[2:INIT]" exe="/" sig=0 arch=c000003e syscall=138 compat=0 ip=0x56442e15846e code=0x7ffc0000
Mar  7 18:23:04 my-machine kernel: [149402.823740] audit: type=1326 audit(1709806984.125:804): auid=4294967295 uid=65532 gid=65532 ses=4294967295 subj=unconfined pid=172134 comm="runc:[2:INIT]" exe="/" sig=0 arch=c000003e syscall=217 compat=0 ip=0x56442e15846e code=0x7ffc0000
Mar  7 18:23:04 my-machine kernel: [149402.823741] audit: type=1326 audit(1709806984.125:805): auid=4294967295 uid=65532 gid=65532 ses=4294967295 subj=unconfined pid=172134 comm="runc:[2:INIT]" exe="/" sig=0 arch=c000003e syscall=217 compat=0 ip=0x56442e15846e code=0x7ffc0000
Mar  7 18:23:04 my-machine kernel: [149402.825096] audit: type=1326 audit(1709806984.129:806): auid=4294967295 uid=65532 gid=65532 ses=4294967295 subj=unconfined pid=172134 comm="http-echo" exe="/http-echo" sig=0 arch=c000003e syscall=97 compat=0 ip=0x403e6e code=0x7ffc0000
Mar  7 18:23:04 my-machine kernel: [149402.825435] audit: type=1326 audit(1709806984.129:807): auid=4294967295 uid=65532 gid=65532 ses=4294967295 subj=unconfined pid=172134 comm="http-echo" exe="/http-echo" sig=0 arch=c000003e syscall=293 compat=0 ip=0x468590 code=0x7ffc0000
```

It shows that the syscalls - `fstatfs` (138), `getdents64` (217), `getrlimit` (97), `pipe2` (293) are also used by the `fine-pod`. After some experiments, I found that the pod can start successfully with only `fstatfs`, `getdents64`, `pipe2` added in the allowed syscalls of `fine-grained.json` profile (without `getrlimit`).

Nonetheless, I still added `getrlimit` in this PR to make it consistent with what is described in the tutorial:

> You should see no output in the `syslog`. This is because the profile allowed all necessary syscalls and specified that an error should occur if one outside of the list is invoked.