### PR TITLE
Create OWNERS for ar localization

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -199,6 +199,8 @@ aliases:
     - MaxymVlasov
   sig-docs-ar-owners: # Admins for Arabic content
     - mboukhalfa
+  sig-docs-ar-reviews: # PR reviews for Arabic content
+    - mboukhalfa
   # authoritative source: git.k8s.io/community/OWNERS_ALIASES
   committee-steering: # provide PR approvals for announcements
     - bentheelder

--- a/content/ar/OWNERS
+++ b/content/ar/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the localization project for Arabic.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-ar-reviews
+
+approvers:
+- sig-docs-ar-owners
+
+labels:
+- language/ar


### PR DESCRIPTION
Adding OWNERS to fix the issue with approve for arabic team. 

Slack discussion :  https://kubernetes.slack.com/archives/CP9FKRD51/p1710921248918939
