### PR TITLE
[zh] fix miss `Linux kernel: v5.12` in `2024-04-23-recursive-read-only-mounts.md`

### DIFF
--- a/content/zh-cn/blog/_posts/2024-04-23-recursive-read-only-mounts.md
+++ b/content/zh-cn/blog/_posts/2024-04-23-recursive-read-only-mounts.md
@@ -152,6 +152,8 @@ To enable `recursiveReadOnly` mounts, the following components have to be used:
   * runc：v1.1 或更新版本
   * crun: v1.8.6 或更新版本
 
+* Linux 内核: v5.12 或更新版本
+
 
 <!--
 ## What's next?


### PR DESCRIPTION
 fix: https://github.com/kubernetes/website/issues/46220

add `Linux kernel: v5.12 or later` in `Feature availability` section


<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
