### PR TITLE
[ru] Sync the main page with KubeCon 2024 events

### DIFF
--- a/content/ru/_index.html
+++ b/content/ru/_index.html
@@ -32,6 +32,8 @@ Kubernetes группирует контейнеры, составляющие �
 
 Kubernetes — это проект с открытым исходным кодом, который даёт вам полную свободу воспользоваться преимуществами локальной, гибридной или публичной облачной инфраструктуры, позволяя без усилий перераспределять рабочую нагрузку по мере необходимости.
 
+Для загрузки Kubernetes перейдите в раздел [Download](/releases/download/).
+
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
@@ -43,12 +45,17 @@ Kubernetes — это проект с открытым исходным кодо
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Смотреть видео</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Европе, 19-22 марта 2024 года</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-open-source-summit-ai-dev-china/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Китае 21-23 августа</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Северной Америке, 12-15 ноября 2024 года</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в США 12-15 ноября</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Индии 11-12 декабря</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Updating upcoming KubeCon events on the main page, like it was just done in English:  #46413

Additionally, I translated another paragraph linking to the download page to keep the localised page fully in sync. (Hopefully, I'll be able to add a Russian translation of this page ASAP, too.)