### PR TITLE
Add area/localization label in content/bn/OWNERS

### DIFF
--- a/content/bn/OWNERS
+++ b/content/bn/OWNERS
@@ -10,4 +10,5 @@ approvers:
 - sig-docs-bn-owners
 
 labels:
+- area/localization
 - language/bn


### PR DESCRIPTION
## Feature Description

- Add `area/localization` label in content/bn/OWNERS
    - other languages have `area/localization` label (ref. #42206 )

```console
$ pwd
/path/to/website
$ grep -RIn "area/localization" ./content/**/OWNERS
./content/bn/OWNERS:13:- area/localization
./content/de/OWNERS:14:- area/localization
./content/es/OWNERS:14:- area/localization
./content/fr/OWNERS:14:- area/localization
./content/hi/OWNERS:14:- area/localization
./content/id/OWNERS:14:- area/localization
./content/it/OWNERS:12:- area/localization
./content/ja/OWNERS:14:- area/localization
./content/ko/OWNERS:14:- area/localization
./content/pl/OWNERS:14:- area/localization
./content/pt-br/OWNERS:12:- area/localization
./content/ru/OWNERS:14:- area/localization
./content/uk/OWNERS:14:- area/localization
./content/vi/OWNERS:14:- area/localization
./content/zh-cn/OWNERS:14:- area/localization
```