### PR TITLE
Improve blog article summaries presentation with author metadata in front matter

### DIFF
--- a/content/en/blog/_posts/2024-01-15-SIG-Release-Spotlight/index.md
+++ b/content/en/blog/_posts/2024-01-15-SIG-Release-Spotlight/index.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Release (Release Team Subproject)"
 date: 2024-01-15
 slug: sig-release-spotlight-2023
 canonicalUrl: https://www.kubernetes.dev/blog/2024/01/15/sig-release-spotlight-2023/
+author: >
+  Nitish Kumar
 ---
-
-**Author:** Nitish Kumar
 
 The Release Special Interest Group (SIG Release), where Kubernetes sharpens its blade 
 with cutting-edge features and bug fixes every 4 months. Have you ever considered how such a big 

--- a/content/en/blog/_posts/2024-01-23-image-filesystem.md
+++ b/content/en/blog/_posts/2024-01-23-image-filesystem.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Image Filesystem: Configuring Kubernetes to store containers on a separate filesystem'
 date: 2024-01-23
 slug: kubernetes-separate-image-filesystem
+author: >
+  Kevin Hannon (Red Hat)
 ---
-
-**Author:** Kevin Hannon (Red Hat)
 
 A common issue in running/operating Kubernetes clusters is running out of disk space.
 When the node is provisioned, you should aim to have a good amount of storage space for your container images and running containers.

--- a/content/en/blog/_posts/2024-02-22-k8s-book-club/index.md
+++ b/content/en/blog/_posts/2024-02-22-k8s-book-club/index.md
@@ -4,9 +4,9 @@ title: "A look into the Kubernetes Book Club"
 slug: k8s-book-club
 date: 2024-02-22
 canonicalUrl: https://www.k8s.dev/blog/2024/02/22/k8s-book-club/
+author: >
+  Frederico Muñoz (SAS Institute)
 ---
