### PR TITLE
Ready blog section for vanilla Docsy

### DIFF
--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -4,9 +4,7 @@ linkTitle: Blog
 menu:
   main:
     title: "Blog"
-    weight: 40
-    post: >
-       <p>Read the latest news for Kubernetes and the containers space in general, and get technical how-tos hot off the presses.</p>
+    weight: 20
 ---
 {{< comment >}}
 


### PR DESCRIPTION
Align the (currently unused) menu entry for the blog section so it's got the front matter data that plain Docsy would use.

The way this works is to set `menu` front matter that Docsy would display in a reasonable way, and specifically _not_ to include a detailed description (`post`). This change does not change the way the current site displays or, at least, that's what I intend.

[Current blog section index](https://k8s.io/blog) | [Preview blog section index](https://deploy-preview-45868--kubernetes-io-main-staging.netlify.app/blog/)

/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171