### PR TITLE
Modify registry.k8s.io/nginx-slim version from 0.8 to 0.24

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -101,7 +101,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: registry.k8s.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.24
         ports:
         - containerPort: 80
           name: web

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -593,7 +593,7 @@ In one terminal window, patch the `web` StatefulSet to change the container
 image again:
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.8"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.24"}]'
 ```
 ```
 statefulset.apps/web patched
@@ -661,9 +661,9 @@ Get the Pods to view their container images:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0.8
-registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.24
+registry.k8s.io/nginx-slim:0.24
+registry.k8s.io/nginx-slim:0.24
 
 ```
 
@@ -705,7 +705,7 @@ Patch the StatefulSet again to change the container image that this
 StatefulSet uses:
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.7"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"registry.k8s.io/nginx-slim:0.21"}]'
 ```
 ```
 statefulset.apps/web patched
@@ -740,7 +740,7 @@ Get the Pod's container image:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.24
 ```
 
 Notice that, even though the update strategy is `RollingUpdate` the StatefulSet
@@ -790,7 +790,7 @@ Get the Pod's container:
 kubectl get pod web-2 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.21
 
 ```
 
@@ -834,7 +834,7 @@ Get the `web-1` Pod's container image:
 kubectl get pod web-1 --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'
 ```
 ```
-registry.k8s.io/nginx-slim:0.8
+registry.k8s.io/nginx-slim:0.24
 ```
 
 `web-1` was restored to its original configuration because the Pod's ordinal
@@ -892,9 +892,9 @@ Get the container image details for the Pods in the StatefulSet:
 for p in 0 1 2; do kubectl get pod "web-$p" --template '{{range $i, $c := .spec.containers}}{{$c.image}}{{end}}'; echo; done
 ```
 ```
-registry.k8s.io/nginx-slim:0.7
-registry.k8s.io/nginx-slim:0.7
-registry.k8s.io/nginx-slim:0.7
+registry.k8s.io/nginx-slim:0.21
+registry.k8s.io/nginx-slim:0.21
+registry.k8s.io/nginx-slim:0.21
 ```
 
 By moving the `partition` to `0`, you allowed the StatefulSet to

--- a/content/en/examples/application/web/web-parallel.yaml
+++ b/content/en/examples/application/web/web-parallel.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: registry.k8s.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.24
         ports:
         - containerPort: 80
           name: web

--- a/content/en/examples/application/web/web.yaml
+++ b/content/en/examples/application/web/web.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: registry.k8s.io/nginx-slim:0.7
+        image: registry.k8s.io/nginx-slim:0.21
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
This pull request aims to fix the error raised by pulling the image `registry.k8s.io/nginx-slim:0.8` that says:
```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of registry.k8s.io/nginx-slim:0.8 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```
