### PR TITLE
Update KubeCon 2024 events

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -47,12 +47,15 @@ To download Kubernetes, visit the [download](/releases/download/) section.
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on March 19-22, 2024</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-open-source-summit-ai-dev-china/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon China on August 21-23</a>
         <br>
         <br>
         <br>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 12-15</a>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 12-15, 2024</a>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon India on December 11-12</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Removing the past European event and adding two upcoming KubeCon 2024 events (in Hong Kong and India).

Please, note I'm intentionally removing the 2024 year from all those links' text to fit them for small screens — to prevent the situation pictured here:

![image](https://github.com/kubernetes/website/assets/1560718/fbe014af-6b87-42f8-9e45-b2663b7f3d1c)

For the same reason, I'm using the "KubeCon + CloudNativeCon China" title instead of the full long name ("KubeCon + CloudNativeCon + Open Source Summit + AI_dev China").

Fixes #46386