### PR TITLE
Update node-hello image to Google's newer image

### DIFF
--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -154,7 +154,9 @@ external IP address.
    The response to a successful request is a hello message:
 
    ```shell
-   Hello Kubernetes!
+   Hello, world!
+   Version: 2.0.0
+   Hostname: hello-world-2895499144-2e5uh
    ```
 
 ## {{% heading "cleanup" %}}

--- a/content/en/examples/service/load-balancer-example.yaml
+++ b/content/en/examples/service/load-balancer-example.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: load-balancer-example
     spec:
       containers:
-      - image: gcr.io/google-samples/node-hello:1.0
+      - image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0
         name: hello-world
         ports:
         - containerPort: 8080


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
This PR fixes https://github.com/kubernetes/website/issues/45961 by updating the tutorial to use Google's newer image: [hello-app](https://us-docker.pkg.dev/google-samples/containers/gke/hello-app)

This fix closely resembles https://github.com/kubernetes/website/pull/46553

[Original](https://kubernetes.io/docs/tutorials/stateless-application/expose-external-ip-address/)
[Fix](https://deploy-preview-46568--kubernetes-io-main-staging.netlify.app/docs/tutorials/stateless-application/expose-external-ip-address/)