### PR TITLE
Update 2024 blog content files to move author details in front-matter 

### DIFF
--- a/content/en/blog/_posts/2024-02-21-prevent-unauthorized-volume-mode-conversion-ga.md
+++ b/content/en/blog/_posts/2024-02-21-prevent-unauthorized-volume-mode-conversion-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.30: Preventing unauthorized volume mode conversion moves to GA"
 date: 2024-04-30
 slug: prevent-unauthorized-volume-mode-conversion-ga
+author: >
+  Raunak Pradip Shah (Mirantis)
 ---
-
-**Author:** Raunak Pradip Shah (Mirantis)
 
 With the release of Kubernetes 1.30, the feature to prevent the modification of the volume mode
 of a [PersistentVolumeClaim](/docs/concepts/storage/persistent-volumes/) that was created from

--- a/content/en/blog/_posts/2024-04-22-userns-beta/index.md
+++ b/content/en/blog/_posts/2024-04-22-userns-beta/index.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes 1.30: Beta Support For Pods With User Namespaces"
 date: 2024-04-22
 slug: userns-beta
+author: >
+  Rodrigo Campos Catelin (Microsoft),
+  Giuseppe Scrivano (Red Hat),
+  Sascha Grunert (Red Hat) 
 ---
-
-**Authors:** Rodrigo Campos Catelin (Microsoft), Giuseppe Scrivano (Red Hat), Sascha Grunert (Red Hat)
 
 Linux provides different namespaces to isolate processes from each other. For
 example, a typical Kubernetes pod runs within a network namespace to isolate the

--- a/content/en/blog/_posts/2024-04-23-recursive-read-only-mounts.md
+++ b/content/en/blog/_posts/2024-04-23-recursive-read-only-mounts.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.30: Read-only volume mounts can be finally literally read-only'
 date: 2024-04-23
 slug: recursive-read-only-mounts
+author: >
+  Akihiro Suda (NTT) 
 ---
-
-**Author:** Akihiro Suda (NTT)
 
 Read-only volume mounts have been a feature of Kubernetes since the beginning.
 Surprisingly, read-only mounts are not completely read-only under certain conditions on Linux.

--- a/content/en/blog/_posts/2024-04-24-validating-admission-policy-ga/index.md
+++ b/content/en/blog/_posts/2024-04-24-validating-admission-policy-ga/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.30: Validating Admission Policy Is Generally Available"
 slug: validating-admission-policy-ga
 date: 2024-04-24
+author: >
+  Jiahui Feng (Google)
 ---
-
-**Author:** Jiahui Feng (Google)
 
 On behalf of the Kubernetes project, I am excited to announce that ValidatingAdmissionPolicy has reached
 **general availability**

--- a/content/en/blog/_posts/2024-04-25-structured-authentication-configuration-beta.md
+++ b/content/en/blog/_posts/2024-04-25-structured-authentication-configuration-beta.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.30: Structured Authentication Configuration Moves to Beta"
 date: 2024-04-25
 slug: structured-authentication-moves-to-beta
+author: >
+  [Anish Ramasekar](https://github.com/aramase) (Microsoft)
 ---
-
-**Author:** [Anish Ramasekar](https://github.com/aramase) (Microsoft)
 
 With Kubernetes 1.30, we (SIG Auth) are moving Structured Authentication Configuration to beta.
 

--- a/content/en/blog/_posts/2024-04-26-structured-authz-beta.md
+++ b/content/en/blog/_posts/2024-04-26-structured-authz-beta.md
@@ -3,12 +3,12 @@ layout: blog
 title: 'Kubernetes 1.30: Multi-Webhook and Modular Authorization Made Much Easier'
 date: 2024-04-26
 slug: multi-webhook-and-modular-authorization-made-much-easier
+author: >
+  [Rita Zhang](https://github.com/ritazh) (Microsoft),
+  [Jordan Liggitt](https://github.com/liggitt) (Google),
+  [Nabarun Pal](https://github.com/palnabarun) (VMware),
+  [Leigh Capili](https://github.com/stealthybox) (VMware)
 ---
-
-**Authors:** [Rita Zhang](https://github.com/ritazh) (Microsoft), [Jordan
-Liggitt](https://github.com/liggitt) (Google), [Nabarun
-Pal](https://github.com/palnabarun) (VMware), [Leigh
-Capili](https://github.com/stealthybox) (VMware)
 
 With Kubernetes 1.30, we (SIG Auth) are moving Structured Authorization
 Configuration to beta.


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2024 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.


Useful Link
[Preview Blog Summary Page](https://deploy-preview-45983--kubernetes-io-main-staging.netlify.app/blog)