### PR TITLE
Refine API reference page link retrieval mechanism to support localized pages

### DIFF
--- a/layouts/partials/docs/api-reference-links.html
+++ b/layouts/partials/docs/api-reference-links.html
@@ -28,6 +28,8 @@
     <!-- Loop through sections -->
     {{- range $apiRefSection := $apiRefSections.Sections -}}
         {{- $apiRefDir := $apiRefSection.RelPermalink -}}
+        {{- $fragmentApiRefDir := split $apiRefDir "/docs" -}}
+        {{- $apiRefDir := printf "/docs%s" (index ($fragmentApiRefDir) 1) -}}
         {{- $apiReferenceFiles := site.GetPage $apiRefDir -}}
 
         <!-- Loop through API reference files -->


### PR DESCRIPTION
This PR contains changes to resolved an issue where API reference links were not appearing on localized pages. Despite adding `api-metadata` to the front-matter of localized pages.


**Additional Context:**
The root cause of the problem was identified in the `GetPage` function with the particular `site` object, which already possessed knowledge of the language for the current page and thus didn't require a language identifier _(considerable debugging efforts were essential to uncover this)_. Consequently, it failed to detect any localized API reference pages to link. Implemented necessary adjustments to rectify this issue, ensuring that API reference links now display correctly for both English pages and localized pages.

**Useful Preview Links**

#### Exisiting localized pages using `api-metadata`
[Preview Chinese Page](https://deploy-preview-45846--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/services-networking/network-policies/) | [Current Chinese Page (with no API link)](https://kubernetes.io/zh-cn/docs/concepts/services-networking/network-policies/)

[Preview Chinese Page](https://deploy-preview-45846--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/overview/working-with-objects/namespaces/) | [Current Chinese Page (with no API link)](https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/namespaces/)

_(Note: The link text is in English as expected because the locazlied string `[api_reference_title]` is not yet added to [zh-cn.toml](https://github.com/kubernetes/website/blob/main/data/i18n/zh-cn/zh-cn.toml))_


#### English pages API links functioned as usual, without any changes.

[Preview Pod](https://deploy-preview-45846--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/pods/) | [Current Pod](https://kubernetes.io/docs/concepts/workloads/pods/)

[Preview Deployment](https://deploy-preview-45846--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/controllers/deployment/) | [Current Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)

[Preview ReplicaSet](https://deploy-preview-45846--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/controllers/replicaset) | [Current ReplicaSet](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)