### PR TITLE
[kubeadm reference] Fix Config API's value syntax for external etcd cluster and `kubeletExtraArgs`

### DIFF
--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -156,7 +156,7 @@ configuration types to be used during a <code>kubeadm init</code> run.</p>
 </span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">value</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;someValue&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">effect</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;NoSchedule&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">kubeletExtraArgs</span>:<span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">v</span>:<span style="color:#bbb"> </span><span style="color:#099">4</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">v</span>:<span style="color:#bbb"> </span><span style="color:#099">&#34;4&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">ignorePreflightErrors</span>:<span style="color:#bbb">
 </span><span style="color:#bbb">    </span>- IsPrivilegedUser<span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">imagePullPolicy</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;IfNotPresent&#34;</span><span style="color:#bbb">
@@ -183,8 +183,8 @@ configuration types to be used during a <code>kubeadm init</code> run.</p>
 </span><span style="color:#bbb">      </span>- <span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># external:</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># endpoints:</span><span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># - &#34;10.100.0.1:2379&#34;</span><span style="color:#bbb">
-</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># - &#34;10.100.0.2:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># - &#34;https://10.100.0.1:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># - &#34;https://10.100.0.2:2379&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># caFile: &#34;/etcd/kubernetes/pki/etcd/etcd-ca.crt&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># certFile: &#34;/etcd/kubernetes/pki/etcd/etcd.crt&#34;</span><span style="color:#bbb">
 </span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># keyFile: &#34;/etcd/kubernetes/pki/etcd/etcd.key&#34;</span><span style="color:#bbb">


### PR DESCRIPTION
Hello.


A configuration example on [Config API reference](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/) to bootstrap cluster using `kubeadm init`, contains several invalid syntax on values for latest k8s.

### 1. Config API for external etcd cluster must contain endpoints within `proto://addr:port` style, not `addr:port` style.


This is correctly (but implicitly) mentioned in [another page](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/#external-etcd-nodes)

If you try `kubeadm init` with the current example on the documentation to try external etcd architecture, it results a runtime error as following:


```
[etcd.external.endpoints: Invalid value: "10.101.0.11:2380": URL parse error: parse "10.101.0.11:2380": first path segment in URL cannot contain colon, etcd.external.endpoints: Invalid value: "10.101.0.21:2380": URL parse error: parse "10.101.0.21:2380": first path segment in URL cannot contain colon, etcd.external.endpoints: Invalid value: "10.101.0.51:2380": URL parse error: parse "10.101.0.51:2380": first path segment in URL cannot contain colon]
To see the stack trace of this error execute with --v=5 or higher
```

### 2. kubeletExtraArgs must be an array of `quoted strings`

See [this](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/apis/kubeadm/v1beta3/types.go#L230).

If you run `kubeadm init` with configuration example part from [Config API reference](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/), it fails.



### Additional information

Also [the documentation of Config API v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) contains same (maybe invalid) syntax, but I have no idea about how to try v1beta4 or whether I should examine compatibility for past kubernetes releases possibly affected by this PR or not.

(So the fixation for v1beta4 documentation is not included in the PR, at now)

If anyone has knowledge about the situation, give me suggestion how should we fix the documentation error.

Thanks.


### Appendix for reproduction

This issue is reproducible under kubenetes v1.28.5.

#### an example of invalid configuration

```
apiVersion: kubeadm.k8s.io/v1beta3
kind: InitConfiguration
nodeRegistration:
  name: somehost.example.com
  kubeletExtraArgs:
    v: 5
localAPIEndpoint:
  advertiseAddress: 0.0.0.0
  bindPort: 6443
---
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
etcd:
  external:
    endpoints:
    - "10.10.108.11:2380"
    - "10.10.108.12:2380"
    - "10.10.108.13:2380"
kubernetesVersion: 1.28.5
networking:
  podSubnet: 10.140.0.0/16
```



#### an example of valid configuration

```
apiVersion: kubeadm.k8s.io/v1beta3
kind: InitConfiguration
nodeRegistration:
  name: somehost.example.com
  kubeletExtraArgs:
    v: "5"
localAPIEndpoint:
  advertiseAddress: 0.0.0.0
  bindPort: 6443
---
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
etcd:
  external:
    endpoints:
    - "http://10.10.108.11:2380"
    - "http://10.10.108.12:2380"
    - "http://10.10.108.13:2380"
kubernetesVersion: 1.28.5

networking:
  podSubnet: 10.140.0.0/16
```