### PR TITLE
[zh] Fix command line tool link in kubectl.md

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/kubectl.md
+++ b/content/zh-cn/docs/reference/kubectl/kubectl.md
@@ -19,7 +19,7 @@ kubectl 管理控制 Kubernetes 集群。
 <!--
 Find more information in [Command line tool](/docs/reference/kubectl/) (`kubectl`).
 -->
-更多信息请查阅[命令行工具](/zh-cn/docs/kubectl/)（`kubectl`）。
+更多信息请查阅[命令行工具](/zh-cn/docs/reference/kubectl/)（`kubectl`）。
 
 ```shell
 kubectl [flags]


### PR DESCRIPTION
 Fixed the command line tool link in kubectl.md, the correct link should be `/zh-cn/docs/reference/kubectl/`.