### PR TITLE
Fix discovery document link in kubernetes-api.md

### DIFF
--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -43,7 +43,7 @@ The two supported mechanisms are as follows:
   detail specific schema for the resources. For reference about resource schemas,
   please refer to the OpenAPI document.
 
-- The [Kubernetes OpenAPI Document](#openapi-specification) provides (full)
+- The [Kubernetes OpenAPI Document](#openapi-interface-definition) provides (full)
   [OpenAPI v2.0 and 3.0 schemas](https://www.openapis.org/) for all Kubernetes API
 endpoints.
   The OpenAPI v3 is the preferred method for accessing OpenAPI as it

--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -86,7 +86,7 @@ Without indicating the resource type using the `Accept` header, the default
 response for the `/api` and `/apis` endpoint is an unaggregated discovery
 document.
 
-The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-v{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)
+The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)
 for the built-in resources can be found in the Kubernetes GitHub repository.
 This Github document can be used as a reference of the base set of the available resources
 if a Kubernetes cluster is not available to query.


### PR DESCRIPTION
Removed an extra "v" in the link to fix the broken link.
