### PR TITLE
Contribute as sig-docs reviewer blog post

### DIFF
--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "From Code to Quill: Embark on a Legendary Kubernetes Quest with SIG-Docs"
+title: "From Code to Quill: Embark on a Legendary Kubernetes Quest with SIG Docs"
 date: 2024-04-28
 slug: contribute-as-sig-docs-reviewer
 author: >

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -98,7 +98,7 @@ Kubernetes documentation contribution process. Here are the steps to get you sta
 
 After consistently contributing to documentation reviews and demonstrating your understanding
 of Kubernetes documentation standards, you can express your interest in becoming an official
-SIG Docs reviewer. Engage with the SIG Docs chairs or leads on Slack or during SIG Docs
+SIG Docs reviewer. As you build up this skill set, reviews are still welcome! You don't need to be a formal reviewer in the SIG to leave reviews on PRs or blog posts. Engage with the SIG Docs chairs or leads on Slack or during SIG Docs
 meetings to discuss the next steps.
 
 ## See YOU in the Docs!

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -14,7 +14,7 @@ What is the truth behind this tale as old as time (or at least as old as Kuberne
 Imagine Sarah: an enthusiast of open-source whose keyboard had seen more action crafting
 technical masterpieces for her projects than a knight's sword in battle. Sarah's had such
 a smooth relationship with Git, that she could `git commit` and `git push` in her sleep,
-and her etiquette in pull-requests was so polished, it could make a silver spoon look tarnished.
+and her etiquette in pull requests was so polished, it could make a silver spoon look tarnished.
 
 But here's the twist: when it came to the mysterious _art-of-coding_, Sarah felt more
 like a fish out of water — or more accurately, like trying to navigate a Kubernetes cluster

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -41,7 +41,7 @@ making you the unsung hero of their open-source odyssey.
 The Kubernetes project depends substantially on SIG Docs to ensure that documentation
 is accurate, up to date, and easily accessible. By becoming a reviewer, you can help users
 and contributors navigate and understand Kubernetes more effectively. In addition, reviewing
-documentation provides unique opportunities for:
+documentation provides unique opportunities to:
 
 - **Expand your Kubernetes knowledge**: Engage deeply with new features and functionalities
   by reviewing their documentation.

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -1,71 +1,70 @@
 ---
 layout: blog
 title: "From Code to Quill: Embark on a Legendary Kubernetes Quest with SIG Docs"
-date: 2024-04-28
+date: 2024-05-16
 slug: contribute-as-sig-docs-reviewer
-author: >
-   Ricardo Amaro (Acquia)
+author: "Ricardo Amaro (Acquia)"
 ---
 
-You've probably come across the saying, "Contributing doesn't always mean writing lines of code"
-whispered to the wind or glimpsed in the margins of a sacred open-source tome.
-What is the truth behind this tale as old as time (or at least as old as Kubernetes itself)?
+You've likely heard the adage, "Contributing isn't just about writing code",
+whispered in forums or seen etched into the digital walls of open source communities.
+But what depth of truth lies within this ancient wisdom, especially in the vast,
+evolving world of Kubernetes?
 
-Imagine Sarah: an enthusiast of open-source whose keyboard had seen more action crafting
-technical masterpieces for her projects than a knight's sword in battle. Sarah's had such
-a smooth relationship with Git, that she could `git commit` and `git push` in her sleep,
-and her etiquette in pull requests was so polished, it could make a silver spoon look tarnished.
+Today, contributing to open source extends far beyond the realm of coding.
+It's an inclusive journey that welcomes the diverse skills of all who wish
+to be a part of it. Whether you're a seasoned developer or someone whose strengths
+lie outside traditional programming, your contributions hold immense value.
 
-But here's the twist: when it came to the mysterious _art-of-coding_, Sarah felt more
-like a fish out of water — or more accurately, like trying to navigate a Kubernetes cluster
-with a compass and a star map. The very thought of diving into the codebase made her feel like
-she was trying to read ancient hieroglyphs without a Rosetta Stone.
+Imagine yourself embarking on a journey that leverages your expertise and love
+for free software to enhance your capabilities and strengthen the very foundation
+of the Kubernetes ecosystem. This is a real opportunity for you to shine, to make
+an indelible mark on a project that powers some of the most critical infrastructure
+in the world today.
 
-Did Sarah let this stop her? Not at all. She discovered a path as impactful as a well-placed
-line of code: joining the Special Interest Group (SIG) Docs team. It was there that Sarah found her true calling,
-helping transform the dense field of Kubernetes documentation into a well-tended garden of knowledge.
+Your journey begins with a single step: joining the Special Interest Group (SIG) Docs. 
+Here, your talent for articulating complex concepts, your keen eye for detail,
+and your unwavering commitment to clarity become your most powerful tools. As a contributor,
+you can transform dense technical landscapes into navigable pathways, making Kubernetes
+accessible to all.
 
-Sarah's odyssey from a mere mortal Kubernetes user to a demigod of documentation didn't
-just prove that contributions of knowledge and expertise are as valuable as code
-contributions—it also showed that you don't need to be a coding wizard to make a significant
-impact. Her journey is a beacon of hope for all who fear the merge conflict, a testament
-to the power of the written word in the realm of open-source.
+This is your call to adventure, an invitation to expand beyond the familiar territories
+of code and into the rich, uncharted domains of documentation and collaboration,
+empowering a global community of users and contributors.
 
-So, let Sarah's story inspire you. No matter if you're a code ninja or a prose maestro,
-there's a place for you in the open-source pantheon. And who knows? Maybe one day,
-your documentation will be the guiding light for a lost soul in the Kubernetes sea,
-making you the unsung hero of their open-source odyssey.
+## Why become a SIG Docs reviewer?
 
-## Why Become a SIG Docs Reviewer?
-
-The Kubernetes project depends substantially on SIG Docs to ensure that documentation
+The Kubernetes project depends substantially on the SIG Docs to ensure that documentation
 is accurate, up to date, and easily accessible. By becoming a reviewer, you can help users
 and contributors navigate and understand Kubernetes more effectively. In addition, reviewing
-documentation provides unique opportunities to:
+documentation provides unique opportunities for:
 
-- **Expand your Kubernetes knowledge**: Engage deeply with new features and functionalities
+- **Expanding your Kubernetes knowledge**: Engage deeply with new features and functionalities
   by reviewing their documentation.
-- **Improve your technical writing skills**: Develop an eye for detail and clarity in technical
+- **Improving your technical writing skills**: Develop an eye for detail and clarity in technical
   writing.
-- **Strengthen the Kubernetes community**: Help maintain the high quality of Kubernetes
+- **Strengthening the Kubernetes community**: Help maintain the high quality of Kubernetes
   documentation, supporting both new and experienced users.
-- **Build your network**: Expanding your professional network, and getting together with
+- **Building your network**: Expanding your professional network, and getting together with
   contributors from around the globe.
 
-## Who Are We Looking For?
+## Who are we looking for?
 
-We're seeking open-source enthusiasts with:
+We're seeking open source enthusiasts with:
 
-- Experience with Git and GitHub, comfortable with the process of reviewing pull requests
+- Experience of Git and GitHub, comfortable with the process of reviewing pull requests
   and providing constructive feedback.
 - Familiarity with Markdown and documentation frameworks (Hugo experience is a plus but
   not required).
 - A passion for making complex technical concepts understandable and accessible.
 
-Prior experience in technical writing or documentation review in any open-source project
-will be beneficial but not mandatory.
+Experience in technical writing or documentation review in open source projects is beneficial, 
+but not mandatory. Kubernetes experience is welcome at all levels. Those less familiar 
+with Kubernetes or containers can provide valuable fresh perspectives for beginners accessibility. 
+We value diversity of experiences and the fresh eyes you can provide to make sure our content 
+is clear and understandable for everyone.
 
-## How to Get Started
+## How to get started
 
 Becoming a SIG Docs reviewer is a journey that starts with familiarizing yourself with the
 Kubernetes documentation contribution process. Here are the steps to get you started:
@@ -82,7 +81,7 @@ Kubernetes documentation contribution process. Here are the steps to get you sta
    `good first issue` or `help wanted`. These are great for beginners. Leave constructive
    feedback and suggestions. Familiarize yourself with the
    [content guide](/docs/contribute/style/content-guide/) and the 
-   [style guide](/docs/contribute/style/style-guide/) to provide more effective
+   [style guide](/docs/contribute/style/style-guide/) to provide more effectively 
    [reviewing Pull Requests](/docs/contribute/review/reviewing-prs/).
 
 1. **Attend SIG Docs Meetings**: Participate in the 
@@ -90,18 +89,24 @@ Kubernetes documentation contribution process. Here are the steps to get you sta
    meetings are an excellent opportunity to meet fellow contributors, discuss documentation
    improvements, and volunteer for reviewing tasks.
 
-1. **Shadow an Experienced Reviewer**: If possible, shadow an 
-   [experienced reviewer](/docs/contribute/participate/roles-and-responsibilities/) 
-   to learn best practices and tips for reviewing efficiently and effectively.
+1. **Shadow an Experienced Reviewer**: To better understand the review process, sign up for our official
+   [PR Wrangling shadow program](/docs/contribute/participate/pr-wranglers/#pr-wrangler-shadow-program)
+   where you will be able to shadow an [experienced reviewer](/docs/contribute/participate/roles-and-responsibilities/) 
+   and learn best practices and tips for reviewing efficiently and effectively.
 
-## What's Next?
+1. **Contributor Ladder**: Familiarize yourself with the
+   [CNCF contributor ladder](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md),
+   which guides your progression from newcomer to advanced contributor roles in the Kubernetes community.
+
+## What's next?
 
 After consistently contributing to documentation reviews and demonstrating your understanding
 of Kubernetes documentation standards, you can express your interest in becoming an official
-SIG Docs reviewer. As you build up this skill set, reviews are still welcome! You don't need to be a formal reviewer in the SIG to leave reviews on PRs or blog posts. Engage with the SIG Docs chairs or leads on Slack or during SIG Docs
-meetings to discuss the next steps.
+SIG Docs reviewer. Engage with the SIG Docs chairs or leads on the
+[public Slack channel](https://kubernetes.slack.com/channels/C1J0BPD2M)
+or during SIG Docs meetings to discuss the next steps.
 
-## See YOU in the Docs!
+## See _you_ in the docs!
 
 Becoming a SIG Docs reviewer is more than contributing; it's embracing the heart of the
 Kubernetes community 🚀. Enhance your knowledge and writing skills while contributing

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -38,7 +38,7 @@ making you the unsung hero of their open-source odyssey.
 
 ## Why Become a SIG Docs Reviewer?
 
-The Kubernetes project depends substantially on the SIG Docs team to ensure that documentation
+The Kubernetes project depends substantially on SIG Docs to ensure that documentation
 is accurate, up to date, and easily accessible. By becoming a reviewer, you can help users
 and contributors navigate and understand Kubernetes more effectively. In addition, reviewing
 documentation provides unique opportunities for:

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -82,7 +82,7 @@ Kubernetes documentation contribution process. Here are the steps to get you sta
    `good first issue` or `help wanted`. These are great for beginners. Leave constructive
    feedback and suggestions. Familiarize yourself with the
    [content guide](/docs/contribute/style/content-guide/) and the 
-   [style guide](/docs/contribute/style/style-guide/) to provide more effectively 
+   [style guide](/docs/contribute/style/style-guide/) to provide more effective
    [reviewing Pull Requests](/docs/contribute/review/reviewing-prs/).
 
 1. **Attend SIG Docs Meetings**: Participate in the 

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -1,0 +1,109 @@
+---
+layout: blog
+title: "From Code to Quill: Embark on a Legendary Kubernetes Quest with SIG-Docs"
+date: 2024-04-28
+slug: contribute-as-sig-docs-reviewer
+author: >
+   Ricardo Amaro (Acquia)
+---
+
+You've probably come across the saying, "Contributing doesn't always mean writing lines of code"
+whispered to the wind or glimpsed in the margins of a sacred open-source tome.
+What is the truth behind this tale as old as time (or at least as old as Kubernetes itself)?
+
+Imagine Sarah: an enthusiast of open-source whose keyboard had seen more action crafting
+technical masterpieces for her projects than a knight's sword in battle. Sarah's had such
+a smooth relationship with Git, that she could `git commit` and `git push` in her sleep,
+and her etiquette in pull-requests was so polished, it could make a silver spoon look tarnished.
+
+But here's the twist: when it came to the mysterious _art-of-coding_, Sarah felt more
+like a fish out of water — or more accurately, like trying to navigate a Kubernetes cluster
+with a compass and a star map. The very thought of diving into the codebase made her feel like
+she was trying to read ancient hieroglyphs without a Rosetta Stone.
+
+Did Sarah let this stop her? Not at all. She discovered a path as impactful as a well-placed
+line of code: joining the Special Interest Group (SIG) Docs team. It was there that Sarah found her true calling,
+helping transform the dense field of Kubernetes documentation into a well-tended garden of knowledge.
+
+Sarah's odyssey from a mere mortal Kubernetes user to a demigod of documentation didn't
+just prove that contributions of knowledge and expertise are as valuable as code
+contributions—it also showed that you don't need to be a coding wizard to make a significant
+impact. Her journey is a beacon of hope for all who fear the merge conflict, a testament
+to the power of the written word in the realm of open-source.
+
+So, let Sarah's story inspire you. No matter if you're a code ninja or a prose maestro,
+there's a place for you in the open-source pantheon. And who knows? Maybe one day,
+your documentation will be the guiding light for a lost soul in the Kubernetes sea,
+making you the unsung hero of their open-source odyssey.
+
+## Why Become a SIG Docs Reviewer?
+
+The Kubernetes project depends substantially on the SIG Docs team to ensure that documentation
+is accurate, up to date, and easily accessible. By becoming a reviewer, you can help users
+and contributors navigate and understand Kubernetes more effectively. In addition, reviewing
+documentation provides unique opportunities for:
+
+- **Expand your Kubernetes knowledge**: Engage deeply with new features and functionalities
+  by reviewing their documentation.
+- **Improve your technical writing skills**: Develop an eye for detail and clarity in technical
+  writing.
+- **Strengthen the Kubernetes community**: Help maintain the high quality of Kubernetes
+  documentation, supporting both new and experienced users.
+- **Build your network**: Expanding your professional network, and getting together with
+  contributors from around the globe.
+
+## Who Are We Looking For?
+
+We're seeking open-source enthusiasts with:
+
+- Experience with Git and GitHub, comfortable with the process of reviewing pull requests
+  and providing constructive feedback.
+- Familiarity with Markdown and documentation frameworks (Hugo experience is a plus but
+  not required).
+- A passion for making complex technical concepts understandable and accessible.
+
+Prior experience in technical writing or documentation review in any open-source project
+will be beneficial but not mandatory.
+
+## How to Get Started
+
+Becoming a SIG Docs reviewer is a journey that starts with familiarizing yourself with the
+Kubernetes documentation contribution process. Here are the steps to get you started:
+
+1. **Familiarize Yourself with SIG Docs**: Start by reading the
+   [SIG Docs contributor guide](/docs/contribute/) to understand
+   how documentation contributions are made.
+
+1. **Join the Kubernetes Slack**: Connect with the SIG Docs community on the
+   [#sig-docs channel](https://kubernetes.slack.com/messages/sig-docs). It's a great place
+   to ask questions, find mentorship, and get to know the community.
+
+1. **Start Reviewing Pull Requests**: Look for open pull requests labeled with
+   `good first issue` or `help wanted`. These are great for beginners. Leave constructive
+   feedback and suggestions. Familiarize yourself with the
+   [content guide](/docs/contribute/style/content-guide/) and the 
+   [style guide](/docs/contribute/style/style-guide/) to provide more effectively 
+   [reviewing Pull Requests](/docs/contribute/review/reviewing-prs/).
+
+1. **Attend SIG Docs Meetings**: Participate in the 
+   [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs). These
+   meetings are an excellent opportunity to meet fellow contributors, discuss documentation
+   improvements, and volunteer for reviewing tasks.
+
+1. **Shadow an Experienced Reviewer**: If possible, shadow an 
+   [experienced reviewer](/docs/contribute/participate/roles-and-responsibilities/) 
+   to learn best practices and tips for reviewing efficiently and effectively.
+
+## What's Next?
+
+After consistently contributing to documentation reviews and demonstrating your understanding
+of Kubernetes documentation standards, you can express your interest in becoming an official
+SIG Docs reviewer. Engage with the SIG Docs chairs or leads on Slack or during SIG Docs
+meetings to discuss the next steps.
+
+## See YOU in the Docs!
+
+Becoming a SIG Docs reviewer is more than contributing; it's embracing the heart of the
+Kubernetes community 🚀. Enhance your knowledge and writing skills while contributing
+to our valuable documentation. This is your opportunity to guide others with your expertise
+and make a lasting impact. Welcome aboard—see you there! 🌟

--- a/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
+++ b/content/en/blog/_posts/2024-04-28-contribute-as-sig-docs-reviewer.md
@@ -3,6 +3,7 @@ layout: blog
 title: "From Code to Quill: Embark on a Legendary Kubernetes Quest with SIG Docs"
 date: 2024-05-16
 slug: contribute-as-sig-docs-reviewer
+canonicalUrl: https://www.kubernetes.dev/blog/2024/05/16/contribute-as-sig-docs-reviewer/
 author: "Ricardo Amaro (Acquia)"
 ---
 


### PR DESCRIPTION
This blog post aims to attract open-source contributors with Git/GitHub knowledge to become Kubernetes SIG-Docs reviewers.

cc/ @sftim