### PR TITLE
Fix NameGenerationRetries feature gate name in docs to match the RetryGenerateName name in code

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
@@ -1,5 +1,5 @@
 ---
-title: NameGenerationRetries
+title: RetryGenerateName
 content_type: feature_gate
 
 _build:

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
@@ -1,5 +1,5 @@
 ---
-title: NameGenerationRetries
+title: RetryGenerateName
 content_type: feature_gate
 
 _build:


### PR DESCRIPTION
Fhix fixes an oversight in feature gate naming. It was noticed here: https://github.com/kubernetes/enhancements/issues/4420#issuecomment-2146317270