### PR TITLE
Fix broken link in "Set Kubelet Parameters Via A Configuration File" page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -296,4 +296,4 @@ they can follow these steps to inspect the kubelet configuration:
   [`KubeletConfiguration`](/docs/reference/config-api/kubelet-config.v1beta1/)
   reference.
 - Learn more about kubelet configuration merging in the
-  [reference document](/docs/reference/node/kubelet-config-directory-merging.md).
+  [reference document](/docs/reference/node/kubelet-config-directory-merging).


### PR DESCRIPTION
- Removed `.md` typo formatting  to render the webpage.
- Proposed solution to issue https://github.com/kubernetes/website/issues/46088