### PR TITLE
[hi] Update reference to CNCF landscape (v2) in 'Training' page

### DIFF
--- a/content/hi/training/_index.html
+++ b/content/hi/training/_index.html
@@ -149,6 +149,6 @@ class: training
     </center>
   </div>
   <div class="main-section landscape-section">
-    {{< cncf-landscape helpers=false category="kubernetes-training-partner" >}}
+    {{< cncf-landscape helpers=false category="special--kubernetes-training-partner" >}}
   </div>
 </div>


### PR DESCRIPTION
Updated [hi] Invalid Link of Kubernetes Training Partners in training page. #46018

