### PR TITLE
[fr] Update list of versions to match English

### DIFF
--- a/content/fr/docs/home/supported-doc-versions.md
+++ b/content/fr/docs/home/supported-doc-versions.md
@@ -1,27 +1,10 @@
 ---
 title: Versions supportées de la documentation Kubernetes
-description: Documentation de Kubernetes
-content_type: concept
-card:
-  name: about
-  weight: 10
-  title: Versions supportées de la documentation
+content_type: custom
+layout: supported-versions
+weight: 10
 ---
 
 <!-- overview -->
 
 Ce site contient la documentation de la version actuelle de Kubernetes et les quatre versions précédentes de Kubernetes.
-
-
-
-<!-- body -->
-
-## Version courante
-
-La version actuelle est [{{< param "version" >}}](/).
-
-## Versions précédentes
-
-{{< versions-other >}}
-
-

--- a/data/i18n/fr/fr.toml
+++ b/data/i18n/fr/fr.toml
@@ -1,5 +1,11 @@
 # i18n strings for the French (main) site.
 
+[docs_version_latest_heading]
+other = "Version courante"
+
+[docs_version_other_heading]
+other = "Versions précédentes"
+
 [deprecation_warning]
 other = " documentation non maintenue. Vous consultez une version statique. Pour une documentation à jour, veuillez consulter: "
 


### PR DESCRIPTION
Align https://kubernetes.io/fr/docs/home/supported-doc-versions/ with https://kubernetes.io/docs/home/supported-doc-versions/

[Preview](https://deploy-preview-46344--kubernetes-io-main-staging.netlify.app/fr/docs/home/supported-doc-versions/) of the updated page

/language fr