### PR TITLE
Fix example KMS configuration documentation

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kms-provider.md
@@ -284,12 +284,12 @@ defined in a CustomResourceDefinition, your cluster must be running Kubernetes v
        providers:
          - kms:
              name: myKmsPluginFoo
-             endpoint: unix:///tmp/socketfile.sock
+             endpoint: unix:///tmp/socketfile-foo.sock
              cachesize: 100
              timeout: 3s
          - kms:
              name: myKmsPluginBar
-             endpoint: unix:///tmp/socketfile.sock
+             endpoint: unix:///tmp/socketfile-bar.sock
              cachesize: 100
              timeout: 3s
    ```
@@ -308,12 +308,12 @@ defined in a CustomResourceDefinition, your cluster must be running Kubernetes v
          - kms:
              apiVersion: v2
              name: myKmsPluginFoo
-             endpoint: unix:///tmp/socketfile.sock
+             endpoint: unix:///tmp/socketfile-foo.sock
              timeout: 3s
          - kms:
              apiVersion: v2
              name: myKmsPluginBar
-             endpoint: unix:///tmp/socketfile.sock
+             endpoint: unix:///tmp/socketfile-bar.sock
              timeout: 3s
    ```
 


### PR DESCRIPTION
Updated example configuration to specify separate unix domain socket paths. Two KMS providers will use separate socket files.

cc @enj 