### PR TITLE
Add kirkonru to sig-docs-ru

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -177,9 +177,11 @@ aliases:
     - truongnh1992
   sig-docs-ru-owners: # Admins for Russian content
     - Arhell
+    - kirkonru
     - shurup
   sig-docs-ru-reviews: # PR reviews for Russian content
     - Arhell
+    - kirkonru
     - shurup
   sig-docs-pl-owners: # Admins for Polish content
     - mfilocha


### PR DESCRIPTION
Since we have @kirkonru in the organisation, we can add him to the reviewers and owners list for the Russian localisation :tada: 

Related PR: https://github.com/kubernetes/org/pull/4846