### PR TITLE
Remove Redundant 'the' word in pod-lifecycle.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -150,7 +150,7 @@ the `Terminated` state.
 Kubernetes manages container failures within Pods using a [`restartPolicy`](#restart-policy) defined in the Pod `spec`. This policy determines how Kubernetes reacts to containers exiting due to errors or other reasons, which falls in the following sequence:
 
 1. **Initial crash**: Kubernetes attempts an immediate restart based on the Pod `restartPolicy`.
-1. **Repeated crashes**: After the the initial crash Kubernetes applies an exponential
+1. **Repeated crashes**: After the initial crash Kubernetes applies an exponential
    backoff delay for subsequent restarts, described in [`restartPolicy`](#restart-policy).
    This prevents rapid, repeated restart attempts from overloading the system.
 1. **CrashLoopBackOff state**: This indicates that the backoff delay mechanism is currently


### PR DESCRIPTION
Changes in `content/en/docs/concepts/workloads/pods/pod-lifecycle.md` file in [container-restarts][1] section

  - remove redundant "the" in line 153 which was `Repeated crashes: After the the initial crash`, become to `Repeated crashes: After the initial crash`


[1]: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-restarts