### PR TITLE
[zh-cn] Fix the full_link of glossary in container.md

### DIFF
--- a/content/zh-cn/docs/reference/glossary/container.md
+++ b/content/zh-cn/docs/reference/glossary/container.md
@@ -2,7 +2,7 @@
 title: 容器（Container）
 id: container
 date: 2018-04-12
-full_link: /zh-cn/docs/concepts/overview/what-is-kubernetes/#why-containers
+full_link: /zh-cn/docs/concepts/containers/
 short_description: >
   容器是可移植、可执行的轻量级的镜像，镜像中包含软件及其相关依赖。
 


### PR DESCRIPTION
The original link "https://kubernetes.io/zh-cn/docs/concepts/overview/what-is-kubernetes/#why-containers" is no longer in use

