### PR TITLE
[es] Sync navbar items for vanilla Docsy

### DIFF
--- a/content/es/blog/_index.md
+++ b/content/es/blog/_index.md
@@ -4,7 +4,5 @@ linkTitle: Blog
 menu:
   main:
     title: "Blog"
-    weight: 40
-    post: >
-       <p>Lea las últimas noticias sobre Kubernetes y el mundo de los contenedores, tutoriales técnicos y mucho más.</p>
+    weight: 20
 ---

--- a/content/es/case-studies/_index.html
+++ b/content/es/case-studies/_index.html
@@ -6,5 +6,9 @@ abstract: Colección de casos de éxito de usuarios ejecutando Kubernetes en pro
 layout: basic
 class: gridPage
 cid: caseStudies
+body_class: caseStudies
+menu:
+  main:
+    weight: 60
 ---
 

--- a/content/es/community/_index.html
+++ b/content/es/community/_index.html
@@ -2,6 +2,10 @@
 title: Comunidad
 layout: basic
 cid: community
+body_class: community
+menu:
+    main:
+        weight: 50
 ---
 
 <section id="mainContent">

--- a/content/es/docs/home/_index.md
+++ b/content/es/docs/home/_index.md
@@ -12,8 +12,6 @@ menu:
   main:
     title: "Documentación"
     weight: 20
-    post: >
-      <p>Aprenda cómo usar Kubernetes con la documentación, los tutoriales y revisando la información de referencia. También puedes <a href="/editdocs/" data-auto-burger-exclude>contribuir con la documentación</a>!</p>
 overview: >
   Kubernetes es una plataforma de código abierto para automatizar la implementación, el escalado y la administración de aplicaciones en contenedores.
   El proyecto está amparado por la Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).

--- a/content/es/partners/_index.html
+++ b/content/es/partners/_index.html
@@ -4,6 +4,10 @@ bigheader: Kubernetes Partners
 abstract: Expandiendo el ecosistema de Kubernetes.
 class: gridPage
 cid: partners
+body_class: partners
+menu:
+  main:
+    weight: 40
 ---
 
 <section id="users">


### PR DESCRIPTION
Align how we style the partners page to work more the way Docsy expects it to.

Update the following pages to align how we style them with Vanilla Docsy:
- Blog
- Case studies
- Community
- Documentation
- Partners

[Current page](https://kubernetes.io/es/) | [Preview](https://deploy-preview-46474--kubernetes-io-main-staging.netlify.app/es/)

/area web-development

Helps with issue https://github.com/kubernetes/website/issues/41171