### PR TITLE
Fix incorrect /security alias

### DIFF
--- a/content/ru/docs/reference/issues-security/security.md
+++ b/content/ru/docs/reference/issues-security/security.md
@@ -1,6 +1,6 @@
 ---
 title: Общие сведения о безопасности Kubernetes и раскрытии информации
-aliases: [/security/]
+aliases: [/ru/security/]
 reviewers:
 - eparis
 - erictune


### PR DESCRIPTION
https://kubernetes.io/security must route to the EN docs.