### PR TITLE
Fix feature-state for "Manage HugePages"

### DIFF
--- a/content/en/docs/tasks/manage-hugepages/scheduling-hugepages.md
+++ b/content/en/docs/tasks/manage-hugepages/scheduling-hugepages.md
@@ -7,7 +7,7 @@ description: Configure and manage huge pages as a schedulable resource in a clus
 ---
 
 <!-- overview -->
-{{< feature-state feature_gate_name="HugePage" >}}
+{{< feature-state feature_gate_name="HugePages" >}}
 
 Kubernetes supports the allocation and consumption of pre-allocated huge pages
 by applications in a Pod. This page describes how users can consume huge pages.

--- a/content/en/docs/tasks/manage-hugepages/scheduling-hugepages.md
+++ b/content/en/docs/tasks/manage-hugepages/scheduling-hugepages.md
@@ -7,7 +7,7 @@ description: Configure and manage huge pages as a schedulable resource in a clus
 ---
 
 <!-- overview -->
-{{< feature-state state="stable" >}}
+{{< feature-state feature_gate_name="HugePage" >}}
 
 Kubernetes supports the allocation and consumption of pre-allocated huge pages
 by applications in a Pod. This page describes how users can consume huge pages.


### PR DESCRIPTION
Removed the always stable state and replaced with picking up from feature state option of feature gate name like some other examples I have seen in doc.


Fixes https://github.com/kubernetes/website/issues/46654