### PR TITLE
Update 2021 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2021-03-09-The-Evolution-of-Kubernetes-Dashboard/index.md
+++ b/content/en/blog/_posts/2021-03-09-The-Evolution-of-Kubernetes-Dashboard/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "The Evolution of Kubernetes Dashboard"
 date: 2021-03-09
 slug: the-evolution-of-kubernetes-dashboard
+author: >
+  Marcin Maciaszczyk (Kubermatic),
+  Sebastian Florek (Kubermatic)
 ---
-
-Authors: Marcin Maciaszczyk, Kubermatic & Sebastian Florek, Kubermatic
 
 In October 2020, the Kubernetes Dashboard officially turned five. As main project maintainers, we can barely believe that so much time has passed since our very first commits to the project. However, looking back with a bit of nostalgia, we realize that quite a lot has happened since then. Now it’s due time to celebrate “our baby” with a short recap.
 

--- a/content/en/blog/_posts/2021-04-06-PodSecurityPolicy-Past-Present-and-Future.md
+++ b/content/en/blog/_posts/2021-04-06-PodSecurityPolicy-Past-Present-and-Future.md
@@ -3,8 +3,9 @@ layout: blog
 title: "PodSecurityPolicy Deprecation: Past, Present, and Future"
 date: 2021-04-06
 slug: podsecuritypolicy-deprecation-past-present-and-future
+author: >
+  Tabitha Sable (Kubernetes SIG Security)
 ---
-**Author:** Tabitha Sable (Kubernetes SIG Security)
 
 {{% pageinfo color="primary" %}}
 **Update:** *With the release of Kubernetes v1.25, PodSecurityPolicy has been removed.*

--- a/content/en/blog/_posts/2021-04-08-cronjob-reaches-ga/index.md
+++ b/content/en/blog/_posts/2021-04-08-cronjob-reaches-ga/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kubernetes 1.21: CronJob Reaches GA'
 date: 2021-04-09
 slug: kubernetes-release-1.21-cronjob-ga
+author: >
+   Alay Patel (Red Hat),
+   Maciej Szulik (Red Hat)
 ---
-
- **Authors:** Alay Patel (Red Hat), and Maciej Szulik (Red Hat)
 
 In Kubernetes v1.21, the 
 [CronJob](/docs/concepts/workloads/controllers/cron-jobs/) resource

--- a/content/en/blog/_posts/2021-04-08-kubernetes-release-1.21.md
+++ b/content/en/blog/_posts/2021-04-08-kubernetes-release-1.21.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.21: Power to the Community'
 date: 2021-04-08
 slug: kubernetes-1-21-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.21 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md)
 ---
-
-**Authors:** [Kubernetes 1.21 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md)
 
 We’re pleased to announce the release of Kubernetes 1.21, our first release of 2021! This release consists of 51 enhancements: 13 enhancements have graduated to stable, 16 enhancements are moving to beta, 20 enhancements are entering alpha, and 2 features have been deprecated.
 

--- a/content/en/blog/_posts/2021-04-12-introducing-suspended-jobs.md
+++ b/content/en/blog/_posts/2021-04-12-introducing-suspended-jobs.md
@@ -3,9 +3,9 @@ title: "Introducing Suspended Jobs"
 date: 2021-04-12
 slug: introducing-suspended-jobs
 layout: blog
+author: >
+  Adhityaa Chandrasekar (Google)
 ---
-
-**Author:** Adhityaa Chandrasekar (Google)
 
 [Jobs](/docs/concepts/workloads/controllers/job/) are a crucial part of
 Kubernetes' API. While other kinds of workloads such as [Deployments](/docs/concepts/workloads/controllers/deployment/),

--- a/content/en/blog/_posts/2021-04-13-kube-state-metrics-goes-v-2-0.md
+++ b/content/en/blog/_posts/2021-04-13-kube-state-metrics-goes-v-2-0.md
@@ -3,9 +3,12 @@ layout: blog
 title: "kube-state-metrics goes v2.0"
 date: 2021-04-13
 slug: kube-state-metrics-v-2-0
+author: >
+  Lili Cosic (Red Hat),
+  Frederic Branczyk (Polar Signals),
+  Manuel Rüger (Sony Interactive Entertainment), 
+  Tariq Ibrahim (Salesforce)
 ---
-
-**Authors:** Lili Cosic (Red Hat), Frederic Branczyk (Polar Signals), Manuel Rüger (Sony Interactive Entertainment), Tariq Ibrahim (Salesforce)
 
 ## What?
 

--- a/content/en/blog/_posts/2021-04-14-local-storage-features-go-beta.md
+++ b/content/en/blog/_posts/2021-04-14-local-storage-features-go-beta.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Local Storage: Storage Capacity Tracking, Distributed Provisioning and Generic Ephemeral Volumes hit Beta"
 date: 2021-04-14
 slug: local-storage-features-go-beta
