### PR TITLE
Annotation azure-load-balancer-disable-tcp-reset registered & documented

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2067,16 +2067,16 @@ Example: `service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset: "fal
 Used on: Service
 
 This annotation only works for Azure standard load balancer backed service.
-This annotation is used on the service to specify whether the load balancer
+This annotation is used on the Service to specify whether the load balancer
 should disable or enable TCP reset on idle timeout. If enabled, it helps
 applications to behave more predictably, to detect the termination of a connection,
 remove expired connections and initiate new connections. 
-Its values is  boolean i.e. `true` or `false`.
+You can set the value to be either true or false.
 
 See [Load Balancer TCP Reset](https://learn.microsoft.com/en-gb/azure/load-balancer/load-balancer-tcp-reset) for more information.
 
 {{< note >}} 
-As TCP reset should actually always be enabled, in order to avoid dropping packets silently, this annotation is deprecated since v1.18
+This annotation is deprecated.
 {{< /note >}}
 
 ### pod-security.kubernetes.io/enforce

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2060,6 +2060,25 @@ on an existing Service object. See the AWS documentation on this topic for more
 details.
 {{< /caution >}}
 
+### service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset (deprecated) {#service-beta-kubernetes-azure-load-balancer-disble-tcp-reset}
+
+Example: `service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset: "false"`
+
+Used on: Service
+
+This annotation only works for Azure standard load balancer backed service.
+This annotation is used on the service to specify whether the load balancer
+should disable or enable TCP reset on idle timeout. If enabled, it helps
+applications to behave more predictably, to detect the termination of a connection,
+remove expired connections and initiate new connections. 
+Its values is  boolean i.e. `true` or `false`.
+
+See [Load Balancer TCP Reset](https://learn.microsoft.com/en-gb/azure/load-balancer/load-balancer-tcp-reset) for more information.
+
+{{< note >}} 
+As TCP reset should actually always be enabled, in order to avoid dropping packets silently, this annotation is deprecated since v1.18
+{{< /note >}}
+
 ### pod-security.kubernetes.io/enforce
 
 Type: Label


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/website/issues/45369

Added legacy annotation service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset and a note explaining its deprecation.

