### PR TITLE
[id] Switch liveness image to multi-arch agnhost container image

### DIFF
--- a/content/id/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/id/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -267,8 +267,8 @@ metadata:
 spec:
   containers:
   - args:
-    - /server
-    image: registry.k8s.io/liveness
+    - liveness
+    image: registry.k8s.io/e2e-test-images/agnhost:2.40
     livenessProbe:
       httpGet:
         # ketika "host" tidak ditentukan, "PodIP" akan digunakan

--- a/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -126,7 +126,7 @@ liveness-exec   1/1       Running   1          1m
 ## Mendefinisikan probe liveness dengan permintaan HTTP
 
 Jenis kedua dari _probe liveness_ menggunakan sebuah permintaan GET HTTP. Berikut ini
-berkas konfigurasi untuk Pod yang menjalankan Container dari image `registry.k8s.io/liveness`.
+berkas konfigurasi untuk Pod yang menjalankan Container dari image `registry.k8s.io/e2e-test-images/agnhost`.
 
 {{% codenew file="pods/probe/http-liveness.yaml" %}}
 

--- a/content/id/examples/pods/probe/http-liveness.yaml
+++ b/content/id/examples/pods/probe/http-liveness.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: registry.k8s.io/liveness
+    image: registry.k8s.io/e2e-test-images/agnhost:2.40
     args:
-    - /server
+    - liveness
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
id equivalent for https://github.com/kubernetes/website/pull/45837