### PR TITLE
Configure Kubernetes components's OTEL traces configuration (emitting traces directly and tuning with environment)

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-traces.md
+++ b/content/en/docs/concepts/cluster-administration/system-traces.md
@@ -60,34 +60,6 @@ see [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-co
 Additionally, for trace resource attribute configuration such as Kubernetes cluster name, namespace, Pod name, etc., 
 environment variables can also be used with `OTEL_RESOURCE_ATTRIBUTES`, see [OTLP Kubernetes Resource](https://opentelemetry.io/docs/specs/semconv/resource/k8s/).
 
-Below is an example that shows how to configure  to emit traces directly to a backend.
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: apiserver
-  labels:
-    component: apiserver
-spec:
-  selector:
-    matchLabels:
-      component: apiserver
-  template:
-    metadata:
-      labels:
-        component: apiserver
-    spec:
-      containers:
-      - name: apiserver
-        env:
-          - name: OTEL_EXPORTER_OTLP_HEADERS
-            value: "<header_key1>=<header_value1>,<header_key2>=<header_value2>"
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: "<resource_key1>=<resource_value1>,<resource_key1>=<resource_value1>"
-```
-Note: Replace header_key, header_value, resource_key, resource_value with your actual keys and values.
-
-
 ## Component traces
 
 ### kube-apiserver traces

--- a/content/en/docs/concepts/cluster-administration/system-traces.md
+++ b/content/en/docs/concepts/cluster-administration/system-traces.md
@@ -22,6 +22,9 @@ with the gRPC exporter and can be collected and routed to tracing backends using
 
 ## Trace Collection
 
+Kubernetes components have built-in grpc exporters for OTLP to export traces, either with an OpenTelemetry Collector, 
+or without an OpenTelemetry Collector.
+
 For a complete guide to collecting traces and using the collector, see
 [Getting Started with the OpenTelemetry Collector](https://opentelemetry.io/docs/collector/getting-started/).
 However, there are a few things to note that are specific to Kubernetes components.
@@ -46,6 +49,44 @@ service:
       receivers: [otlp]
       exporters: [logging]
 ```
+
+To directly emit traces to a backend without utilizing a collector, 
+specify the endpoint field in the Kubernetes TracingConfiguration with the desired trace backend address. 
+This method negates the need for a collector and simplifies the overall structure.
+
+For trace backend header configuration, including authentication details, environment variables can be used with `OTEL_EXPORTER_OTLP_HEADERS`, 
+see [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/).
+
+Additionally, for trace resource attribute configuration such as Kubernetes cluster name, namespace, Pod name, etc., 
+environment variables can also be used with `OTEL_RESOURCE_ATTRIBUTES`, see [OTLP Kubernetes Resource](https://opentelemetry.io/docs/specs/semconv/resource/k8s/).
+
+Below is an example that shows how to configure  to emit traces directly to a backend.
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apiserver
+  labels:
+    component: apiserver
+spec:
+  selector:
+    matchLabels:
+      component: apiserver
+  template:
+    metadata:
+      labels:
+        component: apiserver
+    spec:
+      containers:
+      - name: apiserver
+        env:
+          - name: OTEL_EXPORTER_OTLP_HEADERS
+            value: "<header_key1>=<header_value1>,<header_key2>=<header_value2>"
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: "<resource_key1>=<resource_value1>,<resource_key1>=<resource_value1>"
+```
+Note: Replace header_key, header_value, resource_key, resource_value with your actual keys and values.
+
 
 ## Component traces
 
@@ -125,4 +166,6 @@ there are no guarantees of backwards compatibility for tracing instrumentation.
 ## {{% heading "whatsnext" %}}
 
 * Read about [Getting Started with the OpenTelemetry Collector](https://opentelemetry.io/docs/collector/getting-started/)
+* Read about [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/)
+
 

--- a/content/en/docs/concepts/cluster-administration/system-traces.md
+++ b/content/en/docs/concepts/cluster-administration/system-traces.md
@@ -22,7 +22,7 @@ with the gRPC exporter and can be collected and routed to tracing backends using
 
 ## Trace Collection
 
-Kubernetes components have built-in grpc exporters for OTLP to export traces, either with an OpenTelemetry Collector, 
+Kubernetes components have built-in gRPC exporters for OTLP to export traces, either with an OpenTelemetry Collector, 
 or without an OpenTelemetry Collector.
 
 For a complete guide to collecting traces and using the collector, see
@@ -51,7 +51,7 @@ service:
 ```
 
 To directly emit traces to a backend without utilizing a collector, 
-specify the endpoint field in the Kubernetes TracingConfiguration with the desired trace backend address. 
+specify the endpoint field in the Kubernetes tracing configuration file with the desired trace backend address. 
 This method negates the need for a collector and simplifies the overall structure.
 
 For trace backend header configuration, including authentication details, environment variables can be used with `OTEL_EXPORTER_OTLP_HEADERS`, 


### PR DESCRIPTION
This PR is related to K8s trace, and  introduces:
1. How to emit traces to trace backend directly(this is a scenario on public cloud)
2. How to configure OTEL_EXPORTER_OTLP_HEADERS, OTEL_RESOURCE_ATTRIBUTES environment variables to tune OTEL options, including authentication, K8s attributes. 

This PR is based on below discussion.
https://github.com/kubernetes/kubernetes/issues/123531

CC  @dashpole 