### PR TITLE
Update 2022 blog content files to move author details in front-matter 

### DIFF
--- a/content/en/blog/_posts/2022-01-07-kubernetes-is-moving-on-from-dockershim.md
+++ b/content/en/blog/_posts/2022-01-07-kubernetes-is-moving-on-from-dockershim.md
@@ -3,9 +3,14 @@ layout: blog
 title: "Kubernetes is Moving on From Dockershim: Commitments and Next Steps"
 date: 2022-01-07
 slug: kubernetes-is-moving-on-from-dockershim
+author: >
+  Sergey Kanzhelev (Google),
+  Jim Angel (Google),
+  Davanum Srinivas (VMware),
+  Shannon Kularathna (Google),
+  Chris Short (AWS),
+  Dawn Chen (Google)
 ---
-
-**Authors:** Sergey Kanzhelev (Google), Jim Angel (Google), Davanum Srinivas (VMware), Shannon Kularathna (Google), Chris Short (AWS), Dawn Chen (Google)
 
 Kubernetes is removing dockershim in the upcoming v1.24 release. We're excited
 to reaffirm our community values by supporting open source container runtimes,

--- a/content/en/blog/_posts/2022-01-19-Securing-Admission-Controllers.md
+++ b/content/en/blog/_posts/2022-01-19-Securing-Admission-Controllers.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Securing Admission Controllers"
 date: 2022-01-19
 slug: secure-your-admission-controllers-and-webhooks
+author: >
+   Rory McCune (Aqua Security)
 ---
-
-**Author:** Rory McCune (Aqua Security)
 
 [Admission control](/docs/reference/access-authn-authz/admission-controllers/) is a key part of Kubernetes security, alongside authentication and authorization. Webhook admission controllers are extensively used to help improve the security of Kubernetes clusters in a variety of ways including restricting the privileges of workloads and ensuring that images deployed to the cluster meet organization’s security requirements.
 

--- a/content/en/blog/_posts/2022-02-07-sig-multicluster-spotlight/index.md
+++ b/content/en/blog/_posts/2022-02-07-sig-multicluster-spotlight/index.md
@@ -4,9 +4,10 @@ title: "Spotlight on SIG Multicluster"
 date: 2022-02-07
 slug: sig-multicluster-spotlight-2022
 canonicalUrl: https://www.kubernetes.dev/blog/2022/02/04/sig-multicluster-spotlight-2022/
+author: >
+   Dewan Ahmed (Aiven),
+   Chris Short (AWS)
 ---
-
-**Authors:** Dewan Ahmed (Aiven) and Chris Short (AWS)
 
 ## Introduction
 

--- a/content/en/blog/_posts/2022-02-16-sig-node-ci-subproject-celebrates/index.md
+++ b/content/en/blog/_posts/2022-02-16-sig-node-ci-subproject-celebrates/index.md
@@ -4,9 +4,10 @@ title: 'SIG Node CI Subproject Celebrates Two Years of Test Improvements'
 date: 2022-02-16
 slug: sig-node-ci-subproject-celebrates
 canonicalUrl: https://www.kubernetes.dev/blog/2022/02/16/sig-node-ci-subproject-celebrates-two-years-of-test-improvements/
+author: >
+   Sergey Kanzhelev (Google),
+   Elana Hashman (Red Hat)
 ---
-
-**Authors:** Sergey Kanzhelev (Google), Elana Hashman (Red Hat)
 
 Ensuring the reliability of SIG Node upstream code is a continuous effort
 that takes a lot of behind-the-scenes effort from many contributors.

--- a/content/en/blog/_posts/2022-03-31-ready-for-dockershim-removal.md
+++ b/content/en/blog/_posts/2022-03-31-ready-for-dockershim-removal.md
@@ -3,10 +3,9 @@ layout: blog
 title: "Is Your Cluster Ready for v1.24?"
 date: 2022-03-31
 slug: ready-for-dockershim-removal
+author: >
+   Kat Cosgrove
 ---
-
-**Author:** Kat Cosgrove
-
 
 Way back in December of 2020, Kubernetes announced the [deprecation of Dockershim](/blog/2020/12/02/dont-panic-kubernetes-and-docker/). In Kubernetes, dockershim is a software shim that allows you to use the entire Docker engine as your container runtime within Kubernetes. In the upcoming v1.24 release, we are removing Dockershim - the delay between deprecation and removal in line with the [project’s policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) of supporting features for at least one year after deprecation. If you are a cluster operator, this guide includes the practical realities of what you need to know going into this release. Also, what do you need to do to ensure your cluster doesn’t fall over!
 

--- a/content/en/blog/_posts/2022-04-07-Kubernetes-1-24-removals-and-deprecations.md
+++ b/content/en/blog/_posts/2022-04-07-Kubernetes-1-24-removals-and-deprecations.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes Removals and Deprecations In 1.24"
 date: 2022-04-07
 slug: upcoming-changes-in-kubernetes-1-24
+author: >
+   Mickey Boxell (Oracle)
 ---
-
-**Author**: Mickey Boxell (Oracle)
 
 As Kubernetes evolves, features and APIs are regularly revisited and removed. New features may offer
 an alternative or improved approach to solving existing problems, motivating the team to remove the

--- a/content/en/blog/_posts/2022-04-28-Increasing-the-security-bar-in-Ingress-NGINX/index.md
+++ b/content/en/blog/_posts/2022-04-28-Increasing-the-security-bar-in-Ingress-NGINX/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Increasing the security bar in Ingress-NGINX v1.2.0'
 date: 2022-04-28
 slug: ingress-nginx-1-2-0
+author: >
+   Ricardo Katz (VMware),
+   James Strong (Chainguard)
 ---
