### PR TITLE
Add other error message for metrics-server in default kubeadm config

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -469,6 +469,7 @@ on the side of the metrics-server:
 ```
 x509: certificate signed by unknown authority
 x509: certificate is valid for IP-foo not IP-bar
+x509: cannot validate certificate for IP-foo because it doesn't contain any IP SANs
 ```
 
 See [Enabling signed kubelet serving certificates](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs)


### PR DESCRIPTION
This is the error message currently printed by the default-manifest metrics-server for a default kubeadm cluster installation for every node.

I believe this PR will make troubleshooting the metrics-server on a basic kubeadm install easier because this error message currently brings very few results online for kubernetes as it is not documented anywhere, even in the project repository.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
