### PR TITLE
kubectl debian install guide does not mention gnupg at all

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -130,7 +130,7 @@ The following methods exist for installing kubectl on Linux:
    ```shell
    sudo apt-get update
    # apt-transport-https may be a dummy package; if so, you can skip that package
-   sudo apt-get install -y apt-transport-https ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    ```
 
 2. Download the public signing key for the Kubernetes package repositories. The same signing key is used for all repositories so you can disregard the version in the URL:


### PR DESCRIPTION
On a bare-metal Debian 12 clean install, gnupg is needed to succesfully complete the proposed steps.

Maybe it should be noted with prose rather than simply adding the package to the install list, but I never contributed before and would like to keep minimum noise posible
