### PR TITLE
Update use of deprecated ioutils module

### DIFF
--- a/content/en/examples/examples_test.go
+++ b/content/en/examples/examples_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -365,7 +364,7 @@ func walkConfigFiles(inDir string, t *testing.T, fn func(name, path string, data
 
 		file := filepath.Base(path)
 		if ext := filepath.Ext(file); ext == ".json" || ext == ".yaml" {
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The ioutils module was [deprecated in Go 1.16](https://go.dev/doc/go1.16#ioutil). This updates the example test code to use the newer recommended replacement.

