### PR TITLE
Swap manual installation with Homebrew setup to align with macOS user expectations

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -27,6 +27,29 @@ The following methods exist for installing kubectl on macOS:
   - [Enable shell autocompletion](#enable-shell-autocompletion)
   - [Install `kubectl convert` plugin](#install-kubectl-convert-plugin)
 
+### Install with Homebrew on macOS
+
+If you are on macOS and using [Homebrew](https://brew.sh/) package manager,
+you can install kubectl with Homebrew.
+
+1. Run the installation command:
+
+   ```bash
+   brew install kubectl
+   ```
+
+   or
+
+   ```bash
+   brew install kubernetes-cli
+   ```
+
+1. Test to ensure the version you installed is up-to-date:
+
+   ```bash
+   kubectl version --client
+   ```
+
 ### Install kubectl binary with curl on macOS
 
 1. Download the latest release:
@@ -127,29 +150,6 @@ The following methods exist for installing kubectl on macOS:
 
    ```bash
    rm kubectl.sha256
-   ```
-
-### Install with Homebrew on macOS
-
-If you are on macOS and using [Homebrew](https://brew.sh/) package manager,
-you can install kubectl with Homebrew.
-
-1. Run the installation command:
-
-   ```bash
-   brew install kubectl
-   ```
-
-   or
-
-   ```bash
-   brew install kubernetes-cli
-   ```
-
-1. Test to ensure the version you installed is up-to-date:
-
-   ```bash
-   kubectl version --client
    ```
 
 ### Install with Macports on macOS


### PR DESCRIPTION
Adjusted the installation process to better accommodate the preferences of macOS users. Recognizing that many Mac users are accustomed to using Homebrew as a convenient package manager for software installation, I've swapped the manual setup instructions with Homebrew commands.
