### PR TITLE
Add a note to specify the required Hugo version in the prerequisites.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ To use this repository, you need the following installed locally:
 - [Hugo (Extended version)](https://gohugo.io/)
 - A container runtime, like [Docker](https://www.docker.com/).
 
+> [!NOTE]
+Make sure to install the Hugo extended version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L11) file.
+
 Before you start, install the dependencies. Clone the repository and navigate to the directory:
 
 ```bash
@@ -55,8 +58,6 @@ If you see errors, it probably means that the hugo container did not have enough
 Open up your browser to <http://localhost:1313> to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.
 
 ## Running the website locally using Hugo
-
-Make sure to install the Hugo extended version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L11) file.
 
 To install dependencies, deploy and test the site locally, run:
 


### PR DESCRIPTION
Fixes #45597

The instruction to install a specific Hugo extended version as defined in [netlify.toml](https://github.com/kubernetes/website/blob/main/netlify.toml#L11) is mentioned in the [Running the website locally using Hugo](https://github.com/kubernetes/website?tab=readme-ov-file#running-the-website-locally-using-hugo) section.

However, I believe it would be helpful to move the instruction to the [Prerequisites](https://github.com/kubernetes/website?tab=readme-ov-file#prerequisites) section. This would prevent readers from inadvertently installing the latest Hugo extended version (currently v0.124.1) which is incompatible with k/w.


Suggestions and feedback are welcome!

Kind regards,
Aditya.


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
