### PR TITLE
Fix issue with JavaScript errors on browser console logs when visiting Kubernetes documentation website

### DIFF
--- a/static/js/dismiss_banner.js
+++ b/static/js/dismiss_banner.js
@@ -19,23 +19,44 @@ $(document).ready(function() {
     return matches ? "true" : undefined;
   }
 
-  /* Check the presence of a cookie */
   let announcement = document.querySelector("#announcement");
-  let token = `announcement_ack_${announcement.getAttribute('data-announcement-name').replace(/\s/g, '_')}`; // Generate the unique token for announcement
-  let acknowledged = getCookie(token);
-  if (acknowledged === "true") {
-    announcement.remove(); // Remove the announcement if the cookie is set
+
+  if(announcement){
+    let announcementName = announcement.getAttribute('data-announcement-name');
+    if(announcementName){
+      let token = `announcement_ack_${announcementName.replace(/\s/g, '_')}`;
+      let acknowledged = getCookie(token);
+
+      if(acknowledged == "true"){
+        announcement.remove();
+      }
+      else{
+        announcement.classList.add('display-announcement');
+      }
+
+    }
+    else{
+      console.log("Attribute 'data-announcement-name' is null or undefined.");
+    }
   }
-  else {
-    announcement.classList.add('display-announcement') // Display the announcement if the cookie is not set
+  else{
+    console.log("Element with id 'announcement' not found.");
   }
+
+
 
   /* Driver code to set the cookie */
   let button = document.querySelector('#banner-dismiss');
-  button.removeAttribute('style');
-  button.addEventListener('click', function() {
-    setCookie(token, "true", 
-    button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
-    announcement.remove();
-  });
+  if(button){
+     button.removeAttribute('style');
+     button.addEventListener('click', function() {
+        setCookie(token, "true", 
+        button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
+        announcement.remove();
+    });
+  }
+  else{
+    console.log("Element with id 'banner-dismiss' not found.");
+  }
+  
 });


### PR DESCRIPTION
This pull request aims to close #45830.

Previously, when the users visit the documentation website, they will encounter a null attribute error in their browser's console. 

This pull request implements error handling in order to prevent null attribute errors. At the same time, this pull request preserves the existing functionality of dismissing announcement banners.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
