### PR TITLE
Rename example pod-with-affinity-anti-affinity.yaml

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -173,7 +173,7 @@ scheduling decision for the Pod.
 
 For example, consider the following Pod spec:
 
-{{% code_sample file="pods/pod-with-affinity-anti-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-affinity-preferred-weight.yaml" %}}
 
 If there are two possible nodes that match the
 `preferredDuringSchedulingIgnoredDuringExecution` rule, one with the

--- a/content/en/examples/examples_test.go
+++ b/content/en/examples/examples_test.go
@@ -613,7 +613,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"pod-projected-svc-token":             {&api.Pod{}},
 			"pod-rs":                              {&api.Pod{}, &api.Pod{}},
 			"pod-single-configmap-env-variable":   {&api.Pod{}},
-			"pod-with-affinity-anti-affinity":     {&api.Pod{}},
+			"pod-with-affinity-preferred-weight":  {&api.Pod{}},
 			"pod-with-node-affinity":              {&api.Pod{}},
 			"pod-with-pod-affinity":               {&api.Pod{}},
 			"pod-with-scheduling-gates":           {&api.Pod{}},

--- a/content/en/examples/pods/pod-with-affinity-preferred-weight.yaml
+++ b/content/en/examples/pods/pod-with-affinity-preferred-weight.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: with-affinity-anti-affinity
+  name: with-affinity-preferred-weight
 spec:
   affinity:
     nodeAffinity:


### PR DESCRIPTION
This [https://github.com/kubernetes/website/blob/main/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml](https://github.com/kubernetes/website/blob/main/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml) example stresses  preferred affinity weights and not the antiAffinity.  The file name and pod name may make some confusing.