### PR TITLE
Turn interactive tutorials into custom 404 pages

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive-gone.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive-gone.html
@@ -1,5 +1,11 @@
 ---
-title: Interactive Tutorial - Exposing Your App
+title: Not found
+# This page was previously titled "Interactive Tutorial - Creating a Cluster"
+# before Katacoda shut down.
+#
+# There is no need to localize this Not Found page; the website automatically
+# serves a 404 response when a page is missing. If you have an existing localized
+# version of this page, it is OK to remove that localized version.
 weight: 20
 headless: true
 toc_hide: true
@@ -7,6 +13,7 @@ _build:
   list: never
   publishResources: false
 ---
+
 <!DOCTYPE html>
 
 <html lang="en">
@@ -20,7 +27,7 @@ _build:
               Content unavailable
             </h2>
             <p>
-              The interactive tutorial for exposing your app is not available.
+              The interactive tutorial for creating a cluster is not available.
               For more information, see the
               <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
                 shutdown announcement</a>.
@@ -31,4 +38,3 @@ _build:
 
 </body>
 </html>
-

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive-gone.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive-gone.html
@@ -1,5 +1,11 @@
 ---
-title: Interactive Tutorial - Updating Your App
+title: Not found
+# This page was previously titled "Interactive Tutorial - Deploying an App"
+# before Katacoda shut down.
+#
+# There is no need to localize this Not Found page; the website automatically
+# serves a 404 response when a page is missing. If you have an existing localized
+# version of this page, it is OK to remove that localized version.
 weight: 20
 headless: true
 toc_hide: true
@@ -20,7 +26,7 @@ _build:
               Content unavailable
             </h2>
             <p>
-              The interactive tutorial for updating an application in your cluster is not available.
+              The interactive tutorial for deploying an application to your cluster is not available.
               For more information, see the
               <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
                 shutdown announcement</a>.
@@ -31,4 +37,3 @@ _build:
 
 </body>
 </html>
-

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive-gone.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive-gone.html
@@ -1,5 +1,11 @@
 ---
-title: Interactive Tutorial - Creating a Cluster
+title: Not found
+# This page was previously titled "Interactive Tutorial - Exploring Your App"
+# before Katacoda shut down.
+#
+# There is no need to localize this Not Found page; the website automatically
+# serves a 404 response when a page is missing. If you have an existing localized
+# version of this page, it is OK to remove that localized version.
 weight: 20
 headless: true
 toc_hide: true
@@ -7,7 +13,6 @@ _build:
   list: never
   publishResources: false
 ---
-
 <!DOCTYPE html>
 
 <html lang="en">
@@ -21,7 +26,7 @@ _build:
               Content unavailable
             </h2>
             <p>
-              The interactive tutorial for creating a cluster is not available.
+              The interactive tutorial for exploring your app is not available.
               For more information, see the
               <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
                 shutdown announcement</a>.

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive-gone.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive-gone.html
@@ -1,5 +1,11 @@
 ---
-title: Interactive Tutorial - Scaling Your App
+title: Not found
+# This page was previously titled "Interactive Tutorial - Exposing Your App"
+# before Katacoda shut down.
+#
+# There is no need to localize this Not Found page; the website automatically
+# serves a 404 response when a page is missing. If you have an existing localized
+# version of this page, it is OK to remove that localized version.
 weight: 20
 headless: true
 toc_hide: true
@@ -20,7 +26,7 @@ _build:
               Content unavailable
             </h2>
             <p>
-              The interactive tutorial for scaling an application that's running in your cluster is not available.
+              The interactive tutorial for exposing your app is not available.
               For more information, see the
               <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
                 shutdown announcement</a>.

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive-gone.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive-gone.html
@@ -1,5 +1,11 @@
 ---
-title: Interactive Tutorial - Exploring Your App
+title: Not found
+# This page was previously titled "Interactive Tutorial - Scaling Your App"
+# before Katacoda shut down.
+#
+# There is no need to localize this Not Found page; the website automatically
+# serves a 404 response when a page is missing. If you have an existing localized
+# version of this page, it is OK to remove that localized version.
 weight: 20
 headless: true
 toc_hide: true
@@ -20,7 +26,7 @@ _build:
               Content unavailable
             </h2>
             <p>
-              The interactive tutorial for exploring your app is not available.
+              The interactive tutorial for scaling an application that's running in your cluster is not available.
               For more information, see the
               <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
                 shutdown announcement</a>.
@@ -31,3 +37,4 @@ _build:
 
 </body>
 </html>
+

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-interactive-gone.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-interactive-gone.html
@@ -1,5 +1,11 @@
 ---
-title: Interactive Tutorial - Deploying an App
+title: Not found
+# This page was previously titled "Interactive Tutorial - Updating Your App"
+# before Katacoda shut down.
+#
+# There is no need to localize this Not Found page; the website automatically
+# serves a 404 response when a page is missing. If you have an existing localized
+# version of this page, it is OK to remove that localized version.
 weight: 20
 headless: true
 toc_hide: true
@@ -20,7 +26,7 @@ _build:
               Content unavailable
             </h2>
             <p>
-              The interactive tutorial for deploying an application to your cluster is not available.
+              The interactive tutorial for updating an application in your cluster is not available.
               For more information, see the
               <a href="https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/">
                 shutdown announcement</a>.
@@ -31,3 +37,4 @@ _build:
 
 </body>
 </html>
+

--- a/static/_redirects
+++ b/static/_redirects
@@ -34,6 +34,14 @@
 /docs/reference/kubectl/cheatsheet/   /docs/reference/kubectl/quick-reference/ 301
 /kubectlguide /docs/reference/kubectl/quick-reference/ 302
 
+# Serve custom "not found" pages
+/docs/tutorials/kubernetes-basics/expose/expose-interactive/ /docs/tutorials/kubernetes-basics/expose/expose-interactive-gone/ 404
+/docs/tutorials/kubernetes-basics/scale/scale-interactive/ /docs/tutorials/kubernetes-basics/scale/scale-interactive-gone/ 404
+/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/ /docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive-gone/ 404
+/docs/tutorials/kubernetes-basics/explore/explore-interactive/ /docs/tutorials/kubernetes-basics/explore/explore-interactive-gone/ 404
+/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/ /docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive-gone/ 404
+/docs/tutorials/kubernetes-basics/update/update-interactive/ /docs/tutorials/kubernetes-basics/update/update-interactive-gone/ 404
+
 /docs/concepts/abstractions/controllers/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
 /docs/concepts/abstractions/controllers/statefulsets/     /docs/concepts/workloads/controllers/statefulset/ 301
 /docs/concepts/abstractions/init-containers/     /docs/concepts/workloads/pods/init-containers/ 301


### PR DESCRIPTION
Katacoda has shut down for good, and we have not added a local / in-project alternative playground in the time since. Serving a 404 helps cement that these pages are no longer part of the site.

[**Current**](https://k8s.io/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/) vs [**Preview**](https://deploy-preview-46323--kubernetes-io-main-staging.netlify.app/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/)

---

You can see that Netlify now serves a 404 response:
```console
$ curl -I https://deploy-preview-46323--kubernetes-io-main-staging.netlify.app/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/
HTTP/2 404
accept-ranges: bytes
age: 5
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; hit
content-type: text/html; charset=UTF-8
date: Sat, 11 May 2024 18:09:42 GMT
etag: "36ab67890e83ba39dc167967790a3a18-ssl"
server: Netlify
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-nf-request-id: 01HXMDHCHAWGSRN9EWJ6XEM9PC
x-robots-tag: noindex
content-length: 463824
```

/area web-development