### PR TITLE
Update 2023 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2023-01-02-cross-namespace-data-sources-alpha.md
+++ b/content/en/blog/_posts/2023-01-02-cross-namespace-data-sources-alpha.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.26: Alpha support for cross-namespace storage data sources"
 date: 2023-01-02
 slug: cross-namespace-data-sources-alpha
+author: >
+  Takafumi Takahashi (Hitachi Vantara)
 ---
-
-**Author:** Takafumi Takahashi (Hitachi Vantara)
 
 Kubernetes v1.26, released last month, introduced an alpha feature that
 lets you specify a data source for a PersistentVolumeClaim, even where the source

--- a/content/en/blog/_posts/2023-01-05-retroactive-default-storage-class.md
+++ b/content/en/blog/_posts/2023-01-05-retroactive-default-storage-class.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.26: Retroactive Default StorageClass"
 date: 2023-01-05
 slug: retroactive-default-storage-class
+author: >
+  Roman Bednář (Red Hat)
 ---
-
-**Author:** Roman Bednář (Red Hat)
 
 The v1.25 release of Kubernetes introduced an alpha feature to change how a default
 StorageClass was assigned to a PersistentVolumeClaim (PVC). With the feature enabled,

--- a/content/en/blog/_posts/2023-01-06-unhealthy-pod-eviction-policy-for-pdb.md
+++ b/content/en/blog/_posts/2023-01-06-unhealthy-pod-eviction-policy-for-pdb.md
@@ -3,10 +3,11 @@ layout: blog
 title: "Kubernetes 1.26: Eviction policy for unhealthy pods guarded by PodDisruptionBudgets"
 date: 2023-01-06
 slug: "unhealthy-pod-eviction-policy-for-pdbs"
+author: >
+  Filip Křepinský (Red Hat),
+  Morten Torkildsen (Google),
+  Ravi Gudimetla (Apple)
 ---
-
-**Authors:** Filip Křepinský (Red Hat), Morten Torkildsen (Google), Ravi Gudimetla (Apple)
-
 
 Ensuring the disruptions to your applications do not affect its availability isn't a simple
 task. Last month's release of Kubernetes v1.26 lets you specify an  _unhealthy pod eviction policy_

--- a/content/en/blog/_posts/2023-01-12-protect-mission-critical-pods-priorityclass/index.md
+++ b/content/en/blog/_posts/2023-01-12-protect-mission-critical-pods-priorityclass/index.md
@@ -4,9 +4,9 @@ title: "Protect Your Mission-Critical Pods From Eviction With PriorityClass"
 date: 2023-01-12
 slug: protect-mission-critical-pods-priorityclass
 description: "Pod priority and preemption help to make sure that mission-critical pods are up in the event of a resource crunch by deciding order of scheduling and eviction."
+author: >
+  Sunny Bhambhani (InfraCloud Technologies)
 ---
-
-**Author:** Sunny Bhambhani (InfraCloud Technologies)
 
 Kubernetes has been widely adopted, and many organizations use it as their de-facto
 orchestration engine for running workloads that need to be created and deleted frequently.

--- a/content/en/blog/_posts/2023-01-20-Security-Behavior-Analysis/index.md
+++ b/content/en/blog/_posts/2023-01-20-Security-Behavior-Analysis/index.md
@@ -3,10 +3,9 @@ layout: blog
 title: Consider All Microservices Vulnerable — And Monitor Their Behavior
 date: 2023-01-20
 slug: security-behavior-analysis
+author: >
+  David Hadas (IBM Research Labs)
 ---
-
-**Author:**
-David Hadas (IBM Research Labs)
 
 _This post warns Devops from a false sense of security. Following security
 best practices when developing and configuring microservices do not result

--- a/content/en/blog/_posts/2023-02-03-sig-instrumentation-spotlight.md
+++ b/content/en/blog/_posts/2023-02-03-sig-instrumentation-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Instrumentation"
 slug: sig-instrumentation-spotlight-2023
 date: 2023-02-03
 canonicalUrl: https://www.kubernetes.dev/blog/2023/02/03/sig-instrumentation-spotlight-2023/
+author: >
+  Imran Noor Mohamed (Delivery Hero)
 ---
-
-**Author:** Imran Noor Mohamed (Delivery Hero)
 
 Observability requires the right data at the right time for the right consumer
 (human or piece of software) to make the right decision. In the context of Kubernetes,

--- a/content/en/blog/_posts/2023-02-06-k8s-gcr-io-freeze-announcement.md
+++ b/content/en/blog/_posts/2023-02-06-k8s-gcr-io-freeze-announcement.md
@@ -3,9 +3,9 @@ layout: blog
 title: "k8s.gcr.io Image Registry Will Be Frozen From the 3rd of April 2023"
 date: 2023-02-06
 slug: k8s-gcr-io-freeze-announcement
+author: >
+   Mahamed Ali (Rackspace Technology)
 ---
-
-**Authors**: Mahamed Ali (Rackspace Technology)
 
 The Kubernetes project runs a community-owned image registry called `registry.k8s.io`
 to host its container images. On the 3rd of April 2023, the old registry `k8s.gcr.io`

--- a/content/en/blog/_posts/2023-03-01-introducing-kwok/index.md
+++ b/content/en/blog/_posts/2023-03-01-introducing-kwok/index.md
@@ -4,9 +4,11 @@ title: "Introducing KWOK: Kubernetes WithOut Kubelet"
 date: 2023-03-01
 slug: introducing-kwok
 canonicalUrl: https://kubernetes.dev/blog/2023/03/01/introducing-kwok/
+author: >
+  Shiming Zhang (DaoCloud),
+  Wei Huang (Apple),
+  Yibo Zhuang (Apple)
 ---
-
-**Author:** Shiming Zhang (DaoCloud), Wei Huang (Apple), Yibo Zhuang (Apple)
 
 <img style="float: right; display: inline-block; margin-left: 2em; max-width: 15em;" src="/blog/2023/03/01/introducing-kwok/kwok.svg" alt="KWOK logo" />
 

--- a/content/en/blog/_posts/2023-03-10-forensic-container-analysis/index.md
+++ b/content/en/blog/_posts/2023-03-10-forensic-container-analysis/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Forensic container analysis"
 date: 2023-03-10
 slug: forensic-container-analysis
+author: >
+  Adrian Reber (Red Hat)
 ---
-
-**Authors:** Adrian Reber (Red Hat)
 
 In my previous article, [Forensic container checkpointing in
 Kubernetes][forensic-blog], I introduced checkpointing in Kubernetes

--- a/content/en/blog/_posts/2023-03-10-image-registry-change.md
+++ b/content/en/blog/_posts/2023-03-10-image-registry-change.md
@@ -3,13 +3,19 @@ layout: blog
 title: "k8s.gcr.io Redirect to registry.k8s.io - What You Need to Know"
 date: 2023-03-10T17:00:00.000Z
 slug: image-registry-redirect
