### PR TITLE
Fix path of kubelet systemd config file

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -315,9 +315,9 @@ sudo curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${
 sudo chmod +x {kubeadm,kubelet}
 
 RELEASE_VERSION="v0.16.2"
-curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubelet/kubelet.service" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /etc/systemd/system/kubelet.service
-sudo mkdir -p /etc/systemd/system/kubelet.service.d
-curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubelet/kubelet.service" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /usr/lib/systemd/system/kubelet.service
+sudo mkdir -p /usr/lib/systemd/system/kubelet.service.d
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | sudo tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
 ```
 
 {{< note >}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -163,9 +163,16 @@ Note that the kubeadm CLI command never touches this drop-in file.
 
 This configuration file installed by the `kubeadm`
 [package](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf) is written to
-`/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` and is used by systemd.
+`/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf` and is used by systemd.
 It augments the basic
-[`kubelet.service`](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubelet/kubelet.service):
+[`kubelet.service`](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubelet/kubelet.service).
+
+If you want to override that further, you can make a directory `/etc/systemd/system/kubelet.service.d/`
+(not `/usr/lib/systemd/system/kubelet.service.d/`) and put your own customizations into a file there.
+For example, you might add a new local file `/etc/systemd/system/kubelet.service.d/local-overrides.conf`
+to override the unit settings configured by `kubeadm`.
+
+Here is what you are likely to find in `/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf`:
 
 {{< note >}}
 The contents below are just an example. If you don't want to use a package manager


### PR DESCRIPTION
The changed doc claimed that as part of installing the kubeadm package, the file `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` will be created.

But on Ubuntu 22.04, if I `apt-get install kubeadm=1.28.x-1.1` that file doesn't exist. Instead,  `/lib/systemd/system/kubelet.service.d/10-kubeadm.conf` is created.

Note: I have no quick access to different Ubuntu versions unfortunately. So I don't know if with different versions the file is installed at a different location.

