### PR TITLE
[bn] Fix task pages about installing kubectl

### DIFF
--- a/content/bn/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/bn/docs/tasks/tools/install-kubectl-linux.md
@@ -34,10 +34,10 @@ kubectl এর সর্বশেষ সামঞ্জস্যপূর্ণ 
    {{< note >}}
 একটি নির্দিষ্ট সংস্করণ ডাউনলোড করতে, নির্দিষ্ট সংস্করণের সাথে কমান্ডের `$(curl -L -s https://dl.k8s.io/release/stable.txt)` অংশটি প্রতিস্থাপন করুন। 
 
-উদাহরণস্বরূপ, লিনাক্সে সংস্করণ {{< param "fullversion" >}} ডাউনলোড করতে, টাইপ করুন:
+উদাহরণস্বরূপ, লিনাক্সে সংস্করণ {{% skew currentPatchVersion %}} ডাউনলোড করতে, টাইপ করুন:
 
    ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
+   curl -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/linux/amd64/kubectl
    ```
    {{< /note >}}
 

--- a/content/bn/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/bn/docs/tasks/tools/install-kubectl-macos.md
@@ -44,16 +44,16 @@ macOS এ kubectl ইনস্টল করার জন্য নিম্ন�
    {{< note >}}
    একটি নির্দিষ্ট সংস্করণ ডাউনলোড করতে, নির্দিষ্ট সংস্করণের সাথে কমান্ডের `$(curl -L -s https://dl.k8s.io/release/stable.txt)` অংশটি প্রতিস্থাপন করুন।
 
-   উদাহরণস্বরূপ, Intel macOS-এ সংস্করণ {{< param "fullversion" >}} ডাউনলোড করতে, টাইপ করুন:
+   উদাহরণস্বরূপ, Intel macOS-এ সংস্করণ {{% skew currentPatchVersion %}} ডাউনলোড করতে, টাইপ করুন:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl"
+   curl -LO "https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/darwin/amd64/kubectl"
    ```
 
    এবং অ্যাপল সিলিকনে macOS এর জন্য, টাইপ করুন:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/arm64/kubectl"
+   curl -LO "https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/darwin/arm64/kubectl"
    ```
 
    {{< /note >}}

--- a/content/bn/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/bn/docs/tasks/tools/install-kubectl-windows.md
@@ -24,12 +24,12 @@ kubectl এর সর্বশেষ সামঞ্জস্যপূর্ণ 
 
 ### উইন্ডোজে কার্ল ব্যাবহার kubectl বাইনারি ইনস্টল করুন
 
-1. [latest release {{< param "fullversion" >}}](https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe) ডাউনলোড করুন।
+1. সর্বশেষ {{< skew currentVersion >}} প্যাচ রিলিজ ডাউনলোড করুন: [kubectl {{% skew currentPatchVersion %}}](https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe)।
 
    অথবা যদি আপনার `curl` ইনস্টল থাকে, এই কমান্ডটি ব্যবহার করুন:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe"
+   curl.exe -LO "https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe"
    ```
 
    {{< note >}}
@@ -41,7 +41,7 @@ kubectl এর সর্বশেষ সামঞ্জস্যপূর্ণ 
    `kubectl` চেকসাম ফাইলটি ডাউনলোড করুন:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe.sha256"
+   curl.exe -LO "https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe.sha256"
    ```
 
    চেকসাম ফাইলের বিপরীতে `kubectl` বাইনারি যাচাই করুন:
@@ -170,7 +170,7 @@ kubectl Bash, Zsh, Fish এবং PowerShell-এর জন্য ওটোকম
 1. কমান্ড সহ সর্বশেষ রিলিজ ডাউনলোড করুন:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe"
+   curl.exe -LO "https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe"
    ```
 
 1. বাইনারি যাচাই করুন (অপশনাল)।
@@ -178,7 +178,7 @@ kubectl Bash, Zsh, Fish এবং PowerShell-এর জন্য ওটোকম
    `kubectl-convert` চেকসাম ফাইলটি ডাউনলোড কর্সনা 
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe.sha256"
+   curl.exe -LO "https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe.sha256"
    ```
 
    চেকসাম ফাইলের বিপরীতে `kubectl-convert` বাইনারি যাচাই করুন:


### PR DESCRIPTION
Three existing pages are broken as the links don't expand the current patch release correctly.
Fix that (use `skew` shortcode instead of deprecated `param` shortcode).

To see the problem, search in page for `release//bin`; there should be a version number between the two `/` characters.

Current | Preview
------------|------------
[Linux](https://k8s.io/bn/docs/tasks/tools/install-kubectl-linux/) (broken) | [Linux (preview)](https://deploy-preview-46346--kubernetes-io-main-staging.netlify.app/bn/docs/tasks/tools/install-kubectl-linux/)
[macOS](https://k8s.io/bn/docs/tasks/tools/install-kubectl-macos/) (broken) | [macOS (preview)](https://deploy-preview-46346--kubernetes-io-main-staging.netlify.app/bn/docs/tasks/tools/install-kubectl-macos/)
[Windows](https://k8s.io/bn/docs/tasks/tools/install-kubectl-windows/) (broken) | [Windows (preview)](https://deploy-preview-46346--kubernetes-io-main-staging.netlify.app/bn/docs/tasks/tools/install-kubectl-windows/)

The pages that this PR updates are stale and need further updates; this is a minimum change to make them useful.

/language bn

Split out of https://github.com/kubernetes/website/pull/46324