### PR TITLE
[es] Update list of versions to match English 

### DIFF
--- a/content/es/docs/home/supported-doc-versions.md
+++ b/content/es/docs/home/supported-doc-versions.md
@@ -1,10 +1,8 @@
 ---
 title: Versiones Soportadas de la Documentación
 content_type: custom
-card:
-  name: about
-  weight: 10
-  title: Versiones Soportadas de la Documentación
+layout: supported-versions
+weight: 10
 ---
 
 <!-- overview -->
@@ -17,17 +15,4 @@ esa versión es compatible actualmente.
 
 Lea [Período de soporte](/releases/patch-releases/#support-period) para obtener información sobre
 qué versiones de Kubernetes son oficialmente compatibles y durante cuánto tiempo.
-
-<!-- body -->
-
-## Versión Actual
-
-La versión actual es
-[{{< param "version" >}}](/).
-
-## Versiones anteriores
-
-{{< versions-other >}}
-
-
 

--- a/data/i18n/es/es.toml
+++ b/data/i18n/es/es.toml
@@ -1,5 +1,14 @@
 # i18n strings for the Spanish (main) site.
 
+[docs_version_current]
+other = "(esta documentación)"
+
+[docs_version_latest_heading]
+other = "Versión actual"
+
+[docs_version_other_heading]
+other = "Versiones anteriores"
+
 [deprecation_warning]
 other = " ya no mantiene activamente la documentación. La versión que está viendo actualmente es una instantánea estática. Para la documentación actualizada, visita la "
 


### PR DESCRIPTION
Align https://kubernetes.io/es/docs/home/supported-doc-versions/ with https://kubernetes.io/docs/home/supported-doc-versions/

[Preview of the updated page.](https://deploy-preview-46348--kubernetes-io-main-staging.netlify.app/es/docs/home/supported-doc-versions/)

/language es