### PR TITLE
Correcting scenario inconsistencies and output checks

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -569,7 +569,7 @@ In one terminal window, patch the `web` StatefulSet to change the container
 image again:
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"gcr.io/google_containers/nginx-slim:0.8"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.8"}]'
 ```
 ```
 statefulset.apps/web patched
@@ -637,9 +637,9 @@ Get the Pods to view their container images:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-gcr.io/google_containers/nginx-slim:0.8
-gcr.io/google_containers/nginx-slim:0.8
-gcr.io/google_containers/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0
 
 ```
 

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -112,8 +112,8 @@ nginx     ClusterIP    None         <none>        80/TCP    12s
 kubectl get statefulset web
 ```
 ```
-NAME     READT   AGE
-web       2      20s
+NAME   READY   AGE
+web    2/2     37s
 ```
 
 ### Ordered Pod creation
@@ -637,9 +637,9 @@ Get the Pods to view their container images:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0.8
+gcr.io/google_containers/nginx-slim:0.8
+gcr.io/google_containers/nginx-slim:0.8
+gcr.io/google_containers/nginx-slim:0.8
 
 ```
 

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -639,7 +639,7 @@ for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.
 ```
 registry.k8s.io/nginx-slim:0.8
 registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0
+registry.k8s.io/nginx-slim:0.8
 
 ```
 

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -112,8 +112,8 @@ nginx     ClusterIP    None         <none>        80/TCP    12s
 kubectl get statefulset web
 ```
 ```
-NAME      DESIRED   CURRENT   AGE
-web       2         1         20s
+NAME     READT   AGE
+web       2      20s
 ```
 
 ### Ordered Pod creation

--- a/content/en/examples/application/web/web.yaml
+++ b/content/en/examples/application/web/web.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: registry.k8s.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.7
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
This PR fixes discrepancies between the tutorial documentation and the actual output and changes the manifest to suit original scenario.

1. [The documented output at line 115-116](https://github.com/kubernetes/website/blob/ddec959814fff4d4d32bd401c9567c3b62a4d68f/content/en/docs/tutorials/stateful-application/basic-stateful-set.md?plain=1#L115) of `basic-stateful-set.md` shows DESIRED and CURRENT status columns for `kubectl get statefulset web`.

```
NAME      DESIRED   CURRENT   AGE
web       2         1         20s
```

 However, the actual output displays READY status instead. This is updated to match reality.

```
NAME   READY   AGE
web    2/2     37s
```

2. The documented container image names [at line 640-642](https://github.com/kubernetes/website/blob/ddec959814fff4d4d32bd401c9567c3b62a4d68f/content/en/docs/tutorials/stateful-application/basic-stateful-set.md?plain=1#L596) after patching statefulset by command `kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"gcr.io/google_containers/nginx-slim:0.8"}]'` and getting pod images via  `for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done` are shown as `registry.k8s.io/nginx-slim:0.8`.
But the actual image names are `gcr.io/google_containers/nginx-slim:0.8`.                                                                        
<br>If you try to display this as `gcr.io/google_containers/nginx-slim:0.8`, it is not following  the community rules. Also, even if it is displayed as `registry.k8s.io/nginx-slim:0.8`, the original container image is `registry.k8s.io/nginx-slim:0.8`, so the container image will not be updated and will proceed. This contradicts the documentation.
<br>So I changed the container image in Statefulset in the first document (application/web/web.yaml) to `registry.k8s.io/nginx-slim:0.7` and rolled it to `registry.k8s.io/nginx-slim:0.8` I changed the format to update and updated it to a format that does not conflict with the scenario.