### PR TITLE
Fix feature gates that have been been removed in 1.30

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/api-self-subject-review.md
@@ -18,6 +18,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28"  
+    toVersion: "1.29"
+removed: true
 ---
 Activate the `SelfSubjectReview` API which allows users
 to see the requesting subject's authentication information.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-file.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/csi-migration-azure-file.md
@@ -21,6 +21,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.26"  
+    toVersion: "1.29" 
+removed: true
 ---
 Enables shims and translation logic to route volume
 operations from the Azure-File in-tree plugin to AzureFile CSI plugin.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/expanded-dns-config.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/expanded-dns-config.md
@@ -17,6 +17,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28"  
+    toVersion: "1.29" 
+removed: true
 ---
 Enable kubelet and kube-apiserver to allow more DNS
 search paths and longer list of DNS search paths. This feature requires container

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/experimental-host-user-namespace-defaulting.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/experimental-host-user-namespace-defaulting.md
@@ -13,6 +13,8 @@ stages:
   - stage: deprecated
     defaultValue: false
     fromVersion: "1.28"  
+    toVersion: "1.29" 
+removed: true
 ---
 Enabling the defaulting user
 namespace to host. This is for containers that are using other host namespaces,

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ip-tables-ownership-cleanup.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ip-tables-ownership-cleanup.md
@@ -17,5 +17,7 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28" 
+    toVersion: "1.29" 
+removed: true
 ---
 This causes kubelet to no longer create legacy iptables rules.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-get-allocatable.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-get-allocatable.md
@@ -17,6 +17,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28" 
+    toVersion: "1.29" 
+removed: true
 ---
 Enable the kubelet's pod resources
 `GetAllocatableResources` functionality. This API augments the

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources.md
@@ -17,6 +17,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28"  
+    toVersion: "1.29" 
+removed: true
 ---
 Enable the kubelet's pod resources gRPC endpoint. See
 [Support Device Monitoring](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/606-compute-device-assignment/README.md)

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/legacy-service-account-token-tracking.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/legacy-service-account-token-tracking.md
@@ -17,7 +17,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28"  
-
+    toVersion: "1.29" 
+removed: true
 ---
 Track usage of Secret-based
 [service account tokens](/docs/concepts/security/service-accounts/#get-a-token).

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/minimize-ip-tables-restore.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/minimize-ip-tables-restore.md
@@ -17,6 +17,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28" 
+    toVersion: "1.29" 
+removed: true
 ---
 Enables new performance improvement logics
 in the kube-proxy iptables mode.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/proxy-terminating-endpoints.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/proxy-terminating-endpoints.md
@@ -17,6 +17,8 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.28"  
+    toVersion: "1.29" 
+removed: true
 ---
 Enable the kube-proxy to handle terminating
 endpoints when `ExternalTrafficPolicy=Local`.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/security-context-deny.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/security-context-deny.md
@@ -9,5 +9,7 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.27"
+    toVersion: "1.29"
+removed: true
 ---
 This gate signals that the `SecurityContextDeny` admission controller is deprecated.


### PR DESCRIPTION
The feature gates data are not accurate. This PR fixes those that have been dropped in v1.30.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
