### PR TITLE
fix: the order of statefulset updates for pods

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -1180,8 +1180,8 @@ above.
 
 Use this when your application requires or expects that changes, such as rolling out a new
 version of your application, happen in the strict order of the ordinal (pod number) that the StatefulSet provides.
-In other words, if you have Pods `app-0`, `app-1` and `app-2`, Kubernetes will update `app-0` first and check it.
-Once the checks are good, Kubernetes updates `app-1` and finally `app-2`.
+In other words, if you have Pods `app-0`, `app-1` and `app-2`, Kubernetes will update `app-2` first and check it.
+Once the checks are good, Kubernetes updates `app-1` and finally `app-0`.
 
 If you added two more Pods, Kubernetes would set up `app-3` and wait for that to become healthy before deploying
 `app-4`.


### PR DESCRIPTION
### Description:
This change fix the order of statefulset updates for pods which should be backward in the **basic-stateful-set** of **tutorials**.
