### PR TITLE
[main] Fix drop-in dir logic explaination

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -115,11 +115,10 @@ The suffix of a valid kubelet drop-in configuration file **must** be `.conf`. Fo
 The kubelet processes files in its config drop-in directory by sorting the **entire file name** alphanumerically.
 For instance, `00-kubelet.conf` is processed first, and then overridden with a file named `01-kubelet.conf`.
 
-These files may contain partial configurations and might not be valid config files by themselves.
-Validation is only performed on the final resulting configuration structure
-stored internally in the kubelet.
-This offers you flexibility in how you manage and combine kubelet configuration that comes from different sources.
-However, it's important to note that the behavior varies based on the data type of the configuration fields.
+These files may contain partial configurations but should not be invalid and must include type metadata, specifically `apiVersion` and `kind`. 
+Validation is only performed on the final resulting configuration structure stored internally in the kubelet. 
+This offers flexibility in managing and merging kubelet configurations from different sources while preventing undesirable configurations. 
+However, it is important to note that behavior varies based on the data type of the configuration fields.
 
 Different data types in the kubelet configuration structure merge differently. See the
 [reference document](/docs/reference/node/kubelet-config-directory-merging.md)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/124796

The current behavior of the drop-in directory merging logic is not properly documented. Ideally, Validation is performed on each drop-in configuration file before merging it into the final configuration structure stored internally by the kubelet.
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
