### PR TITLE
Modify `node-hello` image to `hello-app`

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/http-proxy-access-api.md
+++ b/content/en/docs/tasks/extend-kubernetes/http-proxy-access-api.md
@@ -17,7 +17,7 @@ If you do not already have an application running in your cluster, start
 a Hello world application by entering this command:
 
 ```shell
-kubectl create deployment node-hello --image=gcr.io/google-samples/node-hello:1.0 --port=8080
+kubectl create deployment hello-app --image=gcr.io/google-samples/hello-app:2.0 --port=8080
 ```
 
 <!-- steps -->

--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -243,7 +243,7 @@ spec:
     spec:
       containers:
       - name: patch-demo-ctr-3
-        image: gcr.io/google-samples/node-hello:1.0
+        image: gcr.io/google-samples/hello-app:2.0
 ```
 
 In your patch command, set `type` to `merge`:
@@ -264,7 +264,7 @@ The output shows that your list of one Container replaced the existing `containe
 ```yaml
 spec:
   containers:
-  - image: gcr.io/google-samples/node-hello:1.0
+  - image: gcr.io/google-samples/hello-app:2.0
     ...
     name: patch-demo-ctr-3
 ```

--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -156,7 +156,7 @@ external IP address.
    ```shell
    Hello, world!
    Version: 2.0.0
-   Hostname: hello-world-2895499144-2e5uh
+   Hostname: 0bd46b45f32f
    ```
 
 ## {{% heading "cleanup" %}}

--- a/content/en/examples/pods/inject/envars.yaml
+++ b/content/en/examples/pods/inject/envars.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: envar-demo-container
-    image: gcr.io/google-samples/node-hello:1.0
+    image: gcr.io/google-samples/hello-app:2.0
     env:
     - name: DEMO_GREETING
       value: "Hello from the environment"

--- a/content/en/examples/pods/security/security-context-2.yaml
+++ b/content/en/examples/pods/security/security-context-2.yaml
@@ -7,7 +7,7 @@ spec:
     runAsUser: 1000
   containers:
   - name: sec-ctx-demo-2
-    image: gcr.io/google-samples/node-hello:1.0
+    image: gcr.io/google-samples/hello-app:2.0
     securityContext:
       runAsUser: 2000
       allowPrivilegeEscalation: false

--- a/content/en/examples/pods/security/security-context-3.yaml
+++ b/content/en/examples/pods/security/security-context-3.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: sec-ctx-3
-    image: gcr.io/google-samples/node-hello:1.0
+    image: gcr.io/google-samples/hello-app:2.0

--- a/content/en/examples/pods/security/security-context-4.yaml
+++ b/content/en/examples/pods/security/security-context-4.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: sec-ctx-4
-    image: gcr.io/google-samples/node-hello:1.0
+    image: gcr.io/google-samples/hello-app:2.0
     securityContext:
       capabilities:
         add: ["NET_ADMIN", "SYS_TIME"]

--- a/content/en/examples/service/load-balancer-example.yaml
+++ b/content/en/examples/service/load-balancer-example.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: load-balancer-example
     spec:
       containers:
-      - image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0
+      - image: gcr.io/google-samples/hello-app:2.0
         name: hello-world
         ports:
         - containerPort: 8080


### PR DESCRIPTION
This pull request aims to fix the error raised by pulling the image `gcr.io/google-samples/node-hello:1.0` that says:
```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of gcr.io/google-samples/node-hello:1.0 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

The pull request modifies the image [node-hello](gcr.io/google-samples/node-hello@sha256:d238d0ab54efb76ec0f7b1da666cefa9b40be59ef34346a761b8adc2dd45459b) to [hello-app](gcr.io/google-samples/hello-app@sha256:7104356ed4e3476a96a23b96f8d7c04dfa7a1881aa97d66a76217f6bc8a370d0), so the error will be fixed.

Moreover, the tutorial in the other languages is revised.

The documentation is modified by the following groups:
+ **tutorial:** 
  1. stateless application -> exposing external IP address
+ **task:** 
  1. extend kubernetes
  2. manage kubernetes objects
+ **pod:**
  1. inject
  2. security
  3. service