### PR TITLE
Add Namespace Patching to RBAC good practice

### DIFF
--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -185,8 +185,9 @@ mutating webhooks, also mutate admitted objects.
 
 Users who can perform `patch` operations on `namespace` objects through a namespaced rolebinding can modify 
 labels on that namespace. In clusters where Pod Security Admission is used, this may allow a user to configure the namespace
-for a more permissive policy than intended by the administrators. For clusters where network policy is used, users may be 
-able to gain access to services intended to be blocked.  
+for a more permissive policy than intended by the administrators.
+For clusters where NetworkPolicy is used, users may be set labels that indirectly allow
+access to services that an administrator did not intend to allow.
 
 ## Kubernetes RBAC - denial of service risks {#denial-of-service-risks}
 

--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -181,6 +181,13 @@ Users with control over `validatingwebhookconfigurations` or `mutatingwebhookcon
 can control webhooks that can read any object admitted to the cluster, and in the case of
 mutating webhooks, also mutate admitted objects.
 
+### Namespace modification
+
+Users who can perform `patch` operations on `namespace` objects through a namespaced rolebinding can modify 
+labels on that namespace. In clusters where Pod Security Admission is used, this may allow a user to configure the namespace
+for a more permissive policy than intended by the administrators. For clusters where network policy is used, users may be 
+able to gain access to services intended to be blocked.  
+
 ## Kubernetes RBAC - denial of service risks {#denial-of-service-risks}
 
 ### Object creation denial-of-service {#object-creation-dos}

--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -183,7 +183,7 @@ mutating webhooks, also mutate admitted objects.
 
 ### Namespace modification
 
-Users who can perform `patch` operations on `namespace` objects through a namespaced rolebinding can modify 
+Users who can perform **patch** operations on Namespace objects (through a namespaced RoleBinding to a Role with that access) can modify
 labels on that namespace. In clusters where Pod Security Admission is used, this may allow a user to configure the namespace
 for a more permissive policy than intended by the administrators.
 For clusters where NetworkPolicy is used, users may be set labels that indirectly allow


### PR DESCRIPTION
Updating the RBAC Good Practices guide to include information on Patch operations against Namespaces being a security risk.