### PR TITLE
Update 2019 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
+++ b/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'APIServer dry-run and kubectl diff'
 date: 2019-01-14
+author: >
+  Antoine Pelisse (Google Cloud) 
 ---
-
-**Author**: Antoine Pelisse (Google Cloud, @apelisse)
 
 Declarative configuration management, also known as configuration-as-code, is
 one of the key strengths of Kubernetes. It allows users to commit the desired state of

--- a/content/en/blog/_posts/2019-01-15-container-storage-interface-ga.md
+++ b/content/en/blog/_posts/2019-01-15-container-storage-interface-ga.md
@@ -2,12 +2,12 @@
 title: Container Storage Interface (CSI) for Kubernetes GA
 date: 2019-01-15
 slug: container-storage-interface-ga
+author: >
+  Saad Ali (Google)
 ---
 
 ![Kubernetes Logo](/images/blog-logging/2018-04-10-container-storage-interface-beta/csi-kubernetes.png)
 ![CSI Logo](/images/blog-logging/2018-04-10-container-storage-interface-beta/csi-logo.png)
-
-**Author:** Saad Ali, Senior Software Engineer, Google
 
 The Kubernetes implementation of the [Container Storage Interface](https://github.com/container-storage-interface/spec/blob/master/spec.md) (CSI) has been promoted to GA in the Kubernetes v1.13 release. Support for CSI was [introduced as alpha](http://blog.kubernetes.io/2018/01/introducing-container-storage-interface.html) in Kubernetes v1.9 release, and [promoted to beta](https://kubernetes.io/blog/2018/04/10/container-storage-interface-beta/) in the Kubernetes v1.10 release.
 

--- a/content/en/blog/_posts/2019-01-17-update-volume-snapshot-alpha.md
+++ b/content/en/blog/_posts/2019-01-17-update-volume-snapshot-alpha.md
@@ -1,9 +1,11 @@
 ---
 title: Update on Volume Snapshot Alpha for Kubernetes
 date: 2019-01-17
+author: >
+  DJing Xu (Google),
+  Xing Yang (Huawei),
+  Saad Ali (Google)
 ---
-
-**Authors:** Jing Xu (Google), Xing Yang (Huawei), Saad Ali (Google)
 
 Volume snapshotting support was introduced in Kubernetes v1.12 as an alpha feature. In Kubernetes v1.13, it remains an alpha feature, but a few enhancements were added and some breaking changes were made. This post summarizes the changes.
 

--- a/content/en/blog/_posts/2019-02-06-poseidon-firmament-scheduler-announcement.md
+++ b/content/en/blog/_posts/2019-02-06-poseidon-firmament-scheduler-announcement.md
@@ -1,9 +1,10 @@
 ---
 title: Poseidon-Firmament Scheduler – Flow Network Graph Based Scheduler
 date: 2019-02-06
+author: >
+  Deepak Vij (Huawei),
+  Shivram Shrivastava (Huawei)  
 ---
-
-**Authors:** Deepak Vij (Huawei), Shivram Shrivastava (Huawei)  
 
 ## Introduction  
 

--- a/content/en/blog/_posts/2019-02-11-runc-CVE-2019-5736.md
+++ b/content/en/blog/_posts/2019-02-11-runc-CVE-2019-5736.md
@@ -2,9 +2,9 @@
 title: Runc and CVE-2019-5736
 date: 2019-02-11
 evergreen: false # mentions PodSecurityPolicy
+author: >
+  Kubernetes Product Security Committee
 ---
-
-Authors: Kubernetes Product Security Committee
 
 This morning [a container escape vulnerability in runc was announced](https://www.openwall.com/lists/oss-security/2019/02/11/2). We wanted to provide some guidance to Kubernetes users to ensure everyone is safe and secure.
 

--- a/content/en/blog/_posts/2019-02-12-building-a-kubernetes-edge-control-plane-for-envoy-v2.md
+++ b/content/en/blog/_posts/2019-02-12-building-a-kubernetes-edge-control-plane-for-envoy-v2.md
@@ -2,13 +2,11 @@
 title: Building a Kubernetes Edge (Ingress) Control Plane for Envoy v2
 date: 2019-02-12
 slug: building-a-kubernetes-edge-control-plane-for-envoy-v2
+author: >
+  Daniel Bryant (Datawire),
+  Flynn (Datawire),
+  Richard Li (Datawire) 
 ---
-
-
-**Author:**
-Daniel Bryant, Product Architect, Datawire;
-Flynn, Ambassador Lead Developer, Datawire;
-Richard Li, CEO and Co-founder, Datawire
 
 
 Kubernetes has become the de facto runtime for container-based microservice applications, but this orchestration framework alone does not provide all of the infrastructure necessary for running a distributed system. Microservices typically communicate through Layer 7 protocols such as HTTP, gRPC, or WebSockets, and therefore having the ability to make routing decisions, manipulate protocol metadata, and observe at this layer is vital. However, traditional load balancers and edge proxies have predominantly focused on L3/4 traffic. This is where the [Envoy Proxy](https://www.envoyproxy.io/) comes into play.

--- a/content/en/blog/_posts/2019-02-28-automate-operations-on-your-cluster-with-operatorhub.md
+++ b/content/en/blog/_posts/2019-02-28-automate-operations-on-your-cluster-with-operatorhub.md
@@ -1,10 +1,9 @@
 ---
 title: Automate Operations on your Cluster with OperatorHub.io
 date: 2019-02-28
+author: >
+  Diane Mueller (Red Hat)
 ---
-
-**Author:**
-Diane Mueller, Director of Community Development, Cloud Platforms, Red Hat
 
 One of the important challenges facing developers and Kubernetes administrators has been a lack of ability to quickly find common services that are operationally ready for Kubernetes. Typically, the presence of an Operator for a specific service - a pattern that was introduced in 2016 and has gained momentum - is a good signal for the operational readiness of the service on Kubernetes. However, there has to date not existed a registry of Operators to simplify the discovery of such services.   
 

--- a/content/en/blog/_posts/2019-03-07-raw-block-volume-support-to-beta.md
+++ b/content/en/blog/_posts/2019-03-07-raw-block-volume-support-to-beta.md
@@ -1,10 +1,10 @@
 ---
 title: Raw Block Volume support to Beta
 date: 2019-03-07
+author: >
+  Ben Swartzlander (NetApp),
+  Saad Ali (Google) 
 ---
-
-**Authors:**
-Ben Swartzlander (NetApp), Saad Ali (Google)
 
 Kubernetes v1.13 moves raw block volume support to beta. This feature allows persistent volumes to be exposed inside containers as a block device instead of as a mounted file system.
 

--- a/content/en/blog/_posts/2019-03-15-Kubernetes-setup-using-Ansible-and-Vagrant.md
+++ b/content/en/blog/_posts/2019-03-15-Kubernetes-setup-using-Ansible-and-Vagrant.md
@@ -2,9 +2,9 @@
 layout: blog
 title: Kubernetes Setup Using Ansible and Vagrant
 date: 2019-03-15
+author: >
+  Naresh L J (Infosys) 
 ---
-
-**Author:** Naresh L J (Infosys)
 
 ## Objective
 This blog post describes the steps required to setup a multi node Kubernetes cluster for development purposes. This setup provides a production-like cluster that can be setup on your local machine. 

--- a/content/en/blog/_posts/2019-03-19-kubeedge-k8s-based-edge-intro.md
+++ b/content/en/blog/_posts/2019-03-19-kubeedge-k8s-based-edge-intro.md
@@ -2,9 +2,10 @@
 title: KubeEdge, a Kubernetes Native Edge Computing Framework
 date: 2019-03-19
 slug: kubeedge-k8s-based-edge-intro
+author: >
+  Sanil Kumar D (Huawei),
+  Jun Du(Huawei)
 ---
-
-**Author:** Sanil Kumar D (Huawei), Jun Du(Huawei)
 
 ## KubeEdge becomes the first Kubernetes Native Edge Computing Platform with both Edge and Cloud components open sourced!
 

--- a/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
+++ b/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
@@ -3,10 +3,10 @@ title: A Look Back and What's in Store for Kubernetes Contributor Summits
 date: 2019-03-20
 layout: blog
 evergreen: true
+author: >
+  Paris Pittman (Google),
+  Jonas Rosland (VMware) 
 ---
-
-**Authors:**
-Paris Pittman (Google), Jonas Rosland (VMware)
 
 {{<figure width="600" src="/images/blog/2019-03-14-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits/celebrationsig.jpg" caption="Seattle Contributor Summit">}}
 

--- a/content/en/blog/_posts/2019-03-21-a-guide-to-kubernetes-admission-controllers.md
+++ b/content/en/blog/_posts/2019-03-21-a-guide-to-kubernetes-admission-controllers.md
@@ -1,9 +1,9 @@
 ---
 title: A Guide to Kubernetes Admission Controllers
 date: 2019-03-21
+author: >
+  Malte Isberner (StackRox)
 ---
-
-**Author:** Malte Isberner (StackRox)
 
 Kubernetes has greatly improved the speed and manageability of backend clusters in production today. Kubernetes has emerged as the de facto standard in container orchestrators thanks to its flexibility, scalability, and ease of use. Kubernetes also provides a range of features that secure production workloads. A more recent introduction in security features is a set of plugins called “[admission controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/).” Admission controllers must be enabled to use some of the more advanced security features of Kubernetes, such as [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) that enforce a security configuration baseline across an entire namespace. The following must-know tips and tricks will help you leverage admission controllers to make the most of these security capabilities in Kubernetes.
 

--- a/content/en/blog/_posts/2019-03-22-e2e-testing-for-everyone.md
+++ b/content/en/blog/_posts/2019-03-22-e2e-testing-for-everyone.md
@@ -1,9 +1,9 @@
 ---
 title: Kubernetes End-to-end Testing for Everyone
 date: 2019-03-22
+author: >
+  Patrick Ohly (Intel)
 ---
-
-**Author:** Patrick Ohly (Intel)
 
 More and more components that used to be part of Kubernetes are now
 being developed outside of Kubernetes. For example, storage drivers

--- a/content/en/blog/_posts/2019-03-25-1-14-release-announcement.md
+++ b/content/en/blog/_posts/2019-03-25-1-14-release-announcement.md
@@ -3,9 +3,9 @@ title: 'Kubernetes 1.14: Production-level support for Windows Nodes, Kubectl Upd
 date: 2019-03-25
 slug: kubernetes-1-14-release-announcement
 evergreen: true
+author: >
+  [Kubernetes v1.14 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.14/release_team.md)
 ---
-
-**Authors:** The 1.14 [Release Team](https://bit.ly/k8s114-team)
 
 We’re pleased to announce the delivery of Kubernetes 1.14, our first release of 2019!
 

--- a/content/en/blog/_posts/2019-03-28-PID-Limiting.md
+++ b/content/en/blog/_posts/2019-03-28-PID-Limiting.md
@@ -1,9 +1,9 @@
 ---
 title: 'Process ID Limiting for Stability Improvements in Kubernetes 1.14'
 date: 2019-04-15
+author: >
+  Derek Carr
 ---
-
-**Author: Derek Carr** 
 
 Have you ever seen someone take more than their fair share of the cookies? The one person who reaches in and grabs a half dozen fresh baked chocolate chip chunk morsels and skitters off like Cookie Monster exclaiming “Om nom nom nom.”
 

--- a/content/en/blog/_posts/2019-03-28-running-kubernetes-locally-on-linux-with-minikube.md
+++ b/content/en/blog/_posts/2019-03-28-running-kubernetes-locally-on-linux-with-minikube.md
@@ -1,8 +1,9 @@
 ---                                           
 title: 'Running Kubernetes locally on Linux with Minikube - now with Kubernetes 1.14 support'                                                           
-date: 2019-03-28                                  
+date: 2019-03-28
+author: >
+  [Ihor Dvoretskyi](https://twitter.com/idvoretskyi) (Cloud Native Computing Foundation)
 ---
-**Author**: [Ihor Dvoretskyi](https://twitter.com/idvoretskyi), Developer Advocate, Cloud Native Computing Foundation
 
 <center>{{<figure width="600" src="/images/blog/2019-03-28-running-kubernetes-locally-on-linux-with-minikube/ihor-dvoretskyi-1470985-unsplash.jpg">}}</center>
 

--- a/content/en/blog/_posts/2019-03-29-kube-proxy-subtleties-debugging-an-intermittent-connection-resets.md
+++ b/content/en/blog/_posts/2019-03-29-kube-proxy-subtleties-debugging-an-intermittent-connection-resets.md
@@ -1,9 +1,9 @@
 ---
 title: 'kube-proxy Subtleties: Debugging an Intermittent Connection Reset'
 date: 2019-03-29
+author: >
+  [Yongkun Gui](mailto:ygui@google.com) (Google)
 ---
-
-**Author:** [Yongkun Gui](mailto:ygui@google.com), Google
 
 I recently came across a bug that causes intermittent connection resets.  After
 some digging, I found it was caused by a subtle combination of several different

--- a/content/en/blog/_posts/2019-04-01-kubernetes-v1-14-delivers-production-level-support-for-nodes-and-windows-containers.md
+++ b/content/en/blog/_posts/2019-04-01-kubernetes-v1-14-delivers-production-level-support-for-nodes-and-windows-containers.md
@@ -1,9 +1,10 @@
 ---
 title: 'Kubernetes v1.14 delivers production-level support for Windows nodes and Windows containers'
 date: 2019-04-01
+author: >
+  Michael Michael (VMware),
+  Patrick Lang (Microsoft)
 ---
-
-**Authors:** Michael Michael (VMware), Patrick Lang (Microsoft)
 
 The first release of Kubernetes in 2019 brings a highly anticipated feature -  production-level support for Windows workloads. Up until now Windows node support in Kubernetes has been in beta, allowing many users to experiment and see the value of Kubernetes for Windows containers. While in beta, developers in the Kubernetes community and Windows Server team worked together to improve the container runtime, build a continuous testing process, and complete features needed for a good user experience. Kubernetes now officially supports adding Windows nodes as worker nodes and scheduling Windows containers, enabling a vast ecosystem of Windows applications to leverage the power of our platform.
 

--- a/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
+++ b/content/en/blog/_posts/2019-04-04-local-persistent-volumes-ga.md
@@ -2,9 +2,11 @@
 layout: blog
 title: 'Kubernetes 1.14: Local Persistent Volumes GA'
 date: 2019-04-04
+author: >
+  Michelle Au (Google),
+  Matt Schallert (Uber),
+  Celina Ward (Uber)
 ---
-
-**Authors**: Michelle Au (Google), Matt Schallert (Uber), Celina Ward (Uber)
 
 The [Local Persistent Volumes](https://kubernetes.io/docs/concepts/storage/volumes/#local)
 feature has been promoted to GA in Kubernetes 1.14.

--- a/content/en/blog/_posts/2019-04-16-pod-priority-and-preemption-in-kubernetes.md
+++ b/content/en/blog/_posts/2019-04-16-pod-priority-and-preemption-in-kubernetes.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Pod Priority and Preemption in Kubernetes'
 date: 2019-04-16
+author: >
+  Bobby Salamat 
 ---
-
-**Author**: Bobby Salamat
 
 Kubernetes is well-known for running scalable workloads. It scales your workloads based on their resource usage. When a workload is scaled up, more instances of the application get created. When the application is critical for your product, you want to make sure that these new instances are scheduled even when your cluster is under resource pressure. One obvious solution to this problem is to over-provision your cluster resources to have some amount of slack resources available for scale-up situations. This approach often works, but costs more as you would have to pay for the resources that are idle most of the time.
 

--- a/content/en/blog/_posts/2019-04-17-future-of-cloud-providers.md
+++ b/content/en/blog/_posts/2019-04-17-future-of-cloud-providers.md
@@ -2,9 +2,11 @@
 layout: blog
 title: 'The Future of Cloud Providers in Kubernetes'
 date: 2019-04-17
+author: >
+  Andrew Sy Kim (VMware),
+  Mike Crute (AWS),
+  Walter Fender (Google)
 ---
-
-**Authors:** Andrew Sy Kim (VMware), Mike Crute (AWS), Walter Fender (Google)
 
 Approximately 9 months ago, the Kubernetes community agreed to form the Cloud Provider Special Interest Group (SIG). The justification was to have a single governing SIG to own and shape the integration points between Kubernetes and the many cloud providers it supported. A lot has been in motion since then and we’re here to share with you what has been accomplished so far and what we hope to see in the future.
 

--- a/content/en/blog/_posts/2019-04-19-Introducing-kube-iptables-tailer-Better-Networking-Visibility-in-Kubernetes-Clusters.md
+++ b/content/en/blog/_posts/2019-04-19-Introducing-kube-iptables-tailer-Better-Networking-Visibility-in-Kubernetes-Clusters.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Introducing kube-iptables-tailer: Better Networking Visibility in Kubernetes Clusters"
 date: 2019-04-19
 slug: introducing-kube-iptables-tailer
+author: >
+  Saifuding Diliyaer (Box)
 ---
-
-**Authors:** Saifuding Diliyaer, Software Engineer, Box
 
 At Box, we use Kubernetes to empower our engineers to own the whole lifecycle of their microservices. When it comes to networking, our engineers use Tigera’s [Project Calico](https://www.tigera.io/tigera-calico/) to declaratively manage network policies for their apps running in our Kubernetes clusters. App owners define a Calico policy in order to enable their Pods to send/receive network traffic, which is instantiated as iptables rules.
 

--- a/content/en/blog/_posts/2019-04-24-Hardware-Accelerated-SSLTLS-Termination-in-Ingress-Controllers-using-Kubernetes-Device-Plugins-and-RuntimeClass.md
+++ b/content/en/blog/_posts/2019-04-24-Hardware-Accelerated-SSLTLS-Termination-in-Ingress-Controllers-using-Kubernetes-Device-Plugins-and-RuntimeClass.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Hardware Accelerated SSL/TLS Termination in Ingress Controllers using Kubernetes Device Plugins and RuntimeClass'
 date: 2019-04-24
+author: >
+  Mikko Ylinen (Intel)
 ---
-
-**Authors:** Mikko Ylinen (Intel)
 
 ## Abstract
 

--- a/content/en/blog/_posts/2019-04-26-latest-on-localization.md
+++ b/content/en/blog/_posts/2019-04-26-latest-on-localization.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'How You Can Help Localize Kubernetes Docs'
 date: 2019-04-26
+author: >
+  Zach Corleissen (Linux Foundation) 
 ---
-
-**Author: Zach Corleissen (Linux Foundation)**
 
 Last year we optimized the Kubernetes website for [hosting multilingual content](/blog/2018/11/08/kubernetes-docs-updates-international-edition/). Contributors responded by adding multiple new localizations: as of April 2019, Kubernetes docs are partially available in nine different languages, with six added in 2019 alone. You can see a list of available languages in the language selector at the top of each page.
 

--- a/content/en/blog/_posts/2019-05-02-kubecon-diversity-lunch-and-hack.md
+++ b/content/en/blog/_posts/2019-05-02-kubecon-diversity-lunch-and-hack.md
@@ -3,9 +3,9 @@ title: "Join us for the 2019 KubeCon Diversity Lunch & Hack"
 date: 2019-05-02
 slug: kubecon-diversity-lunch-and-hack
 evergreen: false
+author: >
+  Kiran Oliver (The New Stack)
 ---
-
-**Authors:** Kiran Oliver, Podcast Producer, The New Stack
 
 Join us for the 2019 KubeCon Diversity Lunch & Hack: Building Tech Skills & An Inclusive Community - Sponsored by Google Cloud and VMware
 

--- a/content/en/blog/_posts/2019-05-13-kubernetes-1-14-release-interview.md
+++ b/content/en/blog/_posts/2019-05-13-kubernetes-1-14-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Cat shirts and Groundhog Day: the Kubernetes 1.14 release interview"
 date: 2019-05-13
+author: >
+  Craig Box (Google) 
 ---
-
-<b>Author</b>: Craig Box (Google)
 
 Last week we celebrated one year of the [Kubernetes Podcast from Google](https://kubernetespodcast.com/). In this weekly show, my co-host Adam Glick and I focus on all the great things that are happening in the world of Kubernetes and Cloud Native. From the news of the week, to interviews with people in the community, we help you stay up to date on everything Kubernetes.
 

--- a/content/en/blog/_posts/2019-05-14-expanding-our-contributor-workshops.md
+++ b/content/en/blog/_posts/2019-05-14-expanding-our-contributor-workshops.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Expanding our Contributor Workshops"
 date: 2019-05-14
 slug: expanding-our-contributor-workshops
+author: >
+  Guinevere Saenger (GitHub),
+  Paris Pittman (Google) 
 ---
-
-**Authors:** Guinevere Saenger (GitHub) and Paris Pittman (Google)
 
 **tl;dr** - learn about the contributor community with us and land your first
 PR! We have spots available in [Barcelona][eu] (registration **closes** on

--- a/content/en/blog/_posts/2019-05-17-Kubernetes-Cloud-Native-and-the-Future-of-Software.md
+++ b/content/en/blog/_posts/2019-05-17-Kubernetes-Cloud-Native-and-the-Future-of-Software.md
@@ -2,9 +2,10 @@
 layout: blog
 title: 'Kubernetes, Cloud Native, and the Future of Software'
 date: 2019-05-17
+author: >
+  Brian Grant (Google),
+  Jaice Singer DuMars (Google)
 ---
-
-**Authors:** Brian Grant (Google), Jaice Singer DuMars (Google)
 
 # Kubernetes, Cloud Native, and the Future of Software
 

--- a/content/en/blog/_posts/2019-05-23-Kyma-extend-and-build-on-kubernetes-with-ease.md
+++ b/content/en/blog/_posts/2019-05-23-Kyma-extend-and-build-on-kubernetes-with-ease.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Kyma - extend and build on Kubernetes with ease'
 date: 2019-05-23
+author: >
+  Lukasz Gornicki (SAP) 
 ---
-
-**Authors:** Lukasz Gornicki (SAP)
 
 According to this recently completed [CNCF Survey](https://www.cncf.io/blog/2018/08/29/cncf-survey-use-of-cloud-native-technologies-in-production-has-grown-over-200-percent/), the adoption rate of Cloud Native technologies in production is growing rapidly. Kubernetes is at the heart of this technological revolution. Naturally, the growth of cloud native technologies has been accompanied by the growth of the ecosystem that surrounds it. Of course, the complexity of cloud native technologies have increased as well. Just google for the phrase “Kubernetes is hard”, and you’ll get plenty of articles that explain this complexity problem. The best thing about the CNCF community is that problems like this can be solved by smart people building new tools to enable Kubernetes users: Projects like Knative and its [Build resource](https://github.com/knative/build) extension, for example, serve to reduce complexity across a range of scenarios. Even though increasing complexity might seem like the most important issue to tackle, it is not the only challenge you face when transitioning to Cloud Native.
 

--- a/content/en/blog/_posts/2019-06-12-contributor-summit-shanghai.md
+++ b/content/en/blog/_posts/2019-06-12-contributor-summit-shanghai.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Join us at the Contributor Summit in Shanghai'
 date: 2019-06-12
+author: >
+  Josh Berkus (Red Hat)
 ---
-
-**Author**: Josh Berkus (Red Hat)
 
 ![Picture of contributor panel at 2018 Shanghai contributor summit.  Photo by Josh Berkus, licensed CC-BY 4.0](/images/blog/2019-
 06-11-contributor-summit-shanghai/panel.png)

--- a/content/en/blog/_posts/2019-06-19-kubernetes-1-15-release-announcement.md
+++ b/content/en/blog/_posts/2019-06-19-kubernetes-1-15-release-announcement.md
@@ -4,8 +4,9 @@ title: "Kubernetes 1.15: Extensibility and Continuous Improvement"
 date: 2019-06-19
 slug: kubernetes-1-15-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.15 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.15/release_team.md)
 ---
-**Authors:** The 1.15 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.15/release_team.md)
 
 We’re pleased to announce the delivery of Kubernetes 1.15, our second release of 2019! Kubernetes 1.15 consists of 25 enhancements: 2 moving to stable, 13 in beta, and 10 in alpha. The main themes of this release are:
 

--- a/content/en/blog/_posts/2019-06-20-Future-of-CRDs-Structural-Schemas.md
+++ b/content/en/blog/_posts/2019-06-20-Future-of-CRDs-Structural-Schemas.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Future of CRDs: Structural Schemas"
 date: 2019-06-20
 slug: crd-structural-schema
+author: >
+  Stefan Schimanski (Red Hat)
 ---
-
-**Authors:** Stefan Schimanski (Red Hat)
 
 CustomResourceDefinitions were introduced roughly two years ago as the primary way to extend the Kubernetes API with custom resources. From the beginning they stored arbitrary JSON data, with the exception that `kind`, `apiVersion` and `metadata` had to follow the Kubernetes API conventions. In Kubernetes 1.8 CRDs gained the ability to define an optional OpenAPI v3 based validation schema.
 

--- a/content/en/blog/_posts/2019-06-21-volume-cloning-alpha.md
+++ b/content/en/blog/_posts/2019-06-21-volume-cloning-alpha.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Introducing Volume Cloning Alpha for Kubernetes'
 date: 2019-06-21
+author: >
+  John Griffith (Red Hat)
 ---
-
-**Author**: John Griffith (Red Hat)
 
 Kubernetes v1.15 introduces alpha support for volume cloning. This feature allows you to create new volumes using the contents of existing volumes in the user's namespace using the Kubernetes API.
 

--- a/content/en/blog/_posts/2019-06-24-kubeadm-ha-v115.md
+++ b/content/en/blog/_posts/2019-06-24-kubeadm-ha-v115.md
@@ -2,12 +2,14 @@
 layout: blog
 title: 'Automated High Availability in kubeadm v1.15: Batteries Included But Swappable'
 date: 2019-06-24
+author: >
+  [Lucas Käldström](https://github.com/luxas) (Weaveworks),
+  [Fabrizio Pandini](https://github.com/fabriziopandini) (independent)
 ---
 
-**Authors**:
-
- - Lucas Käldström, [@luxas](https://github.com/luxas), SIG Cluster Lifecycle co-chair & kubeadm subproject owner, Weaveworks
- - Fabrizio Pandini, [@fabriziopandini](https://github.com/fabriziopandini), kubeadm subproject owner, Independent
+_At the time of publication, Lucas Käldström was writing as SIG Cluster Lifecycle co-chair
+and as a subproject owner for `kubeadm`; Fabrizio Pandini was writing as a subproject
+owner for `kubeadm`._
 
 [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/) is a tool that enables Kubernetes administrators
 to quickly and easily bootstrap minimum viable clusters that are fully compliant with 

--- a/content/en/blog/_posts/2019-06-25-recap-of-contributor-summit-bcn-2019.md
+++ b/content/en/blog/_posts/2019-06-25-recap-of-contributor-summit-bcn-2019.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Recap of Kubernetes Contributor Summit Barcelona 2019'
 date: 2019-06-25
+author: >
+  Jonas Rosland (VMware)
 ---
-
-**Author**: Jonas Rosland (VMware)
 
 First of all, **THANK YOU** to everyone who made the Kubernetes Contributor Summit in Barcelona possible. We had an amazing team of volunteers tasked with planning and executing the event, and it was so much fun meeting and talking to all new and current contributors during the main event and the pre-event celebration.
 

--- a/content/en/blog/_posts/2019-07-18-some-apis-are-being-deprecated.md
+++ b/content/en/blog/_posts/2019-07-18-some-apis-are-being-deprecated.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Deprecated APIs Removed In 1.16: Here’s What You Need To Know"
 date: 2019-07-18
 slug: api-deprecations-in-1-16
+author: >
+  Vallery Lancey (Lyft) 
 ---
-
-**Author**: Vallery Lancey (Lyft)
 
 As the Kubernetes API evolves, APIs are periodically reorganized or upgraded.
 When APIs evolve, the old API is deprecated and eventually removed.

--- a/content/en/blog/_posts/2019-07-23-get-started-with-kubernetes-using-python.md
+++ b/content/en/blog/_posts/2019-07-23-get-started-with-kubernetes-using-python.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "Get started with Kubernetes (using Python)"
 date: 2019-07-23
+author: >
+  Jason Haley (independent consultant)
 ---
-
-**Author**: Jason Haley (Independent Consultant)
 
 So, you know you want to run your application in Kubernetes but don’t know where to start. Or maybe you’re getting started but still don’t know what you don’t know. In this blog you’ll walk through how to containerize an application and get it running in Kubernetes.
 

--- a/content/en/blog/_posts/2019-08-06-OPA-Gatekeeper-Policy-and-Governance-for-Kubernetes.md
+++ b/content/en/blog/_posts/2019-08-06-OPA-Gatekeeper-Policy-and-Governance-for-Kubernetes.md
@@ -4,9 +4,14 @@ layout: blog
 title: "OPA Gatekeeper: Policy and Governance for Kubernetes"
 date: 2019-08-06
 slug: OPA-Gatekeeper-Policy-and-Governance-for-Kubernetes 
+author: >
+  Rita Zhang (Microsoft),
+  Max Smythe (Google),
+  Craig Hooper (Commonwealth Bank AU),
+  Tim Hinrichs (Styra),
+  Lachie Evenson (Microsoft),
+  Torin Sandall (Styra)
 ---
-
-**Authors:** Rita Zhang (Microsoft), Max Smythe (Google), Craig Hooper (Commonwealth Bank AU), Tim Hinrichs (Styra), Lachie Evenson (Microsoft), Torin Sandall (Styra)
 
 The [Open Policy Agent Gatekeeper](https://github.com/open-policy-agent/gatekeeper) project can be leveraged to help enforce policies and strengthen governance in your Kubernetes environment. In this post, we will walk through the goals, history, and current state of the project.
 

--- a/content/en/blog/_posts/2019-08-30-announcing-etcd-3.4.md
+++ b/content/en/blog/_posts/2019-08-30-announcing-etcd-3.4.md
@@ -4,9 +4,10 @@ layout: blog
 title: "Announcing etcd 3.4"
 date: 2019-08-30
 slug: announcing-etcd-3-4
+author: >
+  [Gyuho Lee](https://github.com/gyuho) (Amazon Web Services),
+  [Jingyi Hu](https://github.com/jingyih) (Google)
 ---
-
-**Authors:** Gyuho Lee (Amazon Web Services, @[gyuho](https://github.com/gyuho)), Jingyi Hu (Google, @[jingyih](https://github.com/jingyih))
 
 etcd 3.4 focuses on stability, performance and ease of operation, with features like pre-vote and non-voting member and improvements to storage backend and client balancer.
 

--- a/content/en/blog/_posts/2019-09-18-kubernetes-1-16-release-announcement.md
+++ b/content/en/blog/_posts/2019-09-18-kubernetes-1-16-release-announcement.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.16: Custom Resources, Overhauled Metrics, and Volume Extensions"
 date: 2019-09-18
 slug: kubernetes-1-16-release-announcement
+author: >
+  [Kubernetes 1.16 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.16/release_team.md)
 ---
-
-**Authors:** [Kubernetes 1.16 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.16/release_team.md)
 
 We’re pleased to announce the delivery of Kubernetes 1.16, our third release of 2019! Kubernetes 1.16 consists of 31 enhancements: 8 enhancements moving to stable, 8 enhancements in beta, and 15 enhancements in alpha.
 

--- a/content/en/blog/_posts/2019-09-24-san-diego-contributor-summit.md
+++ b/content/en/blog/_posts/2019-09-24-san-diego-contributor-summit.md
@@ -4,9 +4,11 @@ title: "Contributor Summit San Diego Registration Open!"
 date: 2019-09-24
 slug: san-diego-contributor-summit
 evergreen: true
+author: >
+  Paris Pittman (Google),
+  Jeffrey Sica (Red Hat),
+  Jonas Rosland (VMware)
 ---
-
-**Authors:** Paris Pittman (Google), Jeffrey Sica (Red Hat), Jonas Rosland (VMware)
 
 [Contributor Summit San Diego 2019 Event Page]  
 In record time, we’ve hit capacity for the *new contributor workshop* session of

--- a/content/en/blog/_posts/2019-10-03-2019-Steering-Committee-Election-Results.md
+++ b/content/en/blog/_posts/2019-10-03-2019-Steering-Committee-Election-Results.md
@@ -3,10 +3,12 @@ layout: blog
 title: "2019 Steering Committee Election Results"
 date: 2019-10-03
 slug: 2019-steering-committee-election-results
+author: >
+  Bob Killen (University of Michigan),
+  Jorge Castro (VMware),
+  Brian Grant (Google),
+  Ihor Dvoretskyi (CNCF) 
 ---
-
-**Authors**: Bob Killen (University of Michigan), Jorge Castro (VMware),
-Brian Grant (Google), and Ihor Dvoretskyi (CNCF)
 
 The [2019 Steering Committee Election] is a landmark milestone for the
 Kubernetes project. The initial bootstrap committee is graduating to emeritus

--- a/content/en/blog/_posts/2019-10-10-contributor-summit-san-diego-schedule.md
+++ b/content/en/blog/_posts/2019-10-10-contributor-summit-san-diego-schedule.md
@@ -3,9 +3,11 @@ layout: blog
 title: "Contributor Summit San Diego Schedule Announced!"
 date: 2019-10-10
 slug: contributor-summit-san-diego-schedule
+author: >
+  Josh Berkus (Red Hat),
+  Paris Pittman (Google),
+  Jonas Rosland (VMware)
 ---
-
-**Authors:** Josh Berkus (Red Hat), Paris Pittman (Google), Jonas Rosland (VMware)
 
 There are many great sessions planned for the Contributor Summit, spread across
 five rooms of current contributor content in addition to the new contributor

--- a/content/en/blog/_posts/2019-10-29-2019-sig-docs-survey.md
+++ b/content/en/blog/_posts/2019-10-29-2019-sig-docs-survey.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes Documentation Survey"
 date: 2019-10-29
 slug: kubernetes-documentation-end-user-survey
+author: >
+  [Aimee Ukasick](https://www.linkedin.com/in/aimee-ukasick/),
+  and Kubernetes SIG Docs
 ---
-
-**Author:** [Aimee Ukasick](https://www.linkedin.com/in/aimee-ukasick/) and SIG Docs
 
 In September, SIG Docs conducted its first survey about the [Kubernetes
 documentation](https://kubernetes.io/docs/). We'd like to thank the CNCF's Kim

--- a/content/en/blog/_posts/2019-11-05-grokkin-the-docs.md
+++ b/content/en/blog/_posts/2019-11-05-grokkin-the-docs.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Grokkin' the Docs"
 date: 2019-11-05
 slug: Grokkin-the-Docs
+author: >
+  [Aimee Ukasick](https://www.linkedin.com/in/aimee-ukasick/) (independent contributor)
 ---
-
-**Author:** [Aimee Ukasick](https://www.linkedin.com/in/aimee-ukasick/), Independent Contributor
 
 {{< figure
     src="/images/blog/grokkin-the-docs/grok-definition.png"

--- a/content/en/blog/_posts/2019-11-05-kubernetes-with-microk8s.md
+++ b/content/en/blog/_posts/2019-11-05-kubernetes-with-microk8s.md
@@ -1,8 +1,10 @@
 ---                                           
 title: 'Running Kubernetes locally on Linux with Microk8s'                                                           
 date: 2019-11-26
+author: >
+  [Ihor Dvoretskyi](https://twitter.com/idvoretskyi) (Cloud Native Computing Foundation),
+  [Carmine Rimi](https://twitter.com/carminerimi)
 ---
-**Authors**: [Ihor Dvoretskyi](https://twitter.com/idvoretskyi), Developer Advocate, Cloud Native Computing Foundation; [Carmine Rimi](https://twitter.com/carminerimi)
 
 This article, the second in a [series](/blog/2019/03/28/running-kubernetes-locally-on-linux-with-minikube-now-with-kubernetes-1.14-support/) about local deployment options on Linux, and covers [MicroK8s](https://microk8s.io/). Microk8s is the click-and-run solution for deploying a Kubernetes cluster locally, originally developed by Canonical, the publisher of Ubuntu.
 

--- a/content/en/blog/_posts/2019-11-26-cloud-native-java-controller-sdk.md
+++ b/content/en/blog/_posts/2019-11-26-cloud-native-java-controller-sdk.md
@@ -1,12 +1,12 @@
-
 ---
 layout: blog
 title: "Develop a Kubernetes controller in Java"
 date: 2019-11-26
 slug: Develop-A-Kubernetes-Controller-in-Java
+author: >
+  Min Kim (Ant Financial), 
+  Tony Ado (Ant Financial)
 ---
-
-**Authors:** Min Kim (Ant Financial), Tony Ado (Ant Financial)
 
 The official [Kubernetes Java SDK](https://github.com/kubernetes-client/java) project
 recently released their latest work on providing the Java Kubernetes developers

--- a/content/en/blog/_posts/2019-12-02-gardener-project-update.md
+++ b/content/en/blog/_posts/2019-12-02-gardener-project-update.md
@@ -3,10 +3,10 @@ layout: blog
 title: "Gardener Project Update"
 date: 2019-12-02
 slug: gardener-project-update
+author: >
+  [Rafael Franzke](mailto:rafael.franzke@sap.com) (SAP), 
+  [Vasu Chandrasekhara](mailto:vasu.chandrasekhara@sap.com) (SAP)
 ---
-
-**Authors:** [Rafael Franzke](mailto:rafael.franzke@sap.com) (SAP), [Vasu
-Chandrasekhara](mailto:vasu.chandrasekhara@sap.com) (SAP)
 
 Last year, we introduced [Gardener](https://gardener.cloud) in the [Kubernetes
 Community

--- a/content/en/blog/_posts/2019-12-06-kubernetes-1-16-release-interview.md
+++ b/content/en/blog/_posts/2019-12-06-kubernetes-1-16-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "When you're in the release team, you're family: the Kubernetes 1.16 release interview"
 date: 2019-12-06
+author: >
+  Craig Box (Google)
 ---
-
-<b>Author</b>: Craig Box (Google)
 
 It is a pleasure to co-host the weekly [Kubernetes Podcast from Google](https://kubernetespodcast.com/) with Adam Glick.  We get to talk to friends old and new from the community, as well as give people a download on the Cloud Native news every week.
 

--- a/content/en/blog/_posts/2019-12-09-csi-volume-migration-beta.md
+++ b/content/en/blog/_posts/2019-12-09-csi-volume-migration-beta.md
@@ -3,9 +3,9 @@ layout: blog
 title: "Kubernetes 1.17 Feature: Kubernetes In-Tree to CSI Volume Migration Moves to Beta"
 date: 2019-12-09T09:00:00+08:00
 slug: kubernetes-1-17-feature-csi-migration-beta
+author: >
+  David Zhu (Software Engineer, Google)
 ---
-
-**Authors:** David Zhu, Software Engineer, Google
 
 The Kubernetes in-tree storage plugin to [Container Storage Interface (CSI)](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) migration infrastructure is now beta in Kubernetes v1.17. CSI migration was introduced as alpha in Kubernetes v1.14.
 

--- a/content/en/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md
+++ b/content/en/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md
@@ -4,9 +4,9 @@ title: "Kubernetes 1.17: Stability"
 date: 2019-12-09T13:00:00-08:00
 slug: kubernetes-1-17-release-announcement
 evergreen: true
+author: >
+  [Kubernetes 1.17 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.17/release_team.md)
 ---
-
-**Authors:** [Kubernetes 1.17 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.17/release_team.md)
 
 We’re pleased to announce the delivery of Kubernetes 1.17, our fourth and final release of 2019! Kubernetes v1.17 consists of 22 enhancements: 14 enhancements have graduated to stable, 4 enhancements are moving to beta, and 4 enhancements are entering alpha.
 

--- a/content/en/blog/_posts/2019-12-09-volume-snapshot-beta.md
+++ b/content/en/blog/_posts/2019-12-09-volume-snapshot-beta.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes 1.17 Feature: Kubernetes Volume Snapshot Moves to Beta"
 date: 2019-12-09T10:00:00-08:00
 slug: kubernetes-1-17-feature-cis-volume-snapshot-beta
+author: >
+  Xing Yang (VMware),
+  Xiangqian Yu (Google)
 ---
-
-**Authors:** Xing Yang, VMware & Xiangqian Yu, Google
 
 The Kubernetes Volume Snapshot feature is now beta in Kubernetes v1.17. It was introduced [as alpha](https://kubernetes.io/blog/2018/10/09/introducing-volume-snapshot-alpha-for-kubernetes/) in Kubernetes v1.12, with a [second alpha](https://kubernetes.io/blog/2019/01/17/update-on-volume-snapshot-alpha-for-kubernetes/) with breaking changes in Kubernetes v1.13.  This post summarizes the changes in the beta release.
 


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2019 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-46234--kubernetes-io-main-staging.netlify.app/blog)