### PR TITLE
[de] Update controller definition for clarity and conciseness

### DIFF
--- a/content/de/docs/reference/glossary/controller.md
+++ b/content/de/docs/reference/glossary/controller.md
@@ -11,8 +11,8 @@ tags:
 - architecture
 - fundamental
 ---
-In Kubernetes sind Controller Kontrollschleifen, die den Zustand des {{< glossary_tooltip term_id="cluster" text="Clusters">}} beobachten, und dann Änderungen ausführen oder anfragen, wenn benötigt.
-Jeder Controller versucht den aktuellen Clusterzustand in Richtung des Wunschzustands zu bewegen.
+In Kubernetes sind Controller Kontrollschleifen, die den Zustand des {{< glossary_tooltip term_id="cluster" text="Clusters">}} überwachen und bei Bedarf Änderungen ausführen oder anfordern.
+Jeder Controller versucht, den aktuellen Clusterzustand in Richtung des Wunschzustands zu bewegen.
 
 <!--more-->
 


### PR DESCRIPTION
This commit updates the definition of controllers in Kubernetes to enhance clarity and conciseness. The changes include:

- Simplified the description by removing redundant phrases and improving the flow.
- Corrected grammatical structure for better readability.

Changes made:
- From: "In Kubernetes sind Controller Kontrollschleifen, die den Zustand des Clusters beobachten, und dann Änderungen ausführen oder anfragen, wenn benötigt."
- To: "In Kubernetes sind Controller Kontrollschleifen, die den Zustand des Clusters überwachen und bei Bedarf Änderungen ausführen oder anfordern."

- From: "Jeder Controller versucht den aktuellen Clusterzustand in Richtung des Wunschzustands zu bewegen."
- To: "Jeder Controller versucht, den aktuellen Clusterzustand in Richtung des Wunschzustands zu bewegen."

This revision aims to make the text more accessible and easier to understand for both new and existing Kubernetes community members.
