### PR TITLE
Add a note about /etc/apt/keyrings to pkgs.k8s.io migration guide

### DIFF
--- a/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
+++ b/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
@@ -173,6 +173,8 @@ publishing packages to the Google-hosted repository in the future.
    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
+   Note: In releases older than Debian 12 and Ubuntu 22.04, the folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command.
+
 3. Update the `apt` package index:
 
    ```shell

--- a/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
+++ b/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
@@ -173,7 +173,7 @@ publishing packages to the Google-hosted repository in the future.
    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
-   Note: In releases older than Debian 12 and Ubuntu 22.04, the folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command.
+_Update: In releases older than Debian 12 and Ubuntu 22.04, the folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command._
 
 3. Update the `apt` package index:
 


### PR DESCRIPTION
This PR updates [the pkgs.k8s.io announcement blog post](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/) to include a note about creating `/etc/apt/keyrings` directory on older versions of some distros upon migrating to the new package repositories. This has been an issue for many users, e.g. see https://github.com/kubernetes/release/issues/3491

The note has been copied from Installing Kubeadm page.

cc @kubernetes/release-engineering 