### PR TITLE
Add notes on etcd tracing problems to api-server-tracing blog post

### DIFF
--- a/content/en/blog/_posts/2021-09-03-api-server-tracing.md
+++ b/content/en/blog/_posts/2021-09-03-api-server-tracing.md
@@ -42,6 +42,7 @@ samplingRatePerMillion: 10000
 
 ### Enabling Etcd Tracing
 
+_Update: the following was added after the blog was published_
 Add `--experimental-enable-distributed-tracing`,  `--experimental-distributed-tracing-address=0.0.0.0:4317`, `--experimental-distributed-tracing-service-name=etcd` flags to etcd to enable tracing.  Note that this traces every request, so it will probably generate a lot of traces if you enable it. Required etcd version is [3.5 up to 3.5.4](https://etcd.io/docs/v3.5/op-guide/monitoring/#distributed-tracing).
 
 Starting from version 3.5.5 until version 3.5.10, the default sampling rate for traces is set to 0%, meaning no traces were collected by default. Unfortunately, there is no option provided to configure a higher sampling rate. ([See details](https://github.com/etcd-io/etcd/pull/16951)) 

--- a/content/en/blog/_posts/2021-09-03-api-server-tracing.md
+++ b/content/en/blog/_posts/2021-09-03-api-server-tracing.md
@@ -42,7 +42,11 @@ samplingRatePerMillion: 10000
 
 ### Enabling Etcd Tracing
 
-Add `--experimental-enable-distributed-tracing`,  `--experimental-distributed-tracing-address=0.0.0.0:4317`, `--experimental-distributed-tracing-service-name=etcd` flags to etcd to enable tracing.  Note that this traces every request, so it will probably generate a lot of traces if you enable it. Required etcd version is [v3.5+](https://etcd.io/docs/v3.5/op-guide/monitoring/#distributed-tracing).
+Add `--experimental-enable-distributed-tracing`,  `--experimental-distributed-tracing-address=0.0.0.0:4317`, `--experimental-distributed-tracing-service-name=etcd` flags to etcd to enable tracing.  Note that this traces every request, so it will probably generate a lot of traces if you enable it. Required etcd version is [3.5 up to 3.5.4](https://etcd.io/docs/v3.5/op-guide/monitoring/#distributed-tracing).
+
+Starting from version 3.5.5 until version 3.5.10, the default sampling rate for traces is set to 0%, meaning no traces were collected by default. Unfortunately, there is no option provided to configure a higher sampling rate. ([See details](https://github.com/etcd-io/etcd/pull/16951)) 
+
+In version [3.5.11](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v3511-2023-12-07), the number of samples to collect per million spans can be configured using the newly introduced `--experimental-distributed-tracing-sampling-rate=1000000` flag.
 
 ### Example Trace: List Nodes
 


### PR DESCRIPTION
This PR adds some details about working and non working etcd versions to the api-server-tracing blog post.

Even though the post is older, it is still very useful. :smiley: 

cc @dashpole 