### PR TITLE
Mark feature AdmissionWebhookMatchConditions to stable in 1.30

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -721,7 +721,7 @@ The `matchPolicy` for an admission webhooks defaults to `Equivalent`.
 
 ### Matching requests: `matchConditions`
 
-{{< feature-state state="beta" for_k8s_version="v1.28" >}}
+{{< feature-state feature_gate_name="AdmissionWebhookMatchConditions" >}}
 
 You can define _match conditions_ for webhooks if you need fine-grained request filtering. These
 conditions are useful if you find that match rules, `objectSelectors` and `namespaceSelectors` still

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/admission-webhook-match-conditions.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/admission-webhook-match-conditions.md
@@ -12,7 +12,11 @@ stages:
     toVersion: "1.27"
   - stage: beta
     defaultValue: true
-    fromVersion: "1.28"  
+    fromVersion: "1.28"
+    toVersion: "1.29"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.30"
 ---
 Enable [match conditions](/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions)
 on mutating & validating admission webhooks.


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

For MatchConditions Beta graduation in v1.30.

https://github.com/kubernetes/enhancements/issues/3716

/sig api-machinery
/milestone v1.30

Opening this PR as a replacement for this other placeholder PR https://github.com/kubernetes/website/pull/45279