### PR TITLE
fix minor typo in connect-applications-service.md

### DIFF
--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -115,7 +115,7 @@ As mentioned previously, a Service is backed by a group of Pods. These Pods are
 exposed through
 {{<glossary_tooltip term_id="endpoint-slice" text="EndpointSlices">}}.
 The Service's selector will be evaluated continuously and the results will be POSTed
-to an EndpointSlice that is connected to the Service using a
+to an EndpointSlice that is connected to the Service using
 {{< glossary_tooltip text="labels" term_id="label" >}}.
 When a Pod dies, it is automatically removed from the EndpointSlices that contain it 
 as an endpoint. New Pods that match the Service's selector will automatically get added


### PR DESCRIPTION
Source: [page](https://kubernetes.io/docs/tutorials/services/connect-applications-service/)

The top one is old, the bottom one is new.
> EndpointSlice that is connected to the Service using **_a labels_**.
> EndpointSlice that is connected to the Service using **_labels_**. 

This pull request removes ' a'. That's all.
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
