### PR TITLE
[certificateSigningRequest] Use base64 native no-wrap option instead of piping to tr command

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -530,7 +530,7 @@ Some points to note:
   You can get the content using this command: 
 
   ```shell
-  cat myuser.csr | base64 | tr -d "\n"
+  cat myuser.csr | base64 -w0
   ```
 
 


### PR DESCRIPTION
Instead of using `tr -d '\n'` to remove the default wrapping behavior of base64 use builtin `base64` option `-w0`.

