### PR TITLE
Add doc string on how to update `{eol,schedule}.yaml`

### DIFF
--- a/data/releases/eol.yaml
+++ b/data/releases/eol.yaml
@@ -1,3 +1,8 @@
+# Use "schedule-builder" to maintain this file:
+# https://github.com/kubernetes/release/tree/master/cmd/schedule-builder
+# For example by running:
+# schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
+---
 branches:
 - endOfLifeDate: "2024-02-28"
   finalPatchRelease: 1.26.15

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,3 +1,8 @@
+# Use "schedule-builder" to maintain this file:
+# https://github.com/kubernetes/release/tree/master/cmd/schedule-builder
+# For example by running:
+# schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
+---
 schedules:
 - endOfLifeDate: "2025-06-28"
   maintenanceModeStartDate: "2025-04-28"


### PR DESCRIPTION
The merge of https://github.com/kubernetes/release/pull/3583 introduced a documentation string to both files mentioning how to update them. We now sync the changes to match the output of the latest schedule-builder tool revision.

/cc @kubernetes/release-engineering 