### PR TITLE
fix(blog-2018-07-24): Authors entry field contains unparsable chars

### DIFF
--- a/content/en/blog/_posts/2018-07-24-cpu-manager.md
+++ b/content/en/blog/_posts/2018-07-24-cpu-manager.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Feature Highlight: CPU Manager"
 date:  2018-07-24
 author: >
-  [Balaji Subramaniam]((mailto:balaji.subramaniam@intel.com)) (Intel),
-  [Connor Doyle](mailto:connor.p.doyle@intel.com) (Intel]) 
+  [Balaji Subramaniam](mailto:balaji.subramaniam@intel.com) (Intel),
+  [Connor Doyle](mailto:connor.p.doyle@intel.com) (Intel) 
 ---
 
 This blog post describes the [CPU Manager](/docs/tasks/administer-cluster/cpu-management-policies/), a beta feature in [Kubernetes](https://kubernetes.io/). The CPU manager feature enables better placement of workloads in the [Kubelet](/docs/reference/command-line-tools-reference/kubelet/), the Kubernetes node agent, by allocating exclusive CPUs to certain pod containers.


### PR DESCRIPTION
On blog entry on 2018-07-24: Author's field contains unparsable characters. 
Fails with:
```
 error calling Parse: parse "(mailto:<redacted>)": first path segment in URL cannot contain colon
```