### PR TITLE
[ja] Update list of versions to match English

### DIFF
--- a/content/de/docs/home/supported-doc-versions.md
+++ b/content/de/docs/home/supported-doc-versions.md
@@ -1,30 +1,14 @@
 ---
 title: Unterstützte Versionen der Kubernetes-Dokumentation
-content_type: concept
-card:
-  name: about
-  weight: 10
-  title: Unterstützte Versionen der Dokumentation
+content_type: custom
+layout: supported-versions
+weight: 10
 ---
 
 <!-- overview -->
 
 Diese Website enthält Dokumentation für die aktuelle Version von Kubernetes
 und die vier vorherigen Versionen von Kubernetes.
-
-
-
-<!-- body -->
-
-## Aktuelle Version
-
-Die aktuelle Version ist
-[{{< param "version" >}}](/).
-
-## Vorherige Versionen
-
-{{< versions-other >}}
-
 
 
 

--- a/content/ja/docs/home/supported-doc-versions.md
+++ b/content/ja/docs/home/supported-doc-versions.md
@@ -2,10 +2,7 @@
 title: 利用可能なドキュメントバージョン
 content_type: custom
 layout: supported-versions
-card:
-  name: about
-  weight: 10
-  title: 利用可能なドキュメントバージョン
+weight: 10
 ---
 
 本ウェブサイトには、現行版とその直前4バージョンのKubernetesドキュメントがあります。

--- a/data/i18n/de/de.toml
+++ b/data/i18n/de/de.toml
@@ -1,5 +1,11 @@
 # i18n strings for the German (main) site.
 
+[docs_version_latest_heading]
+other = "Aktuelle Version"
+
+[docs_version_other_heading]
+other = "Vorherige Versionen"
+
 [deprecation_warning]
 other = " Die Dokumentation wird nicht mehr aktiv gepflegt. Die aktuell angezeigte Version ist eine statische Momentaufnahme. Aktuelle Dokumentation finden Sie unter "
 

--- a/data/i18n/ja/ja.toml
+++ b/data/i18n/ja/ja.toml
@@ -1,6 +1,12 @@
 # i18n strings for the English (main) site.
 # NOTE: Please keep the entries in alphabetical order when editing
 
+[docs_version_latest_heading]
+other = "現行版"
+
+[docs_version_other_heading]
+other = "以前のバージョン"
+
 [caution]
 other = "注意:"
 


### PR DESCRIPTION
Align https://kubernetes.io/ja/docs/home/supported-doc-versions/ with https://kubernetes.io/docs/home/supported-doc-versions/



/language ja