### PR TITLE
[zh] Sync 3 reference files in setup-tools/kubeadm/generated

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_wait-control-plane.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_wait-control-plane.md
@@ -1,20 +1,19 @@
 <!--
-Show the join command for control-plane and worker node
+EXPERIMENTAL: Wait for the control plane to start
 -->
-显示针对控制平面和工作节点的 join 命令。
+**实验特性**：等待控制平面启动
 
 <!--
 ### Synopsis
+
+EXPERIMENTAL: Wait for the control plane to start
 -->
 ### 概要
 
-<!--
-Show the join command for control-plane and worker node
--->
-显示针对控制平面和工作节点的 join 命令。
+**实验特性**：等待控制平面启动
 
 ```
-kubeadm init phase show-join-command [flags]
+kubeadm join phase wait-control-plane [flags]
 ```
 
 <!--
@@ -33,14 +32,12 @@ kubeadm init phase show-join-command [flags]
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td>
-</td>
-<td style="line-height: 130%; word-wrap: break-word;">
-<!--
-help for show-join-command
--->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
 <p>
-show-join-command 操作的帮助命令。
+<!--
+help for wait-control-plane
+-->
+wait-control-plane 操作的帮助命令。
 </p>
 </td>
 </tr>
@@ -64,13 +61,11 @@ show-join-command 操作的帮助命令。
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td>
-</td>
-<td style="line-height: 130%; word-wrap: break-word;">
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 [EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
-<p>
 [实验] 到 '真实' 主机根文件系统的路径。
 </p>
 </td>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node.md
@@ -62,6 +62,20 @@ Perform the renewal of certificates used by component changed during upgrades.
 </tr>
 
 <tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+Path to a kubeadm configuration file.
+-->
+到 kubeadm 配置文件的路径。
+</p>
+</td>
+</tr>
+
+<tr>
 <td colspan="2">--dry-run</td>
 </tr>
 


### PR DESCRIPTION
Sync 3 files with en text:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_show-join-command.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_wait-control-plane.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node.md
```
See [preview](https://deploy-preview-46203--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node/) please.