### PR TITLE
[ar] Fix Kubernetes title spell in ar.toml, and punctuation style nits in Kubernetes basics page

### DIFF
--- a/content/ar/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/ar/docs/tutorials/kubernetes-basics/_index.html
@@ -1,12 +1,12 @@
 ---
-title: تعلم أساسيات كوبيرنيتيس.
-linkTitle: تعلم أساسيات كوبيرنيتيس.
+title: تعلم أساسيات كوبيرنيتيس
+linkTitle: تعلم أساسيات كوبيرنيتيس
 no_list: true
 weight: 10
 card:
   name: tutorials
   weight: 20
-  title: نبذة عن الأساسيات.
+  title: نبذة عن الأساسيات
 ---
 
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -511,7 +511,7 @@ description = "Довершена система оркестрації конт
 languageNameLatinScript = "Ukrainian"
 
 [languages.ar]
-title = "كوبرنيتيز"
+title = "كوبيرنيتيس"
 languageName = "العربية (Arabic)"
 weight = 17
 contentDir = "content/ar"


### PR DESCRIPTION
This commit will make two adjustments:
- Update the Arabic page title given the new standard transliteration of "kubernetes"
- Remove periods from some page titles
