### PR TITLE
[zh] Add 5 new feature gates

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
@@ -1,0 +1,20 @@
+---
+title: CustomResourceFieldSelectors
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"  
+---
+
+<!--
+Enable `selectableFields` in the
+{{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} API to allow filtering
+of custom resource **list**, **watch** and **deletecollection** requests.
+-->
+在 {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} API 中启用
+`selectableFields`，以针对 **list**、**watch** 和 **deletecollection** 请求过滤自定义资源。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/runtime-class-in-image-cri-api.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/runtime-class-in-image-cri-api.md
@@ -1,0 +1,18 @@
+---
+title: RuntimeClassInImageCriApi
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.29"
+---
+
+<!--
+Enables images to be pulled based on the [runtime class](/docs/concepts/containers/runtime-class/)
+of the pods that reference them.
+-->
+允许基于 Pod 所引用的[运行时类](/zh-cn/docs/concepts/containers/runtime-class/)来拉取镜像。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selinux-mount.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selinux-mount.md
@@ -1,0 +1,27 @@
+---
+title: SELinuxMount
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.30"
+---
+
+<!--
+Speeds up container startup by allowing kubelet to mount volumes
+for a Pod directly with the correct SELinux label instead of changing each file on the volumes
+recursively.
+It widens the performance improvements behind the `SELinuxMountReadWriteOncePod`
+feature gate by extending the implementation to all volumes.
+
+Enabling the `SELinuxMount` feature gate requires the feature gate `SELinuxMountReadWriteOncePod` to
+be enabled.
+-->
+允许 kubelet 直接使用正确的 SELinux 标签为 Pod 挂载卷，而不是以递归方式更改卷上的每个文件，进而加快容器的启动速度。
+这一变更拓宽了针对 `SELinuxMountReadWriteOncePod` 特性门控所作的性能改进，将其对应的实现扩展到覆盖所有卷。
+
+想要启用 `SELinuxMount` 特性门控，需先启用 `SELinuxMountReadWriteOncePod` 特性门控。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-traffic-distribution.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-traffic-distribution.md
@@ -1,0 +1,21 @@
+---
+title: ServiceTrafficDistribution
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+- stage: alpha 
+  defaultValue: false
+  fromVersion: "1.30"
+---
+
+<!--
+Allows usage of the optional `spec.trafficDistribution` field in Services. The
+field offers a way to express preferences for how traffic is distributed to
+Service endpoints.
+-->
+允许在 Service 中使用可选的 `spec.trafficDistribution` 字段。
+此字段提供了一种对 Service 端点进行流量分发的偏好的表达方式。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-migrator.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-migrator.md
@@ -1,0 +1,19 @@
+---
+title: StorageVersionMigrator
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.30"
+    toVersion: "1.32"
+---
+
+<!--
+Enables storage version migration. See [Migrate Kubernetes Objects Using Storage Version Migration](/docs/tasks/manage-kubernetes-objects/storage-version-migration) for more details.
+-->
+启用存储版本迁移机制。
+有关细节参阅[使用存储版本迁移功能来迁移 Kubernetes 对象](/zh-cn/docs/tasks/manage-kubernetes-objects/storage-version-migration)。


### PR DESCRIPTION
Add zh text to five new gates:

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/runtime-class-in-image-cri-api.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/selinux-mount.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/service-traffic-distribution.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/storage-version-migrator.md
```