### PR TITLE
Update 2017 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2017-01-00-Fission-Serverless-Functions-As-Service-For-Kubernetes.md
+++ b/content/en/blog/_posts/2017-01-00-Fission-Serverless-Functions-As-Service-For-Kubernetes.md
@@ -3,9 +3,9 @@ title: " Fission: Serverless Functions as a Service for Kubernetes "
 date: 2017-01-30
 slug: fission-serverless-functions-as-service-for-kubernetes
 url: /blog/2017/01/Fission-Serverless-Functions-As-Service-For-Kubernetes
+author: >
+  Soam Vasani (Platform9 Systems)
 ---
-_Editor's note: Today’s post is by Soam Vasani, Software Engineer at Platform9 Systems, talking about a new open source Serverless Function (FaaS) framework for Kubernetes._&nbsp;  
-
 [Fission](https://github.com/fission/fission) is a Functions as a Service (FaaS) / Serverless function framework built on Kubernetes.  
 
 Fission allows you to easily create HTTP services on Kubernetes from functions. It works at the source level and abstracts away container images (in most cases). It also simplifies the Kubernetes learning curve, by enabling you to make useful services without knowing much about Kubernetes.  
@@ -127,6 +127,3 @@ Fission is open source and developed in the open by [Platform9 Systems](http://p
 - Connect with the community on [Slack](http://slack.k8s.io/)
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
 
-
-
-_--Soam Vasani, Software Engineer, Platform9 Systems_

--- a/content/en/blog/_posts/2017-01-00-How-We-Run-Kubernetes-In-Kubernetes-Kubeception.md
+++ b/content/en/blog/_posts/2017-01-00-How-We-Run-Kubernetes-In-Kubernetes-Kubeception.md
@@ -3,9 +3,10 @@ title: " How we run Kubernetes in Kubernetes aka Kubeception "
 date: 2017-01-20
 slug: how-we-run-kubernetes-in-kubernetes-kubeception
 url: /blog/2017/01/How-We-Run-Kubernetes-In-Kubernetes-Kubeception
+author: >
+  Hector Fernandez (Giant Swarm)
+  Puja Abbassi (Giant Swarm)
 ---
-_Editor's note: Today’s post is by the team at Giant Swarm, showing how they run Kubernetes in Kubernetes._  
-
 [Giant Swarm](https://giantswarm.io/)’s container infrastructure started out with the goal to be an easy way for developers to deploy containerized microservices. Our first generation was extensively using [fleet](https://github.com/coreos/fleet) as a base layer for our infrastructure components as well as for scheduling user containers.  
 
 In order to give our users a more powerful way to manage their containers we introduced Kubernetes into our stack in early 2016. However, as we needed a quick way to flexibly spin up and manage different users’ Kubernetes clusters resiliently we kept the underlying fleet layer.  
@@ -119,6 +120,3 @@ This setup is still in its early days and our roadmap is planning for improvemen
 
 Most importantly, we are working on making the inner Kubernetes clusters a third party resource that can then be managed by a custom controller. The result would be much like the [Operator concept by CoreOS](https://coreos.com/blog/introducing-operators.html). And to ensure that the community at large can benefit from this project we will be open sourcing this in the near future.
 
-
-
-_-- Hector Fernandez, Software Engineer & Puja Abbassi, Developer Advocate, Giant Swarm_

--- a/content/en/blog/_posts/2017-01-00-Kubernetes-Ux-Survey-Infographic.md
+++ b/content/en/blog/_posts/2017-01-00-Kubernetes-Ux-Survey-Infographic.md
@@ -3,9 +3,9 @@ title: " Kubernetes UX Survey Infographic "
 date: 2017-01-09
 slug: kubernetes-ux-survey-infographic
 url: /blog/2017/01/Kubernetes-Ux-Survey-Infographic
+author: >
+  Dan Romlein (UX Designer)
 ---
-_Editor's note: Today’s post is by Dan Romlein, UX Designer at Apprenda and member of the SIG-UI, sharing UX survey results from the Kubernetes community.&nbsp;_  
-
 The following infographic summarizes the findings of a survey that the team behind [Dashboard](https://github.com/kubernetes/dashboard), the official web UI for Kubernetes, sent during KubeCon in November 2016. Following the KubeCon launch of the survey, it was promoted on Twitter and various Slack channels over a two week period and generated over 100 responses. We’re delighted with the data it provides us to now make feature and roadmap decisions more in-line with the needs of you, our users.  
 
 **Satisfaction with Dashboard**  

--- a/content/en/blog/_posts/2017-01-00-Running-Mongodb-On-Kubernetes-With-Statefulsets.md
+++ b/content/en/blog/_posts/2017-01-00-Running-Mongodb-On-Kubernetes-With-Statefulsets.md
@@ -3,8 +3,9 @@ title: " Running MongoDB on Kubernetes with StatefulSets "
 date: 2017-01-30
 slug: running-mongodb-on-kubernetes-with-statefulsets
 url: /blog/2017/01/Running-Mongodb-On-Kubernetes-With-Statefulsets
+author: >
+  Sandeep Dinesh (Google Cloud Platform)
 ---
-_Editor's note: Today’s post is by Sandeep Dinesh, Developer Advocate, Google Cloud Platform, showing how to run a database in a container._
 
 {{% warning %}}
 This post is several years old. The code examples need changes to work on a current Kubernetes cluster.
@@ -260,4 +261,3 @@ Happy Hacking!
 
 For more cool Kubernetes and Container blog posts, follow me on [Twitter](https://twitter.com/sandeepdinesh) and [Medium](https://medium.com/@SandeepDinesh).
 
-_--Sandeep Dinesh, Developer Advocate, Google Cloud Platform._

--- a/content/en/blog/_posts/2017-01-00-Scaling-Kubernetes-Deployments-With-Policy-Base-Networking.md
+++ b/content/en/blog/_posts/2017-01-00-Scaling-Kubernetes-Deployments-With-Policy-Base-Networking.md
@@ -3,9 +3,9 @@ title: " Scaling Kubernetes deployments with Policy-Based Networking "
 date: 2017-01-19
 slug: scaling-kubernetes-deployments-with-policy-base-networking
 url: /blog/2017/01/Scaling-Kubernetes-Deployments-With-Policy-Base-Networking
+author: >
+  Harmeet Sahni (Nuage Networks)
 ---
-_Editor's note: Today’s post is by Harmeet Sahni, Director of Product Management, at Nuage Networks, writing about their contributions to Kubernetes and insights on policy-based networking. &nbsp;_  
-
 Although it’s just been eighteen-months since Kubernetes 1.0 was released, we’ve seen Kubernetes emerge as the leading container orchestration platform for deploying distributed applications. One of the biggest reasons for this is the vibrant open source community that has developed around it. The large number of Kubernetes contributors come from diverse backgrounds means we, and the community of users, are assured that we are investing in an open platform. Companies like Google (Container Engine), Red Hat (OpenShift), and CoreOS (Tectonic) are developing their own commercial offerings based on Kubernetes. This is a good thing since it will lead to more standardization and offer choice to the users.&nbsp;  
 
 **Networking requirements for Kubernetes applications**  
@@ -54,5 +54,3 @@ Being able to monitor the traffic flowing between Kubernetes Pods is very useful
 
 Even though we started working on our integration with Kubernetes over a year ago, it feels we are just getting started. We have always felt that this is a truly open community and we want to be an integral part of it. You can find out more about our Kubernetes integration on our [GitHub page](https://github.com/nuagenetworks/nuage-kubernetes).  
 
-
-_--Harmeet Sahni, Director of Product Management, Nuage Networks_  

--- a/content/en/blog/_posts/2017-01-00-Stronger-Foundation-For-Creating-And-Managing-Kubernetes-Clusters.md
+++ b/content/en/blog/_posts/2017-01-00-Stronger-Foundation-For-Creating-And-Managing-Kubernetes-Clusters.md
@@ -3,9 +3,9 @@ title: " A Stronger Foundation for Creating and Managing Kubernetes Clusters "
 date: 2017-01-12
 slug: stronger-foundation-for-creating-and-managing-kubernetes-clusters
 url: /blog/2017/01/Stronger-Foundation-For-Creating-And-Managing-Kubernetes-Clusters
+author: >
+   [Lucas Käldström](https://twitter.com/kubernetesonarm) (independent)
 ---
-_Editor's note: Today’s post is by Lucas Käldström an independent Kubernetes maintainer and SIG-Cluster-Lifecycle member, sharing what the group has been building and what’s upcoming.&nbsp;_  
-
 Last time you heard from us was in September, when we announced [kubeadm](https://kubernetes.io/blog/2016/09/how-we-made-kubernetes-easy-to-install). The work on making kubeadm a first-class citizen in the Kubernetes ecosystem has continued and evolved. Some of us also met before KubeCon and had a very productive meeting where we talked about what the scopes for our SIG, kubeadm, and kops are.&nbsp;  
 
 **Continuing to Define SIG-Cluster-Lifecycle**  
@@ -100,6 +100,3 @@ In short, we're excited on the roadmap ahead in bringing a lot of these improvem
 
 Thank you for all the feedback and contributions. I hope this has given you some insight in what we’re doing and encouraged&nbsp;you to join us at our meetings to say hi!
 
-
-
-_-- [Lucas Käldström](https://twitter.com/kubernetesonarm), Independent Kubernetes maintainer and SIG-Cluster-Lifecycle member_

--- a/content/en/blog/_posts/2017-02-00-Caas-The-Foundation-For-Next-Gen-Paas.md
+++ b/content/en/blog/_posts/2017-02-00-Caas-The-Foundation-For-Next-Gen-Paas.md
@@ -3,12 +3,9 @@ title: " Containers as a Service, the foundation for next generation PaaS "
 date: 2017-02-21
 slug: caas-the-foundation-for-next-gen-paas
 url: /blog/2017/02/Caas-The-Foundation-For-Next-Gen-Paas
+author: >
+  [Brendan Burns](https://twitter.com/brendandburns) (Microsoft)
 ---
-
-_Today’s post is by Brendan Burns, Partner Architect, at Microsoft & Kubernetes co-founder._  
-
-
-
 Containers are revolutionizing the way that people build, package and deploy software. But what is often overlooked is how they are revolutionizing the way that people build the software that builds, packages and deploys software. (it’s ok if you have to read that sentence twice…) Today, and in a talk at [Container World](https://tmt.knect365.com/container-world/) tomorrow, I’m taking a look at how container orchestrators like Kubernetes form the foundation for next generation platform as a service (PaaS). In particular, I’m interested in how cloud container as a service (CaaS) platforms like [Azure Container Service](https://azure.microsoft.com/en-us/services/container-service/), [Google Container Engine](https://cloud.google.com/container-engine/) and [others](/docs/getting-started-guides/#hosted-solutions) are becoming the new infrastructure layer that PaaS is built upon.  
 
 To see this, it’s important to consider the set of services that have traditionally been provided by PaaS platforms:  
@@ -33,13 +30,6 @@ Kubernetes is infrastructure for next generation applications, PaaS and more. Gi
 Furthermore, because we know that the world of PaaS and software development in general is a hybrid one, we’re excited to announce the preview availability of [Windows clusters in Azure Container Service](https://learn.microsoft.com/en-us/azure/container-service/container-service-kubernetes-walkthrough). We’re also working on [hybrid clusters](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/windows.md) in [ACS-Engine](https://github.com/Azure/acs-engine) and expect to roll those out to general availability in the coming months.  
 
 I’m thrilled to see how containers and container as a service is changing the world of compute, I’m confident that we’re only scratching the surface of the transformation we’ll see in the coming months and years.  
-
-
-
-
-
-_--[Brendan Burns](https://twitter.com/brendandburns), Partner Architect, at Microsoft and co-founder of Kubernetes_
-
 
 
 

--- a/content/en/blog/_posts/2017-02-00-Highly-Available-Kubernetes-Clusters.md
+++ b/content/en/blog/_posts/2017-02-00-Highly-Available-Kubernetes-Clusters.md
@@ -3,6 +3,8 @@ title: " Highly Available Kubernetes Clusters "
 date: 2017-02-02
 slug: highly-available-kubernetes-clusters
 url: /blog/2017/02/Highly-Available-Kubernetes-Clusters
+author: >
+  Jerzy Szczepkowski (Google) 
 ---
 
 Today’s post shows how to set-up a reliable, highly available distributed Kubernetes cluster. The support for running such clusters on Google Compute Engine (GCE) was added as an alpha feature in [Kubernetes 1.5 release](https://kubernetes.io/blog/2016/12/kubernetes-1-5-supporting-production-workloads/).
@@ -325,6 +327,3 @@ We have shown how, by adding worker node pools and master replicas, a Highly Ava
 - Connect with the community on [Slack](http://slack.k8s.io/)
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
 
-
-
-_--Jerzy Szczepkowski, Software Engineer, Google_

--- a/content/en/blog/_posts/2017-02-00-Postgresql-Clusters-Kubernetes-Statefulsets.md
+++ b/content/en/blog/_posts/2017-02-00-Postgresql-Clusters-Kubernetes-Statefulsets.md
@@ -3,6 +3,8 @@ title: " Deploying PostgreSQL Clusters using StatefulSets "
 date: 2017-02-24
 slug: postgresql-clusters-kubernetes-statefulsets
 url: /blog/2017/02/Postgresql-Clusters-Kubernetes-Statefulsets
+author: >
+  Jeff McCormick ([Crunchy Data](http://crunchydata.com/))
 ---
 _Editor’s note: Today’s guest post is by Jeff McCormick, a developer at Crunchy Data, showing how to build a PostgreSQL cluster using the new Kubernetes StatefulSet feature._  
 
@@ -306,7 +308,3 @@ The container is designed to create a subdirectory on that path using the pod ho
 StatefulSets is an exciting feature added to Kubernetes for container builders that are implementing clustering. The ordinal values assigned to the set provide a very simple mechanism to make clustering decisions when deploying a PostgreSQL cluster.  
 
 
-
-
-
-_--Jeff McCormick, Developer, [Crunchy Data](http://crunchydata.com/)_

--- a/content/en/blog/_posts/2017-02-00-Run-Deep-Learning-With-Paddlepaddle-On-Kubernetes.md
+++ b/content/en/blog/_posts/2017-02-00-Run-Deep-Learning-With-Paddlepaddle-On-Kubernetes.md
@@ -3,11 +3,10 @@ title: " Run Deep Learning with PaddlePaddle on Kubernetes "
 date: 2017-02-08
 slug: run-deep-learning-with-paddlepaddle-on-kubernetes
 url: /blog/2017/02/Run-Deep-Learning-With-Paddlepaddle-On-Kubernetes
+author: >
+  Yi Wang ([Baidu Research](http://research.baidu.com/)),
+  Xiang Li ([CoreOS](https://coreos.com/))
 ---
-
-_Editor's note: Today's post is a joint post from the deep learning team at Baidu and the etcd team at CoreOS._  
-
-
 
 **[![](https://3.bp.blogspot.com/-Mwn3FU9hffI/WJk8QBxA6SI/AAAAAAAAA8w/AS5QoMdPTN8bL9jnixlsCXzj1IfYerhRQCLcB/s200/baidu_research_logo_rgb.png)](https://3.bp.blogspot.com/-Mwn3FU9hffI/WJk8QBxA6SI/AAAAAAAAA8w/AS5QoMdPTN8bL9jnixlsCXzj1IfYerhRQCLcB/s1600/baidu_research_logo_rgb.png)**
 
@@ -158,9 +157,6 @@ To solve the problems mentioned above, we will add a PaddlePaddle master that un
 Another potential improvement is better PaddlePaddle job configuration. Our experience of having the same number of trainers and parameter servers was mostly collected from using special-purpose clusters. That strategy was observed performant on our clients' clusters that run only PaddlePaddle jobs. However, this strategy might not be optimal on general-purpose clusters that run many kinds of jobs.  
 
 PaddlePaddle trainers can utilize multiple GPUs to accelerate computations. GPU is not a first class resource in Kubernetes yet. We have to manage GPUs semi-manually. We would love to work with Kubernetes community to improve GPU support to ensure PaddlePaddle runs the best on Kubernetes.   
-
-_--Yi Wang, [Baidu Research](http://research.baidu.com/) and Xiang Li, [CoreOS](https://coreos.com/)_   
-
 
 
 - [Download](http://get.k8s.io/) Kubernetes

--- a/content/en/blog/_posts/2017-03-00-Advanced-Scheduling-In-Kubernetes.md
+++ b/content/en/blog/_posts/2017-03-00-Advanced-Scheduling-In-Kubernetes.md
@@ -3,6 +3,9 @@ title: " Advanced Scheduling in Kubernetes "
 date: 2017-03-31
 slug: advanced-scheduling-in-kubernetes
 url: /blog/2017/03/Advanced-Scheduling-In-Kubernetes
+author: >
+  Ian Lewis (Google),
+  David Oppenheimer (Google)
 ---
 _Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6) on what's new in Kubernetes 1.6_
 
@@ -227,6 +230,3 @@ Share your voice at our weekly [community meeting](https://github.com/kubernetes
 
 Many thanks for your contributions.
 
-
-
-_--Ian Lewis, Developer Advocate, and David Oppenheimer, Software Engineer, Google_

--- a/content/en/blog/_posts/2017-03-00-Dynamic-Provisioning-And-Storage-Classes-Kubernetes.md
+++ b/content/en/blog/_posts/2017-03-00-Dynamic-Provisioning-And-Storage-Classes-Kubernetes.md
@@ -3,6 +3,10 @@ title: " Dynamic Provisioning and Storage Classes in Kubernetes "
 date: 2017-03-29
 slug: dynamic-provisioning-and-storage-classes-kubernetes
 url: /blog/2017/03/Dynamic-Provisioning-And-Storage-Classes-Kubernetes
+author: >
+  Saad Ali (Google),
+  Michelle Au (Google),
+  Matthew De Lio (Google)  
 ---
 
 _Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6) on what's new in Kubernetes 1.6_
@@ -202,8 +206,6 @@ Yes, you can assign a StorageClass to an existing PV by editing the appropriate 
 
 **What happens if I delete a PersistentVolumeClaim (PVC)?**  
 If the volume was dynamically provisioned, then the default reclaim policy is set to “delete”. This means that, by default, when the PVC is deleted, the underlying PV and storage asset will also be deleted. If you want to retain the data stored on the volume, then you must change the reclaim policy from “delete” to “retain” after the PV is provisioned.  
-
-_--Saad Ali & Michelle Au, Software Engineers, and Matthew De Lio, Product Manager, Google_  
 
 
 - Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)

--- a/content/en/blog/_posts/2017-03-00-K8Sport-Engaging-The-Kubernetes-Community.md
+++ b/content/en/blog/_posts/2017-03-00-K8Sport-Engaging-The-Kubernetes-Community.md
@@ -3,8 +3,9 @@ title: " The K8sPort: Engaging Kubernetes Community One Activity at a Time "
 date: 2017-03-24
 slug: k8sport-engaging-the-kubernetes-community
 url: /blog/2017/03/K8Sport-Engaging-The-Kubernetes-Community
+author: >
+   Ryan Quackenbush (Apprenda) 
 ---
-_Editor's note: Today’s post is by Ryan Quackenbush, Advocacy Programs Manager at Apprenda, showing a new community portal for Kubernetes advocates: the K8sPort._   
 
 The [**K8sPort**](http://k8sport.org/) is a hub designed to help you, the Kubernetes community, earn credit for the hard work you’re putting forth in making this one of the most successful open source projects ever. Back at KubeCon Seattle in November, I [presented](https://youtu.be/LwViH5eLoOI) a lightning talk of a preview of K8sPort.   
 
@@ -43,9 +44,3 @@ If you’re interested in joining the advocacy hub, please join us at [k8sport.o
 
 For a quick walkthrough on K8sPort authentication and the hub itself, see this quick demo, below.
 
-
-
-
-
-
-_--Ryan Quackenbush, Advocacy Programs Manager, Apprenda_

--- a/content/en/blog/_posts/2017-03-00-Kubernetes-1-6-Multi-User-Multi-Workloads-At-Scale.md
+++ b/content/en/blog/_posts/2017-03-00-Kubernetes-1-6-Multi-User-Multi-Workloads-At-Scale.md
@@ -3,8 +3,12 @@ title: " Kubernetes 1.6: Multi-user, Multi-workloads at Scale "
 date: 2017-03-28
 slug: kubernetes-1.6-multi-user-multi-workloads-at-scale
 url: /blog/2017/03/Kubernetes-1-6-Multi-User-Multi-Workloads-At-Scale
+author: >
+  Aparna Sinha (Google)
 ---
-Today we’re announcing the release of Kubernetes 1.6.  
+_This article is by Aparna Sinha on behalf of the Kubernetes 1.6 release team._
+
+Today we’re announcing the release of Kubernetes 1.6. 
 
 In this release the community’s focus is on scale and automation, to help you deploy multiple workloads to multiple users on a cluster. We are announcing that 5,000 node clusters are supported. We moved dynamic storage provisioning to _stable_. Role-based access control ([RBAC](/docs/reference/access-authn-authz/rbac/)), [kubefed](/docs/tutorials/federation/set-up-cluster-federation-kubefed/), [kubeadm](/docs/getting-started-guides/kubeadm/), and several scheduling features are moving to _beta_. We have also added intelligent defaults throughout to enable greater automation out of the box.  
 
@@ -105,8 +109,5 @@ Share your voice at our weekly [community meeting](https://github.com/kubernetes
 
 Many thanks for your contributions and advocacy!
 
-
-
-_-- Aparna Sinha, Senior Product Manager,&nbsp;Kubernetes, Google_  
 
 _**PS: read this [series of in-depth articles](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6) on what's new in Kubernetes 1.6**_

--- a/content/en/blog/_posts/2017-03-00-Scalability-Updates-In-Kubernetes-1-6.md
+++ b/content/en/blog/_posts/2017-03-00-Scalability-Updates-In-Kubernetes-1-6.md
@@ -3,6 +3,8 @@ title: " Scalability updates in Kubernetes 1.6: 5,000 node and 150,000 pod clust
 date: 2017-03-30
 slug: scalability-updates-in-kubernetes-1.6
 url: /blog/2017/03/Scalability-Updates-In-Kubernetes-1-6
+author: >
+   Wojciech Tyczynski (Google)  
 ---
 _Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6) on what's new in Kubernetes 1.6_
 
@@ -79,10 +81,6 @@ If you are interested in scalability and performance, please join our community 
 - Chat with us in the Kubernetes Slack [scalability channel](https://kubernetes.slack.com/messages/sig-scale/):&nbsp;
 - Join our Special Interest Group, [SIG-Scalability](https://github.com/kubernetes/community/blob/master/sig-scalability/README.md), which meets every Thursday at 9:00 AM PST
 Thanks for the support and contributions! Read more in-depth posts on what's new in Kubernetes 1.6 [here](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6).
-
-_-- Wojciech Tyczynski, Software Engineer, Google_  
-
-
 
 
 [1] We are investigating why 5000-node clusters have better startup time than 2000-node clusters. The current theory is that it is related to running 5000-node experiments using 64-core master and 2000-node experiments using 32-core master.  

--- a/content/en/blog/_posts/2017-04-00-Configuring-Private-Dns-Zones-Upstream-Nameservers-Kubernetes.md
+++ b/content/en/blog/_posts/2017-04-00-Configuring-Private-Dns-Zones-Upstream-Nameservers-Kubernetes.md
@@ -3,6 +3,9 @@ title: " Configuring Private DNS Zones and Upstream Nameservers in Kubernetes "
 date: 2017-04-04
 slug: configuring-private-dns-zones-upstream-nameservers-kubernetes
 url: /blog/2017/04/Configuring-Private-Dns-Zones-Upstream-Nameservers-Kubernetes
+author: >
+   Bowei Du (Google),
+   Matthew DeLio (Google) 
 ---
 _Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6) on what's new in Kubernetes 1.6_
 
@@ -136,13 +139,6 @@ If you’d like to contribute or simply help provide feedback and drive the road
 - Chat with us on the Kubernetes [Slack network channel](https://kubernetes.slack.com/messages/sig-network/)
 - Join our Special Interest Group, [SIG-Network](https://github.com/kubernetes/community/wiki/SIG-Network), which meets on Tuesdays at 14:00 PT
 Thanks for your support and contributions. Read more in-depth posts on what's new in Kubernetes 1.6 [here](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6).
-
-
-
-
-
-_--Bowei Du, Software Engineer and Matthew DeLio, Product Manager, Google_  
-
 
 
 - Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)

--- a/content/en/blog/_posts/2017-04-00-Multi-Stage-Canary-Deployments-With-Kubernetes-In-The-Cloud-Onprem.md
+++ b/content/en/blog/_posts/2017-04-00-Multi-Stage-Canary-Deployments-With-Kubernetes-In-The-Cloud-Onprem.md
@@ -3,9 +3,9 @@ title: " How Bitmovin is Doing Multi-Stage Canary Deployments with Kubernetes in
 date: 2017-04-21
 slug: multi-stage-canary-deployments-with-kubernetes-in-the-cloud-onprem
 url: /blog/2017/04/Multi-Stage-Canary-Deployments-With-Kubernetes-In-The-Cloud-Onprem
+author: >
+  Daniel Hoelbling-Inzko (Bitmovin)
 ---
-_Editor's Note: Today’s post is by Daniel Hoelbling-Inzko, Infrastructure Architect at Bitmovin, a company that provides services that transcode digital video and audio to streaming formats, sharing insights about their use of Kubernetes._  
-
 Running a large scale video encoding infrastructure on multiple public clouds is tough. At [Bitmovin](http://bitmovin.com/), we have been doing it successfully for the last few years, but from an engineering perspective, it’s neither been enjoyable nor particularly fun.   
 
 So obviously, one of the main things that really sold us on using Kubernetes, was it’s common abstraction from the different supported cloud providers and the well thought out programming interface it provides. More importantly, the Kubernetes project did not settle for the lowest common denominator approach. Instead, they added the necessary abstract concepts that are required and useful to run containerized workloads in a cloud and then did all the hard work to map these concepts to the different cloud providers and their offerings.  
@@ -204,11 +204,6 @@ To summarize this post - by migrating our infrastructure to Kubernetes, Bitmovin
 
 
 We want to thank the Kubernetes community for the incredible job they have done with the project. The velocity at which the project moves is just breathtaking! Maintaining such a high level of quality and robustness in such a diverse environment is really astonishing.
-
-
-
-_--Daniel Hoelbling-Inzko, Infrastructure Architect, Bitmovin_
-
 
 
 - Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)

--- a/content/en/blog/_posts/2017-04-00-Rbac-Support-In-Kubernetes.md
+++ b/content/en/blog/_posts/2017-04-00-Rbac-Support-In-Kubernetes.md
@@ -3,6 +3,10 @@ title: " RBAC Support in Kubernetes "
 date: 2017-04-06
 slug: rbac-support-in-kubernetes
 url: /blog/2017/04/Rbac-Support-In-Kubernetes
+author: >
+  Jacob Simpson (Google),
+  Greg Castle (Google),
+  CJ Cullen (Google)
 ---
 _Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6) on what's new in Kubernetes 1.6_
 
@@ -113,14 +117,6 @@ If you’d like to contribute or simply help provide feedback and drive the road
 - Join the biweekly [SIG-Auth meetings](https://github.com/kubernetes/community/blob/master/sig-auth/README.md) on Wednesday at 11:00 AM PT
 
 Thanks for your support and contributions. Read more in-depth posts on what's new in Kubernetes 1.6 [here](https://kubernetes.io/blog/2017/03/five-days-of-kubernetes-1-6).
-
-
-
-
-
-_-- Jacob Simpson, Greg Castle & CJ Cullen, Software Engineers at Google_
-
-
 
 
 

--- a/content/en/blog/_posts/2017-05-00-Draft-Kubernetes-Container-Development.md
+++ b/content/en/blog/_posts/2017-05-00-Draft-Kubernetes-Container-Development.md
@@ -3,9 +3,9 @@ title: " Draft: Kubernetes container development made easy "
 date: 2017-05-31
 slug: draft-kubernetes-container-development
 url: /blog/2017/05/Draft-Kubernetes-Container-Development
+author: >
+  Brendan Burns (Microsoft Azure)
 ---
-_Today's post is by __Brendan Burns, Director of Engineering at Microsoft Azure and Kubernetes co-founder._  
-
 About a month ago Microsoft announced the acquisition of Deis to expand our expertise in containers and Kubernetes. Today, I’m excited to announce a new open source project derived from this newly expanded Azure team: Draft.   
 
 While by now the strengths of Kubernetes for deploying and managing applications at scale are well understood. The process of developing a new application for Kubernetes is still too hard. It’s harder still if you are new to containers, Kubernetes, or developing cloud applications.  
@@ -180,15 +180,6 @@ The push refers to a repository [docker.io/microsoft/tufted-lamb]
 Now when we run curl http://$SERVICE\_IP, our first app has been deployed and updated to our Kubernetes cluster via Draft!
 
 We hope this gives you a sense for everything that Draft can do to streamline development for Kubernetes. Happy drafting!
-
-
-
-_--Brendan Burns, Director of Engineering, Microsoft Azure_
-
-
-
-
-
 
 
 - Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)

--- a/content/en/blog/_posts/2017-05-00-Kubernetes-Monitoring-Guide.md
+++ b/content/en/blog/_posts/2017-05-00-Kubernetes-Monitoring-Guide.md
@@ -3,10 +3,9 @@ title: " Kubernetes: a monitoring guide "
 date: 2017-05-19
 slug: kubernetes-monitoring-guide
 url: /blog/2017/05/Kubernetes-Monitoring-Guide
+author: >
+  Jean-Mathieu Saponaro (Datadog)
 ---
-_Today’s post is by Jean-Mathieu Saponaro, Research & Analytics Engineer at Datadog, discussing what Kubernetes changes for monitoring, and how you can prepare to properly monitor a containerized infrastructure orchestrated by Kubernetes._  
-
-
 Container technologies are taking the infrastructure world by storm. While containers solve or simplify infrastructure management processes, they also introduce significant complexity in terms of orchestration. That’s where Kubernetes comes to our rescue. Just like a conductor directs an orchestra, [Kubernetes](/docs/concepts/overview/what-is-kubernetes/) oversees our ensemble of containers—starting, stopping, creating, and destroying them automatically to keep our applications humming along.  
 
 Kubernetes makes managing a containerized infrastructure much easier by creating levels of abstractions such as [pods](/docs/concepts/workloads/pods/pod/) and [services](/docs/concepts/services-networking/service/). We no longer have to worry about where applications are running or if they have enough resources to work properly. But that doesn’t change the fact that, in order to ensure good performance, we need to monitor our applications, the containers running them, and Kubernetes itself.  
@@ -71,11 +70,6 @@ Whether you want to track these key performance metrics by combining Heapster, a
 Using Kubernetes drastically simplifies container management. But it requires us to rethink our monitoring strategies on several fronts, and to make sure all the key metrics from the different components are properly collected, aggregated, and tracked. We hope our monitoring guide will help you to effectively monitor your Kubernetes clusters. [Feedback and suggestions](https://github.com/DataDog/the-monitor) are more than welcome.
 
 &nbsp;
-
-
-
-_--Jean-Mathieu Saponaro, Research & Analytics Engineer, Datadog_
-
 
 
 - Get involved with the Kubernetes project on [GitHub](https://github.com/kubernetes/kubernetes)&nbsp;

--- a/content/en/blog/_posts/2017-05-00-Kubernetes-Security-Process-Explained.md
+++ b/content/en/blog/_posts/2017-05-00-Kubernetes-Security-Process-Explained.md
@@ -3,10 +3,10 @@ title: " Dancing at the Lip of a Volcano: The Kubernetes Security Process - Expl
 date: 2017-05-18
 slug: kubernetes-security-process-explained
 url: /blog/2017/05/Kubernetes-Security-Process-Explained
+author: >
+  Brandon Philips (CoreOS),
+  Jess Frazelle (Google)
 ---
-_Editor's note: Today’s post is by&nbsp; __Jess Frazelle of Google and Brandon Philips of CoreOS about the Kubernetes security disclosures and response policy.__ &nbsp;_  
-
-
 Software running on servers underpins ever growing amounts of the world's commerce, communications, and physical infrastructure. And nearly all of these systems are connected to the internet; which means vital security updates must be applied rapidly. As software developers and IT professionals, we often find ourselves dancing on the edge of a volcano: we may either fall into magma induced oblivion from a security vulnerability exploited before we can fix it, or we may slide off the side of the mountain because of an inadequate process to address security vulnerabilities.&nbsp;  
 
 The Kubernetes community believes that we can help teams restore their footing on this volcano with a foundation built on Kubernetes. And the bedrock of this foundation requires a process for quickly acknowledging, patching, and releasing security updates to an ever growing community of Kubernetes users.&nbsp;  
@@ -26,10 +26,7 @@ As we [continue to harden Kubernetes](https://lwn.net/Articles/720215/), the sec
 
 As a thank you to the Kubernetes community, a special 25 percent discount to CoreOS Fest is available using k8s25code&nbsp;or via this special [25 percent off link](https://coreosfest17.eventbrite.com/?discount=k8s25code) to register today for CoreOS Fest 2017.&nbsp;  
 
-_--Brandon Philips of CoreOS and Jess Frazelle of Google_  
-
-
-
+  
 - Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
 - Join the community portal for advocates on [K8sPort](http://k8sport.org/)
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates

--- a/content/en/blog/_posts/2017-05-00-Kubespray-Ansible-Collaborative-Kubernetes-Ops.md
+++ b/content/en/blog/_posts/2017-05-00-Kubespray-Ansible-Collaborative-Kubernetes-Ops.md
@@ -3,8 +3,9 @@ title: " Kubespray Ansible Playbooks foster Collaborative Kubernetes Ops "
 date: 2017-05-19
 slug: kubespray-ansible-collaborative-kubernetes-ops
 url: /blog/2017/05/Kubespray-Ansible-Collaborative-Kubernetes-Ops
+author: >
+   Rob Hirschfeld (RackN)
 ---
-_Today’s guest post is by Rob Hirschfeld, co-founder of open infrastructure automation project, Digital Rebar and co-chair of the SIG Cluster Ops. &nbsp;_  
 
 **Why Kubespray?**  
 
@@ -105,11 +106,6 @@ I am excited to see and be part of the community progress towards enterprise-rea
 With Kubespray and Digital Rebar as a repeatable base, extensions get much faster and easier. Even better, using upstream directly allows improvements to be quickly cycled back into upstream. That means we’re closer to building a community focused on the operational side of Kubernetes with an [SRE mindset](https://rackn.com/sre).  
 
 If this is interesting, please engage with us in the [Cluster Ops SIG](https://github.com/kubernetes/community/tree/master/sig-cluster-ops), [Kubespray](https://github.com/kubernetes-incubator/kubespray)&nbsp;or [Digital Rebar](http://rebar.digital/) communities.&nbsp;  
-
-
-_-- Rob Hirschfeld, co-founder of RackN and co-chair of the Cluster Ops SIG_
-
-
 
 
 

--- a/content/en/blog/_posts/2017-06-00-Kubernetes-1-7-Security-Hardening-Stateful-Application-Extensibility-Updates.md
+++ b/content/en/blog/_posts/2017-06-00-Kubernetes-1-7-Security-Hardening-Stateful-Application-Extensibility-Updates.md
@@ -3,8 +3,13 @@ title: " Kubernetes 1.7: Security Hardening, Stateful Application Updates and Ex
 date: 2017-06-30
 slug: kubernetes-1.7-security-hardening-stateful-application-extensibility-updates
 url: /blog/2017/06/Kubernetes-1-7-Security-Hardening-Stateful-Application-Extensibility-Updates
+author: >
+   Aparna Sinha (Google),
+   Ihor Dvoretskyi (Mirantis)
 ---
-Today we’re announcing Kubernetes 1.7, a milestone release that adds security, storage and extensibility features motivated by widespread production use of Kubernetes in the most demanding enterprise environments.&nbsp;  
+_This article is by Aparna Sinha and Ihor Dvoretskyi, on behalf of the Kubernetes 1.7 release team._
+
+Today we’re announcing Kubernetes 1.7, a milestone release that adds security, storage and extensibility features motivated by widespread production use of Kubernetes in the most demanding enterprise environments.
 
 At-a-glance, security enhancements in this release include encrypted secrets, network policy for pod-to-pod communication, node authorizer to limit kubelet access and client / server TLS certificate rotation.&nbsp;  
 
@@ -77,5 +82,3 @@ The simplest way to get involved is joining one of the many [Special Interest Gr
 
 Many thanks to our vast community of contributors and supporters in making this and all releases possible.  
 
-
-_-- Aparna Sinha, Group Product Manager, Kubernetes Google and Ihor Dvoretskyi, Program Manager, Kubernetes Mirantis_  

--- a/content/en/blog/_posts/2017-07-00-How-Watson-Health-Cloud-Deploys.md
+++ b/content/en/blog/_posts/2017-07-00-How-Watson-Health-Cloud-Deploys.md
@@ -3,6 +3,8 @@ title: " How Watson Health Cloud Deploys Applications with Kubernetes "
 date: 2017-07-14
 slug: how-watson-health-cloud-deploys
 url: /blog/2017/07/How-Watson-Health-Cloud-Deploys
+author: >
+   Sandhya Kapoor (IBM)
 ---
 Today’s post is by [Sandhya Kapoor](https://www.linkedin.com/in/sandhyakapoor/), Senior Technologist, Watson Platform for Health, IBM
 
@@ -139,11 +141,6 @@ Exposing services with Ingress:
 
 
 To expose our services to outside the cluster, we used Ingress. In IBM Cloud Kubernetes Service, if we create a paid cluster, an Ingress controller is automatically installed for us to use. We were able to access services through Ingress by creating a YAML resource file that specifies the service path.
-
-
-
-–Sandhya Kapoor, Senior Technologist, Watson Platform for Health, IBM
-
 
 
 - Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)

--- a/content/en/blog/_posts/2017-08-00-High-Performance-Networking-With-Ec2.md
+++ b/content/en/blog/_posts/2017-08-00-High-Performance-Networking-With-Ec2.md
@@ -3,6 +3,9 @@ title: " High Performance Networking with EC2 Virtual Private Clouds "
 date: 2017-08-11
 slug: high-performance-networking-with-ec2
 url: /blog/2017/08/High-Performance-Networking-With-Ec2
+author: >
+  Juergen Brendel (Pani Networks)
+  Chris Marino (Pani Networks)
 ---
 
 
@@ -71,7 +74,3 @@ When using Romana v2.0, native VPC networking is now available for clusters of a
 
 
 ![](https://archive.org/download/hpc-ec2-vpc-2/hpc-ec2-vpc-2.png)
-
-
-
--- _Juergen Brendel and Chris Marino, co-founders of Pani Networks, sponsor of the Romana project_

--- a/content/en/blog/_posts/2017-08-00-Kompose-Helps-Developers-Move-Docker.md
+++ b/content/en/blog/_posts/2017-08-00-Kompose-Helps-Developers-Move-Docker.md
@@ -3,8 +3,9 @@ title: " Kompose Helps Developers Move Docker Compose Files to Kubernetes "
 date: 2017-08-10
 slug: kompose-helps-developers-move-docker
 url: /blog/2017/08/Kompose-Helps-Developers-Move-Docker
+author: >
+  Charlie Drage (Red Hat)
 ---
-_Editor's note: today's post is by Charlie Drage, Software Engineer at Red Hat giving an update about the Kubernetes project Kompose._  
 
 I'm pleased to announce that [Kompose](https://github.com/kubernetes/kompose), a conversion tool for developers to transition Docker Compose applications to Kubernetes, has graduated from the [Kubernetes Incubator](https://github.com/kubernetes/community/blob/master/incubator.md) to become an official part of the project.   
 
@@ -145,10 +146,6 @@ As we continue development, we will strive to convert as many Docker Compose key
 - [Kompose Quick Start Guide](https://github.com/kubernetes/kompose/blob/master/docs/installation.md)
 - [Kompose Web Site](http://kompose.io/)
 - [Kompose Documentation](https://github.com/kubernetes/kompose/tree/master/docs)
-
-
-
---Charlie Drage, Software Engineer, Red Hat
 
 
 - Post questions (or answer questions) on[Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)

--- a/content/en/blog/_posts/2017-08-00-Kubernetes-Meets-High-Performance.md
+++ b/content/en/blog/_posts/2017-08-00-Kubernetes-Meets-High-Performance.md
@@ -3,8 +3,9 @@ title: " Kubernetes Meets High-Performance Computing "
 date: 2017-08-22
 slug: kubernetes-meets-high-performance
 url: /blog/2017/08/Kubernetes-Meets-High-Performance
+author: >
+   Robert Lalonde (Univa) 
 ---
-Editor's note: today's post is by Robert Lalonde, general manager at Univa, on supporting mixed HPC and containerized applications &nbsp;
 
 Anyone who has worked with Docker can appreciate the enormous gains in efficiency achievable with containers. While Kubernetes excels at orchestrating containers, high-performance computing (HPC) applications can be tricky to deploy on Kubernetes.
 

--- a/content/en/blog/_posts/2017-09-00-Introducing-Resource-Management-Working.md
+++ b/content/en/blog/_posts/2017-09-00-Introducing-Resource-Management-Working.md
@@ -3,8 +3,9 @@ title: " Introducing the Resource Management Working Group "
 date: 2017-09-21
 slug: introducing-resource-management-working
 url: /blog/2017/09/Introducing-Resource-Management-Working
+author: >
+   Jeremy Eder (Red Hat)
 ---
-_**Editor's note: today's post is by Jeremy Eder, Senior Principal Software Engineer at Red Hat, on the formation of the Resource Management Working Group**_  
 
 ## Why are we here?
 Kubernetes has evolved to support diverse and increasingly complex classes of applications. We can onboard and scale out modern, cloud-native web applications based on microservices, batch jobs, and stateful applications with persistent storage requirements.  

--- a/content/en/blog/_posts/2017-09-00-Kubernetes-18-Security-Workloads-And.md
+++ b/content/en/blog/_posts/2017-09-00-Kubernetes-18-Security-Workloads-And.md
@@ -4,10 +4,9 @@ date: 2017-09-29
 slug: kubernetes-18-security-workloads-and
 url: /blog/2017/09/Kubernetes-18-Security-Workloads-And
 evergreen: true
+author: >
+  [Kubernetes v1.8 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.8/release_team.md)
 ---
-
-**Authors:** Kubernetes v1.8 release team
-
 
 We’re pleased to announce the delivery of Kubernetes 1.8, our third release this year. Kubernetes 1.8 represents a snapshot of many exciting enhancements and refinements underway. In addition to functional improvements, we’re increasing project-wide focus on maturing [process](https://github.com/kubernetes/sig-release), formalizing [architecture](https://github.com/kubernetes/community/tree/master/sig-architecture), and strengthening Kubernetes’ [governance model](https://github.com/kubernetes/community/tree/master/community/elections/2017). The evolution of mature processes clearly signals that sustainability is a driving concern, and helps to ensure that Kubernetes is a viable and thriving project far into the future.  
 

--- a/content/en/blog/_posts/2017-09-00-Kubernetes-Statefulsets-Daemonsets.md
+++ b/content/en/blog/_posts/2017-09-00-Kubernetes-Statefulsets-Daemonsets.md
@@ -4,9 +4,10 @@ title: " Kubernetes StatefulSets & DaemonSets Updates "
 date: 2017-09-27
 slug: kubernetes-statefulsets-daemonsets
 url: /blog/2017/09/Kubernetes-Statefulsets-Daemonsets
+author: >
+   Janet Kuo (Google),
+   Kenneth Owens (Kenneth Owens)
 ---
-Editor's note: today's post is by Janet Kuo and Kenneth Owens, Software Engineers at Google.
-
 
 This post talks about recent updates to the [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) and [StatefulSet](/docs/concepts/workloads/controllers/statefulset/) API objects for Kubernetes. We explore these features using [Apache ZooKeeper](https://zookeeper.apache.org/) and [Apache Kafka](https://kafka.apache.org/) StatefulSets and a [Prometheus node exporter](https://github.com/prometheus/node_exporter) DaemonSet.
 

--- a/content/en/blog/_posts/2017-09-00-Windows-Networking-At-Parity-With-Linux.md
+++ b/content/en/blog/_posts/2017-09-00-Windows-Networking-At-Parity-With-Linux.md
@@ -3,8 +3,9 @@ title: " Windows Networking at Parity with Linux for Kubernetes "
 date: 2017-09-08
 slug: windows-networking-at-parity-with-linux
 url: /blog/2017/09/Windows-Networking-At-Parity-With-Linux
+author: >
+   Jason Messer (Microsoft)
 ---
-_**Editor's note: today's post is by Jason Messer, Principal PM Manager at Microsoft, on improvements to the Windows network stack to support the Kubernetes CNI model.**_  
 
  Since I last blogged about [Kubernetes Networking for Windows](https://blogs.technet.microsoft.com/networking/2017/04/04/windows-networking-for-kubernetes/) four months ago, the Windows Core Networking team has made tremendous progress in both the platform and open source Kubernetes projects. With the updates, Windows is now on par with Linux in terms of networking. Customers can now deploy mixed-OS, Kubernetes clusters in any environment including Azure, on-premises, and on 3rd-party cloud stacks with the same network primitives and topologies supported on Linux without any workarounds, “hacks”, or 3rd-party switch extensions.  
 

--- a/content/en/blog/_posts/2017-10-00-Enforcing-Network-Policies-In-Kubernetes.md
+++ b/content/en/blog/_posts/2017-10-00-Enforcing-Network-Policies-In-Kubernetes.md
@@ -3,8 +3,10 @@ title: " Enforcing Network Policies in Kubernetes "
 date: 2017-10-30
 slug: enforcing-network-policies-in-kubernetes
 url: /blog/2017/10/Enforcing-Network-Policies-In-Kubernetes
+author: >
+   Ahmet Alp Balkan (Google) 
 ---
-_**Editor's note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/10/five-days-of-kubernetes-18) on what's new in Kubernetes 1.8. Today’s post comes from Ahmet Alp Balkan, Software Engineer, Google.**_  
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2017/10/five-days-of-kubernetes-18) on what's new in Kubernetes 1.8._
 
 
 

--- a/content/en/blog/_posts/2017-10-00-Kubeadm-V18-Released.md
+++ b/content/en/blog/_posts/2017-10-00-Kubeadm-V18-Released.md
@@ -3,8 +3,10 @@ title: "  kubeadm v1.8 Released: Introducing Easy Upgrades for Kubernetes Cluste
 date: 2017-10-25
 slug: kubeadm-v18-released
 url: /blog/2017/10/Kubeadm-V18-Released
+author: >
+  Lucas Käldström (Weaveworks)
 ---
-**_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/10/five-days-of-kubernetes-18) on what's new in Kubernetes 1.8_**  
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2017/10/five-days-of-kubernetes-18) on what's new in Kubernetes 1.8._
 
 Since its debut in [September 2016](https://kubernetes.io/blog/2016/09/how-we-made-kubernetes-easy-to-install), the Cluster Lifecycle Special Interest Group (SIG) has established kubeadm as the easiest Kubernetes bootstrap method. Now, we’re releasing kubeadm v1.8.0 in tandem with the release of [Kubernetes v1.8.0](https://kubernetes.io/blog/2017/09/kubernetes-18-security-workloads-and). In this blog post, I’ll walk you through the changes we’ve made to kubeadm since the last update, the scope of kubeadm, and how you can contribute to this effort.  
 
@@ -99,7 +101,3 @@ If you want to get involved in these efforts, join SIG Cluster Lifecycle. We [me
 
 If you want to know what a kubeadm developer does at a given time in the Kubernetes release cycle, check out [this doc](https://github.com/kubernetes/kubeadm/blob/master/docs/release-cycle.md). Finally, don’t hesitate to join if any of our upcoming projects are of interest to you!  
 
-Thank you,  
-Lucas Käldström  
-Kubernetes maintainer & SIG Cluster Lifecycle co-lead  
-[Weaveworks](https://www.weave.works/?utm_source=k8&utm_medium=ww&utm_campaign=blog) contractor

--- a/content/en/blog/_posts/2017-10-00-Request-Routing-And-Policy-Management.md
+++ b/content/en/blog/_posts/2017-10-00-Request-Routing-And-Policy-Management.md
@@ -3,8 +3,12 @@ title: " Request Routing and Policy Management with the Istio Service Mesh "
 date: 2017-10-10
 slug: request-routing-and-policy-management
 url: /blog/2017/10/Request-Routing-And-Policy-Management
+author: >
+  Frank Budinsky (IBM),
+  Andra Cismaru (Google),
+  Israel Shalom (Google)
 ---
- **_Editor's note: Today’s post by Frank Budinsky, Software Engineer, IBM, Andra Cismaru, Software Engineer, Google, and Israel Shalom, Product Manager, Google, is the second post in a three-part series on Istio. It offers a closer look at request routing and policy management._**  
+_**Editor's note:** Today’s post is the second post in a three-part series on Istio._
 
 In a [previous article](https://kubernetes.io/blog/2017/05/managing-microservices-with-istio-service-mesh), we looked at a [simple application (Bookinfo)](https://istio.io/docs/guides/bookinfo.html) that is composed of four separate microservices. The article showed how to deploy an application with Kubernetes and an Istio-enabled cluster without changing any application code. The article also outlined how to view Istio provided L7 metrics on the running services.  
 

--- a/content/en/blog/_posts/2017-10-00-Software-Conformance-Certification.md
+++ b/content/en/blog/_posts/2017-10-00-Software-Conformance-Certification.md
@@ -3,10 +3,9 @@ title: " Introducing Software Certification for Kubernetes "
 date: 2017-10-19
 slug: software-conformance-certification
 url: /blog/2017/10/Software-Conformance-Certification
+author: >
+  William Denniss (Google)
 ---
-
-_**Editor's Note: Today's post is by William Denniss, Product Manager, Google Cloud on the new Certified Kubernetes Conformance Program.**_    
-
 
 Over the last three years, Kubernetes® has seen wide-scale adoption by a vibrant and diverse community of providers. In fact, there are now more than [60](https://docs.google.com/spreadsheets/d/1LxSqBzjOxfGx3cmtZ4EbB_BGCxT_wlxW_xgHVVa23es/edit#gid=0) known Kubernetes platforms and distributions. From the start, one goal of Kubernetes has been consistency and portability.  
 

--- a/content/en/blog/_posts/2017-10-00-Using-Rbac-Generally-Available-18.md
+++ b/content/en/blog/_posts/2017-10-00-Using-Rbac-Generally-Available-18.md
@@ -3,8 +3,10 @@ title: " Using RBAC, Generally Available in Kubernetes v1.8 "
 date: 2017-10-28
 slug: using-rbac-generally-available-18
 url: /blog/2017/10/Using-Rbac-Generally-Available-18
+author: >
+  Eric Chiang (CoreOS)
 ---
-**_Editor's note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2017/10/five-days-of-kubernetes-18) on what's new in Kubernetes 1.8. Today’s post comes from Eric Chiang, software engineer, CoreOS, and SIG-Auth co-lead._**  
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2017/10/five-days-of-kubernetes-18) on what's new in Kubernetes 1.8._
 
 Kubernetes 1.8 represents a significant milestone for the [role-based access control (RBAC) authorizer](/docs/reference/access-authn-authz/rbac/), which was promoted to GA in this release. RBAC is a mechanism for controlling access to the Kubernetes API, and since its [beta in 1.6](https://kubernetes.io/blog/2017/04/rbac-support-in-kubernetes), many Kubernetes clusters and provisioning strategies have enabled it by default.  
 

--- a/content/en/blog/_posts/2017-11-00-Containerd-Container-Runtime-Options-Kubernetes.md
+++ b/content/en/blog/_posts/2017-11-00-Containerd-Container-Runtime-Options-Kubernetes.md
@@ -3,9 +3,10 @@ title: "  Containerd Brings More Container Runtime Options for Kubernetes "
 date: 2017-11-02
 slug: containerd-container-runtime-options-kubernetes
 url: /blog/2017/11/Containerd-Container-Runtime-Options-Kubernetes
+author: >
+  Lantao Liu (Google),
+  Mike Brown (IBM)
 ---
-
-**Authors:** Lantao Liu (Google), and Mike Brown (IBM)
 
 _Update: Kubernetes support for Docker via `dockershim` is now deprecated.
 For more information, read the [deprecation notice](/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation).

--- a/content/en/blog/_posts/2017-11-00-Kubernetes-Easy-Way.md
+++ b/content/en/blog/_posts/2017-11-00-Kubernetes-Easy-Way.md
@@ -3,9 +3,9 @@ title: " Kubernetes the Easy Way "
 date: 2017-11-01
 slug: kubernetes-easy-way
 url: /blog/2017/11/Kubernetes-Easy-Way
+author: >
+  Dan Garfield (Codefresh)
 ---
- **_Editor's note: Today's post is by Dan Garfield, VP of Marketing at Codefresh, on how to set up and easily deploy a Kubernetes cluster._**  
-
 
 Kelsey Hightower wrote an invaluable guide for Kubernetes called [Kubernetes the Hard Way](https://github.com/kelseyhightower/kubernetes-the-hard-way). It’s an awesome resource for those looking to understand the ins and outs of Kubernetes—but what if you want to put Kubernetes on easy mode? That’s something we’ve been working on together with Google Cloud. In this guide, we’ll show you how to get a cluster up and running, as well as how to actually deploy your code to that cluster and run it.   
 

--- a/content/en/blog/_posts/2017-11-00-Securing-Software-Supply-Chain-Grafeas.md
+++ b/content/en/blog/_posts/2017-11-00-Securing-Software-Supply-Chain-Grafeas.md
@@ -3,8 +3,10 @@ title: " Securing Software Supply Chain with Grafeas "
 date: 2017-11-03
 slug: securing-software-supply-chain-grafeas
 url: /blog/2017/11/Securing-Software-Supply-Chain-Grafeas
+author: >
+  Kelsey Hightower (Google),
+  Sandra Guo (Google)
 ---
- **_Editor's note: This post is written by Kelsey Hightower, Staff Developer Advocate at Google, and Sandra Guo, Product Manager at Google._**  
 
 Kubernetes has evolved to support increasingly complex classes of applications, enabling the development of two major industry trends: hybrid cloud and microservices. With increasing complexity in production environments, customers—especially enterprises—are demanding better ways to manage their software supply chain with more centralized visibility and control over production deployments.  
 

--- a/content/en/blog/_posts/2017-12-00-Introducing-Kubeflow-Composable.md
+++ b/content/en/blog/_posts/2017-12-00-Introducing-Kubeflow-Composable.md
@@ -3,11 +3,10 @@ title: " Introducing Kubeflow - A Composable, Portable, Scalable ML Stack Built 
 date: 2017-12-21
 slug: introducing-kubeflow-composable
 url: /blog/2017/12/Introducing-Kubeflow-Composable
+author: >
+  Jeremy Lewi (Google),
+  David Aronchick (Google)
 ---
-
-**_Today’s post is by David Aronchick and Jeremy Lewi, a PM and Engineer on the Kubeflow project, a new open source GitHub repo dedicated to making using machine learning (ML) stacks on Kubernetes easy, fast and extensible._**  
-
-
 
 ## Kubernetes and Machine Learning
 Kubernetes has quickly become the hybrid solution for deploying complicated workloads anywhere. While it started with just stateless services, customers have begun to move complex workloads to the platform, taking advantage of rich APIs, reliability and performance provided by Kubernetes. One of the fastest growing use cases is to use Kubernetes as the deployment platform of choice for machine learning.  
@@ -168,8 +167,6 @@ And we’re just getting started! We would love for you to help. How you might a
 - Please download and run kubeflow, and submit bugs!
 Thank you for your support so far, we could not be more excited!  
 
-_Jeremy Lewi & David Aronchick_
-Google
 
 Note:
 * This article was amended in June 2023 to update the trained model bucket location.

--- a/content/en/blog/_posts/2017-12-00-Kubernetes-19-Workloads-Expanded-Ecosystem.md
+++ b/content/en/blog/_posts/2017-12-00-Kubernetes-19-Workloads-Expanded-Ecosystem.md
@@ -4,9 +4,9 @@ date: 2017-12-15
 slug: kubernetes-19-workloads-expanded-ecosystem
 url: /blog/2017/12/Kubernetes-19-Workloads-Expanded-Ecosystem
 evergreen: true
+author: >
+  [Kubernetes v1.9 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.9/release_team.md)
 ---
-
-**Authors:** Kubernetes v1.9 release team
 
 We’re pleased to announce the delivery of Kubernetes 1.9, our fourth and final release this year.  
 

--- a/content/en/blog/_posts/2017-12-00-Paddle-Paddle-Fluid-Elastic-Learning.md
+++ b/content/en/blog/_posts/2017-12-00-Paddle-Paddle-Fluid-Elastic-Learning.md
@@ -3,8 +3,16 @@ title: " PaddlePaddle Fluid: Elastic Deep Learning on Kubernetes "
 date: 2017-12-06
 slug: paddle-paddle-fluid-elastic-learning
 url: /blog/2017/12/Paddle-Paddle-Fluid-Elastic-Learning
+author: >
+  Xu Yan (Baidu Research),
+  Helin Wang (Baidu Research),
+  Yi Wu (Baidu Research),
+  Xi Chen (Baidu Research),
+  Weibao Gong (Baidu Research),
+  Xiang Li (CoreOS),
+  Yi Wang (Baidu Research) 
 ---
-_Editor's note: Today's post is a joint post from the deep learning team at Baidu and the etcd team at CoreOS._
+_**Editor's note:** Today's post is a joint post from the deep learning team at Baidu and the etcd team at CoreOS_
 
 
 
@@ -39,11 +47,4 @@ In the second test, each experiment ran 400 Nginx pods, which has higher priorit
 
 We continue to work on FluidEDL and welcome comments and contributions. Visit the [PaddlePaddle repo](https://github.com/PaddlePaddle/cloud), where you can find the [design doc](https://github.com/PaddlePaddle/cloud/tree/develop/doc/design), a [simple tutorial](https://github.com/PaddlePaddle/cloud/blob/develop/doc/autoscale/example/autoscale.md), and [experiment details](https://github.com/PaddlePaddle/cloud/tree/develop/doc/edl/experiment).  
 
-- Xu Yan (Baidu Research)
-- Helin Wang (Baidu Research)
-- Yi Wu (Baidu Research)
-- Xi Chen (Baidu Research)
-- Weibao Gong (Baidu Research)
-- Xiang Li (CoreOS)
 
-- Yi Wang (Baidu Research)


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2018 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-46627--kubernetes-io-main-staging.netlify.app/blog)