### PR TITLE
Add “Immutable infrastructure” to glossary

### DIFF
--- a/content/en/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/en/docs/reference/glossary/immutable-infrastructure.md
@@ -22,5 +22,6 @@ can only be made by creating a new version of the container or recreating the ex
 By preventing or identifying unauthorized changes, immutable infrastructures make it easier to identify and mitigate security risks. 
 Operating such a system becomes a lot more straightforward because administrators can make assumptions about it.
 After all, they know no one made mistakes or changes they forgot to communicate.
-Immutable infrastructure goes hand-in-hand with infrastructure as code where all automation needed to create infrastructure is stored in version control (e.g. Git).
+Immutable infrastructure goes hand-in-hand with infrastructure as code where all automation needed
+to create infrastructure is stored in version control (such as Git).
 This combination of immutability and version control means that there is a durable audit log of every authorized change to a system.

--- a/content/en/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/en/docs/reference/glossary/immutable-infrastructure.md
@@ -10,7 +10,6 @@ aka:
 tags:
 - architecture
 - storage
-- tool
 ---
  Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed.
 

--- a/content/en/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/en/docs/reference/glossary/immutable-infrastructure.md
@@ -1,0 +1,27 @@
+---
+title: Immutable Infrastructure
+id: immutable-infrastructure
+date: 2024-03-25
+full_link:
+short_description: >
+  Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed
+
+aka: 
+tags:
+- architecture
+- storage
+- tool
+---
+ Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed.
+
+<!--more-->
+
+Immutability can be enforced by an automated process that overwrites unauthorized changes or through a system that won’t allow changes in the first place.
+{{< glossary_tooltip text="Containers" term_id="container" >}} are a good example of immutable infrastructure because persistent changes to containers
+can only be made by creating a new version of the container or recreating the existing container from its image.
+
+By preventing or identifying unauthorized changes, immutable infrastructures make it easier to identify and mitigate security risks. 
+Operating such a system becomes a lot more straightforward because administrators can make assumptions about it.
+After all, they know no one made mistakes or changes they forgot to communicate.
+Immutable infrastructure goes hand-in-hand with infrastructure as code where all automation needed to create infrastructure is stored in version control (e.g. Git).
+This combination of immutability and version control means that there is a durable audit log of every authorized change to a system.

--- a/content/en/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/en/docs/reference/glossary/immutable-infrastructure.md
@@ -9,7 +9,6 @@ short_description: >
 aka: 
 tags:
 - architecture
-- storage
 ---
  Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed.
 


### PR DESCRIPTION
Added “Immutable infrastructure” to glossary as part of https://github.com/kubernetes/website/issues/45655 using the content from https://glossary.cncf.io/immutable-infrastructure.

Closes https://github.com/kubernetes/website/issues/45655