+author: >
+   Bob Killen (Google),
+   Davanum Srinivas (AWS),
+   Chris Short (AWS),
+   Frederico Muñoz (SAS Institute),
+   Tim Bannister (The Scale Factory),
+   Ricky Sadowski (AWS),
+   Grace Nguyen (Expo),
+   Mahamed Ali (Rackspace Technology),
+   Mars Toktonaliev (independent),
+   Laura Santamaria (Dell),
+   Kat Cosgrove (Dell)
 ---
-
-**Authors**: Bob Killen (Google), Davanum Srinivas (AWS), Chris Short (AWS), Frederico Muñoz (SAS
-Institute), Tim Bannister (The Scale Factory), Ricky Sadowski (AWS), Grace Nguyen (Expo), Mahamed
-Ali (Rackspace Technology), Mars Toktonaliev (independent), Laura Santamaria (Dell), Kat Cosgrove
-(Dell)
-
 
 On Monday, March 20th, the k8s.gcr.io registry [will be redirected to the community owned
 registry](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/),

--- a/content/en/blog/_posts/2023-03-17-kubernetes-1.27-deprecations-and-removals.md
+++ b/content/en/blog/_posts/2023-03-17-kubernetes-1.27-deprecations-and-removals.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes Removals and Major Changes In v1.27"
 date: 2023-03-17T14:00:00+0000
 slug: upcoming-changes-in-kubernetes-v1-27
+author: >
+   Harshita Sao
 ---
-
-**Author**: Harshita Sao
 
 As Kubernetes develops and matures, features may be deprecated, removed, or replaced
 with better ones for the project's overall health. Based on the information available

--- a/content/en/blog/_posts/2023-03-30-kubescape-validating-admission-policy-library.md
+++ b/content/en/blog/_posts/2023-03-30-kubescape-validating-admission-policy-library.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes Validating Admission Policies: A Practical Example"
 date: 2023-03-30T00:00:00+0000
 slug: kubescape-validating-admission-policy-library
+author: >
+   Craig Box (ARMO),
+   Ben Hirschberg (ARMO)
 ---
-
-**Authors**: Craig Box (ARMO), Ben Hirschberg (ARMO)
 
 Admission control is an important part of the Kubernetes control plane, with several internal
 features depending on the ability to approve or change an API object as it is submitted to the

--- a/content/en/blog/_posts/2023-04-06-keeping-kubernetes-secure-with-updated-go-versions.md
+++ b/content/en/blog/_posts/2023-04-06-keeping-kubernetes-secure-with-updated-go-versions.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Keeping Kubernetes Secure with Updated Go Versions"
 date: 2023-04-06
 slug: keeping-kubernetes-secure-with-updated-go-versions
