### PR TITLE
Improve example for EndpointSlice label

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1117,7 +1117,7 @@ duration (defaults to one year).
 
 Type: Label
 
-Example: `endpointslice.kubernetes.io/managed-by: "controller"`
+Example: `endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io`
 
 Used on: EndpointSlices
 


### PR DESCRIPTION
Update https://kubernetes.io/docs/reference/labels-annotations-taints/ to revise the entry for `endpointslice.kubernetes.io/managed-by`.

Use the most common value for this label (`endpointslice-controller.k8s.io`) as the example value.