### PR TITLE
Update cri-dockerd links to point to the official docs

### DIFF
--- a/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
+++ b/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
@@ -64,7 +64,7 @@ time to review the [dockershim migration documentation](/docs/tasks/administer-c
 and consult your Kubernetes hosting vendor (if you have one) what container runtime options are available for you.
 Read up [container runtime documentation with instructions on how to use containerd and CRI-O](/docs/setup/production-environment/container-runtimes/#container-runtimes)
 to help prepare you when you're ready to upgrade to 1.24. CRI-O, containerd, and
-Docker with [Mirantis cri-dockerd](https://github.com/Mirantis/cri-dockerd) are
+Docker with [Mirantis cri-dockerd](https://mirantis.github.io/cri-dockerd/) are
 not the only container runtime options, we encourage you to explore the [CNCF landscape on container runtimes](https://landscape.cncf.io/?group=projects-and-products&view-mode=card#runtime--container-runtime)
 in case another suits you better.
 

--- a/content/en/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/en/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -109,7 +109,7 @@ Kubernetes clusters. Containers make this kind of interoperability possible.
 
 Mirantis and Docker have [committed][mirantis] to maintaining a replacement adapter for
 Docker Engine, and to maintain that adapter even after the in-tree dockershim is removed
-from Kubernetes. The replacement adapter is named [`cri-dockerd`](https://github.com/Mirantis/cri-dockerd).
+from Kubernetes. The replacement adapter is named [`cri-dockerd`](https://mirantis.github.io/cri-dockerd/).
 
 You can install `cri-dockerd` and use it to connect the kubelet to Docker Engine. Read [Migrate Docker Engine nodes from dockershim to cri-dockerd](/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd/) to learn more.
 

--- a/content/en/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes.md
+++ b/content/en/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes.md
@@ -48,6 +48,6 @@ You can provide feedback via the GitHub issue [**Dockershim removal feedback & i
 
 * Mirantis blog: [The Future of Dockershim is cri-dockerd](https://www.mirantis.com/blog/the-future-of-dockershim-is-cri-dockerd/) (published 2021/04/21)
 
-* Mirantis: [Mirantis/cri-dockerd](https://github.com/Mirantis/cri-dockerd) Git repository (on GitHub)
+* Mirantis: [Mirantis/cri-dockerd](https://mirantis.github.io/cri-dockerd/) Official Documentation
 
 * Tripwire: [How Dockershim’s Forthcoming Deprecation Affects Your Kubernetes](https://www.tripwire.com/state-of-security/security-data-protection/cloud/how-dockershim-forthcoming-deprecation-affects-your-kubernetes/) (published 2021/07/01)

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -325,15 +325,14 @@ This config option supports live configuration reload to apply this change: `sys
 
 {{< note >}}
 These instructions assume that you are using the
-[`cri-dockerd`](https://github.com/Mirantis/cri-dockerd) adapter to integrate
+[`cri-dockerd`](https://mirantis.github.io/cri-dockerd/) adapter to integrate
 Docker Engine with Kubernetes.
 {{< /note >}}
 
 1. On each of your nodes, install Docker for your Linux distribution as per
   [Install Docker Engine](https://docs.docker.com/engine/install/#server).
 
-2. Install [`cri-dockerd`](https://github.com/Mirantis/cri-dockerd), following
-   the instructions in that source code repository.
+2. Install [`cri-dockerd`](https://mirantis.github.io/cri-dockerd/usage/install), following the directions in the install section of the documentation.
 
 For `cri-dockerd`, the CRI socket is `/run/cri-dockerd.sock` by default.
 
@@ -343,7 +342,7 @@ For `cri-dockerd`, the CRI socket is `/run/cri-dockerd.sock` by default.
 available container runtime that was formerly known as Docker Enterprise Edition.
 
 You can use Mirantis Container Runtime with Kubernetes using the open source
-[`cri-dockerd`](https://github.com/Mirantis/cri-dockerd) component, included with MCR.
+[`cri-dockerd`](https://mirantis.github.io/cri-dockerd/) component, included with MCR.
 
 To learn more about how to install Mirantis Container Runtime,
 visit [MCR Deployment Guide](https://docs.mirantis.com/mcr/20.10/install.html).

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -93,7 +93,7 @@ for more information.
 {{< note >}}
 Docker Engine does not implement the [CRI](/docs/concepts/architecture/cri/)
 which is a requirement for a container runtime to work with Kubernetes.
-For that reason, an additional service [cri-dockerd](https://github.com/Mirantis/cri-dockerd)
+For that reason, an additional service [cri-dockerd](https://mirantis.github.io/cri-dockerd/)
 has to be installed. cri-dockerd is a project based on the legacy built-in
 Docker Engine support that was [removed](/dockershim) from the kubelet in version 1.24.
 {{< /note >}}
@@ -186,7 +186,7 @@ These instructions are for Kubernetes {{< skew currentVersion >}}.
    # sudo mkdir -p -m 755 /etc/apt/keyrings
    curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
-   
+
 {{< note >}}
 In releases older than Debian 12 and Ubuntu 22.04, folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command.
 {{< /note >}}

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -47,7 +47,7 @@ to `cri-dockerd`.
 
 ## {{% heading "prerequisites" %}}
 
-*   [`cri-dockerd`](https://github.com/mirantis/cri-dockerd#build-and-install)
+*   [`cri-dockerd`](https://mirantis.github.io/cri-dockerd/usage/install)
     installed and started on each node.
 *   A [network plugin](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/).
 


### PR DESCRIPTION
We get a lot of questions around the installation of cri-dockerd in the repo. We've found that many of the questions come from users being linked to the repo from the kubernetes docs and then they try to use the development installation method when they are not developers.

We now have an official documentation page that provides a straightforward installation using the different packages available. This PR is to update the links in the website so users get directed to the official docs rather than the repo.