### PR TITLE
State that the list just includes technical milestones, since we would be missing key milestones like when in March 2018 Kubernetes becomes the first graduated CNCF project

### DIFF
--- a/content/en/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
+++ b/content/en/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
@@ -105,6 +105,7 @@ Some notable updates, milestones and events since 1.0 include:
 * April 2017 — [Introduction of Role-Based Access Controls or RBAC](/blog/2017/04/rbac-support-in-kubernetes/).
 * June 2017 — In [Kubernetes 1.7](/blog/2017/06/kubernetes-1-7-security-hardening-stateful-application-extensibility-updates/), ThirdPartyResources or "TPRs" are replaced with CustomResourceDefinitions (CRDs).
 * December 2017 — [Kubernetes 1.9](/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/) sees the Workloads API becoming GA (Generally Available). The release blog states: _"Deployment and ReplicaSet, two of the most commonly used objects in Kubernetes, are now stabilized after more than a year of real-world use and feedback."_
+* March 2018 - [Kubernetes becomes the first graduated CNCF project](https://www.cncf.io/blog/2018/03/06/kubernetes-first-cncf-project-graduate/) supported by a vibrant, healthy and diverse community.
 * December 2018 — In 1.13, the Container Storage Interface (CSI) reaches GA, kubeadm tool for bootstrapping minimum viable clusters reaches GA, and CoreDNS becomes the default DNS server.
 * September 2019 — [Custom Resource Definitions go GA](/blog/2019/09/18/kubernetes-1-16-release-announcement/)in Kubernetes 1.16.
 * August 2020 — [Kubernetes 1.19](/blog/2016/12/kubernetes-1-5-supporting-production-workloads/) increases the support window for releases to 1 year.

--- a/content/en/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
+++ b/content/en/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
@@ -98,14 +98,13 @@ or [full dual stack support launching in 1.23](/blog/2021/12/08/dual-stack-netwo
 community "lessons learned" from the [removal of widely used beta APIs in 1.22](/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/)
 or the deprecation of [Dockershim](/blog/2020/12/02/dockershim-faq/).
 
-Some notable updates, milestones and events since 1.0 include:
+Some notable technical updates, milestones and events since 1.0 include:
 
 * December 2016 - [Kubernetes 1.5](/blog/2016/12/kubernetes-1-5-supporting-production-workloads/)introduces runtime pluggability with initial CRI support and alpha Windows node support. OpenAPI also appears for the first time, paving the way for clients to be able to discover extension APIs.
   * This release also introduced StatefulSets and PodDisruptionBudgets in Beta.
 * April 2017 — [Introduction of Role-Based Access Controls or RBAC](/blog/2017/04/rbac-support-in-kubernetes/).
 * June 2017 — In [Kubernetes 1.7](/blog/2017/06/kubernetes-1-7-security-hardening-stateful-application-extensibility-updates/), ThirdPartyResources or "TPRs" are replaced with CustomResourceDefinitions (CRDs).
 * December 2017 — [Kubernetes 1.9](/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/) sees the Workloads API becoming GA (Generally Available). The release blog states: _"Deployment and ReplicaSet, two of the most commonly used objects in Kubernetes, are now stabilized after more than a year of real-world use and feedback."_
-* March 2018 - [Kubernetes becomes the first graduated CNCF project](https://www.cncf.io/blog/2018/03/06/kubernetes-first-cncf-project-graduate/) supported by a vibrant, healthy and diverse community.
 * December 2018 — In 1.13, the Container Storage Interface (CSI) reaches GA, kubeadm tool for bootstrapping minimum viable clusters reaches GA, and CoreDNS becomes the default DNS server.
 * September 2019 — [Custom Resource Definitions go GA](/blog/2019/09/18/kubernetes-1-16-release-announcement/)in Kubernetes 1.16.
 * August 2020 — [Kubernetes 1.19](/blog/2016/12/kubernetes-1-5-supporting-production-workloads/) increases the support window for releases to 1 year.


### PR DESCRIPTION
We are at least missing a key milestone saying that in March 2018 Kubernetes becomes the first graduated CNCF project. I think this is an important fact to state since it opens up to another new level of growing maturity.
In alternative, just state that these are **technical** updates, milestones and events.