### PR TITLE
improve markdown formatting in docs

### DIFF
--- a/content/en/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
@@ -28,7 +28,10 @@ guide. You can file document formatting bugs against the
 
 ## ServiceAccount {#ServiceAccount}
 
-ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
+ServiceAccount binds together:
+* a name, understood by users, and perhaps by peripheral systems, for an identity
+* a principal that can be authenticated and authorized
+* a set of secrets
 
 <hr>
 


### PR DESCRIPTION
small fix to improve the markdown formatting for the page https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/