### PR TITLE
Correction of CEL sample code.

### DIFF
--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -133,8 +133,8 @@ Examples:
 {{< table caption="Examples of CEL expressions using regex library functions" >}}
 | CEL Expression                                              | Purpose                                                  |
 |-------------------------------------------------------------|----------------------------------------------------------|
-| `"abc 123".find('[0-9]*')`                                  | Find the first number in a string                        |
-| `"1, 2, 3, 4".findAll('[0-9]*').map(x, int(x)).sum() < 100` | Verify that the numbers in a string sum to less than 100 |
+| `"abc 123".find('[0-9]+')`                                  | Find the first number in a string                        |
+| `"1, 2, 3, 4".findAll('[0-9]+').map(x, int(x)).sum() < 100` | Verify that the numbers in a string sum to less than 100 |
 {{< /table >}}
 
 See the [Kubernetes regex library](https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/library#Regex)
@@ -239,7 +239,7 @@ Examples:
 | `quantity("500000G").isInteger()`                                         | Test if conversion to integer would throw an error    |
 | `quantity("50k").asInteger()`                                             | Precise conversion to integer                         |
 | `quantity("9999999999999999999999999999999999999G").asApproximateFloat()` | Lossy conversion to float                              |
-| `quantity("50k").add("20k")`                                              | Add two quantities                                    |
+| `quantity("50k").add(quantity("20k"))`                                   | Add two quantities                                    |
 | `quantity("50k").sub(20000)`                                              | Subtract an integer from a quantity                   |
 | `quantity("50k").add(20).sub(quantity("100k")).sub(-50000)`               | Chain adding and subtracting integers and quantities  |
 | `quantity("200M").compareTo(quantity("0.2G"))`                            | Compare two quantities                                |


### PR DESCRIPTION
## 1. Sample code for Kubernetes regex library.
### before
| CEL Expression | Purpose |
| ------------- | ------------- |
| "abc 123".find('[0-9]*') | Find the first number in a string |
| "1, 2, 3, 4".findAll('[0-9]*').map(x, int(x)).sum() < 100  | Verify that the numbers in a string sum to less than 100  |
#### Execution Result
The execution environment below is CEL Playground.
```
"abc 123".find('[0-9]*')
""
```
```
"1, 2, 3, 4".findAll('[0-9]*').map(x, int(x)).sum() < 100
failed to evaluate: type conversion error from 'string' to 'int'

"1, 2, 3, 4".findAll('[0-9]*')
["1","","2","","3","","4"]
```
### after
```
"abc 123".find('[0-9]+')
"123"
```
```
"1, 2, 3, 4".findAll('[0-9]+').map(x, int(x)).sum() < 100
true
```
### basis
https://www.regular-expressions.info/zerolength.html
- The regular expression `[0-9]*` also matches `""` (empty characters).
- This can be solved by requiring at least a one-digit match.
## 2.Sample code for Kubernetes quantity library.
### before
| CEL Expression | Purpose |
| ------------- | ------------- |
| quantity("50k").add("20k") | Add two quantities |
### after
`quantity("50k").add(quantity("20k"))`
### basis
The argument of the member function `add` is of type `Quantity` or `int` , not `string` .