### PR TITLE
Update KubeProxyWinkernelConfiguration sourceVip configuration docs

### DIFF
--- a/content/en/docs/reference/config-api/kube-proxy-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kube-proxy-config.v1alpha1.md
@@ -750,8 +750,9 @@ to create endpoints and policies</p>
 <code>string</code>
 </td>
 <td>
-   <p>sourceVip is the IP address of the source VIP endpoint used for
-NAT when loadbalancing</p>
+   <p>sourceVip is the IP address of the source VIP endpoint used for NAT when loadbalancing.
+   In overlay networking mode, if this configuration is not specified, `sourceVip` will be set 
+   to the IP of a Host Networking Service (HNS) endpoint named `source_vip`. </p>
 </td>
 </tr>
 <tr><td><code>enableDSR</code> <B>[Required]</B><br/>


### PR DESCRIPTION
### What will change
This PR updates the documentation for `KubeProxyWinkernelConfiguration` to include a note about the precedence regarding the `sourceVip` configuration on Windows nodes operating in overlay networking mode. Specifically, the documentation change clarifies that if the `sourceVip` configuration is not explicitly specified in the `KubeProxyWinkernelConfiguration`, kube-proxy will attempt to fetch the IP address from a well-known Host Networking Service (HNS) endpoint named `source_vip`. 

### Why this change
This update aims to bring awareness to a new well-known HNS endpoint name introduced in the accompanying change https://github.com/kubernetes/kubernetes/pull/123394. With this new documentation change, one should be able to determine and choose to set the sourceVip explicitly by specifying it in the kube-proxy configuration, or by using creating an HNS endpoint on the Windows node with the name `source_vip` which will be automatically detected when kube-proxy starts.

/sig windows
cc @jsturtevant 

### References
- https://github.com/kubernetes/kubernetes/pull/123394
