### PR TITLE
[ja] update the term "Node" in /docs/concepts/scheduling-eviction/_index.md

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/_index.md
+++ b/content/ja/docs/concepts/scheduling-eviction/_index.md
@@ -15,7 +15,7 @@ Kubernetesにおいてスケジューリングとは、稼働させたい{{<glos
 ## スケジューリング
 
 * [Kubernetesのスケジューラー](/ja/docs/concepts/scheduling-eviction/kube-scheduler/)
-* [Node上へのPodのスケジューリング](/ja/docs/concepts/scheduling-eviction/assign-pod-node/)
+* [ノード上へのPodのスケジューリング](/ja/docs/concepts/scheduling-eviction/assign-pod-node/)
 * [Podのオーバーヘッド](/ja/docs/concepts/scheduling-eviction/pod-overhead/)
 * [Pod Topology Spread Constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 * [Taints and Tolerations](/docs/concepts/scheduling-eviction/taint-and-toleration/)


### PR DESCRIPTION
## Feature Description

- Fix the term "Node/node" to "ノード" in `/docs/concepts/scheduling-eviction/_index.md`

## Ref

https://kubernetes.io/ja/docs/contribute/localization/#terminology

> ただし、ノード(Node)に関しては明確にKubernetesとしてのNodeリソース(例: kind: Nodeやkubectl get nodes)を指していないのであれば、「ノード」と表記してください。