### PR TITLE
Update button label to 'See available versions' in docs homepage

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -64,4 +64,6 @@ cards:
 - name: about
   title: About the documentation
   description: This website contains documentation for the current and previous 4 versions of Kubernetes.
+  button: "See available versions"
+  button_path: "docs/supported-doc-versions"
 ---

--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -65,5 +65,5 @@ cards:
   title: About the documentation
   description: This website contains documentation for the current and previous 4 versions of Kubernetes.
   button: "See available versions"
-  button_path: "docs/supported-doc-versions"
+  button_path: "/docs/home/supported-doc-versions"
 ---

--- a/content/en/docs/home/supported-doc-versions.md
+++ b/content/en/docs/home/supported-doc-versions.md
@@ -2,10 +2,7 @@
 title: Available Documentation Versions
 content_type: custom
 layout: supported-versions
-card:
-  name: about
-  weight: 10
-  title: Available Documentation Versions
+weight: 10
 ---
 
 This website contains documentation for the current version of Kubernetes


### PR DESCRIPTION
Changed link of "About the documentation" to button with text "See available versions" on homepage

This will fix https://github.com/kubernetes/website/issues/43249