+author: >
+   [Jordan Liggitt](https://github.com/liggitt) (Google)
 ---
-
-**Author**: [Jordan Liggitt](https://github.com/liggitt) (Google)
 
 ### The problem
 

--- a/content/en/blog/_posts/2023-04-11-kubernetes-1.27-blog.md
+++ b/content/en/blog/_posts/2023-04-11-kubernetes-1.27-blog.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.27: Chill Vibes"
 date: 2023-04-11
 slug: kubernetes-v1-27-release
+author: >
+   [Kubernetes v1.27 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.27/release-team.md)
 ---
-
-**Authors**: [Kubernetes v1.27 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.27/release-team.md)
 
 Announcing the release of Kubernetes v1.27, the first release of 2023!
 

--- a/content/en/blog/_posts/2023-04-17-topology-spread-features.md
+++ b/content/en/blog/_posts/2023-04-17-topology-spread-features.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes 1.27: More fine-grained pod topology spread policies reached beta"
 date: 2023-04-17
 slug: fine-grained-pod-topology-spread-features-beta
+author: >
+   [Alex Wang](https://github.com/denkensk) (Shopee),
+   [Kante Yin](https://github.com/kerthcet) (DaoCloud),
+   [Kensei Nakada](https://github.com/sanposhiho) (Mercari)
 ---
-
-**Authors:** [Alex Wang](https://github.com/denkensk) (Shopee), [Kante Yin](https://github.com/kerthcet) (DaoCloud), [Kensei Nakada](https://github.com/sanposhiho) (Mercari)
 
 In Kubernetes v1.19, [Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 went to general availability (GA).

--- a/content/en/blog/_posts/2023-04-18-efficient-selinux-relabeling-beta.md
+++ b/content/en/blog/_posts/2023-04-18-efficient-selinux-relabeling-beta.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: Efficient SELinux volume relabeling (Beta)"
 date: 2023-04-18T10:00:00-08:00
 slug: kubernetes-1-27-efficient-selinux-relabeling-beta
+author: >
+   Jan Šafránek (Red Hat)
 ---
-
-**Author:** Jan Šafránek (Red Hat)
 
 ## The problem
 

--- a/content/en/blog/_posts/2023-04-20-read-write-once-pod-access-mode-beta.md
+++ b/content/en/blog/_posts/2023-04-20-read-write-once-pod-access-mode-beta.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: Single Pod Access Mode for PersistentVolumes Graduates to Beta"
 date: 2023-04-20
 slug: read-write-once-pod-access-mode-beta
+author: >
+   Chris Henzie (Google)
 ---
-
-**Author:** Chris Henzie (Google)
 
 With the release of Kubernetes v1.27 the ReadWriteOncePod feature has graduated
 to beta. In this blog post, we'll take a closer look at this feature, what it

--- a/content/en/blog/_posts/2023-04-21-node-log-query-alpha.md
+++ b/content/en/blog/_posts/2023-04-21-node-log-query-alpha.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: Query Node Logs Using The Kubelet API"
 date: 2023-04-21
 slug: node-log-query-alpha
+author: >
+   Aravindh Puthiyaparambil (Red Hat)
 ---
-
-**Author:** Aravindh Puthiyaparambil (Red Hat)
 
 Kubernetes 1.27 introduced a new feature called _Node log query_ that allows
 viewing logs of services running on the node.

--- a/content/en/blog/_posts/2023-04-24-openapi-v3-field-validation-ga.md
+++ b/content/en/blog/_posts/2023-04-24-openapi-v3-field-validation-ga.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.27: Server Side Field Validation and OpenAPI V3 move to GA"
 date: 2023-04-24
 slug: openapi-v3-field-validation-ga
+author: >
+   Jeffrey Ying (Google),
+   Antoine Pelisse (Google)
 ---
-
-**Author**: Jeffrey Ying (Google), Antoine Pelisse (Google)
 
 Before Kubernetes v1.8 (!), typos, mis-indentations or minor errors in
 YAMLs could have catastrophic consequences (e.g. a typo like

--- a/content/en/blog/_posts/2023-04-25-Updates-to-the-Auto-refreshing-Official-CVE-Feed/index.md
+++ b/content/en/blog/_posts/2023-04-25-Updates-to-the-Auto-refreshing-Official-CVE-Feed/index.md
@@ -3,9 +3,11 @@ layout: blog
 title: Updates to the Auto-refreshing Official CVE Feed
 date: 2023-04-25
 slug: k8s-cve-feed-beta
+author: >
+  Cailyn Edwards (Shopify),
+  Mahé Tardy (Isovalent),
+  Pushkar Joglekar
 ---
-
-**Authors**: Cailyn Edwards (Shopify), Mahé Tardy (Isovalent), Pushkar Joglekar
 
 Since launching the [Auto-refreshing Official CVE feed](/docs/reference/issues-security/official-cve-feed/) as an alpha
 feature in the 1.25 release, we have made significant improvements and updates. We are excited to announce the release of the

--- a/content/en/blog/_posts/2023-04-28-statefulset-migration.md
+++ b/content/en/blog/_posts/2023-04-28-statefulset-migration.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: StatefulSet Start Ordinal Simplifies Migration"
 date: 2023-04-28
 slug: statefulset-start-ordinal
+author: >
+   Peter Schuurman (Google)
 ---
-
-**Author**: Peter Schuurman (Google)
 
 Kubernetes v1.26 introduced a new, alpha-level feature for
 [StatefulSets](/docs/concepts/workloads/controllers/statefulset/) that controls

--- a/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
+++ b/content/en/blog/_posts/2023-05-02-hpa-container-resource-metric.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: HorizontalPodAutoscaler ContainerResource type metric moves to beta"
 date: 2023-05-02T12:00:00+0800
 slug: hpa-container-resource-metric
+author: >
+   [Kensei Nakada](https://github.com/sanposhiho) (Mercari)
 ---
-
-**Author:** [Kensei Nakada](https://github.com/sanposhiho) (Mercari)
 
 Kubernetes 1.20 introduced the [`ContainerResource` type metric](/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics)
 in HorizontalPodAutoscaler (HPA).

--- a/content/en/blog/_posts/2023-05-04-statefulset-autodelete.md
+++ b/content/en/blog/_posts/2023-05-04-statefulset-autodelete.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.27: StatefulSet PVC Auto-Deletion (beta)'
 date: 2023-05-04
 slug: kubernetes-1-27-statefulset-pvc-auto-deletion-beta
+author: >
+   Matthew Cary (Google)
 ---
-
-**Author:** Matthew Cary (Google)
 
 Kubernetes v1.27 graduated to beta a new policy mechanism for
 [`StatefulSets`](/docs/concepts/workloads/controllers/statefulset/) that controls the lifetime of

--- a/content/en/blog/_posts/2023-05-05-memory-qos-cgroups-v2/index.md
+++ b/content/en/blog/_posts/2023-05-05-memory-qos-cgroups-v2/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.27: Quality-of-Service for Memory Resources (alpha)'
 date: 2023-05-05
 slug: qos-memory-resources
+author: >
+  Dixita Narang (Google)
 ---
-
-**Authors:** Dixita Narang (Google)
 
 Kubernetes v1.27, released in April 2023, introduced changes to
 Memory QoS (alpha) to improve memory management capabilites in Linux nodes.  

--- a/content/en/blog/_posts/2023-05-08-volume-group-snapshot-alpha.md
+++ b/content/en/blog/_posts/2023-05-08-volume-group-snapshot-alpha.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: Introducing An API For Volume Group Snapshots"
 date: 2023-05-08
 slug: kubernetes-1-27-volume-group-snapshot-alpha
+author: >
+   Xing Yang (VMware)
 ---
-
-**Author:** Xing Yang (VMware)
 
 Volume group snapshot is introduced as an Alpha feature in Kubernetes v1.27.
 This feature introduces a Kubernetes API that allows users to take crash consistent

--- a/content/en/blog/_posts/2023-05-09-Safer-More-Performant-Pruning-in-kubectl-apply.md
+++ b/content/en/blog/_posts/2023-05-09-Safer-More-Performant-Pruning-in-kubectl-apply.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.27: Safer, More Performant Pruning in kubectl apply"
 date: 2023-05-09
 slug: introducing-kubectl-applyset-pruning
+author: >
+   Katrina Verey (independent),
+   Justin Santa Barbara (Google)
 ---
-
-**Authors:** Katrina Verey (independent) and Justin Santa Barbara (Google)
 
 Declarative configuration management with the `kubectl apply` command is the gold standard approach
 to creating or modifying Kubernetes resources. However, one challenge it presents is the deletion

--- a/content/en/blog/_posts/2023-05-11-nodeport-dynamic-and-static-allocation.md
+++ b/content/en/blog/_posts/2023-05-11-nodeport-dynamic-and-static-allocation.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: Avoid Collisions Assigning Ports to NodePort Services"
 date: 2023-05-11
 slug: nodeport-dynamic-and-static-allocation
+author: >
+   Xu Zhenglun (Alibaba)
 ---
-
-**Author:** Xu Zhenglun (Alibaba)
 
 In Kubernetes, a Service can be used to provide a unified traffic endpoint for 
 applications running on a set of Pods. Clients can use the virtual IP address (or _VIP_) provided

--- a/content/en/blog/_posts/2023-05-12-in-place-pod-resize/index.md
+++ b/content/en/blog/_posts/2023-05-12-in-place-pod-resize/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.27: In-place Resource Resize for Kubernetes Pods (alpha)"
 date: 2023-05-12
 slug: in-place-pod-resize-alpha
+author: >
+  Vinay Kulkarni (Kubescaler Labs)
 ---
-
-**Author:** Vinay Kulkarni (Kubescaler Labs)
 
 If you have deployed Kubernetes pods with CPU and/or memory resources
 specified, you may have noticed that changing the resource values involves

--- a/content/en/blog/_posts/2023-05-15-kubernetes-1-27-updates-on-speeding-up-pod-startup.md
+++ b/content/en/blog/_posts/2023-05-15-kubernetes-1-27-updates-on-speeding-up-pod-startup.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes 1.27: updates on speeding up Pod startup"
 date: 2023-05-15T00:00:00+0000
 slug: speed-up-pod-startup
+author: >
+   Paco Xu (DaoCloud),
+   Sergey Kanzhelev (Google),
+   Ruiwen Zhao (Google)
 ---
-
-**Authors**: Paco Xu (DaoCloud), Sergey Kanzhelev (Google), Ruiwen Zhao (Google)
 
 How can Pod start-up be accelerated on nodes in large clusters? This is a common issue that
 cluster administrators may face.

--- a/content/en/blog/_posts/2023-05-16-kmsv2-beta.md
+++ b/content/en/blog/_posts/2023-05-16-kmsv2-beta.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes 1.27: KMS V2 Moves to Beta"
 date: 2023-05-16
 slug: kms-v2-moves-to-beta
+author: >
+  Anish Ramasekar,
+  Mo Khan,
+  Rita Zhang (Microsoft)
 ---
-
-**Authors:** Anish Ramasekar, Mo Khan, and Rita Zhang (Microsoft)
 
 With Kubernetes 1.27, we (SIG Auth) are moving Key Management Service (KMS) v2 API to beta.
 

--- a/content/en/blog/_posts/2023-05-18-seccomp-profiles-edge.md
+++ b/content/en/blog/_posts/2023-05-18-seccomp-profiles-edge.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Having fun with seccomp profiles on the edge"
 date: 2023-05-18
 slug: seccomp-profiles-edge
+author: >
+  Sascha Grunert
 ---
-
-**Author**: Sascha Grunert
 
 The [Security Profiles Operator (SPO)][spo] is a feature-rich
 [operator][operator] for Kubernetes to make managing seccomp, SELinux and

--- a/content/en/blog/_posts/2023-05-24-oci-security-profiles.md
+++ b/content/en/blog/_posts/2023-05-24-oci-security-profiles.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Using OCI artifacts to distribute security profiles for seccomp, SELinux and AppArmor"
 date: 2023-05-24
 slug: oci-security-profiles
+author: >
+  Sascha Grunert
 ---
-
-**Author**: Sascha Grunert
 
 The [Security Profiles Operator (SPO)][spo] makes managing seccomp, SELinux and
 AppArmor profiles within Kubernetes easier than ever. It allows cluster

--- a/content/en/blog/_posts/2023-06-09-dl-adopt-cdn.md
+++ b/content/en/blog/_posts/2023-06-09-dl-adopt-cdn.md
@@ -3,10 +3,11 @@ layout: blog
 title: "dl.k8s.io to adopt a Content Delivery Network"
 date: 2023-06-09
 slug: dl-adopt-cdn
+author: >
+  Arnaud Meukam (VMware),
+  Hannah Aubry (Fastly),
+  Frederico Muñoz (SAS Institute)
 ---
-
-**Authors**: Arnaud Meukam (VMware), Hannah Aubry (Fastly), Frederico
-Muñoz (SAS Institute)
 
 We're happy to announce that dl.k8s.io, home of the official Kubernetes
 binaries, will soon be powered by [Fastly](https://www.fastly.com).

--- a/content/en/blog/_posts/2023-06-29-container-image-signature-verification/index.md
+++ b/content/en/blog/_posts/2023-06-29-container-image-signature-verification/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Verifying Container Image Signatures Within CRI Runtimes"
 date: 2023-06-29
 slug: container-image-signature-verification
+author: >
+  Sascha Grunert
 ---
-
-**Author**: Sascha Grunert
 
 The Kubernetes community has been signing their container image-based artifacts
 since release v1.24. While the graduation of the [corresponding enhancement][kep]

--- a/content/en/blog/_posts/2023-07-06-confidential-kubernetes.md
+++ b/content/en/blog/_posts/2023-07-06-confidential-kubernetes.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Confidential Kubernetes: Use Confidential Virtual Machines and Enclaves to improve your cluster security"
 date: 2023-07-06
 slug: "confidential-kubernetes"
+author: >
+  Fabian Kammel (Edgeless Systems),
+  Mikko Ylinen (Intel),
+  Tobin Feldman-Fitzthum (IBM)
 ---
-
-**Authors:** Fabian Kammel (Edgeless Systems), Mikko Ylinen (Intel), Tobin Feldman-Fitzthum (IBM)
 
 In this blog post, we will introduce the concept of Confidential Computing (CC) to improve any computing environment's security and privacy properties. Further, we will show how
 the Cloud-Native ecosystem, particularly Kubernetes, can benefit from the new compute paradigm.

--- a/content/en/blog/_posts/2023-07-20-sig-cli-spotlight.md
+++ b/content/en/blog/_posts/2023-07-20-sig-cli-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG CLI"
 date: 2023-07-20
 slug: sig-cli-spotlight-2023
 canonicalUrl: https://www.kubernetes.dev/blog/2023/07/20/sig-cli-spotlight-2023/
+author: >
+  Arpit Agrawal
 ---
-
-**Author**: Arpit Agrawal
 
 In the world of Kubernetes, managing containerized applications at
 scale requires powerful and efficient tools. The command-line

--- a/content/en/blog/_posts/2023-08-14-sig-contribex-spotlight.md
+++ b/content/en/blog/_posts/2023-08-14-sig-contribex-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG ContribEx"
 date: 2023-08-14
 slug: sig-contribex-spotlight-2023
 canonicalUrl: https://www.kubernetes.dev/blog/2023/08/14/sig-contribex-spotlight-2023/
+author: >
+  Fyka Ansari
 ---
-
-**Author**: Fyka Ansari
 
 Welcome to the world of Kubernetes and its vibrant contributor
 community! In this blog post, we'll be shining a spotlight on the

--- a/content/en/blog/_posts/2023-08-15-kubernetes-1.28-blog.md
+++ b/content/en/blog/_posts/2023-08-15-kubernetes-1.28-blog.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.28: Planternetes"
 date: 2023-08-15T12:00:00+0000
 slug: kubernetes-v1-28-release
+author: >
+  [Kubernetes v1.28 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/release-team.md)
 ---
-
-**Authors**: [Kubernetes v1.28 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/release-team.md)
 
 Announcing the release of Kubernetes v1.28 Planternetes, the second release of 2023!
 

--- a/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
+++ b/content/en/blog/_posts/2023-08-15-pkgs-k8s-io-introduction.md
@@ -3,9 +3,9 @@ layout: blog
 title: "pkgs.k8s.io: Introducing Kubernetes Community-Owned Package Repositories"
 date: 2023-08-15T20:00:00+0000
 slug: pkgs-k8s-io-introduction
+author: >
+  Marko Mudrinić (Kubermatic)
 ---
-
-**Author**: Marko Mudrinić (Kubermatic)
 
 On behalf of Kubernetes SIG Release, I am very excited to introduce the
 Kubernetes community-owned software

--- a/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
+++ b/content/en/blog/_posts/2023-08-16-non-graceful-node-shutdown-to-ga.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.28: Non-Graceful Node Shutdown Moves to GA"
 date: 2023-08-16T10:00:00-08:00
 slug: kubernetes-1-28-non-graceful-node-shutdown-GA
+author: >
+  Xing Yang (VMware),
+  Ashutosh Kumar (Elastic)
 ---
-
-**Authors:** Xing Yang (VMware) and Ashutosh Kumar (Elastic)
 
 The Kubernetes Non-Graceful Node Shutdown feature is now GA in Kubernetes v1.28.
 It was introduced as

--- a/content/en/blog/_posts/2023-08-18-retroactive-default-storage-class-ga.md
+++ b/content/en/blog/_posts/2023-08-18-retroactive-default-storage-class-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.28: Retroactive Default StorageClass move to GA"
 date: 2023-08-18
 slug: retroactive-default-storage-class-ga
+author: >
+  Roman Bednář (Red Hat)
 ---
-
-**Author:** Roman Bednář (Red Hat)
 
 Announcing graduation to General Availability (GA) - Retroactive Default StorageClass Assignment in Kubernetes v1.28!
 

--- a/content/en/blog/_posts/2023-08-21-job-update-post.md
+++ b/content/en/blog/_posts/2023-08-21-job-update-post.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.28: Improved failure handling for Jobs"
 date: 2023-08-21
 slug: kubernetes-1-28-jobapi-update
+author: >
+  Kevin Hannon (G-Research),
+  Michał Woźniak (Google)
 ---
-
-**Authors:** Kevin Hannon (G-Research), Michał Woźniak (Google)
 
 This blog discusses two new features in Kubernetes 1.28 to improve Jobs for batch
 users: [Pod replacement policy](/docs/concepts/workloads/controllers/job/#pod-replacement-policy)

--- a/content/en/blog/_posts/2023-08-23-kubelet-podresources-api-ga.md
+++ b/content/en/blog/_posts/2023-08-23-kubelet-podresources-api-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.28: Node podresources API Graduates to GA'
 date: 2023-08-23
 slug: kubelet-podresources-api-GA
+author: >
+  Francesco Romani (Red Hat)
 ---
-
-**Author:** Francesco Romani (Red Hat)
 
 The podresources API is an API served by the kubelet locally on the node, which exposes the compute resources exclusively
 allocated to containers. With the release of Kubernetes 1.28, that API is now Generally Available.

--- a/content/en/blog/_posts/2023-08-24-swap-beta1-graduation.md
+++ b/content/en/blog/_posts/2023-08-24-swap-beta1-graduation.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.28: Beta support for using swap on Linux"
 date: 2023-08-24T10:00:00-08:00
 slug: swap-linux-beta
+author: >
+ Itamar Holder (Red Hat)
 ---
-
-**Author:** Itamar Holder (Red Hat)
 
 The 1.22 release [introduced Alpha support](/blog/2021/08/09/run-nodes-with-swap-alpha/)
 for configuring swap memory usage for Kubernetes workloads running on Linux on a per-node basis.

--- a/content/en/blog/_posts/2023-08-25-sidecar-kep.md
+++ b/content/en/blog/_posts/2023-08-25-sidecar-kep.md
@@ -3,9 +3,13 @@ layout: blog
 title: "Kubernetes v1.28: Introducing native sidecar containers"
 date: 2023-08-25
 slug: native-sidecar-containers
+author: >
+  Todd Neal (AWS),
+  Matthias Bertschy (ARMO),
+  Sergey Kanzhelev (Google),
+  Gunju Kim (NAVER),
+  Shannon Kularathna (Google)
 ---
-
-***Authors:*** Todd Neal (AWS), Matthias Bertschy (ARMO), Sergey Kanzhelev (Google), Gunju Kim (NAVER), Shannon Kularathna (Google)
 
 This post explains how to use the new sidecar feature, which enables restartable init containers and is available in alpha in Kubernetes 1.28. We want your feedback so that we can graduate this feature as soon as possible.
 

--- a/content/en/blog/_posts/2023-08-28-a-new-alpha-mechanism-for-safer-cluster-upgrades.md
+++ b/content/en/blog/_posts/2023-08-28-a-new-alpha-mechanism-for-safer-cluster-upgrades.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.28: A New (alpha) Mechanism For Safer Cluster Upgrades"
 date: 2023-08-28
 slug: kubernetes-1-28-feature-mixed-version-proxy-alpha
+author: >
+  Richa Banker (Google)
 ---
-
-**Author:** Richa Banker (Google)
 
 This blog describes the _mixed version proxy_, a new alpha feature in Kubernetes 1.28. The
 mixed version proxy enables an HTTP request for a resource to be served by the correct API server

--- a/content/en/blog/_posts/2023-08-29-Gateway-API-v080.md
+++ b/content/en/blog/_posts/2023-08-29-Gateway-API-v080.md
@@ -3,9 +3,14 @@ layout: blog
 title: "Gateway API v0.8.0: Introducing Service Mesh Support"
 date: 2023-08-29T10:00:00-08:00
 slug: gateway-api-v0-8
+author: >
+  Flynn (Buoyant),
+  John Howard (Google),
+  Keith Mattix (Microsoft),
+  Michael Beaumont (Kong),
+  Mike Morris (independent),
+  Rob Scott (Google)
 ---
-
-***Authors:*** Flynn (Buoyant), John Howard (Google), Keith Mattix (Microsoft), Michael Beaumont (Kong), Mike Morris (independent), Rob Scott (Google)
 
 We are thrilled to announce the v0.8.0 release of Gateway API! With this
 release, Gateway API support for service mesh has reached [Experimental

--- a/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
+++ b/content/en/blog/_posts/2023-08-31-legacy-package-repository-deprecation/index.md
@@ -4,9 +4,13 @@ title: "Kubernetes Legacy Package Repositories Will Be Frozen On September 13, 2
 date: 2023-08-31T15:30:00-07:00
 slug: legacy-package-repository-deprecation
 evergreen: true
+author: >
+  Bob Killen (Google),
+  Chris Short (AWS),
+  Jeremy Rickard (Microsoft),
+  Marko Mudrinić (Kubermatic),
+  Tim Bannister (The Scale Factory)
 ---
-
-**Authors**: Bob Killen (Google), Chris Short (AWS), Jeremy Rickard (Microsoft), Marko Mudrinić (Kubermatic), Tim Bannister (The Scale Factory)
 
 On August 15, 2023, the Kubernetes project announced the general availability of
 the community-owned package repositories for Debian and RPM packages available

--- a/content/en/blog/_posts/2023-09-12-comparing-local-kubernetes-development-tools.md
+++ b/content/en/blog/_posts/2023-09-12-comparing-local-kubernetes-development-tools.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Comparing Local Kubernetes Development Tools: Telepresence, Gefyra, and mirrord'
 date: 2023-09-12
 slug: local-k8s-development-tools
+author: >
+  Eyal Bukchin (MetalBear)
 ---
-
-**Author:** Eyal Bukchin (MetalBear)
 
 The Kubernetes development cycle is an evolving landscape with a myriad of tools seeking to streamline the process. Each tool has its unique approach, and the choice often comes down to individual project requirements, the team's expertise, and the preferred workflow.
 

--- a/content/en/blog/_posts/2023-09-13-userns-stateful-pods/index.md
+++ b/content/en/blog/_posts/2023-09-13-userns-stateful-pods/index.md
@@ -3,9 +3,11 @@ layout: blog
 title: "User Namespaces: Now Supports Running Stateful Pods in Alpha!"
 date: 2023-09-13
 slug: userns-alpha
+author: >
+  Rodrigo Campos Catelin (Microsoft),
+  Giuseppe Scrivano (Red Hat),
+  Sascha Grunert (Red Hat)
 ---
-
-**Authors:** Rodrigo Campos Catelin (Microsoft), Giuseppe Scrivano (Red Hat), Sascha Grunert (Red Hat)
 
 Kubernetes v1.25 introduced support for user namespaces for only stateless
 pods. Kubernetes 1.28 lifted that restriction, after some design changes were

--- a/content/en/blog/_posts/2023-09-25-kubeadm-use-etcd-learner-mode.md
+++ b/content/en/blog/_posts/2023-09-25-kubeadm-use-etcd-learner-mode.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'kubeadm: Use etcd Learner to Join a Control Plane Node Safely'
 date: 2023-09-25
 slug: kubeadm-use-etcd-learner-mode
+author: >
+  Paco Xu (DaoCloud)
 ---
-
-**Author:** Paco Xu (DaoCloud)
 
 The [`kubeadm`](/docs/reference/setup-tools/kubeadm/) tool now supports etcd learner mode, which
 allows you to enhance the resilience and stability

--- a/content/en/blog/_posts/2023-09-26-happy-7th-birthday-kubeadm.md
+++ b/content/en/blog/_posts/2023-09-26-happy-7th-birthday-kubeadm.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Happy 7th Birthday kubeadm!'
 date: 2023-09-26
 slug: happy-7th-birthday-kubeadm
+author: >
+  Fabrizio Pandini (VMware)
 ---
-
-**Author:** Fabrizio Pandini (VMware)
 
 What a journey so far!
 

--- a/content/en/blog/_posts/2023-10-02-steering-committee-results-2023.md
+++ b/content/en/blog/_posts/2023-10-02-steering-committee-results-2023.md
@@ -4,9 +4,9 @@ title: "Announcing the 2023 Steering Committee Election Results"
 date: 2023-10-02
 slug: steering-committee-results-2023
 canonicalUrl: https://www.kubernetes.dev/blog/2023/10/02/steering-committee-results-2023/
+author: >
+  Kaslin Fields
 ---
-
-**Author**: Kaslin Fields
 
 The [2023 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2023) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2023. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 

--- a/content/en/blog/_posts/2023-10-05-sig-architecture-conformance-spotlight.md
+++ b/content/en/blog/_posts/2023-10-05-sig-architecture-conformance-spotlight.md
@@ -4,10 +4,9 @@ title: "Spotlight on SIG Architecture: Conformance"
 slug: sig-architecture-conformance-spotlight-2023
 date: 2023-10-05
 canonicalUrl: https://www.k8s.dev/blog/2023/10/05/sig-architecture-conformance-spotlight-2023/
+author: >
+  Frederico Muñoz (SAS Institute)
 ---
-
-
-**Author**: Frederico Muñoz (SAS Institute)
 
 _This is the first interview of a SIG Architecture Spotlight series
 that will cover the different subprojects. We start with the SIG

--- a/content/en/blog/_posts/2023-10-10-cri-o-community-package-infrastructure.md
+++ b/content/en/blog/_posts/2023-10-10-cri-o-community-package-infrastructure.md
@@ -3,9 +3,9 @@ layout: blog
 title: "CRI-O is moving towards pkgs.k8s.io"
 date: 2023-10-10
 slug: cri-o-community-package-infrastructure
+author: >
+  Sascha Grunert
 ---
-
-**Author:** Sascha Grunert
 
 The Kubernetes community [recently announced](/blog/2023/08/31/legacy-package-repository-deprecation/)
 that their legacy package repositories are frozen, and now they moved to

--- a/content/en/blog/_posts/2023-10-12-bootstrap-an-air-gapped-cluster-with-kubeadm/index.md
+++ b/content/en/blog/_posts/2023-10-12-bootstrap-an-air-gapped-cluster-with-kubeadm/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Bootstrap an Air Gapped Cluster With Kubeadm"
 date: 2023-10-12
 slug: bootstrap-an-air-gapped-cluster-with-kubeadm
+author: >
+  Rob Mengert (Defense Unicorns)
 ---
-
-**Author:** Rob Mengert (Defense Unicorns)
 
 Ever wonder how software gets deployed onto a system that is deliberately disconnected from the Internet and other networks? These systems are typically disconnected due to their sensitive nature. Sensitive as in utilities (power/water), banking, healthcare, weapons systems, other government use cases, etc. Sometimes it's technically a water gap, if you're running Kubernetes on an underwater vessel. Still, these environments need software to operate. This concept of deployment in a disconnected state is what it means to deploy to the other side of an [air gap](https://en.wikipedia.org/wiki/Air_gap_(networking)).
 

--- a/content/en/blog/_posts/2023-10-20-kcs-shanghai/index.md
+++ b/content/en/blog/_posts/2023-10-20-kcs-shanghai/index.md
@@ -4,9 +4,10 @@ title: "A Quick Recap of 2023 China Kubernetes Contributor Summit"
 slug: kcs-shanghai
 date: 2023-10-20
 canonicalUrl: https://www.kubernetes.dev/blog/2023/10/20/kcs-shanghai/
+author: >
+  Paco Xu (DaoCloud),
+  Michael Yao (DaoCloud)
 ---
-
-**Author:** Paco Xu and Michael Yao (DaoCloud)
 
 On September 26, 2023, the first day of
 [KubeCon + CloudNativeCon + Open Source Summit China 2023](https://www.lfasiallc.com/kubecon-cloudnativecon-open-source-summit-china/),

--- a/content/en/blog/_posts/2023-10-23-pv-last-phase-transtition-time.md
+++ b/content/en/blog/_posts/2023-10-23-pv-last-phase-transtition-time.md
@@ -3,9 +3,9 @@ layout: blog
 title: PersistentVolume Last Phase Transition Time in Kubernetes
 date: 2023-10-23
 slug: persistent-volume-last-phase-transition-time
+author: >
+  Roman Bednář (Red Hat)
 ---
-
-**Author:** Roman Bednář (Red Hat)
 
 In the recent Kubernetes v1.28 release, we (SIG Storage) introduced a new alpha feature that aims to improve PersistentVolume (PV)
 storage management and help cluster administrators gain better insights into the lifecycle of PVs.

--- a/content/en/blog/_posts/2023-10-24-kubernetes-1.28-release-interview.md
+++ b/content/en/blog/_posts/2023-10-24-kubernetes-1.28-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Plants, process and parties: the Kubernetes 1.28 release interview"
 date: 2023-10-24
+author: >
+  Craig Box
 ---
-
-**Author**: Craig Box
 
 Since 2018, one of my favourite contributions to the Kubernetes community has been to [share the story of each release](https://www.google.com/search?q=%22release+interview%22+site%3Akubernetes.io%2Fblog). Many of these stories were told on behalf of a past employer; by popular demand, I've brought them back, now under my own name. If you were a fan of the old show, I would be delighted if you would [subscribe](https://craigbox.substack.com/about).
 

--- a/content/en/blog/_posts/2023-10-25-introducing-ingress2gateway/index.md
+++ b/content/en/blog/_posts/2023-10-25-introducing-ingress2gateway/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Introducing ingress2gateway; Simplifying Upgrades to Gateway API"
 date: 2023-10-25T10:00:00-08:00
 slug: introducing-ingress2gateway
+author: >
+  Lior Lieberman (Google),
+  Kobi Levi (independent)
 ---
-
-***Authors:*** Lior Lieberman (Google), Kobi Levi (independent)
 
 Today we are releasing [ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway), a tool
 that can help you migrate from [Ingress](/docs/concepts/services-networking/ingress/) to [Gateway

--- a/content/en/blog/_posts/2023-10-31-Gateway-API-GA/index.md
+++ b/content/en/blog/_posts/2023-10-31-Gateway-API-GA/index.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Gateway API v1.0: GA Release"
 date: 2023-10-31T10:00:00-08:00
 slug: gateway-api-ga
+author: >
+  Shane Utt (Kong),
+  Nick Young (Isovalent),
+  Rob Scott (Google)
 ---
-
-**Authors:** Shane Utt (Kong), Nick Young (Isovalent), Rob Scott (Google)
 
 On behalf of Kubernetes SIG Network, we are pleased to announce the v1.0 release of [Gateway
 API](https://gateway-api.sigs.k8s.io/)! This release marks a huge milestone for

--- a/content/en/blog/_posts/2023-11-02-kcseu2023-spotlight/index.md
+++ b/content/en/blog/_posts/2023-11-02-kcseu2023-spotlight/index.md
@@ -4,9 +4,9 @@ title: "Kubernetes Contributor Summit: Behind-the-scenes"
 slug: k8s-contributor-summit-behind-the-scenes
 date: 2023-11-03
 canonicalUrl:  https://www.k8s.dev/blog/2023/11/03/k8s-contributor-summit-behind-the-scenes/
+author: >
+  Frederico Muñoz (SAS Institute)
 ---
-
-**Author** : Frederico Muñoz (SAS Institute)
 
 Every year, just before the official start of KubeCon+CloudNativeCon, there's a special event that
 has a very special place in the hearts of those organizing and participating in it: the Kubernetes

--- a/content/en/blog/_posts/2023-11-02-sig-architecture-prod-readiness-spotlight.md
+++ b/content/en/blog/_posts/2023-11-02-sig-architecture-prod-readiness-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Architecture: Production Readiness"
 slug: sig-architecture-production-readiness-spotlight-2023
 date: 2023-11-02
 canonicalUrl: https://www.k8s.dev/blog/2023/11/02/sig-architecture-production-readiness-spotlight-2023/
+author: >
+  Frederico Muñoz (SAS Institute)
 ---
-
-**Author**: Frederico Muñoz (SAS Institute)
 
 _This is the second interview of a SIG Architecture Spotlight series that will cover the different
 subprojects. In this blog, we will cover the [SIG Architecture: Production Readiness

--- a/content/en/blog/_posts/2023-11-07-introducing-sig-etcd.md
+++ b/content/en/blog/_posts/2023-11-07-introducing-sig-etcd.md
@@ -4,10 +4,12 @@ title: "Introducing SIG etcd"
 slug: introducing-sig-etcd
 date: 2023-11-07
 canonicalUrl: https://etcd.io/blog/2023/introducing-sig-etcd/
+author: >
+  Han Kang (Google),
+  Marek Siarkowicz (Google),
+  Frederico Muñoz (SAS Institute)
 ---
-
-**Authors**:  Han Kang (Google), Marek Siarkowicz (Google), Frederico Muñoz (SAS Institute)
-
+ 
 Special Interest Groups (SIGs) are a fundamental part of the Kubernetes project, with a substantial share of the community activity happening within them. When the need arises, [new SIGs can be created](https://github.com/kubernetes/community/blob/master/sig-wg-lifecycle.md), and that was precisely what happened recently.
 
 [SIG etcd](https://github.com/kubernetes/community/blob/master/sig-etcd/README.md) is the most recent addition to the list of Kubernetes SIGs. In this article we will get to know it a bit better, understand its origins, scope, and plans.

--- a/content/en/blog/_posts/2023-11-16-mid-cycle-1.29.md
+++ b/content/en/blog/_posts/2023-11-16-mid-cycle-1.29.md
@@ -3,10 +3,13 @@ layout: blog
 title: 'Kubernetes Removals, Deprecations, and Major Changes in Kubernetes 1.29'
 date: 2023-11-16
 slug: kubernetes-1-29-upcoming-changes
+author: >
+  Carol Valencia,
+  Kristin Martin,
+  Abigail McCarthy,
+  James Quigley,
+  Hosam Kamel
 ---
-
-**Authors:** Carol Valencia, Kristin Martin, Abigail McCarthy, James Quigley, Hosam Kamel
-
 
 As with every release, Kubernetes v1.29 will introduce feature deprecations and removals. Our continued ability to produce high-quality releases is a testament to our robust development cycle and healthy community. The following are some of the deprecations and removals coming in the Kubernetes 1.29 release. 
 

--- a/content/en/blog/_posts/2023-11-16-the-case-for-kubernetes-limits/index.md
+++ b/content/en/blog/_posts/2023-11-16-the-case-for-kubernetes-limits/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "The Case for Kubernetes Resource Limits: Predictability vs. Efficiency"
 date: 2023-11-16
 slug: the-case-for-kubernetes-resource-limits
+author: >
+  Milan Plžík (Grafana Labs)
 ---
-
-**Author:** Milan Plžík (Grafana Labs)
 
 There’s been quite a lot of posts suggesting that not using Kubernetes resource limits might be a fairly useful thing (for example, [For the Love of God, Stop Using CPU Limits on Kubernetes](https://home.robusta.dev/blog/stop-using-cpu-limits/) or [Kubernetes: Make your services faster by removing CPU limits](https://erickhun.com/posts/kubernetes-faster-services-no-cpu-limits/) ). The points made there are totally valid – it doesn’t make much sense to pay for compute power that will not be used due to limits, nor to artificially increase latency. This post strives to argue that limits have their legitimate use as well.
 

--- a/content/en/blog/_posts/2023-11-24-sig-testing-spotlight.md
+++ b/content/en/blog/_posts/2023-11-24-sig-testing-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Testing"
 slug: sig-testing-spotlight-2023
 date: 2023-11-24
 canonicalUrl: https://www.kubernetes.dev/blog/2023/11/24/sig-testing-spotlight-2023/
+author: >
+  Sandipan Panda
 ---
-
-**Author:** Sandipan Panda
 
 Welcome to another edition of the _SIG spotlight_ blog series, where we
 highlight the incredible work being done by various Special Interest

--- a/content/en/blog/_posts/2023-11-28-Gateway-API-Future.md
+++ b/content/en/blog/_posts/2023-11-28-Gateway-API-Future.md
@@ -3,9 +3,13 @@ layout: blog
 title: "New Experimental Features in Gateway API v1.0"
 date: 2023-11-28T10:00:00-08:00
 slug: gateway-api-ga
+author: >
+  Candace Holman (Red Hat),
+  Dave Protasowski (VMware),
+  Gaurav K Ghildiyal (Google),
+  John Howard (Google),
+  Simone Rodigari (IBM)
 ---
-
-***Authors:*** Candace Holman (Red Hat), Dave Protasowski (VMware), Gaurav K Ghildiyal (Google), John Howard (Google), Simone Rodigari (IBM)
 
 Recently, the [Gateway API](https://gateway-api.sigs.k8s.io/) [announced its v1.0 GA release](/blog/2023/10/31/gateway-api-ga/), marking a huge milestone for the project.
 

--- a/content/en/blog/_posts/2023-12-13-kubernetes-1.29.md
+++ b/content/en/blog/_posts/2023-12-13-kubernetes-1.29.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes v1.29: Mandala'
 date: 2023-12-13
 slug: kubernetes-v1-29-release
+author: >
+ [Kubernetes v1.29 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release-team.md)
 ---
-
-**Authors:** [Kubernetes v1.29 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release-team.md)
 
 **Editors:** Carol Valencia, Kristin Martin, Abigail McCarthy, James Quigley
 

--- a/content/en/blog/_posts/2023-12-14-disabling-in-tree-cloud-provider-goes-beta.md
+++ b/content/en/blog/_posts/2023-12-14-disabling-in-tree-cloud-provider-goes-beta.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.29: Cloud Provider Integrations Are Now Separate Components"
 date: 2023-12-14T09:30:00-08:00
 slug: cloud-provider-integration-changes
+author: >
+  Michael McCune (Red Hat),
+  Andrew Sy Kim (Google)
 ---
-
-**Authors:** Michael McCune (Red Hat), Andrew Sy Kim (Google)
 
 For Kubernetes v1.29, you need to use additional components to integrate your
 Kubernetes cluster with a cloud infrastructure provider. By default, Kubernetes

--- a/content/en/blog/_posts/2023-12-15-node-expand-secret-moves-ga.md
+++ b/content/en/blog/_posts/2023-12-15-node-expand-secret-moves-ga.md
@@ -3,8 +3,10 @@ layout: blog
 title: "Kubernetes 1.29: CSI Storage Resizing Authenticated and Generally Available in v1.29"
 date: 2023-12-15
 slug: csi-node-expand-secret-support-ga
+author: >
+  Humble Chirammal (Vmware),
+  Louis Koo (deeproute.ai)
 ---
-**Authors:** Humble Chirammal (Vmware), Louis Koo (deeproute.ai)
 
 Kubernetes version v1.29 brings generally available support for authentication
 during CSI (Container Storage Interface) storage resize operations.

--- a/content/en/blog/_posts/2023-12-15-volume-attributes-class/index.md
+++ b/content/en/blog/_posts/2023-12-15-volume-attributes-class/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.29: VolumeAttributesClass for Volume Modification"
 date: 2023-12-15
 slug: kubernetes-1-29-volume-attributes-class
+author: >
+  Sunny Song (Google)
 ---
-
-**Author**: Sunny Song (Google)
 
 The v1.29 release of Kubernetes introduced an alpha feature to support modifying a volume
 by changing the `volumeAttributesClassName` that was specified for a PersistentVolumeClaim (PVC).

--- a/content/en/blog/_posts/2023-12-18-kubernetes-1-29-feature-loadbalancer-ip-mode-alpha.md
+++ b/content/en/blog/_posts/2023-12-18-kubernetes-1-29-feature-loadbalancer-ip-mode-alpha.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.29: New (alpha) Feature, Load Balancer IP Mode for Services"
 date: 2023-12-18
 slug: kubernetes-1-29-feature-loadbalancer-ip-mode-alpha
+author: >
+  [Aohan Yang](https://github.com/RyanAoh)
 ---
-
-**Author:** [Aohan Yang](https://github.com/RyanAoh)
 
 This blog introduces a new alpha feature in Kubernetes 1.29. 
 It provides a configurable approach to define how Service implementations, 

--- a/content/en/blog/_posts/2023-12-18-read-write-once-pod-access-mode-ga.md
+++ b/content/en/blog/_posts/2023-12-18-read-write-once-pod-access-mode-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.29: Single Pod Access Mode for PersistentVolumes Graduates to Stable"
 date: 2023-12-18
 slug: read-write-once-pod-access-mode-ga
+author: >
+  Chris Henzie (Google)
 ---
-
-**Author:** Chris Henzie (Google)
 
 With the release of Kubernetes v1.29, the `ReadWriteOncePod` volume access mode
 has graduated to general availability: it's part of Kubernetes' stable API. In

--- a/content/en/blog/_posts/2023-12-19-PodReadyToStartContainersCondition-in-beta.md
+++ b/content/en/blog/_posts/2023-12-19-PodReadyToStartContainersCondition-in-beta.md
@@ -3,10 +3,10 @@ layout: blog
 title: "Kubernetes 1.29: PodReadyToStartContainers Condition Moves to Beta"
 date: 2023-12-19
 slug: pod-ready-to-start-containers-condition-now-in-beta
+author: >
+  Zefeng Chen (independent),
+  Kevin Hannon (Red Hat)
 ---
-
-**Authors**: Zefeng Chen (independent), Kevin Hannon (Red Hat)
-
 
 With the recent release of Kubernetes 1.29, the `PodReadyToStartContainers`
 [condition](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions) is 

--- a/content/en/blog/_posts/2023-12-19-taint-eviction-controller.md
+++ b/content/en/blog/_posts/2023-12-19-taint-eviction-controller.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.29: Decoupling taint-manager from node-lifecycle-controller"
 date: 2023-12-19
 slug: kubernetes-1-29-taint-eviction-controller
+author: >
+  Yuan Chen (Apple),
+  Andrea Tosatto (Apple)
 ---
-
-**Authors:** Yuan Chen (Apple), Andrea Tosatto (Apple)
 
 This blog discusses a new feature in Kubernetes 1.29 to improve the handling of taint-based pod eviction.
 

--- a/content/en/blog/_posts/2023-12-20-contextual-logging-in-kubernetes-1-29.md
+++ b/content/en/blog/_posts/2023-12-20-contextual-logging-in-kubernetes-1-29.md
@@ -4,9 +4,10 @@ title: "Contextual logging in Kubernetes 1.29: Better troubleshooting and enhanc
 slug: contextual-logging-in-kubernetes-1-29
 date: 2023-12-20T09:30:00-08:00
 canonicalUrl: https://www.kubernetes.dev/blog/2023/12/20/contextual-logging/
+author: >
+  [Mengjiao Liu](https://github.com/mengjiao-liu/) (DaoCloud), 
+  [Patrick Ohly](https://github.com/pohly) (Intel)
 ---
-
-**Authors**: [Mengjiao Liu](https://github.com/mengjiao-liu/) (DaoCloud), [Patrick Ohly](https://github.com/pohly) (Intel)
 
 On behalf of the [Structured Logging Working Group](https://github.com/kubernetes/community/blob/master/wg-structured-logging/README.md) 
 and [SIG Instrumentation](https://github.com/kubernetes/community/tree/master/sig-instrumentation#readme), 

--- a/content/en/blog/_posts/free-katacoda-kubernetes-tutorials-are-shutting-down.md
+++ b/content/en/blog/_posts/free-katacoda-kubernetes-tutorials-are-shutting-down.md
@@ -4,9 +4,9 @@ title: "Free Katacoda Kubernetes Tutorials Are Shutting Down"
 date: 2023-02-14
 slug: kubernetes-katacoda-tutorials-stop-from-2023-03-31
 evergreen: true
+author: >
+  Natali Vlatko (SIG Docs Co-Chair for Kubernetes)
 ---
-
-**Author**: Natali Vlatko, SIG Docs Co-Chair for Kubernetes
 
 [Katacoda](https://katacoda.com/kubernetes), the popular learning platform from O’Reilly that has been helping people learn all about 
 Java, Docker, Kubernetes, Python, Go, C++, and more, [shut down for public use in June 2022](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html). 


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2023 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-45984--kubernetes-io-main-staging.netlify.app/blog)