### PR TITLE
[ja] update the term "Node" in `/docs/concepts/scheduling-eviction/taint-and-toleration.md`

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/ja/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -6,19 +6,19 @@ weight: 50
 
 
 <!-- overview -->
-[_Nodeアフィニティ_](/ja/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)は
-{{< glossary_tooltip text="Pod" term_id="pod" >}}の属性であり、ある{{< glossary_tooltip text="Node" term_id="node" >}}群を*引きつけます*（優先条件または必須条件）。反対に _taint_ はNodeがある種のPodを排除できるようにします。
+[_ノードアフィニティ_](/ja/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)は
+{{< glossary_tooltip text="Pod" term_id="pod" >}}の属性であり、ある{{< glossary_tooltip text="ノード" term_id="node" >}}群を*引きつけます*（優先条件または必須条件）。反対に _taint_ はノードがある種のPodを排除できるようにします。
 
-_toleration_ はPodに適用され、一致するtaintが付与されたNodeへPodがスケジューリングされることを認めるものです。ただしそのNodeへ必ずスケジューリングされるとは限りません。
+_toleration_ はPodに適用され、一致するtaintが付与されたノードへPodがスケジューリングされることを認めるものです。ただしそのノードへ必ずスケジューリングされるとは限りません。
 
-taintとtolerationは組になって機能し、Podが不適切なNodeへスケジューリングされないことを保証します。taintはNodeに一つまたは複数個付与することができます。これはそのNodeがtaintを許容しないPodを受け入れるべきではないことを示します。
+taintとtolerationは組になって機能し、Podが不適切なノードへスケジューリングされないことを保証します。taintはノードに一つまたは複数個付与することができます。これはそのノードがtaintを許容しないPodを受け入れるべきではないことを示します。
 
 
 <!-- body -->
 
 ## コンセプト
 
