### PR TITLE
Signpost to API reference for NetworkPolicy

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -5,6 +5,9 @@ reviewers:
 - danwinship
 title: Network Policies
 content_type: concept
+api_metadata:
+- apiVersion: "networking.k8s.io/v1"
+  kind: "NetworkPolicy"
 weight: 70
 description: >-
   If you want to control traffic flow at the IP address or port level (OSI layer 3 or 4),


### PR DESCRIPTION
This builds on the change for https://github.com/kubernetes/website/pull/45496 and adds that mechanism to the NetworkPolicy page (https://k8s.io/docs/concepts/services-networking/network-policies/)

_[Preview](https://deploy-preview-45746--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/network-policies/) of the update page_