### PR TITLE
Fix the YAML format  in setup-ha-etcd-with-kubeadm

### DIFF
--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -128,6 +128,7 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
    # Replace the value of "containerRuntimeEndpoint" for a different container runtime if needed.
    ```
    -->
+   
    ```sh
    cat << EOF > /etc/systemd/system/kubelet.service.d/kubelet.conf
    # 将下面的 "systemd" 替换为你的容器运行时所使用的 cgroup 驱动。
@@ -194,6 +195,7 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
    # Create temp directories to store files that will end up on other hosts
    mkdir -p /tmp/${HOST0}/ /tmp/${HOST1}/ /tmp/${HOST2}/
    -->
+
    ```sh
    # 使用你的主机 IP 更新 HOST0、HOST1 和 HOST2 的 IP 地址
    export HOST0=10.0.0.6


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fixes: https://github.com/kubernetes/website/issues/45033

Compared to the English version, the Chinese version has incorrect indentation：
![image](https://github.com/kubernetes/website/assets/44460091/0f860544-5a81-489d-98d1-b155f1630867)
page: https://kubernetes.io/zh-cn/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/

Here is [the preview page](https://deploy-preview-45876--kubernetes-io-main-staging.netlify.app/zh-cn/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/).
