### PR TITLE
[ja] minor fix in content/ja/docs/reference/_index.md

### DIFF
--- a/content/ja/docs/reference/_index.md
+++ b/content/ja/docs/reference/_index.md
@@ -23,9 +23,9 @@ no_list: true
 * [API アクセスコントロール](/docs/reference/access-authn-authz/) - KubernetesがAPIアクセスをどのように制御するかの詳細です。
 * [よく知られたラベル、アノテーション、テイント](/docs/reference/labels-annotations-taints/)
 
-## 公式にサポートされているクライアントライブラリー
+## 公式にサポートされているクライアントライブラリ
 
-プログラミング言語からKubernetesのAPIを呼ぶためには、[クライアントライブラリー](/docs/reference/using-api/client-libraries/)を使うことができます。公式にサポートしているクライアントライブラリー:
+プログラミング言語からKubernetesのAPIを呼ぶためには、[クライアントライブラリ](/docs/reference/using-api/client-libraries/)を使うことができます。公式にサポートしているクライアントライブラリ:
 
 - [Kubernetes Go client library](https://github.com/kubernetes/client-go/)
 - [Kubernetes Python client library](https://github.com/kubernetes-client/python)


### PR DESCRIPTION
## Change List

- fix "ライブラリー" to "ライブラリ" in `content/ja/docs/reference/_index.md`

ref. https://kubernetes.io/ja/docs/contribute/localization/#long-vowel

> - -ear、-eer、-re、-ty、-dy、-ryで終わる単語は長音を付与しない
>     - 例: 「クリア」「エンジニア」「アーキテクチャ」「セキュリティ」「スタディ」「ディレクトリ」

/assign nasa9084 