### PR TITLE
[pt-br] Update navbar items for vanilla Docsy

### DIFF
--- a/content/pt-br/blog/_index.md
+++ b/content/pt-br/blog/_index.md
@@ -4,7 +4,5 @@ linkTitle: Blog
 menu:
   main:
     title: "Blog"
-    weight: 40
-    post: >
-       <p>Leia as últimas novidades sobre Kubernetes e contêineres em geral, e obtenha detalhes técnicos atualizados</p>
+    weight: 20
 ---

--- a/content/pt-br/case-studies/_index.md
+++ b/content/pt-br/case-studies/_index.md
@@ -6,4 +6,7 @@ abstract: Alguns usuários que estão executando o Kubernetes em produção.
 layout: basic
 class: gridPage
 cid: caseStudies
+menu:
+  main:
+    weight: 60
 ---

--- a/content/pt-br/community/_index.html
+++ b/content/pt-br/community/_index.html
@@ -3,6 +3,9 @@ title: Comunidade
 layout: basic
 cid: community
 community_styles_migrated: true
+menu:
+  main:
+    weight: 50
 ---
 <img
   id="banner"

--- a/content/pt-br/docs/home/_index.md
+++ b/content/pt-br/docs/home/_index.md
@@ -14,8 +14,6 @@ menu:
   main:
     title: "Documentação"
     weight: 20
-    post: >
-      <p>Aprenda a usar o Kubernetes com documentação conceitual, tutorial e de referência. Você também pode <a href="/editdocs/" data-auto-burger-exclude>ajudar a contribuir para a documentação</a>!</p>
 overview: >
   O Kubernetes é uma engine de orquestração de contêineres Open Source utilizado para automatizar a implantação, dimensionamento e gerenciamento de aplicativos em contêiner. O projeto é hospedado por the Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
 cards:

--- a/content/pt-br/docs/tutorials/hello-minikube.md
+++ b/content/pt-br/docs/tutorials/hello-minikube.md
@@ -2,12 +2,6 @@
 title: Olá, Minikube!
 content_type: tutorial
 weight: 5
-menu:
-  main:
-    title: "Iniciar"
-    weight: 10
-    post: >
-      <p>Pronto para meter a mão na massa? Vamos criar um cluster Kubernetes simples e executar uma aplicação exemplo.</p>
 card:
   name: tutorials
   weight: 10

--- a/content/pt-br/partners/_index.html
+++ b/content/pt-br/partners/_index.html
@@ -4,6 +4,10 @@ bigheader: Parceiro Kubernetes
 abstract: Crescendo o ecossistema do Kubernetes.
 class: gridPage
 cid: parceiros
+body_class: partners
+menu:
+  main:
+    weight: 40
 ---
 
 <section id="users">


### PR DESCRIPTION
Update navbar items in the Brazilian Portuguese localization so layout renders correctly using vanilla Docsy.

Changes in the same vein as #45869 and #46192 in order to allow #46409 to move forward.

/cc @edsoncelio @mboukhalfa @sftim
/area web-development