### PR TITLE
[ja] revise `content/ja/docs/contribute/localization.md`

### DIFF
--- a/content/ja/docs/contribute/localization.md
+++ b/content/ja/docs/contribute/localization.md
@@ -76,7 +76,7 @@ card:
 Kubernetesのリソース名や技術用語などは、原則としてそのままの表記を使用します。
 例えば、PodやService、Deploymentなどは翻訳せずにそのまま表記してください。
 
-ただし、ノード(Node)に関しては明確にKubernetesとしてのNodeリソース(例: `kind: Node`や`kubectl get nodes`)を指していないのであれば、「ノード」と表記してください。
+ただし、ノード(Node)に関してはKubernetesとしてのNodeリソース(例: `kind: Node`や`kubectl get nodes`、Nodeコントローラーなど)を指していないのであれば、「ノード」と表記してください。
 
 またこれらの単語は、複数形ではなく単数形を用います。
 例えば、原文に"pods"と表記されている場合でも、日本語訳では"Pod"と表記してください。


### PR DESCRIPTION
## Feature Description

- revise `content/ja/docs/contribute/localization.md`
    - "Node" に関する箇所の微修正

ref. https://github.com/kubernetes/website/pull/46076#discussion_r1591857109

> あと別件かと思うのですが
> 
> > ただし、ノード(Node)に関しては明確にKubernetesとしてのNodeリソース(例: kind: Nodeやkubectl get nodes)を指していないのであれば、「ノード」と表記してください。
> 
> という現在の表現ですが、`kind: Node`　くらいNodeリソース感が無いと"ノード"にすべきなのかな？という印象を受けるので基本下記のようにしてみても良いかもです。 (といっても微修正ですが)
> 
> > ただし、ノード(Node)に関してはKubernetesとしてのNodeリソース(例: kind: Nodeやkubectl get nodes、Nodeコントローラーなど)を指していないのであれば、「ノード」と表記してください。

/cc @bells17 
/assign @nasa9084 

cc @kubernetes/sig-docs-ja-reviews 