### PR TITLE
blog: fix loadbalancer scheme (DIY: Create Your Own Cloud with Kubernetes (Part 2) blog post)

### DIFF
--- a/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
+++ b/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
@@ -237,7 +237,7 @@ The role of a external load balancer is to provide a stable address available ex
 external traffic to the services network.
 The services network plugin will direct it to your pods and virtual machines as usual.
 
-{{< figure src="net-services.svg" caption="A diagram showing the role of the external load balancer on the Kubernetes network scheme" alt="The role of the external load balancer on the Kubernetes network scheme" >}}
+{{< figure src="net-loadbalancer.svg" caption="A diagram showing the role of the external load balancer on the Kubernetes network scheme" alt="The role of the external load balancer on the Kubernetes network scheme" >}}
 
 In most cases, setting up a load balancer on bare metal is achieved by creating floating IP address
 on the nodes within the cluster, and announce it externally using ARP/NDP or BGP protocols.


### PR DESCRIPTION
Wrong scheme link replaced to correct one:
<img width="760" alt="Screenshot 2024-04-10 at 8 45 15" src="https://github.com/kubernetes/website/assets/7556217/88180753-c0d0-4aba-b039-c1b553a28fdd">
