### PR TITLE
Ready docs landing page for vanilla Docsy

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -13,9 +13,7 @@ hide_feedback: true
 menu:
   main:
     title: "Documentation"
-    weight: 20
-    post: >
-      <p>Learn how to use Kubernetes with conceptual, tutorial, and reference documentation. You can even <a href="/editdocs/" data-auto-burger-exclude data-proofer-ignore>help contribute to the docs</a>!</p>
+    weight: 10
 description: >
   Kubernetes is an open source container orchestration engine for automating deployment, scaling, and management of containerized applications. The open source project is hosted by the Cloud Native Computing Foundation.
 overview: >


### PR DESCRIPTION
Align the (currently unused) menu entry for the documentation landing page, so it's got the front matter data that plain Docsy would use.

The way this works is to set `menu` front matter that Docsy would display in a reasonable way, and specifically _not_ to include a detailed description (`post`). This change does not change the way the current site displays or, at least, that's what I intend.

[Current documentation landing page](https://k8s.io/docs/home/) | [Preview documentation landing page](https://deploy-preview-45939--kubernetes-io-main-staging.netlify.app/docs/home/)

/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171