### PR TITLE
Remove GA ServiceNodePortStaticSubrange feature gate

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -523,8 +523,6 @@ spec:
 
 #### Reserve Nodeport ranges to avoid collisions  {#avoid-nodeport-collisions}
 
-{{< feature-state for_k8s_version="v1.29" state="stable" >}}
-
 The policy for assigning ports to NodePort services applies to both the auto-assignment and
 the manual assignment scenarios. When a user wants to create a NodePort service that
 uses a specific port, the target port may conflict with another port that has already been assigned.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/service-nodeport-static-subrange.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/service-nodeport-static-subrange.md
@@ -17,6 +17,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.29" 
+    toVersion: "1.30" 
+
+removed: true  
 ---
 Enables the use of different port allocation
 strategies for NodePort Services. For more details, see


### PR DESCRIPTION
This PR remove GA feature gate ServiceNodePortStaticSubrange

code remove in k/k: https://github.com/kubernetes/kubernetes/pull/124738

KEP: https://github.com/kubernetes/enhancements/issues/3668