### PR TITLE
Backport fix for tab layout rendering in release-1.25

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/change-package-repository.md
@@ -136,7 +136,7 @@ This step should be done upon upgrading from one to another Kubernetes minor
 release in order to get access to the packages of the desired Kubernetes minor
 version.
 
-{{< tabs name="k8s_install_versions" >}}
+{{< tabs name="k8s_upgrade_versions" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 
 1. Open the file that defines the Kubernetes `apt` repository using a text editor of your choice:


### PR DESCRIPTION
Applied fix for Broken tab layout on "Changing The Kubernetes Package Repository" page in 1.25

This will help with https://github.com/kubernetes/website/issues/45048