### PR TITLE
Fix link for service.NodePort

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -641,7 +641,7 @@ Please check the documentation of the relevant [Ingress controller](/docs/concep
 You can expose a Service in multiple ways that don't directly involve the Ingress resource:
 
 * Use [Service.Type=LoadBalancer](/docs/concepts/services-networking/service/#loadbalancer)
-* Use [Service.Type=NodePort](/docs/concepts/services-networking/service/#nodeport)
+* Use [Service.Type=NodePort](/docs/concepts/services-networking/service/#type-nodeport)
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
This PR fixes the link for `service.NodePort` under the [Ingress docs](https://kubernetes.io/docs/concepts/services-networking/ingress/)
Fixes #45848