### PR TITLE
Update blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
+++ b/content/en/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
@@ -4,9 +4,9 @@ date: 2015-03-20
 slug: welcome-to-kubernetes-blog
 url: /blog/2015/03/Welcome-To-Kubernetes-Blog
 evergreen: true
+author: >
+  Kit Merker (Google)
 ---
-
-**Author:** Kit Merker (Google)
 
 Welcome to the new Kubernetes Blog. Follow this blog to learn about the Kubernetes Open Source project. We plan to post release notes, how-to articles, events, and maybe even some off topic fun here from time to time.
 

--- a/content/en/blog/_posts/2015-04-00-Kubernetes-And-Mesosphere-Dcos.md
+++ b/content/en/blog/_posts/2015-04-00-Kubernetes-And-Mesosphere-Dcos.md
@@ -3,6 +3,8 @@ title: " Kubernetes and the Mesosphere DCOS "
 date: 2015-04-22
 slug: kubernetes-and-mesosphere-dcos
 url: /blog/2015/04/Kubernetes-And-Mesosphere-Dcos
+author: >
+   Craig McLuckie (Google)
 ---
 
 # Kubernetes and the Mesosphere DCOS
@@ -22,10 +24,6 @@ By way of background, Kubernetes is a cluster management framework that was star
 Kubernetes was designed from the start to make these capabilities available to everyone, and built by the same engineers that built the system internally known as Borg.  For many users the promise of 'Google style app management' is interesting, but they want to run these new classes of applications on the same set of physical resources as their existing workloads like Hadoop, Spark, Kafka, etc.  Now they will have access to commercially supported offering that brings the two worlds together.
 
 Mesosphere, one of the earliest supporters of the Kubernetes project, has been working closely with the core Kubernetes team to create a natural experience for users looking to get the best of both worlds, adding Kubernetes to every Mesos deployment they instantiate, whether it be in the public cloud, private cloud, or in a hybrid deployment model.  This is well aligned with the overall Kubernetes vision of creating ubiquitous management framework that runs anywhere a container can.  It will be interesting to see how you blend together the old world and the new on a commercially supported, versatile platform.
-
-Craig McLuckie
-
-Product Manager, Google and Kubernetes co-founder
 
 [1]: https://mesosphere.com/product/
 [2]: http://research.google.com/pubs/pub43438.html

--- a/content/en/blog/_posts/2015-05-00-Appc-Support-For-Kubernetes-Through-Rkt.md
+++ b/content/en/blog/_posts/2015-05-00-Appc-Support-For-Kubernetes-Through-Rkt.md
@@ -3,6 +3,8 @@ title: " AppC Support for Kubernetes through RKT "
 date: 2015-05-04
 slug: appc-support-for-kubernetes-through-rkt
 url: /blog/2015/05/Appc-Support-For-Kubernetes-Through-Rkt
+author: >
+   Craig McLuckie (Google)
 ---
 We very recently accepted a pull request to the Kubernetes project to add appc support for the Kubernetes community. &nbsp;Appc is a new open container specification that was initiated by CoreOS, and is supported through CoreOS rkt container runtime.
 
@@ -21,6 +23,3 @@ Docker has done an amazing job of democratizing container technologies and makin
 
 
 The really nice thing is that with Kubernetes you can now pick the container runtime that works best for you based on your workloads’ needs, change runtimes without having the replace your cluster environment, or even mix together applications where different parts are running in different container runtimes in the same cluster. &nbsp;Additional choices can’t help but ultimately benefit the end developer.
-
--- Craig McLuckie  
-Google Product Manager and Kubernetes co-founder  

--- a/content/en/blog/_posts/2015-05-00-Docker-And-Kubernetes-And-Appc.md
+++ b/content/en/blog/_posts/2015-05-00-Docker-And-Kubernetes-And-Appc.md
@@ -3,6 +3,8 @@ title: " Docker and Kubernetes and AppC  "
 date: 2015-05-18
 slug: docker-and-kubernetes-and-appc
 url: /blog/2015/05/Docker-And-Kubernetes-And-Appc
+author: >
+   Craig McLuckie (Google)
 ---
 Recently we announced the intent in Kubernetes, our open source cluster manager, to support AppC and RKT, an alternative container format that has been driven by CoreOS with input from many companies (including Google). &nbsp;This announcement has generated a surprising amount of buzz and has been construed as a move from Google to support Appc over Docker. &nbsp;Many have taken it as signal that Google is moving away from supporting Docker. &nbsp;I would like to take a moment to clarify Google’s position in this.
 
