### PR TITLE
Disambiguate Pod Phase from kubectl status...

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -79,14 +79,24 @@ Here are the possible values for `phase`:
 Value       | Description
 :-----------|:-----------
 `Pending`   | The Pod has been accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run. This includes time a Pod spends waiting to be scheduled as well as the time spent downloading container images over the network.
-`Running`   | The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting.
+`Running`   | The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting.    
 `Succeeded` | All containers in the Pod have terminated in success, and will not be restarted.
 `Failed`    | All containers in the Pod have terminated, and at least one container has terminated in failure. That is, the container either exited with non-zero status or was terminated by the system.
 `Unknown`   | For some reason the state of the Pod could not be obtained. This phase typically occurs due to an error in communicating with the node where the Pod should be running.
 
 {{< note >}}
-When a Pod is being deleted, it is shown as `Terminating` by some kubectl commands.
-This `Terminating` status is not one of the Pod phases.
+When a pod is not able to stay running, it is shown as `CrashLoopBackoff` by some kubectl commands.
+This is, however, not one of the not a Pod phases, that is to stay this "Status" is not a phase....
+```
+  NAMESPACE               NAME               READY   STATUS             RESTARTS   AGE
+  alessandras-namespace   alessandras-pod    0/1     CrashLoopBackOff   200        2d9h 
+```
+
+{{< /note >}}
+
+
+{{< note >}}
+Similar to the above example with `CrashLoopBackoff`, this `Terminating` status also not one of the Pod phases.
 A Pod is granted a term to terminate gracefully, which defaults to 30 seconds.
 You can use the flag `--force` to [terminate a Pod by force](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced).
 {{< /note >}}

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -79,7 +79,7 @@ Here are the possible values for `phase`:
 Value       | Description
 :-----------|:-----------
 `Pending`   | The Pod has been accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run. This includes time a Pod spends waiting to be scheduled as well as the time spent downloading container images over the network.
-`Running`   | The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting.    
+`Running`   | The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting.
 `Succeeded` | All containers in the Pod have terminated in success, and will not be restarted.
 `Failed`    | All containers in the Pod have terminated, and at least one container has terminated in failure. That is, the container either exited with non-zero status or was terminated by the system.
 `Unknown`   | For some reason the state of the Pod could not be obtained. This phase typically occurs due to an error in communicating with the node where the Pod should be running.

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -86,7 +86,7 @@ Value       | Description
 
 {{< note >}}
 When a pod is not able to stay running, it may be shown as `CrashLoopBackoff` by some kubectl commands in its `Status`.
-This is, however, not one of the not a Pod phases, that is to stay this "Status" is not a phase....
+Make sure not to confuse "Status", a display field for user intuition, with the pod "Phase", which is an explicit part of the Kubernetes data model. 
 ```
   NAMESPACE               NAME               READY   STATUS             RESTARTS   AGE
   alessandras-namespace   alessandras-pod    0/1     CrashLoopBackOff   200        2d9h 

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -85,7 +85,7 @@ Value       | Description
 `Unknown`   | For some reason the state of the Pod could not be obtained. This phase typically occurs due to an error in communicating with the node where the Pod should be running.
 
 {{< note >}}
-When a pod is not able to stay running, it is shown as `CrashLoopBackoff` by some kubectl commands.
+When a pod is not able to stay running, it may be shown as `CrashLoopBackoff` by some kubectl commands in its `Status`.
 This is, however, not one of the not a Pod phases, that is to stay this "Status" is not a phase....
 ```
   NAMESPACE               NAME               READY   STATUS             RESTARTS   AGE


### PR DESCRIPTION
This PR disambiguates CrashLoopBackoff "Status" from the formal concept of the "Phase"... 