### PR TITLE
Update note around spec.schedulerName being ReportingController

### DIFF
--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -217,7 +217,6 @@ If a Pod doesn't specify a scheduler name, kube-apiserver will set it to
 to get those pods scheduled.
 
 {{< note >}}
-Pod's scheduling events have `.spec.schedulerName` as the ReportingController.
 Events for leader election use the scheduler name of the first profile in the
 list.
 {{< /note >}}

--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -217,8 +217,9 @@ If a Pod doesn't specify a scheduler name, kube-apiserver will set it to
 to get those pods scheduled.
 
 {{< note >}}
-Events for leader election use the scheduler name of the first profile in the
-list.
+Pod's scheduling events have `.spec.schedulerName` as the `ReportingController`. Events for leader election use the scheduler name of the first profile in the list.
+
+For more information, please refer to the `reportingController` section under [Event API Reference](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/).
 {{< /note >}}
 
 {{< note >}}

--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -217,7 +217,8 @@ If a Pod doesn't specify a scheduler name, kube-apiserver will set it to
 to get those pods scheduled.
 
 {{< note >}}
-Pod's scheduling events have `.spec.schedulerName` as the `ReportingController`. Events for leader election use the scheduler name of the first profile in the list.
+Pod's scheduling events have `.spec.schedulerName` as their `reportingController`.
+Events for leader election use the scheduler name of the first profile in the list.
 
 For more information, please refer to the `reportingController` section under [Event API Reference](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/).
 {{< /note >}}

--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -220,7 +220,8 @@ to get those pods scheduled.
 Pod's scheduling events have `.spec.schedulerName` as their `reportingController`.
 Events for leader election use the scheduler name of the first profile in the list.
 
-For more information, please refer to the `reportingController` section under [Event API Reference](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/).
+For more information, please refer to the `reportingController` section under
+[Event API Reference](/docs/reference/kubernetes-api/cluster-resources/event-v1/).
 {{< /note >}}
 
 {{< note >}}


### PR DESCRIPTION
The note that said, "Pod's scheduling events have .spec.schedulerName as the ReportingController", is no longer true. I do not find the `spec.schedulerName` set to `ReportingController`.

```yaml
$ k get pod nginx -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    cni.projectcalico.org/containerID: bec575f5e565edc9b9d97deb83cb891036232c559d0acb9759a7092bb2537942
    cni.projectcalico.org/podIP: 10.244.49.103/32
    cni.projectcalico.org/podIPs: 10.244.49.103/32
  creationTimestamp: "2024-05-05T08:13:03Z"
  labels:
    run: nginx
  name: nginx
  namespace: default
  resourceVersion: "505064"
  uid: 1df8c6cc-8aed-4c99-8fe9-7f119d96ab1e
spec:
  containers:
  - image: nginx
    imagePullPolicy: Always
    name: nginx
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-6pdm4
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: wk2
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: kube-api-access-6pdm4
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2024-05-05T08:13:06Z"
    status: "True"
    type: PodReadyToStartContainers
  - lastProbeTime: null
    lastTransitionTime: "2024-05-05T08:13:03Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2024-05-05T08:13:06Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2024-05-05T08:13:06Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2024-05-05T08:13:03Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: containerd://78e055ca9357e78b2bf16d908a4422d4227878a7bc55df9a7349d01a00fcaf5a
    image: docker.io/library/nginx:latest
    imageID: docker.io/library/nginx@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee
    lastState: {}
    name: nginx
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2024-05-05T08:13:06Z"
  hostIP: 172.16.1.13
  hostIPs:
  - ip: 172.16.1.13
  phase: Running
  podIP: 10.244.49.103
  podIPs:
  - ip: 10.244.49.103
  qosClass: BestEffort
  startTime: "2024-05-05T08:13:03Z"
```
The Pod events show the name as default-scheduler as well.
```shell
$ k describe pod nginx
Name:             nginx
Namespace:        default
Priority:         0
Service Account:  default
Node:             wk2/172.16.1.13
Start Time:       Sun, 05 May 2024 08:13:03 +0000
Labels:           run=nginx
Annotations:      cni.projectcalico.org/containerID: bec575f5e565edc9b9d97deb83cb891036232c559d0acb9759a7092bb2537942
                  cni.projectcalico.org/podIP: 10.244.49.103/32
                  cni.projectcalico.org/podIPs: 10.244.49.103/32
Status:           Running
IP:               10.244.49.103
IPs:
  IP:  10.244.49.103
Containers:
  nginx:
    Container ID:   containerd://78e055ca9357e78b2bf16d908a4422d4227878a7bc55df9a7349d01a00fcaf5a
    Image:          nginx
    Image ID:       docker.io/library/nginx@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Sun, 05 May 2024 08:13:06 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-6pdm4 (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  kube-api-access-6pdm4:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  21m   default-scheduler  Successfully assigned default/nginx to wk2
  Normal  Pulling    21m   kubelet            Pulling image "nginx"
  Normal  Pulled     21m   kubelet            Successfully pulled image "nginx" in 2.518s (2.518s including waiting). Image size: 70991807 bytes.
  Normal  Created    21m   kubelet            Created container nginx
  Normal  Started    21m   kubelet            Started container nginx
```