### PR TITLE
Add missing check-required-ports anchor

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -58,7 +58,7 @@ may [fail](https://github.com/kubernetes/kubeadm/issues/31).
 If you have more than one network adapter, and your Kubernetes components are not reachable on the default
 route, we recommend you add IP route(s) so Kubernetes cluster addresses go via the appropriate adapter.
 
-## Check required ports
+## Check required ports {#check-required-ports}
 
 These [required ports](/docs/reference/networking/ports-and-protocols/)
 need to be open in order for Kubernetes components to communicate with each other.


### PR DESCRIPTION
Small fix for adding a missing check-required-ports anchor to the documentation in https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/