### PR TITLE
Fix typo in blog post: “do to” -> “due to”

### DIFF
--- a/content/en/blog/_posts/2023-05-12-in-place-pod-resize/index.md
+++ b/content/en/blog/_posts/2023-05-12-in-place-pod-resize/index.md
@@ -56,7 +56,7 @@ resize exceeds the maximum resources the node can ever allocate for a pod.
 
 Here are a few examples where this feature may be useful:
 - Pod is running on node but with either too much or too little resources.
-- Pods are not being scheduled do to lack of sufficient CPU or memory in a
+- Pods are not being scheduled due to lack of sufficient CPU or memory in a
 cluster that is underutilized by running pods that were overprovisioned.
 - Evicting certain stateful pods that need more resources to schedule them
 on bigger nodes is an expensive or disruptive operation when other lower


### PR DESCRIPTION
This PR corrects a minor typo in a blog post by replacing the phrase “do to” with “due to.” The change improves readability and accuracy. Please review and merge as appropriate.

For reference, the affected blog post is titled "Kubernetes 1.27: In-place Resource Resize for Kubernetes Pods (alpha)". You can find it [here](https://kubernetes.io/blog/2023/05/12/in-place-pod-resize-alpha/). 😊