### PR TITLE
Add missing information about feature state of ServiceTrafficDistribution

### DIFF
--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -576,6 +576,8 @@ pool.
 
 ## Traffic Distribution
 
+{{< feature-state feature_gate_name="ServiceTrafficDistribution" >}}
+
 The `spec.trafficDistribution` field within a Kubernetes Service allows you to
 express preferences for how traffic should be routed to Service endpoints.
 Implementations like kube-proxy use the `spec.trafficDistribution` field as a


### PR DESCRIPTION
As of now, we only have feature state information at https://kubernetes.io/docs/concepts/services-networking/service/#trafic-distribution. It would be nice to also have it be available at https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution

Preview: https://deploy-preview-45907--kubernetes-io-main-staging.netlify.app/docs/reference/networking/virtual-ips/#traffic-distribution

<img width="632" alt="image" src="https://github.com/kubernetes/website/assets/26463869/f27b26df-3f71-4610-81cd-394d46466ced">


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
