### PR TITLE
[no] Update list of versions to match English

### DIFF
--- a/content/no/docs/home/supported-doc-versions.md
+++ b/content/no/docs/home/supported-doc-versions.md
@@ -1,0 +1,9 @@
+---
+title: Tilgjengelige dokumentasjonsversjoner
+content_type: custom
+layout: supported-versions
+weight: 10
+---
+
+Dette nettstedet inneholder dokumentasjon for den nåværende versjonen 
+av Kubernetes og de fire tidligere versjonene av Kubernetes.

--- a/data/i18n/no/no.toml
+++ b/data/i18n/no/no.toml
@@ -1,5 +1,14 @@
 # i18n strings for the Norwegian translation.
 
+[docs_version_current]
+other = "(denne dokumentasjonen)"
+
+[docs_version_latest_heading]
+other = "Siste versjon"
+
+[docs_version_other_heading]
+other = "Eldre versjoner"
+
 [main_read_about]
 other = "Les om"
 


### PR DESCRIPTION
Align https://kubernetes.io/es/docs/home/supported-doc-versions/ with https://kubernetes.io/docs/home/supported-doc-versions/

/language no
