### PR TITLE
[ja] Update list of versions to match English 

### DIFF
--- a/content/ja/docs/home/supported-doc-versions.md
+++ b/content/ja/docs/home/supported-doc-versions.md
@@ -2,10 +2,7 @@
 title: 利用可能なドキュメントバージョン
 content_type: custom
 layout: supported-versions
-card:
-  name: about
-  weight: 10
-  title: 利用可能なドキュメントバージョン
+weight: 10
 ---
 
 本ウェブサイトには、現行版とその直前4バージョンのKubernetesドキュメントがあります。

--- a/data/i18n/ja/ja.toml
+++ b/data/i18n/ja/ja.toml
@@ -1,6 +1,15 @@
 # i18n strings for the English (main) site.
 # NOTE: Please keep the entries in alphabetical order when editing
 
+[docs_version_current]
+other = "(この文書)"
+
+[docs_version_latest_heading]
+other = "最新のバージョン"
+
+[docs_version_other_heading]
+other = "以前のバージョン"
+
 [caution]
 other = "注意:"
 


### PR DESCRIPTION
Align https://kubernetes.io/ja/docs/home/supported-doc-versions/ with https://kubernetes.io/docs/home/supported-doc-versions/

[Preview of the updated page.](https://deploy-preview-46352--kubernetes-io-main-staging.netlify.app/ja/docs/home/supported-doc-versions/)

/language ja