### PR TITLE
[zh] Add 5 docs in command-line-tools-reference/feature-gates

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-service-lb-status-on-non-lb.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-service-lb-status-on-non-lb.md
@@ -1,0 +1,17 @@
+---
+title: AllowServiceLBStatusOnNonLB
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.29"    
+---
+
+<!--
+Enables `.status.ingress.loadBalancer` to be set on Services of types other than `LoadBalancer`.
+-->
+允许对类型为 `LoadBalancer` 以外的 Service 设置 `.status.ingress.loadBalancer`。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-managed-by.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-managed-by.md
@@ -1,0 +1,18 @@
+---
+title: JobManagedBy
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+
+<!--
+Allows to delegate reconciliation of a Job object to an external controller.
+-->
+允许将 Job 对象的调和委托给外部控制器。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-success-policy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-success-policy.md
@@ -1,0 +1,18 @@
+---
+title: JobSuccessPolicy
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+
+<!--
+Allow users to specify when a Job can be declared as succeeded based on the set of succeeded pods.
+-->
+允许用户基于一组成功的 Pod 来声明这组 Pod 所属的 Job 为成功。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamice-resources.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamice-resources.md
@@ -1,0 +1,23 @@
+---
+title: KubeletPodResourcesDynamicResources
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+  
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.27"  
+---
+
+<!--
+Extend the kubelet's pod resources gRPC endpoint to
+to include resources allocated in `ResourceClaims` via `DynamicResourceAllocation` API.
+See [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources) for more details.
+with information about the allocatable resources, enabling clients to properly
+track the free compute resources on a node.
+-->
+扩展 kubelet 的 Pod 资源 gRPC 端点，通过 `DynamicResourceAllocation` API 把已分配的资源算入 `ResourceClaims` 中。
+有关更多细节，参见[资源分配报告](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)。
+使用可分配资源的信息，使客户端能够正确跟踪节点上的空闲计算资源。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
@@ -1,0 +1,24 @@
+---
+title: NameGenerationRetries
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.30"
+---
+
+<!--
+Enables retrying of object creation when the
+{{< glossary_tooltip text="API server" term_id="kube-apiserver" >}}
+is expected to generate a [name](/docs/concepts/overview/working-with-objects/names/#names).
+When this feature is enabled, requests using `generateName` are retried automatically in case the
+control plane detects a name conflict with an existing object, up to a limit of 8 total attempts.
+-->
+当 {{< glossary_tooltip text="API 服务器" term_id="kube-apiserver" >}}要生成[名称](/zh-cn/docs/concepts/overview/working-with-objects/names/#names)时，
+允许重试对象创建。当此特性被启用时，如果控制平面检测到与某个现有对象存在名称冲突，
+则使用 `generateName` 的请求将被自动重试，最多重试 8 次。


### PR DESCRIPTION
Add zh text to 5 feature-gates:

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/allow-service-lb-status-on-non-lb.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-managed-by.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-success-policy.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamice-resources.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
```