### PR TITLE
Fixed selected search bar border styling

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1059,10 +1059,11 @@ div.alert > em.javascript-required {
   flex-grow: 1;
   overflow-x: hidden;
   width: auto;
-}
 
-.search-bar:focus-within {
-  border: 2.5px solid rgba(47, 135, 223, 0.7);
+  &:focus-within {
+    outline: 1.5px solid rgba(47, 135, 223, 0.7);
+    border: 1px solid rgba(47, 135, 223, 0.7);
+  }
 }
 
 .search-bar i.search-icon {


### PR DESCRIPTION
Currently, when selecting the search bar, the border size changes, which disrupts the position of other elements in the UI.

I replaced the selected `border` style with an `outline` that will be displayed in addition to the regular border, when selected.

Here's a demonstration, current vs. fixed:

https://github.com/kubernetes/website/assets/32395585/628a293c-c19d-4f8b-a846-7b39ca843d3c

