### PR TITLE
Switch liveness image to multi-arch agnhost container image

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -140,7 +140,7 @@ liveness-exec   1/1       Running   1          1m
 ## Define a liveness HTTP request
 
 Another kind of liveness probe uses an HTTP GET request. Here is the configuration
-file for a Pod that runs a container based on the `registry.k8s.io/e2e-test-images/agnhost:2.40` image.
+file for a Pod that runs a container based on the `registry.k8s.io/e2e-test-images/agnhost` image.
 
 {{% code_sample file="pods/probe/http-liveness.yaml" %}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -140,7 +140,7 @@ liveness-exec   1/1       Running   1          1m
 ## Define a liveness HTTP request
 
 Another kind of liveness probe uses an HTTP GET request. Here is the configuration
-file for a Pod that runs a container based on the `registry.k8s.io/liveness` image.
+file for a Pod that runs a container based on the `registry.k8s.io/e2e-test-images/agnhost:2.40` image.
 
 {{% code_sample file="pods/probe/http-liveness.yaml" %}}
 

--- a/content/en/examples/pods/probe/http-liveness.yaml
+++ b/content/en/examples/pods/probe/http-liveness.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: registry.k8s.io/liveness
+    image: registry.k8s.io/e2e-test-images/agnhost:2.40
     args:
-    - /server
+    - liveness
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
The current image referenced in the liveness example is amd64 only, switch to the agnhost image and pass the parameter of liveness for equivalent functionality. This image has the benefit of being current, multi-arch and managed from a supply chain viewpoint in the kubernetes code tree.

See also:

https://github.com/kubernetes/website/issues/45809
https://github.com/kubernetes/website/issues/45822