### PR TITLE
Fix multiple typos under "content/en/docs/reference"

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-audit.v1.md
@@ -253,7 +253,7 @@ be specified per rule in which case the union of both are omitted.</p>
 <td>
    <p>OmitManagedFields indicates whether to omit the managed fields of the request
 and response bodies from being written to the API audit log.
-This is used as a global default - a value of 'true' will omit the managed fileds,
+This is used as a global default - a value of 'true' will omit the managed fields,
 otherwise the managed fields will be included in the API audit log.
 Note that this can also be specified per rule in which case the value specified
 in a rule will override the global default.</p>

--- a/content/en/docs/reference/config-api/kubeconfig.v1.md
+++ b/content/en/docs/reference/config-api/kubeconfig.v1.md
@@ -55,7 +55,7 @@ TODO(jlowdermilk): remove this after eliminating downstream dependencies.</p>
 <a href="#NamedCluster"><code>[]NamedCluster</code></a>
 </td>
 <td>
-   <p>Clusters is a map of referencable names to cluster configs</p>
+   <p>Clusters is a map of referenceable names to cluster configs</p>
 </td>
 </tr>
 <tr><td><code>users</code> <B>[Required]</B><br/>
@@ -69,7 +69,7 @@ TODO(jlowdermilk): remove this after eliminating downstream dependencies.</p>
 <a href="#NamedContext"><code>[]NamedContext</code></a>
 </td>
 <td>
-   <p>Contexts is a map of referencable names to context configs</p>
+   <p>Contexts is a map of referenceable names to context configs</p>
 </td>
 </tr>
 <tr><td><code>current-context</code> <B>[Required]</B><br/>

--- a/content/en/docs/reference/instrumentation/metrics.md
+++ b/content/en/docs/reference/instrumentation/metrics.md
@@ -1510,7 +1510,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	</ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_failures_total</div>
-	<div class="metric_help">Number of PersistenVolumeClaims creation requests</div>
+	<div class="metric_help">Number of PersistentVolumeClaims creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
@@ -62,7 +62,7 @@ APIServiceSpec contains information for locating and communicating with a server
 
 - **groupPriorityMinimum** (int32), required
 
-  GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
+  GroupPriorityMinimum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMinimum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
 
 - **versionPriority** (int32), required
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1.md
@@ -75,7 +75,7 @@ VolumeAttachmentSpec is the specification of a VolumeAttachment request.
   source represents the volume that should be attached.
 
   <a name="VolumeAttachmentSource"></a>
-  *VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.*
+  *VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.*
 
   - **source.inlineVolumeSpec** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeSpec" >}}">PersistentVolumeSpec</a>)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1.md
@@ -139,7 +139,7 @@ EndpointSlice represents a subset of the endpoints that implement a service. For
 
   - **ports.name** (string)
 
-    name represents the name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is dervied from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
+    name represents the name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is derived from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
 
   - **ports.appProtocol** (string)
 

--- a/content/en/docs/reference/node/kubelet-config-directory-merging.md
+++ b/content/en/docs/reference/node/kubelet-config-directory-merging.md
@@ -59,7 +59,7 @@ address: "192.168.0.8"
 ```
 
 ### Lists
-You can overide the slices/lists values of the kubelet configuration.
+You can override the slices/lists values of the kubelet configuration.
 However, the entire list gets overridden during the merging process.
 For example, you can override the `clusterDNS` list as follows:
 

--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -67,7 +67,7 @@ Example CEL expressions:
 
 CEL is configured with the following options, libraries and language features, introduced at the specified Kubernetes versions:
 
-| CEL option, library or language feature                                                                                | Included                                                                                                                                  | Availablity               |
+| CEL option, library or language feature                                                                                | Included                                                                                                                                  | Availability               |
 |------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
 | [Standard macros](https://github.com/google/cel-spec/blob/v0.7.0/doc/langdef.md#macros)                                | `has`, `all`, `exists`, `exists_one`, `map`, `filter`                                                                                     | All Kubernetes versions   |
 | [Standard functions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions)       | See [official list of standard definitions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions)   | All Kubernetes versions   |


### PR DESCRIPTION
Fix multiple typos under `content/en/docs/reference`

> Some backgrounds on how theses typos are fixed, I've wrote a (Chinese) blog about this: https://nova.moe/fast-typo-fix/ (English version: https://nova.moe/fast-typo-fix-en/) 😇
