### PR TITLE
fix superfluous white space

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -49,8 +49,7 @@ Cluster administrator actions include:
 
 - [Draining a node](/docs/tasks/administer-cluster/safely-drain-node/) for repair or upgrade.
 - Draining a node from a cluster to scale the cluster down (learn about
-[Cluster Autoscaling](https://github.com/kubernetes/autoscaler/#readme)
-).
+[Cluster Autoscaling](https://github.com/kubernetes/autoscaler/#readme)).
 - Removing a pod from a node to permit something else to fit on that node.
 
 These actions might be taken directly by the cluster administrator, or by automation


### PR DESCRIPTION
Just noticed a superfluous white space just before a closing parenthesis:

![image](https://github.com/kubernetes/website/assets/13865903/5c1084d5-045d-43d8-ad8f-efa61fdceff7)