### PR TITLE
[zh] Add 4 new feature gates: r*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/recursive-read-only-mounts.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/recursive-read-only-mounts.md
@@ -1,0 +1,19 @@
+---
+title: RecursiveReadOnlyMounts
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+
+<!--
+Enables support for recursive read-only mounts.
+For more details, see [read-only mounts](/docs/concepts/storage/volumes/#read-only-mounts).
+-->
+启用对递归只读挂载的支持。
+更多细节参阅[只读挂载](/zh-cn/docs/concepts/storage/volumes/#read-only-mounts)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/relaxed-environment-variable-validation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/relaxed-environment-variable-validation.md
@@ -1,0 +1,17 @@
+---
+title: RelaxedEnvironmentVariableValidation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+
+<!--
+Allow almost all printable ASCII characters in environment variables.
+-->
+允许在环境变量中使用几乎所有可打印的 ASCII 字符。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/retroactive-default-storage-class.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/retroactive-default-storage-class.md
@@ -1,0 +1,28 @@
+---
+title: RetroactiveDefaultStorageClass
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.25"
+    toVersion: "1.25"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.26"
+    toVersion: "1.27"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.28"
+    toVersion: "1.28"
+
+removed: true
+---
+
+<!--
+Allow assigning StorageClass to unbound PVCs retroactively.
+-->
+允通过反射机制为未绑定的 PVC 设置 StorageClass。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/retroactive-default-storage-class.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/retroactive-default-storage-class.md
@@ -25,4 +25,4 @@ removed: true
 <!--
 Allow assigning StorageClass to unbound PVCs retroactively.
 -->
-允通过反射机制为未绑定的 PVC 设置 StorageClass。
+允许通过反射机制为未绑定的 PVC 设置 StorageClass。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/root-ca-config-map.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/root-ca-config-map.md
@@ -1,0 +1,38 @@
+---
+# Removed from Kubernetes
+title: RootCAConfigMap
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.13"
+    toVersion: "1.19"
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.20"
+    toVersion: "1.20"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.21"
+    toVersion: "1.22"
+
+removed: true
+---
+
+<!--
+Configure the `kube-controller-manager` to publish a
+{{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} named `kube-root-ca.crt`
+to every namespace. This ConfigMap contains a CA bundle used for verifying connections
+to the kube-apiserver. See
+[Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md)
+for more details.
+-->
+配置 `kube-controller-manager` 以向每个命名空间发布名为 `kube-root-ca.crt` 的
+{{< glossary_tooltip text="ConfigMap" term_id="configmap" >}}。
+这个 ConfigMap 包含一个 CA 证书包，用于验证与 kube-apiserver 的连接。
+更多细节参阅[绑定的服务账户令牌](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md)。


### PR DESCRIPTION
Add zh text to 4 new feature gates:

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/recursive-read-only-mounts.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/relaxed-environment-variable-validation.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/retroactive-default-storage-class.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/root-ca-config-map.md
```