### PR TITLE
[es] Fix broken Netlify status badge link in README

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -1,6 +1,6 @@
 # La documentación de Kubernetes
 
-[![Build Status](https://api.travis-ci.org/kubernetes/website.svg?branch=master)](https://travis-ci.org/kubernetes/website)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/be93b718-a6df-402a-b4a4-855ba186c97d/deploy-status)](https://app.netlify.com/sites/kubernetes-io-main-staging/deploys)
 [![GitHub release](https://img.shields.io/github/release/kubernetes/website.svg)](https://github.com/kubernetes/website/releases/latest)
 
 Bienvenido!


### PR DESCRIPTION
I was going through the repo README files and found a broken Netlify status badge link in README-es.md. Fixed the badge link by using the value from the english README.md file. The badge now works.

