### PR TITLE
Use lowercases for some terms in kubectl/introduction.md

### DIFF
--- a/content/en/docs/reference/kubectl/introduction.md
+++ b/content/en/docs/reference/kubectl/introduction.md
@@ -1,49 +1,49 @@
 ---
-title: "Introduction To Kubectl"
+title: "Introduction to kubectl"
 content_type: concept
 weight: 1
 ---
 
-Kubectl is the Kubernetes cli version of a swiss army knife, and can do many things.
+kubectl is the Kubernetes cli version of a swiss army knife, and can do many things.
 
-While this Book is focused on using Kubectl to declaratively manage Applications in Kubernetes, it
-also covers other Kubectl functions.
+While this Book is focused on using kubectl to declaratively manage applications in Kubernetes, it
+also covers other kubectl functions.
 
 ## Command Families
 
-Most Kubectl commands typically fall into one of a few categories:
+Most kubectl commands typically fall into one of a few categories:
 
 | Type                                   | Used For                   | Description                                        |
 |----------------------------------------|----------------------------|----------------------------------------------------|
-| Declarative Resource Management        | Deployment and Operations (e.g. GitOps)   | Declaratively manage Kubernetes Workloads using Resource Config     |
-| Imperative Resource Management         | Development Only           | Run commands to manage Kubernetes Workloads using Command Line arguments and flags |
-| Printing Workload State | Debugging  | Print information about Workloads |
-| Interacting with Containers | Debugging  | Exec, Attach, Cp, Logs |
-| Cluster Management | Cluster Ops | Drain and Cordon Nodes |
+| Declarative Resource Management        | Deployment and operations (e.g. GitOps)   | Declaratively manage Kubernetes workloads using resource configuration     |
+| Imperative Resource Management         | Development Only           | Run commands to manage Kubernetes workloads using Command Line arguments and flags |
+| Printing Workload State | Debugging  | Print information about workloads |
+| Interacting with Containers | Debugging  | Exec, attach, cp, logs |
+| Cluster Management | Cluster operations | Drain and cordon Nodes |
 
 ## Declarative Application Management
 
-The preferred approach for managing Resources is through
-declarative files called Resource Config used with the Kubectl *Apply* command.
+The preferred approach for managing resources is through
+declarative files called resource configuration used with the kubectl *Apply* command.
 This command reads a local (or remote) file structure and modifies cluster state to
 reflect the declared intent.
 
 {{< alert color="success" title="Apply" >}}
-Apply is the preferred mechanism for managing Resources in a Kubernetes cluster.
+Apply is the preferred mechanism for managing resources in a Kubernetes cluster.
 {{< /alert >}}
 
-## Printing state about Workloads
+## Printing State about Workloads
 
-Users will need to view Workload state.
+Users will need to view workload state.
 
-- Printing summarize state and information about Resources
-- Printing complete state and information about Resources
-- Printing specific fields from Resources
-- Query Resources matching labels
+- Printing summarize state and information about resources
+- Printing complete state and information about resources
+- Printing specific fields from resources
+- Query resources matching labels
 
 ## Debugging Workloads
 
-Kubectl supports debugging by providing commands for:
+kubectl supports debugging by providing commands for:
 
 - Printing Container logs
 - Printing cluster events
@@ -52,20 +52,20 @@ Kubectl supports debugging by providing commands for:
 
 ## Cluster Management
 
-On occasion, users may need to perform operations to the Nodes of cluster.  Kubectl supports
-commands to drain Workloads from a Node so that it can be decommission or debugged.
+On occasion, users may need to perform operations to the Nodes of cluster. kubectl supports
+commands to drain workloads from a Node so that it can be decommissioned or debugged.
 
 ## Porcelain
 
-Users may find using Resource Config overly verbose for *Development* and prefer to work with
-the cluster *imperatively* with a shell-like workflow.  Kubectl offers porcelain commands for
-generating and modifying Resources.
+Users may find using resource configuration overly verbose for *development* and prefer to work with
+the cluster *imperatively* with a shell-like workflow. kubectl offers porcelain commands for
+generating and modifying resources.
 
-- Generating + creating Resources such as Deployments, StatefulSets, Services, ConfigMaps, etc
-- Setting fields on Resources
-- Editing (live) Resources in a text editor
+- Generating + creating resources such as Deployments, StatefulSets, Services, ConfigMaps, etc.
+- Setting fields on resources
+- Editing (live) resources in a text editor
 
-{{< alert color="warning" title="Porcelain For Dev Only" >}}
+{{< alert color="warning" title="Porcelain for Dev Only" >}}
 Porcelain commands are time saving for experimenting with workloads in a dev cluster, but shouldn't
 be used for production.
 {{< /alert >}}


### PR DESCRIPTION
Inspired by https://github.com/kubernetes/website/pull/46056#discussion_r1584032947, it is suggested to make changes to the text by converting the first letter of certain terms from uppercase to lowercase, or to a more natural way.

Thanks @tengqm 