### PR TITLE
Fix typo in kubeadm-config v1beta4 config reference

### DIFF
--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
@@ -448,7 +448,7 @@ of view and as an authentication method for the node in the bootstrap phase of
 <code>string</code>
 </td>
 <td>
-   <p><code>ontrolPlaneEndpoint</code> sets a stable IP address or DNS name for the control plane;
+   <p><code>controlPlaneEndpoint</code> sets a stable IP address or DNS name for the control plane;
 It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
 In case the <code>controlPlaneEndpoint</code> is not specified, the <code>advertiseAddress</code> + <code>bindPort</code>
 are used; in case the <code>controlPlaneEndpoint</code> is specified but without a TCP port,
@@ -591,7 +591,7 @@ to the cluster.</p>
 <td>
    <p><code>localAPIEndpoint</code> represents the endpoint of the API server instance that's deployed on this
 control plane node. In HA setups, this differs from <code>ClusterConfiguration.controlPlaneEndpoint</code>
-in the sense that <code>ontrolPlaneEndpoint</code> is the global endpoint for the cluster, which then
+in the sense that <code>controlPlaneEndpoint</code> is the global endpoint for the cluster, which then
 loadbalances the requests to each individual API server.
 This configuration object lets you customize what IP/DNS name and port the local API server
 advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default


### PR DESCRIPTION
When adding formatting to the controlPlaneEndpoint config reference for kubeadm-config v1beta4 it appears the first letter of the value was accidentally dropped. This adds it back in the two places where this happened.

My guess is adding the "c" in the `<code>` block in 74516499205c439c913aa8c197eaf9ee0f85763c accidentally picked up the leading "c" from the name.

Closes: #45602