-
-**Author**: Frederico Muñoz (SAS Institute)
 
 Learning Kubernetes and the entire ecosystem of technologies around it is not without its
 challenges. In this interview, we will talk with [Carlos Santana

--- a/content/en/blog/_posts/2024-03-01-sig-cloud-provider-spotlight.md
+++ b/content/en/blog/_posts/2024-03-01-sig-cloud-provider-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Cloud Provider"
 slug: sig-cloud-provider-spotlight-2024
 date: 2024-03-01
 canonicalUrl: https://www.k8s.dev/blog/2024/03/01/sig-cloud-provider-spotlight-2024/
+author: >
+  Arujjwal Negi
 ---
-
-**Author**: Arujjwal Negi
 
 One of the most popular ways developers use Kubernetes-related services is via cloud providers, but
 have you ever wondered how cloud providers can do that? How does this whole process of integration

--- a/content/en/blog/_posts/2024-03-07-cri-o-seccomp-oci-artifacts.md
+++ b/content/en/blog/_posts/2024-03-07-cri-o-seccomp-oci-artifacts.md
@@ -3,9 +3,9 @@ layout: blog
 title: "CRI-O: Applying seccomp profiles from OCI registries"
 date: 2024-03-07
 slug: cri-o-seccomp-oci-artifacts
+author: >
+  Sascha Grunert
 ---
-
-**Author:** Sascha Grunert
 
 Seccomp stands for secure computing mode and has been a feature of the Linux
 kernel since version 2.6.12. It can be used to sandbox the privileges of a

--- a/content/en/blog/_posts/2024-03-12-mid-cycle-1.30.md
+++ b/content/en/blog/_posts/2024-03-12-mid-cycle-1.30.md
@@ -3,9 +3,13 @@ layout: blog
 title: 'A Peek at Kubernetes v1.30'
 date: 2024-03-12
 slug: kubernetes-1-30-upcoming-changes
+author: >
+  Amit Dsouza,
+  Frederick Kautz,
+  Kristin Martin,
+  Abigail McCarthy,
+  Natali Vlatko  
 ---
-
-**Authors:** Amit Dsouza, Frederick Kautz, Kristin Martin, Abigail McCarthy, Natali Vlatko 
 
 ## A quick look: exciting changes in Kubernetes v1.30
 

--- a/content/en/blog/_posts/2024-04-03-windows-ops-readiness.md
+++ b/content/en/blog/_posts/2024-04-03-windows-ops-readiness.md
@@ -3,10 +3,11 @@ layout: blog
 title: "Introducing the Windows Operational Readiness Specification"
 date: 2024-04-03
 slug: intro-windows-ops-readiness
+author: >
+  Jay Vyas (Tesla),
+  Amim Knabben (Broadcom),
+  Tatenda Zifudzi (AWS)
 ---
-
-**Authors:** Jay Vyas (Tesla), Amim Knabben (Broadcom), and Tatenda Zifudzi (AWS)
-
 
 Since Windows support [graduated to stable](/blog/2019/03/25/kubernetes-1-14-release-announcement/)
 with Kubernetes 1.14 in 2019, the capability to run Windows workloads has been much

--- a/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
+++ b/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "DIY: Create Your Own Cloud with Kubernetes (Part 1)"
 slug: diy-create-your-own-cloud-with-kubernetes-part-1
 date: 2024-04-05T07:30:00+00:00
+author: >
+  Andrei Kvapil (Ænix)
 ---
-
-**Author**: Andrei Kvapil (Ænix)
 
 At Ænix, we have a deep affection for Kubernetes and dream that all modern technologies will soon
 start utilizing its remarkable patterns.

--- a/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
+++ b/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "DIY: Create Your Own Cloud with Kubernetes (Part 2)"
 slug: diy-create-your-own-cloud-with-kubernetes-part-2
 date: 2024-04-05T07:35:00+00:00
+author: >
+  Andrei Kvapil (Ænix)
 ---
-
-**Author**: Andrei Kvapil (Ænix)
 
 Continuing our series of posts on how to build your own cloud using just the Kubernetes ecosystem.
 In the [previous article](/blog/2024/04/05/diy-create-your-own-cloud-with-kubernetes-part-1/), we

--- a/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-3/index.md
+++ b/content/en/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-3/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "DIY: Create Your Own Cloud with Kubernetes (Part 3)"
 slug: diy-create-your-own-cloud-with-kubernetes-part-3
 date: 2024-04-05T07:40:00+00:00
+author: >
+  Andrei Kvapil (Ænix)
 ---
-
-**Author**: Andrei Kvapil (Ænix)
 
 Approaching the most interesting phase, this article delves into running Kubernetes within
 Kubernetes. Technologies such as Kamaji and Cluster API are highlighted, along with their

--- a/content/en/blog/_posts/2024-04-11-SIG-Architecture-Code-Organization-Spotlight.md
+++ b/content/en/blog/_posts/2024-04-11-SIG-Architecture-Code-Organization-Spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Architecture: Code Organization"
 slug: sig-architecture-code-spotlight-2024
 canonicalUrl: https://www.kubernetes.dev/blog/2024/04/11/sig-architecture-code-spotlight-2024
 date: 2024-04-11
+author: >
+  Frederico Muñoz (SAS Institute)
 ---
-
-**Author: Frederico Muñoz (SAS Institute)**
 
 _This is the third interview of a SIG Architecture Spotlight series that will cover the different
 subprojects. We will cover [SIG Architecture: Code Organization](https://github.com/kubernetes/community/blob/e44c2c9d0d3023e7111d8b01ac93d54c8624ee91/sig-architecture/README.md#code-organization)._

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -21,7 +21,12 @@ have blog posts -->
 			<li class="media mb-4">
 				<div class="media-body">
 					<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
-					<p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+					<p class="mb-2 mb-md-3">
+						<small class="text-muted">
+							{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
+							{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}
+						</small>
+					</p>
 					{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left mr-3 pt-1 d-none d-md-block") }}
 					<p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
 					<p class="pt-0"><a href="{{ .RelPermalink }}">{{ T "ui_read_more"}}</a></p>


### PR DESCRIPTION
This PR contains changes to incorporate `author` metadata into front matter for improved handling of author details instead of listing authors in the blog content. Utilized Docsy's ([example blog](https://www.docsy.dev/blog/2024/0.9.0/)) native support for `author` metadata to ensure consistency and compatibility.

Fixes https://github.com/kubernetes/website/issues/40175

#### Summary of changes

- Modified the blog content files _(only blogs published in 2024)_ to include the following `author` metadata in front matter.

```yaml
slug: 
title: 
date:
author: >
  Author-Name (Affiliation)
```

- Other examples demonstrating inclusion of authors in blog content:

    - Multiple authors:
    ```yaml
    slug: 
    title: 
    date:
    author: >
      Author-1 (Affiliation),
      Author-2 (Affiliation),
      Author-3 (Affiliation)
   ```
   - Author with hyperlink (use markdown inline link format):
      
    ```yaml
    slug: 
    title: 
    date:
    author: >
      [Team of Writers](<url-to-link>)
   ```
- Modify `layouts/blog/list.html` layout to integrate author name(s) into the [index page](https://deploy-preview-45865--kubernetes-io-main-staging.netlify.app/blog) summary alongside the publication date.   
    

#### Useful Links

[Preview New Blog Summary Page](https://deploy-preview-45865--kubernetes-io-main-staging.netlify.app/blog) | [Current  Blog Summary Page](https://kubernetes.io/blog/)

[Preview Single Author Blog](https://deploy-preview-45865--kubernetes-io-main-staging.netlify.app/blog/2024/04/11/sig-architecture-code-spotlight-2024/) | [Current Single Author Blog](https://kubernetes.io/blog/2024/04/11/sig-architecture-code-spotlight-2024/)

[Preview Multiple Author Blog](https://deploy-preview-45865--kubernetes-io-main-staging.netlify.app/blog/2024/04/03/intro-windows-ops-readiness/) | [Current Multiple Author Blog](https://kubernetes.io/blog/2024/04/03/intro-windows-ops-readiness/)





