### PR TITLE
Tweak heading level in Pod lifecycle concept page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -196,8 +196,7 @@ To investigate the root cause of a `CrashLoopBackOff` issue, a user can:
    application code. Running this container image locally or in a development
    environment can help diagnose application specific issues.
 
-
-## Container restart policy {#restart-policy}
+### Container restart policy {#restart-policy}
 
 The `spec` of a Pod has a `restartPolicy` field with possible values Always, OnFailure,
 and Never. The default value is Always.


### PR DESCRIPTION
Update https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/

Make [Container restart policy](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy) fit within the topic of how Pods handle container problems; it belongs there.