### PR TITLE
Update 2020 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2020-01-08-csi-driver-testing.md
+++ b/content/en/blog/_posts/2020-01-08-csi-driver-testing.md
@@ -1,9 +1,9 @@
 ---
 title: Testing of CSI drivers
 date: 2020-01-08
+author: >
+  Patrick Ohly (Intel)
 ---
-
-**Author:** Patrick Ohly (Intel)
 
 When developing a [Container Storage Interface (CSI)
 driver](https://kubernetes-csi.github.io/docs/), it is useful to leverage

--- a/content/en/blog/_posts/2020-01-10-Remembering-Brad-Childs.md
+++ b/content/en/blog/_posts/2020-01-10-Remembering-Brad-Childs.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Remembering Brad Childs"
 date: 2020-01-10T10:00:00-08:00
 slug: Remembering-Brad-Childs
+author: >
+  Paul Morie (Red Hat)
 ---
-
-**Authors:** Paul Morie, Red Hat
 
 Last year, the Kubernetes family lost one of its own. Brad Childs was a
 SIG Storage chair and long time contributor to the project. Brad worked on a

--- a/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
+++ b/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md
@@ -3,9 +3,15 @@ layout: blog
 title: "Kubernetes on MIPS"
 date: 2020-01-15
 slug: Kubernetes-on-MIPS
+author: >
+  TimYin Shi,
+  Dominic Yin, 
+  Wang Zhan,
+  Jessica Jiang,
+  Will Cai,
+  Jeffrey Gao, 
+  Simon Sun (Inspur)
 ---
-
-**Authors:** TimYin Shi, Dominic Yin, Wang Zhan, Jessica Jiang, Will Cai, Jeffrey Gao, Simon Sun (Inspur)
 
 ## Background
 

--- a/content/en/blog/_posts/2020-01-21-Docs-Review-2019.md
+++ b/content/en/blog/_posts/2020-01-21-Docs-Review-2019.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Reviewing 2019 in Docs"
 date: 2020-01-21
 slug: reviewing-2019-in-docs
+author: >
+  Zach Corleissen (Cloud Native Computing Foundation)
 ---
-
-**Author:** Zach Corleissen (Cloud Native Computing Foundation)
 
 Hi, folks! I'm one of the co-chairs for the Kubernetes documentation special interest group (SIG Docs). This blog post is a review of SIG Docs in 2019. Our contributors did amazing work last year, and I want to highlight their successes. 
 

--- a/content/en/blog/_posts/2020-01-21-csi-ephemeral-inline-volumes.md
+++ b/content/en/blog/_posts/2020-01-21-csi-ephemeral-inline-volumes.md
@@ -1,9 +1,9 @@
 ---
 title: CSI Ephemeral Inline Volumes
 date: 2020-01-21
+author: >
+  Patrick Ohly (Intel) 
 ---
-
-**Author:** Patrick Ohly (Intel)
 
 Typically, volumes provided by an external storage driver in
 Kubernetes are *persistent*, with a lifecycle that is completely

--- a/content/en/blog/_posts/2020-01-22-Gamified-Chaos-Engineering-Tool-for-Kubernetes.md
+++ b/content/en/blog/_posts/2020-01-22-Gamified-Chaos-Engineering-Tool-for-Kubernetes.md
@@ -3,9 +3,9 @@ layout: blog
 title: "KubeInvaders - Gamified Chaos Engineering Tool for Kubernetes"
 date: 2020-01-22
 slug: kubeinvaders-gamified-chaos-engineering-tool-for-kubernetes
+author: >
+  Eugenio Marzo (Sourcesense)
 ---
-
-**Authors** Eugenio Marzo, Sourcesense
 
 Some months ago, I released my latest project called KubeInvaders. The
 first time I shared it with the community was during an Openshift

--- a/content/en/blog/_posts/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced.md
+++ b/content/en/blog/_posts/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Contributor Summit Amsterdam Schedule Announced"
 date: 2020-02-18
 slug: Contributor-Summit-Amsterdam-Schedule-Announced
+author: >
+  Jeffrey Sica (Red Hat),
+  Amanda Katona (VMware)
 ---
-
-**Authors:** Jeffrey Sica (Red Hat), Amanda Katona (VMware)
 
 ![Contributor Summit](/images/blog/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced/contribsummit.jpg)
 

--- a/content/en/blog/_posts/2020-02-28-bring-your-ideas-to-world-with-kubectl-plugins.md
+++ b/content/en/blog/_posts/2020-02-28-bring-your-ideas-to-world-with-kubectl-plugins.md
@@ -1,9 +1,9 @@
 ---
 title: Bring your ideas to the world with kubectl plugins
 date: 2020-02-28
+author: >
+  Cornelius Weig (TNG Technology Consulting GmbH)
 ---
-
-**Author:** Cornelius Weig (TNG Technology Consulting GmbH)
 
 `kubectl` is the most critical tool to interact with Kubernetes and has to address multiple user personas, each with their own needs and opinions. 
 One way to make `kubectl` do what you need is to build new functionality into `kubectl`.

--- a/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
+++ b/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
@@ -4,9 +4,10 @@ title: Contributor Summit Amsterdam Postponed
 date: 2020-03-04
 slug: Contributor-Summit-Delayed
 evergreen: true
+author: >
+  Dawn Foster (VMware),
+  Jorge Castro (VMware) 
 ---
-
-**Authors:** Dawn Foster (VMware), Jorge Castro (VMware)
 
 The CNCF has announced that [KubeCon + CloudNativeCon EU has been delayed](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/) until July/August of 2020. As a result the Contributor Summit planning team is weighing options for how to proceed. Here’s the current plan:
 

--- a/content/en/blog/_posts/2020-03-18-Kong-Ingress-Controller-and-Service-Mesh.md
+++ b/content/en/blog/_posts/2020-03-18-Kong-Ingress-Controller-and-Service-Mesh.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kong Ingress Controller and Service Mesh: Setting up Ingress to Istio on Kubernetes'
 date: 2020-03-18
 slug: kong-ingress-controller-and-istio-service-mesh
+author: >
+  Kevin Chen,
+  Kong
 ---
-
-**Author:** Kevin Chen, Kong
 
 Kubernetes has become the de facto way to orchestrate containers and the services within services. But how do we give services outside our cluster access to what is within? Kubernetes comes with the Ingress API object that manages external access to services within a cluster.
 

--- a/content/en/blog/_posts/2020-03-19-kubernetes-the-hard-way.md
+++ b/content/en/blog/_posts/2020-03-19-kubernetes-the-hard-way.md
@@ -3,9 +3,9 @@ layout: blog
 title: Join SIG Scalability and Learn Kubernetes the Hard Way
 date: 2020-03-19
 slug: join-sig-scalability
+author: >
+  Alex Handy
 ---
-
-**Authors:** Alex Handy
 
 Contributing to SIG Scalability is a great way to learn Kubernetes in all its depth and breadth, and the team would love to have you [join as a contributor](https://github.com/kubernetes/community/tree/master/sig-scalability#scalability-special-interest-group). I took a look at the value of learning the hard way and interviewed the current SIG chairs to give you an idea of what contribution feels like.
 

--- a/content/en/blog/_posts/2020-03-25-kubernetes-1.18-release-announcement.md
+++ b/content/en/blog/_posts/2020-03-25-kubernetes-1.18-release-announcement.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.18: Fit & Finish'
 date: 2020-03-25
 slug: kubernetes-1-18-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.18 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.18/release_team.md) 
 ---
-
-**Authors:** [Kubernetes 1.18 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.18/release_team.md)
 
 We're pleased to announce the delivery of Kubernetes 1.18, our first release of 2020! Kubernetes 1.18 consists of 38 enhancements: 15 enhancements are moving to stable, 11 enhancements in beta, and 12 enhancements in alpha.
 

--- a/content/en/blog/_posts/2020-03-30-topology-manager-beta.md
+++ b/content/en/blog/_posts/2020-03-30-topology-manager-beta.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Kubernetes Topology Manager Moves to Beta - Align Up!"
 date: 2020-04-01
 slug: kubernetes-1-18-feature-topoloy-manager-beta
+author: >
+  Kevin Klues (NVIDIA),
+  Victor Pickard (Red Hat),
+  Conor Nolan (Intel) 
 ---
-
-**Authors:** Kevin Klues (NVIDIA), Victor Pickard (Red Hat), Conor Nolan (Intel)
 
 This blog post describes the **<code>TopologyManager</code>**, a beta feature of Kubernetes in release 1.18. The **<code>TopologyManager</code>** feature enables NUMA alignment of CPUs and peripheral devices (such as SR-IOV VFs and GPUs), allowing your workload to run in an environment optimized for low-latency.
 

--- a/content/en/blog/_posts/2020-04-01-server-side-apply-beta2.md
+++ b/content/en/blog/_posts/2020-04-01-server-side-apply-beta2.md
@@ -3,9 +3,9 @@ layout: blog
 title: Kubernetes 1.18 Feature Server-side Apply Beta 2
 date: 2020-04-01
 slug: Kubernetes-1.18-Feature-Server-side-Apply-Beta-2
+author: >
+  Antoine Pelisse (Google)
 ---
-
-**Authors:** Antoine Pelisse (Google)
 
 ## What is Server-side Apply?
 Server-side Apply is an important effort to migrate “kubectl apply” to the apiserver. It was started in 2018 by the Apply working group.

--- a/content/en/blog/_posts/2020-04-02-Improvements-to-the-Ingress-API-in-Kubernetes-1.18.md
+++ b/content/en/blog/_posts/2020-04-02-Improvements-to-the-Ingress-API-in-Kubernetes-1.18.md
@@ -3,9 +3,10 @@ layout: blog
 title: Improvements to the Ingress API in Kubernetes 1.18
 date: 2020-04-02
 slug: Improvements-to-the-Ingress-API-in-Kubernetes-1.18
+author: >
+  Rob Scott (Google),
+  Christopher M Luciano (IBM) 
 ---
-
-**Authors:** Rob Scott (Google), Christopher M Luciano (IBM)
 
 The Ingress API in Kubernetes has enabled a large number of controllers to provide simple and powerful ways to manage inbound network traffic to Kubernetes workloads. In Kubernetes 1.18, we've made 3 significant additions to this API:
 

--- a/content/en/blog/_posts/2020-04-03-Introducing-Windows-CSI-support-alpha-for-Kubernetes.md
+++ b/content/en/blog/_posts/2020-04-03-Introducing-Windows-CSI-support-alpha-for-Kubernetes.md
@@ -3,8 +3,11 @@ layout: blog
 title: "Introducing Windows CSI support alpha for Kubernetes"
 date: 2020-04-03
 slug: kubernetes-1-18-feature-windows-csi-support-alpha
+author: >
+  Deep Debroy [Docker],
+  Jing Xu [Google],
+  Krishnakumar R (KK) [Microsoft]
 ---
-**Authors:** Authors: Deep Debroy [Docker], Jing Xu [Google], Krishnakumar R (KK) [Microsoft]
 
 <em>The alpha version of [CSI Proxy][csi-proxy] for Windows is being released with Kubernetes 1.18. CSI proxy enables CSI Drivers on Windows by allowing containers in Windows to perform privileged storage operations.</em>
 

--- a/content/en/blog/_posts/2020-04-06-API-Priority-and-Fairness-Alpha.md
+++ b/content/en/blog/_posts/2020-04-06-API-Priority-and-Fairness-Alpha.md
@@ -3,9 +3,11 @@ layout: blog
 title: "API Priority and Fairness Alpha"
 date: 2020-04-06
 slug: kubernetes-1-18-feature-api-priority-and-fairness-alpha
+author: >
+  Min Kim (Ant Financial),
+  Mike Spreitzer (IBM),
+  Daniel Smith (Google)
 ---
-
-**Authors:** Min Kim (Ant Financial), Mike Spreitzer (IBM), Daniel Smith (Google)
 
 This blog describes “API Priority And Fairness”, a new alpha feature in Kubernetes 1.18. API Priority And Fairness permits cluster administrators to divide the concurrency of the control plane into different weighted priority levels. Every request arriving at a kube-apiserver will be categorized into one of the priority levels and get its fair share of the control plane’s throughput.
 

--- a/content/en/blog/_posts/2020-04-21-Cluster-API-v1alpha3-Delivers-New-Features-and-an-Improved-User-Experience.md
+++ b/content/en/blog/_posts/2020-04-21-Cluster-API-v1alpha3-Delivers-New-Features-and-an-Improved-User-Experience.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Cluster API v1alpha3 Delivers New Features and an Improved User Experience"
 date: 2020-04-21
 slug: cluster-api-v1alpha3-delivers-new-features-and-an-improved-user-experience
+author: >
+  Daniel Lipovetsky (D2IQ)
 ---
-
-**Author:** Daniel Lipovetsky (D2IQ)
 
 <img src="/images/blog/2020-04-21-Cluster-API-v1alpha3-Delivers-New-Features-and-an-Improved-User-Experience/kubernetes-cluster-logos_final-02.svg" align="right" width="25%" alt="Cluster API Logo: Turtles All The Way Down">
 

--- a/content/en/blog/_posts/2020-04-21-contributor-communication-upstream-marketing.md
+++ b/content/en/blog/_posts/2020-04-21-contributor-communication-upstream-marketing.md
@@ -3,9 +3,9 @@ layout: blog
 title: How Kubernetes contributors are building a better communication process
 date: 2020-04-21
 slug: contributor-communication
+author: >
+  Paris Pittman
 ---
-
-**Authors:** Paris Pittman
 
 > "Perhaps we just need to use a different word. We may need to use community development or project advocacy as a word in the open source realm as opposed to marketing, and perhaps then people will realize that they need to do it." 
 > ~ [*Nithya Ruff*](https://todogroup.org/www.linkedin.com/in/nithyaruff/) (from [*TODO Group*](https://todogroup.org/guides/marketing-open-source-projects/))

--- a/content/en/blog/_posts/2020-05-05-introducing-podtopologyspread.md
+++ b/content/en/blog/_posts/2020-05-05-introducing-podtopologyspread.md
@@ -3,9 +3,10 @@ title: "Introducing PodTopologySpread"
 date: 2020-05-05
 slug: introducing-podtopologyspread
 url: /blog/2020/05/Introducing-PodTopologySpread
+author: >
+  Wei Huang (IBM),
+  Aldo Culquicondor (Google)
 ---
-
-**Author:** Wei Huang (IBM), Aldo Culquicondor (Google)
 
 Managing Pods distribution across a cluster is hard. The well-known Kubernetes
 features for Pod affinity and anti-affinity, allow some control of Pod placement

--- a/content/en/blog/_posts/2020-05-06-third-party-dual-sourced-content.md
+++ b/content/en/blog/_posts/2020-05-06-third-party-dual-sourced-content.md
@@ -3,9 +3,9 @@ title: "How Docs Handle Third Party and Dual Sourced Content"
 date: 2020-05-06
 slug: third-party-dual-sourced
 url: /blog/2020/05/third-party-dual-sourced-content
+author: >
+  Zach Corleissen (Cloud Native Computing Foundation)
 ---
-
-**Author:** Zach Corleissen, Cloud Native Computing Foundation
 
 *Editor's note: Zach is one of the chairs for the Kubernetes documentation special interest group (SIG Docs).*
 

--- a/content/en/blog/_posts/2020-05-21-wsl2-dockerdesktop-k8s.md
+++ b/content/en/blog/_posts/2020-05-21-wsl2-dockerdesktop-k8s.md
@@ -3,9 +3,10 @@ layout: blog
 title: "WSL+Docker: Kubernetes on the Windows Desktop"
 date: 2020-05-21
 slug: wsl-docker-kubernetes-on-the-windows-desktop
+author: >
+  [Nuno do Carmo](https://twitter.com/nunixtech) (Docker Captain and WSL Corsair),
+  [Ihor Dvoretskyi](https://twitter.com/idvoretskyi) (Developer Advocate, Cloud Native Computing Foundation)
 ---
-
-**Authors**: [Nuno do Carmo](https://twitter.com/nunixtech) Docker Captain and WSL Corsair; [Ihor Dvoretskyi](https://twitter.com/idvoretskyi), Developer Advocate, Cloud Native Computing Foundation
 
 # Introduction
 

--- a/content/en/blog/_posts/2020-05-28-my-exciting-journey-into-kubernetes-history.md
+++ b/content/en/blog/_posts/2020-05-28-my-exciting-journey-into-kubernetes-history.md
@@ -3,9 +3,9 @@ title: "My exciting journey into Kubernetes’ history"
 date: 2020-05-28
 slug: kubernetes-history
 url: /blog/2020/05/my-exciting-journey-into-kubernetes-history
+author: >
+  Sascha Grunert (SUSE Software Solutions)
 ---
-
-**Author:** Sascha Grunert, SUSE Software Solutions
 
 _Editor's note: Sascha is part of [SIG Release][0] and is working on many other
 different container runtime related topics. Feel free to reach him out on

--- a/content/en/blog/_posts/2020-05-29-K8s-KPIs-with-Kuberhealthy.md
+++ b/content/en/blog/_posts/2020-05-29-K8s-KPIs-with-Kuberhealthy.md
@@ -2,9 +2,10 @@
 layout: blog
 title: "K8s KPIs with Kuberhealthy"
 date: 2020-05-29
+author: >
+  Joshulyne Park (Comcast),
+  Eric Greer (Comcast)
 ---
-
-**Authors:** Joshulyne Park (Comcast), Eric Greer (Comcast)
 
 ### Building Onward from Kuberhealthy v2.0.0
 

--- a/content/en/blog/_posts/2020-06-05-Supporting-the-Evolving-Ingress-Specification-in-Kubernetes-1.18.md
+++ b/content/en/blog/_posts/2020-06-05-Supporting-the-Evolving-Ingress-Specification-in-Kubernetes-1.18.md
@@ -3,9 +3,9 @@ layout: blog
 title: Supporting the Evolving Ingress Specification in Kubernetes 1.18
 date: 2020-06-05
 slug: Supporting-the-Evolving-Ingress-Specification-in-Kubernetes-1.18
+author: >
+  Alex Gervais (Datawire.io)
 ---
-
-**Authors:** Alex Gervais (Datawire.io)
 
 Earlier this year, the Kubernetes team released [Kubernetes 1.18](https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/), which extended Ingress. In this blog post, we’ll walk through what’s new in the new Ingress specification, what it means for your applications, and how to upgrade to an ingress controller that supports this new specification.
 

--- a/content/en/blog/_posts/2020-06-15-better-docs-ux-with-docsy.md
+++ b/content/en/blog/_posts/2020-06-15-better-docs-ux-with-docsy.md
@@ -4,9 +4,9 @@ title: A Better Docs UX With Docsy
 date: 2020-06-15
 slug: better-docs-ux-with-docsy
 url: /blog/2020/06/better-docs-ux-with-docsy
+author: >
+  Zach Corleissen (Cloud Native Computing Foundation)
 ---
-
-**Author:** Zach Corleissen, Cloud Native Computing Foundation
 
 *Editor's note: Zach is one of the chairs for the Kubernetes documentation special interest group (SIG Docs).*
 

--- a/content/en/blog/_posts/2020-06-29-working-with-terraform-and-kubernetes.md
+++ b/content/en/blog/_posts/2020-06-29-working-with-terraform-and-kubernetes.md
@@ -4,9 +4,9 @@ title: "Working with Terraform and Kubernetes"
 date: 2020-06-29
 slug: working-with-terraform-and-kubernetes
 url: /blog/2020/06/working-with-terraform-and-kubernetes
+author: >
+  [Philipp Strube](https://twitter.com/pst418) (Kubestack) 
 ---
-
-**Author:** [Philipp Strube](https://twitter.com/pst418), Kubestack
 
 Maintaining Kubestack, an open-source [Terraform GitOps Framework](https://www.kubestack.com/lp/terraform-gitops-framework) for Kubernetes, I unsurprisingly spend a lot of time working with Terraform and Kubernetes. Kubestack provisions managed Kubernetes services like AKS, EKS and GKE using Terraform but also integrates cluster services from Kustomize bases into the GitOps workflow. Think of cluster services as everything that's required on your Kubernetes cluster, before you can deploy application workloads.
 

--- a/content/en/blog/_posts/2020-07-27-kubernetes-1-17-release-interview.md
+++ b/content/en/blog/_posts/2020-07-27-kubernetes-1-17-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Music and math: the Kubernetes 1.17 release interview"
 date: 2020-07-27
+author: >
+  Adam Glick (Google)
 ---
-
-**Author**: Adam Glick (Google)
 
 Every time the Kubernetes release train stops at the station, we like to ask the release lead to take a moment to reflect on their experience. That takes the form of an interview on the weekly [Kubernetes Podcast from Google](https://kubernetespodcast.com/) that I co-host with [Craig Box](https://twitter.com/craigbox). If you're not familiar with the show, every week we summarise the new in the Cloud Native ecosystem, and have an insightful discussion with an interesting guest from the broader Kubernetes community.
 

--- a/content/en/blog/_posts/2020-08-03-kubernetes-1-18-release-interview.md
+++ b/content/en/blog/_posts/2020-08-03-kubernetes-1-18-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Physics, politics and Pull Requests: the Kubernetes 1.18 release interview"
 date: 2020-08-03
+author: >
+   Craig Box (Google)
 ---
-
-**Author**: Craig Box (Google)
 
 The start of the COVID-19 pandemic couldn't delay the release of Kubernetes 1.18, but unfortunately [a small bug](https://github.com/kubernetes/utils/issues/141) could — thankfully only by a day.  This was the last cat that needed to be herded by 1.18 release lead [Jorge Alarcón](https://twitter.com/alejandrox135) before the [release on March 25](https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/).
 

--- a/content/en/blog/_posts/2020-08-14-introducing-hierarchical-namespaces.md
+++ b/content/en/blog/_posts/2020-08-14-introducing-hierarchical-namespaces.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Introducing Hierarchical Namespaces"
 date: 2020-08-14
+author: >
+  Adrian Ludwin (Google)
 ---
-
-**Author**: Adrian Ludwin (Google)
 
 Safely hosting large numbers of users on a single Kubernetes cluster has always
 been a troublesome task. One key reason for this is that different organizations

--- a/content/en/blog/_posts/2020-08-21-Moving-Forward-From-Beta/index.md
+++ b/content/en/blog/_posts/2020-08-21-Moving-Forward-From-Beta/index.md
@@ -10,9 +10,9 @@ slug: moving-forward-from-beta
 # the localized version.
 # If unsure: omit this next field.
 evergreen: true
+author: >
+   Tim Bannister (The Scale Factory)
 ---
-
-**Author**: Tim Bannister, The Scale Factory
 
 In Kubernetes, features follow a defined
 [lifecycle](/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).

--- a/content/en/blog/_posts/2020-08-26-kubernetes-release-1.19.md
+++ b/content/en/blog/_posts/2020-08-26-kubernetes-release-1.19.md
@@ -4,9 +4,9 @@ title: 'Kubernetes  1.19: Accentuate the Paw-sitive'
 date: 2020-08-26
 slug: kubernetes-release-1.19-accentuate-the-paw-sitive
 evergreen: true
+author: >
+  [Kubernetes 1.19 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.19/release_team.md)
 ---
-
-**Authors:** [Kubernetes 1.19 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.19/release_team.md)
 
 Finally, we have arrived with Kubernetes 1.19, the second release for 2020, and by far the longest release cycle lasting 20 weeks in total. It consists of 34 enhancements: 10 enhancements are moving to stable, 15 enhancements in beta, and 9 enhancements in alpha.
 

--- a/content/en/blog/_posts/2020-08-31-increase-kubernetes-support-one-year.md
+++ b/content/en/blog/_posts/2020-08-31-increase-kubernetes-support-one-year.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Increasing the Kubernetes Support Window to One Year'
 date: 2020-08-31 
 slug: kubernetes-1-19-feature-one-year-support
+author: >
+  Tim Pepper (VMware),
+  Nick Young (VMware)
 ---
-
-**Authors:** Tim Pepper (VMware), Nick Young (VMware)
 
 Starting with Kubernetes 1.19, the support window for Kubernetes versions [will increase from 9 months to one year](https://github.com/kubernetes/enhancements/issues/1498). The longer support window is intended to allow organizations to perform major upgrades at a time of the year that works the best for them.
 

--- a/content/en/blog/_posts/2020-09-01-generic-ephemeral-volumes.md
+++ b/content/en/blog/_posts/2020-09-01-generic-ephemeral-volumes.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Ephemeral volumes with storage capacity tracking: EmptyDir on steroids'
 date: 2020-09-01
 slug: ephemeral-volumes-with-storage-capacity-tracking
+author: >
+  Patrick Ohly (Intel)
 ---
-
-**Author:** Patrick Ohly (Intel)
 
 Some applications need additional storage but don't care whether that
 data is stored persistently across restarts. For example, caching

--- a/content/en/blog/_posts/2020-09-02-scaling-kubernetes-networking-endpointslices.md
+++ b/content/en/blog/_posts/2020-09-02-scaling-kubernetes-networking-endpointslices.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Scaling Kubernetes Networking With EndpointSlices'
 date: 2020-09-02
 slug: scaling-kubernetes-networking-with-endpointslices
+author: >
+  Rob Scott (Google)
 ---
-
-**Author:** Rob Scott (Google)
 
 EndpointSlices are an exciting new API that provides a scalable and extensible alternative to the Endpoints API. EndpointSlices track IP addresses, ports, readiness, and topology information for Pods backing a Service.
 

--- a/content/en/blog/_posts/2020-09-03-warnings/index.md
+++ b/content/en/blog/_posts/2020-09-03-warnings/index.md
@@ -4,9 +4,9 @@ title: "Warning: Helpful Warnings Ahead"
 date: 2020-09-03
 slug: warnings
 evergreen: true
+author: >
+   [Jordan Liggitt](https://github.com/liggitt) (Google)
 ---
-
-**Author**: [Jordan Liggitt](https://github.com/liggitt) (Google)
 
 As Kubernetes maintainers, we're always looking for ways to improve usability while preserving compatibility.
 As we develop features, triage bugs, and answer support questions, we accumulate information that would be helpful for Kubernetes users to know.

--- a/content/en/blog/_posts/2020-09-04-introducing-structured-logs.md
+++ b/content/en/blog/_posts/2020-09-04-introducing-structured-logs.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Introducing Structured Logs'
 date: 2020-09-04
 slug: kubernetes-1-19-Introducing-Structured-Logs
+author: >
+  Marek Siarkowicz (Google),
+  Nathan Beach (Google) 
 ---
-
-**Authors:** Marek Siarkowicz (Google), Nathan Beach (Google)
 
 Logs are an essential aspect of observability and a critical tool for debugging. But Kubernetes logs have traditionally been unstructured strings, making any automated parsing difficult and any downstream processing, analysis, or querying challenging to do reliably.
 

--- a/content/en/blog/_posts/2020-09-16-gsoc20-building-operators-for-cluster-addons.md
+++ b/content/en/blog/_posts/2020-09-16-gsoc20-building-operators-for-cluster-addons.md
@@ -3,9 +3,9 @@ layout: blog
 title: "GSoC 2020 - Building operators for cluster addons"
 date: 2020-09-16
 slug: gsoc20-building-operators-for-cluster-addons
+author: >
+  Somtochi Onyekwere
 ---
-
-**Author**: Somtochi Onyekwere
 
 # Introduction
 

--- a/content/en/blog/_posts/2020-09-30-writing-crl-scheduler/index.md
+++ b/content/en/blog/_posts/2020-09-30-writing-crl-scheduler/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "A Custom Kubernetes Scheduler to Orchestrate Highly Available Applications"
 date: 2020-12-21
 slug: writing-crl-scheduler
+author: >
+   Chris Seto (Cockroach Labs)
 ---
-
-**Author**: Chris Seto (Cockroach Labs)
 
 As long as you're willing to follow the rules, deploying on Kubernetes and air travel can be quite pleasant. More often than not, things will "just work". However, if one is interested in travelling with an alligator that must remain alive or scaling a database that must remain available, the situation is likely to become a bit more complicated. It may even be easier to build one's own plane or database for that matter. Travelling with reptiles aside, scaling a highly available stateful system is no trivial task.
 

--- a/content/en/blog/_posts/2020-10-12-steering-committee-results.md
+++ b/content/en/blog/_posts/2020-10-12-steering-committee-results.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Announcing the 2020 Steering Committee Election Results"
 date: 2020-10-12
 slug: steering-committee-results-2020
+author: >
+   Kaslin Fields
 ---
-
-**Author**: Kaslin Fields
 
 The [2020 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2020) is now complete. In 2019, the committee arrived at its final allocation of 7 seats, 3 of which were up for election in 2020. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 

--- a/content/en/blog/_posts/2020-11-02-remembering-dan-kohn.md
+++ b/content/en/blog/_posts/2020-11-02-remembering-dan-kohn.md
@@ -4,9 +4,9 @@ title: "Remembering Dan Kohn"
 date: 2020-11-02
 slug: remembering-dan-kohn
 evergreen: true
+author: >
+  Kubernetes Steering Committee
 ---
-
-**Author**: The Kubernetes Steering Committee
 
 Dan Kohn was instrumental in getting Kubernetes and CNCF community to where it is today. He shared our values, motivations, enthusiasm, community spirit, and helped the Kubernetes community to become the best that it could be. Dan loved getting people together to solve problems big and small. He enabled people to grow their individual scope in the community which often helped launch their career in open source software.
 

--- a/content/en/blog/_posts/2020-11-18-cloud-native-security-for-your-cluster/index.md
+++ b/content/en/blog/_posts/2020-11-18-cloud-native-security-for-your-cluster/index.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Cloud native security for your clusters"
 date: 2020-11-18
 slug: cloud-native-security-for-your-clusters
+author: >
+  [Pushkar Joglekar](https://twitter.com/pudijoglekar)
 ---
-
-**Author**: [Pushkar Joglekar](https://twitter.com/pudijoglekar)
 
 Over the last few years a small, security focused community has been working diligently to deepen our understanding of security, given the evolving cloud native infrastructure and corresponding iterative deployment practices. To enable sharing of this knowledge with the rest of the community, members of [CNCF SIG Security](https://github.com/cncf/sig-security) (a group which reports into [CNCF TOC](https://github.com/cncf/toc#sigs) and who are friends with [Kubernetes SIG Security](https://github.com/kubernetes/community/tree/master/sig-security)) led by Emily Fox, collaborated on a whitepaper outlining holistic cloud native security concerns and best practices. After over 1200 comments, changes, and discussions from 35 members across the world, we are proud to share [cloud native security whitepaper v1.0](https://www.cncf.io/blog/2020/11/18/announcing-the-cloud-native-security-white-paper) that serves as essential reading for security leadership in enterprises, financial and healthcare industries, academia, government, and non-profit organizations.
 

--- a/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
+++ b/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
@@ -4,6 +4,17 @@ title: "Don't Panic: Kubernetes and Docker"
 date: 2020-12-02
 slug: dont-panic-kubernetes-and-docker
 evergreen: true
+author: >
+  Jorge Castro,
+  Duffie Cooley,
+  Kat Cosgrove,
+  Justin Garrison,
+  Noah Kantrowitz,
+  Bob Killen,
+  Rey Lejano,
+  Dan “POP” Papandrea,
+  Jeffrey Sica,
+  Davanum “Dims” Srinivas
 ---
 
 **Update:** _Kubernetes support for Docker via `dockershim` is now removed.
@@ -11,9 +22,6 @@ For more information, read the [removal FAQ](/dockershim).
 You can also discuss the deprecation via a dedicated [GitHub issue](https://github.com/kubernetes/kubernetes/issues/106917)._
 
 ---
-
-**Authors:** Jorge Castro, Duffie Cooley, Kat Cosgrove, Justin Garrison, Noah Kantrowitz, Bob Killen, Rey Lejano, Dan “POP” Papandrea, Jeffrey Sica, Davanum “Dims” Srinivas
-
 
 Kubernetes is [deprecating
 Docker](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#deprecation)

--- a/content/en/blog/_posts/2020-12-04-gsod-2020-improving-api-reference-experience.md
+++ b/content/en/blog/_posts/2020-12-04-gsod-2020-improving-api-reference-experience.md
@@ -3,9 +3,9 @@ layout: blog
 title: "GSoD 2020: Improving the API Reference Experience"
 date: 2020-12-04
 slug: gsod-2020-improving-api-reference-experience
+author: >
+  [Philippe Martin](https://github.com/feloy)
 ---
-
-**Author**: [Philippe Martin](https://github.com/feloy)
 
 _Editor's note: Better API references have been my goal since I joined Kubernetes docs three and a half years ago. Philippe has succeeded fantastically. More than a better API reference, though, Philippe embodied the best of the Kubernetes community in this project: excellence through collaboration, and a process that made the community itself better. Thanks, Google Season of Docs, for making Philippe's work possible. —Zach Corleissen_
 

--- a/content/en/blog/_posts/2020-12-08-kubernetes-release-1.20.md
+++ b/content/en/blog/_posts/2020-12-08-kubernetes-release-1.20.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.20: The Raddest Release'
 date: 2020-12-08
 slug: kubernetes-1-20-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.20 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release_team.md)
 ---
-
-**Authors:** [Kubernetes 1.20 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release_team.md)
 
 We’re pleased to announce the release of Kubernetes 1.20, our third and final release of 2020! This release consists of 42 enhancements: 11 enhancements have graduated to stable, 15 enhancements are moving to beta, and 16 enhancements are entering alpha.
 

--- a/content/en/blog/_posts/2020-12-10-Kubernetes-Volume-Snapshot-Moves-to-GA.md
+++ b/content/en/blog/_posts/2020-12-10-Kubernetes-Volume-Snapshot-Moves-to-GA.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kubernetes 1.20: Kubernetes Volume Snapshot Moves to GA'
 date: 2020-12-10
 slug: kubernetes-1.20-volume-snapshot-moves-to-ga
+author: >
+  Xing Yang (VMware),
+  Xiangqian Yu (Google) 
 ---
-
-**Authors**: Xing Yang, VMware & Xiangqian Yu, Google
 
 The Kubernetes Volume Snapshot feature is now GA in Kubernetes v1.20. It was introduced as [alpha](https://kubernetes.io/blog/2018/10/09/introducing-volume-snapshot-alpha-for-kubernetes/) in Kubernetes v1.12, followed by a [second alpha](https://kubernetes.io/blog/2019/01/17/update-on-volume-snapshot-alpha-for-kubernetes/) with breaking changes in Kubernetes v1.13, and promotion to [beta](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-feature-cis-volume-snapshot-beta/) in Kubernetes 1.17. This blog post summarizes the changes releasing the feature from beta to GA.
 

--- a/content/en/blog/_posts/2020-12-10-Pod-Impersonation-and-Short-lived-Volumes-in-CSI-Drivers.md
+++ b/content/en/blog/_posts/2020-12-10-Pod-Impersonation-and-Short-lived-Volumes-in-CSI-Drivers.md
@@ -3,9 +3,9 @@ layout: blog
 title: 'Kubernetes 1.20: Pod Impersonation and Short-lived Volumes in CSI Drivers'
 date: 2020-12-18
 slug: kubernetes-1.20-pod-impersonation-short-lived-volumes-in-csi
+author: >
+  Shihang Zhang (Google)
 ---
-
-**Author**: Shihang Zhang (Google)
 
 Typically when a [CSI](https://github.com/container-storage-interface/spec/blob/baa71a34651e5ee6cb983b39c03097d7aa384278/spec.md) driver mounts credentials such as secrets and certificates, it has to authenticate against storage providers to access the credentials. However, the access to those credentials are controlled on the basis of the pods' identities rather than the CSI driver's identity. CSI drivers, therefore, need some way to retrieve pod's service account token. 
 

--- a/content/en/blog/_posts/2020-12-14-Granular-Control-of-Volume-Permission-Changes.md
+++ b/content/en/blog/_posts/2020-12-14-Granular-Control-of-Volume-Permission-Changes.md
@@ -3,9 +3,10 @@ layout: blog
 title: 'Kubernetes 1.20: Granular Control of Volume Permission Changes'
 date: 2020-12-14 
 slug: kubernetes-release-1.20-fsGroupChangePolicy-fsGroupPolicy
+author: >
+  Hemant Kumar (Red Hat),
+  Christian Huffman (Red Hat)
 ---
-
-**Authors**: Hemant Kumar, Red Hat & Christian Huffman, Red Hat
 
 Kubernetes 1.20 brings two important beta features, allowing Kubernetes admins and users alike to have more adequate control over how volume permissions are applied when a volume is mounted inside a Pod.
 

--- a/content/en/blog/_posts/2020-12-16-third-party-device-metrics-hits-ga.md
+++ b/content/en/blog/_posts/2020-12-16-third-party-device-metrics-hits-ga.md
@@ -3,9 +3,11 @@ layout: blog
 title: 'Third Party Device Metrics Reaches GA'
 date: 2020-12-16
 slug: third-party-device-metrics-reaches-ga
+author: >
+  Renaud Gaubert (NVIDIA),
+  David Ashpole (Google),
+  Pramod Ramarao (NVIDIA)
 ---
-
- **Authors:** Renaud Gaubert (NVIDIA), David Ashpole (Google), and Pramod Ramarao (NVIDIA)
 
  With Kubernetes 1.20, infrastructure teams who manage large scale Kubernetes clusters, are seeing the graduation of two exciting and long awaited features:
  * The Pod Resources API (introduced in 1.13) is finally graduating to GA. This allows Kubernetes plugins to obtain information about the node’s resource usage and assignment; for example: which pod/container consumes which device.


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2020 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-46128--kubernetes-io-main-staging.netlify.app/blog)