### PR TITLE
[id] Fix incorrect relative URLs

### DIFF
--- a/content/id/docs/concepts/architecture/controller.md
+++ b/content/id/docs/concepts/architecture/controller.md
@@ -60,7 +60,7 @@ Job adalah sumber daya dalam Kubernetes yang menjalankan a
 {{< glossary_tooltip term_id="pod" >}}, atau mungkin beberapa Pod sekaligus, 
 untuk melakukan sebuah pekerjaan dan kemudian berhenti.
 
-(Setelah [dijadwalkan](../../../../en/docs/concepts/scheduling-eviction/), objek Pod 
+(Setelah [dijadwalkan](/en/docs/concepts/scheduling-eviction/), objek Pod 
 akan menjadi bagian dari keadaan yang diinginkan oleh kubelet).
 
 Ketika _controller job_ melihat tugas baru, maka _controller_ itu memastikan bahwa, 

--- a/content/id/docs/reference/access-authn-authz/rbac.md
+++ b/content/id/docs/reference/access-authn-authz/rbac.md
@@ -1,7 +1,7 @@
 ---
 title: Menggunakan Otorisasi RBAC
 content_type: concept
-aliases: [../../../rbac/]
+aliases: [/id/rbac/]
 weight: 70
 ---
 


### PR DESCRIPTION
I found two pages where relative URLs (`../../<etc>`) were used with no visible reason. This PR fixes them.