### PR TITLE
Reword port definition section of Service concept

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -144,7 +144,7 @@ field.
 
 ### Port definitions {#field-spec-ports}
 
-Port definitions in Pods have names, and you can reference these names in the
+Ports are named in the Pod definition, and you can reference these names in the
 `targetPort` attribute of a Service. For example, we can bind the `targetPort`
 of the Service to the Pod port in the following way:
 


### PR DESCRIPTION
Small reformulating in the port definition section
Ports definition in pods seems confusing it would be clearer to specify that we are talking about the pods resource (pods definition)
