### PR TITLE
Fix typo in Service page

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -990,7 +990,7 @@ to control how Kubernetes routes traffic to healthy (“ready”) backends.
 
 See [Traffic Policies](/docs/reference/networking/virtual-ips/#traffic-policies) for more details.
 
-### Trafic distribution
+### Traffic distribution
 
 {{< feature-state feature_gate_name="ServiceTrafficDistribution" >}}
 


### PR DESCRIPTION
Fixed typo in Service page from trafic-distribution to not traffic-distribution.

Closes https://github.com/kubernetes/website/issues/46073