### PR TITLE
Corrected the command for restoring an etcd snapshot 

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -345,7 +345,7 @@ either be a snapshot file from a previous backup operation, or from a remaining
 When restoring the cluster, use the `--data-dir` option to specify to which folder the cluster should be restored:
 
 ```shell
-etcdutl --data-dir <data-dir-location> snapshot restore snapshot.db
+etcdctl --data-dir <data-dir-location> snapshot restore snapshot.db
 ```
 where `<data-dir-location>` is a directory that will be created during the restore process.
 


### PR DESCRIPTION
This pull request addresses a correction in the Kubernetes documentation regarding the command used for restoring an etcd snapshot. The existing documentation incorrectly specifies the use of etcdutl for snapshot restoration. The correct tool to be used is etcdctl.

Change Details:
Incorrect Command:
etcdutl --data-dir <data-dir-location> snapshot restore snapshot.db

Correct Command:
etcdctl snapshot restore snapshot.db --data-dir=<data-dir-location>

Corrected the command for restoring an etcd snapshot from 'etcdutl' to 'etcdctl'

1. Replaced the incorrect command etcdutl --data-dir <data-dir-location> snapshot restore snapshot.db  with the correct etcdctl snapshot restore snapshot.db --data-dir=<data-dir-location>
2.  Ensures accurate and up-to-date instructions for users
3.  Enhances clarity and usability of the Kubernetes documentation

