### PR TITLE
Clarify node drain requirement for kubelet minor version upgrades

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -217,7 +217,7 @@ Optionally upgrade `kubelet` instances to **{{< skew currentVersion >}}** (or th
 
 {{< note >}}
 Before performing a minor version `kubelet` upgrade, [drain](/docs/tasks/administer-cluster/safely-drain-node/) pods from that node.
-In-place minor version `kubelet` upgrades are not supported.
+In-place minor version `kubelet` upgrades, to a newer minor version of Kubernetes, without a node drain, are not supported.
 {{</ note >}}
 
 {{< warning >}}

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -218,10 +218,9 @@ Optionally upgrade `kubelet` instances to **{{< skew currentVersion >}}** (or th
 {{< note >}}
 Before performing a minor version `kubelet` upgrade,
 [drain](/docs/tasks/administer-cluster/safely-drain-node/) pods from the node
-and clear the contents of [kubelet managed
-directories](/docs/reference/node/kubelet-files).
-In-place minor version `kubelet` upgrades, without first draining pods and
-clearing the content of kubelet managed-directories, are not supported.
+and clear the contents of [kubelet managed directories](/docs/reference/node/kubelet-files).
+In-place `kubelet` minor version upgrades without first draining pods and
+clearing the content of kubelet managed-directories are not supported.
 {{</ note >}}
 
 {{< warning >}}

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -216,8 +216,12 @@ Optionally upgrade `kubelet` instances to **{{< skew currentVersion >}}** (or th
 **{{< skew currentVersionAddMinor -1 >}}**, **{{< skew currentVersionAddMinor -2 >}}**, or **{{< skew currentVersionAddMinor -3 >}}**)
 
 {{< note >}}
-Before performing a minor version `kubelet` upgrade, [drain](/docs/tasks/administer-cluster/safely-drain-node/) pods from that node.
-In-place minor version `kubelet` upgrades, to a newer minor version of Kubernetes, without a node drain, are not supported.
+Before performing a minor version `kubelet` upgrade,
+[drain](/docs/tasks/administer-cluster/safely-drain-node/) pods from the node
+and clear the contents of [kubelet managed
+directories](/docs/reference/node/kubelet-files).
+In-place minor version `kubelet` upgrades, without first draining pods and
+clearing the content of kubelet managed-directories, are not supported.
 {{</ note >}}
 
 {{< warning >}}


### PR DESCRIPTION
Addresses the issue raised in #46356 where I suggested that the language here could be made more clear. 

This change clarifies the requirement that nodes are drained before a minor version upgrade takes place. The old wording implied that a minor version upgrade of the kubelet was not supported at all. 


