### PR TITLE
[zh] Sync 9 reference files in setup-tools/kubeadm

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_check-expiration.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_check-expiration.md
@@ -30,6 +30,25 @@ kubeadm certs check-expiration [flags]
 <tbody>
 
 <tr>
+<td colspan="2">
+<!--
+--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true
+-->
+--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值：true
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
+-->
+如果为 true，忽略模板中缺少某字段或映射键的错误。仅适用于 golang 和 jsonpath 输出格式。
+</p>
+</td>
+</tr>
+
+<tr>
 <!--
 <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"</td> 
 -->
@@ -53,6 +72,26 @@ kubeadm certs check-expiration [flags]
 <p>Path to a kubeadm configuration file.</p> 
 -->
 <p>到 kubeadm 配置文件的路径。</p>
+</td>
+</tr>
+
+<tr>
+<td colspan="2">
+<!--
+-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "text"
+-->
+-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："text"
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+Output format. One of: text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
+-->
+输出格式。可选值为：
+text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file。
+</p>
 </td>
 </tr>
 
@@ -83,6 +122,20 @@ kubeadm certs check-expiration [flags]
 -->
 <p>在和集群连接时使用该 kubeconfig 文件。
 如果此标志未被设置，那么将会在一些标准的位置去搜索存在的 kubeconfig 文件。</p>
+</td>
+</tr>
+
+<tr>
+<td colspan="2">--show-managed-fields</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+If true, keep the managedFields when printing objects in JSON or YAML format.
+-->
+如果为 true，在以 JSON 或 YAML 格式打印对象时保留 managedFields。
+</p>
 </td>
 </tr>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
