### PR TITLE
[zh-cn] sync kubeadm_init_phase_certs_ca kubeadm_init_phase_control-plane_all

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_ca.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_ca.md
@@ -18,11 +18,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令目前处于 Alpha 阶段。
-
 ```
 kubeadm init phase certs ca [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
@@ -176,17 +176,19 @@ Don't apply any changes; just output what would be done.
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-EtcdLearnerMode=true|false (ALPHA - default=false)<br/>
-PublicKeysECDSA=true|false (ALPHA - default=false)<br/>
+EtcdLearnerMode=true|false (BETA - default=true)<br/>
+PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)
+UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)<br/>
+WaitForAllControlPlaneComponents=true|false (ALPHA - default=false)
 -->
 <p>
 一组用来描述各种特性门控的键值（key=value）对。选项是：<br/>
-EtcdLearnerMode=true|false (ALPHA - 默认值=false)<br/>
-PublicKeysECDSA=true|false (ALPHA - 默认值=false)<br/>
+EtcdLearnerMode=true|false (BETA - 默认值=true)<br/>
+PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
 UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)
+WaitForAllControlPlaneComponents=true|false (ALPHA - 默认值=false)
 </p>
 </td>
 </tr>


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_ca.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md