-Nodeにtaintを付与するには[kubectl taint](/docs/reference/generated/kubectl/kubectl-commands#taint)コマンドを使用します。
+ノードにtaintを付与するには[kubectl taint](/docs/reference/generated/kubectl/kubectl-commands#taint)コマンドを使用します。
 例えば、次のコマンドは
 
 ```shell
@@ -72,17 +72,17 @@ tolerationがtaintと合致するのは、`key`と`effect`が同一であり、�
 {{< /note >}}
 
 上記の例では`effect`に`NoSchedule`を指定しました。代わりに、`effect`に`PreferNoSchedule`を指定することができます。
-これは`NoSchedule`の「ソフトな」バージョンであり、システムはtaintに対応するtolerationが設定されていないPodがNodeへ配置されることを避けようとしますが、必須の条件とはしません。3つ目の`effect`の値として`NoExecute`がありますが、これについては後述します。
+これは`NoSchedule`の「ソフトな」バージョンであり、システムはtaintに対応するtolerationが設定されていないPodがノードへ配置されることを避けようとしますが、必須の条件とはしません。3つ目の`effect`の値として`NoExecute`がありますが、これについては後述します。
 
-同一のNodeに複数のtaintを付与することや、同一のPodに複数のtolerationを設定することができます。
-複数のtaintやtolerationが設定されている場合、Kubernetesはフィルタのように扱います。最初はNodeの全てのtaintがある状態から始め、Podが対応するtolerationを持っているtaintは無視され外されていきます。無視されずに残ったtaintが効果を及ぼします。
+同一のノードに複数のtaintを付与することや、同一のPodに複数のtolerationを設定することができます。
+複数のtaintやtolerationが設定されている場合、Kubernetesはフィルタのように扱います。最初はノードの全てのtaintがある状態から始め、Podが対応するtolerationを持っているtaintは無視され外されていきます。無視されずに残ったtaintが効果を及ぼします。
 具体的には、
 
-* effect `NoSchedule`のtaintが無視されず残った場合、KubernetesはそのPodをNodeへスケジューリングしません。
-* effect `NoSchedule`のtaintは残らず、effect `PreferNoSchedule`のtaintは残った場合、KubernetesはそのNodeへのスケジューリングをしないように試みます。
-* effect `NoExecute`のtaintが残った場合、既に稼働中のPodはそのNodeから排除され、まだ稼働していないPodはスケジューリングされないようになります。
+* effect `NoSchedule`のtaintが無視されず残った場合、KubernetesはそのPodをノードへスケジューリングしません。
+* effect `NoSchedule`のtaintは残らず、effect `PreferNoSchedule`のtaintは残った場合、Kubernetesはそのノードへのスケジューリングをしないように試みます。
+* effect `NoExecute`のtaintが残った場合、既に稼働中のPodはそのノードから排除され、まだ稼働していないPodはスケジューリングされないようになります。
 
-例として、下記のようなtaintが付与されたNodeを考えます。
+例として、下記のようなtaintが付与されたノードを考えます。
 
 ```shell
 kubectl taint nodes node1 key1=value1:NoSchedule
@@ -104,11 +104,11 @@ tolerations:
   effect: "NoExecute"
 ```
 
-この例では、3つ目のtaintと合致するtolerationがないため、PodはNodeへはスケジューリングされません。
-しかし、これらのtaintが追加された時点で、そのNodeでPodが稼働していれば続けて稼働することが可能です。 これは、Podのtolerationと合致しないtaintは3つあるtaintのうちの3つ目のtaintのみであり、それが`NoSchedule`であるためです。
+この例では、3つ目のtaintと合致するtolerationがないため、Podはノードへはスケジューリングされません。
+しかし、これらのtaintが追加された時点で、そのノードでPodが稼働していれば続けて稼働することが可能です。 これは、Podのtolerationと合致しないtaintは3つあるtaintのうちの3つ目のtaintのみであり、それが`NoSchedule`であるためです。
 
-一般に、effect `NoExecute`のtaintがNodeに追加されると、合致するtolerationが設定されていないPodは即時にNodeから排除され、合致するtolerationが設定されたPodが排除されることは決してありません。
-しかし、effect`NoExecute`に対するtolerationは`tolerationSeconds`フィールドを任意で指定することができ、これはtaintが追加された後にそのNodeにPodが残る時間を示します。例えば、
+一般に、effect `NoExecute`のtaintがノードに追加されると、合致するtolerationが設定されていないPodは即時にノードから排除され、合致するtolerationが設定されたPodが排除されることは決してありません。
+しかし、effect`NoExecute`に対するtolerationは`tolerationSeconds`フィールドを任意で指定することができ、これはtaintが追加された後にそのノードにPodが残る時間を示します。例えば、
 
 ```yaml
 tolerations:
@@ -119,34 +119,34 @@ tolerations:
   tolerationSeconds: 3600
 ```
 
-この例のPodが稼働中で、対応するtaintがNodeへ追加された場合、PodはそのNodeに3600秒残り、その後排除されます。仮にtaintがそれよりも前に外された場合、Podは排除されません。
+この例のPodが稼働中で、対応するtaintがノードへ追加された場合、Podはそのノードに3600秒残り、その後排除されます。仮にtaintがそれよりも前に外された場合、Podは排除されません。
 
 ## ユースケースの例
 
-taintとtolerationは、実行されるべきではないNodeからPodを遠ざけたり、排除したりするための柔軟な方法です。いくつかのユースケースを示します。
+taintとtolerationは、実行されるべきではないノードからPodを遠ざけたり、排除したりするための柔軟な方法です。いくつかのユースケースを示します。
 
-* **専有Node**: あるNode群を特定のユーザーに専有させたい場合、そのNode群へtaintを追加し(`kubectl taint nodes nodename dedicated=groupName:NoSchedule`) 対応するtolerationをPodへ追加します（これを実現する最も容易な方法はカスタム
+* **専有ノード**: あるノード群を特定のユーザーに専有させたい場合、そのノード群へtaintを追加し(`kubectl taint nodes nodename dedicated=groupName:NoSchedule`) 対応するtolerationをPodへ追加します（これを実現する最も容易な方法はカスタム
 [アドミッションコントローラー](/docs/reference/access-authn-authz/admission-controllers/)を書くことです）。
-tolerationが設定されたPodはtaintの設定された（専有の）Nodeと、クラスターにあるその他のNodeの使用が認められます。もしPodが必ず専有Node*のみ*を使うようにしたい場合は、taintと同様のラベルをそのNode群に設定し(例: `dedicated=groupName`)、アドミッションコントローラーはNodeアフィニティを使ってPodが`dedicated=groupName`のラベルの付いたNodeへスケジューリングすることが必要であるということも設定する必要があります。
+tolerationが設定されたPodはtaintの設定された（専有の）ノードと、クラスターにあるその他のノードの使用が認められます。もしPodが必ず専有ノード*のみ*を使うようにしたい場合は、taintと同様のラベルをそのノード群に設定し(例: `dedicated=groupName`)、アドミッションコントローラーはノードアフィニティを使ってPodが`dedicated=groupName`のラベルの付いたノードへスケジューリングすることが必要であるということも設定する必要があります。
 
-* **特殊なハードウェアを備えるNode**: クラスターの中の少数のNodeが特殊なハードウェア（例えばGPU）を備える場合、そのハードウェアを必要としないPodがスケジューリングされないようにして、後でハードウェアを必要とするPodができたときの余裕を確保したいことがあります。
-これは特殊なハードウェアを持つNodeにtaintを追加(例えば `kubectl taint nodes nodename special=true:NoSchedule` または
+* **特殊なハードウェアを備えるノード**: クラスターの中の少数のノードが特殊なハードウェア（例えばGPU）を備える場合、そのハードウェアを必要としないPodがスケジューリングされないようにして、後でハードウェアを必要とするPodができたときの余裕を確保したいことがあります。
+これは特殊なハードウェアを持つノードにtaintを追加(例えば `kubectl taint nodes nodename special=true:NoSchedule` または
 `kubectl taint nodes nodename special=true:PreferNoSchedule`)して、ハードウェアを使用するPodに対応するtolerationを追加することで可能です。
-専有Nodeのユースケースと同様に、tolerationを容易に適用する方法はカスタム
+専有ノードのユースケースと同様に、tolerationを容易に適用する方法はカスタム
 [アドミッションコントローラー](/docs/reference/access-authn-authz/admission-controllers/)を使うことです。
 例えば、特殊なハードウェアを表すために[拡張リソース](/docs/concepts/configuration/manage-compute-resources-container/#extended-resources)
-を使い、ハードウェアを備えるNodeに拡張リソースの名称のtaintを追加して、
+を使い、ハードウェアを備えるノードに拡張リソースの名称のtaintを追加して、
 [拡張リソースtoleration](/docs/reference/access-authn-authz/admission-controllers/#extendedresourcetoleration)
-アドミッションコントローラーを実行することが推奨されます。Nodeにはtaintが付与されているため、tolerationのないPodはスケジューリングされません。しかし拡張リソースを要求するPodを作成しようとすると、`拡張リソースtoleration` アドミッションコントローラーはPodに自動的に適切なtolerationを設定し、Podはハードウェアを備えるNodeへスケジューリングされます。
-これは特殊なハードウェアを備えたNodeではそれを必要とするPodのみが稼働し、Podに対して手作業でtolerationを追加しなくて済むようにします。
+アドミッションコントローラーを実行することが推奨されます。ノードにはtaintが付与されているため、tolerationのないPodはスケジューリングされません。しかし拡張リソースを要求するPodを作成しようとすると、`拡張リソースtoleration` アドミッションコントローラーはPodに自動的に適切なtolerationを設定し、Podはハードウェアを備えるノードへスケジューリングされます。
+これは特殊なハードウェアを備えたノードではそれを必要とするPodのみが稼働し、Podに対して手作業でtolerationを追加しなくて済むようにします。
 
-* **taintを基にした排除**: Nodeに問題が起きたときにPodごとに排除する設定を行うことができます。次のセクションにて説明します。
+* **taintを基にした排除**: ノードに問題が起きたときにPodごとに排除する設定を行うことができます。次のセクションにて説明します。
 
 ## taintを基にした排除
 
 {{< feature-state for_k8s_version="v1.18" state="stable" >}}
 
-上述したように、effect `NoExecute`のtaintはNodeで実行中のPodに次のような影響を与えます。
+上述したように、effect `NoExecute`のtaintはノードで実行中のPodに次のような影響を与えます。
 
  * 対応するtolerationのないPodは即座に除外される
  * 対応するtolerationがあり、それに`tolerationSeconds`が指定されていないPodは残り続ける
@@ -155,26 +155,26 @@ tolerationが設定されたPodはtaintの設定された（専有の）Nodeと�
 Nodeコントローラーは特定の条件を満たす場合に自動的にtaintを追加します。
 組み込まれているtaintは下記の通りです。
 
- * `node.kubernetes.io/not-ready`: Nodeの準備ができていない場合。これはNodeCondition `Ready`が`False`である場合に対応します。
- * `node.kubernetes.io/unreachable`: NodeがNodeコントローラーから到達できない場合。これはNodeCondition`Ready`が`Unknown`の場合に対応します。
- * `node.kubernetes.io/out-of-disk`: Nodeのディスクの空きがない場合。
- * `node.kubernetes.io/memory-pressure`: Nodeのメモリーが不足している場合。
- * `node.kubernetes.io/disk-pressure`: Nodeのディスクが不足している場合。
- * `node.kubernetes.io/network-unavailable`: Nodeのネットワークが利用できない場合。
- * `node.kubernetes.io/unschedulable`: Nodeがスケジューリングできない場合。
- * `node.cloudprovider.kubernetes.io/uninitialized`: kubeletが外部のクラウド事業者により起動されたときに設定されるtaintで、このNodeは利用不可能であることを示します。cloud-controller-managerによるコントローラーがこのNodeを初期化した後にkubeletはこのtaintを外します。
+ * `node.kubernetes.io/not-ready`: ノードの準備ができていない場合。これはNodeCondition `Ready`が`False`である場合に対応します。
+ * `node.kubernetes.io/unreachable`: ノードがノードコントローラーから到達できない場合。これはNodeCondition`Ready`が`Unknown`の場合に対応します。
+ * `node.kubernetes.io/out-of-disk`: ノードのディスクの空きがない場合。
+ * `node.kubernetes.io/memory-pressure`: ノードのメモリーが不足している場合。
+ * `node.kubernetes.io/disk-pressure`: ノードのディスクが不足している場合。
+ * `node.kubernetes.io/network-unavailable`: ノードのネットワークが利用できない場合。
+ * `node.kubernetes.io/unschedulable`: ノードがスケジューリングできない場合。
+ * `node.cloudprovider.kubernetes.io/uninitialized`: kubeletが外部のクラウド事業者により起動されたときに設定されるtaintで、このノードは利用不可能であることを示します。cloud-controller-managerによるコントローラーがこのノードを初期化した後にkubeletはこのtaintを外します。
 
-Nodeから追い出すときには、Nodeコントローラーまたはkubeletは関連するtaintを`NoExecute`効果の状態で追加します。
-不具合のある状態から通常の状態へ復帰した場合は、kubeletまたはNodeコントローラーは関連するtaintを外すことができます。
+ノードから追い出すときには、ノードコントローラーまたはkubeletは関連するtaintを`NoExecute`効果の状態で追加します。
+不具合のある状態から通常の状態へ復帰した場合は、kubeletまたはノードコントローラーは関連するtaintを外すことができます。
 
 {{< note >}}
-コントロールプレーンは新しいtaintをNodeに加えるレートを制限しています。
-このレート制限は一度に多くのNodeが到達不可能になった場合（例えばネットワークの断絶）に、退役させられるNodeの数を制御します。
+コントロールプレーンは新しいtaintをノードに加えるレートを制限しています。
+このレート制限は一度に多くのノードが到達不可能になった場合（例えばネットワークの断絶）に、退役させられるノードの数を制御します。
 {{< /note >}}
 
-Podに`tolerationSeconds`を指定することで不具合があるか応答のないNodeに残る時間を指定することができます。
+Podに`tolerationSeconds`を指定することで不具合があるか応答のないノードに残る時間を指定することができます。
 
-例えば、ローカルの状態を多数持つアプリケーションとネットワークが分断された場合を考えます。ネットワークが復旧して、Podを排除しなくて済むことを見込んで、長時間Nodeから排除されないようにしたいこともあるでしょう。
+例えば、ローカルの状態を多数持つアプリケーションとネットワークが分断された場合を考えます。ネットワークが復旧して、Podを排除しなくて済むことを見込んで、長時間ノードから排除されないようにしたいこともあるでしょう。
 この場合Podに設定するtolerationは次のようになります。
 
 ```yaml
@@ -188,7 +188,7 @@ tolerations:
 {{< note >}}
 Kubernetesはユーザーまたはコントローラーが明示的に指定しない限り、自動的に`node.kubernetes.io/not-ready`と`node.kubernetes.io/unreachable`に対するtolerationを`tolerationSeconds=300`にて設定します。
 
-自動的に設定されるtolerationは、taintに対応する問題がNodeで検知されても5分間はそのNodeにPodが残されることを意味します。
+自動的に設定されるtolerationは、taintに対応する問題がノードで検知されても5分間はそのノードにPodが残されることを意味します。
 {{< /note >}}
 
 [DaemonSet](/ja/docs/concepts/workloads/controllers/daemonset/)のPodは次のtaintに対して`NoExecute`のtolerationが`tolerationSeconds`を指定せずに設定されます。
@@ -200,9 +200,9 @@ Kubernetesはユーザーまたはコントローラーが明示的に指定し�
 
 ## 条件によるtaintの付与
 
-NodeのライフサイクルコントローラーはNodeの状態に応じて`NoSchedule`効果のtaintを付与します。
-スケジューラーはNodeの状態ではなく、taintを確認します。
-Nodeに何がスケジューリングされるかは、そのNodeの状態に影響されないことを保証します。ユーザーは適切なtolerationをPodに付与することで、どの種類のNodeの問題を無視するかを選ぶことができます。
+ノードのライフサイクルコントローラーはノードの状態に応じて`NoSchedule`効果のtaintを付与します。
+スケジューラーはノードの状態ではなく、taintを確認します。
+ノードに何がスケジューリングされるかは、そのノードの状態に影響されないことを保証します。ユーザーは適切なtolerationをPodに付与することで、どの種類のノードの問題を無視するかを選ぶことができます。
 
 DaemonSetのコントローラーは、DaemonSetが中断されるのを防ぐために自動的に次の`NoSchedule`tolerationを全てのDaemonSetに付与します。
 


### PR DESCRIPTION
## Feature Description

- Fix the term "Node/node" to "ノード" in `/docs/concepts/scheduling-eviction/taint-and-toleration.md`

## Ref

https://kubernetes.io/ja/docs/contribute/localization/#terminology

> ただし、ノード(Node)に関しては明確にKubernetesとしてのNodeリソース(例: kind: Nodeやkubectl get nodes)を指していないのであれば、「ノード」と表記してください。