### PR TITLE
Delete rewrite-target annotation in ingress example

### DIFF
--- a/content/en/examples/service/networking/example-ingress.yaml
+++ b/content/en/examples/service/networking/example-ingress.yaml
@@ -2,8 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
fix: https://github.com/kubernetes/website/issues/46546

with new ingress 0.22 + capture groups must be explicit, see https://github.com/kubernetes/ingress-nginx/blob/main/docs/examples/rewrite/README.md

Just delete rewrite-target annotation and ingress will work as expect by default.