### PR TITLE
Fix nested single quotes in example command

### DIFF
--- a/content/en/docs/reference/kubectl/quick-reference.md
+++ b/content/en/docs/reference/kubectl/quick-reference.md
@@ -78,7 +78,7 @@ kubectl config view --raw
 kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
 
 # get the certificate for the e2e user
-kubectl config view --raw -o jsonpath='{.users[?(.name == 'e2e')].user.client-certificate-data}' | base64 -d
+kubectl config view --raw -o jsonpath='{.users[?(.name == "e2e")].user.client-certificate-data}' | base64 -d
 
 kubectl config view -o jsonpath='{.users[].name}'    # display the first user
 kubectl config view -o jsonpath='{.users[*].name}'   # get a list of users


### PR DESCRIPTION
The jsonpath does not parse properly with nested single quotes, changed single quotes to double quotes.

Nested single quotes gives the following error:
kubectl config view --raw -o jsonpath='{.users[?(.name == 'e2e')].user.client-certificate-data}' | base64 -d
error: error executing jsonpath "{.users[?(.name == e2e)].user.client-certificate-data}": Error executing template: unrecognized identifier e2e. Printing more information for debugging the template: [..]
