### PR TITLE
Remove redundant link from glossary term "Init Container"

### DIFF
--- a/content/en/docs/reference/glossary/init-container.md
+++ b/content/en/docs/reference/glossary/init-container.md
@@ -2,10 +2,9 @@
 title: Init Container
 id: init-container
 date: 2018-04-12
-full_link: 
+full_link: /docs/concepts/workloads/pods/init-containers/
 short_description: >
   One or more initialization containers that must run to completion before any app containers run.
-full_link: /docs/concepts/workloads/pods/init-containers/
 aka: 
 tags:
 - fundamental


### PR DESCRIPTION
There are 2 full links in this glossary file so removed one full link and kept the other one to align with other files.