### PR TITLE
Ready training section for vanilla Docsy

### DIFF
--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -5,6 +5,10 @@ abstract: Training programs, certifications, and partners.
 layout: basic
 cid: training
 class: training
+body_class: training
+menu:
+  main:
+    weight: 30
 ---
 
 <section class="call-to-action">


### PR DESCRIPTION
Add a Docsy-style menu entry to the training section.

The way this works is to set `menu` front matter that Docsy would display in a reasonable way. This change does not change the way the current site displays or, at least, that's what I intend.

[Current partner section index](https://k8s.io/training/) | [Preview partner section index](https://deploy-preview-45870--kubernetes-io-main-staging.netlify.app/training/)


/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171