### PR TITLE
Warn on new use of param shortcode

### DIFF
--- a/layouts/shortcodes/param.html
+++ b/layouts/shortcodes/param.html
@@ -1,1 +1,13 @@
-{{- .Page.Param (.Get 0) -}}
+{{- $name := (.Get 0) -}}
+{{- with $name -}}
+{{- with ($.Page.Param .) }}{{ . }}{{ else }}{{ errorf "Param %q not found: %s" $name $.Position }}{{ end -}}
+{{- else }}{{ errorf "Missing param key: %s" $.Position }}{{ end -}}
+{{- with $.Page.File.Filename -}}
+{{- $warningText := slice
+    "Deprecated param shortcode detected."
+    "The Kubernetes website does not / should not use param shortcodes."
+    ( printf "Check %q" ( replaceRE "^/src/" "" .  ) ) -}}
+    {{- if and (eq $.Site.LanguagePrefix "") (ne $name "version" ) -}}
+    {{- warnf (delimit $warningText " " ) -}}
+    {{- end -}}
+{{- end -}}


### PR DESCRIPTION
[AIUI] we prefer not to use the `param` shortcode (we switched to a new approach in PR https://github.com/kubernetes/website/pull/40692)

Change that shortcode to warn if it's used other than for `version` (which we still support, although I recommend using the `skew` shortcode in its place).
~As part of this:~
- ~switch Bengali to the new approach~
- ~fix a broken link in a blog article~
- ~change a couple of pages to use the `skew` shortcode~

/area web-development