### PR TITLE
Ready glossary page for vanilla Docsy

### DIFF
--- a/content/en/docs/reference/glossary/index.md
+++ b/content/en/docs/reference/glossary/index.md
@@ -5,6 +5,7 @@ approvers:
 title: Glossary
 layout: glossary
 noedit: true
+body_class: glossary
 default_active_tag: fundamental
 weight: 5
 card:


### PR DESCRIPTION
Set front matter for the glossary page so that we can use Docsy-native custom styling, if we want to.

The way this works is to set `body_class` front matter. This change does not change the way the current site displays.

[Current glossary page](https://k8s.io/docs/reference/glossary/) | [Preview glossary page](https://deploy-preview-45937--kubernetes-io-main-staging.netlify.app/docs/reference/glossary/)

/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171