### PR TITLE
Ready Hello, Minikube page for vanilla Docsy

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -2,12 +2,6 @@
 title: Hello Minikube
 content_type: tutorial
 weight: 5
-menu:
-  main:
-    title: "Get Started"
-    weight: 10
-    post: >
-      <p>Ready to get your hands dirty? Build a simple Kubernetes cluster that runs a sample app.</p>
 card:
   name: tutorials
   weight: 10


### PR DESCRIPTION
Delete the `menu` front matter for [Hello, Minikube](https://kubernetes.io/docs/tutorials/hello-minikube/). Docsy would use this menu, but we don't want this page in the top navigation.

This change does not change the way the current site displays or, at least, that's what I intend.

[Current page](https://kubernetes.io/docs/tutorials/hello-minikube/) | [Preview](https://deploy-preview-45938--kubernetes-io-main-staging.netlify.app/docs/tutorials/hello-minikube/)

/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171