### PR TITLE
Correct alignment in kubectl get pods dnsutils

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -45,7 +45,7 @@ pod/dnsutils created
 kubectl get pods dnsutils
 ```
 ```
-NAME      READY     STATUS    RESTARTS   AGE
+NAME       READY     STATUS    RESTARTS   AGE
 dnsutils   1/1       Running   0          <some-time>
 ```
 


### PR DESCRIPTION
This changes corrects an aligment in the output of the command `kubectl get pods dnsutils`, in the **Debugging DNS Resolution** page