### PR TITLE
Add certificateAuthority in structured authn docs

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -356,6 +356,10 @@ kind: AuthenticationConfiguration
 jwt:
 - issuer:
     url: https://example.com # Same as --oidc-issuer-url.
+    # PEM encoded CA certificates used to validate the connection when fetching
+    # discovery information. If not set, the system verifier will be used.
+    # Same value as the content of the file referenced by the --oidc-ca-file flag.
+    certificateAuthority: <PEM encoded CA certificates>
     audiences:
     - my-app # Same as --oidc-client-id.
   # rules applied to validate token claims to authenticate users.


### PR DESCRIPTION
- Add `certificateAuthority` in structured authn docs

KEP issue: https://github.com/kubernetes/enhancements/issues/3331

/sig auth
/assign enj