### PR TITLE
Remove references to deleted "feature-states.css" file

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -45,8 +45,6 @@
   {{ end }}
 {{- end }}
 
-<link rel="stylesheet" href="{{ "css/feature-states.css" | relURL }}">
-
 {{- if or (eq .Params.class "gridPage") (eq .Params.class "gridPage gridPageHome") }}
   <link rel="stylesheet" href="{{ "css/gridpage.css" | relURL }}">
 {{- end }}


### PR DESCRIPTION
This pull request removes references to `feature-states.css`, which was recently deleted in commit https://github.com/kubernetes/website/commit/f8bd5568c781021593e054f81a48a0eb0c3e7ab5 as part of revising appearance of feature-state shortcode. The site is currently throwing error (details below), prompting this change. 

>  // Error reported in browser's console: 
GET https://kubernetes.io/css/feature-states.css net::ERR_ABORTED 404 (Not Found)


[Preview Page (Above error not found in browser console logs)](https://deploy-preview-46146--kubernetes-io-main-staging.netlify.app/docs/home/) 



/area web-development