+author: >
+  Patrick Ohly (Intel)
 ---
-
- **Authors:** Patrick Ohly (Intel)
 
 The ["generic ephemeral
 volumes"](/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes)

--- a/content/en/blog/_posts/2021-04-15-Three-Tenancy-Models-for-Kubernetes.md
+++ b/content/en/blog/_posts/2021-04-15-Three-Tenancy-Models-for-Kubernetes.md
@@ -3,9 +3,13 @@ layout: blog
 title: 'Three Tenancy Models For Kubernetes'
 date: 2021-04-15
 slug: three-tenancy-models-for-kubernetes
+author: >
+  Ryan Bezdicek (Medtronic),
+  Jim Bugwadia (Nirmata),
+  Tasha Drew (VMware),
+  Fei Guo (Alibaba), 
+  Adrian Ludwin (Google)
 ---
-
-**Authors:** Ryan Bezdicek (Medtronic), Jim Bugwadia (Nirmata), Tasha Drew (VMware),  Fei Guo (Alibaba), Adrian Ludwin (Google)
 
 Kubernetes clusters are typically used by several teams in an organization. In other cases, Kubernetes may be used to deliver applications to end users requiring segmentation and isolation of resources across users from different organizations. Secure sharing of Kubernetes control plane and worker node resources allows maximizing productivity and saving costs in both cases.
 

--- a/content/en/blog/_posts/2021-04-16-volume-health-monitoring-alpha.md
+++ b/content/en/blog/_posts/2021-04-16-volume-health-monitoring-alpha.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Volume Health Monitoring Alpha Update"
 date: 2021-04-16
 slug: volume-health-monitoring-alpha-update
+author: >
+  Xing Yang (VMware) 
 ---
-
-**Author:** Xing Yang (VMware)
 
 The CSI Volume Health Monitoring feature, originally introduced in 1.19 has undergone a large update for the 1.21 release.
 

--- a/content/en/blog/_posts/2021-04-19-introducing-indexed-jobs.md
+++ b/content/en/blog/_posts/2021-04-19-introducing-indexed-jobs.md
@@ -2,9 +2,9 @@
 title: "Introducing Indexed Jobs"
 date: 2021-04-19
 slug: introducing-indexed-jobs
+author: >
+  Aldo Culquicondor (Google)
 ---
-
-**Author:** Aldo Culquicondor (Google)
 
 Once you have containerized a non-parallel [Job](/docs/concepts/workloads/controllers/job/),
 it is quite easy to get it up and running on Kubernetes without modifications to

--- a/content/en/blog/_posts/2021-04-20-Defining-NetworkPolicy-Conformance-For-CNIs.md
+++ b/content/en/blog/_posts/2021-04-20-Defining-NetworkPolicy-Conformance-For-CNIs.md
@@ -3,9 +3,14 @@ layout: blog
 title: "Defining Network Policy Conformance for Container Network Interface (CNI) providers"
 date: 2021-04-20
 slug: defining-networkpolicy-conformance-cni-providers
+author: >
+  Matt Fenwick (Synopsys),
+  Jay Vyas (VMWare),
+  Ricardo Katz,
+  Amim Knabben (Loadsmart),
+  Douglas Schilling Landgraf (Red Hat),
+  Christopher Tomkins (Tigera)
 ---
-
-Authors: Matt Fenwick (Synopsys), Jay Vyas (VMWare), Ricardo Katz, Amim Knabben (Loadsmart), Douglas Schilling Landgraf (Red Hat), Christopher Tomkins (Tigera)
 
 Special thanks to Tim Hockin and Bowie Du (Google), Dan Winship and Antonio Ojea (Red Hat),
 Casey Davenport and Shaun Crampton (Tigera), and Abhishek Raut and Antonin Bas (VMware) for

--- a/content/en/blog/_posts/2021-04-20-annotating-k8s-for-humans.md
+++ b/content/en/blog/_posts/2021-04-20-annotating-k8s-for-humans.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Annotating Kubernetes Services for Humans'
 date: 2021-04-20
 slug: annotating-k8s-for-humans
+author: >
+  Richard Li (Ambassador Labs)
 ---
-
-**Author:** Richard Li, Ambassador Labs
 
 Have you ever been asked to troubleshoot a failing Kubernetes service and struggled to find basic information about the service such as the source repository and owner?
 

--- a/content/en/blog/_posts/2021-04-21-Graceful-Node-Shutdown-Beta.md
+++ b/content/en/blog/_posts/2021-04-21-Graceful-Node-Shutdown-Beta.md
@@ -3,9 +3,11 @@ layout: blog
 title: 'Graceful Node Shutdown Goes Beta'
 date: 2021-04-21
 slug: graceful-node-shutdown-beta
+author: >
+  David Porter (Google),
+  Mrunal Patel (Red Hat),
+  Tim Bannister (The Scale Factory)
 ---
-
-**Authors:** David Porter (Google), Mrunal Patel (Red Hat), and Tim Bannister (The Scale Factory)
 
 Graceful node shutdown, beta in 1.21, enables kubelet to gracefully evict pods during a node shutdown.
 

--- a/content/en/blog/_posts/2021-04-22-gateway-api/index.md
+++ b/content/en/blog/_posts/2021-04-22-gateway-api/index.md
@@ -1,12 +1,15 @@
-
 ---
 layout: blog
 title: 'Evolving Kubernetes networking with the Gateway API'
 date: 2021-04-22
 slug: evolving-kubernetes-networking-with-the-gateway-api
+author: >
+   Mark Church (Google),
+   Harry Bagdi (Kong),
+   Daneyon Hanson (Red Hat),
+   Nick Young (VMware),
+   Manuel Zapf (Traefik Labs)
 ---
-
-**Authors:** Mark Church (Google), Harry Bagdi (Kong), Daneyon Hanson (Red Hat), Nick Young (VMware), Manuel Zapf (Traefik Labs)
 
 The Ingress resource is one of the many Kubernetes success stories. It created a [diverse ecosystem of Ingress controllers](/docs/concepts/services-networking/ingress-controllers/) which were used across hundreds of thousands of clusters in a standardized and consistent way. This standardization helped users adopt Kubernetes. However, five years after the creation of Ingress, there are signs of fragmentation into different but [strikingly similar CRDs](https://dave.cheney.net/paste/ingress-is-dead-long-live-ingressroute.pdf) and [overloaded annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/). The same portability that made Ingress pervasive also limited its future.
 

--- a/content/en/blog/_posts/2021-04-23-metrics-stability-ga/index.md
+++ b/content/en/blog/_posts/2021-04-23-metrics-stability-ga/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kubernetes 1.21: Metrics Stability hits GA'
 date: 2021-04-23
 slug: kubernetes-release-1.21-metrics-stability-ga
+author: >
+  Han Kang (Google),
+  Elana Hashman (Red Hat)
 ---
-
-**Authors**: Han Kang (Google), Elana Hashman (Red Hat)
 
 Kubernetes 1.21 marks the graduation of the metrics stability framework and along with it, the first officially supported stable metrics. Not only do stable metrics come with supportability guarantees, the metrics stability framework brings escape hatches that you can use if you encounter problematic metrics.
 

--- a/content/en/blog/_posts/2021-05-14-using-finalizers-to-control-deletion.md
+++ b/content/en/blog/_posts/2021-05-14-using-finalizers-to-control-deletion.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Using Finalizers to Control Deletion'
 date: 2021-05-14
 slug: using-finalizers-to-control-deletion
+author: >
+  Aaron Alpar (Kasten)
 ---
-
-**Authors:** Aaron Alpar (Kasten)
 
 Deleting objects in Kubernetes can be challenging. You may think you’ve deleted something, only to find it still persists. While issuing a `kubectl delete` command and hoping for the best might work for day-to-day operations, understanding how Kubernetes `delete` commands operate will help you understand why some objects linger after deletion. 
 

--- a/content/en/blog/_posts/2021-06-21-writing-a-controller-for-pod-labels.md
+++ b/content/en/blog/_posts/2021-06-21-writing-a-controller-for-pod-labels.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Writing a Controller for Pod Labels"
 date: 2021-06-21
 slug: writing-a-controller-for-pod-labels
+author: >
+  Arthur Busser (Padok) 
 ---
-
-**Authors**: Arthur Busser (Padok)
 
 [Operators][what-is-an-operator] are proving to be an excellent solution to
 running stateful distributed applications in Kubernetes. Open source tools like

--- a/content/en/blog/_posts/2021-06-28-announcing-kubernetes-community-group-annual-reports/index.md
+++ b/content/en/blog/_posts/2021-06-28-announcing-kubernetes-community-group-annual-reports/index.md
@@ -6,9 +6,9 @@ description: >
   Special Interest Groups and Working Groups.
 date: 2021-06-28T10:00:00-08:00
 slug: Announcing-Kubernetes-Community-Group-Annual-Reports
+author: >
+  Divya Mohan
 ---
-
-**Authors:** Divya Mohan
 
 {{< figure src="k8s_annual_report_2020.svg" alt="Community annual report 2020" link="https://www.cncf.io/reports/kubernetes-community-annual-report-2020/" >}}
 

--- a/content/en/blog/_posts/2021-07-14-upcoming-changes-in-kubernetes-1-22/index.md
+++ b/content/en/blog/_posts/2021-07-14-upcoming-changes-in-kubernetes-1-22/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes API and Feature Removals In 1.22: Here’s What You Need To Know"
 date: 2021-07-14
 slug: upcoming-changes-in-kubernetes-1-22
+author: >
+  Krishna Kilari (Amazon Web Services),
+  Tim Bannister (The Scale Factory)
 ---
-
-**Authors**: Krishna Kilari (Amazon Web Services), Tim Bannister (The Scale Factory)
 
 As the Kubernetes API evolves, APIs are periodically reorganized or upgraded.
 When APIs evolve, the old APIs they replace are deprecated, and eventually removed.

--- a/content/en/blog/_posts/2021-07-15-SIG-Usability-Spotlight.md
+++ b/content/en/blog/_posts/2021-07-15-SIG-Usability-Spotlight.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Spotlight on SIG Usability"
 date: 2021-07-15
 slug: sig-usability-spotlight-2021
+author: >
+  Kunal Kushwaha (Civo)
 ---
-
-**Author:** Kunal Kushwaha (Civo)
 
 {{< note >}}
 SIG Usability, which is featured in this Spotlight blog, has been deprecated and is no longer active.

--- a/content/en/blog/_posts/2021-07-20-Kubernetes-Release-Cadence/index.md
+++ b/content/en/blog/_posts/2021-07-20-Kubernetes-Release-Cadence/index.md
@@ -3,9 +3,12 @@ layout: blog
 title: "Kubernetes Release Cadence Change: Here’s What You Need To Know"
 date: 2021-07-20
 slug: new-kubernetes-release-cadence
+author: >
+   Celeste Horgan,
+   Adolfo García Veytia,
+   James Laverack,
+   Jeremy Rickard
 ---
-
-**Authors**: Celeste Horgan, Adolfo García Veytia, James Laverack, Jeremy Rickard
 
 On April 23, 2021, the Release Team merged a Kubernetes Enhancement Proposal (KEP) changing the Kubernetes release cycle from four releases a year (once a quarter) to three releases a year. 
 

--- a/content/en/blog/_posts/2021-07-26-update-with-ingress-nginx.md
+++ b/content/en/blog/_posts/2021-07-26-update-with-ingress-nginx.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Updating NGINX-Ingress to use the stable Ingress API'
 date: 2021-07-26
 slug: update-with-ingress-nginx
+author: >
+  James Strong,
+  Ricardo Katz
 ---
-
-**Authors:** James Strong, Ricardo Katz
 
 With all Kubernetes APIs, there is a process to creating, maintaining, and
 ultimately deprecating them once they become GA. The networking.k8s.io API group is no

--- a/content/en/blog/_posts/2021-07-29-kubernetes-1-21-release-interview.md
+++ b/content/en/blog/_posts/2021-07-29-kubernetes-1-21-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Roorkee robots, releases and racing: the Kubernetes 1.21 release interview"
 date: 2021-07-29
+author: >
+  Craig Box (Google)
 ---
-
-**Author**: Craig Box (Google)
 
 With Kubernetes 1.22 due out next week, now is a great time to look back on 1.21. The release team for that version was led by [Nabarun Pal](https://twitter.com/theonlynabarun) from VMware.
 

--- a/content/en/blog/_posts/2021-08-04-kubernetes-release-1.22.md
+++ b/content/en/blog/_posts/2021-08-04-kubernetes-release-1.22.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.22: Reaching New Peaks'
 date: 2021-08-04
 slug: kubernetes-1-22-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.22 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.22/release-team.md)
 ---
-
-**Authors:** [Kubernetes 1.22 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.22/release-team.md)
 
 We’re pleased to announce the release of Kubernetes 1.22, the second release of 2021!
 

--- a/content/en/blog/_posts/2021-08-06-server-side-apply-ga.md
+++ b/content/en/blog/_posts/2021-08-06-server-side-apply-ga.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.22: Server Side Apply moves to GA"
 date: 2021-08-06
 slug: server-side-apply-ga
+author: >
+  Jeffrey Ying (Google)
+  Joe Betz (Google) 
 ---
-
-**Authors:** Jeffrey Ying, Google & Joe Betz, Google
 
 Server-side Apply (SSA) has been promoted to GA in the Kubernetes v1.22 release. The GA milestone means you can depend on the feature and its API, without fear of future backwards-incompatible changes. GA features are protected by the Kubernetes [deprecation policy](/docs/reference/using-api/deprecation-policy/).
 

--- a/content/en/blog/_posts/2021-08-09-alpha-swap-support.md
+++ b/content/en/blog/_posts/2021-08-09-alpha-swap-support.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'New in Kubernetes v1.22: alpha support for using swap memory'
 date: 2021-08-09
 slug: run-nodes-with-swap-alpha
+author: >
+  Elana Hashman (Red Hat)
 ---
-
-**Author:** Elana Hashman (Red Hat)
 
 The 1.22 release introduced alpha support for configuring swap memory usage for
 Kubernetes workloads on a per-node basis.

--- a/content/en/blog/_posts/2021-08-09-csi-windows-support-with-csi-proxy-reaches-ga.md
+++ b/content/en/blog/_posts/2021-08-09-csi-windows-support-with-csi-proxy-reaches-ga.md
@@ -3,9 +3,11 @@ layout: blog
 title: 'Kubernetes 1.22: CSI Windows Support (with CSI Proxy) reaches GA'
 date: 2021-08-09
 slug: csi-windows-support-with-csi-proxy-reaches-ga
+author: >
+  Mauricio Poppe (Google),
+  Jing Xu (Google),
+  Deep Debroy (Apple)
 ---
-
-**Authors:** Mauricio Poppe (Google), Jing Xu (Google), and Deep Debroy (Apple)
 
 *The stable version of CSI Proxy for Windows has been released alongside Kubernetes 1.22.  CSI Proxy enables CSI Drivers running on Windows nodes to perform privileged storage operations.*
 

--- a/content/en/blog/_posts/2021-08-11-memory-manager-moves-to-beta.md
+++ b/content/en/blog/_posts/2021-08-11-memory-manager-moves-to-beta.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes Memory Manager moves to beta"
 date: 2021-08-11
 slug: kubernetes-1-22-feature-memory-manager-moves-to-beta
+author: >
+  Artyom Lukianov (Red Hat),
+  Cezary Zukowski (Samsung) 
 ---
-
-**Authors:** Artyom Lukianov (Red Hat), Cezary Zukowski (Samsung)
 
 The blog post explains some of the internals of the _Memory manager_, a beta feature
 of Kubernetes 1.22. In Kubernetes, the Memory Manager is a

--- a/content/en/blog/_posts/2021-08-16-support-for-hostprocess-containers/index.md
+++ b/content/en/blog/_posts/2021-08-16-support-for-hostprocess-containers/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Alpha in v1.22: Windows HostProcess Containers'
 date: 2021-08-16
 slug: windows-hostprocess-containers
+author: >
+   Brandon Smith (Microsoft)
 ---
-
-**Authors:** Brandon Smith (Microsoft)
 
 Kubernetes v1.22 introduced a new alpha feature for clusters that
 include Windows nodes: HostProcess containers.

--- a/content/en/blog/_posts/2021-08-25-seccomp-default.md
+++ b/content/en/blog/_posts/2021-08-25-seccomp-default.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Enable seccomp for all workloads with a new v1.22 alpha feature"
 date: 2021-08-25
 slug: seccomp-default
+author: >
+  Sascha Grunert (Red Hat)
 ---
-
-**Author:** Sascha Grunert, Red Hat
 
 This blog post is about a new Kubernetes feature introduced in v1.22, which adds
 an additional security layer on top of the existing seccomp support. Seccomp is

--- a/content/en/blog/_posts/2021-08-27-minreadysecond-statefulsets.md
+++ b/content/en/blog/_posts/2021-08-27-minreadysecond-statefulsets.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Minimum Ready Seconds for StatefulSets'
 date: 2021-08-27
 slug: minreadyseconds-statefulsets
+author: >
+  Ravi Gudimetla (Red Hat),
+  Maciej Szulik (Red Hat)
 ---
-
-**Authors:** Ravi Gudimetla (Red Hat), Maciej Szulik (Red Hat)
 
 This blog describes the notion of Availability for `StatefulSet` workloads, and a new alpha feature in Kubernetes 1.22 which adds `minReadySeconds` configuration for `StatefulSets`.
 

--- a/content/en/blog/_posts/2021-08-30-volume-populators-alpha.md
+++ b/content/en/blog/_posts/2021-08-30-volume-populators-alpha.md
@@ -3,10 +3,9 @@ layout: blog
 title: "Kubernetes 1.22: A New Design for Volume Populators"
 date: 2021-08-30
 slug: volume-populators-redesigned
+author: >
+  Ben Swartzlander (NetApp)
 ---
-
-**Authors:**
-Ben Swartzlander (NetApp)
 
 Kubernetes v1.22, released earlier this month, introduced a redesigned approach for volume
 populators. Originally implemented

--- a/content/en/blog/_posts/2021-09-03-api-server-tracing.md
+++ b/content/en/blog/_posts/2021-09-03-api-server-tracing.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Alpha in Kubernetes v1.22: API Server Tracing'
 date: 2021-09-03
 slug: api-server-tracing
+author: >
+  David Ashpole (Google)
 ---
-
-**Authors:** David Ashpole (Google)
 
 In distributed systems, it can be hard to figure out where problems are. You grep through one component's logs just to discover that the source of your problem is in another component.  You search there only to discover that you need to enable debug logs to figure out what really went wrong... And it goes on. The more complex the path your request takes, the harder it is to answer questions about where it went.  I've personally spent many hours doing this dance with a variety of Kubernetes components. Distributed tracing is a tool which is designed to help in these situations, and the Kubernetes API Server is, perhaps, the most important Kubernetes component to be able to debug. At Kubernetes' Sig Instrumentation, our mission is to make it easier to understand what's going on in your cluster, and we are happy to announce that distributed tracing in the Kubernetes API Server reached alpha in 1.22.
 

--- a/content/en/blog/_posts/2021-09-13-read-write-once-pod-access-mode-alpha.md
+++ b/content/en/blog/_posts/2021-09-13-read-write-once-pod-access-mode-alpha.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Introducing Single Pod Access Mode for PersistentVolumes"
 date: 2021-09-13
 slug: read-write-once-pod-access-mode-alpha
+author: >
+  Chris Henzie (Google)
 ---
-
-**Author:** Chris Henzie (Google)
 
 Last month's release of Kubernetes v1.22 introduced a new ReadWriteOncePod access mode for [PersistentVolumes](/docs/concepts/storage/persistent-volumes/#persistent-volumes) and [PersistentVolumeClaims](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 With this alpha feature, Kubernetes allows you to restrict volume access to a single pod in the cluster.

--- a/content/en/blog/_posts/2021-09-27-SIG-Node-Spotlight/index.md
+++ b/content/en/blog/_posts/2021-09-27-SIG-Node-Spotlight/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Spotlight on SIG Node"
 date: 2021-09-27
 slug: sig-node-spotlight-2021
+author: >
+   Dewan Ahmed (Red Hat)
 ---
-
-**Author:** Dewan Ahmed, Red Hat
 
 ## Introduction
 

--- a/content/en/blog/_posts/2021-09-29-data-duplication-in-data-heavy-k8s-env.md
+++ b/content/en/blog/_posts/2021-09-29-data-duplication-in-data-heavy-k8s-env.md
@@ -3,10 +3,9 @@ layout: blog
 title: "How to Handle Data Duplication in Data-Heavy Kubernetes Environments"
 date: 2021-09-29
 slug: how-to-handle-data-duplication-in-data-heavy-kubernetes-environments 
+author: >
+  Augustinas Stirbis (CAST AI)
 ---
-
-**Authors:**
-Augustinas Stirbis (CAST AI)
 
 ## Why Duplicate Data?
 

--- a/content/en/blog/_posts/2021-10-05-nsa-cisa-hardening.md
+++ b/content/en/blog/_posts/2021-10-05-nsa-cisa-hardening.md
@@ -3,10 +3,11 @@ layout: blog
 title: A Closer Look at NSA/CISA Kubernetes Hardening Guidance
 date: 2021-10-05
 slug: nsa-cisa-kubernetes-hardening-guidance
+author: >
+  Jim Angel (Google),
+  Pushkar Joglekar (VMware),
+  Savitha Raghunathan (Red Hat)
 ---
-
-**Authors:** Jim Angel (Google), Pushkar Joglekar (VMware), and Savitha
-Raghunathan (Red Hat)
 
 {{% alert title="Disclaimer" %}}
 The open source tools listed in this article are to serve as examples only 

--- a/content/en/blog/_posts/2021-10-08-clusterclass-and-managed-topologies.md
+++ b/content/en/blog/_posts/2021-10-08-clusterclass-and-managed-topologies.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Introducing ClusterClass and Managed Topologies in Cluster API"
 date: 2021-10-08
 slug: capi-clusterclass-and-managed-topologies
+author: >
+  Fabrizio Pandini (VMware)
 ---
-
-**Author:** Fabrizio Pandini (VMware)
 
 The [Cluster API community](https://cluster-api.sigs.k8s.io/) is happy to announce the implementation of *ClusterClass and Managed Topologies*, a new feature that will greatly simplify how you can provision, upgrade, and operate multiple Kubernetes clusters in a declarative way.
 

--- a/content/en/blog/_posts/2021-10-18-kpng-specialized-proxiers.md
+++ b/content/en/blog/_posts/2021-10-18-kpng-specialized-proxiers.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Use KPNG to Write Specialized kube-proxiers"
 date: 2021-10-18
 slug: use-kpng-to-write-specialized-kube-proxiers
+author: >
+  Lars Ekman (Ericsson)
 ---
-
-**Author**: Lars Ekman (Ericsson)
 
 The post will show you how to create a specialized service kube-proxy
 style network proxier using Kubernetes Proxy NG

--- a/content/en/blog/_posts/2021-11-08-steering-committee-results-2021.md
+++ b/content/en/blog/_posts/2021-11-08-steering-committee-results-2021.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Announcing the 2021 Steering Committee Election Results"
 date: 2021-11-08
 slug: steering-committee-results-2021
+author: >
+  Kaslin Fields
 ---
-
-**Author**: Kaslin Fields
 
 The [2021 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2021) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2021. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 

--- a/content/en/blog/_posts/2021-11-09-non-root-containers-and-devices.md
+++ b/content/en/blog/_posts/2021-11-09-non-root-containers-and-devices.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Non-root Containers And Devices'
 date: 2021-11-09
 slug: non-root-containers-and-devices
+author: >
+  Mikko Ylinen (Intel)
 ---
-
-**Author:** Mikko Ylinen (Intel)
 
 The user/group ID related security settings in Pod's `securityContext` trigger a problem when users want to
 deploy containers that use accelerator devices (via [Kubernetes Device Plugins](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)) on Linux. In this blog

--- a/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
+++ b/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Dockershim removal is coming. Are you ready?"
 date: 2021-11-12
 slug: are-you-ready-for-dockershim-removal
+author: >
+   Sergey Kanzhelev (Google)
 ---
 
-**Authors:** Sergey Kanzhelev, Google. With reviews from Davanum Srinivas, Elana Hashman, Noah Kantrowitz, Rey Lejano.
+**Reviewers:** Davanum Srinivas, Elana Hashman, Noah Kantrowitz, Rey Lejano.
 
 {{% alert color="info" title="Poll closed" %}}
 This poll closed on January 7, 2022.

--- a/content/en/blog/_posts/2021-11-26-memory-qos-cgroups-v2/index.md
+++ b/content/en/blog/_posts/2021-11-26-memory-qos-cgroups-v2/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Quality-of-Service for Memory Resources'
 date: 2021-11-26
 slug: qos-memory-resources
+author: >
+   Tim Xu (Tencent Cloud)
 ---
-
-**Authors:** Tim Xu (Tencent Cloud)
 
 Kubernetes v1.22, released in August 2021, introduced a new alpha feature that improves how Linux nodes implement memory resource requests and limits.
 

--- a/content/en/blog/_posts/2021-12-01-kubernetes-1.22-release-interview.md
+++ b/content/en/blog/_posts/2021-12-01-kubernetes-1.22-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Contribution, containers and cricket: the Kubernetes 1.22 release interview"
 date: 2021-12-01
+author: >
+   Craig Box (Google)
 ---
-
-**Author**: Craig Box (Google)
 
 The Kubernetes release train rolls on, and we look ahead to the release of 1.23 next week. [As is our tradition](https://www.google.com/search?q=%22release+interview%22+site%3Akubernetes.io%2Fblog), I'm pleased to bring you a look back at the process that brought us the previous version.
 

--- a/content/en/blog/_posts/2021-12-07-kubernetes-release-1.23.md
+++ b/content/en/blog/_posts/2021-12-07-kubernetes-release-1.23.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.23: The Next Frontier'
 date: 2021-12-07
 slug: kubernetes-1-23-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.23 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/release-team.md)
 ---
-
-**Authors:** [Kubernetes 1.23 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/release-team.md)
 
 We’re pleased to announce the release of Kubernetes 1.23, the last release of 2021!
 

--- a/content/en/blog/_posts/2021-12-08-dual-stack-networking-ga.md
+++ b/content/en/blog/_posts/2021-12-08-dual-stack-networking-ga.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.23: Dual-stack IPv4/IPv6 Networking Reaches GA'
 date: 2021-12-08
 slug: dual-stack-networking-ga
+author: >
+   Bridget Kromhout (Microsoft)
 ---
-
-**Author:** Bridget Kromhout (Microsoft)
 
 "When will Kubernetes have IPv6?" This question has been asked with increasing frequency ever since alpha support for IPv6 was first added in k8s v1.9. While Kubernetes has supported IPv6-only clusters since v1.18, migration from IPv4 to IPv6 was not yet possible at that point. At long last, [dual-stack IPv4/IPv6 networking](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/563-dual-stack/) has reached general availability (GA) in Kubernetes v1.23.
 

--- a/content/en/blog/_posts/2021-12-09-pod-security-admission-beta.md
+++ b/content/en/blog/_posts/2021-12-09-pod-security-admission-beta.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kubernetes 1.23: Pod Security Graduates to Beta'
 date: 2021-12-09
 slug: pod-security-admission-beta
+author: >
+   Jim Angel (Google),
+   Lachlan Evenson (Microsoft)
 ---
-
-**Authors:** Jim Angel (Google), Lachlan Evenson (Microsoft)
 
 With the release of Kubernetes v1.23, [Pod Security admission](/docs/concepts/security/pod-security-admission/) has now entered beta. Pod Security is a [built-in](/docs/reference/access-authn-authz/admission-controllers/) admission controller that evaluates pod specifications against a predefined set of [Pod Security Standards](/docs/concepts/security/pod-security-standards/) and determines whether to `admit` or `deny` the pod from running.
 

--- a/content/en/blog/_posts/2021-12-10-csi-migration-status.md
+++ b/content/en/blog/_posts/2021-12-10-csi-migration-status.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.23: Kubernetes In-Tree to CSI Volume Migration Status Update"
 date: 2021-12-10
 slug: storage-in-tree-to-csi-migration-status-update
+author: >
+  Jiawei Wang (Google)
 ---
-
-**Author:** Jiawei Wang (Google)
 
 The Kubernetes in-tree storage plugin to [Container Storage Interface (CSI)](/blog/2019/01/15/container-storage-interface-ga/) migration infrastructure has already been [beta](/blog/2019/12/09/kubernetes-1-17-feature-csi-migration-beta/) since v1.17. CSI migration was introduced as alpha in Kubernetes v1.14.
 

--- a/content/en/blog/_posts/2021-12-15-prevent-persistentvolume-leaks-when-deleting-out-of-order.md
+++ b/content/en/blog/_posts/2021-12-15-prevent-persistentvolume-leaks-when-deleting-out-of-order.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.23: Prevent PersistentVolume leaks when deleting out of order"
 date: 2021-12-15T10:00:00-08:00
 slug: kubernetes-1-23-prevent-persistentvolume-leaks-when-deleting-out-of-order
+author: >
+  Deepak Kinni (VMware)
 ---
-
-**Author:** Deepak Kinni (VMware)
 
 [PersistentVolume](/docs/concepts/storage/persistent-volumes/) (or PVs for short) are
 associated with [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaim-policy).

--- a/content/en/blog/_posts/2021-12-16-StatefulSet-PVC-Auto-Deletion.md
+++ b/content/en/blog/_posts/2021-12-16-StatefulSet-PVC-Auto-Deletion.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.23: StatefulSet PVC Auto-Deletion (alpha)'
 date: 2021-12-16
 slug: kubernetes-1-23-statefulset-pvc-auto-deletion
+author: >
+  Matthew Cary (Google)
 ---
-
-**Author:** Matthew Cary (Google)
 
 Kubernetes v1.23 introduced a new, alpha-level policy for
 [StatefulSets](/docs/concepts/workloads/controllers/statefulset/) that controls the lifetime of

--- a/content/en/blog/_posts/2021-12-17-security-profiles-operator-v0.4.0/index.md
+++ b/content/en/blog/_posts/2021-12-17-security-profiles-operator-v0.4.0/index.md
@@ -3,10 +3,11 @@ layout: blog
 title: "What's new in Security Profiles Operator v0.4.0"
 date: 2021-12-17
 slug: security-profiles-operator
----
-
-**Authors:** Jakub Hrozek, Juan Antonio Osorio, Paulo Gomes, Sascha Grunert
-
+author: >
+   Jakub Hrozek,
+   Juan Antonio Osorio,
+   Paulo Gomes,
+   Sascha Grunert
 ---
 
 The [Security Profiles Operator (SPO)](https://sigs.k8s.io/security-profiles-operator)

--- a/content/en/blog/_posts/2021-12-21-admission-controllers-for-container-drift/index.md
+++ b/content/en/blog/_posts/2021-12-21-admission-controllers-for-container-drift/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Using Admission Controllers to Detect Container Drift at Runtime"
 date: 2021-12-21
 slug: admission-controllers-for-container-drift
+author: >
+   Saifuding Diliyaer (Box)
 ---
 
-**Author:** Saifuding Diliyaer (Box)
 {{< figure src="intro-illustration.png" alt="Introductory illustration" attr="Illustration by Munire Aireti" >}}
 
 At Box, we use Kubernetes (K8s) to manage hundreds of micro-services that enable Box to stream data at a petabyte scale. When it comes to the deployment process, we run [kube-applier](https://github.com/box/kube-applier) as part of the GitOps workflows with declarative configuration and automated deployment. Developers declare their K8s apps manifest into a Git repository that requires code reviews and automatic checks to pass, before any changes can get merged and applied inside our K8s clusters. With `kubectl exec` and other similar commands, however, developers are able to directly interact with running containers and alter them from their deployed state. This interaction could then subvert the change control and code review processes that are enforced in our CI/CD pipelines. Further, it allows such impacted containers to continue receiving traffic long-term in production.

--- a/content/en/blog/_posts/2021-12-22-kubernetes-in-kubernetes-and-pxe-bootable-server-farm.md
+++ b/content/en/blog/_posts/2021-12-22-kubernetes-in-kubernetes-and-pxe-bootable-server-farm.md
@@ -3,10 +3,9 @@ layout: blog
 title: "Kubernetes-in-Kubernetes and the WEDOS PXE bootable server farm"
 slug: kubernetes-in-kubernetes-and-pxe-bootable-server-farm
 date: 2021-12-22
+author: >
+  Andrei Kvapil (WEDOS)
 ---
-
-**Author**: Andrei Kvapil (WEDOS)
-
 
 When you own two data centers, thousands of physical servers, virtual machines and hosting for hundreds of thousands sites, Kubernetes can actually simplify the management of all these things. As practice has shown, by using Kubernetes, you can declaratively describe and manage not only applications, but also the infrastructure itself. I work for the largest Czech hosting provider **WEDOS Internet a.s** and today I'll show you two of my projects — [Kubernetes-in-Kubernetes](https://github.com/kvaps/kubernetes-in-kubernetes) and [Kubefarm](https://github.com/kvaps/kubefarm).
 


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2021 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-46103--kubernetes-io-main-staging.netlify.app/blog)