### PR TITLE
 Update cacheDir configuration with "getresource" usage

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -43,7 +43,7 @@ disableLanguages = ["no"]
  [caches.getcsv]
   dir = ":cacheDir/:project"
   maxAge = "60s"
- [caches.getjson]
+ [caches.getresource]
   dir = ":cacheDir/:project"
   maxAge = "60s"
  [caches.images]


### PR DESCRIPTION
 This PR updates the cacheDir setup to utilize `getresource` instead of `getjson`, aligning with recent changes steering us away from 'getJSON' for remote data retrieval. 
 
  Notably, this enhancement now enables correct refreshing of data on the Download Page and CVE feed.
 
 #### Useful Links
 
 [Preview Refreshed CVE Feed Link ](https://deploy-preview-45922--kubernetes-io-main-staging.netlify.app/docs/reference/issues-security/official-cve-feed/) | [Current Stale CVE Feed](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/)
[Preview Download Page with v1.30](https://deploy-preview-45922--kubernetes-io-main-staging.netlify.app//releases/download/#binaries) | [Current Empty Download Page](https://kubernetes.io/releases/download/#binaries)
 
 
 /area web-development