### PR TITLE
[ja] Translate `content/en/docs/reference/glossary/cluster-infrastruc…

### DIFF
--- a/content/ja/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/ja/docs/reference/glossary/cluster-infrastructure.md
@@ -1,0 +1,13 @@
+---
+title: クラスターインフラストラクチャー
+id: cluster-infrastructure
+date: 2019-05-12
+full_link:
+short_description: >
+ インフラストラクチャーレイヤーは、VM、ネットワーキング、セキュリティグループなどを提供および維持します。
+
+aka:
+tags:
+- operation
+---
+ インフラストラクチャーレイヤーは、VM、ネットワーキング、セキュリティグループなどを提供および維持します。


### PR DESCRIPTION
Fixes #45116

This pull request is for the translation of https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/cluster-infrastructure.md.

Original page is https://kubernetes.io/ja/docs/reference/glossary/?all=true#term-cluster-infrastructure.