-
-**Authors:** Ricardo Katz (VMware), James Strong (Chainguard)
 
 The [Ingress](/docs/concepts/services-networking/ingress/) may be one of the most targeted components
 of Kubernetes. An Ingress typically defines an HTTP reverse proxy, exposed to the Internet, containing

--- a/content/en/blog/_posts/2022-04-29-kubernetes-1.23-release-interview.md
+++ b/content/en/blog/_posts/2022-04-29-kubernetes-1.23-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Frontiers, fsGroups and frogs: the Kubernetes 1.23 release interview"
 date: 2022-04-29
+author: >
+   Craig Box (Google)
 ---
-
-**Author**: Craig Box (Google)
 
 One of the highlights of hosting the weekly [Kubernetes Podcast from Google](https://kubernetespodcast.com/) is talking to the release managers for each new Kubernetes version. The release team is constantly refreshing. Many working their way from small documentation fixes, step up to shadow roles, and then eventually lead a release.
 

--- a/content/en/blog/_posts/2022-05-03-dockershim-historical-context.md
+++ b/content/en/blog/_posts/2022-05-03-dockershim-historical-context.md
@@ -3,10 +3,9 @@ layout: blog
 title: "Dockershim: The Historical Context"
 date: 2022-05-03
 slug: dockershim-historical-context
+author: >
+  Kat Cosgrove
 ---
-
-**Author:** Kat Cosgrove
-
 
 Dockershim has been removed as of Kubernetes v1.24, and this is a positive move for the project. However, context is important for fully understanding something, be it socially or in software development, and this deserves a more in-depth review. Alongside the dockershim removal in Kubernetes v1.24, we’ve seen some confusion (sometimes at a panic level) and dissatisfaction with this decision in the community, largely due to a lack of context around this removal. The decision to deprecate and eventually remove dockershim from Kubernetes was not made quickly or lightly. Still, it’s been in the works for so long that many of today’s users are newer than that decision, and certainly newer than the choices that led to the dockershim being necessary in the first place.
 

--- a/content/en/blog/_posts/2022-05-03-kubernetes-release-1.24.md
+++ b/content/en/blog/_posts/2022-05-03-kubernetes-release-1.24.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.24: Stargazer"
 date: 2022-05-03
 slug: kubernetes-1-24-release-announcement
+author: >
+  [Kubernetes 1.24 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)
 ---
-
-**Authors**: [Kubernetes 1.24 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)
 
 We are excited to announce the release of Kubernetes 1.24, the first release of 2022!
 

--- a/content/en/blog/_posts/2022-05-05-volume-expansion-ga.md
+++ b/content/en/blog/_posts/2022-05-05-volume-expansion-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.24: Volume Expansion Now A Stable Feature"
 date: 2022-05-05
 slug: volume-expansion-ga
+author: >
+  Hemant Kumar (Red Hat)
 ---
-
-**Author:** Hemant Kumar (Red Hat)
 
 Volume expansion was introduced as a alpha feature in Kubernetes 1.8 and it went beta in 1.11 and with Kubernetes 1.24 we are excited to announce general availability(GA)
 of volume expansion.

--- a/content/en/blog/_posts/2022-05-06-storage-capacity-GA/index.md
+++ b/content/en/blog/_posts/2022-05-06-storage-capacity-GA/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.24: Storage Capacity Tracking Now Generally Available"
 date: 2022-05-06
 slug: storage-capacity-ga
+author: >
+   Patrick Ohly (Intel)
 ---
-
- **Authors:** Patrick Ohly (Intel)
 
 The v1.24 release of Kubernetes brings [storage capacity](/docs/concepts/storage/storage-capacity/)
 tracking as a generally available feature.

--- a/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md
+++ b/content/en/blog/_posts/2022-05-13-grpc-probes-in-beta.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.24: gRPC container probes in beta"
 date: 2022-05-13
 slug: grpc-probes-now-in-beta
+author: >
+  Sergey Kanzhelev (Google)
 ---
-
-**Author**: Sergey Kanzhelev (Google)
 
 _Update: Since this article was posted, the feature was graduated to GA in v1.27 and doesn't require any feature gates to be enabled.
 

--- a/content/en/blog/_posts/2022-05-16-volume-populators-beta.md
+++ b/content/en/blog/_posts/2022-05-16-volume-populators-beta.md
@@ -3,10 +3,9 @@ layout: blog
 title: "Kubernetes 1.24: Volume Populators Graduate to Beta"
 date: 2022-05-16
 slug: volume-populators-beta
+author: >
+  Ben Swartzlander (NetApp)
 ---
-
-**Author:**
-Ben Swartzlander (NetApp)
 
 The volume populators feature is now two releases old and entering beta! The `AnyVolumeDataSource` feature
 gate defaults to enabled in Kubernetes v1.24, which means that users can specify any custom resource

--- a/content/en/blog/_posts/2022-05-18-prevent-unauthorised-volume-mode-conversion.md
+++ b/content/en/blog/_posts/2022-05-18-prevent-unauthorised-volume-mode-conversion.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.24: Prevent unauthorised volume mode conversion'
 date: 2022-05-18
 slug: prevent-unauthorised-volume-mode-conversion-alpha
+author: >
+  Raunak Pradip Shah (Mirantis)
 ---
-
-**Author:** Raunak Pradip Shah (Mirantis)
 
 Kubernetes v1.24 introduces a new alpha-level feature that prevents unauthorised users 
 from modifying the volume mode of a [`PersistentVolumeClaim`](/docs/concepts/storage/persistent-volumes/) created from an 

--- a/content/en/blog/_posts/2022-05-20-non-graceful-node-shutdown.md
+++ b/content/en/blog/_posts/2022-05-20-non-graceful-node-shutdown.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.24: Introducing Non-Graceful Node Shutdown Alpha"
 date: 2022-05-20
 slug: kubernetes-1-24-non-graceful-node-shutdown-alpha
+author: >
+  Xing Yang (VMware),
+  Yassine Tijani (VMware)
 ---
-
-**Authors** Xing Yang and Yassine Tijani (VMware)
 
 Kubernetes v1.24 introduces alpha support for [Non-Graceful Node Shutdown](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown). This feature allows stateful workloads to failover to a different node after the original node is shutdown or in a non-recoverable state such as hardware failure or broken OS.
 

--- a/content/en/blog/_posts/2022-05-23-service-ip-dynamic-and-static-allocation.md
+++ b/content/en/blog/_posts/2022-05-23-service-ip-dynamic-and-static-allocation.md
@@ -3,10 +3,9 @@ layout: blog
 title: "Kubernetes 1.24: Avoid Collisions Assigning IP Addresses to Services"
 date: 2022-05-23
 slug: service-ip-dynamic-and-static-allocation
+author: >
+  Antonio Ojea (Red Hat)
 ---
-
-**Author:** Antonio Ojea (Red Hat)
-
 
 In Kubernetes, [Services](/docs/concepts/services-networking/service/) are an abstract way to expose
 an application running on a set of Pods. Services

--- a/content/en/blog/_posts/2022-05-25-contextual-logging/index.md
+++ b/content/en/blog/_posts/2022-05-25-contextual-logging/index.md
@@ -4,9 +4,9 @@ title: "Contextual Logging in Kubernetes 1.24"
 date: 2022-05-25
 slug: contextual-logging
 canonicalUrl: https://kubernetes.dev/blog/2022/05/25/contextual-logging/
+author: >
+   Patrick Ohly (Intel)
 ---
-
- **Authors:** Patrick Ohly (Intel)
 
 The [Structured Logging Working
 Group](https://github.com/kubernetes/community/blob/master/wg-structured-logging/README.md)

--- a/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
+++ b/content/en/blog/_posts/2022-05-27-maxunavailable-for-statefulset.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.24: Maximum Unavailable Replicas for StatefulSet'
 date: 2022-05-27
 slug: maxunavailable-for-statefulset
+author: >
+  Mayank Kumar (Salesforce)
 ---
-
-**Author:** Mayank Kumar (Salesforce)
 
 Kubernetes [StatefulSets](/docs/concepts/workloads/controllers/statefulset/), since their introduction in 
 1.5 and becoming stable in 1.9, have been widely used to run stateful applications. They provide stable pod identity, persistent

--- a/content/en/blog/_posts/2022-06-01-annual-report-2021.md
+++ b/content/en/blog/_posts/2022-06-01-annual-report-2021.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Annual Report Summary 2021"
 date: 2022-06-01
 slug: annual-report-summary-2021
+author: >
+  Paris Pittman (Steering Committee)
 ---
-
-**Author:** Paris Pittman (Steering Committee)
 
 Last year, we published our first [Annual Report Summary](/blog/2021/06/28/announcing-kubernetes-community-group-annual-reports/) for 2020 and it's already time for our second edition!
 

--- a/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
+++ b/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
@@ -4,9 +4,12 @@ title: Kubernetes Gateway API Graduates to Beta
 date: 2022-07-13
 slug: gateway-api-graduates-to-beta
 canonicalUrl: https://gateway-api.sigs.k8s.io/blog/2022/graduating-to-beta/
+author: >
+  Shane Utt (Kong),
+  Rob Scott (Google),
+  Nick Young (VMware),
+  Jeff Apple (HashiCorp)
 ---
-
-**Authors:** Shane Utt (Kong), Rob Scott (Google), Nick Young (VMware), Jeff Apple (HashiCorp)
 
 We are excited to announce the v0.5.0 release of Gateway API. For the first
 time, several of our most important Gateway API resources are graduating to

--- a/content/en/blog/_posts/2022-08-02-sig-docs-spotlight/index.md
+++ b/content/en/blog/_posts/2022-08-02-sig-docs-spotlight/index.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Docs"
 date: 2022-08-02
 slug: sig-docs-spotlight-2022
 canonicalUrl: https://kubernetes.dev/blog/2022/08/02/sig-docs-spotlight-2022/
+author: >
+   Purneswar Prasad
 ---
-
-**Author:** Purneswar Prasad
 
 ## Introduction
 

--- a/content/en/blog/_posts/2022-08-03-kms-v2-alpha.md
+++ b/content/en/blog/_posts/2022-08-03-kms-v2-alpha.md
@@ -3,9 +3,12 @@ layout: blog
 title: "Kubernetes 1.25: KMS V2 Improvements"
 date: 2022-09-09
 slug: kms-v2-improvements
+author: >
+  Anish Ramasekar,
+  Rita Zhang,
+  Mo Khan,
+  Xander Grzywinski (Microsoft)
 ---
-
-**Authors:** Anish Ramasekar, Rita Zhang, Mo Khan, and Xander Grzywinski (Microsoft)
 
 With Kubernetes v1.25, SIG Auth is introducing a new `v2alpha1` version of the Key Management Service (KMS) API. There are a lot of improvements in the works, and we're excited to be able to start down the path of a new and improved KMS!
 

--- a/content/en/blog/_posts/2022-08-04-kubernetes-1.25-deprecations-and-removals.md
+++ b/content/en/blog/_posts/2022-08-04-kubernetes-1.25-deprecations-and-removals.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes Removals and Major Changes In 1.25"
 date: 2022-08-04
 slug: upcoming-changes-in-kubernetes-1-25
+author: >
+  Kat Cosgrove,
+  Frederico Muñoz,
+  Debabrata Panigrahi
 ---
-
-**Authors**: Kat Cosgrove, Frederico Muñoz, Debabrata Panigrahi
 
 As Kubernetes grows and matures, features may be deprecated, removed, or replaced with improvements for the health of the project. Kubernetes v1.25 includes several major changes and one major removal.
 

--- a/content/en/blog/_posts/2022-08-11-enhancing-kubernetes-one-kep-at-a-time/index.md
+++ b/content/en/blog/_posts/2022-08-11-enhancing-kubernetes-one-kep-at-a-time/index.md
@@ -4,9 +4,9 @@ title: "Enhancing Kubernetes one KEP at a Time"
 date: 2022-08-11
 slug: enhancing-kubernetes-one-kep-at-a-time
 canonicalUrl: https://www.k8s.dev/blog/2022/08/11/enhancing-kubernetes-one-kep-at-a-time/
+author: >
+  Ryler Hockenbury (Mastercard)
 ---
-
-**Author:** Ryler Hockenbury (Mastercard)
 
 Did you know that Kubernetes v1.24 has [46 enhancements](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/)? That's a lot of new functionality packed into a 4-month release cycle. The Kubernetes release team coordinates the logistics of the release, from remediating test flakes to publishing updated docs. It's a ton of work, but they always deliver.
 

--- a/content/en/blog/_posts/2022-08-16-PSP-historical-context/index.md
+++ b/content/en/blog/_posts/2022-08-16-PSP-historical-context/index.md
@@ -4,9 +4,9 @@ title: "PodSecurityPolicy: The Historical Context"
 date: 2022-08-23T15:00:00-0800
 slug: podsecuritypolicy-the-historical-context
 evergreen: true
+author: >
+  Mahé Tardy (Quarkslab)
 ---
-
-**Author:** Mahé Tardy (Quarkslab)
 
 The PodSecurityPolicy (PSP) admission controller has been removed, as of
 Kubernetes v1.25. Its deprecation was announced and detailed in the blog post

--- a/content/en/blog/_posts/2022-08-18-kubernetes-1.24-release-interview.md
+++ b/content/en/blog/_posts/2022-08-18-kubernetes-1.24-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Stargazing, solutions and staycations: the Kubernetes 1.24 release interview"
 date: 2022-08-18
+author: >
+  Craig Box (Google)
 ---
-
-**Author**: Craig Box (Google)
 
 The Kubernetes project has participants from all around the globe. Some are friends, some are colleagues, and some are strangers. The one thing that unifies them, no matter their differences, are that they all have an interesting story. It is my pleasure to be the documentarian for the stories of the Kubernetes community in the weekly [Kubernetes Podcast from Google](https://kubernetespodcast.com/). With every new Kubernetes release comes an interview with the release team lead, telling the story of that release, but also their own personal story.
 

--- a/content/en/blog/_posts/2022-08-22-sig-storage-spotlight.md
+++ b/content/en/blog/_posts/2022-08-22-sig-storage-spotlight.md
@@ -4,9 +4,9 @@ title: "Spotlight on SIG Storage"
 slug: sig-storage-spotlight
 date: 2022-08-22
 canonicalUrl: https://www.kubernetes.dev/blog/2022/08/22/sig-storage-spotlight-2022/
+author: >
+  Frederico Muñoz (SAS)
 ---
-
-**Author**: Frederico Muñoz (SAS)
 
 Since the very beginning of Kubernetes, the topic of persistent data and how to address the requirement of stateful applications has been an important topic. Support for stateless deployments was natural, present from the start, and garnered attention, becoming very well-known. Work on better support for stateful applications was also present from early on, with each release increasing the scope of what could be run on Kubernetes.
 

--- a/content/en/blog/_posts/2022-08-23-kubernetes-1.25-blog.md
+++ b/content/en/blog/_posts/2022-08-23-kubernetes-1.25-blog.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.25: Combiner"
 date: 2022-08-23
 slug: kubernetes-v1-25-release
+author: >
+  [Kubernetes 1.25 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.25/release-team.md)
 ---
-
-**Authors**: [Kubernetes 1.25 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.25/release-team.md)
 
 Announcing the release of Kubernetes v1.25!
 

--- a/content/en/blog/_posts/2022-08-25-pod-security/index.md
+++ b/content/en/blog/_posts/2022-08-25-pod-security/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes v1.25: Pod Security Admission Controller in Stable"
 date: 2022-08-25
 slug: pod-security-admission-stable
+author: >
+  Tim Allclair (Google),
+  Sam Stoelinga (Google)
 ---
-
-**Authors:** Tim Allclair (Google), Sam Stoelinga (Google)
 
 The release of Kubernetes v1.25 marks a major milestone for Kubernetes out-of-the-box pod security
 controls: Pod Security admission (PSA) graduated to stable, and Pod Security Policy (PSP) has been

--- a/content/en/blog/_posts/2022-08-29-csi-inline-volumes-ga.md
+++ b/content/en/blog/_posts/2022-08-29-csi-inline-volumes-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.25: CSI Inline Volumes have graduated to GA"
 date: 2022-08-29
 slug: csi-inline-volumes-ga
+author: >
+  Jonathan Dobson (Red Hat)
 ---
-
-**Author:** Jonathan Dobson (Red Hat)
 
 CSI Inline Volumes were introduced as an alpha feature in Kubernetes 1.15 and have been beta since 1.16. We are happy to announce that this feature has graduated to General Availability (GA) status in Kubernetes 1.25.
 

--- a/content/en/blog/_posts/2022-08-31-cgroupv2-ga.md
+++ b/content/en/blog/_posts/2022-08-31-cgroupv2-ga.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.25: cgroup v2 graduates to GA"
 date: 2022-08-31
 slug: cgroupv2-ga-1-25
+author: >
+  David Porter (Google),
+  Mrunal Patel (Red Hat)
 ---
-
-**Authors:**: David Porter (Google), Mrunal Patel (Red Hat)
 
 Kubernetes 1.25 brings cgroup v2 to GA (general availability), letting the
 [kubelet](/docs/concepts/overview/components/#kubelet) use the latest container resource

--- a/content/en/blog/_posts/2022-09-02-cosi-kubernetes-object-storage-management.md
+++ b/content/en/blog/_posts/2022-09-02-cosi-kubernetes-object-storage-management.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Introducing COSI: Object Storage Management using Kubernetes APIs"
 date: 2022-09-02
 slug: cosi-kubernetes-object-storage-management
+author: >
+  Sidhartha Mani ([Minio, Inc](https://min.io))
 ---
-
-**Authors:** Sidhartha Mani ([Minio, Inc](https://min.io))
 
 This article introduces the Container Object Storage Interface (COSI), a standard for provisioning and consuming object storage in Kubernetes. It is an alpha feature in Kubernetes v1.25.
 

--- a/content/en/blog/_posts/2022-09-07-iptables-chains.md
+++ b/content/en/blog/_posts/2022-09-07-iptables-chains.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes’s IPTables Chains Are Not API"
 date: 2022-09-07
 slug: iptables-chains-not-api
+author: >
+  Dan Winship (Red Hat)
 ---
-
-**Author:** Dan Winship (Red Hat)
 
 Some Kubernetes components (such as kubelet and kube-proxy) create
 iptables chains and rules as part of their operation. These chains

--- a/content/en/blog/_posts/2022-09-12-Announcing-the-Auto-Refreshing-Official-CVE-Feed/index.md
+++ b/content/en/blog/_posts/2022-09-12-Announcing-the-Auto-Refreshing-Official-CVE-Feed/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: Announcing the Auto-refreshing Official Kubernetes CVE Feed
 date: 2022-09-12 
 slug: k8s-cve-feed-alpha
+author: >
+  Pushkar Joglekar (VMware)
 ---
-
-**Author**: Pushkar Joglekar (VMware)
 
 A long-standing request from the Kubernetes community has been to have a
 programmatic way for end users to keep track of Kubernetes security issues

--- a/content/en/blog/_posts/2022-09-14-pod-has-network-condition.md
+++ b/content/en/blog/_posts/2022-09-14-pod-has-network-condition.md
@@ -3,10 +3,9 @@ layout: blog
 title: 'Kubernetes 1.25: PodHasNetwork Condition for Pods'
 date: 2022-09-14
 slug: pod-has-network-condition
+author: >
+  Deep Debroy (Apple)
 ---
-
-**Author:**
-Deep Debroy (Apple)
 
 Kubernetes 1.25 introduces Alpha support for a new kubelet-managed pod condition
 in the status field of a pod: `PodHasNetwork`. The kubelet, for a worker node,

--- a/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
+++ b/content/en/blog/_posts/2022-09-15-sig-apps-GA-1.25/index.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes 1.25: Two Features for Apps Rollouts Graduate to Stable"
 date: 2022-09-15
 slug: "app-rollout-features-reach-stable"
+author: >
+  Ravi Gudimetla (Apple),
+  Filip Křepinský (Red Hat),
+  Maciej Szulik (Red Hat)
 ---
-
-**Authors:** Ravi Gudimetla (Apple), Filip Křepinský (Red Hat), Maciej Szulik (Red Hat)
 
 This blog describes the two features namely `minReadySeconds` for StatefulSets and `maxSurge` for DaemonSets that SIG Apps is happy to graduate to stable in Kubernetes 1.25.
 

--- a/content/en/blog/_posts/2022-09-19-local-storage-capacity-isolation-ga.md
+++ b/content/en/blog/_posts/2022-09-19-local-storage-capacity-isolation-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.25: Local Storage Capacity Isolation Reaches GA"
 date: 2022-09-19
 slug: local-storage-capacity-isolation-ga
+author: >
+  Jing Xu (Google)
 ---
-
-**Author:** Jing Xu (Google)
 
 Local ephemeral storage capacity isolation was introduced as a alpha feature in Kubernetes 1.7 and it went beta in 1.9. With Kubernetes 1.25 we are excited to announce general availability(GA) of this feature.
 

--- a/content/en/blog/_posts/2022-09-21-csi-nodeexpandsecret.md
+++ b/content/en/blog/_posts/2022-09-21-csi-nodeexpandsecret.md
@@ -4,9 +4,10 @@ title: >-
   Kubernetes 1.25: Use Secrets for Node-Driven Expansion of CSI Volumes
 date: 2022-09-21
 slug: kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha
+author: >
+  Humble Chirammal (Red Hat),
+  Louis Koo (deeproute.ai)
 ---
-
-**Author:** Humble Chirammal (Red Hat), Louis Koo (deeproute.ai)
 
 Kubernetes v1.25, released earlier this month, introduced a new feature
 that lets your cluster expand storage volumes, even when access to those

--- a/content/en/blog/_posts/2022-09-23-crd-validation-rules-graduate-to-beta.md
+++ b/content/en/blog/_posts/2022-09-23-crd-validation-rules-graduate-to-beta.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes 1.25: CustomResourceDefinition Validation Rules Graduate to Beta"
 date: 2022-09-23
 slug: crd-validation-rules-beta
+author: >
+  Joe Betz (Google),
+  Cici Huang (Google),
+  Kermit Alexander (Google)
 ---
-
-**Authors:** Joe Betz (Google), Cici Huang (Google), Kermit Alexander (Google)
 
 In Kubernetes 1.25, [Validation rules for CustomResourceDefinitions](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules) (CRDs) have graduated to Beta!
 

--- a/content/en/blog/_posts/2022-09-26-csi-migration-status.md
+++ b/content/en/blog/_posts/2022-09-26-csi-migration-status.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.25: Kubernetes In-Tree to CSI Volume Migration Status Update"
 date: 2022-09-26
 slug: storage-in-tree-to-csi-migration-status-update-1.25
+author: >
+  Jiawei Wang (Google)
 ---
-
-**Author:** Jiawei Wang (Google)
 
 The Kubernetes in-tree storage plugin to [Container Storage Interface (CSI)](/blog/2019/01/15/container-storage-interface-ga/) migration infrastructure has already been [beta](/blog/2019/12/09/kubernetes-1-17-feature-csi-migration-beta/) since v1.17. CSI migration was introduced as alpha in Kubernetes v1.14.
 Since then, SIG Storage and other Kubernetes special interest groups are working to ensure feature stability and compatibility in preparation for CSI Migration feature to go GA.

--- a/content/en/blog/_posts/2022-09-29-immutability-with-cel.md
+++ b/content/en/blog/_posts/2022-09-29-immutability-with-cel.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Enforce CRD Immutability with CEL Transition Rules"
 date: 2022-09-29
 slug: enforce-immutability-using-cel
+author: >
+  [Alexander Zielenski](https://github.com/alexzielenski) (Google)
 ---
-
-**Author:** [Alexander Zielenski](https://github.com/alexzielenski) (Google)
 
 Immutable fields can be found in a few places in the built-in Kubernetes types.
 For example, you can't change the `.metadata.name` of an object. Specific objects

--- a/content/en/blog/_posts/2022-10-03-add-userns-alpha/index.md
+++ b/content/en/blog/_posts/2022-10-03-add-userns-alpha/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.25: alpha support for running Pods with user namespaces"
 date: 2022-10-03
 slug: userns-alpha
+author: >
+  Rodrigo Campos (Microsoft),
+  Giuseppe Scrivano (Red Hat)
 ---
-
-**Authors:** Rodrigo Campos (Microsoft), Giuseppe Scrivano (Red Hat)
 
 Kubernetes v1.25 introduces the support for user namespaces.
 

--- a/content/en/blog/_posts/2022-10-04-introducing-kueue.md
+++ b/content/en/blog/_posts/2022-10-04-introducing-kueue.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Introducing Kueue"
 date: 2022-10-04
 slug: introducing-kueue
+author: >
+  Abdullah Gharaibeh (Google),
+  Aldo Culquicondor (Google)
 ---
-
-**Authors:** Abdullah Gharaibeh (Google), Aldo Culquicondor (Google)
 
 Whether on-premises or in the cloud, clusters face real constraints for resource usage, quota, and cost management reasons. Regardless of the autoscalling capabilities, clusters have finite capacity.  As a result, users want an easy way to fairly and 
 efficiently share resources. 

--- a/content/en/blog/_posts/2022-10-05-current-state-2019-third-party-audit.md
+++ b/content/en/blog/_posts/2022-10-05-current-state-2019-third-party-audit.md
@@ -4,9 +4,12 @@ title: "Current State: 2019 Third Party Security Audit of Kubernetes"
 date: 2022-10-05
 slug: current-state-2019-third-party-audit
 evergreen: true
+author: >
+  Cailyn Edwards (Shopify),
+  Pushkar Joglekar (VMware),
+  Rey Lejano (SUSE),
+  Rory McCune (DataDog)
 ---
-
-**Authors** (in alphabetical order): Cailyn Edwards (Shopify), Pushkar Joglekar (VMware), Rey Lejano (SUSE) and Rory McCune (DataDog)
 
 We expect the brand new Third Party Security Audit of Kubernetes will be
 published later this month (Oct 2022).

--- a/content/en/blog/_posts/2022-10-18-kubernetes-1.26-deprecations-and-removals.md
+++ b/content/en/blog/_posts/2022-10-18-kubernetes-1.26-deprecations-and-removals.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes Removals, Deprecations, and Major Changes in 1.26"
 date: 2022-11-18
 slug: upcoming-changes-in-kubernetes-1-26
+author: >
+  Frederico Muñoz (SAS)
 ---
-
-**Author**: Frederico Muñoz (SAS)
 
 Change is an integral part of the Kubernetes life-cycle: as Kubernetes grows and matures, features may be deprecated, removed, or replaced with improvements for the health of the project. For Kubernetes v1.26 there are several planned: this article identifies and describes some of them, based on the information available at this mid-cycle point in the v1.26 release process, which is still ongoing and can introduce additional changes.
 

--- a/content/en/blog/_posts/2022-10-20-advanced-server-side-apply.md
+++ b/content/en/blog/_posts/2022-10-20-advanced-server-side-apply.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Server Side Apply Is Great And You Should Be Using It"
 date: 2022-10-20
 slug: advanced-server-side-apply
+author: >
+  Daniel Smith (Google)
 ---
-
-**Author:** Daniel Smith (Google)
 
 [Server-side apply](/docs/reference/using-api/server-side-apply/) (SSA) has now
 been [GA for a few releases](/blog/2021/08/06/server-side-apply-ga/), and I

--- a/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
+++ b/content/en/blog/_posts/2022-11-04-live-and-let-live-with-kluctl-and-ssa.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Live and let live with Kluctl and Server Side Apply"
 date: 2022-11-04
 slug: live-and-let-live-with-kluctl-and-ssa
+author: >
+   Alexander Block
 ---
-
-**Author:** Alexander Block
 
 This blog post was inspired by a previous Kubernetes blog post about
 [Advanced Server Side Apply](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/).

--- a/content/en/blog/_posts/2022-11-28-registry-k8s-io-change.md
+++ b/content/en/blog/_posts/2022-11-28-registry-k8s-io-change.md
@@ -3,9 +3,10 @@ layout: blog
 title: "registry.k8s.io: faster, cheaper and Generally Available (GA)"
 date: 2022-11-28
 slug: registry-k8s-io-faster-cheaper-ga
+author: >
+   Adolfo García Veytia (Chainguard),
+   Bob Killen (Google)
 ---
-
-**Authors**: Adolfo García Veytia (Chainguard), Bob Killen (Google)
 
 Starting with Kubernetes 1.25, our container image registry has changed from k8s.gcr.io to [registry.k8s.io](https://registry.k8s.io). This new registry spreads the load across multiple Cloud Providers & Regions, functioning as a sort of content delivery network (CDN) for Kubernetes container images. This change reduces the project’s reliance on a single entity and provides a faster download experience for a large number of users.
 

--- a/content/en/blog/_posts/2022-12-01-runtime-observability-opentelemetry/index.md
+++ b/content/en/blog/_posts/2022-12-01-runtime-observability-opentelemetry/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Boosting Kubernetes container runtime observability with OpenTelemetry"
 date: 2022-12-01
 slug: runtime-observability-opentelemetry
+author: >
+  Sascha Grunert
 ---
-
-**Authors:** Sascha Grunert
 
 When speaking about observability in the cloud native space, then probably
 everyone will mention [OpenTelemetry (OTEL)][otel] at some point in the

--- a/content/en/blog/_posts/2022-12-02-seccomp-notifier.md
+++ b/content/en/blog/_posts/2022-12-02-seccomp-notifier.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Finding suspicious syscalls with the seccomp notifier"
 date: 2022-12-02
 slug: seccomp-notifier
+author: >
+  Sascha Grunert
 ---
-
-**Authors:** Sascha Grunert
 
 Debugging software in production is one of the biggest challenges we have to
 face in our containerized environments. Being able to understand the impact of

--- a/content/en/blog/_posts/2022-12-05-forensic-container-checkpointing/index.md
+++ b/content/en/blog/_posts/2022-12-05-forensic-container-checkpointing/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Forensic container checkpointing in Kubernetes"
 date: 2022-12-05
 slug: forensic-container-checkpointing-alpha
+author: >
+  Adrian Reber (Red Hat)
 ---
-
-**Authors:** Adrian Reber (Red Hat)
 
 Forensic container checkpointing is based on [Checkpoint/Restore In
 Userspace](https://criu.org/) (CRIU) and allows the creation of stateful copies

--- a/content/en/blog/_posts/2022-12-09-kubernetes-1.26-blog.md
+++ b/content/en/blog/_posts/2022-12-09-kubernetes-1.26-blog.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.26: Electrifying"
 date: 2022-12-09
 slug: kubernetes-v1-26-release
+author: >
+  [Kubernetes 1.26 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)
 ---
-
-**Authors**: [Kubernetes 1.26 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)
 
 It's with immense joy that we announce the release of Kubernetes v1.26!
 

--- a/content/en/blog/_posts/2022-12-12-kubernetes-release-artifact-signing.md
+++ b/content/en/blog/_posts/2022-12-12-kubernetes-release-artifact-signing.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.26: We're now signing our binary release artifacts!"
 date: 2022-12-12
 slug: kubernetes-release-artifact-signing
+author: >
+  Sascha Grunert
 ---
-
-**Author:** Sascha Grunert
 
 The Kubernetes Special Interest Group (SIG) Release is proud to announce that we
 are digitally signing all release artifacts, and that this aspect of Kubernetes

--- a/content/en/blog/_posts/2022-12-13-host-process-containers-ga/index.md
+++ b/content/en/blog/_posts/2022-12-13-host-process-containers-ga/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.26: Windows HostProcess Containers Are Generally Available"
 date: 2022-12-13
 slug: windows-host-process-containers-ga
+author: >
+  Brandon Smith (Microsoft),
+  Mark Rossetti (Microsoft)
 ---
-
-**Authors**: Brandon Smith (Microsoft) and Mark Rossetti (Microsoft)
 
 The long-awaited day has arrived: HostProcess containers, the Windows equivalent to Linux privileged
 containers, has finally made it to **GA in Kubernetes 1.26**!

--- a/content/en/blog/_posts/2022-12-15-dynamic-resource-allocation-alpha/index.md
+++ b/content/en/blog/_posts/2022-12-15-dynamic-resource-allocation-alpha/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.26: Alpha API For Dynamic Resource Allocation"
 date: 2022-12-15
 slug: dynamic-resource-allocation
+author: >
+  Patrick Ohly (Intel),
+  Kevin Klues (NVIDIA)
 ---
-
-**Authors:** Patrick Ohly (Intel), Kevin Klues (NVIDIA)
 
 Dynamic resource allocation is a new API for requesting resources. It is a
 generalization of the persistent volumes API for generic resources, making it possible to:

--- a/content/en/blog/_posts/2022-12-16-non-graceful-node-shutdown-to-beta.md
+++ b/content/en/blog/_posts/2022-12-16-non-graceful-node-shutdown-to-beta.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.26: Non-Graceful Node Shutdown Moves to Beta"
 date: 2022-12-16T10:00:00-08:00
 slug: kubernetes-1-26-non-graceful-node-shutdown-beta
+author: >
+  Xing Yang (VMware),
+  Ashutosh Kumar (VMware)
 ---
-
-**Author:** Xing Yang (VMware), Ashutosh Kumar (VMware)
 
 Kubernetes v1.24 [introduced](https://kubernetes.io/blog/2022/05/20/kubernetes-1-24-non-graceful-node-shutdown-alpha/) an alpha quality implementation of improvements
 for handling a [non-graceful node shutdown](/docs/concepts/architecture/nodes/#non-graceful-node-shutdown).

--- a/content/en/blog/_posts/2022-12-19-devicemanager-ga.md/index.md
+++ b/content/en/blog/_posts/2022-12-19-devicemanager-ga.md/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.26: Device Manager graduates to GA'
 date: 2022-12-19
 slug: devicemanager-ga
+author: >
+  Swati Sehgal (Red Hat)
 ---
-
-**Author:** Swati Sehgal (Red Hat)
 
 The Device Plugin framework was introduced in the Kubernetes v1.8 release as a vendor
 independent framework to enable discovery, advertisement and allocation of external

--- a/content/en/blog/_posts/2022-12-20-validating-admission-policies-alpha/index.md
+++ b/content/en/blog/_posts/2022-12-20-validating-admission-policies-alpha/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.26: Introducing Validating Admission Policies"
 date: 2022-12-20
 slug: validating-admission-policies-alpha
+author: >
+  Joe Betz (Google),
+  Cici Huang (Google)
 ---
-
-**Authors:** Joe Betz (Google), Cici Huang (Google)
 
 In Kubernetes 1.26, the 1st alpha release of validating admission policies is
 available!

--- a/content/en/blog/_posts/2022-12-22-kubelet-credential-providers/index.md
+++ b/content/en/blog/_posts/2022-12-22-kubelet-credential-providers/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kubernetes v1.26: GA Support for Kubelet Credential Providers'
 date: 2022-12-22
 slug: kubelet-credential-providers
+author: >
+  Andrew Sy Kim (Google),
+  Dixita Narang (Google)
 ---
-
-**Authors:** Andrew Sy Kim (Google), Dixita Narang (Google)
 
 Kubernetes v1.26 introduced generally available (GA) support for [_kubelet credential
 provider plugins_]( /docs/tasks/kubelet-credential-provider/kubelet-credential-provider/),

--- a/content/en/blog/_posts/2022-12-23-fsgroup-on-mount.md
+++ b/content/en/blog/_posts/2022-12-23-fsgroup-on-mount.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.26: Support for Passing Pod fsGroup to CSI Drivers At Mount Time"
 date: 2022-12-23
 slug: kubernetes-12-06-fsgroup-on-mount
+author: >
+  Fabio Bertinatto (Red Hat),
+  Hemant Kumar (Red Hat)
 ---
-
-**Authors:** Fabio Bertinatto (Red Hat), Hemant Kumar (Red Hat)
 
 Delegation of `fsGroup` to CSI drivers was first introduced as alpha in Kubernetes 1.22,
 and graduated to beta in Kubernetes 1.25.

--- a/content/en/blog/_posts/2022-12-26-pod-scheduling-readiness.md
+++ b/content/en/blog/_posts/2022-12-26-pod-scheduling-readiness.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.26: Pod Scheduling Readiness"
 date: 2022-12-26
 slug: pod-scheduling-readiness-alpha
+author: >
+  Wei Huang (Apple),
+  Abdullah Gharaibeh (Google)
 ---
-
-**Author:** Wei Huang (Apple), Abdullah Gharaibeh (Google)
 
 Kubernetes 1.26 introduced a new Pod feature: _scheduling gates_. In Kubernetes, scheduling gates
 are keys that tell the scheduler when a Pod is ready to be considered for scheduling.

--- a/content/en/blog/_posts/2022-12-27-cpumanager-goes-GA.md
+++ b/content/en/blog/_posts/2022-12-27-cpumanager-goes-GA.md
@@ -3,10 +3,9 @@ layout: blog
 title: 'Kubernetes v1.26: CPUManager goes GA'
 date: 2022-12-27
 slug: cpumanager-ga
+author: >
+  Francesco Romani (Red Hat)
 ---
-
-**Author:**
-Francesco Romani (Red Hat)
 
 The CPU Manager is a part of the kubelet, the Kubernetes node agent, which enables the user to allocate exclusive CPUs to containers.
 Since Kubernetes v1.10, where it [graduated to Beta](/blog/2018/07/24/feature-highlight-cpu-manager/), the CPU Manager proved itself reliable and

--- a/content/en/blog/_posts/2022-12-29-scalable-job-tracking-ga/index.md
+++ b/content/en/blog/_posts/2022-12-29-scalable-job-tracking-ga/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.26: Job Tracking, to Support Massively Parallel Batch Workloads, Is Generally Available"
 date: 2022-12-29
 slug: "scalable-job-tracking-ga"
+author: >
+  Aldo Culquicondor (Google)
 ---
-
-**Authors:** Aldo Culquicondor (Google)
 
 The Kubernetes 1.26 release includes a stable implementation of the [Job](/docs/concepts/workloads/controllers/job/)
 controller that can reliably track a large amount of Jobs with high levels of

--- a/content/en/blog/_posts/2022-12-30-advancements-in-traffic-engineering/index.md
+++ b/content/en/blog/_posts/2022-12-30-advancements-in-traffic-engineering/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes v1.26: Advancements in Kubernetes Traffic Engineering"
 date: 2022-12-30
 slug: advancements-in-kubernetes-traffic-engineering
+author: >
+  Andrew Sy Kim (Google)
 ---
-
-**Authors:** Andrew Sy Kim (Google)
 
 Kubernetes v1.26 includes significant advancements in network traffic engineering with the graduation of
 two features (Service internal traffic policy support, and EndpointSlice terminating conditions) to GA,


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2022 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-45984--kubernetes-io-main-staging.netlify.app/blog)