### PR TITLE
Fix the incorrect /cve alias

### DIFF
--- a/content/ru/docs/reference/issues-security/issues.md
+++ b/content/ru/docs/reference/issues-security/issues.md
@@ -1,7 +1,7 @@
 ---
 title: Трекер задач (Issues) Kubernetes
 weight: 10
-aliases: [/cve/,/cves/]
+aliases: [/ru/cve/,/ru/cves/]
 ---
 
 Чтобы сообщить о проблеме в области безопасности, воспользуйтесь процедурой [раскрытия информации о безопасности Kubernetes](/ru/docs/reference/issues-security/security/#report-a-vulnerability).


### PR DESCRIPTION
Similarly to #46281, we need to fix the https://kubernetes.io/cve/ and https://kubernetes.io/cves/ aliases. This issue originates from #43368.