### PR TITLE
[dev-1.31] Make cri-tools optional for kubeadm

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -297,10 +297,10 @@ DOWNLOAD_DIR="/usr/local/bin"
 sudo mkdir -p "$DOWNLOAD_DIR"
 ```
 
-Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI)):
+Optionally install crictl (required for interaction with the Container Runtime Interface (CRI), optional for kubeadm):
 
 ```bash
-CRICTL_VERSION="v1.28.0"
+CRICTL_VERSION="v1.31.0"
 ARCH="amd64"
 curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | sudo tar -C $DOWNLOAD_DIR -xz
 ```


### PR DESCRIPTION
Outline that kubeadm needs crictl only as optional dependency per https://github.com/kubernetes/kubeadm/issues/3064

cc @carlory @neolit123 