### PR TITLE
Remove ReadWriteOncePod feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/read-write-once-pod.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/read-write-once-pod.md
@@ -17,6 +17,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.29" 
+    toVersion: "1.30"
+
+removed: true
 ---
 Enables the usage of `ReadWriteOncePod` PersistentVolume
 access mode.


### PR DESCRIPTION
This feature is GA and its feature gates will be removed in v1.31:
https://github.com/kubernetes/kubernetes/pull/124329

Following instructions in:
https://kubernetes.io/docs/contribute/new-content/new-features/#ready-for-review-feature-gates

/assign sftim
/assign carlory