### PR TITLE
Remove ConsistentHTTPGetHandlers feature-gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/consistent-http-get-handlers.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/consistent-http-get-handlers.md
@@ -9,6 +9,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.25"  
+    toVersion: "1.30"
+
+removed: true
 ---
 Normalize HTTP get URL and Header passing for lifecycle
 handlers with probers.


### PR DESCRIPTION
This feature is GA and its feature gates will be removed in v1.31:
https://github.com/kubernetes/kubernetes/pull/124463

Following instructions in:
https://kubernetes.io/docs/contribute/new-content/new-features/#ready-for-review-feature-gates

Preview: https://deploy-preview-46214--kubernetes-io-vnext-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates-removed/
