### PR TITLE
Make ICP license leader text localizable

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -24,6 +24,13 @@ other = "Caution:"
 [cleanup_heading]
 other = "Cleaning up"
 
+# Localization note (no need to translate this note)
+# This is always followed by Chinese text, as required by the Kubernetes
+# project's ICP license, issued by the government of the People's Republic
+# of China.
+[china_icp_license]
+other = "ICP license:"
+
 [community_events_calendar]
 other = "Events Calendar"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,7 +30,7 @@
         <br/>
         {{ with .Site.Params.copyright_linux }}<small class="text-white">Copyright &copy; {{ now.Year }} {{ T "main_copyright_notice" | safeHTML }}</small>{{ end }}
         <br/>
-        <small class="text-white">ICP license: 京ICP备17074266号-3</small>
+        <small class="text-white">{{ T "china_icp_license" }} 京ICP备17074266号-3</small>
         {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
         {{ if not .Site.Params.ui.footer_about_disable }}
           {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}


### PR DESCRIPTION
Don't assume we'll use English text to introduce the ICP license (seen in the footer of every page).

/area localization
/language en