### PR TITLE
Update 2018 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2018-01-00-Core-Workloads-Api-Ga.md
+++ b/content/en/blog/_posts/2018-01-00-Core-Workloads-Api-Ga.md
@@ -3,6 +3,8 @@ title: "Core Workloads API GA"
 date: 2018-01-15
 slug: core-workloads-api-ga
 url: /blog/2018/01/Core-Workloads-Api-Ga
+author: >
+   Kenneth Owens (Google)  
 ---
 
 ## DaemonSet, Deployment, ReplicaSet, and StatefulSet are GA
@@ -91,8 +93,6 @@ In future releases, before completely removing any of the group versions, we wil
 
 ## What’s Next?
 The core workloads API surface is stable, but it’s still software, and software is never complete. We often add features to stable APIs to support new use cases, and we will likely do so for the core workloads API as well. GA stability means that any new features that we do add will be strictly backward compatible with the existing API surface. From this point forward, nothing we do will break our backwards compatibility guarantees. If you’re looking to participate in the evolution of this portion of the API, please feel free to get involved in [GitHub](https://github.com/kubernetes/kubernetes) or to participate in [SIG Apps](https://github.com/kubernetes/community/tree/master/sig-apps).  
-
---Kenneth Owens, Software Engineer, Google  
 
 
 - [Download](https://get.k8s.io/) Kubernetes

--- a/content/en/blog/_posts/2018-01-00-Kubernetes-V19-Beta-Windows-Support.md
+++ b/content/en/blog/_posts/2018-01-00-Kubernetes-V19-Beta-Windows-Support.md
@@ -3,7 +3,11 @@ title: Kubernetes v1.9 releases beta support for Windows Server Containers
 date: 2018-01-09
 slug: kubernetes-v19-beta-windows-support
 url: /blog/2018/01/Kubernetes-V19-Beta-Windows-Support
+author: >
+  Michael Michael (Apprenda)
 ---
+
+_At the time of publication, Michael Michael was writing as SIG-Windows Lead._
 
 With the release of Kubernetes v1.9, our mission of ensuring Kubernetes works well everywhere and for everyone takes a great step forward. We’ve advanced support for Windows Server to beta along with continued feature and functional advancements on both the Kubernetes and Windows platforms. SIG-Windows has been working since March of 2016 to open the door for many Windows-specific applications and workloads to run on Kubernetes, significantly expanding the implementation scenarios and the enterprise reach of Kubernetes.  
 
@@ -57,11 +61,3 @@ As we continue to make progress towards General Availability of this feature in 
 - We meet every other Tuesday at 12:30 Eastern Standard Time (EST) at [https://zoom.us/my/sigwindows](https://zoom.us/my/sigwindows). All our meetings are recorded on youtube and referenced at [https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4](https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4)
 - Chat with us on Slack at [https://kubernetes.slack.com/messages/sig-windows](https://kubernetes.slack.com/messages/sig-windows)
 - Find us on GitHub at [https://github.com/kubernetes/community/tree/master/sig-windows](https://github.com/kubernetes/community/tree/master/sig-windows)
-
-
-
-Thank you,  
-
-Michael Michael (@michmike77)  
-SIG-Windows Lead  
-Senior Director of Product Management, Apprenda

--- a/content/en/blog/_posts/2018-01-00-Reporting-Errors-Using-Kubernetes-Events.md
+++ b/content/en/blog/_posts/2018-01-00-Reporting-Errors-Using-Kubernetes-Events.md
@@ -4,6 +4,8 @@ date: 2018-01-25
 published: true
 slug: reporting-errors-using-kubernetes-events
 url: /blog/2018/01/Reporting-Errors-Using-Kubernetes-Events
+author: >
+  Hakan Baba (Box)
 ---
 
 At [Box](https://www.box.com/), we manage several large scale Kubernetes clusters that serve as an internal platform as a service (PaaS) for hundreds of deployed microservices. The majority of those microservices are applications that power box.com for over 80,000 customers. The PaaS team also deploys several services affiliated with the platform infrastructure as the _control plane_.  
@@ -86,4 +88,4 @@ We have demonstrated a practical use case with Kubernetes Events. The automated 
 _If you have a Kubernetes experience you’d like to share, [submit your story](https://docs.google.com/a/google.com/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform). If you use Kubernetes in your organization and want to voice your experience more directly, consider joining the [CNCF End User Community](https://www.cncf.io/people/end-user-community/) that Box and dozens of like-minded companies are part of._    
 
 Special thanks for Greg Lyons and Mohit Soni for their contributions.  
-Hakan Baba, Sr. Software Engineer, Box
+

--- a/content/en/blog/_posts/2018-03-00-Apache-Spark-23-With-Native-Kubernetes.md
+++ b/content/en/blog/_posts/2018-03-00-Apache-Spark-23-With-Native-Kubernetes.md
@@ -3,6 +3,9 @@ title: "Apache Spark 2.3 with Native Kubernetes Support"
 date: 2018-03-06
 slug: apache-spark-23-with-native-kubernetes
 url: /blog/2018/03/Apache-Spark-23-With-Native-Kubernetes
+author: >
+  Anirudh Ramanathan (Google),
+  Palak Bhatia (Google)
 ---
 ### Kubernetes and Big Data
 
@@ -90,9 +93,6 @@ There's lots of exciting work to be done in the near future. We're actively work
 And we're just getting started! We would love for you to get involved and help us evolve the project further.  
 
 Huge thanks to the Apache Spark and Kubernetes contributors spread across multiple organizations who spent many hundreds of hours working on this effort. We look forward to seeing more of you contribute to the project and help it evolve further.
-
-Anirudh Ramanathan and Palak Bhatia  
-Google
 
 [1]: https://kubernetes.io/docs/concepts/api-extension/custom-resources/
 [2]: https://kubernetes.io/docs/concepts/api-extension/custom-resources/#custom-controllers

--- a/content/en/blog/_posts/2018-03-00-Expanding-User-Support-With-Office-Hours.md
+++ b/content/en/blog/_posts/2018-03-00-Expanding-User-Support-With-Office-Hours.md
@@ -3,9 +3,12 @@ title: "Expanding User Support with Office Hours"
 date: 2018-03-14
 slug: expanding-user-support-with-office-hours
 url: /blog/2018/03/Expanding-User-Support-With-Office-Hours
+author: >
+  [Jorge Castro](https://twitter.com/castrojo)
+  [Ilya Dmitichenko](https://twitter.com/errordeveloper)
 ---
 
-**Today's post is by [Jorge Castro](https://twitter.com/castrojo) and [Ilya Dmitichenko](https://twitter.com/errordeveloper) on Kubernetes office hours.**
+**Today's post is on Kubernetes office hours.**
 
 Today's developer has an almost overwhelming amount of resources available for learning. Kubernetes development teams use [StackOverflow][1], [user documentation][2], [Slack][3], and the [mailing lists][4]. Additionally, the community itself continues to amass an [awesome list][5] of resources.
 

--- a/content/en/blog/_posts/2018-03-00-First-Beta-Version-Of-Kubernetes-1-10.md
+++ b/content/en/blog/_posts/2018-03-00-First-Beta-Version-Of-Kubernetes-1-10.md
@@ -3,9 +3,10 @@ title: "Kubernetes: First Beta Version of Kubernetes 1.10 is Here"
 date: 2018-03-02
 slug: first-beta-version-of-kubernetes-1-10
 url: /blog/2018/03/First-Beta-Version-Of-Kubernetes-1-10
+author: >
+   Nick Chase (Mirantis)
 ---
 
-**Editor's note: Today's post is by Nick Chase. Nick is Head of Content at [Mirantis][1].**
 The Kubernetes community has released the first beta version of Kubernetes 1.10, which means you can now try out some of the new features and give your feedback to the release team ahead of the official release. The release, currently scheduled for March 21, 2018, is targeting the inclusion of more than a dozen brand new alpha features and more mature versions of more than two dozen more.
 
 Specifically, Kubernetes 1.10 will include production-ready versions of Kubelet TLS Bootstrapping, API aggregation, and more detailed storage metrics.

--- a/content/en/blog/_posts/2018-03-00-How-To-Integrate-Rollingupdate-Strategy.md
+++ b/content/en/blog/_posts/2018-03-00-How-To-Integrate-Rollingupdate-Strategy.md
@@ -3,6 +3,8 @@ title: "How to Integrate RollingUpdate Strategy for TPR in Kubernetes"
 date: 2018-03-13
 slug: how-to-integrate-rollingupdate-strategy
 url: /blog/2018/03/How-To-Integrate-Rollingupdate-Strategy
+author: >
+  Orain Xiong (Woqutech)
 ---
 
 With Kubernetes, it's easy to manage and scale stateless applications like web apps and API services right out of the box. To date, almost all of the talks about Kubernetes has been about microservices and stateless applications.
@@ -230,7 +232,6 @@ The upgrade is in monotonically decreasing manner:
 
 RollingUpgrade is meaningful to database administrators. It provides a more effective way to operator database.
 
-\--Orain Xiong, co-founder, Woqutech
 
 [1]: https://lh5.googleusercontent.com/4WiSkxX-XBqARVqQ0No-1tZ31op90LAUkTco3FdIO1mFScNOTVtMCgnjaO8SRUmms-6MAb46CzxlXDhLBqAAAmbx26atJnu4t1FTTALZx_CbUPqrCxjL746DW4TD42-03Ac9VB2c
 [2]: https://lh3.googleusercontent.com/sXqVqfTu6rMWn0mlHLgHHqATe_qsx1tNmMfX60HoTwyhd5HCL4A_ViFBQAZfOoVGioeXcI_XXbzVFUdq2hbKGwS0OXH6PFGqgpZshfBwrT088bz4KqeyTbHpQR2olyzE6eRo1fan

--- a/content/en/blog/_posts/2018-03-00-Principles-Of-Container-App-Design.md
+++ b/content/en/blog/_posts/2018-03-00-Principles-Of-Container-App-Design.md
@@ -3,6 +3,8 @@ title: "Principles of Container-based Application Design"
 date: 2018-03-15
 slug: principles-of-container-app-design
 url: /blog/2018/03/Principles-Of-Container-App-Design
+author: >
+   [Bilgin Ibryam](http://twitter.com/bibryam) (Red Hat)
 ---
 
 It's possible nowadays to put almost any application in a container and run it. Creating cloud-native applications, however—containerized applications that are automated and orchestrated effectively by a cloud-native platform such as Kubernetes—requires additional effort. Cloud-native applications anticipate failure; they run and scale reliably even when their infrastructure experiences outages. To offer such capabilities, cloud-native platforms like Kubernetes impose a set of contracts and constraints on applications. These contracts ensure that applications they run conform to certain constraints and allow the platform to automate application management.
@@ -34,8 +36,6 @@ The white paper is freely available for download:
 
 
 To read more about designing cloud-native applications for Kubernetes, check out my [Kubernetes Patterns][3] book.
-
-— [Bilgin Ibryam][4], Principal Architect, Red Hat
 
 Twitter:    
 Blog: [http://www.ofbizian.com][5]  

--- a/content/en/blog/_posts/2018-03-26-kubernetes-1-10-stabilizing-storage-security-networking.md
+++ b/content/en/blog/_posts/2018-03-26-kubernetes-1-10-stabilizing-storage-security-networking.md
@@ -4,10 +4,9 @@ date: 2018-03-26
 modified_time: '2018-03-27T11:01:39.569-07:00'
 slug: kubernetes-1.10-stabilizing-storage-security-networking
 evergreen: true
+author: >
+  [Kubernetes v1.10 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.10/release_team.md)
 ---
-
-***Editor's note: today's post is by the [1.10 Release
-Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.10/release_team.md)***
 
 We’re pleased to announce the delivery of Kubernetes 1.10, our first release
 of 2018!

--- a/content/en/blog/_posts/2018-04-04-fixing-subpath-volume-vulnerability.md
+++ b/content/en/blog/_posts/2018-04-04-fixing-subpath-volume-vulnerability.md
@@ -2,6 +2,9 @@
 title: Fixing the Subpath Volume Vulnerability in Kubernetes
 date: 2018-04-04
 slug: fixing-subpath-volume-vulnerability
+author: >
+   Michelle Au (Google),
+   Jan Šafránek (Red Hat)
 ---
 
 On March 12, 2018, the Kubernetes Product Security team disclosed [CVE-2017-1002101](https://issue.k8s.io/60813), which allowed containers using [subpath](/docs/concepts/storage/volumes/#using-subpath) volume mounts to access files outside of the volume. This means that a container could access any file available on the host, including volumes for other containers that it should not have access to.
@@ -190,4 +193,3 @@ Special thanks to many folks involved with handling this vulnerability:
 
 If you find a vulnerability in Kubernetes, please follow our responsible disclosure process and [let us know](https://kubernetes.io/security/#report-a-vulnerability); we want to do our best to make Kubernetes secure for all users.
 
--- Michelle Au, Software Engineer, Google; and Jan Šafránek, Software Engineer, Red Hat

--- a/content/en/blog/_posts/2018-04-30-zero-downtime-deployment-kubernetes-jenkins.md
+++ b/content/en/blog/_posts/2018-04-30-zero-downtime-deployment-kubernetes-jenkins.md
@@ -1,8 +1,9 @@
 ---
 title: 'Zero-downtime Deployment in Kubernetes with Jenkins'
 date: 2018-04-30
-author: kbarnard
 slug: zero-downtime-deployment-kubernetes-jenkins
+author: >
+  [Kaitlyn Barnard](https://github.com/kbarnard10)
 ---
 
 Ever since we added the [Kubernetes Continuous Deploy](https://aka.ms/azjenkinsk8s) and [Azure Container Service](https://aka.ms/azjenkinsacs) plugins to the Jenkins update center, "How do I create zero-downtime deployments" is one of our most frequently-asked questions. We created a quickstart template on Azure to demonstrate what zero-downtime deployments can look like. Although our example uses Azure, the concept easily applies to all Kubernetes installations.

--- a/content/en/blog/_posts/2018-05-01-developing-on-kubernetes.md
+++ b/content/en/blog/_posts/2018-05-01-developing-on-kubernetes.md
@@ -2,10 +2,10 @@
 title: Developing on Kubernetes
 date: 2018-05-01
 slug: developing-on-kubernetes
+author: >
+  [Michael Hausenblas](https://twitter.com/mhausenblas) (Red Hat),
+  [Ilya Dmitrichenko](https://twitter.com/errordeveloper) (Weaveworks)
 ---
-
-**Authors**: [Michael Hausenblas](https://twitter.com/mhausenblas) (Red Hat), [Ilya Dmitrichenko](https://twitter.com/errordeveloper) (Weaveworks)
-
 
 How do you develop a Kubernetes app? That is, how do you write and test an app that is supposed to run on Kubernetes? This article focuses on the challenges, tools and methods you might want to be aware of to successfully write Kubernetes apps alone or in a team setting.
 

--- a/content/en/blog/_posts/2018-05-02-policy-in-kubernetes.md
+++ b/content/en/blog/_posts/2018-05-02-policy-in-kubernetes.md
@@ -2,6 +2,13 @@
 title: Current State of Policy in Kubernetes
 date: 2018-05-02
 slug: policy-in-kubernetes
+author: >
+  Zhipeng Huang,
+  Torin Sandall,
+  Michael Elder,
+  Erica Von Buelow,
+  Khalid Ahmed,
+  Yisui Hu
 ---
 
 Kubernetes has grown dramatically in its impact to the industry; and with rapid growth, we are beginning to see variations across components in how they define and apply policies.
@@ -45,5 +52,3 @@ When these concrete proposals got clearer the WG will be able to provide a high 
 ## Towards Cloud Native Policy Driven Architecture
 
 Policy is definitely something goes beyond Kubernetes and applied to a broader cloud native context. Our work in the Kubernetes Policy WG will provide the foundation of building a CNCF wide policy architecture, with the integration of Kubernetes and various other cloud native components such as open policy agent, Istio, Envoy, SPIFEE/SPIRE and so forth. The Policy WG has already collaboration with the CNCF SAFE WG (in-forming) team, and will work on more alignments to make sure a community driven cloud native policy architecture design.
-
-**Authors**: Zhipeng Huang, Torin Sandall, Michael Elder, Erica Von Buelow, Khalid Ahmed, Yisui Hu

--- a/content/en/blog/_posts/2018-05-04-Announcing-Kubeflow-0-1.md
+++ b/content/en/blog/_posts/2018-05-04-Announcing-Kubeflow-0-1.md
@@ -3,6 +3,9 @@ title: 'Announcing Kubeflow 0.1'
 date: 2018-05-04
 author: aronchick
 slug: announcing-kubeflow-0.1
+author: >
+  Jeremy Lewi (Google),
+  David Aronchick (Google)
 ---
 
 # Since Last We Met
@@ -130,5 +133,3 @@ But the most important feature is the one we haven’t heard yet. Please tell us
 * Our [weekly community meeting](https://github.com/kubeflow/community)
 * Please download and run [kubeflow](https://github.com/kubeflow/kubeflow/pull/330/files), and submit bugs!
 
-Thank you for all your support so far!
-*Jeremy Lewi & David Aronchick* Google

--- a/content/en/blog/_posts/2018-05-05-hugo-migration.md
+++ b/content/en/blog/_posts/2018-05-05-hugo-migration.md
@@ -3,8 +3,9 @@ title: 'Docs are Migrating from Jekyll to Hugo'
 date: 2018-05-05
 author: zcorleissen
 slug: hugo-migration
+author: >
+  [Zach Corleissen](https://www.cncf.io/people/staff/) (CNCF) 
 ---
-**Author**: [Zach Corleissen](https://www.cncf.io/people/staff/) (CNCF)
 
 ## Changing the site framework
 

--- a/content/en/blog/_posts/2018-05-17-gardener-the-kubernetes-botanist.md
+++ b/content/en/blog/_posts/2018-05-17-gardener-the-kubernetes-botanist.md
@@ -3,8 +3,10 @@ title: 'Gardener - The Kubernetes Botanist'
 date: 2018-05-17
 author: rfranzke
 slug: gardener
+author: >
+  [Rafael Franzke](mailto:rafael.franzke@sap.com) (SAP),
+  [Vasu Chandrasekhara](mailto:vasu.chandrasekhara@sap.com) (SAP)
 ---
-**Authors**: [Rafael Franzke](mailto:rafael.franzke@sap.com) (SAP), [Vasu Chandrasekhara](mailto:vasu.chandrasekhara@sap.com) (SAP)
 
 Today, Kubernetes is the natural choice for running software in the Cloud. More and more developers and corporations are in the process of containerizing their applications, and many of them are adopting Kubernetes for automated deployments of their Cloud Native workloads.
 

--- a/content/en/blog/_posts/2018-05-22-getting-to-know-kubevirt.md
+++ b/content/en/blog/_posts/2018-05-22-getting-to-know-kubevirt.md
@@ -1,9 +1,10 @@
 ---
 title: 'Getting to Know Kubevirt'
 date: 2018-05-22
-author: kbarnard
+author: >
+  [Jason Brooks](mailto:jbrooks@redhat.com) (Red Hat),
+  [Kaitlyn Barnard](https://github.com/kbarnard10)
 ---
-**Author**: [Jason Brooks](mailto:jbrooks@redhat.com ) (Red Hat)
 
 Once you've become accustomed to running Linux container workloads on Kubernetes, you may find yourself wishing that you could run other sorts of workloads on your Kubernetes cluster. Maybe you need to run an application that isn't architected for containers, or that requires a different version of the Linux kernel -- or an all together different operating system -- than what's available on your container host.
 

--- a/content/en/blog/_posts/2018-05-24-kubernetes-containerd-integration-goes-ga.md
+++ b/content/en/blog/_posts/2018-05-24-kubernetes-containerd-integration-goes-ga.md
@@ -2,9 +2,11 @@
 layout: blog
 title: Kubernetes Containerd Integration Goes GA
 date: 2018-05-24
+author: >
+  Lantao Liu (Google),
+  Mike Brown (IBM)
 ---
 # Kubernetes Containerd Integration Goes GA
-**Authors**: Lantao Liu, Software Engineer, Google and Mike Brown, Open Source Developer Advocate, IBM
 
 In a previous blog - [Containerd Brings More Container Runtime Options for Kubernetes](https://kubernetes.io/blog/2017/11/containerd-container-runtime-options-kubernetes), we introduced the alpha version of the Kubernetes containerd integration. With another 6 months of development, the integration with containerd is now generally available! You can now use [containerd 1.1](https://github.com/containerd/containerd/releases/tag/v1.1.0) as the container runtime for production Kubernetes clusters!
 

--- a/content/en/blog/_posts/2018-05-29-announcing-kustomize.md
+++ b/content/en/blog/_posts/2018-05-29-announcing-kustomize.md
@@ -2,9 +2,10 @@
 layout: blog
 title: Introducing kustomize; Template-free Configuration Customization for Kubernetes
 date: 2018-05-29
+author: >
+  Jeff Regan (Google),
+  Phil Wittrock (Google)
 ---
-
-**Authors:** Jeff Regan (Google), Phil Wittrock (Google)
 
 [**kustomize**]: https://github.com/kubernetes-sigs/kustomize
 [hello world]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/helloWorld

--- a/content/en/blog/_posts/2018-05-30-say-hello-to-discuss-kubernetes.md
+++ b/content/en/blog/_posts/2018-05-30-say-hello-to-discuss-kubernetes.md
@@ -2,9 +2,9 @@
 layout: blog
 title: Say Hello to Discuss Kubernetes
 date: 2018-05-30
+author: >
+  Jorge Castro (Heptio)
 ---
-
-**Author**: Jorge Castro (Heptio)
 
 Communication is key when it comes to engaging a community of over 35,000 people in a global and remote environment. Keeping track of everything in the Kubernetes community can be an overwhelming task. On one hand we have our official resources, like Stack Overflow, GitHub, and the mailing lists, and on the other we have more ephemeral resources like Slack, where you can hop in, chat with someone, and then go on your merry way. 
 

--- a/content/en/blog/_posts/2018-06-05-meet-our-contributors-youtube-mentoring-series.md
+++ b/content/en/blog/_posts/2018-06-05-meet-our-contributors-youtube-mentoring-series.md
@@ -2,9 +2,9 @@
 layout: blog
 title: Meet Our Contributors - Monthly Streaming YouTube Mentoring Series
 date: 2018-07-10
+author: >
+  Paris Pittman (Google)
 ---
-
-**Author**: Paris Pittman (Google)
 
 ![meet_our_contributors](/images/blog/2018-06-05-meet-our-contributors-youtube-mentoring-series/meet-our-contributors.png)
 

--- a/content/en/blog/_posts/2018-06-06-4-years-of-k8s.md
+++ b/content/en/blog/_posts/2018-06-06-4-years-of-k8s.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 4 Years of K8s
 date: 2018-06-06
+author: >
+  Joe Beda (Heptio) 
 ---
-
-**Author**: Joe Beda (CTO and Founder, Heptio)
 
 On June 6, 2014 I checked in the [first commit](https://github.com/kubernetes/kubernetes/commit/2c4b3a562ce34cddc3f8218a2c4d11c7310e6d56) of what would become the public repository for Kubernetes. Many would assume that is where the story starts. It is the beginning of history, right? But that really doesn’t tell the whole story.
 

--- a/content/en/blog/_posts/2018-06-07-dynamic-ingress-kubernetes.md
+++ b/content/en/blog/_posts/2018-06-07-dynamic-ingress-kubernetes.md
@@ -2,9 +2,9 @@
 layout: blog
 title: Dynamic Ingress in Kubernetes
 date:  2018-06-07
+author: >
+  Richard Li (Datawire)
 ---
-
-**Author**: Richard Li (Datawire)
 
 Kubernetes makes it easy to deploy applications that consist of many microservices, but one of the key challenges with this type of architecture is dynamically routing ingress traffic to each of these services.  One approach is [Ambassador](https://www.getambassador.io), a Kubernetes-native open source API Gateway built on the [Envoy Proxy](https://www.envoyproxy.io). Ambassador is designed for dynamic environment where services may come and go frequently.
 

--- a/content/en/blog/_posts/2018-06-26-kubernetes-1-11-release-announcement.md
+++ b/content/en/blog/_posts/2018-06-26-kubernetes-1-11-release-announcement.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.11: In-Cluster Load Balancing and CoreDNS Plugin Graduate t
 date:  2018-06-27
 slug: kubernetes-1.11-release-announcement
 evergreen: true
+author: >
+  [Kubernetes v1.11 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release_team.md)
 ---
-
-**Author**: Kubernetes 1.11 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release_team.md)
 
 We’re pleased to announce the delivery of Kubernetes 1.11, our second release of 2018!
 

--- a/content/en/blog/_posts/2018-06-28-Airflow-Kubernetes-Operator.md
+++ b/content/en/blog/_posts/2018-06-28-Airflow-Kubernetes-Operator.md
@@ -2,9 +2,9 @@
 layout: blog
 title:  'Airflow on Kubernetes (Part 1): A Different Kind of Operator'
 date:   2018-06-28
+author: >
+  Daniel Imberman (Bloomberg LP)
 ---
-
-**Author**: Daniel Imberman (Bloomberg LP)
 
 ## Introduction
 

--- a/content/en/blog/_posts/2018-07-09-IPVS-In-Cluster-Load-Balancing.md
+++ b/content/en/blog/_posts/2018-07-09-IPVS-In-Cluster-Load-Balancing.md
@@ -2,9 +2,11 @@
 layout: blog
 title:  'IPVS-Based In-Cluster Load Balancing Deep Dive'
 date:   2018-07-09
+author: >
+  Jun Du (Huawei),
+  Haibin Xie (Huawei),
+  Wei Liang (Huawei) 
 ---
-
-**Author**: Jun Du(Huawei), Haibin Xie(Huawei), Wei Liang(Huawei)
 
 **Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2018/06/27/kubernetes-1.11-release-announcement/) on what’s new in Kubernetes 1.11**
 

--- a/content/en/blog/_posts/2018-07-10-coredns-ga.md
+++ b/content/en/blog/_posts/2018-07-10-coredns-ga.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "CoreDNS GA for Kubernetes Cluster DNS"
 date: 2018-07-10
+author: >
+  John Belamaric (Infoblox) 
 ---
-
-**Author**: John Belamaric (Infoblox)
 
 **Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2018/06/27/kubernetes-1.11-release-announcement/) on what’s new in Kubernetes 1.11**
 

--- a/content/en/blog/_posts/2018-07-11-dynamic-kubelet-configuration.md
+++ b/content/en/blog/_posts/2018-07-11-dynamic-kubelet-configuration.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Dynamic Kubelet Configuration'
 date: 2018-07-11
+author: >
+  Michael Taufen (Google)
 ---
-
-**Author**: Michael Taufen (Google)
 
 **Editor’s note: The feature has been removed in the version 1.24 after deprecation in 1.22.**
 

--- a/content/en/blog/_posts/2018-07-12-resizing-persistent-volumes-using-kubernetes.md
+++ b/content/en/blog/_posts/2018-07-12-resizing-persistent-volumes-using-kubernetes.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Resizing Persistent Volumes using Kubernetes'
 date: 2018-07-12
+author: >
+  Hemant Kumar (Red Hat)
 ---
-
-**Author**: Hemant Kumar (Red Hat)
 
 **Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2018/06/27/kubernetes-1.11-release-announcement/) on what’s new in Kubernetes 1.11**
 

--- a/content/en/blog/_posts/2018-07-16-kubernetes-1-11-release-interview.md
+++ b/content/en/blog/_posts/2018-07-16-kubernetes-1-11-release-interview.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "How the sausage is made: the Kubernetes 1.11 release interview, from the Kubernetes Podcast"
 date: 2018-07-16
+author: >
+  Craig Box (Google) 
 ---
-
-<b>Author</b>: Craig Box (Google)
 
 At KubeCon EU, my colleague Adam Glick and I were pleased to announce the [Kubernetes Podcast from Google](https://kubernetespodcast.com/). In this weekly conversation, we focus on all the great things that are happening in the world of Kubernetes and Cloud Native. From the news of the week, to interviews with people in the community, we help you stay up to date on everything Kubernetes.
 

--- a/content/en/blog/_posts/2018-07-18-11-ways-not-to-get-hacked.md
+++ b/content/en/blog/_posts/2018-07-18-11-ways-not-to-get-hacked.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "11 Ways (Not) to Get Hacked"
 date:  2018-07-18
+author: >
+  Andrew Martin (ControlPlane) 
 ---
-
-**Author**: Andrew Martin (ControlPlane)
 
 Kubernetes security has come a long way since the project&#39;s inception, but still contains some gotchas. Starting with the control plane, building up through workload and network security, and finishing with a projection into the future of security, here is a list of handy tips to help harden your clusters and increase their resilience if compromised.
 

--- a/content/en/blog/_posts/2018-07-19-kubernetes-win-2018-oscon-most-impact-award.md
+++ b/content/en/blog/_posts/2018-07-19-kubernetes-win-2018-oscon-most-impact-award.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Kubernetes Wins the 2018 OSCON Most Impact Award"
 date:  2018-07-19
 slug: kubernetes-wins-2018-oscon-most-impact-award
+author: >
+  Brian Grant (Google),
+  Tim Hockin (Google) 
 ---
-
-**Authors**: Brian Grant (Principal Engineer, Google) and Tim Hockin (Principal Engineer, Google)
 
 We are humbled to be recognized by the community with this award.
 

--- a/content/en/blog/_posts/2018-07-20-history-kubernetes-community.md
+++ b/content/en/blog/_posts/2018-07-20-history-kubernetes-community.md
@@ -2,9 +2,9 @@
 layout: blog
 title: "The History of Kubernetes & the Community Behind It"
 date:  2018-07-20
+author: >
+  Brendan Burns (Microsoft) 
 ---
-
-**Authors**: Brendan Burns (Distinguished Engineer, Microsoft)
 
 ![oscon award](/images/blog/2018-07-20-history-kubernetes-community.png)
 

--- a/content/en/blog/_posts/2018-07-24-cpu-manager.md
+++ b/content/en/blog/_posts/2018-07-24-cpu-manager.md
@@ -2,9 +2,10 @@
 layout: blog
 title: "Feature Highlight: CPU Manager"
 date:  2018-07-24
+author: >
+  [Balaji Subramaniam]((mailto:balaji.subramaniam@intel.com)) (Intel),
+  [Connor Doyle](mailto:connor.p.doyle@intel.com) (Intel]) 
 ---
-
-**Authors**: Balaji Subramaniam ([Intel](mailto:balaji.subramaniam@intel.com)), Connor Doyle ([Intel](mailto:connor.p.doyle@intel.com))
 
 This blog post describes the [CPU Manager](/docs/tasks/administer-cluster/cpu-management-policies/), a beta feature in [Kubernetes](https://kubernetes.io/). The CPU manager feature enables better placement of workloads in the [Kubelet](/docs/reference/command-line-tools-reference/kubelet/), the Kubernetes node agent, by allocating exclusive CPUs to certain pod containers.
 

--- a/content/en/blog/_posts/2018-07-27-kubevirt-crds-for-virtualization.md
+++ b/content/en/blog/_posts/2018-07-27-kubevirt-crds-for-virtualization.md
@@ -2,9 +2,9 @@
 layout: blog
 title:  'KubeVirt: Extending Kubernetes with CRDs for Virtualized Workloads'
 date:   2018-07-27
+author: >
+  David Vossel (Red Hat)
 ---
-
-**Author**: David Vossel (Red Hat)
 
 ## What is KubeVirt?
 

--- a/content/en/blog/_posts/2018-08-02-dynamically-expand-volume-csi.md
+++ b/content/en/blog/_posts/2018-08-02-dynamically-expand-volume-csi.md
@@ -2,9 +2,9 @@
 layout: blog
 title:  'Dynamically Expand Volume with CSI and Kubernetes'
 date:   2018-08-02
+author: >
+  Orain Xiong (WoquTech) 
 ---
-
-**Author**: Orain Xiong (Co-Founder, WoquTech)
 
 _There is a very powerful storage subsystem within Kubernetes itself, covering a fairly broad spectrum of use cases. Whereas, when planning to build a product-grade relational database platform with Kubernetes, we face a big challenge: coming up with storage. This article describes how to extend latest Container Storage Interface 0.2.0 and integrate with Kubernetes, and demonstrates the essential facet of dynamically expanding volume capacity._
 

--- a/content/en/blog/_posts/2018-08-03-make-kubernetes-production-grade-anywhere.md
+++ b/content/en/blog/_posts/2018-08-03-make-kubernetes-production-grade-anywhere.md
@@ -2,9 +2,10 @@
 layout: blog
 title:  'Out of the Clouds onto the Ground: How to Make Kubernetes Production Grade Anywhere'
 date:   2018-08-03
+author: >
+  Steven Wong (VMware),
+  Michael Gasch (VMware)
 ---
-
-**Authors**: Steven Wong (VMware), Michael Gasch (VMware)
 
 This blog offers some guidelines for running a production grade Kubernetes cluster in an environment like an on-premise data center or edge location.
 

--- a/content/en/blog/_posts/2018-08-10-introducing-kubebuilder.md
+++ b/content/en/blog/_posts/2018-08-10-introducing-kubebuilder.md
@@ -2,9 +2,10 @@
 layout: blog
 title:  'Introducing Kubebuilder: an SDK for building Kubernetes APIs using CRDs'
 date:   2018-08-10
+author: >
+  Phillip Wittrock (Google),
+  Sunil Arora (Google)
 ---
-
-**Author**: Phillip Wittrock (Google), Sunil Arora (Google)
 
 [kubebuilder-repo]: https://github.com/kubernetes-sigs/kubebuilder
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime

--- a/content/en/blog/_posts/2018-08-29-kubernetes-testing-ci-automating-contributor-experience.md
+++ b/content/en/blog/_posts/2018-08-29-kubernetes-testing-ci-automating-contributor-experience.md
@@ -2,9 +2,10 @@
 layout: blog
 title:  'The Machines Can Do the Work, a Story of Kubernetes Testing, CI, and Automating the Contributor Experience'
 date:   2018-08-29
+author: >
+  Aaron Crickenberger (Google),
+  Benjamin Elder (Google)
 ---
-
-**Author**: Aaron Crickenberger (Google) and Benjamin Elder (Google)
 
 _“Large projects have a lot of less exciting, yet, hard work. We value time spent automating repetitive work more highly than toil. Where that work cannot be automated, it is our culture to recognize and reward all types of contributions. However, heroism is not sustainable.”_ - [Kubernetes Community Values](https://git.k8s.io/community/values.md#automation-over-process)
 

--- a/content/en/blog/_posts/2018-09-06-2018-steering-committee-election-cycle-kicks-off.md
+++ b/content/en/blog/_posts/2018-09-06-2018-steering-committee-election-cycle-kicks-off.md
@@ -2,9 +2,11 @@
 layout: blog
 title:  '2018 Steering Committee Election Cycle Kicks Off'
 date:   2018-09-06
+author: >
+  Paris Pittman (Google),
+  Jorge Castro (Heptio),
+  Ihor Dvoretskyi (CNCF)
 ---
-
-**Author**: Paris Pittman (Google), Jorge Castro (Heptio), Ihor Dvoretskyi (CNCF)
 
 Having a clear, definable governance model is crucial for the health of open source projects. For one of the highest velocity projects in the open source world, governance is critical especially for one as large and active as Kubernetes, which is one of the most high-velocity projects in the open source world. A clear structure helps users trust that the project will be nurtured and progress forward. Initially, this structure was laid by the former 7 member bootstrap committee composed of founders and senior contributors with a goal to create the foundational governance building blocks.  
 

--- a/content/en/blog/_posts/2018-09-18-2018-linkerd-2-0.md
+++ b/content/en/blog/_posts/2018-09-18-2018-linkerd-2-0.md
@@ -2,9 +2,9 @@
 layout: blog
 title:  'Hands On With Linkerd 2.0'
 date:   2018-09-18
+author: >
+  Thomas Rampelberg (Buoyant) 
 ---
-
-**Author**: Thomas Rampelberg (Buoyant) 
 
 Linkerd 2.0 was recently announced as generally available (GA), signaling its readiness for production use. In this tutorial, we’ll walk you through how to get Linkerd 2.0 up and running on your Kubernetes cluster in a matter seconds.
 

--- a/content/en/blog/_posts/2018-09-27-kubernetes-1-12-release-announcement.md
+++ b/content/en/blog/_posts/2018-09-27-kubernetes-1-12-release-announcement.md
@@ -3,9 +3,9 @@ layout: blog
 title:  'Kubernetes 1.12: Kubelet TLS Bootstrap and Azure Virtual Machine Scale Sets (VMSS) Move to General Availability'
 date:   2018-09-27
 evergreen: true
+author: >
+  [Kubernetes v1.12 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)
 ---
-
-**Author**: The 1.12 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)
 
 We’re pleased to announce the delivery of Kubernetes 1.12, our third release of 2018!
 

--- a/content/en/blog/_posts/2018-10-01-health-checking-grpc.md
+++ b/content/en/blog/_posts/2018-10-01-health-checking-grpc.md
@@ -2,9 +2,9 @@
 layout: blog
 title:  'Health checking gRPC servers on Kubernetes'
 date: 2018-10-01
+author: >
+  [Ahmet Alp Balkan](https://twitter.com/ahmetb) (Google)
 ---
-
-**Author**: [Ahmet Alp Balkan](https://twitter.com/ahmetb) (Google)
 
 **Update (December 2021):** _Kubernetes now has built-in gRPC health probes starting in v1.23.
 To learn more, see [Configure Liveness, Readiness and Startup Probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe).

--- a/content/en/blog/_posts/2018-10-02-network-bootable-farm-with-ltsp.md
+++ b/content/en/blog/_posts/2018-10-02-network-bootable-farm-with-ltsp.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Building a Network Bootable Server Farm for Kubernetes with LTSP'
 date:  2018-10-02
+author: >
+  Andrei Kvapil (WEDOS) 
 ---
-
-**Author**: Andrei Kvapil (WEDOS)
 
 ![k8s+ltsp](/images/blog/2018-10-01-network-bootable-farm-with-ltsp/k8s+ltsp.svg)
 

--- a/content/en/blog/_posts/2018-10-03-kubedirector.md
+++ b/content/en/blog/_posts/2018-10-03-kubedirector.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'KubeDirector: The easy way to run complex stateful applications on Kubernetes'
 date: 2018-10-03
+author: >
+  Thomas Phelan (BlueData)
 ---
-
-**Author**: Thomas Phelan (BlueData)
 
 KubeDirector is an open source project designed to make it easy to run complex stateful scale-out application clusters on Kubernetes. KubeDirector is built using the custom resource definition (CRD) framework and leverages the native Kubernetes API extensions and design philosophy. This enables transparent integration with Kubernetes user/resource management as well as existing clients and tools.
 

--- a/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
+++ b/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
@@ -2,9 +2,11 @@
 layout: blog
 title: 'Introducing the Non-Code Contributor’s Guide'
 date: 2018-10-04
+author: >
+  [Noah Abrahams](https://twitter.com/noah_abrahams) (InfoSiftr),
+  [Jonas Rosland](https://twitter.com/jonasrosland) (VMware),
+  [Ihor Dvoretskyi](https://twitter.com/idvoretskyi) (CNCF)
 ---
-
-**Author**: [Noah Abrahams](https://twitter.com/noah_abrahams) (InfoSiftr), [Jonas Rosland](https://twitter.com/jonasrosland) (VMware), [Ihor Dvoretskyi](https://twitter.com/idvoretskyi) (CNCF)
 
 It was May 2018 in Copenhagen, and the Kubernetes community was enjoying the contributor summit at KubeCon/CloudNativeCon, complete with the first run of the New Contributor Workshop. As a time of tremendous collaboration between contributors, the topics covered ranged from signing the CLA to deep technical conversations. Along with the vast exchange of information and ideas, however, came continued scrutiny of the topics at hand to ensure that the community was being as inclusive and accommodating as possible. Over that spring week, some of the pieces under the microscope included the many themes being covered, and how they were being presented, but also the overarching characteristics of the people contributing and the skill sets involved. From the discussions and analysis that followed grew the idea that the community was not benefiting as much as it could from the many people who wanted to contribute, but whose strengths were in areas other than writing code.
 

--- a/content/en/blog/_posts/2018-10-08-support-for-azure-vmss.md
+++ b/content/en/blog/_posts/2018-10-08-support-for-azure-vmss.md
@@ -2,9 +2,10 @@
 layout: blog
 title: 'Support for Azure VMSS,  Cluster-Autoscaler and User Assigned Identity'
 date: 2018-10-08
+author: >
+  [Krishnakumar R (KK)](https://twitter.com/kkwriting) (Microsoft),
+  [Pengfei Ni](https://twitter.com/feisky) (Microsoft)
 ---
-
-**Author**: [Krishnakumar R (KK)](https://twitter.com/kkwriting) (Microsoft), [Pengfei Ni](https://twitter.com/feisky) (Microsoft)
 
 ## Introduction
 

--- a/content/en/blog/_posts/2018-10-09-volume-snapshot-alpha.md
+++ b/content/en/blog/_posts/2018-10-09-volume-snapshot-alpha.md
@@ -2,9 +2,11 @@
 layout: blog
 title: 'Introducing Volume Snapshot Alpha for Kubernetes'
 date: 2018-10-09
+author: >
+  Jing Xu (Google),
+  Xing Yang (Huawei),
+  Saad Ali (Google) 
 ---
-
-**Author**: Jing Xu (Google) Xing Yang (Huawei), Saad Ali (Google)
 
 Kubernetes v1.12 introduces alpha support for volume snapshotting. This feature allows creating/deleting volume snapshots, and the ability to create new volumes from a snapshot natively using the Kubernetes API.
 

--- a/content/en/blog/_posts/2018-10-10-runtimeclass.md
+++ b/content/en/blog/_posts/2018-10-10-runtimeclass.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Kubernetes v1.12: Introducing RuntimeClass'
 date: 2018-10-10
+author: >
+  Tim Allclair (Google)
 ---
-
-**Author**: Tim Allclair (Google)
 
 Kubernetes originally launched with support for Docker containers running native applications on a Linux host. Starting with [rkt](https://kubernetes.io/blog/2016/07/rktnetes-brings-rkt-container-engine-to-kubernetes/) in Kubernetes 1.3 more runtimes were coming, which lead to the development of the [Container Runtime Interface](https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/) (CRI). Since then, the set of alternative runtimes has only expanded: projects like [Kata Containers](https://katacontainers.io/) and [gVisor](https://github.com/google/gvisor) were announced for stronger workload isolation, and Kubernetes' Windows support has been [steadily progressing](https://kubernetes.io/blog/2018/01/kubernetes-v19-beta-windows-support/).
 

--- a/content/en/blog/_posts/2018-10-11-topology-aware-volume-provisioning.md
+++ b/content/en/blog/_posts/2018-10-11-topology-aware-volume-provisioning.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Topology-Aware Volume Provisioning in Kubernetes'
 date: 2018-10-11
+author: >
+  Michelle Au (Google)
 ---
-
-**Author**: Michelle Au (Google)
 
 The multi-zone cluster experience with persistent volumes is improving in Kubernetes 1.12 with the topology-aware dynamic provisioning beta feature. This feature allows Kubernetes to make intelligent decisions when dynamically provisioning volumes by getting scheduler input on the best place to provision a volume for a pod.  In multi-zone clusters, this means that volumes will get provisioned in an appropriate zone that can run your pod, allowing you to easily deploy and scale your stateful workloads across failure domains to provide high availability and fault tolerance.
 

--- a/content/en/blog/_posts/2018-10-15-steering-election-results.md
+++ b/content/en/blog/_posts/2018-10-15-steering-election-results.md
@@ -2,9 +2,11 @@
 layout: blog
 title: '2018 Steering Committee Election Results'
 date: 2018-10-15
+author: >
+  Jorge Castro (Heptio),
+  Ihor Dvoretskyi (CNCF),
+  Paris Pittman (Google) 
 ---
-
-**Authors**: Jorge Castro (Heptio), Ihor Dvoretskyi (CNCF), Paris Pittman (Google)
 
 ## Results
 The [Kubernetes Steering Committee Election](https://kubernetes.io/blog/2018/09/06/2018-steering-committee-election-cycle-kicks-off/) is now complete and the following candidates came ahead to secure two year terms that start immediately:

--- a/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
+++ b/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
@@ -3,11 +3,11 @@ layout: blog
 title: "Kubernetes 2018 North American Contributor Summit"
 date: 2018-10-16
 evergreen: true
+author: >
+  Bob Killen (University of Michigan),
+  Sahdev Zala (IBM),
+  Ihor Dvoretskyi (CNCF) 
 ---
-
-**Authors:**
-[Bob Killen][bob] (University of Michigan), [Sahdev Zala][sahdev] (IBM), [Ihor Dvoretskyi][ihor] (CNCF)
-
 
 The 2018 North American Kubernetes Contributor Summit to be hosted right before
 [KubeCon + CloudNativeCon][kubecon] Seattle is shaping up to be the largest yet.

--- a/content/en/blog/_posts/2018-10-18-tips-for-first-kubecon-presentation-part-1.md
+++ b/content/en/blog/_posts/2018-10-18-tips-for-first-kubecon-presentation-part-1.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Tips for Your First Kubecon Presentation - Part 1'
 date: 2018-10-18
+author: >
+  Michael Gasch (VMware)
 ---
-
-**Author**: Michael Gasch (VMware)
 
 First of all, let me congratulate you to this outstanding achievement. Speaking at KubeCon, especially if it's your first time, is a tremendous honor and experience. Well done!
 

--- a/content/en/blog/_posts/2018-10-26-tips-for-first-kubecon-presentation-part-2.md
+++ b/content/en/blog/_posts/2018-10-26-tips-for-first-kubecon-presentation-part-2.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Tips for Your First Kubecon Presentation - Part 2'
 date: 2018-10-26
+author: >
+  Michael Gasch (VMware)
 ---
-
-**Author**: Michael Gasch (VMware)
 
 Hello and welcome back to the second and final part about tips for KubeCon first-time speakers. If you missed the last post, please give it a read [here](https://kubernetes.io/blog/2018/10/18/tips-for-your-first-kubecon-presentation-part-1/).
 

--- a/content/en/blog/_posts/2018-11-07-grpc-load-balancing-with-linkerd.md
+++ b/content/en/blog/_posts/2018-11-07-grpc-load-balancing-with-linkerd.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'gRPC Load Balancing on Kubernetes without Tears'
 date: 2018-11-07
+author: >
+  William Morgan (Buoyant)
 ---
-
-**Author**: William Morgan (Buoyant)
 
 Many new gRPC users are surprised to find that Kubernetes's default load
 balancing often doesn't work out of the box with gRPC. For example, here's what

--- a/content/en/blog/_posts/2018-11-08-kubernetes-docs-update-i18n.md
+++ b/content/en/blog/_posts/2018-11-08-kubernetes-docs-update-i18n.md
@@ -2,9 +2,9 @@
 layout: blog
 title: 'Kubernetes Docs Updates, International Edition'
 date: 2018-11-08
+author: >
+  Zach Corleissen (Linux Foundation) 
 ---
-
-**Author**: Zach Corleissen (Linux Foundation)
 
 As a co-chair of SIG Docs, I'm excited to share that Kubernetes docs have a fully mature workflow for localization (l10n). 
 

--- a/content/en/blog/_posts/2018-12-03-kubernetes-1-13-release-announcement.md
+++ b/content/en/blog/_posts/2018-12-03-kubernetes-1-13-release-announcement.md
@@ -4,9 +4,9 @@ title: 'Kubernetes 1.13: Simplified Cluster Management with Kubeadm, Container S
 date: 2018-12-03
 slug: kubernetes-1-13-release-announcement
 evergreen: true
+author: >
+  [Kubernetes v1.13 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.13/release_team.md)
 ---
-
-**Author**: The 1.13 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.13/release_team.md)
 
 We’re pleased to announce the delivery of Kubernetes 1.13, our fourth and final release of 2018!
 

--- a/content/en/blog/_posts/2018-12-04-kubeadm-ga-release.md
+++ b/content/en/blog/_posts/2018-12-04-kubeadm-ga-release.md
@@ -3,9 +3,10 @@ layout: blog
 title: Production-Ready Kubernetes Cluster Creation with kubeadm
 date: 2018-12-04
 evergreen: true
+author: >
+   Lucas Käldström (CNCF),
+   Luc Perkins (CNCF) 
 ---
-
-**Authors**: Lucas Käldström (CNCF Ambassador) and Luc Perkins (CNCF Developer Advocate)
 
 [kubeadm](/docs/setup/independent/create-cluster-kubeadm/) is a tool that enables Kubernetes administrators to quickly and easily bootstrap minimum viable clusters that are fully compliant with [Certified Kubernetes](https://github.com/cncf/k8s-conformance/blob/master/terms-conditions/Certified_Kubernetes_Terms.md) guidelines. It's been under active development by [SIG Cluster Lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle) since 2016 and we're excited to announce that it has now graduated from beta to stable and generally available (GA)!
 

--- a/content/en/blog/_posts/2018-12-05-new-contributor-shanghai.md
+++ b/content/en/blog/_posts/2018-12-05-new-contributor-shanghai.md
@@ -2,9 +2,12 @@
 layout: blog
 title: 'New Contributor Workshop Shanghai'
 date: 2018-12-05
+author: >
+  Josh Berkus (Red Hat),
+  Yang Li (The Plant),
+  Puja Abbassi (Giant Swarm),
+  XiangPeng Zhao (ZTE)
 ---
-
-**Authors**: Josh Berkus (Red Hat), Yang Li (The Plant), Puja Abbassi (Giant Swarm), XiangPeng Zhao (ZTE)
 
 {{< figure src="/images/blog/2018-12-05-new-contributor-shanghai/attendees.png" caption="Kubecon Shanghai New Contributor Summit attendees. Photo by Jerry Zhang" >}}
 

--- a/content/en/blog/_posts/2018-12-11-Kubernetes-Federation-Evolution.md
+++ b/content/en/blog/_posts/2018-12-11-Kubernetes-Federation-Evolution.md
@@ -2,9 +2,11 @@
 layout: blog
 title: Kubernetes Federation Evolution
 date: 2018-12-12
+author: >
+  Irfan Ur Rehman (Huawei),
+  Paul Morie (RedHat),
+  Shashidhara T D (Huawei)
 ---
-
-**Authors**: Irfan Ur Rehman (Huawei), Paul Morie (RedHat) and Shashidhara T D (Huawei)
 
 Kubernetes provides great primitives for deploying applications to a cluster: it can be as simple as `kubectl create -f app.yaml`. Deploy apps across multiple clusters has never been that simple. How should app workloads be distributed? Should the app resources be replicated into all clusters, replicated into selected clusters, or partitioned into clusters? How is  access to the clusters managed? What happens if some of the resources that a user wants to distribute pre-exist, in some or all of the clusters, in some form?
 

--- a/content/en/blog/_posts/2018-12-11-current-status-and-future-roadmap.md
+++ b/content/en/blog/_posts/2018-12-11-current-status-and-future-roadmap.md
@@ -2,9 +2,10 @@
 layout: blog
 title: 'etcd: Current status and future roadmap'
 date: 2018-12-11
+author: >
+  Gyuho Lee (Amazon),
+  Joe Betz (Google Cloud)
 ---
-
-**Author**: Gyuho Lee (Amazon Container OSS Team, @gyuho), Joe Betz (Google Cloud, @jpbetz)
 
 etcd is a distributed key value store that provides a reliable way to manage the coordination state of distributed systems. etcd was first announced in June 2013 by CoreOS (part of Red Hat as of 2018). Since its adoption in Kubernetes in 2014, etcd has become a fundamental part of the Kubernetes cluster management software design, and the etcd community has grown exponentially. etcd is now being used in production environments of multiple companies, including large cloud provider environments such as AWS, Google Cloud Platform, Azure, and other on-premises Kubernetes implementations. CNCF currently has [32 conformant Kubernetes platforms and distributions](https://www.cncf.io/announcement/2017/11/13/cloud-native-computing-foundation-launches-certified-kubernetes-program-32-conformant-distributions-platforms/), all of which use etcd as the datastore.
 


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2018 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-46361--kubernetes-io-main-staging.netlify.app/blog)