### PR TITLE
Fix mermaid syntax in CRI blog post

### DIFF
--- a/content/en/blog/_posts/2024-05-01-cri-streaming-explained.md
+++ b/content/en/blog/_posts/2024-05-01-cri-streaming-explained.md
@@ -114,7 +114,7 @@ sequenceDiagram
     alt Client alternatives
         Note over kubelet,runtime: Container Runtime Interface (CRI)
         kubectl->>API: exec, attach, port-forward
-        API->>kubelet: 
+        API->>kubelet: exec, attach, port-forward
         kubelet->>runtime: Exec, Attach, PortForward
     else
         Note over crictl,runtime: Container Runtime Interface (CRI)


### PR DESCRIPTION
Fixing the syntax to let it render again.


Refers to https://github.com/kubernetes/website/pull/45821

Preview: https://deploy-preview-46121--kubernetes-io-main-staging.netlify.app/blog/2024/05/01/cri-streaming-explained/