### PR TITLE
Remove 1.30 leads from sig-docs-website-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,8 +14,6 @@ aliases:
     - reylejano
     - sftim
     - tengqm
-    - drewhagen # RT 1.30 Docs Lead
-    - katcosgrove # RT 1.30 Lead
   sig-docs-localization-owners: # Admins for localization content
     - a-mccarthy
     - divya-mohan0209


### PR DESCRIPTION
Cleaning up post-1.30 release.
Removes myself and @katcosgrove from sig-docs-website-owners in OWNERS_ALIASES

/cc @kubernetes/sig-docs-leads 