### PR TITLE
[WIP] Implement one-page version of kubectl reference index for improved readability and user experience

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -24,7 +24,11 @@
             <h1>{{ .Title }}</h1>
             {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
         {{ end }}
-        {{ partial "section-index.html" . }}
+        {{- if eq .Page.RelPermalink "/docs/reference/kubectl/generated/" -}}
+            {{ partial "kubectl-reference-index.html" . }}
+        {{ else }}
+            {{ partial "section-index.html" . }}
+        {{ end }}
     </div>
 {{ end }}
 {{ define "hero" }}

--- a/layouts/partials/kubectl-reference-index.html
+++ b/layouts/partials/kubectl-reference-index.html
@@ -1,0 +1,48 @@
+{{- $parent := .Page -}}
+{{- $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
+{{- $pages = (where $pages "Type" "!=" "search") -}}
+{{- $pages = (where $pages ".Parent" "!=" nil) -}}
+{{- $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
+
+<hr class="panel-line">
+<div id="kubectl-reference-index">
+
+    {{- range $index, $childPage := $pages -}} <!-- Iterate through all the section pages -->
+        {{- $sectionId := (replace $childPage.Title " " "-") | lower -}} <!-- Generate unique ID for each section page -->
+
+        <!-- Display the title of the child page as a header with an anchor link for easy navigation. -->
+        <h3 class="font-weight-bold mt-4 mb-1" id="{{ $sectionId }}"><a href=" {{ .RelPermalink }}">{{- $childPage.Title -}}</a></h3>
+
+        <!-- Details section for each section page -->
+        <p class="content-{{ $sectionId }}">
+            <details class="details-{{ $sectionId }}">
+                <summary class="card-header text-monospace summary-{{ $sectionId }}">{{- $childPage.Title -}}</summary>
+                <div class="border-bottom description-{{ $sectionId }}">
+                    {{- $content := $childPage.Content -}} <!-- Get child page content -->
+                    {{- $content = replaceRE "<h2 id=\"see-also\">.*?<\\/h2>\\s*<ul>([\\s\\S]*?)<\\/ul>" "" $content -}} <!-- Remove the 'See Also' section and its content -->
+                    {{- $content = replaceRE "<h2.*?>(.*?)<\\/h2>" "<h2>$1</h2>" $content -}} <!-- Remove 'id' attribute to eliminate the redundant deep link for sub-sections -->
+                    {{- $content = replaceRE "<table(\\s+[^>]*)?>" "<table class='table table-striped table-responsive'$1>" $content -}} <!-- Add 'class' attribute to table for similar look and feel to other tables on site -->
+                    {{- $content | safeHTML -}} <!-- Display modified content -->
+                </div>
+            </details>
+
+            <!-- Nested details section for sub-command child pages -->
+            {{- range $subPage := $childPage.RegularPages -}}
+                {{- $subSectionId := (replace $subPage.Title " " "-") | lower -}} <!-- Generate unique ID for each sub-command page -->
+                <details class="details-{{ $subSectionId }}">
+                    <summary class="card-header text-monospace summary-{{ $subSectionId }}">{{- $subPage.Title -}}</summary>
+                    <div class="border-bottom description-{{ $subSectionId }}">
+                        {{- $subPageContent := $subPage.Content -}} <!-- Get sub-section page content -->
+                        {{- $subPageContent = replaceRE "<h2 id=\"see-also\">.*?<\\/h2>\\s*<ul>([\\s\\S]*?)<\\/ul>" "" $subPageContent -}} <!-- Remove the 'See Also' section and its content -->
+                        {{- $subPageContent = replaceRE "<h2.*?>(.*?)<\\/h2>" "<h2>$1</h2>" $subPageContent -}} <!-- Remove 'id' attribute to eliminate the redundant deep link for sub-sections -->
+                        {{- $subPageContent = replaceRE "<table(\\s+[^>]*)?>" "<table class='table table-striped table-responsive'$1>" $subPageContent -}} <!-- Add 'class' attribute to table for similar look and feel to other tables on site -->
+                        {{- $subPageContent | safeHTML -}} <!-- Display modified content -->
+                    </div>
+                </details>
+            {{- end -}}
+        </p>
+    {{- end -}}
+</div>
+
+<!-- Display auto-generated information block -->
+{{- partial "docs/auto-generated-pageinfo.html" . -}}


### PR DESCRIPTION
Create a condensed version of https://kubernetes.io/docs/reference/kubectl/generated/ by merging content from all the kubectl subcommands pages during static site generation to produce a single-page layout. This is achieved by using a new partial layout named `kubectl-reference-index.html` which will override default "section-index.html" partial to fetch title, link, and content of all kubectl subcommands pages.

Helps with https://github.com/kubernetes/website/issues/45558

#### Summary of changes

- Incorporation of logic within the `kubectl-reference-index.html` partial layout to iterate through subcommands pages inside "[docs/reference/kubectl/generated(here)](https://github.com/kubernetes/website/tree/main/content/en/docs/reference/kubectl/generated)"  for accurate data extraction. Data from the subcommands pages is dynamically rendered in the reference index using `<details> <summary> ` tags to allow for collapsible sections.

- Pre-rendering data modifications for the index page include:
  - Removal of 'See Also' section's (eg: [here](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/#see-also)) content due to inconsistencies with the logical flow of the index page and some non-functional relative links due to location difference.
   - Removal of `id` attribute from all headings `<h2>` (eg: [here](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/#synopsis))  to eliminate redundant subsection links in the index page.
    - Addition of `class` attribute to `<table>` to maintain consistent look and feel with other tables across the site.

## Useful Links

### [Preview kubectl reference index page](https://deploy-preview-45768--kubernetes-io-main-staging.netlify.app/docs/reference/kubectl/generated/)
### [Preview link to specific command in index page](https://deploy-preview-45768--kubernetes-io-main-staging.netlify.app/docs/reference/kubectl/generated/#kubectl-rollout)