### PR TITLE
[ar] Fix build failure from missing delimiter in kubernetes-basics/_index

### DIFF
--- a/content/ar/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/ar/docs/tutorials/kubernetes-basics/_index.html
@@ -7,7 +7,7 @@ card:
   name: tutorials
   weight: 20
   title: نبذة عن الأساسيات.
-
+---
 
 
 <!DOCTYPE html>


### PR DESCRIPTION
Fix a build failure from content/ar/docs/tutorials/kubernetes-basics/_index.html

```
Error: error building site: assemble: "/src/content/ar/docs/tutorials/kubernetes-basics/_index.html:1:1": EOF looking for end YAML front matter delimiter
Makefile:104: recipe for target 'container-serve' failed
make: *** [container-serve] Error 1
```