### PR TITLE
Updates v1.29 hugo.toml for v1.30 release

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -142,11 +142,11 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.29"
+latest = "v1.30"
 
 version = "v1.29"
-githubbranch = "main"
-docsbranch = "main"
+githubbranch = "v1.29.3"
+docsbranch = "release-1.29"
 deprecated = false
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
@@ -184,34 +184,34 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.29"
-githubbranch = "v1.29.0"
+version = "v1.30"
+githubbranch = "v1.30.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
+version = "v1.29"
+githubbranch = "v1.29.3"
+docsbranch = "release-1.29"
+url = "https://v1-29.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.28"
-githubbranch = "v1.28.4"
+githubbranch = "v1.28.8"
 docsbranch = "release-1.28"
 url = "https://v1-28.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.27"
-githubbranch = "v1.27.8"
+githubbranch = "v1.27.12"
 docsbranch = "release-1.27"
 url = "https://v1-27.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.26"
-githubbranch = "v1.26.11"
+githubbranch = "v1.26.15"
 docsbranch = "release-1.26"
 url = "https://v1-26.docs.kubernetes.io"
-
-[[params.versions]]
-version = "v1.25"
-githubbranch = "v1.25.16"
-docsbranch = "release-1.25"
-url = "https://v1-25.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
This PR updates the hugo.toml for v1.29 ahead of the v1.30 release.

Base branch will be updated from main to release-1.29 once that branch exists.

/hold for v1.30 release day