### PR TITLE
[it] Fix broken Netlify status badge link in README

### DIFF
--- a/README-it.md
+++ b/README-it.md
@@ -1,6 +1,6 @@
 # La documentazione di Kubernetes
 
-[![Build Status](https://api.travis-ci.org/kubernetes/website.svg?branch=master)](https://travis-ci.org/kubernetes/website)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/be93b718-a6df-402a-b4a4-855ba186c97d/deploy-status)](https://app.netlify.com/sites/kubernetes-io-main-staging/deploys) 
 [![GitHub release](https://img.shields.io/github/release/kubernetes/website.svg)](https://github.com/kubernetes/website/releases/latest)
 
 Benvenuto! Questo repository contiene tutte le informazioni necessarie per creare la [documentazione e il sito web di Kubernetes](https://kubernetes.io/). Siamo onorati che tu voglia contribuire!


### PR DESCRIPTION
I was going through the repo README files and found a broken Netlify status badge link in README-it.md. Fixed the badge link by using the value from the english README.md file. The badge now works.