@@ -20,9 +22,3 @@ Our intent with our announcement for AppC and RKT support was to establish Kuber
 
 
 Stepping back a little, one must recognize that Docker has done remarkable work in democratizing container technologies and making them accessible to everyone. &nbsp;We believe that Docker will continue to drive great experiences for developers looking to use containers and plan to support this technology and its burgeoning community indefinitely. &nbsp;We, for one, &nbsp;are looking forward to the upcoming Dockercon where Brendan Burns (a Kubernetes co-founder) will be talking about the role of Docker in modern distributed systems design.
-
-
-
--- Craig McLuckie
-
-Google Group Product Manager, and Kubernetes Project Co-Founder

--- a/content/en/blog/_posts/2015-05-00-Kubernetes-On-Openstack.md
+++ b/content/en/blog/_posts/2015-05-00-Kubernetes-On-Openstack.md
@@ -3,6 +3,8 @@ title: " Kubernetes on OpenStack "
 date: 2015-05-19
 slug: kubernetes-on-openstack
 url: /blog/2015/05/Kubernetes-On-Openstack
+author: >
+   Martin Buhr (independent)
 ---
 
 
@@ -41,6 +43,3 @@ This list will grow, and is curated [here](https://opendev.org/x/k8s-docker-suit
 
 
 [The Kubernetes open source project](https://github.com/GoogleCloudPlatform/kubernetes) has continued to see fantastic community adoption and increasing momentum, with over 11,000 commits and 7,648 stars on GitHub. With supporters ranging from Red Hat and Intel to CoreOS and Box.net, it has come to represent a range of customer interests ranging from enterprise IT to cutting edge startups. We encourage you to give it a try, give us your feedback, and get involved in our growing community.
-
-
-- Martin Buhr, Product Manager, Kubernetes Open Source Project

--- a/content/en/blog/_posts/2015-05-00-Resource-Usage-Monitoring-Kubernetes.md
+++ b/content/en/blog/_posts/2015-05-00-Resource-Usage-Monitoring-Kubernetes.md
@@ -3,6 +3,9 @@ title:  Resource Usage Monitoring in Kubernetes
 date: 2015-05-12
 slug: resource-usage-monitoring-kubernetes
 url: /blog/2015/05/Resource-Usage-Monitoring-Kubernetes
+author: >
+   Vishnu Kannan (Google),
+   Victor Marmol (Google)
 ---
 
 Understanding how an application behaves when deployed is crucial to scaling the application and providing a reliable service. In a Kubernetes cluster, application performance can be examined at many different levels: containers, [pods](/docs/user-guide/pods), [services](/docs/user-guide/services), and whole clusters. As part of Kubernetes we want to provide users with detailed resource usage information about their running applications at all these levels. This will give users deep insights into how their applications are performing and where possible application bottlenecks may be found. In comes [Heapster](https://github.com/kubernetes/heapster), a project meant to provide a base monitoring platform on Kubernetes.  
@@ -96,7 +99,3 @@ Here is a snapshot of the a Google Cloud Monitoring dashboard showing cluster-wi
 
 
 Now that you’ve learned a bit about Heapster, feel free to try it out on your own clusters! The [Heapster repository](https://github.com/kubernetes/heapster) is available on GitHub. It contains detailed instructions to setup Heapster and its storage backends. Heapster runs by default on most Kubernetes clusters, so you may already have it! Feedback is always welcome. Please let us know if you run into any issues via the troubleshooting channels.
-
-
-
-_-- Vishnu Kannan and Victor Marmol, Google Software Engineers_

--- a/content/en/blog/_posts/2015-06-00-The-Distributed-System-Toolkit-Patterns.md
+++ b/content/en/blog/_posts/2015-06-00-The-Distributed-System-Toolkit-Patterns.md
@@ -3,6 +3,8 @@ title: " The Distributed System ToolKit: Patterns for Composite Containers "
 date: 2015-06-29
 slug: the-distributed-system-toolkit-patterns
 url: /blog/2015/06/The-Distributed-System-Toolkit-Patterns
+author: >
+   Brendan Burns (Google)
 ---
 Having had the privilege of presenting some ideas from Kubernetes at DockerCon 2015, I thought I would make a blog post to share some of these ideas for those of you who couldn’t be there.  
 
@@ -41,6 +43,4 @@ Adapter containers standardize and normalize output. &nbsp;Consider the task of 
 ![Adapter Containers](/images/blog/2015-06-00-The-Distributed-System-Toolkit-Patterns/adapter-containers.png)
 
 
-In all of these cases, we've used the container boundary as an encapsulation/abstraction boundary that allows us to build modular, reusable components that we combine to build out applications. &nbsp;This reuse enables us to more effectively share containers between different developers, reuse our code across multiple applications, and generally build more reliable, robust distributed systems more quickly. &nbsp;I hope you’ve seen how Pods and composite container patterns can enable you to build robust distributed systems more quickly, and achieve container code re-use. &nbsp;To try these patterns out yourself in your own applications. I encourage you to go check out open source Kubernetes or Google Container Engine.  
-
- - Brendan Burns, Software Engineer at Google
+In all of these cases, we've used the container boundary as an encapsulation/abstraction boundary that allows us to build modular, reusable components that we combine to build out applications. &nbsp;This reuse enables us to more effectively share containers between different developers, reuse our code across multiple applications, and generally build more reliable, robust distributed systems more quickly. &nbsp;I hope you’ve seen how Pods and composite container patterns can enable you to build robust distributed systems more quickly, and achieve container code re-use. &nbsp;To try these patterns out yourself in your own applications. I encourage you to go check out open source Kubernetes or Google Container Engine.

--- a/content/en/blog/_posts/2015-07-00-How-Did-Quake-Demo-From-Dockercon-Work.md
+++ b/content/en/blog/_posts/2015-07-00-How-Did-Quake-Demo-From-Dockercon-Work.md
@@ -3,6 +3,8 @@ title: " How did the Quake demo from DockerCon Work? "
 date: 2015-07-02
 slug: how-did-quake-demo-from-dockercon-work
 url: /blog/2015/07/How-Did-Quake-Demo-From-Dockercon-Work
+author: >
+   Saied Kazemi (Google)
 ---
 Shortly after its release in 2013, Docker became a very popular open source container management tool for Linux.  Docker has a rich set of commands to control the execution of a container. Commands such as start, stop, restart, kill, pause, and unpause. However, what is still missing is the ability to Checkpoint and Restore (C/R) a container natively via Docker itself.
 
@@ -190,7 +192,3 @@ If you are using a kernel older than 3.19 and your container uses AIO, you need 
 
 - [torvalds: bd9b51e7](https://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=commit;h=bd9b51e7) by Al Viro
 - [torvalds: e4a0d3e72](https://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=commit;h=e4a0d3e72) by Pavel Emelyanov
-
-
-
-- Saied Kazemi, Software Engineer at Google

--- a/content/en/blog/_posts/2015-07-00-Strong-Simple-Ssl-For-Kubernetes.md
+++ b/content/en/blog/_posts/2015-07-00-Strong-Simple-Ssl-For-Kubernetes.md
@@ -3,6 +3,8 @@ title: " Strong, Simple SSL for Kubernetes Services "
 date: 2015-07-14
 slug: strong-simple-ssl-for-kubernetes
 url: /blog/2015/07/Strong-Simple-Ssl-For-Kubernetes
+author: >
+   Evan Brown (Google)
 ---
 Hi, I’m Evan Brown [(@evandbrown](http://twitter.com/evandbrown)) and I work on the solutions architecture team for Google Cloud Platform. I recently wrote an [article](https://cloud.google.com/solutions/automated-build-images-with-jenkins-kubernetes) and [tutorial](https://github.com/GoogleCloudPlatform/kube-jenkins-imager) about using Jenkins on Kubernetes to automate the Docker and GCE image build process. Today I’m going to discuss how I used Kubernetes services and secrets to add SSL to the Jenkins web UI. After reading this, you’ll be able to add SSL termination (and HTTP-\>HTTPS redirects + basic auth) to your public HTTP Kubernetes services.
 

--- a/content/en/blog/_posts/2015-07-00-The-Growing-Kubernetes-Ecosystem.md
+++ b/content/en/blog/_posts/2015-07-00-The-Growing-Kubernetes-Ecosystem.md
@@ -3,6 +3,8 @@ title: " The Growing Kubernetes Ecosystem "
 date: 2015-07-24
 slug: the-growing-kubernetes-ecosystem
 url: /blog/2015/07/The-Growing-Kubernetes-Ecosystem
+author: >
+   Martin Buhr (Google)
 ---
 Over the past year, we’ve seen fantastic momentum in the Kubernetes project, culminating with the release of [Kubernetes v1][4] earlier this week. We’ve also witnessed the ecosystem around Kubernetes blossom, and wanted to draw attention to some of the cooler offerings we’ve seen.
 
@@ -187,7 +189,6 @@ We’ve also seen a community of services partners spring up to assist in adopti
 
  |
 
- \- Martin Buhr, Product Manager at Google
 
  [1]: https://lh4.googleusercontent.com/2dJvY1Cl9i6SQ8apKARcisvFZPDYY5LltIsmz3W-jmon7DFE4p7cz3gsBPuz9KM_LSiuwx1xIPYr9Ygm5DTQ2f-DUyWsg7zs7YL7O3JMCHQ8Ji4B3EGpx26fbF_glQPPPp4RQTE
 [2]: http://blog.cloudbees.com/2015/07/on-demand-jenkins-slaves-with.html

--- a/content/en/blog/_posts/2015-08-00-Using-Kubernetes-Namespaces-To-Manage.md
+++ b/content/en/blog/_posts/2015-08-00-Using-Kubernetes-Namespaces-To-Manage.md
@@ -3,6 +3,8 @@ title: " Using Kubernetes Namespaces to Manage Environments "
 date: 2015-08-28
 slug: using-kubernetes-namespaces-to-manage
 url: /blog/2015/08/Using-Kubernetes-Namespaces-To-Manage
+author: >
+   Ian Lewis (Google)
 ---
 #####  One of the advantages that Kubernetes provides is the ability to manage various environments easier and better than traditional deployment strategies. For most nontrivial applications, you have test, staging, and production environments. You can spin up a separate cluster of resources, such as VMs, with the same configuration in staging and production, but that can be costly and managing the differences between the environments can be difficult.
 
@@ -86,5 +88,3 @@ Notice that the IP addresses are different depending on which namespace is used 
 While you can run staging and production environments in the same cluster and save resources and money by doing so, you will need to be careful to set up resource limits so that your staging environment doesn't starve production for CPU, memory, or disk resources. Setting resource limits properly, and testing that they are working takes a lot of time and effort so unless you can measurably save money by running production in the same cluster as staging or test, you may not really want to do that.
 
 Whether or not you run staging and production in the same cluster, namespaces are a great way to partition different apps within the same cluster. Namespaces will also serve as a level where you can apply resource limits so look for more resource management features at the namespace level in the future.
-
-\- Posted by Ian Lewis, Developer Advocate at Google

--- a/content/en/blog/_posts/2015-09-00-Kubernetes-Performance-Measurements-And.md
+++ b/content/en/blog/_posts/2015-09-00-Kubernetes-Performance-Measurements-And.md
@@ -3,6 +3,8 @@ title: " Kubernetes Performance Measurements and Roadmap "
 date: 2015-09-10
 slug: kubernetes-performance-measurements-and
 url: /blog/2015/09/Kubernetes-Performance-Measurements-And
+author: >
+   Wojciech Tyczynski (Google)
 ---
 No matter how flexible and reliable your container orchestration system is, ultimately, you have some work to be done, and you want it completed quickly. For big problems, a common answer is to just throw more machines at the problem. After all, more compute = faster, right?
 
@@ -114,7 +116,6 @@ This is by no means an exhaustive list. We will be adding new elements (or remov
 - If you have specific performance or scalability questions before then,  please join our scalability special interest group on Slack: https://kubernetes.slack.com/messages/sig-scale
 - General questions? Feel free to join our Kubernetes community on Slack: https://kubernetes.slack.com/messages/kubernetes-users/
 - Submit a pull request or file an issue! You can do this in our GitHub repository. Everyone is also enthusiastically encouraged  to contribute with their own experiments (and their result) or PR contributions improving Kubernetes.
-\- Wojciech Tyczynski, Google Software Engineer
 
 [1]: http://kubernetes.io/images/nav_logo.svg
 [2]: http://kubernetes.io/docs/

--- a/content/en/blog/_posts/2015-10-00-Some-Things-You-Didnt-Know-About-Kubectl_28.md
+++ b/content/en/blog/_posts/2015-10-00-Some-Things-You-Didnt-Know-About-Kubectl_28.md
@@ -3,9 +3,9 @@ title: "Some things you didn’t know about kubectl"
 date: 2015-10-28
 slug: some-things-you-didnt-know-about-kubectl_28
 url: /blog/2015/10/Some-Things-You-Didnt-Know-About-Kubectl_28
+author: >
+  Brendan Burns (Google) 
 ---
-
-**Author:** Brendan Burns (Google)
 
 [kubectl](/docs/reference/kubectl/) is the command line tool for interacting with Kubernetes clusters. Many people use it every day to deploy their container workloads into production clusters. But there’s more to kubectl than just `kubectl create -f or kubectl rolling-update`. kubectl is a veritable multi-tool of container orchestration and management. Below we describe some of the features of kubectl that you may not have seen.   
 

--- a/content/en/blog/_posts/2015-11-00-Creating-A-Raspberry-Pi-Cluster-Running-Kubernetes-The-Shopping-List-Part-1.md
+++ b/content/en/blog/_posts/2015-11-00-Creating-A-Raspberry-Pi-Cluster-Running-Kubernetes-The-Shopping-List-Part-1.md
@@ -3,6 +3,8 @@ title: " Creating a Raspberry Pi cluster running Kubernetes, the shopping list (
 date: 2015-11-25
 slug: creating-a-raspberry-pi-cluster-running-kubernetes-the-shopping-list-part-1
 url: /blog/2015/11/Creating-A-Raspberry-Pi-Cluster-Running-Kubernetes-The-Shopping-List-Part-1
+author: >
+   Arjen Wassink (Quintor)
 ---
 At Devoxx Belgium and Devoxx Morocco, Ray Tsang and I showed a Raspberry Pi cluster we built at Quintor running HypriotOS, Docker and Kubernetes. For those who did not see the talks, you can check out [an abbreviated version of the demo](https://www.youtube.com/watch?v=AAS5Mq9EktI) or the full talk by Ray on [developing and deploying Java-based microservices](https://www.youtube.com/watch?v=kT1vmK0r184) in Kubernetes. While we received many compliments on the talk, the most common question was about how to build a Pi cluster themselves! We’ll be doing just that, in two parts. This first post will cover the shopping list for the cluster, and the second will show you how to get it up and running . . .
 
@@ -48,7 +50,6 @@ Building the Raspberry Pi cluster is pretty straight forward. Most of the work i
 With that, you’re all set! Next up will be running Kubernetes on the Raspberry Pi cluster. We’ll be covering this the [next post](https://kubernetes.io/blog/2015/12/creating-raspberry-pi-cluster-running), so stay tuned!  
 
 
-Arjen Wassink, Java Architect and Team Lead, Quintor  
 
 
 

--- a/content/en/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
+++ b/content/en/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
@@ -4,9 +4,9 @@ date: 2015-11-09
 slug: kubernetes-1-1-performance-upgrades-improved-tooling-and-a-growing-community
 url: /blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
 evergreen: true
+author: >
+  David Aronchick (Google)
 ---
-
-**Author:** David Aronchick (Google)
 
 Since the Kubernetes 1.0 release in July, we’ve seen tremendous adoption by companies building distributed systems to manage their container clusters. We’re also been humbled by the rapid growth of the community who help make Kubernetes better everyday. We have seen commercial offerings such as Tectonic by CoreOS and RedHat Atomic Host emerge to deliver deployment and support of Kubernetes. And a growing ecosystem has added Kubernetes support including tool vendors such as Sysdig and Project Calico.  
 

--- a/content/en/blog/_posts/2015-11-00-Monitoring-Kubernetes-With-Sysdig.md
+++ b/content/en/blog/_posts/2015-11-00-Monitoring-Kubernetes-With-Sysdig.md
@@ -3,6 +3,8 @@ title: " Monitoring Kubernetes with Sysdig "
 date: 2015-11-19
 slug: monitoring-kubernetes-with-sysdig
 url: /blog/2015/11/Monitoring-Kubernetes-With-Sysdig
+author: >
+  Chris Crane (Sysdig)
 ---
 _Today we’re sharing a guest post by Chris Crane from Sysdig about their monitoring integration into Kubernetes.&nbsp;_  
 
@@ -223,7 +225,6 @@ I’m pretty confident that what we’re delivering here represents a huge leap 
 
 
 
- Chris Crane, VP Product, Sysdig&nbsp;
 
 
 

--- a/content/en/blog/_posts/2015-11-00-One-Million-Requests-Per-Second-Dependable-And-Dynamic-Distributed-Systems-At-Scale.md
+++ b/content/en/blog/_posts/2015-11-00-One-Million-Requests-Per-Second-Dependable-And-Dynamic-Distributed-Systems-At-Scale.md
@@ -3,6 +3,8 @@ title: " One million requests per second: Dependable and dynamic distributed sys
 date: 2015-11-11
 slug: one-million-requests-per-second-dependable-and-dynamic-distributed-systems-at-scale
 url: /blog/2015/11/One-Million-Requests-Per-Second-Dependable-And-Dynamic-Distributed-Systems-At-Scale
+author: >
+  Brendan Burns (Google)
 ---
 
 Recently, I’ve gotten in the habit of telling people that building a reliable service isn’t that hard. If you give me two Compute Engine virtual machines, a Cloud Load balancer, supervisord and nginx, I can create you a static web service that will serve a static web page, effectively forever.  
@@ -30,7 +32,3 @@ I hope I’ve shown you how Kubernetes can enable developers of distributed syst
 
 
  "https://www.youtube.com/embed/7TOWLerX0Ps"
-
-
-
-- Brendan Burns, Senior Staff Software Engineer, Google, Inc.

--- a/content/en/blog/_posts/2015-12-00-Creating-Raspberry-Pi-Cluster-Running.md
+++ b/content/en/blog/_posts/2015-12-00-Creating-Raspberry-Pi-Cluster-Running.md
@@ -3,6 +3,8 @@ title: " Creating a Raspberry Pi cluster running Kubernetes, the installation (P
 date: 2015-12-22
 slug: creating-raspberry-pi-cluster-running
 url: /blog/2015/12/Creating-Raspberry-Pi-Cluster-Running
+author: >
+  Arjen Wassink (Quintor)
 ---
 At Devoxx Belgium and Devoxx Morocco, [Ray Tsang](https://twitter.com/saturnism) and I ([Arjen Wassink](https://twitter.com/ArjenWassink)) showed a Raspberry Pi cluster we built at Quintor running HypriotOS, Docker and Kubernetes. While we received many compliments on the talk, the most common question was about how to build a Pi cluster themselves! We’ll be doing just that, in two parts. The [first part covered the shopping list for the cluster](https://kubernetes.io/blog/2015/11/creating-a-Raspberry-Pi-cluster-running-Kubernetes-the-shopping-list-Part-1), and this second one will show you how to get kubernetes up and running . . .
 
@@ -194,6 +196,3 @@ k8s-master-127.0.0.1   3/3       Running   6          2h        127.0.0.1
 ### Enjoy your Kubernetes cluster!
 
 Congratulations! You now have your Kubernetes Raspberry Pi cluster running and can start playing with Kubernetes and start learning. Checkout the [Kubernetes User Guide](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/README.md) to find out what you all can do. And don’t forget to pull some plugs occasionally like Ray and I do :-)
-
-
-Arjen Wassink, Java Architect and Team Lead, Quintor

--- a/content/en/blog/_posts/2015-12-00-How-Weave-Built-A-Multi-Deployment-Solution-For-Scope-Using-Kubernetes.md
+++ b/content/en/blog/_posts/2015-12-00-How-Weave-Built-A-Multi-Deployment-Solution-For-Scope-Using-Kubernetes.md
@@ -3,8 +3,9 @@ title: " How Weave built a multi-deployment solution for Scope using Kubernetes 
 date: 2015-12-12
 slug: how-weave-built-a-multi-deployment-solution-for-scope-using-kubernetes
 url: /blog/2015/12/How-Weave-Built-A-Multi-Deployment-Solution-For-Scope-Using-Kubernetes
+author: >
+  Peter Bourgon (Weaveworks)
 ---
-_Today we hear from Peter Bourgon, Software Engineer at Weaveworks, a company that provides software for developers to network, monitor and control microservices-based apps in docker containers. Peter tells us what was involved in selecting and deploying Kubernetes&nbsp;_  
 
 Earlier this year at Weaveworks we launched [Weave Scope](http://weave.works/product/scope/index.html), an open source solution for visualization and monitoring of containerised apps and services. Recently we released a hosted Scope service into an [Early Access Program](http://blog.weave.works/2015/10/08/weave-the-fastest-path-to-docker-on-amazon-ec2-container-service/). Today, we want to walk you through how we initially prototyped that service, and how we ultimately chose and deployed Kubernetes as our platform.  
 
@@ -120,6 +121,5 @@ After a couple weeks of fighting with the machines, we were able to resolve all 
 * The Kubernetes **domain language is a great match** to the problem domain.&nbsp;
 * We have **a lot more confidence** in operating our application (It's a lot faster, too.).&nbsp;
 * And we're **very happy to be part of a growing Kubernetes userbase** , contributing issues and patches as we can and benefitting from the virtuous cycle of open-source development that powers the most exciting software being written today.&nbsp;
-&nbsp;- Peter Bourgon, Software Engineer at Weaveworks  
 
 _Weave Scope is an open source solution for visualization and monitoring of containerised apps and services. For a hosted Scope service, request an invite to Early Access program at scope.weave.works._

--- a/content/en/blog/_posts/2015-12-00-Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet.md
+++ b/content/en/blog/_posts/2015-12-00-Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet.md
@@ -3,8 +3,9 @@ title: " Managing Kubernetes Pods, Services and Replication Controllers with Pup
 date: 2015-12-17
 slug: managing-kubernetes-pods-services-and-replication-controllers-with-puppet
 url: /blog/2015/12/Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet
+author: >
+  Gareth Rushgrove (Puppet Labs)
 ---
-_Today’s guest post is written by Gareth Rushgrove, Senior Software Engineer at Puppet Labs, a leader in IT automation. Gareth tells us about a new Puppet module that helps manage resources in Kubernetes.&nbsp;_  
 
 People familiar with [Puppet](https://github.com/puppetlabs/puppet)&nbsp;might have used it for managing files, packages and users on host computers. But Puppet is first and foremost a configuration management tool, and config management is a much broader discipline than just managing host-level resources. A good definition of configuration management is that it aims to solve four related problems: identification, control, status accounting and verification and audit. These problems exist in the operation of any complex system, and with the new [Puppet Kubernetes module](https://forge.puppetlabs.com/garethr/kubernetes)&nbsp;we’re starting to look at how we can solve those problems for Kubernetes.  
 
@@ -69,6 +70,4 @@ The advantages of using Puppet rather than just the standard YAML files and kube
 
 It’s also worth noting that most large organisations will have very heterogenous environments, running a wide range of software and operating systems. Having a single toolchain that unifies those discrete systems can make adopting new technology like Kubernetes much easier.  
 
-It’s safe to say that Kubernetes provides an excellent set of primitives on which to build cloud-native systems. And with Puppet, you can address some of the operational and configuration management issues that come with running any complex system in production. [Let us know](mailto:gareth@puppetlabs.com)&nbsp;what you think if you try the module out, and what else you’d like to see supported in the future.  
-
-&nbsp;-&nbsp;Gareth Rushgrove, Senior Software Engineer, Puppet Labs
+It’s safe to say that Kubernetes provides an excellent set of primitives on which to build cloud-native systems. And with Puppet, you can address some of the operational and configuration management issues that come with running any complex system in production. [Let us know](mailto:gareth@puppetlabs.com)&nbsp;what you think if you try the module out, and what else you’d like to see supported in the future.


### PR DESCRIPTION
This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

_**Edit**: I'll split this into several PRs each focusing on a single year blog._

- [x]  Changes merged for 2024 blogs
- [x]  Changes merged for 2023 blogs
- [x]  Changes merged for 2022 blogs
- [x]  Changes merged for 2021 blogs
- [x]  Changes merged for 2020 blogs
- [x]  Changes merged for 2019 blogs
- [x]  Changes merged for 2018 blogs
- [x]  Changes merged for 2017 blogs
- [x]  Changes merged for 2016 blogs

#### Useful Link
[Preview Blog Summary Page](https://deploy-preview-45957--kubernetes-io-main-staging.netlify.app/blog)

