### PR TITLE
Update glossary_tooltip.html to include relLangURL for $external_link

### DIFF
--- a/layouts/shortcodes/glossary_tooltip.html
+++ b/layouts/shortcodes/glossary_tooltip.html
@@ -17,7 +17,7 @@
 
 {{- $tooltip := $tooltip | replaceRE "(?s)<a class='glossary-tooltip'.*?>(.*?).*</a>" "$1" | plainify -}}
 {{- $tooltip := trim $tooltip " \n" -}}
-<a class='glossary-tooltip' title='{{- $tooltip | safeHTML -}}' data-toggle='tooltip' data-placement='top' href='{{ $external_link }}' target='_blank' aria-label='{{ $text }}'>
+<a class='glossary-tooltip' title='{{- $tooltip | safeHTML -}}' data-toggle='tooltip' data-placement='top' href='{{ $external_link | relLangURL }}' target='_blank' aria-label='{{ $text }}'>
 {{- $text -}}
 </a>
 {{- end -}}


### PR DESCRIPTION
This fine-tuning will help to avoid explicit manual language prefixing for the `full_link`. This change does not affect already language prefixed `full_link` (e.g. zh-cn)