### PR TITLE
[ja] Translate content/ja/docs/tasks/tools/install-kubectl-macos.md

### DIFF
--- a/content/ja/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/ja/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -1,6 +1,6 @@
 ---
-title: "bash auto-completion on macOS"
-description: "Some optional configuration for bash auto-completion on macOS."
+title: "macOS上でのbashの自動補完"
+description: "macOS上でのbashの自動補完に対するいくつかの補助的な設定。"
 headless: true
 _build:
   list: never
@@ -8,102 +8,96 @@ _build:
   publishResources: false
 ---
 
-### Introduction
+### はじめに
 
-The kubectl completion script for Bash can be generated with `kubectl completion bash`.
-Sourcing this script in your shell enables kubectl completion.
+Bashにおけるkubectlの補完スクリプトは`kubectl completion bash`コマンドで生成できます。
+シェル内で補完スクリプトをsourceすることでkubectlの自動補完が有効になります。
 
-However, the kubectl completion script depends on
-[**bash-completion**](https://github.com/scop/bash-completion) which you thus have to previously install.
+ただし、補完スクリプトは[**bash-completion**](https://github.com/scop/bash-completion)に依存しているため、事前にインストールしておく必要があります。
 
 {{< warning>}}
-There are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2
-(which is the default on macOS), and v2 is for Bash 4.1+. The kubectl completion
-script **doesn't work** correctly with bash-completion v1 and Bash 3.2.
-It requires **bash-completion v2** and **Bash 4.1+**. Thus, to be able to
-correctly use kubectl completion on macOS, you have to install and use
-Bash 4.1+ ([*instructions*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)).
-The following instructions assume that you use Bash 4.1+
-(that is, any Bash version of 4.1 or newer).
+bash-completionにはv1とv2の2つのバージョンがあります。
+v1はBash 3.2(macOSのデフォルト)用で、v2はBash 4.1以降向けです。
+kubectlの補完スクリプトはbash-completionのv1とBash 3.2では正しく**動作しません**。
+**bash-completion v2**と**Bash 4.1以降**が必要になります。
+したがって、macOSで正常にkubectlの補完を使用するには、Bash 4.1以降をインストールする必要があります([*手順*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba))。
+以下の手順では、Bash4.1以降(Bashのバージョンが4.1またはそれより新しいことを指します)を使用することを前提とします。
 {{< /warning >}}
 
-### Upgrade Bash
+### Bashのアップグレード
 
-The instructions here assume you use Bash 4.1+. You can check your Bash's version by running:
+ここではBash 4.1以降の使用を前提としています。
+Bashのバージョンは下記のコマンドで調べることができます:
 
 ```bash
 echo $BASH_VERSION
 ```
 
-If it is too old, you can install/upgrade it using Homebrew:
+バージョンが古い場合、Homebrewを使用してインストールもしくはアップグレードできます:
 
 ```bash
 brew install bash
 ```
 
-Reload your shell and verify that the desired version is being used:
+シェルをリロードし、希望するバージョンを使用していることを確認してください:
 
 ```bash
 echo $BASH_VERSION $SHELL
 ```
 
-Homebrew usually installs it at `/usr/local/bin/bash`.
+Homebrewは通常、`/usr/local/bin/bash`にインストールします。
 
-### Install bash-completion
+### bash-completionをインストールする
 
 {{< note >}}
-As mentioned, these instructions assume you use Bash 4.1+, which means you will
-install bash-completion v2 (in contrast to Bash 3.2 and bash-completion v1,
-in which case kubectl completion won't work).
+前述のとおり、この手順ではBash 4.1以降であることが前提のため、bash-completion v2をインストールすることになります(これとは逆に、Bash 3.2およびbash-completion v1の場合ではkubectlの補完は動作しません)。
 {{< /note >}}
 
-You can test if you have bash-completion v2 already installed with `type _init_completion`.
-If not, you can install it with Homebrew:
+
+`type _init_completion`を実行することで、bash-completionがすでにインストールされていることを確認できます。
+ない場合は、Homebrewを使用してインストールすることができます:
 
 ```bash
 brew install bash-completion@2
 ```
 
-As stated in the output of this command, add the following to your `~/.bash_profile` file:
+このコマンドの出力で示されたように、`~/.bash_profile`に以下を追記してください:
 
 ```bash
 brew_etc="$(brew --prefix)/etc" && [[ -r "${brew_etc}/profile.d/bash_completion.sh" ]] && . "${brew_etc}/profile.d/bash_completion.sh"
 ```
 
-Reload your shell and verify that bash-completion v2 is correctly installed with `type _init_completion`.
+シェルをリロードし、`type _init_completion`を実行してbash-completion v2が正しくインストールされていることを検証してください。
 
-### Enable kubectl autocompletion
+### kubectlの自動補完を有効にする
 
-You now have to ensure that the kubectl completion script gets sourced in all
-your shell sessions. There are multiple ways to achieve this:
+すべてのシェルセッションにてkubectlの補完スクリプトをsourceできるようにしなければなりません。
+これを行うには複数の方法があります:
 
-- Source the completion script in your `~/.bash_profile` file:
+- 補完スクリプトを`~/.bash_profile`内でsourceする:
 
     ```bash
     echo 'source <(kubectl completion bash)' >>~/.bash_profile
     ```
 
-- Add the completion script to the `/usr/local/etc/bash_completion.d` directory:
+- 補完スクリプトを`/usr/local/etc/bash_completion.d`ディレクトリに追加する:
 
     ```bash
     kubectl completion bash >/usr/local/etc/bash_completion.d/kubectl
     ```
 
-- If you have an alias for kubectl, you can extend shell completion to work with that alias:
+- kubectlにエイリアスを張っている場合は、エイリアスでも動作するようにシェルの補完を拡張することができます:
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
     echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
-- If you installed kubectl with Homebrew (as explained
-  [here](/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)),
-  then the kubectl completion script should already be in `/usr/local/etc/bash_completion.d/kubectl`.
-  In that case, you don't need to do anything.
+- kubectlをHomebrewでインストールした場合([前述](/ja/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)の通り)、kubectlの補完スクリプトはすでに`/usr/local/etc/bash_completion.d/kubectl`に格納されているでしょうか。
+  この場合、なにも操作する必要はありません。
 
    {{< note >}}
-   The Homebrew installation of bash-completion v2 sources all the files in the
-   `BASH_COMPLETION_COMPAT_DIR` directory, that's why the latter two methods work.
+   Homebrewでインストールしたbash-completion v2は`BASH_COMPLETION_COMPAT_DIR`ディレクトリ内のすべてのファイルをsourceするため、後者の2つの方法が機能します。
    {{< /note >}}
 
-In any case, after reloading your shell, kubectl completion should be working.
+どの場合でも、シェルをリロードしたあとに、kubectlの自動補完が機能するはずです。

--- a/content/ja/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/ja/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -1,6 +1,6 @@
 ---
-title: "fish auto-completion"
-description: "Optional configuration to enable fish shell auto-completion."
+title: "fishの自動補完"
+description: "fishシェルの自動補完を有効にする補助的な設定。"
 headless: true
 _build:
   list: never
@@ -9,15 +9,16 @@ _build:
 ---
 
 {{< note >}}
-Autocomplete for Fish requires kubectl 1.23 or later.
+Fishに対する自動補完はkubectl 1.23以降が必要です。
 {{< /note >}}
 
-The kubectl completion script for Fish can be generated with the command `kubectl completion fish`. Sourcing the completion script in your shell enables kubectl autocompletion.
+Fishにおけるkubectlの補完スクリプトは`kubectl completion fish`コマンドで生成できます。
+シェル内で補完スクリプトをsourceすることでkubectlの自動補完が有効になります。
 
-To do so in all your shell sessions, add the following line to your `~/.config/fish/config.fish` file:
+すべてのシェルセッションで使用するには、`~/.config/fish/config.fish`に以下を追記してください:
 
 ```shell
 kubectl completion fish | source
 ```
 
-After reloading your shell, kubectl autocompletion should be working.
+シェルをリロードしたあとに、kubectlの自動補完が機能するはずです。

--- a/content/ja/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
+++ b/content/ja/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
@@ -1,6 +1,6 @@
 ---
-title: "zsh auto-completion"
-description: "Some optional configuration for zsh auto-completion."
+title: "zshの自動補完"
+description: "zshの自動補完に対するいくつかの補助的な設定。"
 headless: true
 _build:
   list: never
@@ -8,19 +8,20 @@ _build:
   publishResources: false
 ---
 
-The kubectl completion script for Zsh can be generated with the command `kubectl completion zsh`. Sourcing the completion script in your shell enables kubectl autocompletion.
+Zshにおけるkubectlの補完スクリプトは`kubectl completion zsh`コマンドで生成できます。
+シェル内で補完スクリプトをsourceすることでkubectlの自動補完が有効になります。
 
-To do so in all your shell sessions, add the following to your `~/.zshrc` file:
+すべてのシェルセッションで使用するには、`~/.zshrc`に以下を追記してください:
 
 ```zsh
 source <(kubectl completion zsh)
 ```
 
-If you have an alias for kubectl, kubectl autocompletion will automatically work with it.
+kubectlにエイリアスを張っている場合でも、kubectlの自動補完は自動的に機能します。
 
-After reloading your shell, kubectl autocompletion should be working.
+シェルをリロードしたあとに、kubectlの自動補完が機能するはずです。
 
-If you get an error like `2: command not found: compdef`, then add the following to the beginning of your `~/.zshrc` file:
+`2: command not found: compdef`のようなエラーが出力された場合は、以下を`~/.zshrc`の先頭に追記してください:
 
 ```zsh
 autoload -Uz compinit

--- a/content/ja/docs/tasks/tools/included/verify-kubectl.md
+++ b/content/ja/docs/tasks/tools/included/verify-kubectl.md
@@ -28,7 +28,7 @@ The connection to the server <server-name:port> was refused - did you specify th
 
 たとえば、ラップトップ上(ローカル環境)でKubernetesクラスターを起動するような場合、[Minikube](https://minikube.sigs.k8s.io/docs/start/)などのツールを最初にインストールしてから、上記のコマンドを再実行する必要があります。
 
-kubectl cluster-infoがURLレスポンスを返したにもかかわらずクラスターにアクセスできない場合は、次のコマンドで設定が正しいことを確認してください:
+`kubectl cluster-info`がURLレスポンスを返したにもかかわらずクラスターにアクセスできない場合は、次のコマンドで設定が正しいことを確認してください:
 
 ```shell
 kubectl cluster-info dump
@@ -41,6 +41,6 @@ Kubernetes 1.26にて、kubectlは以下のクラウドプロバイダーが提�
 手順については以下のプロバイダーのドキュメントを参照してください:
 
 * Azure AKS: [kubelogin plugin](https://azure.github.io/kubelogin/)
-* Google Kubernetes Engine: [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin)
+* Google Kubernetes Engine: [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl?hl=ja#install_plugin)
 
 (この変更とは関係なく、他の理由で同じエラーメッセージが表示される可能性もあります。)

--- a/content/ja/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/ja/docs/tasks/tools/install-kubectl-macos.md
@@ -1,54 +1,52 @@
 ---
-title: Install and Set Up kubectl on macOS
+title: macOS上でのkubectlのインストールおよびセットアップ
 content_type: task
 weight: 10
 ---
 
 ## {{% heading "prerequisites" %}}
 
-You must use a kubectl version that is within one minor version difference of
-your cluster. For example, a v{{< skew currentVersion >}} client can communicate
-with v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersionAddMinor 0 >}},
-and v{{< skew currentVersionAddMinor 1 >}} control planes.
-Using the latest compatible version of kubectl helps avoid unforeseen issues.
+kubectlのバージョンは、クラスターのマイナーバージョンとの差分が1つ以内でなければなりません。
+たとえば、クライアントがv{{< skew currentVersion >}}であれば、v{{< skew currentVersionAddMinor -1 >}}、v{{< skew currentVersionAddMinor 0 >}}、v{{< skew currentVersionAddMinor 1 >}}のコントロールプレーンと通信できます。
+最新の互換性のあるバージョンのkubectlを使うことで、不測の事態を避けることができるでしょう。
 
-## Install kubectl on macOS
 
-The following methods exist for installing kubectl on macOS:
+## macOSへkubectlをインストールする{#install-kubectl-on-macos}
 
-- [Install kubectl on macOS](#install-kubectl-on-macos)
-  - [Install kubectl binary with curl on macOS](#install-kubectl-binary-with-curl-on-macos)
-  - [Install with Homebrew on macOS](#install-with-homebrew-on-macos)
-  - [Install with Macports on macOS](#install-with-macports-on-macos)
-- [Verify kubectl configuration](#verify-kubectl-configuration)
-- [Optional kubectl configurations and plugins](#optional-kubectl-configurations-and-plugins)
-  - [Enable shell autocompletion](#enable-shell-autocompletion)
-  - [Install `kubectl convert` plugin](#install-kubectl-convert-plugin)
+macOSへkubectlをインストールするには、次の方法があります:
 
-### Install kubectl binary with curl on macOS
+- [macOSへkubectlをインストールする](#install-kubectl-on-macos)
+  - [curlを使用してmacOSへkubectlのバイナリをインストールする](#install-kubectl-binary-with-curl-on-macos)
+  - [Homebrewを使用してmacOSへインストールする](#install-with-homebrew-on-macos)
+  - [MacPortsを使用してmacOSへインストールする](#install-with-macports-on-macos)
+- [kubectlの設定を検証する](#verify-kubectl-configuration)
+- [オプションのkubectlの設定とプラグイン](#optional-kubectl-configurations-and-plugins)
+  - [シェルの自動補完を有効にする](#enable-shell-autocompletion)
+  - [`kubectl convert`プラグインをインストールする](#install-kubectl-convert-plugin)
 
-1. Download the latest release:
+### curlを使用してmacOSへkubectlのバイナリをインストールする{#install-kubectl-binary-with-curl-on-macos}
+
+1. 最新リリースをダウンロードしてください:
 
    {{< tabs name="download_binary_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
    {{< /tab >}}
-   {{< tab name="Apple Silicon" codelang="bash" >}}
+   {{< tab name="Appleシリコン" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
    {{< /tab >}}
    {{< /tabs >}}
 
    {{< note >}}
-   To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
-   portion of the command with the specific version.
+   特定のバージョンをダウンロードする場合、コマンドの`$(curl -L -s https://dl.k8s.io/release/stable.txt)`の部分を特定のバージョンに置き換えてください。
 
-   For example, to download version {{< skew currentPatchVersion >}} on Intel macOS, type:
+   例えば、Intel macOSへ{{< skew currentPatchVersion >}}のバージョンをダウンロードするには、次のコマンドを入力します:
 
    ```bash
    curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/amd64/kubectl"
    ```
 
-   And for macOS on Apple Silicon, type:
+   Appleシリコン上のmacOSに対しては、次を入力します:
 
    ```bash
    curl -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/darwin/arm64/kubectl"
@@ -56,32 +54,32 @@ The following methods exist for installing kubectl on macOS:
 
    {{< /note >}}
 
-1. Validate the binary (optional)
+1. バイナリを検証してください(オプション)
 
-   Download the kubectl checksum file:
+   kubectlのチェックサムファイルをダウンロードします:
 
    {{< tabs name="download_checksum_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
    {{< /tab >}}
-   {{< tab name="Apple Silicon" codelang="bash" >}}
+   {{< tab name="Appleシリコン" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256"
    {{< /tab >}}
    {{< /tabs >}}
   
-   Validate the kubectl binary against the checksum file:
+   チェックサムファイルに対してkubectlバイナリを検証します:
 
    ```bash
    echo "$(cat kubectl.sha256)  kubectl" | shasum -a 256 --check
    ```
 
-   If valid, the output is:
+   正しければ、出力は次のようになります:
 
    ```console
    kubectl: OK
    ```
 
-   If the check fails, `shasum` exits with nonzero status and prints output similar to:
+   チェックに失敗すると、`shasum`は0以外のステータスで終了し、次のような出力を表示します:
 
    ```console
    kubectl: FAILED
@@ -89,16 +87,16 @@ The following methods exist for installing kubectl on macOS:
    ```
 
    {{< note >}}
-   Download the same version of the binary and checksum.
+   同じバージョンのバイナリとチェックサムをダウンロードしてください。
    {{< /note >}}
 
-1. Make the kubectl binary executable.
+1. kubectlバイナリを実行可能にしてください。
 
    ```bash
    chmod +x ./kubectl
    ```
 
-1. Move the kubectl binary to a file location on your system `PATH`.
+1. kubectlバイナリを`PATH`の中に移動させてください。
 
    ```bash
    sudo mv ./kubectl /usr/local/bin/kubectl
@@ -106,80 +104,78 @@ The following methods exist for installing kubectl on macOS:
    ```
 
    {{< note >}}
-   Make sure `/usr/local/bin` is in your PATH environment variable.
+   `/usr/local/bin`がPATH環境変数の中に含まれるようにしてください。
    {{< /note >}}
 
-1. Test to ensure the version you installed is up-to-date:
+1. インストールしたバージョンが最新であることを確認してください:
 
    ```bash
    kubectl version --client
    ```
    
-   Or use this for detailed view of version:
+   または、バージョンの詳細を表示するために次を使用します:
 
    ```cmd
    kubectl version --client --output=yaml
    ```
 
-1. After installing and validating kubectl, delete the checksum file:
+1. kubectlをインストールし、検証した後は、チェックサムファイルを削除してください:
 
    ```bash
    rm kubectl.sha256
    ```
 
-### Install with Homebrew on macOS
+### Homebrewを使用してmacOSへインストールする{#install-with-homebrew-on-macos}
 
-If you are on macOS and using [Homebrew](https://brew.sh/) package manager,
-you can install kubectl with Homebrew.
+macOSで[Homebrew](https://brew.sh/)パッケージマネージャーを使用していれば、Homebrewでkubectlをインストールできます。
 
-1. Run the installation command:
+1. インストールコマンドを実行してください:
 
    ```bash
    brew install kubectl
    ```
 
-   or
+   または
 
    ```bash
    brew install kubernetes-cli
    ```
 
-1. Test to ensure the version you installed is up-to-date:
+1. インストールしたバージョンが最新であることを確認してください:
 
    ```bash
    kubectl version --client
    ```
 
-### Install with Macports on macOS
+### MacPortsを使用してmacOSへインストールする{#install-with-macports-on-macos}
 
-If you are on macOS and using [Macports](https://macports.org/) package manager,
-you can install kubectl with Macports.
+macOSで[MacPorts](https://macports.org/)パッケージマネージャーを使用していれば、MacPortsでkubectlをインストールできます。
 
-1. Run the installation command:
+1. インストールコマンドを実行してください:
 
    ```bash
    sudo port selfupdate
    sudo port install kubectl
    ```
 
-1. Test to ensure the version you installed is up-to-date:
+1. インストールしたバージョンが最新であることを確認してください:
 
    ```bash
    kubectl version --client
    ```
 
-## Verify kubectl configuration
+## kubectlの設定を検証する{#verify-kubectl-configuration}
 
 {{< include "included/verify-kubectl.md" >}}
 
-## Optional kubectl configurations and plugins
+## オプションのkubectlの設定とプラグイン{#optional-kubectl-configurations-and-plugins}
 
-### Enable shell autocompletion
+### シェルの自動補完を有効にする{#enable-shell-autocompletion}
 
-kubectl provides autocompletion support for Bash, Zsh, Fish, and PowerShell
-which can save you a lot of typing.
+kubectlはBash、Zsh、Fish、PowerShellの自動補完を提供しています。
+これにより、入力を大幅に削減することができます。
 
-Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
+以下にBash、Fish、Zshの自動補完の設定手順を示します。
 
 {{< tabs name="kubectl_autocompletion" >}}
 {{< tab name="Bash" include="included/optional-kubectl-configs-bash-mac.md" />}}
@@ -187,47 +183,47 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
 
-### Install `kubectl convert` plugin
+### `kubectl convert`プラグインをインストールする{#install-kubectl-convert-plugin}
 
 {{< include "included/kubectl-convert-overview.md" >}}
 
-1. Download the latest release with the command:
+1. 次のコマンドを使用して最新リリースをダウンロードしてください:
 
    {{< tabs name="download_convert_binary_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert"
    {{< /tab >}}
-   {{< tab name="Apple Silicon" codelang="bash" >}}
+   {{< tab name="Appleシリコン" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert"
    {{< /tab >}}
    {{< /tabs >}}
 
-1. Validate the binary (optional)
+1. バイナリを検証してください(オプション)
 
-   Download the kubectl-convert checksum file:
+   kubectl-convertのチェックサムファイルをダウンロードします:
 
    {{< tabs name="download_convert_checksum_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert.sha256"
    {{< /tab >}}
-   {{< tab name="Apple Silicon" codelang="bash" >}}
+   {{< tab name="Appleシリコン" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert.sha256"
    {{< /tab >}}
    {{< /tabs >}}
 
-   Validate the kubectl-convert binary against the checksum file:
+   チェックサムファイルに対してkubectl-convertバイナリを検証します:
 
    ```bash
    echo "$(cat kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
    ```
 
-   If valid, the output is:
+   正しければ、出力は次のようになります:
 
    ```console
    kubectl-convert: OK
    ```
 
-   If the check fails, `shasum` exits with nonzero status and prints output similar to:
+   チェックに失敗すると、`shasum`は0以外のステータスで終了し、次のような出力を表示します:
 
    ```console
    kubectl-convert: FAILED
@@ -235,16 +231,16 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    ```
 
    {{< note >}}
-   Download the same version of the binary and checksum.
+   同じバージョンのバイナリとチェックサムをダウンロードしてください。
    {{< /note >}}
 
-1. Make kubectl-convert binary executable
+1. kubectl-convertバイナリを実行可能にしてください。
 
    ```bash
    chmod +x ./kubectl-convert
    ```
 
-1. Move the kubectl-convert binary to a file location on your system `PATH`.
+1. kubectl-convertバイナリを`PATH`の中に移動してください。
 
    ```bash
    sudo mv ./kubectl-convert /usr/local/bin/kubectl-convert
@@ -252,45 +248,46 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    ```
 
    {{< note >}}
-   Make sure `/usr/local/bin` is in your PATH environment variable.
+   `/usr/local/bin`がPATH環境変数の中に含まれるようにしてください。
    {{< /note >}}
 
-1. Verify plugin is successfully installed
+1. インストールしたバージョンが最新であることを確認してください
 
    ```shell
    kubectl convert --help
    ```
 
-   If you do not see an error, it means the plugin is successfully installed.
+   何もエラーが表示されない場合は、プラグインが正常にインストールされたことを示しています。
 
-1. After installing the plugin, clean up the installation files:
+1. プラグインのインストール後、インストールファイルを削除してください:
 
    ```bash
    rm kubectl-convert kubectl-convert.sha256
    ```
 
-### Uninstall kubectl on macOS
+### macOS上のkubectlをアンインストールする
 
-Depending on how you installed `kubectl`, use one of the following methods.
+`kubectl`のインストール方法に応じて、次の方法を使用してください。
 
-### Uninstall kubectl using the command-line
+### コマンドラインを使用してkubectlをアンインストールする
 
-1.  Locate the `kubectl` binary on your system:
+1.  システム上の`kubectl`バイナリの場所を特定してください:
 
     ```bash
     which kubectl
     ```
 
-1.  Remove the `kubectl` binary:
+1.  `kubectl`バイナリを削除してください:
 
     ```bash
     sudo rm <path>
     ```
-    Replace `<path>` with the path to the `kubectl` binary from the previous step. For example, `sudo rm /usr/local/bin/kubectl`.
+    `<path>`を前のステップの`kubectl`バイナリのパスに置き換えてください。
+    例えば`sudo rm /usr/local/bin/kubectl`。
 
-### Uninstall kubectl using homebrew
+### Homebrewを使用してkubectlをアンインストールする
 
-If you installed `kubectl` using Homebrew, run the following command:
+Homebrewを使用して`kubectl`をインストールした場合は、次のコマンドを実行してください:
 
 ```bash
 brew remove kubectl


### PR DESCRIPTION
Fixes #45345 

This pull request is for the translation of `content/en/docs/tasks/tools/install-kubectl-macos.md` and its dependencies.

This translation is based on the contents of the [content/ja/docs/tasks/tools/install-kubectl.md](https://github.com/kubernetes/website/blob/de98cc74a50fca202fb6febcf482c99e0ca6efb4/content/ja/docs/tasks/tools/install-kubectl.md) (This file has already been deleted).