### PR TITLE
Ready case studies page for vanilla Docsy

### DIFF
--- a/content/en/case-studies/_index.html
+++ b/content/en/case-studies/_index.html
@@ -5,6 +5,10 @@ bigheader: Kubernetes User Case Studies
 abstract: A collection of users running Kubernetes in production.
 layout: basic
 class: gridPage
+body_class: caseStudies
 cid: caseStudies
+menu:
+  main:
+    weight: 60
 ---
 


### PR DESCRIPTION
Align how we style the case studies page to work more the way Docsy expects it to.

The way this works is to set `menu` front matter that Docsy would display in a reasonable way. This change does not change the way the current site displays or, at least, that's what I intend.

[Current case studies section index](https://k8s.io/case-studies/) | [Preview case studies section index](https://deploy-preview-45870--kubernetes-io-main-staging.netlify.app/case-studies/)

/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171