### PR TITLE
Fix documentation feedback button style

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -77,10 +77,10 @@ footer {
     font-size: 1rem;
     border: 0px;
 
-  }
-
-  .button:hover {
-    background-color: darken($blue, 10%);
+    &:hover {
+      background-color: darken($blue, 10%);
+      color: white;
+    }
   }
 
   #cellophane {
@@ -104,6 +104,11 @@ main {
     text-decoration: none;
     font-size: 1rem;
     border: 0px;
+
+    &:hover {
+      background-color: darken($blue, 10%);
+      color: white;
+    }
   }
 }
 

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,9 +1,9 @@
 {{ if not .Params.hide_feedback }}
 <div id="pre-footer">
-  <h2>{{ T "feedback_heading" }}</h2>
+  <h2 id="feedback">{{ T "feedback_heading" }}</h2>
     <p class="feedback--prompt">{{ T "feedback_question" }} </p>
-    <button class="btn btn-primary mb-4 feedback--yes">{{ T "feedback_yes" }}</button>
-    <button class="btn btn-primary mb-4 feedback--no">{{ T "feedback_no" }}</button>
+    <button class="button mb-4 feedback--yes">{{ T "feedback_yes" }}</button>
+    <button class="button mb-4 feedback--no">{{ T "feedback_no" }}</button>
     <p class="feedback--response feedback--response__hidden">
       {{ T "layouts_docs_partials_feedback_thanks" }}
       <a target="_blank" rel="noopener"


### PR DESCRIPTION
Hi!

I noticed that the "Feedback" buttons on documentation pages use the default bootstrap styling. For [example](https://kubernetes.io/docs/concepts/overview/):

<img width="256" alt="grafik" src="https://github.com/kubernetes/website/assets/32395585/4976d679-404f-400b-a86a-4161c923c160">

This PR swaps the `.btn` class of the buttons with the `.button` class, as used by other buttons on the site. The result is a more coherent UI:

<img width="248" alt="grafik" src="https://github.com/kubernetes/website/assets/32395585/00376ae4-0b9d-478d-96a6-27304a0fb077">

The `::hover` pseudoelement was apparently not copied over from [the `main.button` class](https://github.com/kubernetes/website/blob/3e3764debd156cba421aecf551e239c9d5cfb1a9/assets/scss/_base.scss#L82-L84), which this PR catches up with.

