### PR TITLE
[de] Update list of versions to match English

### DIFF
--- a/content/de/docs/home/supported-doc-versions.md
+++ b/content/de/docs/home/supported-doc-versions.md
@@ -1,30 +1,14 @@
 ---
 title: Unterstützte Versionen der Kubernetes-Dokumentation
-content_type: concept
-card:
-  name: about
-  weight: 10
-  title: Unterstützte Versionen der Dokumentation
+content_type: custom
+layout: supported-versions
+weight: 10
 ---
 
 <!-- overview -->
 
 Diese Website enthält Dokumentation für die aktuelle Version von Kubernetes
 und die vier vorherigen Versionen von Kubernetes.
-
-
-
-<!-- body -->
-
-## Aktuelle Version
-
-Die aktuelle Version ist
-[{{< param "version" >}}](/).
-
-## Vorherige Versionen
-
-{{< versions-other >}}
-
 
 
 

--- a/data/i18n/de/de.toml
+++ b/data/i18n/de/de.toml
@@ -1,5 +1,14 @@
 # i18n strings for the German (main) site.
 
+[docs_version_current]
+other = "(dieser Dokumentation)"
+
+[docs_version_latest_heading]
+other = "Aktuelle Version"
+
+[docs_version_other_heading]
+other = "Vorherige Versionen"
+
 [deprecation_warning]
 other = " Die Dokumentation wird nicht mehr aktiv gepflegt. Die aktuell angezeigte Version ist eine statische Momentaufnahme. Aktuelle Dokumentation finden Sie unter "
 


### PR DESCRIPTION
Align https://kubernetes.io/de/docs/home/supported-doc-versions/ with https://kubernetes.io/docs/home/supported-doc-versions/

[Preview of the updated page.](https://deploy-preview-46350--kubernetes-io-main-staging.netlify.app/de/docs/home/supported-doc-versions/)

/language de