### PR TITLE
Add shell access prereq to node upgrade cluster task

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -10,7 +10,7 @@ This page explains how to upgrade a Linux Worker Nodes created with kubeadm.
 
 ## {{% heading "prerequisites" %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs-node-upgrade.md" >}} {{< version-check >}}
 * Familiarize yourself with [the process for upgrading the rest of your kubeadm
 cluster](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade). You will want to
 upgrade the control plane nodes before upgrading your Linux Worker nodes.

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -13,7 +13,7 @@ This page explains how to upgrade a Windows node created with kubeadm.
 
 ## {{% heading "prerequisites" %}}
  
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs-node-upgrade.md" >}} {{< version-check >}}
 * Familiarize yourself with [the process for upgrading the rest of your kubeadm
 cluster](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade). You will want to
 upgrade the control plane nodes before upgrading your Windows nodes.

--- a/content/en/includes/task-tutorial-prereqs-node-upgrade.md
+++ b/content/en/includes/task-tutorial-prereqs-node-upgrade.md
@@ -1,0 +1,3 @@
+You need to have shell access to all the nodes, and the kubectl command-line tool must
+be configured to communicate with your cluster. It is recommended to run this tutorial 
+on a cluster with at least two nodes that are not acting as control plane hosts.


### PR DESCRIPTION
Add need to obtain node shell access before node upgrade cluster task. Fixes #45539 