### PR TITLE
[hi] Update the Build link in README file

### DIFF
--- a/README-hi.md
+++ b/README-hi.md
@@ -1,6 +1,6 @@
 # कुबरनेट्स प्रलेखन
 
-[![Build Status](https://api.travis-ci.org/kubernetes/website.svg?branch=master)](https://travis-ci.org/kubernetes/website)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/be93b718-a6df-402a-b4a4-855ba186c97d/deploy-status)](https://app.netlify.com/sites/kubernetes-io-main-staging/deploys)
 [![GitHub release](https://img.shields.io/github/release/kubernetes/website.svg)](https://github.com/kubernetes/website/releases/latest)
 
 स्वागत है! इस रिपॉजिटरी में [कुबरनेट्स वेबसाइट और दस्तावेज](https://kubernetes.io/) बनाने के लिए आवश्यक सभी संपत्तियाँ हैं। हम बहुत खुश हैं कि आप योगदान करना चाहते हैं!


### PR DESCRIPTION
Updated the Build link in the README-hi.md file to align with the main [README.md](https://github.com/kubernetes/website/blob/main/README.md) file

Also a ref issue #41241 was opened regarding this 