### PR TITLE
fix wording on 2023-12-14 blogpost

### DIFF
--- a/content/en/blog/_posts/2023-12-14-disabling-in-tree-cloud-provider-goes-beta.md
+++ b/content/en/blog/_posts/2023-12-14-disabling-in-tree-cloud-provider-goes-beta.md
@@ -40,7 +40,7 @@ These updated default settings affect a large proportion of Kubernetes users,
 and **will require changes** for users who were previously using the in-tree
 provider integrations. The legacy integrations offered compatibility with
 Azure, AWS, GCE, OpenStack, and vSphere; however for AWS and OpenStack the
-compiled-in integrations were removed in Kubernetes versions 1.26 and 1.27,
+compiled-in integrations were removed in Kubernetes versions 1.27 and 1.26,
 respectively.
 
 ## What has changed?


### PR DESCRIPTION
the AWS and OpenStack removal versions were wrong in one part of the blog.

fixes: #46481 