### PR TITLE
[bn] Localize glossary entry for container runtime

### DIFF
--- a/content/bn/docs/reference/glossary/container-runtime.md
+++ b/content/bn/docs/reference/glossary/container-runtime.md
@@ -1,0 +1,22 @@
+---
+title: কন্টেইনার রানটাইম
+id: container-runtime
+date: 2019-06-05
+full_link: /bn/docs/setup/production-environment/container-runtimes
+short_description: >
+ কন্টেইনার রানটাইম হল সেই সফটওয়্যার যা কন্টেইনার চালানোর জন্য দায়ী।
+
+aka:
+tags:
+- fundamental
+- workload
+---
+ একটি মৌলিক উপাদান যা কুবারনেটিসকে কার্যকরভাবে কন্টেইনার চালানোর ক্ষমতা দেয়।
+ এটি কুবারনেটিস পরিবেশের মধ্যে কন্টেইনারগুলির সম্পাদন এবং জীবনচক্র পরিচালনার জন্য দায়ী।
+
+<!--more-->
+
+কুবারনেটস কনটেইনার রানটাইম সমর্থন করে যেমন
+{{< glossary_tooltip term_id="containerd" >}}, {{< glossary_tooltip term_id="cri-o" >}},
+এবং [কুবারনেটিস CRI (কন্টেইনার রানটাইম
+ইন্টারফেস)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md)।

--- a/content/bn/docs/reference/glossary/container-runtime.md
+++ b/content/bn/docs/reference/glossary/container-runtime.md
@@ -2,7 +2,7 @@
 title: কন্টেইনার রানটাইম
 id: container-runtime
 date: 2019-06-05
-full_link: /bn/docs/setup/production-environment/container-runtimes
+full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
  কন্টেইনার রানটাইম হল সেই সফটওয়্যার যা কন্টেইনার চালানোর জন্য দায়ী।
 


### PR DESCRIPTION
This is PR is Localize `content/bn/docs/reference/glossary/container-runtime.md` and fixed build error:

```bash
ERROR [bn] "docs/concepts/containers/_index.md": "container-runtime" is not a valid glossary term_id, see ./docs/reference/glossary/* for a full list
```
Fixes Issue: #44993 
Tracking Issue: #31677 