### PR TITLE
Update Skew Docs to Fix Compatible Issues between Controller Clients and the API-Server

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -239,3 +239,13 @@ or **{{< skew currentVersionAddMinor -3 >}}**)
 Running a cluster with `kube-proxy` instances that are persistently three minor versions behind
 `kube-apiserver` means they must be upgraded before the control plane can be upgraded.
 {{</ warning >}}
+
+## Controller clients and kube-apiserver upgrades
+
+Controller clients external to the kube-apiserver, such as kubelet, kube-controller-manager, and kube-scheduler, as well as aggregated API servers, must not have a higher version than the kube-apiserver they interact with to ensure compatibility and consistency within the cluster.
+
+When the kube-apiserver is upgraded to a new version, it might introduce changes to its APIs. However, to avoid disrupting critical operations, especially those related to admission control and flow control, the kube-apiserver is designed to be able to understand and communicate using the API versions from the previous release (-1, -2, or -3 versions).
+
+So, even if the kube-apiserver itself is upgraded to a newer version, it can still communicate with its components or modules that may not have been upgraded yet, ensuring that these essential functionalities continue to work without interruption. This capability helps in maintaining the stability and reliability of the Kubernetes cluster during upgrades.
+
+Administrators must coordinate the upgrades of controller clients with the kube-apiserver upgrades to ensure that all components remain compatible and operational within the cluster ecosystem.


### PR DESCRIPTION
This pull request addresses an issue reported by a user regarding the compatibility of the aggregated apiserver library with Kubernetes v1.28 clusters. After updating to version v1.29 of the aggregated apiserver library, the user encountered failures on the Kubernetes v1.28 clusters, accompanied by the following errors:

```
W0425 14:25:27.110980       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
E0425 14:25:27.111035       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.PriorityLevelConfiguration: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
W0425 14:25:34.571189       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.FlowSchema: the server could not find the requested resource
E0425 14:25:34.571265       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.FlowSchema: failed to list *v1.FlowSchema: the server could not find the requested resource
W0425 14:25:39.776616       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
E0425 14:25:39.776683       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.PriorityLevelConfiguration: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
W0425 14:25:58.606055       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.FlowSchema: the server could not find the requested resource
E0425 14:25:58.606080       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.FlowSchema: failed to list *v1.FlowSchema: the server could not find the requested resource
W0425 14:26:01.846754       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
E0425 14:26:01.846786       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.PriorityLevelConfiguration: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
W0425 14:25:27.211376       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
E0425 14:25:27.211394       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.PriorityLevelConfiguration: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
W0425 14:25:34.498183       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.FlowSchema: the server could not find the requested resource
E0425 14:25:34.498228       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.FlowSchema: failed to list *v1.FlowSchema: the server could not find the requested resource
W0425 14:25:35.545134       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
E0425 14:25:35.545287       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.PriorityLevelConfiguration: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
W0425 14:25:49.677632       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
E0425 14:25:49.677657       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.PriorityLevelConfiguration: failed to list *v1.PriorityLevelConfiguration: the server could not find the requested resource
W0425 14:25:51.325292       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: failed to list *v1.FlowSchema: the server could not find the requested resource
E0425 14:25:51.325325       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.4/tools/cache/reflector.go:229: Failed to watch *v1.FlowSchema: failed to list *v1.FlowSchema: the server could not find the requested resource
```

# Changes Made
* Updated the skew docs to instruct users not to have controller clients such as kubelet, kube-controller-manager, and kube-scheduler, as well as aggregated apiservers of a higher version than the kube-apiserver they interact with.

# References
Kubernetes/kubernetes#124533
Kubernetes/kubernetes#124655