### PR TITLE
[it] Add missing localized docs/reference/glossary/index.md

### DIFF
--- a/content/it/docs/reference/glossary/index.md
+++ b/content/it/docs/reference/glossary/index.md
@@ -10,3 +10,4 @@ card:
   weight: 10
   title: Glossario
 ---
+

--- a/content/it/docs/reference/glossary/index.md
+++ b/content/it/docs/reference/glossary/index.md
@@ -1,0 +1,12 @@
+---
+title: Glossario
+layout: glossary
+noedit: true
+body_class: glossary
+default_active_tag: fundamental
+weight: 5
+card:
+  name: reference
+  weight: 10
+  title: Glossario
+---


### PR DESCRIPTION
Glossary's index was missing for localized italian.
Building local hugo fails with
```
ERROR [it] Glossary Bundle not found for language. Create at least an index.md file inside docs/reference/glossary
ERROR [it] No glossary items found
```