### PR TITLE
Use Docsy-style callouts

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -497,14 +497,33 @@ body {
       border-left-width: calc(max(0.5em, 4px));
       border-top-left-radius: calc(max(0.5em, 4px));
       border-bottom-left-radius: calc(max(0.5em, 4px));
+      padding-top: 0.75rem;
   }
-  .alert.callout.caution {
+  .alert.alert-caution {
     border-left-color: #f0ad4e;
   }
-  .alert.callout.note {
+  .alert.alert-info {
     border-left-color: #428bca;
+    h4, h4.alert-heading {
+      color: #000;
+      display: block;
+      float: left;
+      font-size: 1rem;
+      padding: 0;
+      padding-right: 0.5rem;
+      margin: 0;
+      line-height: 1.5;
+      font-weight: bolder;
+    }
   }
-  .alert.callout.warning {
+  .alert.alert-caution {
+    border-left-color: #f0ad4e;
+    h4, h4.alert-heading {
+      font-size: 1em;
+      font-weight: bold;
+    }
+  }
+  .alert.alert-warning {
     border-left-color: #d9534f;
   }
   .alert.third-party-content {

--- a/layouts/shortcodes/caution.html
+++ b/layouts/shortcodes/caution.html
@@ -1,3 +1,11 @@
-<div class="alert alert-warning caution callout" role="alert">
-  <strong>{{ T "caution" }}</strong> {{ trim .Inner " \n" | markdownify }}
+<!-- adapted from Docsy alert shortcode -->
+{{- $_hugo_config := `{ "version": 1 }` -}}
+{{- $color := "caution" -}}
+<div class="alert alert-{{- $color -}}" role="alert">
+{{- with ( T "caution" ) -}}<h4 class="alert-heading">{{- . | safeHTML -}}</h4>{{- end -}}
+{{- if eq .Page.File.Ext "md" -}}
+    {{- .Inner | markdownify -}}
+{{- else -}}
+    {{- .Inner | htmlUnescape | safeHTML -}}
+{{- end -}}
 </div>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,3 +1,11 @@
-<div class="alert alert-info note callout" role="alert">
-  <strong>{{ T "note" }}</strong> {{ trim .Inner " \n" | markdownify }}
+<!-- adapted from Docsy alert shortcode -->
+{{- $_hugo_config := `{ "version": 1 }` -}}
+{{ $color := "info" }}
+<div class="alert alert-{{- $color -}}" role="alert">
+{{- with ( T "note" ) -}}<h4 class="alert-heading">{{- . | safeHTML -}}</h4>{{- end -}}
+{{- if eq .Page.File.Ext "md" -}}
+    {{- .Inner | markdownify -}}
+{{- else -}}
+    {{- .Inner | htmlUnescape | safeHTML -}}
+{{- end -}}
 </div>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,4 +1,11 @@
-<div class="alert alert-danger warning callout" role="alert">
-  <strong>{{ T "warning" }}</strong> {{ trim .Inner " \n" | markdownify }}
+<!-- adapted from Docsy alert shortcode -->
+{{- $_hugo_config := `{ "version": 1 }` -}}
+{{- $color := "danger" -}}
+<div class="alert alert-{{- $color -}}" role="alert">
+{{- with ( T "warning" ) -}}<h4 class="alert-heading">{{- . | safeHTML -}}</h4>{{- end -}}
+{{- if eq .Page.File.Ext "md" -}}
+    {{- .Inner | markdownify -}}
+{{- else -}}
+    {{- .Inner | htmlUnescape | safeHTML -}}
+{{- end -}}
 </div>
-


### PR DESCRIPTION
Adopt callout (notices) that match the Docsy theme we use (see issues https://github.com/kubernetes/website/issues/44564 and https://github.com/kubernetes/website/issues/41171).

/area web-development

## Examples

Before | After
----------|-------
[Authorization configuration and reloads](http://k8s.io/docs/reference/access-authn-authz/authorization/#authorization-configuration-and-reloads) | [Authorization configuration and reloads](https://deploy-preview-46232--kubernetes-io-main-staging.netlify.app/docs/reference/access-authn-authz/authorization/#authorization-configuration-and-reloads)
[Least-privilege access to Secrets](https://k8s.io/docs/concepts/configuration/secret/#configure-least-privilege-access-to-secrets) | [Least-privilege access to Secrets](https://deploy-preview-46232--kubernetes-io-main-staging.netlify.app/docs/concepts/configuration/secret/#configure-least-privilege-access-to-secrets)
[General configuration tips](https://k8s.io/docs/concepts/configuration/overview/#general-configuration-tips) | [General configuration tips](https://deploy-preview-46232--kubernetes-io-main-staging.netlify.app/docs/concepts/configuration/overview/#general-configuration-tips) | 