@@ -18,11 +18,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令目前处于 Alpha 阶段。
-
 ```
 kubeadm init phase certs apiserver-etcd-client [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
@@ -18,11 +18,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令目前处于 Alpha 阶段。
-
 ```
 kubeadm init phase certs apiserver [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
@@ -23,11 +23,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令当前为 Alpha 功能。
-
 ```
 kubeadm init phase certs etcd-peer [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
@@ -23,11 +23,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令当前为 Alpha 功能。
-
 ```
 kubeadm init phase certs etcd-server [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-ca.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-ca.md
@@ -18,11 +18,6 @@ If both files already exist, kubeadm skips the generation step and existing file
 -->
 如果两个文件都已存在，kubeadm 将跳过生成步骤并将使用现有文件。
 
-<!--
-Alpha Disclaimer: this command is currently alpha.
--->
-Alpha 免责声明：此命令目前是 Alpha 阶段。
-
 ```
 kubeadm init phase certs front-proxy-ca [flags]
 ```

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
@@ -12,14 +12,10 @@ Generate the certificate for the front proxy client
 Generate the certificate for the front proxy client, and save them into front-proxy-client.crt and front-proxy-client.key files.
 
 If both files already exist, kubeadm skips the generation step and existing files will be used.
-
-Alpha Disclaimer: this command is currently alpha.
 -->
 为前端代理客户端生成证书，并将其保存到 front-proxy-client.crt 和 front-proxy-client.key 文件中。
 
 如果两个文件都已存在，kubeadm 将跳过生成步骤并将使用现有文件。
-
-Alpha 免责声明：此命令目前是 Alpha 阶段。
 
 ```
 kubeadm init phase certs front-proxy-client [flags]

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_preflight.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_preflight.md
@@ -116,6 +116,25 @@ A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedU
 </td>
 </tr>
 
+<tr>
+<td colspan="2">
+<!--
+--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "registry.k8s.io"
+-->
+--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："registry.k8s.io"
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
+<!--
+Choose a container registry to pull control plane images from
+-->
+选择拉取控制平面镜像的容器仓库。
+</p>
+</td>
+</tr>
+
 </tbody>
 </table>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -3,61 +3,93 @@ title: kubeadm reset
 content_type: concept
 weight: 60
 ---
-<!-- ---
+<!--
 reviewers:
-- mikedanese
 - luxas
 - jbeda
 title: kubeadm reset
 content_type: concept
 weight: 60
---- -->
+-->
 
 <!-- overview -->
-<!-- Performs a best effort revert of changes made by `kubeadm init` or `kubeadm join`. -->
+<!--
+Performs a best effort revert of changes made by `kubeadm init` or `kubeadm join`.
+-->
 该命令尽力还原由 `kubeadm init` 或 `kubeadm join` 所做的更改。
 
 
 <!-- body -->
 {{< include "generated/kubeadm_reset.md" >}}
 
-<!-- ### Reset workflow {#reset-workflow} -->
+<!--
+### Reset workflow {#reset-workflow}
+-->
 ### Reset 工作流程 {#reset-workflow}
 
-<!-- `kubeadm reset` is responsible for cleaning up a node local file system from files that were created using
+<!--
+`kubeadm reset` is responsible for cleaning up a node local file system from files that were created using
 the `kubeadm init` or `kubeadm join` commands. For control-plane nodes `reset` also removes the local stacked
 etcd member of this node from the etcd cluster.
 -->
 `kubeadm reset` 负责从使用 `kubeadm init` 或 `kubeadm join` 命令创建的文件中清除节点本地文件系统。
 对于控制平面节点，`reset` 还从 etcd 集群中删除该节点的本地 etcd Stacked 部署的成员。
 
-<!-- `kubeadm reset phase` can be used to execute the separate phases of the above workflow.
+<!--
+`kubeadm reset phase` can be used to execute the separate phases of the above workflow.
 To skip a list of phases you can use the `--skip-phases` flag, which works in a similar way to
-the `kubeadm join` and `kubeadm init` phase runners. -->
+the `kubeadm join` and `kubeadm init` phase runners.
+-->
 `kubeadm reset phase` 可用于执行上述工作流程的各个阶段。
 要跳过阶段列表，你可以使用 `--skip-phases` 参数，该参数的工作方式类似于 `kubeadm join` 和 `kubeadm init` 阶段运行器。
 
-<!-- ### External etcd clean up -->
+<!--
+### External etcd clean up
+-->
 ### 外部 etcd 清理
 
-<!-- `kubeadm reset` will not delete any etcd data if external etcd is used. This means that if you run `kubeadm init` again using the same etcd endpoints, you will see state from previous clusters. -->
-如果使用了外部 etcd，`kubeadm reset` 将不会删除任何 etcd 中的数据。这意味着，如果再次使用相同的 etcd 端点运行 `kubeadm init`，你将看到先前集群的状态。
+<!--
+`kubeadm reset` will not delete any etcd data if external etcd is used. This means that if you run `kubeadm init` again using the same etcd endpoints, you will see state from previous clusters.
+-->
+如果使用了外部 etcd，`kubeadm reset` 将不会删除任何 etcd 中的数据。
+这意味着，如果再次使用相同的 etcd 端点运行 `kubeadm init`，你将看到先前集群的状态。
 
-<!-- To wipe etcd data it is recommended you use a client like etcdctl, such as: -->
+<!--
+To wipe etcd data it is recommended you use a client like etcdctl, such as:
+-->
 要清理 etcd 中的数据，建议你使用 etcdctl 这样的客户端，例如：
 
 ```bash
 etcdctl del "" --prefix
 ```
 
-<!-- See the [etcd documentation](https://github.com/coreos/etcd/tree/master/etcdctl) for more information. -->
+<!--
+See the [etcd documentation](https://github.com/coreos/etcd/tree/master/etcdctl) for more information.
+-->
 更多详情请参考 [etcd 文档](https://github.com/coreos/etcd/tree/master/etcdctl)。
 
+<!--
+### Graceful kube-apiserver shutdown
+
+If you have your `kube-apiserver` configured with the `--shutdown-delay-duration` flag,
+you can run the following commands to attempt a graceful shutdown for the running API server Pod,
+before you run `kubeadm reset`:
+-->
+### 体面关闭 kube-apiserver
+
+如果你为 `kube-apiserver` 配置了 `--shutdown-delay-duration` 标志，
+你可以在运行 `kubeadm reset` 之前，运行以下命令尝试体面关闭正在运行的 API 服务器 Pod：
+
+```bash
+yq eval -i '.spec.containers[0].command = []' /etc/kubernetes/manifests/kube-apiserver.yaml
+timeout 60 sh -c 'while pgrep kube-apiserver >/dev/null; do sleep 1; done' || true
+```
 
 ## {{% heading "whatsnext" %}}
 
-<!-- * [kubeadm init](/docs/reference/setup-tools/kubeadm/kubeadm-init/) to bootstrap a Kubernetes control-plane node
-* [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/) to bootstrap a Kubernetes worker node and join it to the cluster -->
+<!--
+* [kubeadm init](/docs/reference/setup-tools/kubeadm/kubeadm-init/) to bootstrap a Kubernetes control-plane node
+* [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/) to bootstrap a Kubernetes worker node and join it to the cluster
+-->
 * 参考 [kubeadm init](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init/) 来初始化 Kubernetes 主节点。
 * 参考 [kubeadm join](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-join/) 来初始化 Kubernetes 工作节点并加入集群。
-


### PR DESCRIPTION
Sync with en text:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_check-expiration.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-ca.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_preflight.md
content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
```
See [preview](https://deploy-preview-46238--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset/) please.