### PR TITLE
Added a link to the minikube installation website

### DIFF
--- a/content/en/docs/tasks/tools/included/verify-kubectl.md
+++ b/content/en/docs/tasks/tools/included/verify-kubectl.md
@@ -31,7 +31,7 @@ The connection to the server <server-name:port> was refused - did you specify th
 ```
 
 For example, if you are intending to run a Kubernetes cluster on your laptop (locally),
-you will need a tool like Minikube to be installed first and then re-run the commands stated above.
+you will need a tool like [Minikube](https://minikube.sigs.k8s.io/docs/start/) to be installed first and then re-run the commands stated above.
 
 If kubectl cluster-info returns the url response but you can't access your cluster,
 to check whether it is configured properly, use:


### PR DESCRIPTION
Hi, I was trying to install Kubernetes on my local machine and I noticed that suggestion to install Minikube did not have a hyperlink to it. So I added a link at the mention of install Minikube so it's convenient for people trying to install it on their local machine.
