### PR TITLE
Update resource-usage-monitoring.md

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
@@ -84,7 +84,7 @@ solutions.
 The choice of monitoring platform depends heavily on your needs, budget, and technical resources.
 Kubernetes does not recommend any specific metrics pipeline; [many options](https://landscape.cncf.io/?group=projects-and-products&view-mode=card#observability-and-analysis--monitoring) are available.
 Your monitoring system should be capable of handling the [OpenMetrics](https://openmetrics.io/) metrics
-transmission standard, and needs to chosen to best fit in to your overall design and deployment of
+transmission standard, and needs to be chosen to best fit into your overall design and deployment of
 your infrastructure platform.
 
 

--- a/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
@@ -84,7 +84,7 @@ solutions.
 The choice of monitoring platform depends heavily on your needs, budget, and technical resources.
 Kubernetes does not recommend any specific metrics pipeline; [many options](https://landscape.cncf.io/?group=projects-and-products&view-mode=card#observability-and-analysis--monitoring) are available.
 Your monitoring system should be capable of handling the [OpenMetrics](https://openmetrics.io/) metrics
-transmission standard, and needs to be chosen to best fit into your overall design and deployment of
+transmission standard and needs to be chosen to best fit into your overall design and deployment of
 your infrastructure platform.
 
 


### PR DESCRIPTION
This pull request aims to enhance the grammatical accuracy and overall clarity of a specific sentence within the "Tools for Monitoring Resources" page. 

# Changes
**Original sentence:** "Your monitoring system should be capable of handling the OpenMetrics metrics transmission standard, and needs to chosen to best fit in to your overall design and deployment of your infrastructure platform."
**New sentence:** "Your monitoring system should be capable of handling the OpenMetrics metrics transmission standard and needs to be chosen to best fit into your overall design and deployment of your infrastructure platform."

# Explanation
- The sentence "and needs to chosen" was corrected to "and needs to be chosen" to add the missing verb "be."
- The initial sentence in the first commit assumes that two subjects exist "Your monitoring system" and "needs to be chosen" due to the comma before the conjuntion "and." However, only one subject exists "Your monitoring system" because the other is dependent on it. So, it has been corrected by removing the comma before the conjunction "and."
- The phrase "fit into" was chosen over "fit in to" for a more precise and grammatically sound structure.

Please review the changes and merge at your earliest convenience.