### PR TITLE
Update 2016 blog content files to move author details in front-matter

### DIFF
--- a/content/en/blog/_posts/2016-01-00-Why-Kubernetes-Doesnt-Use-Libnetwork.md
+++ b/content/en/blog/_posts/2016-01-00-Why-Kubernetes-Doesnt-Use-Libnetwork.md
@@ -3,6 +3,8 @@ title: " Why Kubernetes doesn’t use libnetwork "
 date: 2016-01-14
 slug: why-kubernetes-doesnt-use-libnetwork
 url: /blog/2016/01/Why-Kubernetes-Doesnt-Use-Libnetwork
+author: >
+   Tim Hockin (Google)
 ---
 Kubernetes has had a very basic form of network plugins since before version 1.0 was released — around the same time as Docker's [libnetwork](https://github.com/docker/libnetwork) and Container Network Model ([CNM](https://github.com/docker/libnetwork/blob/master/docs/design.md)) was introduced. Unlike libnetwork, the Kubernetes plugin system still retains its "alpha" designation. Now that Docker's network plugin support is released and supported, an obvious question we get is why Kubernetes has not adopted it yet. After all, vendors will almost certainly be writing plugins for Docker — we would all be better off using the same drivers, right?  
 
@@ -34,6 +36,4 @@ This and other issues have been brought up to Docker developers by network vendo
 
 For all of these reasons we have chosen to invest in CNI as the Kubernetes plugin model. There will be some unfortunate side-effects of this. Most of them are relatively minor (for example, `docker inspect` will not show an IP address), but some are significant. In particular, containers started by `docker run` might not be able to communicate with containers started by Kubernetes, and network integrators will have to provide CNI drivers if they want to fully integrate with Kubernetes. On the other hand, Kubernetes will get simpler and more flexible, and a lot of the ugliness of early bootstrapping (such as configuring Docker to use our bridge) will go away.  
 
-As we proceed down this path, we’ll certainly keep our eyes and ears open for better ways to integrate and simplify. If you have thoughts on how we can do that, we really would like to hear them — find us on [slack](http://slack.k8s.io/) or on our [network SIG mailing-list](https://groups.google.com/g/kubernetes-sig-network).  
-
-Tim Hockin, Software Engineer, Google
+As we proceed down this path, we’ll certainly keep our eyes and ears open for better ways to integrate and simplify. If you have thoughts on how we can do that, we really would like to hear them — find us on [slack](http://slack.k8s.io/) or on our [network SIG mailing-list](https://groups.google.com/g/kubernetes-sig-network).

--- a/content/en/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
+++ b/content/en/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
@@ -4,9 +4,9 @@ date: 2016-02-24
 slug: kubecon-eu-2016-kubernetes-community-in
 url: /blog/2016/02/Kubecon-Eu-2016-Kubernetes-Community-In
 evergreen: true
+author: >
+   Sarah Novotny (Google)
 ---
-
-**Author:** Sarah Novotny (Google)
 
 KubeCon EU 2016 is the inaugural European Kubernetes community conference that follows on the American launch in November 2015. KubeCon is fully dedicated to education and community engagement for [Kubernetes](/) enthusiasts, production users and the surrounding ecosystem.
 

--- a/content/en/blog/_posts/2016-02-00-Sharethis-Kubernetes-In-Production.md
+++ b/content/en/blog/_posts/2016-02-00-Sharethis-Kubernetes-In-Production.md
@@ -3,8 +3,9 @@ title: " ShareThis: Kubernetes In Production "
 date: 2016-02-11
 slug: sharethis-kubernetes-in-production
 url: /blog/2016/02/Sharethis-Kubernetes-In-Production
+author: >
+   Juan Valencia (ShareThis)
 ---
-Today’s guest blog post is by Juan Valencia, Technical Lead at ShareThis, a service that helps website publishers drive engagement and consumer sharing behavior across social networks.
 
 ShareThis has grown tremendously since its first days as a tiny widget that allowed you to share to your favorite social services. It now serves over 4.5 million domains per month, helping publishers create a more authentic digital experience.
 

--- a/content/en/blog/_posts/2016-02-00-State-Of-Container-World-January-2016.md
+++ b/content/en/blog/_posts/2016-02-00-State-Of-Container-World-January-2016.md
@@ -3,6 +3,8 @@ title: " State of the Container World, January 2016 "
 date: 2016-02-01
 slug: state-of-container-world-january-2016
 url: /blog/2016/02/State-Of-Container-World-January-2016
+author: >
+   Brendan Burns (Google)
 ---
 At the start of the new year, we sent out a survey to gauge the state of the container world. We’re ready to send the [February edition](https://docs.google.com/forms/d/13yxxBqb5igUhwrrnDExLzZPjREiCnSs-AH-y4SSZ-5c/viewform), but before we do, let’s take a look at the January data from the 119 responses (thank you for participating!).  
 
@@ -53,6 +55,4 @@ Finally, we asked people for free-text answers about the challenges of working w
 - “Storage”
 - “Persistent Data”
 
-_Download the full survey results [here](https://docs.google.com/spreadsheets/d/18wZe7wEDvRuT78CEifs13maXoSGem_hJvbOSmsuJtkA/pub?gid=530616014&single=true&output=csv) (CSV file)._  
-
-_Up-- Brendan Burns, Software Engineer, Google  
+_Download the full survey results [here](https://docs.google.com/spreadsheets/d/18wZe7wEDvRuT78CEifs13maXoSGem_hJvbOSmsuJtkA/pub?gid=530616014&single=true&output=csv) (CSV file)._ 

--- a/content/en/blog/_posts/2016-03-00-1000-Nodes-And-Beyond-Updates-To-Kubernetes-Performance-And-Scalability-In-12.md
+++ b/content/en/blog/_posts/2016-03-00-1000-Nodes-And-Beyond-Updates-To-Kubernetes-Performance-And-Scalability-In-12.md
@@ -3,8 +3,10 @@ title: " 1000 nodes and beyond: updates to Kubernetes performance and scalabilit
 date: 2016-03-28
 slug: 1000-nodes-and-beyond-updates-to-kubernetes-performance-and-scalability-in-12
 url: /blog/2016/03/1000-Nodes-And-Beyond-Updates-To-Kubernetes-Performance-And-Scalability-In-12
+author: >
+   Wojciech Tyczynski (Google)
 ---
-_Editor's&nbsp;note: this is the first in a [series of in-depth posts](https://kubernetes.io/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
+_**Editor's note:**  this is the first in a [series of in-depth posts](/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
 
 We're proud to announce that with the [release of 1.2](https://kubernetes.io/blog/2016/03/kubernetes-1-2-even-more-performance-upgrades-plus-easier-application-deployment-and-management), Kubernetes now supports 1000-node clusters, with a reduction of 80% in 99th percentile tail latency for most API operations. This means in just six months, we've increased our overall scale by 10 times while maintaining a great user experience&nbsp;—&nbsp;the&nbsp;99th percentile pod startup times are less than 3 seconds, and 99th percentile latency of most API operations is tens of milliseconds (the exception being LIST operations, which take hundreds of milliseconds in very large clusters).
 
@@ -160,9 +162,7 @@ Please join our community and help us build the future of Kubernetes! There are 
 
 - Our [scalability slack channel](https://kubernetes.slack.com/messages/sig-scale/)
 - The scalability “Special Interest Group”, which meets every Thursday at 9 AM Pacific Time at [SIG-Scale hangout](https://plus.google.com/hangouts/_/google.com/k8scale-hangout)&nbsp;
-&nbsp;And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/)  
-
-- _Wojciech Tyczynski, Software Engineer, Google_  
+&nbsp;And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/)
 
 
 * * *

--- a/content/en/blog/_posts/2016-03-00-Appformix-Helping-Enterprises.md
+++ b/content/en/blog/_posts/2016-03-00-Appformix-Helping-Enterprises.md
@@ -3,8 +3,9 @@ title: " AppFormix: Helping Enterprises Operationalize Kubernetes "
 date: 2016-03-29
 slug: appformix-helping-enterprises
 url: /blog/2016/03/Appformix-Helping-Enterprises
+author: >
+   Sumeet Singh (AppFormix)
 ---
-_Today’s guest post is written Sumeet Singh, founder and CEO of [AppFormix](http://www.appformix.com/), a cloud infrastructure performance optimization service helping enterprise operators streamline their cloud operations on any OpenStack or Kubernetes cloud._  
 
 If you run clouds for a living, you’re well aware that the tools we've used since the client/server era for monitoring, analytics and optimization just don’t cut it when applied to the agile, dynamic and rapidly changing world of modern cloud infrastructure.  
 
@@ -46,6 +47,4 @@ With AppFormix, developers and operators can work collaboratively to optimize ap
 
 
 
-As you can see, we’re working hard to give Kubernetes users a useful, performant toolset for both OpenStack and Kubernetes environments that allows operators to deliver self-service IT to their application developers. We’re excited to be partner contributing to the Kubernetes ecosystem and community.  
-
-_-- Sumeet Singh, Founder and CEO, AppFormix_
+As you can see, we’re working hard to give Kubernetes users a useful, performant toolset for both OpenStack and Kubernetes environments that allows operators to deliver self-service IT to their application developers. We’re excited to be partner contributing to the Kubernetes ecosystem and community.

--- a/content/en/blog/_posts/2016-03-00-Building-Highly-Available-Applications-Using-Kubernetes-New-Multi-Zone-Clusters-aka-Ubernetes-Lite.md
+++ b/content/en/blog/_posts/2016-03-00-Building-Highly-Available-Applications-Using-Kubernetes-New-Multi-Zone-Clusters-aka-Ubernetes-Lite.md
@@ -3,8 +3,11 @@ title: " Building highly available applications using Kubernetes new multi-zone 
 date: 2016-03-29
 slug: building-highly-available-applications-using-kubernetes-new-multi-zone-clusters-a.k.a-ubernetes-lite
 url: /blog/2016/03/Building-Highly-Available-Applications-Using-Kubernetes-New-Multi-Zone-Clusters-aka-Ubernetes-Lite
+author: >
+   Quinton Hoole (Google),
+   Justin Santa Barbara (Google)
 ---
-_Editor's note: this is the third post in a [series of in-depth posts](https://kubernetes.io/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
+_**Editor's note:**  this is the third post in a [series of in-depth posts](/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
 
 
 
@@ -234,6 +237,4 @@ Please join our community and help us build the future of Kubernetes! There are 
 - The federation “Special Interest Group,” which meets every Thursday at 9:30 a.m. Pacific Time at [SIG-Federation hangout&nbsp;](https://plus.google.com/hangouts/_/google.com/ubernetes)
 
 
-And of course for more information about the project in general, go to www.kubernetes.io  
-
-&nbsp;-- _Quinton Hoole, Staff Software Engineer, Google, and Justin Santa Barbara_
+And of course for more information about the project in general, go to www.kubernetes.io

--- a/content/en/blog/_posts/2016-03-00-Elasticbox-Introduces-Elastickube-To.md
+++ b/content/en/blog/_posts/2016-03-00-Elasticbox-Introduces-Elastickube-To.md
@@ -3,6 +3,8 @@ title: " ElasticBox introduces ElasticKube to help manage Kubernetes within the 
 date: 2016-03-11
 slug: elasticbox-introduces-elastickube-to
 url: /blog/2016/03/Elasticbox-Introduces-Elastickube-To
+author: >
+   Brannan Matherson (ElasticBox)
 ---
 Today’s guest post is brought to you by Brannan Matherson, from ElasticBox, who’ll discuss a new open source project to help standardize container deployment and management in enterprise environments. This highlights the advantages of authentication and user management for containerized applications
 
@@ -44,7 +46,3 @@ Hear What Others are Saying
 “Kubernetes has provided us the level of sophistication required for enterprises to manage containers across complex networking environments and the appropriate amount of visibility into the application lifecycle. &nbsp;Additionally, the community commitment and engagement has been exceptional, and we look forward to being a major contributor to this next wave of modern cloud computing and application management.” &nbsp;
 
 _~Alberto Arias Maestro, Co-founder and Chief Technology Officer, ElasticBox_
-
-
-
-_-- Brannan Matherson, Head of Product Marketing, ElasticBox_

--- a/content/en/blog/_posts/2016-03-00-Five-Days-Of-Kubernetes-12.md
+++ b/content/en/blog/_posts/2016-03-00-Five-Days-Of-Kubernetes-12.md
@@ -3,6 +3,8 @@ title: " Five Days of Kubernetes 1.2 "
 date: 2016-03-28
 slug: five-days-of-kubernetes-12
 url: /blog/2016/03/Five-Days-Of-Kubernetes-12
+author: >
+  David Aronchick (Google)
 ---
 The Kubernetes project has had some huge milestones over the past few weeks. We released [Kubernetes 1.2](https://kubernetes.io/blog/2016/03/kubernetes-1-2-even-more-performance-upgrades-plus-easier-application-deployment-and-management), had our [first conference in Europe](https://kubecon.io/), and were accepted into the [Cloud Native Computing Foundation](https://cncf.io/). While we catch our breath, we would like to take a moment to highlight some of the great work contributed by the community since our last milestone, just four months ago.
 
@@ -47,7 +49,4 @@ BONUS
 
 
 
-You can follow us on twitter here [@Kubernetesio](https://twitter.com/kubernetesio)  
-
-
-_--David Aronchick, Senior Product Manager for Kubernetes, Google_
+You can follow us on twitter here [@Kubernetesio](https://twitter.com/kubernetesio)

--- a/content/en/blog/_posts/2016-03-00-How-Container-Metadata-Changes-Your-Point-Of-View.md
+++ b/content/en/blog/_posts/2016-03-00-How-Container-Metadata-Changes-Your-Point-Of-View.md
@@ -3,8 +3,9 @@ title: " How container metadata changes your point of view "
 date: 2016-03-28
 slug: how-container-metadata-changes-your-point-of-view
 url: /blog/2016/03/How-Container-Metadata-Changes-Your-Point-Of-View
+author: >
+  Apurva Davé (Sysdig)
 ---
-_Today’s guest post is brought to you by Apurva Davé, VP of Marketing at Sysdig, who’ll discuss using Kubernetes metadata & Sysdig to understand what’s going on in your Kubernetes cluster.&nbsp;_  
 
 Sure, metadata is a fancy word. It actually means “data that describes other data.” While that definition isn’t all that helpful, it turns out metadata itself is especially helpful in container environments. When you have any complex system, the availability of metadata helps you sort and process the variety of data coming out of that system, so that you can get to the heart of an issue with less headache.  
 
@@ -86,6 +87,4 @@ This kind of view provides yet another logical, instead of physical, view of how
 ### Metadata: love it, use it&nbsp;
 This is a pretty quick tour of metadata, but I hope it inspires you to spend a little time thinking about the relevance to your own system and how you could leverage it. Here we built a pretty simple example — apps and services — but imagine collecting metadata across your apps, environments, software components and cloud providers. You could quickly assess performance differences across any slice of this infrastructure effectively, all while Kubernetes is efficiently scheduling resource usage.  
 
-Get started with metadata for visualizing these resources today, and in a followup post we’ll talk about the power of adaptive alerting based on metadata.  
-
-_-- Apurva Davé is a closet Kubernetes fanatic, loves data, and oh yeah is also the VP of Marketing at Sysdig._
+Get started with metadata for visualizing these resources today, and in a followup post we’ll talk about the power of adaptive alerting based on metadata.

--- a/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-And-Simplifying-Advanced-Networking-With-Ingress.md
+++ b/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-And-Simplifying-Advanced-Networking-With-Ingress.md
@@ -3,8 +3,10 @@ title: " Kubernetes 1.2 and simplifying advanced networking with Ingress "
 date: 2016-03-31
 slug: kubernetes-1.2-and-simplifying-advanced-networking-with-ingress
 url: /blog/2016/03/Kubernetes-1-2-And-Simplifying-Advanced-Networking-With-Ingress
+author: >
+  Prashanth Balasubramanian (independent)
 ---
-_Editor's note: This is the sixth post in a [series of in-depth posts](https://kubernetes.io/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2._  
+_**Editor's note:** This is the sixth post in a [series of in-depth posts](/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
 _Ingress is currently in beta and under active development._  
 
 In Kubernetes, Services and Pods have IPs only routable by the cluster network, by default. All traffic that ends up at an edge router is either dropped or forwarded elsewhere. In Kubernetes 1.2, we’ve made improvements to the Ingress object, to simplify allowing inbound connections to reach the cluster services. It can be configured to give services externally-reachable URLs, load balance traffic, terminate SSL, offer name based virtual hosting and lots more.  
@@ -110,6 +112,4 @@ There are many ways to participate. If you’re particularly interested in Kuber
 - Our [Kubernetes Networking Special Interest Group](https://groups.google.com/forum/#!forum/kubernetes-sig-network) email list
 - The Big Data “Special Interest Group,” which meets biweekly at 3pm (15h00) Pacific Time at [SIG-Networking hangout](https://zoom.us/j/5806599998)
 
-And of course for more information about the project in general, go to[www.kubernetes.io](http://kubernetes.io/)  
-
--- _Prashanth Balasubramanian, Software Engineer_
+And of course for more information about the project in general, go to[www.kubernetes.io](http://kubernetes.io/) 

--- a/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management-.md
+++ b/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management-.md
@@ -4,8 +4,9 @@ date: 2016-03-17
 slug: kubernetes-1.2-even-more-performance-upgrades-plus-easier-application-deployment-and-management
 url: /blog/2016/03/Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management
 evergreen: true
+author: >
+  David Aronchick (Google)
 ---
-**Author:** David Aronchick (Google)
 
 Today the Kubernetes project released Kubernetes 1.2. This release represents significant improvements for large organizations building distributed systems. Now with over 680 unique contributors to the project, this release represents our largest yet.  
 

--- a/content/en/blog/_posts/2016-03-00-Kubernetes-In-Enterprise-With-Fujitsus.md
+++ b/content/en/blog/_posts/2016-03-00-Kubernetes-In-Enterprise-With-Fujitsus.md
@@ -3,8 +3,9 @@ title: " Kubernetes in the Enterprise with Fujitsu’s Cloud Load Control "
 date: 2016-03-11
 slug: kubernetes-in-enterprise-with-fujitsus
 url: /blog/2016/03/Kubernetes-In-Enterprise-With-Fujitsus
+author: >
+  Florian Walker (FUJITSU)
 ---
-Today’s guest post is by Florian Walker, Product Manager at Fujitsu and working on Cloud Load Control, an offering focused on the usage of Kubernetes in an enterprise context. Florian tells us what potential Fujitsu sees in Kubernetes, and how they make it accessible to enterprises.
 
 Earlier this year, Fujitsu released its Kubernetes-based offering Fujitsu ServerView[Cloud Load Control](http://www.fujitsu.com/software/clc/) (CLC) to the public. Some might be surprised since Fujitsu’s reputation is not necessarily related to software development, but rather to hardware manufacturing and IT services. As a long-time member of the Linux foundation and founding member of the ​Open Container Initiative and the Cloud Native Computing Foundation, Fujitsu does not only build software, but is committed to open source software, and contributes to several projects, including Kubernetes. But we not only believe in Kubernetes as an open source project, we also chose it as the core of our offering, because it provides the best balance of feature set, resource requirements and complexity to run distributed applications at scale.
 
@@ -68,7 +69,3 @@ Acknowledging that container technology and Kubernetes is new territory for a lo
 2014 seems to be light years away, we believe the decision for Kubernetes was the right one. It is built from the ground-up to enable the creation of container-based, distributed applications, and best supports this use case.
 
 With Cloud Load Control, we’re excited to enable enterprises to run Kubernetes in production environments and to help their operators to efficiently use it, so DevOps teams can build awesome applications on top of it.
-
-
-
-_-- Florian Walker, Product Manager, FUJITSU_

--- a/content/en/blog/_posts/2016-03-00-Scaling-Neural-Network-Image-Classification-Using-Kubernetes-With-Tensorflow-Serving.md
+++ b/content/en/blog/_posts/2016-03-00-Scaling-Neural-Network-Image-Classification-Using-Kubernetes-With-Tensorflow-Serving.md
@@ -3,6 +3,8 @@ title: " Scaling neural network image classification using Kubernetes with Tenso
 date: 2016-03-23
 slug: scaling-neural-network-image-classification-using-kubernetes-with-tensorflow-serving
 url: /blog/2016/03/Scaling-Neural-Network-Image-Classification-Using-Kubernetes-With-Tensorflow-Serving
+author: >
+  Fangwei Li (Google)
 ---
 In 2011, Google developed an internal deep learning infrastructure called [DistBelief](http://research.google.com/pubs/pub40565.html), which allowed Googlers to build ever larger [neural networks](https://en.wikipedia.org/wiki/Artificial_neural_network) and scale training to thousands of cores. Late last year, Google [introduced TensorFlow](http://googleresearch.blogspot.com/2015/11/tensorflow-googles-latest-machine_9.html), its second-generation machine learning system. TensorFlow is general, flexible, portable, easy-to-use and, most importantly, developed with the open source community.
 
@@ -29,6 +31,4 @@ Inference can be very resource intensive. Our server executes the following Tens
 
 Fortunately, this is where Kubernetes can help us. Kubernetes distributes inference request processing across a cluster using its [External Load Balancer](/docs/user-guide/load-balancer/). Each [pod](/docs/user-guide/pods/) in the cluster contains a [TensorFlow Serving Docker image](https://tensorflow.github.io/serving/docker) with the TensorFlow Serving-based gRPC server and a trained Inception-v3 model. The model is represented as a [set of files](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/session_bundle/README.md) describing the shape of the TensorFlow graph, model weights, assets, and so on. Since everything is neatly packaged together, we can dynamically scale the number of replicated pods using the [Kubernetes Replication Controller](/docs/user-guide/replication-controller/operations/) to keep up with the service demands.  
 
-To help you try this out yourself, we’ve written a [step-by-step tutorial](https://tensorflow.github.io/serving/serving_inception), which shows you how to create the TensorFlow Serving Docker container to serve the Inception-v3 image classification model, configure a Kubernetes cluster and run classification requests against it. We hope this will make it easier for you to integrate machine learning into your own applications and scale it with Kubernetes! To learn more about TensorFlow Serving, check out [tensorflow.github.io/serving](http://tensorflow.github.io/serving).&nbsp;  
-
-- _Fangwei Li, Software Engineer, Google_
+To help you try this out yourself, we’ve written a [step-by-step tutorial](https://tensorflow.github.io/serving/serving_inception), which shows you how to create the TensorFlow Serving Docker container to serve the Inception-v3 image classification model, configure a Kubernetes cluster and run classification requests against it. We hope this will make it easier for you to integrate machine learning into your own applications and scale it with Kubernetes! To learn more about TensorFlow Serving, check out [tensorflow.github.io/serving](http://tensorflow.github.io/serving).

--- a/content/en/blog/_posts/2016-03-00-Using-Spark-And-Zeppelin-To-Process-Big-Data-On-Kubernetes.md
+++ b/content/en/blog/_posts/2016-03-00-Using-Spark-And-Zeppelin-To-Process-Big-Data-On-Kubernetes.md
@@ -3,8 +3,10 @@ title: " Using Spark and Zeppelin to process big data on Kubernetes 1.2 "
 date: 2016-03-30
 slug: using-spark-and-zeppelin-to-process-big-data-on-kubernetes
 url: /blog/2016/03/Using-Spark-And-Zeppelin-To-Process-Big-Data-On-Kubernetes
+author: >
+  Zach Loafman (Google)
 ---
-_Editor's note: this is the fifth post in a [series of in-depth posts](https://kubernetes.io/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2&nbsp;_  
+_**Editor's note:** this is the fifth post in a [series of in-depth posts](/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
 
 With big data usage growing exponentially, many Kubernetes customers have expressed interest in running [Apache Spark](http://spark.apache.org/) on their Kubernetes clusters to take advantage of the portability and flexibility of containers. Fortunately, with Kubernetes 1.2, you can now have a platform that runs Spark and Zeppelin, and your other applications side-by-side.  
 
@@ -133,6 +135,4 @@ Please join our community and help us build the future of Kubernetes! There are 
 - Our [Big Data slack channel](https://kubernetes.slack.com/messages/sig-big-data/)
 - Our [Kubernetes Big Data Special Interest Group email list](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data)
 - The Big Data “Special Interest Group,” which meets every Monday at 1pm (13h00) Pacific Time at [SIG-Big-Data hangout&nbsp;](https://plus.google.com/hangouts/_/google.com/big-data)
-And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/).  
-
-&nbsp;-- _Zach Loafman, Software Engineer, Google_
+And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/).

--- a/content/en/blog/_posts/2016-04-00-Adding-Support-For-Kubernetes-In-Rancher.md
+++ b/content/en/blog/_posts/2016-04-00-Adding-Support-For-Kubernetes-In-Rancher.md
@@ -3,8 +3,9 @@ title: " Adding Support for Kubernetes in Rancher "
 date: 2016-04-08
 slug: adding-support-for-kubernetes-in-rancher
 url: /blog/2016/04/Adding-Support-For-Kubernetes-In-Rancher
+author: >
+  Darren Shepherd (Rancher Labs) 
 ---
-_Today’s guest post is written by Darren Shepherd, Chief Architect at Rancher Labs, an open-source software platform for managing containers._  
 
 Over the last year, we’ve seen a tremendous increase in the number of companies looking to leverage containers in their software development and IT organizations. To achieve this, organizations have been looking at how to build a centralized container management capability that will make it simple for users to get access to containers, while centralizing visibility and control with the IT organization. In 2014 we started the open-source Rancher project to address this by building a management platform for containers.  
 
@@ -31,8 +32,4 @@ Even better, we have been able to add a number of services around the core Kuber
 
 
 
-Like Kubernetes, Rancher is an open-source software project, free to use by anyone, and given to the community without any restrictions. You can find all of the source code, upcoming releases and issues for Rancher on [GitHub](http://www.github.com/rancher/rancher). We’re thrilled to be joining the Kubernetes community, and look forward to working with all of the other contributors. View a demo of the new Kubernetes support in Rancher [here](http://rancher.com/kubernetes/).&nbsp;
-
-
-
-_-- Darren Shepherd, Chief Architect, Rancher Labs_
+Like Kubernetes, Rancher is an open-source software project, free to use by anyone, and given to the community without any restrictions. You can find all of the source code, upcoming releases and issues for Rancher on [GitHub](http://www.github.com/rancher/rancher). We’re thrilled to be joining the Kubernetes community, and look forward to working with all of the other contributors. View a demo of the new Kubernetes support in Rancher [here](http://rancher.com/kubernetes/).

--- a/content/en/blog/_posts/2016-04-00-Building-Awesome-User-Interfaces-For-Kubernetes.md
+++ b/content/en/blog/_posts/2016-04-00-Building-Awesome-User-Interfaces-For-Kubernetes.md
@@ -3,8 +3,10 @@ title: " SIG-UI: the place for building awesome user interfaces for Kubernetes "
 date: 2016-04-20
 slug: building-awesome-user-interfaces-for-kubernetes
 url: /blog/2016/04/Building-Awesome-User-Interfaces-For-Kubernetes
+author: >
+  Piotr Bryk (Google) 
 ---
-_Editor’s note: This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the SIG-UI team describing their mission and showing the cool projects they work on._  
+_**Editor's note:** This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the SIG-UI team describing their mission and showing the cool projects they work on._  
 
 Kubernetes has been handling production workloads for a long time now (see [case studies](http://kubernetes.io/#talkToUs)). It runs on public, private and hybrid clouds as well as bare metal. It can handle all types of workloads (web serving, batch and mixed) and enable [zero-downtime rolling updates](https://www.youtube.com/watch?v=9C6YeyyUUmI). It abstracts service discovery, load balancing and storage so that applications running on Kubernetes aren’t restricted to a specific cloud provider or environment.  
 
@@ -27,6 +29,4 @@ We believe that collaboration is the key to SIG UI success, so we invite everyon
 
 - Email us at the [sig-ui mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
 - Chat with us on the [Kubernetes Slack](http://slack.k8s.io/): #[sig-ui channel](https://kubernetes.slack.com/messages/sig-ui/)
-- Join our meetings: biweekly on Wednesdays 9AM PT (US friendly) and weekly 10AM CET (Europe friendly). See the [SIG-UI calendar](https://calendar.google.com/calendar/embed?src=google.com_52lm43hc2kur57dgkibltqc6kc%40group.calendar.google.com&ctz=Europe/Warsaw) for details.&nbsp;
-
-_-- Piotr Bryk, Software Engineer, Google_  
+- Join our meetings: biweekly on Wednesdays 9AM PT (US friendly) and weekly 10AM CET (Europe friendly). See the [SIG-UI calendar](https://calendar.google.com/calendar/embed?src=google.com_52lm43hc2kur57dgkibltqc6kc%40group.calendar.google.com&ctz=Europe/Warsaw) for details.

--- a/content/en/blog/_posts/2016-04-00-Configuration-Management-With-Containers.md
+++ b/content/en/blog/_posts/2016-04-00-Configuration-Management-With-Containers.md
@@ -3,8 +3,10 @@ title: " Configuration management with Containers "
 date: 2016-04-04
 slug: configuration-management-with-containers
 url: /blog/2016/04/Configuration-Management-With-Containers
+author: >
+  Paul Morie (Red Hat)
 ---
-_Editor’s note: this is our seventh post in a [series of in-depth posts](https://kubernetes.io/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
+_**Editor's note:** this is our seventh post in a [series of in-depth posts](/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
 
 A [good practice](http://12factor.net/config) when writing applications is to separate application code from configuration. We want to enable application authors to easily employ this pattern within Kubernetes. While  the Secrets API allows separating information like credentials and keys from an application, no object existed in the past for ordinary, non-secret configuration. In [Kubernetes 1.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md/#v120), we've added a new API resource called ConfigMap to handle this type of configuration data.  
 
@@ -196,6 +198,4 @@ If you’re interested in Kubernetes and configuration, you’ll want to partici
 
 
 
-And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/) and follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio).  
-
--- _Paul Morie, Senior Software Engineer, Red Hat_
+And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/) and follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio).

--- a/content/en/blog/_posts/2016-04-00-Container-Survey-Results-March-2016.md
+++ b/content/en/blog/_posts/2016-04-00-Container-Survey-Results-March-2016.md
@@ -3,6 +3,8 @@ title: " Container survey results - March 2016 "
 date: 2016-04-08
 slug: container-survey-results-march-2016
 url: /blog/2016/04/Container-Survey-Results-March-2016
+author: >
+  Brendan Burns (Google)
 ---
 Last month, we had our third installment of our container survey and today we look at the results. &nbsp;(raw data is available [here](https://docs.google.com/spreadsheets/d/13356w6I2xxKnmjblFSsKGVANZGGlX2yFMzb8eOIe2Oo/edit?usp=sharing))
 
@@ -30,6 +32,4 @@ Finally, [Kubernetes](http://kubernetes.io/) is still the favorite for container
 
 Finally, the absolute use of containers appears to be ticking up. &nbsp;The number of people running more than 250 containers has grown from 12% to nearly 20%. &nbsp;And the number people running containers on 50 or more machines has grown from 10% to 18%.
 
-As always, the raw data is available for you to analyze [here](https://docs.google.com/spreadsheets/d/13356w6I2xxKnmjblFSsKGVANZGGlX2yFMzb8eOIe2Oo/edit?usp=sharing).  
-
---Brendan Burns, Software Engineer, Google
+As always, the raw data is available for you to analyze [here](https://docs.google.com/spreadsheets/d/13356w6I2xxKnmjblFSsKGVANZGGlX2yFMzb8eOIe2Oo/edit?usp=sharing).

--- a/content/en/blog/_posts/2016-04-00-Introducing-Kubernetes-Openstack-Sig.md
+++ b/content/en/blog/_posts/2016-04-00-Introducing-Kubernetes-Openstack-Sig.md
@@ -3,8 +3,11 @@ title: " Introducing the Kubernetes OpenStack Special Interest Group "
 date: 2016-04-22
 slug: introducing-kubernetes-openstack-sig
 url: /blog/2016/04/Introducing-Kubernetes-Openstack-Sig
+author: >
+  Steve Gordon (Red Hat),
+  Ihor Dvoretskyi (Mirantis)
 ---
-_Editor’s note: This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the SIG-OpenStack team about their mission to facilitate ideas between the OpenStack and Kubernetes communities.&nbsp;_  
+_**Editor's note:**  This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the SIG-OpenStack team about their mission to facilitate ideas between the OpenStack and Kubernetes communities.&nbsp;_  
 
 
 
@@ -59,7 +62,3 @@ If you’re interested in Kubernetes and OpenStack, there are several ways to pa
 - Email us at the [SIG-OpenStack mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
 - Chat with us on the [Kubernetes Slack](http://slack.k8s.io/): [#sig-openstack channel](https://kubernetes.slack.com/messages/sig-openstack/)&nbsp;and #openstack-kubernetes on freenode
 - Join our meeting occurring every second Tuesday at 2 PM PDT; attend via the zoom videoconference found in our [meeting notes](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit#).
-
-
-
-_-- Steve Gordon, Principal Product Manager at Red Hat, and Ihor Dvoretskyi, OpenStack Operations Engineer at Mirantis_

--- a/content/en/blog/_posts/2016-04-00-Kubernetes-Network-Policy-APIs.md
+++ b/content/en/blog/_posts/2016-04-00-Kubernetes-Network-Policy-APIs.md
@@ -3,8 +3,10 @@ title: " SIG-Networking: Kubernetes Network Policy APIs Coming in 1.3 "
 date: 2016-04-18
 slug: kubernetes-network-policy-apis
 url: /blog/2016/04/Kubernetes-Network-Policy-APIs
+author: >
+  Chris Marino (Pani Networks)
 ---
-_Editor’s note: This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the Network-SIG team describing network policy APIs coming in 1.3 - policies for security, isolation and multi-tenancy._  
+_**Editor's note:** This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the Network-SIG team describing network policy APIs coming in 1.3 - policies for security, isolation and multi-tenancy._  
 
 The [Kubernetes network SIG](https://kubernetes.slack.com/messages/sig-network/) has been meeting regularly since late last year to work on bringing network policy to Kubernetes and we’re starting to see the results of this effort.  
 
@@ -163,7 +165,4 @@ If you’re interested in Kubernetes and networking, there are several ways to p
 - Our [Kubernetes Networking Special Interest Group](https://groups.google.com/forum/#!forum/kubernetes-sig-network) email list&nbsp;
 
 
-The Networking “Special Interest Group,” which meets bi-weekly at 3pm (15h00) Pacific Time at [SIG-Networking hangout](https://zoom.us/j/5806599998).&nbsp;
-
-
-_--Chris Marino, Co-Founder, Pani Networks_  
+The Networking “Special Interest Group,” which meets bi-weekly at 3pm (15h00) Pacific Time at [SIG-Networking hangout](https://zoom.us/j/5806599998).

--- a/content/en/blog/_posts/2016-04-00-Kubernetes-On-Aws_15.md
+++ b/content/en/blog/_posts/2016-04-00-Kubernetes-On-Aws_15.md
@@ -3,11 +3,9 @@ title: " How to deploy secure, auditable, and reproducible Kubernetes clusters o
 date: 2016-04-15
 slug: kubernetes-on-aws_15
 url: /blog/2016/04/Kubernetes-On-Aws_15
+author: >
+  Colin Hom (CoreOS)
 ---
-
-_Today’s guest post is written by Colin Hom, infrastructure engineer at [CoreOS](https://coreos.com/), the company delivering Google’s Infrastructure for Everyone Else (#GIFEE) and running the world's containers securely on CoreOS Linux, Tectonic and Quay._  
-
-_Join us at [CoreOS Fest Berlin](https://coreos.com/fest/), the Open Source Distributed Systems Conference, and learn more about CoreOS and Kubernetes._  
 
 At CoreOS, we're all about deploying Kubernetes in production at scale. Today we are excited to share a tool that makes deploying Kubernetes on Amazon Web Services (AWS) a breeze. Kube-aws is a tool for deploying auditable and reproducible Kubernetes clusters to AWS, currently used by CoreOS to spin up production clusters.  
 
@@ -116,7 +114,3 @@ A [github issue](https://github.com/coreos/coreos-kubernetes/issues/340) tracks 
 
 
 _Learn more about Kubernetes and meet the community at [CoreOS Fest Berlin](https://coreos.com/fest/) - May 9-10, 2016_
-
-
-
-_– Colin Hom, infrastructure engineer, CoreOS_

--- a/content/en/blog/_posts/2016-04-00-Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters.md
+++ b/content/en/blog/_posts/2016-04-00-Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters.md
@@ -3,8 +3,10 @@ title: " SIG-ClusterOps: Promote operability and interoperability of Kubernetes 
 date: 2016-04-19
 slug: sig-clusterops-promote-operability-and-interoperability-of-k8s-clusters
 url: /blog/2016/04/Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters
+author: >
+  Rob Hirschfeld (RackN)
 ---
-_Editor’s note: This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the SIG-ClusterOps team whose mission is to promote operability and interoperability of Kubernetes clusters -- to listen, help & escalate._  
+_**Editor's note:** This week we’re featuring [Kubernetes Special Interest Groups](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)); Today’s post is by the SIG-ClusterOps team whose mission is to promote operability and interoperability of Kubernetes clusters -- to listen, help & escalate._  
 
 We think Kubernetes is an awesome way to run applications at scale! Unfortunately, there's a bootstrapping problem: we need good ways to build secure & reliable scale environments around Kubernetes. While some parts of the platform administration leverage the platform (cool!), there are fundamental operational topics that need to be addressed and questions (like upgrade and conformance) that need to be answered.  
 
@@ -26,8 +28,4 @@ Cluster Ops can be hard work – don't do it alone. We're here to listen, to hel
 - Chat with us on the [Cluster Ops Slack channel](https://kubernetes.slack.com/messages/sig-cluster-ops/)
 - Email us at the [Cluster Ops SIG email list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-ops)
 
-The Cluster Ops Special Interest Group meets weekly at 13:00PT on Thursdays, you can join us via the [video hangout](https://plus.google.com/hangouts/_/google.com/sig-cluster-ops) and see latest [meeting notes](https://docs.google.com/document/d/1IhN5v6MjcAUrvLd9dAWtKcGWBWSaRU8DNyPiof3gYMY/edit) for agendas and topics covered.  
-
-
-
-_--Rob Hirschfeld, CEO, RackN&nbsp;_
+The Cluster Ops Special Interest Group meets weekly at 13:00PT on Thursdays, you can join us via the [video hangout](https://plus.google.com/hangouts/_/google.com/sig-cluster-ops) and see latest [meeting notes](https://docs.google.com/document/d/1IhN5v6MjcAUrvLd9dAWtKcGWBWSaRU8DNyPiof3gYMY/edit) for agendas and topics covered.

--- a/content/en/blog/_posts/2016-04-00-Using-Deployment-Objects-With.md
+++ b/content/en/blog/_posts/2016-04-00-Using-Deployment-Objects-With.md
@@ -3,8 +3,10 @@ title: " Using Deployment objects with Kubernetes 1.2 "
 date: 2016-04-01
 slug: using-deployment-objects-with
 url: /blog/2016/04/Using-Deployment-Objects-With
+author: >
+  Janet Kuo (Google) 
 ---
-_Editor's note: this is the seventh post in a [series of in-depth posts](https://kubernetes.io/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
+_**Editor's note:** this is the seventh post in a [series of in-depth posts](/blog/2016/03/five-days-of-kubernetes-12) on what's new in Kubernetes 1.2_  
 
 Kubernetes has made deploying and managing applications very straightforward, with most actions a single API or command line away, including rolling out new applications, canary testing and upgrading. So why would we need Deployments?  
 
@@ -138,7 +140,6 @@ But there’s so much more in Deployment that this article didn’t cover! To di
 - The Configuration “Special Interest Group,” which meets weekly on Wednesdays at 10am (10h00) Pacific Time at [SIG-Config hangout](https://hangouts.google.com/hangouts/_/google.com/kube-sig-config)
 And of course for more information about the project in general, go to [www.kubernetes.io](http://www.kubernetes.io/).  
 
- -- _Janet Kuo, Software Engineer, Google_  
 
 
 **1** “kubectl run” outputs the type and name of the resource(s) it creates. In 1.2, it now creates a deployment resource. You can use that in subsequent commands, such as "kubectl get deployment ", or "kubectl expose deployment ". If you want to write a script to do that automatically, in a forward-compatible manner, use "-o name" flag with "kubectl run", and it will generate short output "deployments/", which can also be used on subsequent command lines. The "--generator" flag can be used with "kubectl run" to generate other types of resources, for example, set it to "run/v1" to create a Replication Controller, which was the default in 1.1 and 1.0, and to "run-pod/v1" to create a Pod, such as for --restart=Never pods.

--- a/content/en/blog/_posts/2016-05-00-Coreosfest2016-Kubernetes-Community.md
+++ b/content/en/blog/_posts/2016-05-00-Coreosfest2016-Kubernetes-Community.md
@@ -3,6 +3,8 @@ title: " CoreOS Fest 2016: CoreOS and Kubernetes Community meet in Berlin (& San
 date: 2016-05-03
 slug: coreosfest2016-kubernetes-community
 url: /blog/2016/05/Coreosfest2016-Kubernetes-Community
+author: >
+  Sarah Novotny (independent)
 ---
 [CoreOS Fest 2016](https://coreos.com/fest/) will bring together the container and open source distributed systems community, including many thought leaders in the Kubernetes space. It is the second annual CoreOS community conference, held for the first time in Berlin on May 9th and 10th. CoreOS believes Kubernetes is the container orchestration component to deliver GIFEE (Google’s Infrastructure for Everyone Else).  
 
@@ -37,7 +39,4 @@ If you can’t make it to Berlin, Kubernetes is also a focal point at the **Core
 - [CoreOS Fest - Berlin](https://ti.to/coreos/coreos-fest-2016/en), at the [Berlin Congress Center](https://www.google.com/maps/place/bcc+Berlin+Congress+Center+GmbH/@52.5206732,13.4165195,15z/data=!4m2!3m1!1s0x0:0xd2a15220241f2080) ([hotel option](http://www.parkinn-berlin.de/))
 - satellite event in [San Francisco](https://www.eventbrite.com/e/coreos-fest-san-francisco-satellite-event-tickets-22705108591), at the [111 Minna Gallery](https://www.google.com/maps/place/111+Minna+Gallery/@37.7873222,-122.3994124,15z/data=!4m2!3m1!1s0x0:0xb55875af8c0ca88b?sa=X&ved=0ahUKEwjZ8cPLtL7MAhVQ5GMKHa8bCM4Q_BIIdjAN)
 
-Learn more at:&nbsp;[coreos.com/fest/](https://coreos.com/fest/)&nbsp;and on Twitter&nbsp;[@CoreOSFest](https://twitter.com/coreosfest) #CoreOSFest  
-
-
-_-- Sarah Novotny, Kubernetes Community Manager_
+Learn more at:&nbsp;[coreos.com/fest/](https://coreos.com/fest/)&nbsp;and on Twitter&nbsp;[@CoreOSFest](https://twitter.com/coreosfest) #CoreOSFest

--- a/content/en/blog/_posts/2016-05-00-Hypernetes-Security-And-Multi-Tenancy-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-05-00-Hypernetes-Security-And-Multi-Tenancy-In-Kubernetes.md
@@ -3,8 +3,10 @@ title: " Hypernetes: Bringing Security and Multi-tenancy to Kubernetes "
 date: 2016-05-24
 slug: hypernetes-security-and-multi-tenancy-in-kubernetes
 url: /blog/2016/05/Hypernetes-Security-And-Multi-Tenancy-In-Kubernetes
----
-_Today’s guest post is written by Harry Zhang and Pengfei Ni, engineers at HyperHQ, describing a new hypervisor based container called HyperContainer_  
+author: >
+  Harry Zhang (HyperHQ),
+  Pengfei Ni (HyperHQ)
+--- 
 
 While many developers and security professionals are comfortable with Linux containers as an effective boundary, many users need a stronger degree of isolation, particularly for those running in a multi-tenant environment. Sadly, today, those users are forced to run their containers inside virtual machines, even one VM per container.  
 
@@ -193,9 +195,3 @@ We believe all of these [open source projects](https://github.com/hyperhq/) are 
 
 
 This post introduces some of the technical details about HyperContainer and the Hypernetes project. We hope that people will be interested in this new category of secure container and its integration with Kubernetes. If you are looking to try out Hypernetes and HyperContainer, we have just announced the public beta of our new secure container cloud service ([Hyper\_](https://hyper.sh/)), which is built on these technologies. But even if you are running on-premise, we believe that Hypernetes and HyperContainer will let you run Kubernetes in a more secure way.
-
-
-
-
-
-_~Harry Zhang and Pengfei Ni, engineers at HyperHQ_

--- a/content/en/blog/_posts/2016-06-00-Bringing-End-To-End-Testing-To-Azure.md
+++ b/content/en/blog/_posts/2016-06-00-Bringing-End-To-End-Testing-To-Azure.md
@@ -3,9 +3,9 @@ title: " Bringing End-to-End Kubernetes Testing to Azure (Part 1) "
 date: 2016-06-06
 slug: bringing-end-to-end-testing-to-azure
 url: /blog/2016/06/Bringing-End-To-End-Testing-To-Azure
+author: >
+  Travis Newhouse (AppFormix)
 ---
-
-_Today’s guest post is by Travis Newhouse, Chief Architect at AppFormix, writing about their experiences bringing Kubernetes to Azure._  
 
 At [AppFormix](http://www.appformix.com/), continuous integration testing is part of our culture. We see many benefits to running end-to-end tests regularly, including minimizing regressions and ensuring our software works together as a whole. To ensure a high quality experience for our customers, we require the ability to run end-to-end testing not just for our application, but for the entire orchestration stack. Our customers are adopting Kubernetes as their container orchestration technology of choice, and they demand choice when it comes to where their containers execute, from private infrastructure to public providers, including Azure. After several weeks of work, we are pleased to announce we are contributing a nightly, continuous integration job that executes e2e tests on the Azure platform. After running the e2e tests each night for only a few weeks, we have already found and fixed two issues in Kubernetes. We hope our contribution of an e2e job will help the community maintain support for the Azure platform as Kubernetes evolves.    
 

--- a/content/en/blog/_posts/2016-06-00-Container-Design-Patterns.md
+++ b/content/en/blog/_posts/2016-06-00-Container-Design-Patterns.md
@@ -3,6 +3,9 @@ title: " Container Design Patterns "
 date: 2016-06-21
 slug: container-design-patterns
 url: /blog/2016/06/Container-Design-Patterns
+author: >
+  Brendan Burns (Google),
+  David Oppenheimer (Google)
 ---
 Kubernetes automates deployment, operations, and scaling of applications, but our goals in the Kubernetes project extend beyond system management -- we want Kubernetes to help developers, too. Kubernetes should make it easy for them to write the distributed applications and services that run in cloud and datacenter environments. To enable this, Kubernetes defines not only an API for administrators to perform management actions, but also an API for containerized applications to interact with the management platform.  
 
@@ -19,6 +22,4 @@ This week Kubernetes co-founder Brendan Burns is presenting a [**paper**](https:
 
 As the Kubernetes project continues to bring our decade of experience with [Borg](https://queue.acm.org/detail.cfm?id=2898444) to the open source community, we aim not only to make application deployment and operations at scale simple and reliable, but also to make it easy to create “cloud-native” applications in the first place. Our work on documenting our ideas around design patterns for container-based services, and Kubernetes’s enabling of such patterns, is a first step in this direction. We look forward to working with the academic and practitioner communities to identify and codify additional patterns, with the aim of helping containers fulfill the promise of bringing increased simplicity and reliability to the entire software lifecycle, from development, to deployment, to operations.  
 
-To learn more about the Kubernetes project visit [kubernetes.io](http://kubernetes.io/) or chat with us on Slack at [slack.kubernetes.io](http://slack.kubernetes.io/).  
-
--_-Brendan Burns and David Oppenheimer, Software Engineers, Google_  
+To learn more about the Kubernetes project visit [kubernetes.io](http://kubernetes.io/) or chat with us on Slack at [slack.kubernetes.io](http://slack.kubernetes.io/).

--- a/content/en/blog/_posts/2016-07-00-Automation-Platform-At-Wercker-With-Kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-Automation-Platform-At-Wercker-With-Kubernetes.md
@@ -3,8 +3,9 @@ title: " Steering an Automation Platform at Wercker with Kubernetes "
 date: 2016-07-15
 slug: automation-platform-at-wercker-with-kubernetes
 url: /blog/2016/07/Automation-Platform-At-Wercker-With-Kubernetes
+author: >
+  Andy Smith (Wercker)
 ---
-_Editor’s note: today’s guest post is by Andy Smith, the CTO of Wercker, sharing how Kubernetes helps them save time and speed up development. &nbsp;_  
 
 At [Wercker](http://wercker.com/) we run millions of containers that execute our users’ CI/CD jobs. The vast majority of them are ephemeral and only last as long as builds, tests and deploys take to run, the rest are ephemeral, too -- aren't we all --, but tend to last a bit longer and run our infrastructure. As we are running many containers across many nodes, we were in need of a highly scalable scheduler that would make our lives easier, and as such, decided to implement Kubernetes.  
 
@@ -61,7 +62,3 @@ While we generally treat all of our pods and containers as ephemeral and expect 
 Kubernetes saves us the non-trivial task of managing many, many containers across many nodes. It provides a robust API and tooling for introspecting these containers, and it includes much built in support for logging, metrics, monitoring and debugging. Service discovery and networking alone saves us so much time and speeds development immensely.
 
 Cheers to you Kubernetes, keep up the good work :)
-
-
-
-_-- Andy Smith, CTO, Wercker_

--- a/content/en/blog/_posts/2016-07-00-Autoscaling-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-Autoscaling-In-Kubernetes.md
@@ -3,8 +3,11 @@ title: " Autoscaling in Kubernetes "
 date: 2016-07-12
 slug: autoscaling-in-kubernetes
 url: /blog/2016/07/Autoscaling-In-Kubernetes
+author: >
+  Jerzy Szczepkowski (Google),
+  Marcin Wielgus (Google)
 ---
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
 
 Customers using Kubernetes respond to end user requests quickly and ship software faster than ever before. But what happens when you build a service that is even more popular than you planned for, and run out of compute? In [Kubernetes 1.3](https://kubernetes.io/blog/2016/07/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads/), we are proud to announce that we have a solution: autoscaling. On [Google Compute Engine](https://cloud.google.com/compute/) (GCE) and [Google Container Engine](https://cloud.google.com/container-engine/) (GKE) (and coming soon on [AWS](https://aws.amazon.com/)), Kubernetes will automatically scale up your cluster as soon as you need it, and scale it back down to save you money when you don’t.
 
@@ -404,7 +407,3 @@ However Cluster Autoscaler alone can also be quite helpful whenever there are ir
 
 
 In all of these cases Cluster Autoscaler can reduce the number of unused nodes and give quite significant savings because you will only pay for these nodes that you actually need to run your pods. It also makes sure that you always have enough compute power to run your tasks.
-
-
-
-_-- Jerzy Szczepkowski and Marcin Wielgus, Software Engineers, Google_

--- a/content/en/blog/_posts/2016-07-00-Bringing-End-To-End-Kubernetes-Testing-To-Azure-2.md
+++ b/content/en/blog/_posts/2016-07-00-Bringing-End-To-End-Kubernetes-Testing-To-Azure-2.md
@@ -3,8 +3,9 @@ title: " Bringing End-to-End Kubernetes Testing to Azure (Part 2) "
 date: 2016-07-18
 slug: bringing-end-to-end-kubernetes-testing-to-azure-2
 url: /blog/2016/07/Bringing-End-To-End-Kubernetes-Testing-To-Azure-2
+author: >
+  Travis Newhouse (AppFormix)
 ---
-_Editor’s Note: Today’s guest post is Part II from a [series](https://kubernetes.io/blog/2016/06/bringing-end-to-end-testing-to-azure) by Travis Newhouse, Chief Architect at AppFormix, writing about their contributions to Kubernetes._  
 
 Historically, Kubernetes testing has been hosted by Google, running e2e tests on [Google Compute Engine](https://cloud.google.com/compute/) (GCE) and [Google Container Engine](https://cloud.google.com/container-engine/) (GKE). In fact, the gating checks for the submit-queue are a subset of tests executed on these test platforms. Federated testing aims to expand test coverage by enabling organizations to host test jobs for a variety of platforms and contribute test results to benefit the Kubernetes project. Members of the Kubernetes test team at Google and SIG-Testing have created a [Kubernetes test history dashboard](http://storage.googleapis.com/kubernetes-test-history/static/index.html) that publishes the results from all federated test jobs (including those hosted by Google).  
 
@@ -45,9 +46,4 @@ The second [pull-request cleaned up an unused import](https://github.com/kuberne
 
 The addition of a nightly e2e test job for Kubernetes on Azure has helped to define the process to contribute a federated test to the Kubernetes project. During the course of the work, we also saw the immediate benefit of expanding test coverage to more platforms when our Azure test job identified compatibility issues.  
 
-We want to thank Aaron Crickenberger, Erick Fejta, Joe Finney, and Ryan Hutchinson for their help to incorporate the results of our Azure e2e tests into the Kubernetes test history. If you’d like to get involved with testing to create a stable, high quality releases of Kubernetes, join us in the [Kubernetes Testing SIG (sig-testing)](https://github.com/kubernetes/community/tree/master/sig-testing).  
-
-
-
-
-_--Travis Newhouse, Chief Architect at AppFormix_
+We want to thank Aaron Crickenberger, Erick Fejta, Joe Finney, and Ryan Hutchinson for their help to incorporate the results of our Azure e2e tests into the Kubernetes test history. If you’d like to get involved with testing to create a stable, high quality releases of Kubernetes, join us in the [Kubernetes Testing SIG (sig-testing)](https://github.com/kubernetes/community/tree/master/sig-testing).

--- a/content/en/blog/_posts/2016-07-00-Citrix-Netscaler-And-Kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-Citrix-Netscaler-And-Kubernetes.md
@@ -3,8 +3,9 @@ title: " Citrix + Kubernetes = A Home Run "
 date: 2016-07-14
 slug: citrix-netscaler-and-kubernetes
 url: /blog/2016/07/Citrix-Netscaler-And-Kubernetes
+author: >
+  Mikko Disini (Citrix Systems)
 ---
-_Editor’s note: today’s guest post is by Mikko Disini, a Director of Product Management at Citrix Systems, sharing their collaboration experience on a Kubernetes integration.&nbsp;_  
 
 Technical collaboration is like sports. If you work together as a team, you can go down the homestretch and pull through for a win. That’s our experience with the Google Cloud Platform team.  
 
@@ -23,7 +24,4 @@ Next, NetScaler CPX needed to be inserted in the data path of GCP ingress load b
 
 NetScaler CPX use case is supported in [Kubernetes 1.3](https://kubernetes.io/blog/2016/07/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads/). Citrix customers and the broader enterprise market will have the opportunity to leverage NetScaler with Kubernetes, thereby lowering the friction to move workloads to the cloud.&nbsp;
 
-You can learn more about&nbsp;NetScaler CPX [here](https://www.citrix.com/networking/microservices.html).  
-
-
-_&nbsp;-- Mikko Disini, Director of Product Management - NetScaler, Citrix Systems_
+You can learn more about&nbsp;NetScaler CPX [here](https://www.citrix.com/networking/microservices.html).

--- a/content/en/blog/_posts/2016-07-00-Cross-Cluster-Services.md
+++ b/content/en/blog/_posts/2016-07-00-Cross-Cluster-Services.md
@@ -3,9 +3,12 @@ title: " Cross Cluster Services - Achieving Higher Availability for your Kuberne
 date: 2016-07-14
 slug: cross-cluster-services
 url: /blog/2016/07/Cross-Cluster-Services
+author: >
+  Quinton Hoole (Google),
+  Allan Naim (Google),
 ---
 
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
 
 As Kubernetes users scale their production deployments we’ve heard a clear desire to deploy services across zone, region, cluster and cloud boundaries. Services that span clusters provide geographic distribution, enable hybrid and multi-cloud scenarios and improve the level of high availability beyond single cluster multi-zone deployments. Customers who want their services to span one or more (possibly remote) clusters, need them to be reachable in a consistent manner from both within and outside their clusters.  
 
@@ -334,9 +337,3 @@ We'd love to hear feedback on Kubernetes Cross Cluster Services. To join the com
 
 
 Please give Cross Cluster Services a try, and let us know how it goes!
-
-
-
-
-
-_-- Quinton Hoole, Engineering Lead, Google and Allan Naim, Product Manager, Google_

--- a/content/en/blog/_posts/2016-07-00-Dashboard-Web-Interface-For-Kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-Dashboard-Web-Interface-For-Kubernetes.md
@@ -3,9 +3,11 @@ title: " Dashboard - Full Featured Web Interface for Kubernetes "
 date: 2016-07-15
 slug: dashboard-web-interface-for-kubernetes
 url: /blog/2016/07/Dashboard-Web-Interface-For-Kubernetes
+author: >
+  Piotr Bryk (Google)
 ---
 
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
 
 [Kubernetes Dashboard](http://github.com/kubernetes/dashboard) is a project that aims to bring a general purpose monitoring and operational web interface to the Kubernetes world.&nbsp;Three months ago we [released](https://kubernetes.io/blog/2016/04/building-awesome-user-interfaces-for-kubernetes) the first production ready version, and since then the dashboard has made massive improvements. In a single UI, you’re able to perform majority of possible interactions with your Kubernetes clusters without ever leaving your browser. This blog post breaks down new features introduced in the latest release and outlines the roadmap for the future.&nbsp;  
 
@@ -66,9 +68,3 @@ We would love to talk with you and hear your feedback!
 - Email us at the [SIG-UI mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
 - Chat with us on the Kubernetes Slack&nbsp;[#SIG-UI channel](https://kubernetes.slack.com/messages/sig-ui/)
 - Join our meetings: 4PM CEST. See the [SIG-UI calendar](https://calendar.google.com/calendar/embed?src=google.com_52lm43hc2kur57dgkibltqc6kc%40group.calendar.google.com&ctz=Europe/Warsaw) for details.
-
-
-
-
-
-_-- Piotr Bryk, Software Engineer, Google_

--- a/content/en/blog/_posts/2016-07-00-Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads.md
+++ b/content/en/blog/_posts/2016-07-00-Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads.md
@@ -4,9 +4,9 @@ date: 2016-07-06
 slug: kubernetes-1.3-bridging-cloud-native-and-enterprise-workloads
 url: /blog/2016/07/Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads
 evergreen: true
+author: >
+  Aparna Sinha (Google)
 ---
-
-**Author:** Aparna Sinha, Google
 
 Nearly two years ago, when we officially kicked off the Kubernetes project, we wanted to simplify distributed systems management and provide the core technology required to everyone. The community’s response to this effort has blown us away. Today, thousands of customers, partners and developers are running clusters in production using Kubernetes and have joined the cloud native revolution.&nbsp;  
 

--- a/content/en/blog/_posts/2016-07-00-Kubernetes-In-Rancher-Further-Evolution.md
+++ b/content/en/blog/_posts/2016-07-00-Kubernetes-In-Rancher-Further-Evolution.md
@@ -3,8 +3,9 @@ title: " Kubernetes in Rancher: the further evolution "
 date: 2016-07-12
 slug: kubernetes-in-rancher-further-evolution
 url: /blog/2016/07/Kubernetes-In-Rancher-Further-Evolution
+author: >
+  [Alena Prokharchyk](https://github.com/alena1108) (Rancher Labs)
 ---
-_Editor’s note: today's guest post is from Alena Prokharchyk, Principal Software Engineer at Rancher Labs, who’ll share how they are incorporating new Kubernetes features into their platform._  
 
 Kubernetes was the first external orchestration platform supported by [Rancher](http://rancher.com/kubernetes), and since its release, it has become one of the most widely used among our users, and continues to grow rapidly in adoption. As Kubernetes has evolved, so has Rancher in terms of adapting new Kubernetes features. We’ve started with supporting Kubernetes version 1.1, then switched to 1.2 as soon as it was released, and now we’re working on supporting the exciting new features in 1.3. I’d like to walk you through the features that we’ve been adding support for during each of these stages.  
 
@@ -178,18 +179,6 @@ So we’ve decided to eliminate the need of Rancher Kubernetes distribution, and
 - Enhanced UI to represent even more Kubernetes objects like: Deployment, Ingress, Daemonset.
 
 All of that is to make Kubernetes experience even more powerful and user intuitive. We’re so excited by all of the progress in the Kubernetes community, and thrilled to be participating. Kubernetes 1.3 is an incredibly significant release, and you’ll be able to upgrade to it very soon within Rancher.
-
-
-
-
-
-_-- Alena Prokharchyk, Principal Software Engineer, Rancher Labs. [Twitter @lemonjet](https://twitter.com/Lemonjet) & [GitHub alena1108](https://github.com/alena1108)_
-
-
-
-
-
-
 
 
  ![Rancher-and-Kubernetes.png](https://lh4.googleusercontent.com/isAt46fnmGerA0uPoTUlUS7y5MtmOYfMvKoTC52CK0ckUfFKVO_coY78jgLoQuxe4J3GVf3N2_IWCuKwxpRT6q_h4ek4yepfyWBmN_WSqyB2v7rRaZrpG4hPpuH0hIbIcmTDgUul)

--- a/content/en/blog/_posts/2016-07-00-Minikube-Easily-Run-Kubernetes-Locally.md
+++ b/content/en/blog/_posts/2016-07-00-Minikube-Easily-Run-Kubernetes-Locally.md
@@ -3,8 +3,10 @@ title: " Minikube: easily run Kubernetes locally  "
 date: 2016-07-11
 slug: minikube-easily-run-kubernetes-locally
 url: /blog/2016/07/Minikube-Easily-Run-Kubernetes-Locally
+author: >
+  Dan Lorenc (Google)
 ---
-_Editor's note: This is the first post in a [series of in-depth articles](https://kubernetes.io/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3&nbsp;_
+_**Editor's note:**  This is the first post in a [series of in-depth articles](/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
 
 While Kubernetes is one of the best tools for managing containerized applications available today, and has been production-ready for over a year, Kubernetes has been missing a great local development platform.  
 
@@ -128,6 +130,3 @@ We'd love to hear feedback on Minikube. To join the community:
 
 Please give Minikube a try, and let us know how it goes!
 
-
-
-_--Dan Lorenc, Software Engineer, Google_  

--- a/content/en/blog/_posts/2016-07-00-Oh-The-Places-You-Will-Go.md
+++ b/content/en/blog/_posts/2016-07-00-Oh-The-Places-You-Will-Go.md
@@ -3,8 +3,9 @@ title: " Happy Birthday Kubernetes. Oh, the places you’ll go! "
 date: 2016-07-21
 slug: oh-the-places-you-will-go
 url: /blog/2016/07/Oh-The-Places-You-Will-Go
+author: >
+  Justin Santa Barbara (independent)
 ---
-_Editor’s note, Today’s guest post is from an independent Kubernetes contributor, Justin Santa Barbara, sharing his reflection on growth of the project from inception to its future._  
 
 **Dear K8s,**  
 
@@ -32,5 +33,3 @@ So I’m looking forward to seeing more and more growth happen further and furth
 
 So I’m looking forward to your second birthday: I can try to predict what you’ll look like then, but I know you’ll surpass even the most audacious things I can imagine. Oh, the places you’ll go!  
 
-
-_-- Justin Santa Barbara, Independent Kubernetes Contributor_  

--- a/content/en/blog/_posts/2016-07-00-Rktnetes-Brings-Rkt-Container-Engine-To-Kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-Rktnetes-Brings-Rkt-Container-Engine-To-Kubernetes.md
@@ -3,8 +3,11 @@ title: " rktnetes brings rkt container engine to Kubernetes "
 date: 2016-07-11
 slug: rktnetes-brings-rkt-container-engine-to-kubernetes
 url: /blog/2016/07/Rktnetes-Brings-Rkt-Container-Engine-To-Kubernetes
+author: >
+  Yifan Gu (CoreOS),
+  Josh Wood (CoreOS)
 ---
-_Editor’s note: this post is part of&nbsp;a [series of in-depth articles](https://kubernetes.io/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3&nbsp;_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
 
 As part of [Kubernetes 1.3](https://kubernetes.io/blog/2016/07/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads/), we’re happy to report that our work to bring interchangeable container engines to Kubernetes is bearing early fruit. What we affectionately call “rktnetes” is included in the version 1.3 Kubernetes release, and is ready for development use. rktnetes integrates support for [CoreOS rkt](https://coreos.com/rkt/) into Kubernetes as the container runtime on cluster nodes, and is now part of the mainline Kubernetes source code. Today it’s easier than ever for developers and ops pros with container portability in mind to try out running Kubernetes with a different container engine.
 
@@ -81,4 +84,3 @@ Recent work aims to make rktnetes cluster creation much easier, too. While not y
 We’re excited to see the experiments the wider Kubernetes and CoreOS communities devise to put rktnetes to the test, and we welcome your input – and pull requests!  
 
 
-_--Yifan Gu and Josh Wood, rktnetes Team, [CoreOS](https://coreos.com/). Twitter [@CoreOSLinux](https://twitter.com/coreoslinux)._  

--- a/content/en/blog/_posts/2016-07-00-The-Bet-On-Kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-The-Bet-On-Kubernetes.md
@@ -3,8 +3,9 @@ title: " The Bet on Kubernetes, a Red Hat Perspective "
 date: 2016-07-21
 slug: the-bet-on-kubernetes
 url: /blog/2016/07/The-Bet-On-Kubernetes
+author: >
+  Clayton Coleman (Red Hat)
 ---
-_Editor’s note: Today’s guest post is from a Kubernetes contributor Clayton Coleman, Architect on OpenShift at Red Hat, sharing their adoption of the project from its beginnings._  
 
 Two years ago, Red Hat made a big bet on Kubernetes. We bet on a simple idea: that an open source community is the best place to build the future of application orchestration, and that only an open source community could successfully integrate the diverse range of capabilities necessary to succeed. As a Red Hatter, that idea is not far-fetched - we’ve seen it successfully applied in many communities, but we’ve also seen it fail, especially when a broad reach is not supported by solid foundations. On the one year anniversary of Kubernetes 1.0, two years after the first open-source commit to the Kubernetes project, it’s worth asking the question:  
 
@@ -41,6 +42,4 @@ In a recent post to the kubernetes-dev list, Brian Grant [laid out a great set o
 
 Of special interest to us is the story of extension - how the core of Kubernetes can become the beating heart of the datacenter operating system, and enable even more patterns for application management to build on top of Kubernetes, not just into it. Work done in the 1.2 and 1.3 releases around third party APIs, API discovery, flexible scheduler policy, external authorization and authentication (beyond those built into Kubernetes) is just the start. When someone has a need, we want them to easily find a solution, and we also want it to be easy for others to consume and contribute to that solution. Likewise, the best way to prove ideas is to prototype them against real needs and to iterate against real problems, which should be easy and natural.  
 
-By Kubernetes’ second birthday, I hope to reflect back on a long year of refinement, user success, and community participation. It has been a privilege and an honor to contribute to Kubernetes, and it still feels like we are just getting started. Thank you, and I hope you come along for the ride!  
-
-_-- Clayton Coleman, Contributor and Architect on Kubernetes and OpenShift at Red Hat. Follow him on Twitter and GitHub: @smarterclayton_  
+By Kubernetes’ second birthday, I hope to reflect back on a long year of refinement, user success, and community participation. It has been a privilege and an honor to contribute to Kubernetes, and it still feels like we are just getting started. Thank you, and I hope you come along for the ride!

--- a/content/en/blog/_posts/2016-07-00-Thousand-Instances-Of-Cassandra-Using-Kubernetes-Pet-Set.md
+++ b/content/en/blog/_posts/2016-07-00-Thousand-Instances-Of-Cassandra-Using-Kubernetes-Pet-Set.md
@@ -3,9 +3,11 @@ title: " Thousand Instances of Cassandra using Kubernetes Pet Set "
 date: 2016-07-13
 slug: thousand-instances-of-cassandra-using-kubernetes-pet-set
 url: /blog/2016/07/Thousand-Instances-Of-Cassandra-Using-Kubernetes-Pet-Set
+author: >
+   [Chris Love](https://twitter.com/chrislovecnm/) (Datapipe)
 ---
 
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/07/five-days-of-kubernetes-1-3) on what's new in Kubernetes 1.3_
 
 
 ## Running The Greek Pet Monster Races
@@ -372,4 +374,3 @@ Yes we deployed 1,000 pets, but one really did not want to join the party! Techn
 - Image credits: Cassandra [image](https://commons.wikimedia.org/wiki/File:Cassandra1.jpeg) and Cyclops [image](https://commons.wikimedia.org/wiki/File:Polyphemus.gif)
 
 
-_-- Chris Love, Senior DevOps Open Source Consultant for [Datapipe](https://www.datapipe.com/). [Twitter @chrislovecnm](https://twitter.com/chrislovecnm/)_  

--- a/content/en/blog/_posts/2016-07-00-Update-On-Kubernetes-For-Windows-Server-Containers.md
+++ b/content/en/blog/_posts/2016-07-00-Update-On-Kubernetes-For-Windows-Server-Containers.md
@@ -3,6 +3,8 @@ title: " Updates to Performance and Scalability in Kubernetes 1.3 -- 2,000 node 
 date: 2016-07-07
 slug: update-on-kubernetes-for-windows-server-containers
 url: /blog/2016/07/Update-On-Kubernetes-For-Windows-Server-Containers
+author: >
+   Wojciech Tyczynski (Google)
 ---
 We are proud to announce that with the [release of version 1.3](https://kubernetes.io/blog/2016/07/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads/), Kubernetes now supports 2000-node clusters with even better end-to-end pod startup time. The latency of our API calls are within our one-second [Service Level Objective (SLO)](https://en.wikipedia.org/wiki/Service_level_objective) and most of them are even an order of magnitude better than that. It is possible to run larger deployments than a 2,000 node cluster, but performance may be degraded and it may not meet our strict SLO.
 
@@ -99,8 +101,4 @@ Please join our community and help us build the future of Kubernetes! If you’r
 - chatting with us on our [Slack channel](https://kubernetes.slack.com/messages/sig-scale/)
 - joining the scalability [Special Interest Group](https://github.com/kubernetes/community/blob/master/README.md#special-interest-groups-sig), which meets every Thursday at 9 AM Pacific Time on this [SIG-Scale Hangout](https://plus.google.com/hangouts/_/google.com/k8scale-hangout)
 
-For more information about the Kubernetes project, visit [kubernetes.io](http://kubernetes.io/) and follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio).&nbsp;
-
-
-
-_-- Wojciech Tyczynski, Software Engineer, Google_  
+For more information about the Kubernetes project, visit [kubernetes.io](http://kubernetes.io/) and follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio).

--- a/content/en/blog/_posts/2016-07-00-happy-k8sbday-1.md
+++ b/content/en/blog/_posts/2016-07-00-happy-k8sbday-1.md
@@ -3,6 +3,8 @@ title: " A Very Happy Birthday Kubernetes "
 date: 2016-07-21
 slug: happy-k8sbday-1
 url: /blog/2016/07/happy-k8sbday-1
+author: >
+  Sarah Novotny (independent)
 ---
 Last year at OSCON, I got to reconnect with a bunch of friends and see what they have been working on. That turned out to be the [Kubernetes 1.0 launch event](https://www.youtube.com/playlist?list=PL69nYSiGNLP0Ljwa9J98xUd6UlM604Y-l). Even that day, it was clear the project was supported by a broad community -- a group that showed an ambitious vision for distributed computing.&nbsp;  
 
@@ -21,7 +23,3 @@ The Kubernetes community continues to work to make our project more welcoming an
 
 [![](https://1.bp.blogspot.com/-Wn9QJb6wQ7w/V5Cm1Y2iKhI/AAAAAAAAAnc/SZ3yFFcxjmoqAmz9chp8o2KJJUoKI0KQwCLcB/s640/k8s%2BCommit%2BInfographic.png)](https://1.bp.blogspot.com/-Wn9QJb6wQ7w/V5Cm1Y2iKhI/AAAAAAAAAnc/SZ3yFFcxjmoqAmz9chp8o2KJJUoKI0KQwCLcB/s1600/k8s%2BCommit%2BInfographic.png)
 
-
-
-
-_-- Sarah Novotny, Kubernetes Community Wonk_

--- a/content/en/blog/_posts/2016-07-00-openstack-kubernetes-communities.md
+++ b/content/en/blog/_posts/2016-07-00-openstack-kubernetes-communities.md
@@ -3,6 +3,8 @@ title: " Why OpenStack's embrace of Kubernetes is great for both communities "
 date: 2016-07-26
 slug: openstack-kubernetes-communities
 url: /blog/2016/07/openstack-kubernetes-communities
+author: >
+  Martin Buhr (Google)
 ---
 Today, [Mirantis](https://www.mirantis.com/), the leading&nbsp;contributor&nbsp;to [OpenStack](http://stackalytics.com/?release=mitaka), [announced](https://techcrunch.com/2016/07/25/openstack-will-soon-be-able-to-run-on-top-of-kubernetes/) that it will re-write its private cloud platform to use Kubernetes as its underlying orchestration engine. We think this is a great step forward for both the OpenStack and Kubernetes communities. With Kubernetes under the hood, OpenStack users will benefit from the tremendous efficiency, manageability and resiliency that Kubernetes brings to the table, while positioning their applications to use more cloud-native patterns. The Kubernetes community, meanwhile, can feel confident in their choice of orchestration framework, while gaining the ability to manage both container- and VM-based applications from a single platform.  
 
@@ -27,6 +29,5 @@ Conversely, incorporating Kubernetes into OpenStack will give Kubernetes users a
 We are excited by the ever increasing momentum of the cloud-native movement as embodied by Kubernetes and related projects, and look forward to working with Mirantis, its partner Intel, and others within the OpenStack community to brings the benefits of cloud-native to their applications and infrastructure.  
 
 
-_--Martin Buhr, Product Manager, Strategic Initiatives, Google_  
 
 [1] Check out the announcement of Kubernetes-OpenStack Special Interest Group [here](https://kubernetes.io/blog/2016/04/introducing-kubernetes-openstack-sig), and a great talk about OpenStack on Kubernetes by CoreOS CEO Alex Polvi at the most recent OpenStack summit [here](https://www.youtube.com/watch?v=e-j9FOO-i84).  

--- a/content/en/blog/_posts/2016-07-00-stateful-applications-in-containers-kubernetes.md
+++ b/content/en/blog/_posts/2016-07-00-stateful-applications-in-containers-kubernetes.md
@@ -3,9 +3,9 @@ title: " Stateful Applications in Containers!? Kubernetes 1.3 Says “Yes!” "
 date: 2016-07-13
 slug: stateful-applications-in-containers-kubernetes
 url: /blog/2016/07/stateful-applications-in-containers-kubernetes
+author: >
+  [Mark Balch](https://twitter.com/markbalch) (Diamanti)
 ---
-
-_Editor's note: today’s guest post is from Mark Balch, VP of Products at Diamanti, who’ll share more about the contributions they’ve made to Kubernetes._    
 
 Congratulations to the Kubernetes community on another [value-packed release](https://kubernetes.io/blog/2016/07/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads/). A focus on stateful applications and federated clusters are two reasons why I’m so excited about 1.3. Kubernetes support for stateful apps such as Cassandra, Kafka, and MongoDB is critical. Important services rely on databases, key value stores, message queues, and more. Additionally, relying on one data center or container cluster simply won’t work as apps grow to serve millions of users around the world. Cluster federation allows users to deploy apps across multiple clusters and data centers for scale and resiliency.
 
@@ -37,6 +37,3 @@ Join the conversation and contribute! Here are some places to get started:
 - Product Management [group](https://groups.google.com/forum/#!forum/kubernetes-sig-pm)
 - Kubernetes [Storage SIG](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)&nbsp;
 - Kubernetes [Cluster Federation SIG](https://groups.google.com/forum/#!forum/kubernetes-sig-federation)
-
-
-_-- Mark Balch, VP Products, [Diamanti](https://diamanti.com/). Twitter [@markbalch](https://twitter.com/markbalch)_  

--- a/content/en/blog/_posts/2016-08-00-Challenges-Remotely-Managed-Onpremise-Kubernetes-Cluster.md
+++ b/content/en/blog/_posts/2016-08-00-Challenges-Remotely-Managed-Onpremise-Kubernetes-Cluster.md
@@ -3,9 +3,9 @@ title: " Challenges of a Remotely Managed, On-Premises, Bare-Metal Kubernetes Cl
 date: 2016-08-02
 slug: challenges-remotely-managed-onpremise-kubernetes-cluster
 url: /blog/2016/08/Challenges-Remotely-Managed-Onpremise-Kubernetes-Cluster
+author: >
+  Bich Le (Platform9)
 ---
-
-_Today's post is written by Bich Le, chief architect at Platform9, describing how their engineering team overcame challenges in remotely managing bare-metal Kubernetes clusters.&nbsp;_  
 
 **Introduction**  
 
@@ -53,7 +53,4 @@ We faced complex challenges in other areas that deserve their own posts: (1) _Au
 
 **Conclusion**  
 
-[Platform9 Managed Kubernetes](https://platform9.com/products/docker/) uses a SaaS-managed model to try to hide the complexity of deploying, operating and maintaining bare-metal&nbsp;Kubernetes&nbsp;clusters in customers’ data centers.&nbsp;These requirements led to the development of a unique cluster deployment and management architecture, which in turn led to unique technical challenges.This article described an overview of some of those challenges and how we solved them. For more information on the motivation behind PMK, feel free to view Madhura Maskasky's [blog post](https://platform9.com/blog/containers-as-a-service-kubernetes-docker/).  
-
-
-_--Bich Le, Chief Architect, Platform9_  
+[Platform9 Managed Kubernetes](https://platform9.com/products/docker/) uses a SaaS-managed model to try to hide the complexity of deploying, operating and maintaining bare-metal&nbsp;Kubernetes&nbsp;clusters in customers’ data centers.&nbsp;These requirements led to the development of a unique cluster deployment and management architecture, which in turn led to unique technical challenges.This article described an overview of some of those challenges and how we solved them. For more information on the motivation behind PMK, feel free to view Madhura Maskasky's [blog post](https://platform9.com/blog/containers-as-a-service-kubernetes-docker/).

--- a/content/en/blog/_posts/2016-08-00-Create-Couchbase-Cluster-Using-Kubernetes.md
+++ b/content/en/blog/_posts/2016-08-00-Create-Couchbase-Cluster-Using-Kubernetes.md
@@ -3,8 +3,9 @@ title: " Create a Couchbase cluster using Kubernetes "
 date: 2016-08-15
 slug: create-couchbase-cluster-using-kubernetes
 url: /blog/2016/08/Create-Couchbase-Cluster-Using-Kubernetes
+author: >
+  Arun Gupta (Couchbase)
 ---
-_Editor’s note: today’s guest post is by Arun Gupta, Vice President Developer Relations at Couchbase, showing how to setup a Couchbase cluster with Kubernetes._  
 
 [Couchbase Server](http://www.couchbase.com/nosql-databases/couchbase-server) is an open source, distributed NoSQL document-oriented database. It exposes a fast key-value store with managed cache for submillisecond data operations, purpose-built indexers for fast queries and a query engine for executing SQL queries. For mobile and Internet of Things (IoT) environments, [Couchbase Lite](http://developer.couchbase.com/mobile) runs native on-device and manages sync to Couchbase Server.  
 
@@ -412,7 +413,6 @@ For further information check out the Couchbase [Developer Portal](http://develo
 
 
 
-_--Arun Gupta, Vice President Developer Relations at Couchbase_
 
 
 

--- a/content/en/blog/_posts/2016-08-00-Kubernetes-Namespaces-Use-Cases-Insights.md
+++ b/content/en/blog/_posts/2016-08-00-Kubernetes-Namespaces-Use-Cases-Insights.md
@@ -3,6 +3,9 @@ title: " Kubernetes Namespaces: use cases and insights "
 date: 2016-08-16
 slug: kubernetes-namespaces-use-cases-insights
 url: /blog/2016/08/Kubernetes-Namespaces-Use-Cases-Insights
+author: >
+  Mike Altarace (Google Cloud Platform),
+  Daz Wilkin (Google Cloud Platform)
 ---
 
 _“Who's on first, What's on second, I Don't Know's on third”&nbsp;_
@@ -133,7 +136,6 @@ As mentioned previously, Kubernetes does not (currently) provide a mechanism to 
 
 
 
-_--Mike Altarace & Daz Wilkin, Strategic Customer Engineers, Google Cloud Platform_
 
 
 

--- a/content/en/blog/_posts/2016-08-00-Security-Best-Practices-Kubernetes-Deployment.md
+++ b/content/en/blog/_posts/2016-08-00-Security-Best-Practices-Kubernetes-Deployment.md
@@ -3,6 +3,8 @@ title: " Security Best Practices for Kubernetes Deployment "
 date: 2016-08-31
 slug: security-best-practices-kubernetes-deployment
 url: /blog/2016/08/Security-Best-Practices-Kubernetes-Deployment
+author: >
+  Michael Cherny (Aqua Security)
 ---
 _Note: some of the recommendations in this post are no longer current. Current cluster hardening options are described in this [documentation](/docs/tasks/administer-cluster/securing-a-cluster/)._
 
@@ -228,7 +230,6 @@ We recommend implementing the best practices that were highlighted in this blog,
 
 
 
-_--Michael Cherny, Head of Security Research, and Amir Jerbi, CTO and co-founder [Aqua Security](https://www.aquasec.com/)_
 
 
 

--- a/content/en/blog/_posts/2016-08-00-Sig-Apps-Running-Apps-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-08-00-Sig-Apps-Running-Apps-In-Kubernetes.md
@@ -3,8 +3,10 @@ title: " SIG Apps: build apps for and operate them in Kubernetes "
 date: 2016-08-16
 slug: sig-apps-running-apps-in-kubernetes
 url: /blog/2016/08/Sig-Apps-Running-Apps-In-Kubernetes
+author: >
+  Matt Farina (Hewlett Packard Enterprise)
 ---
-_Editor’s note: This post is by the Kubernetes SIG-Apps team sharing how they focus on the developer and devops experience of running applications in Kubernetes._  
+_**Editor's note:** This post is by the Kubernetes SIG-Apps team sharing how they focus on the developer and devops experience of running applications in Kubernetes._  
 
 Kubernetes is an incredible manager for containerized applications. Because of this, [numerous](https://kubernetes.io/blog/2016/02/sharethis-kubernetes-in-production) [companies](https://blog.box.com/blog/kubernetes-box-microservices-maximum-velocity/) [have](http://techblog.yahoo.co.jp/infrastructure/os_n_k8s/) [started](http://www.nextplatform.com/2015/11/12/inside-ebays-shift-to-kubernetes-and-containers-atop-openstack/) to run their applications in Kubernetes.  
 
@@ -39,4 +41,4 @@ When it comes to application operation there’s still a lot to be figured out a
 - Join our open meetings: weekly at 9AM PT on Wednesdays, [full details here](https://github.com/kubernetes/community/blob/master/sig-apps/README.md#meeting).
 
 
-_--Matt Farina, Principal Engineer, Hewlett Packard Enterprise_  
+

--- a/content/en/blog/_posts/2016-08-00-Stateful-Applications-Using-Kubernetes-Datera.md
+++ b/content/en/blog/_posts/2016-08-00-Stateful-Applications-Using-Kubernetes-Datera.md
@@ -3,8 +3,10 @@ title: " Scaling Stateful Applications using Kubernetes Pet Sets and FlexVolumes
 date: 2016-08-29
 slug: stateful-applications-using-kubernetes-datera
 url: /blog/2016/08/Stateful-Applications-Using-Kubernetes-Datera
+author: >
+  Shailesh Mittal (Datera Inc),
+  Ashok Rajagopala (Datera Inc)
 ---
-_Editor’s note: today’s guest post is by Shailesh Mittal, Software Architect and Ashok Rajagopalan, Sr Director Product at Datera Inc, talking about Stateful Application provisioning with Kubernetes on Datera Elastic Data Fabric._  
 
 **Introduction**  
 

--- a/content/en/blog/_posts/2016-09-00-Cloud-Native-Application-Interfaces.md
+++ b/content/en/blog/_posts/2016-09-00-Cloud-Native-Application-Interfaces.md
@@ -3,14 +3,12 @@ title: " Cloud Native Application Interfaces "
 date: 2016-09-01
 slug: cloud-native-application-interfaces
 url: /blog/2016/09/Cloud-Native-Application-Interfaces
+author: >
+  Brian Grant (Google),
+  Craig Mcluckie (Google)
 ---
 
-
 **Standard Interfaces (or, the Thirteenth Factor)**
-
-_--by Brian Grant and Craig Mcluckie, Google_
-
-
 
 When you say we need ‘software standards’ in erudite company, you get some interesting looks. Most concede that software standards have been central to the success of the boldest and most successful projects out there (like the Internet). Most are also skeptical about how they apply to the innovative world we live in today. Our projects are executed in week increments, not years. Getting bogged down behind mega-software-corporation-driven standards practices would be the death knell in this fluid, highly competitive world.  
 
@@ -53,7 +51,3 @@ Standardizing interfaces (at least by convention) between the management system 
 
 
 Kubernetes and Cloud Native Computing Foundation ([CNCF](https://cncf.io/)) represent a great opportunity to support the emergence of standard interfaces, and to support the emergence of a fully automated software world. We’d love to see this community embrace the ideal of promoting standard interfaces from working technology. The obvious first step is to identify the immediate set of critical interfaces, and establish working groups in CNCF to start assess what exists in this area as candidates, and to sponsor work to start developing standard interfaces that work across container formats, orchestrators, developer tools and the myriad other systems that are needed to deliver on the Cloud Native vision.
-
-
-
-_--Brian Grant and Craig Mcluckie, Google_

--- a/content/en/blog/_posts/2016-09-00-Creating-Postgresql-Cluster-Using-Helm.md
+++ b/content/en/blog/_posts/2016-09-00-Creating-Postgresql-Cluster-Using-Helm.md
@@ -3,8 +3,9 @@ title: " Creating a PostgreSQL Cluster using Helm "
 date: 2016-09-09
 slug: creating-postgresql-cluster-using-helm
 url: /blog/2016/09/Creating-Postgresql-Cluster-Using-Helm
+author: >
+  Jeff McCormick (Crunchy Data)
 ---
-_Editor’s note: Today’s guest post is by Jeff McCormick, a developer at Crunchy Data, showing how to deploy a PostgreSQL cluster using Helm, a Kubernetes package manager._  
 
 [Crunchy Data](http://www.crunchydata.com/) supplies a set of open source PostgreSQL and PostgreSQL related containers. The Crunchy PostgreSQL Container Suite includes containers that deploy, monitor, and administer the open source PostgreSQL database, for more details view this GitHub [repository](https://github.com/crunchydata/crunchy-containers).   
 
@@ -135,7 +136,6 @@ The Kubernetes Helm and Charts projects provide a streamlined way to package up 
 
 
 
-_--Jeff McCormick, Developer, Crunchy Data_
 
 
 

--- a/content/en/blog/_posts/2016-09-00-Deploying-To-Multiple-Kubernetes-With-Kit.md
+++ b/content/en/blog/_posts/2016-09-00-Deploying-To-Multiple-Kubernetes-With-Kit.md
@@ -3,8 +3,9 @@ title: " Deploying to Multiple Kubernetes Clusters with kit "
 date: 2016-09-06
 slug: deploying-to-multiple-kubernetes-with-kit
 url: /blog/2016/09/Deploying-To-Multiple-Kubernetes-With-Kit
+author: >
+  Chesley Brown (InVision)
 ---
-_Editor’s note: today’s guest post is by&nbsp;Chesley Brown, Full-Stack Engineer, at InVision, talking about how they build and open&nbsp;sourced kit to help them to continuously deploy updates to multiple clusters._  
 
 Our Docker journey at InVision may sound familiar. We started with Docker in our development environments, trying to get consistency there first. We wrangled our legacy monolith application into Docker images and streamlined our Dockerfiles to minimize size and amp the efficiency. Things were looking good. Did we learn a lot along the way? For sure. But at the end of it all, we had our entire engineering team working with Docker locally for their development environments. Mission accomplished! Well, not quite. Development was one thing, but moving to production was a whole other ballgame.  
 
@@ -56,7 +57,6 @@ In the near future, we want to make deployments even smarter so as to handle upd
 We hope you take a closer look at [kit](https://github.com/InVisionApp/kit) and tell us what you think! Check out our [InVision Engineering](http://engineering.invisionapp.com/) blog for more posts about the cool things we are up to at InVision. If you want to work on kit or other interesting things like this, click through to [our jobs page](https://www.invisionapp.com/company#jobs). We'd love to hear from you!  
 
 
-_--Chesley Brown, Full-Stack Engineer, at&nbsp;[InVision](https://www.invisionapp.com/)._  
 
 
 - [Download](http://get.k8s.io/) Kubernetes

--- a/content/en/blog/_posts/2016-09-00-High-Performance-Network-Policies-Kubernetes.md
+++ b/content/en/blog/_posts/2016-09-00-High-Performance-Network-Policies-Kubernetes.md
@@ -3,10 +3,11 @@ title: " High performance network policies in Kubernetes clusters "
 date: 2016-09-21
 slug: high-performance-network-policies-kubernetes
 url: /blog/2016/09/High-Performance-Network-Policies-Kubernetes
+author: >
+  Juergen Brendel (Pani Networks),
+  Pritesh Kothari  (Pani Networks),
+  Chris Marin (Pani Networks)
 ---
-_Editor's note: today’s post is by Juergen Brendel, Pritesh Kothari and Chris Marino co-founders of Pani Networks, the sponsor of the Romana project, the network policy software used for these benchmark tests._  
-
-
 
 **Network Policies**
 

--- a/content/en/blog/_posts/2016-09-00-How-We-Made-Kubernetes-Easy-To-Install.md
+++ b/content/en/blog/_posts/2016-09-00-How-We-Made-Kubernetes-Easy-To-Install.md
@@ -3,9 +3,9 @@ title: " How we made Kubernetes insanely easy to install "
 date: 2016-09-28
 slug: how-we-made-kubernetes-easy-to-install
 url: /blog/2016/09/How-We-Made-Kubernetes-Easy-To-Install
+author: >
+  [Luke Marsden](https://twitter.com/lmarsden) (Weaveworks)  
 ---
-
-_Editor's note: Today’s post is by [Luke Marsden](https://twitter.com/lmarsden), Head of Developer Experience, at Weaveworks, showing the Special Interest Group Cluster-Lifecycle’s recent work on kubeadm, a tool to make installing Kubernetes much simpler._  
 
 Over at&nbsp;[SIG-cluster-lifecycle](https://github.com/kubernetes/community/blob/master/sig-cluster-lifecycle/README.md), we've been hard at work the last few months on kubeadm, a tool that makes Kubernetes dramatically easier to install. We've heard from users that installing Kubernetes is harder than it should be, and we want folks to be focused on writing great distributed apps not wrangling with infrastructure!  
 
@@ -51,7 +51,6 @@ Finally, I want to give a huge shout-out to so many people in the SIG-cluster-li
 
 This truly has been an excellent cross-company and cross-timezone achievement, with a lovely bunch of people. There's lots more work to do in SIG-cluster-lifecycle, so if you’re interested in these challenges join our SIG. Looking forward to collaborating with you all!  
 
-_--[Luke Marsden](https://twitter.com/lmarsden), Head of Developer Experience at [Weaveworks](https://twitter.com/weaveworks)_  
 
 
 - Try [kubeadm](/docs/getting-started-guides/kubeadm/) to install Kubernetes today

--- a/content/en/blog/_posts/2016-09-00-Kubernetes-1-4-Making-It-Easy-To-Run-On-Kuberentes-Anywhere.md
+++ b/content/en/blog/_posts/2016-09-00-Kubernetes-1-4-Making-It-Easy-To-Run-On-Kuberentes-Anywhere.md
@@ -3,6 +3,8 @@ title: " Kubernetes 1.4: Making it easy to run on Kubernetes anywhere "
 date: 2016-09-26
 slug: kubernetes-1.4-making-it-easy-to-run-on-kuberentes-anywhere
 url: /blog/2016/09/Kubernetes-1-4-Making-It-Easy-To-Run-On-Kuberentes-Anywhere
+author: >
+  Aparna Sinha (Google)
 ---
 Today we’re happy to announce the release of Kubernetes 1.4.  
   
@@ -77,6 +79,4 @@ We’re very grateful to our community of over 900 contributors who contributed 
 - Connect with the community on [Slack](http://slack.k8s.io/)
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
   
-Thank you for your support!&nbsp;  
-  
-_-- Aparna Sinha, Product Manager, Google_  
+Thank you for your support!

--- a/content/en/blog/_posts/2016-10-00-Dynamic-Provisioning-And-Storage-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-10-00-Dynamic-Provisioning-And-Storage-In-Kubernetes.md
@@ -3,6 +3,8 @@ title: " Dynamic Provisioning and Storage Classes in Kubernetes "
 date: 2016-10-07
 slug: dynamic-provisioning-and-storage-in-kubernetes
 url: /blog/2016/10/Dynamic-Provisioning-And-Storage-In-Kubernetes
+author: >
+  Saad Ali (Google)
 ---
 
 Storage is a critical part of running containers, and Kubernetes offers some powerful primitives for managing it. Dynamic volume provisioning, a feature unique to Kubernetes, allows storage volumes to be created on-demand. Without dynamic provisioning, cluster administrators have to manually make calls to their cloud or storage provider to create new storage volumes, and then create PersistentVolume objects to represent them in Kubernetes. The dynamic provisioning feature eliminates the need for cluster administrators to pre-provision storage. Instead, it automatically provisions storage when it is requested by users. This feature was introduced as alpha in Kubernetes 1.2, and has been improved and promoted to beta in the [latest release, 1.4](https://kubernetes.io/blog/2016/09/kubernetes-1-4-making-it-easy-to-run-on-kuberentes-anywhere/). This release makes dynamic provisioning far more flexible and useful.
@@ -179,7 +181,6 @@ If you’re interested in getting involved with the design and development of Ku
 
 
 
-_-- Saad Ali, Software Engineer, Google_
 
 
 

--- a/content/en/blog/_posts/2016-10-00-Globally-Distributed-Services-Kubernetes-Cluster-Federation.md
+++ b/content/en/blog/_posts/2016-10-00-Globally-Distributed-Services-Kubernetes-Cluster-Federation.md
@@ -3,8 +3,10 @@ title: " Building Globally Distributed Services using Kubernetes Cluster Federat
 date: 2016-10-14
 slug: globally-distributed-services-kubernetes-cluster-federation
 url: /blog/2016/10/Globally-Distributed-Services-Kubernetes-Cluster-Federation
+author: >
+  Allan Naim (Google),
+  Quinton Hoole (Google)
 ---
-_Editor's note: Today’s post is by Allan Naim, Product Manager, and Quinton Hoole, Staff Engineer at Google, showing how to deploy a multi-homed service behind a global load balancer and have requests sent to the closest cluster._  
 
 In Kubernetes 1.3, we announced Kubernetes Cluster Federation and introduced the concept of Cross Cluster Service Discovery, enabling developers to deploy a service that was sharded across a federation of clusters spanning different zones, regions or cloud providers. This enables developers to achieve higher availability for their applications, without sacrificing quality of service, as detailed in our [previous](https://kubernetes.io/blog/2016/07/cross-cluster-services) blog post.   
 

--- a/content/en/blog/_posts/2016-10-00-Helm-Charts-Making-It-Simple-To-Package-And-Deploy-Apps-On-Kubernetes.md
+++ b/content/en/blog/_posts/2016-10-00-Helm-Charts-Making-It-Simple-To-Package-And-Deploy-Apps-On-Kubernetes.md
@@ -3,6 +3,8 @@ title: " Helm Charts: making it simple to package and deploy common applications
 date: 2016-10-10
 slug: helm-charts-making-it-simple-to-package-and-deploy-apps-on-kubernetes
 url: /blog/2016/10/Helm-Charts-Making-It-Simple-To-Package-And-Deploy-Apps-On-Kubernetes
+author: >
+  Vic Iglesias (Google)
 ---
 There are thousands of people and companies packaging their applications for deployment on Kubernetes. This usually involves crafting a few different Kubernetes resource definitions that configure the application runtime, as well as defining the mechanism that users and other apps leverage to communicate with the application. There are some very common applications that users regularly look for guidance on deploying, such as databases, CI tools, and content management systems. These types of applications are usually not ones that are developed and iterated on by end users, but rather their configuration is customized to fit a specific use case. Once that application is deployed users can link it to their existing systems or leverage their functionality to solve their pain points.  
 
@@ -113,8 +115,6 @@ Now that you’ve seen workflows for both developers and users, we hope that you
 - SIG Apps - [Weekly Meeting](https://github.com/kubernetes/community/tree/master/sig-apps#meeting)
 - [Submit a Kubernetes Charts Issue](https://github.com/kubernetes/charts/issues)
 A big thank you to the folks at Bitnami, Deis, Google and the [other contributors](https://github.com/kubernetes/charts/graphs/contributors) who have helped get the Charts repository to where it is today. We still have a lot of work to do but it's been wonderful working together as a community to move this effort forward.  
-
-_--Vic Iglesias, Cloud Solutions Architect, Google_  
 
 
 - [Download](http://get.k8s.io/) Kubernetes

--- a/content/en/blog/_posts/2016-10-00-Kubernetes-Service-Technology-Partners-Program.md
+++ b/content/en/blog/_posts/2016-10-00-Kubernetes-Service-Technology-Partners-Program.md
@@ -3,6 +3,8 @@ title: " Introducing Kubernetes Service Partners program and a redesigned Partne
 date: 2016-10-31
 slug: kubernetes-service-technology-partners-program
 url: /blog/2016/10/Kubernetes-Service-Technology-Partners-Program
+author: >
+  Allan Naim (Google)
 ---
 Kubernetes has become a leading container orchestration system by being a powerful and flexible way to run distributed systems at scale. Through our very active open source community, equating to hundreds of person years of work, Kubernetes achieved four major releases in just one year to become a critical part of thousands of companies infrastructures. However, even with all that momentum, adopting cloud native computing is a significant transition for many organizations. It can be challenging to adopt a new methodology, and many teams are looking for advice and support through that journey.  
 
@@ -13,7 +15,6 @@ The Service Partners provide hands-on best practice guidance for running your ap
 The list of partners will grow weekly, and we look forward to collaborating with the community to build a vibrant Kubernetes ecosystem.  
 
 
-_--Allan Naim, Product Manager, Google, on behalf of the Kubernetes team._  
 
 
 

--- a/content/en/blog/_posts/2016-10-00-Production-Kubernetes-Dashboard-UI-1-4-improvements_3.md
+++ b/content/en/blog/_posts/2016-10-00-Production-Kubernetes-Dashboard-UI-1-4-improvements_3.md
@@ -3,6 +3,8 @@ title: " How we improved Kubernetes Dashboard UI in 1.4 for your production need
 date: 2016-10-03
 slug: production-kubernetes-dashboard-ui-1.4-improvements_3
 url: /blog/2016/10/Production-Kubernetes-Dashboard-UI-1-4-improvements_3
+author: >
+  Dan Romlein (Apprenda)
 ---
 With the release of [Kubernetes 1.4](https://kubernetes.io/blog/2016/09/kubernetes-1-4-making-it-easy-to-run-on-kuberentes-anywhere/) last week, Dashboard – the official web UI for Kubernetes – has a number of exciting updates and improvements of its own. The past three months have been busy ones for the Dashboard team, and we’re excited to share the resulting features of that effort here. If you’re not familiar with Dashboard, the [GitHub repo](https://github.com/kubernetes/dashboard#kubernetes-dashboard) is a great place to get started.
 
@@ -69,7 +71,6 @@ If you’ve been following along with Dashboard since 1.0, &nbsp;you may have be
 **There’s a Lot More Where That Came From**  
 Dashboard is gaining momentum, and these early stages are a very exciting and rewarding time to be involved. If you’d like to learn more about contributing, check out [SIG UI](https://github.com/kubernetes/community/blob/master/sig-ui/README.md). Chat with us Kubernetes Slack: [#sig-ui channel](https://kubernetes.slack.com/messages/sig-ui/).  
 
-_--Dan Romlein, UX designer, Apprenda_  
 
 
 

--- a/content/en/blog/_posts/2016-10-00-Tail-Kubernetes-With-Stern.md
+++ b/content/en/blog/_posts/2016-10-00-Tail-Kubernetes-With-Stern.md
@@ -3,8 +3,9 @@ title: " Tail Kubernetes with Stern "
 date: 2016-10-31
 slug: tail-kubernetes-with-stern
 url: /blog/2016/10/Tail-Kubernetes-With-Stern
+author: >
+  Antti Kupila (Wercker)
 ---
-_Editor’s note: today’s post is by Antti Kupila, Software Engineer, at Wercker, about building a tool to tail multiple pods and containers on Kubernetes._  
 
 We love Kubernetes here at [Wercker](http://wercker.com/) and build all our infrastructure on top of it. When deploying anything you need to have good visibility to what's going on and logs are a first view into the inner workings of your application. Good old tail -f has been around for a long time and Kubernetes has this too, built right into [kubectl](/docs/user-guide/kubectl-overview/).  
 

--- a/content/en/blog/_posts/2016-11-00-Bringing-Kubernetes-Support-To-Azure.md
+++ b/content/en/blog/_posts/2016-11-00-Bringing-Kubernetes-Support-To-Azure.md
@@ -3,8 +3,9 @@ title: " Bringing Kubernetes Support to Azure Container Service "
 date: 2016-11-07
 slug: bringing-kubernetes-support-to-azure
 url: /blog/2016/11/Bringing-Kubernetes-Support-To-Azure
+author: >
+  Brendan Burns (Microsoft)
 ---
-_Editor's note: Today’s post is by Brendan Burns, Partner Architect, at Microsoft & Kubernetes co-founder talking about bringing Kubernetes to Azure Container Service._
 
 With more than a thousand people coming to [KubeCon](http://events.linuxfoundation.org/events/kubecon) in my hometown of Seattle, nearly three years after I helped start the Kubernetes project, it’s amazing and humbling to see what a small group of people and a radical idea have become after three years of hard work from a large and growing community. In July of 2014, scarcely a month after Kubernetes became publicly available, Microsoft announced its initial support for Azure. The release of [Kubernetes 1.4](https://kubernetes.io/blog/2016/09/kubernetes-1-4-making-it-easy-to-run-on-kuberentes-anywhere/), brought support for native Microsoft networking, [load-balancer](https://github.com/kubernetes/kubernetes/pull/28821) and [disk integration](https://github.com/kubernetes/kubernetes/pull/29836).&nbsp;
 

--- a/content/en/blog/_posts/2016-11-00-Kompose-Tool-Go-From-Docker-Compose-To-Kubernetes.md
+++ b/content/en/blog/_posts/2016-11-00-Kompose-Tool-Go-From-Docker-Compose-To-Kubernetes.md
@@ -3,8 +3,9 @@ title: " Kompose: a tool to go from Docker-compose to Kubernetes "
 date: 2016-11-22
 slug: kompose-tool-go-from-docker-compose-to-kubernetes
 url: /blog/2016/11/Kompose-Tool-Go-From-Docker-Compose-To-Kubernetes
+author: >
+  Sebastien Goasguen (Skippbox)
 ---
-_Editor's note: Today’s post is by Sebastien Goasguen, Founder of Skippbox, showing a new tool to move from ‘docker-compose’ to Kubernetes._  
 
 At [Skippbox](http://www.skippbox.com/), we developed **kompose** a tool to automatically transform your Docker Compose application into Kubernetes manifests. Allowing you to start a Compose application on a Kubernetes cluster with a single kompose up command. We’re extremely happy to have donated kompose to the [Kubernetes Incubator](https://github.com/kubernetes-incubator). So here’s a quick introduction about it and some motivating factors that got us to develop it.  
 

--- a/content/en/blog/_posts/2016-11-00-Kubernetes-Containers-Logging-Monitoring-With-Sematext.md
+++ b/content/en/blog/_posts/2016-11-00-Kubernetes-Containers-Logging-Monitoring-With-Sematext.md
@@ -3,9 +3,9 @@ title: " Kubernetes Containers Logging and Monitoring with Sematext "
 date: 2016-11-18
 slug: kubernetes-containers-logging-monitoring-with-sematext
 url: /blog/2016/11/Kubernetes-Containers-Logging-Monitoring-With-Sematext
+author: >
+  Stefan Thies (Sematext)
 ---
-_Editor's note: Today’s post is by Stefan Thies, Developer Evangelist, at Sematext, showing key Kubernetes metrics and log elements to help you troubleshoot and tune Docker and Kubernetes._  
-
 
 Managing microservices in containers is typically done with Cluster Managers and Orchestration tools. Each container platform has a slightly different set of options to deploy containers or schedule tasks on each cluster node. Because we do [container monitoring and logging](http://sematext.com/kubernetes) at Sematext, part of our job is to share our knowledge of these tools, especially as it pertains to container observability and devops. Today we’ll show a tutorial for Container Monitoring and Log Collection on Kubernetes.  
 
@@ -220,8 +220,6 @@ There are many other useful features Logsene and Sematext Docker Agent give you 
 Most of those topics are described in our [Docker Log Management](https://sematext.com/blog/2015/08/12/docker-log-management/) post and are relevant for Kubernetes log management as well. If you want to learn more about [Docker monitoring](http://blog.sematext.com/2016/01/12/docker-swarm-collecting-metrics-events-logs/), read more on our [blog](https://sematext.com/blog/tag/docker,kubernetes).
 
 
-
-_--Stefan Thies, Developer Evangelist, at Sematext_
 
 
 

--- a/content/en/blog/_posts/2016-11-00-Skytap-Modernizing-Microservice-Architecture-With-Kubernetes.md
+++ b/content/en/blog/_posts/2016-11-00-Skytap-Modernizing-Microservice-Architecture-With-Kubernetes.md
@@ -3,8 +3,10 @@ title: " Modernizing the Skytap Cloud Micro-Service Architecture with Kubernetes
 date: 2016-11-07
 slug: skytap-modernizing-microservice-architecture-with-kubernetes
 url: /blog/2016/11/Skytap-Modernizing-Microservice-Architecture-With-Kubernetes
+author: >
+  Shawn Falkner-Horine (Skytap),
+  Joe Burchett (Skytap)
 ---
-_Editor's note: Today’s guest post is by the Tools and Infrastructure Engineering team at Skytap, a public cloud provider focused on empowering DevOps workflows, sharing their experience on adopting Kubernetes.&nbsp;_  
 
 [Skytap](https://www.skytap.com/) is a global public cloud that provides our customers the ability to save and clone complex virtualized environments in any given state. Our customers include enterprise organizations running applications in a hybrid cloud, educational organizations providing [virtual training labs](https://www.skytap.com/solutions/virtual-training/), users who need easy-to-maintain development and test labs, and a variety of organizations with diverse DevOps workflows.  
 
@@ -164,7 +166,6 @@ We love application modernization challenges. The Skytap platform is well suited
 
 
 
-_--Shawn Falkner-Horine and Joe Burchett, Tools and Infrastructure Engineering, Skytap_
 
 
 

--- a/content/en/blog/_posts/2016-11-00-Visualize-Kubelet-Performance-With-Node-Dashboard.md
+++ b/content/en/blog/_posts/2016-11-00-Visualize-Kubelet-Performance-With-Node-Dashboard.md
@@ -3,6 +3,8 @@ title: " Visualize Kubelet Performance with Node Dashboard "
 date: 2016-11-17
 slug: visualize-kubelet-performance-with-node-dashboard
 url: /blog/2016/11/Visualize-Kubelet-Performance-With-Node-Dashboard
+author: >
+  Zhou Fang (Google)
 ---
 
 _Since this article was published, the Node Performance Dashboard was retired and is no longer available._
@@ -114,10 +116,6 @@ The [node performance dashboard](http://node-perf-dash.k8s.io/) is a brand new f
 
 
 Please join our community and help us build the future of Kubernetes! If you’re particularly interested in nodes or performance testing, participate by chatting with us in our [Slack channel](https://kubernetes.slack.com/messages/sig-scale/) or join our meeting which meets every Tuesday at 10 AM PT on this [SIG-Node Hangout](https://github.com/kubernetes/community/tree/master/sig-node).
-
-
-
-_--Zhou Fang, Software Engineering Intern, Google_  
 
 
 - [Download](http://get.k8s.io/) Kubernetes

--- a/content/en/blog/_posts/2016-12-00-Cluster-Federation-In-Kubernetes-1-5.md
+++ b/content/en/blog/_posts/2016-12-00-Cluster-Federation-In-Kubernetes-1-5.md
@@ -3,8 +3,11 @@ title: " Cluster Federation in Kubernetes 1.5 "
 date: 2016-12-22
 slug: cluster-federation-in-kubernetes-1.5
 url: /blog/2016/12/Cluster-Federation-In-Kubernetes-1-5
+author: >
+  Lukasz Guminski (Container Solutions),
+  Allan Naim (Google)
 ---
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
 
 In the latest [Kubernetes 1.5 release](https://kubernetes.io/blog/2016/12/kubernetes-1-5-supporting-production-workloads/), you’ll notice that support for Cluster Federation is maturing. That functionality was introduced in Kubernetes 1.3, and the 1.5 release includes a number of new features, including an easier setup experience and a step closer to supporting all Kubernetes API objects.
 
@@ -314,7 +317,3 @@ PS. When done, remember to destroy your clusters:
 $ . 5-destroy.sh
  ```
 
-
-
-
-_-__-Lukasz Guminski, Software Engineer at Container Solutions. Allan Naim, Product Manager, Google_

--- a/content/en/blog/_posts/2016-12-00-Container-Runtime-Interface-Cri-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-12-00-Container-Runtime-Interface-Cri-In-Kubernetes.md
@@ -3,8 +3,10 @@ title: " Introducing Container Runtime Interface (CRI) in Kubernetes "
 date: 2016-12-19
 slug: container-runtime-interface-cri-in-kubernetes
 url: /blog/2016/12/Container-Runtime-Interface-Cri-In-Kubernetes
+author: >
+  Yu-Ju Hong (Google)
 ---
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
 
 
 At the lowest layers of a Kubernetes node is the software that, among other things, starts and stops containers. We call this the “Container Runtime”. The most widely known container runtime is Docker, but it is not alone in this space. In fact, the container runtime space has been rapidly evolving. As part of the effort to make Kubernetes more extensible, we've been working on a new plugin API for container runtimes in Kubernetes, called "CRI".
@@ -219,9 +221,3 @@ CRI is being actively developed and maintained by the Kubernetes [SIG-Node](http
 - Join the #sig-node channel on [Slack](https://kubernetes.slack.com/)
 - Subscribe to the [SIG-Node mailing list](mailto:kubernetes-sig-node@googlegroups.com)
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
-
-
-
-
-
-_--Yu-Ju Hong, Software Engineer, Google_

--- a/content/en/blog/_posts/2016-12-00-From-Network-Policies-To-Security-Policies.md
+++ b/content/en/blog/_posts/2016-12-00-From-Network-Policies-To-Security-Policies.md
@@ -3,9 +3,9 @@ title: " From Network Policies to Security Policies "
 date: 2016-12-08
 slug: from-network-policies-to-security-policies
 url: /blog/2016/12/From-Network-Policies-To-Security-Policies
+author: >
+  Bernard Van De Walle (Aporeto)
 ---
-_Editor's note: Today’s post is by Bernard Van De Walle, Kubernetes Lead Engineer, at Aporeto, showing how they took a new approach to the Kubernetes network policy enforcement._  
-
 
 **Kubernetes Network Policies&nbsp;**  
 
@@ -42,6 +42,3 @@ To learn more, download the code, and engage with the project, visit:
 
 - Trireme on [GitHub](https://github.com/aporeto-inc/trireme-kubernetes)
 - Trireme for Kubernetes by Aporeto on [GitHub](https://github.com/aporeto-inc/trireme-kubernetes)
-
-
-_--Bernard Van De Walle, Kubernetes lead engineer, [Aporeto](https://www.aporeto.com/)_  

--- a/content/en/blog/_posts/2016-12-00-Kubernetes-1-5-Supporting-Production-Workloads.md
+++ b/content/en/blog/_posts/2016-12-00-Kubernetes-1-5-Supporting-Production-Workloads.md
@@ -3,6 +3,8 @@ title: " Kubernetes 1.5: Supporting Production Workloads "
 date: 2016-12-13
 slug: kubernetes-1.5-supporting-production-workloads
 url: /blog/2016/12/Kubernetes-1-5-Supporting-Production-Workloads
+author: >
+  Aparna Sinha(Google)
 ---
 
 Today we’re announcing the release of Kubernetes 1.5. This release follows close on the heels of KubeCon/CloundNativeCon, where users gathered to share how they’re running their applications on Kubernetes. Many of you expressed interest in running stateful applications in containers with the eventual goal of running all applications on Kubernetes. If you have been waiting to try running a distributed database on Kubernetes, or for ways to guarantee application disruption SLOs for stateful and stateless apps, this release has solutions for you.&nbsp;  
@@ -65,7 +67,4 @@ Ready to start contributing? Share your voice at our weekly [community meeting](
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
 - Connect with the community on [Slack](http://slack.k8s.io/)
 
-Thank you for your contributions and support!  
-
-
-_-- Aparna Sinha, Senior Product Manager, Google_  
+Thank you for your contributions and support!

--- a/content/en/blog/_posts/2016-12-00-Kubernetes-Supports-Openapi.md
+++ b/content/en/blog/_posts/2016-12-00-Kubernetes-Supports-Openapi.md
@@ -3,8 +3,10 @@ title: " Kubernetes supports OpenAPI "
 date: 2016-12-23
 slug: kubernetes-supports-openapi
 url: /blog/2016/12/Kubernetes-Supports-Openapi
+author: >
+  Mehdy Bohlool (Google)
 ---
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
 
 [OpenAPI](https://www.openapis.org/) allows API providers to define their operations and models, and enables developers to automate their tools and generate their favorite language’s client to talk to that API server. Kubernetes has supported swagger 1.2 (older version of OpenAPI spec) for a while, but the spec was incomplete and invalid, making it hard to generate tools/clients based on it.   
 
@@ -185,7 +187,6 @@ If you want to get involved in development of OpenAPI support, client libraries,
 
 
 
-_--Mehdy Bohlool, Software Engineer, Google_
 
 
 

--- a/content/en/blog/_posts/2016-12-00-Statefulset-Run-Scale-Stateful-Applications-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-12-00-Statefulset-Run-Scale-Stateful-Applications-In-Kubernetes.md
@@ -3,8 +3,11 @@ title: " StatefulSet: Run and Scale Stateful Applications Easily in Kubernetes "
 date: 2016-12-20
 slug: statefulset-run-scale-stateful-applications-in-kubernetes
 url: /blog/2016/12/Statefulset-Run-Scale-Stateful-Applications-In-Kubernetes
+author: >
+  Kenneth Owens (Google),
+  Eric Tune (Google)
 ---
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
 
 In the latest release, [Kubernetes 1.5](https://kubernetes.io/blog/2016/12/kubernetes-1-5-supporting-production-workloads/), we’ve moved the feature formerly known as PetSet into beta as [StatefulSet](/docs/concepts/abstractions/controllers/statefulsets/). There were no major changes to the API Object, other than the community selected name, but we added the semantics of “at most one pod per index” for deployment of the Pods in the set. Along with ordered deployment, ordered termination, unique network names, and persistent stable storage, we think we have the right primitives to support many containerized stateful workloads. We don’t claim that the feature is 100% complete (it is software after all), but we believe that it is useful in its current form, and that we can extend the API in a backwards-compatible way as we progress toward an eventual GA release.
 
@@ -437,7 +440,6 @@ The Operators for [etcd](https://coreos.com/blog/introducing-the-etcd-operator.h
 
 
 
-_--Kenneth Owens & Eric Tune, Software Engineers, Google_
 
 
 

--- a/content/en/blog/_posts/2016-12-00-Windows-Server-Support-Kubernetes.md
+++ b/content/en/blog/_posts/2016-12-00-Windows-Server-Support-Kubernetes.md
@@ -3,8 +3,10 @@ title: " Windows Server Support Comes to Kubernetes "
 date: 2016-12-21
 slug: windows-server-support-kubernetes
 url: /blog/2016/12/Windows-Server-Support-Kubernetes
+author: >
+  [Michael Michael](https://twitter.com/michmike77) (Apprenda)
 ---
-_Editor’s note: this post is part of a [series of in-depth articles](https://kubernetes.io/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
+_**Editor's note:** this post is part of a [series of in-depth articles](/blog/2016/12/five-days-of-kubernetes-1-5/) on what's new in Kubernetes 1.5_
 
 Extending on the theme of giving users choice, [Kubernetes 1.5 release](https://kubernetes.io/blog/2016/12/kubernetes-1-5-supporting-production-workloads/) includes the support for Windows Servers. WIth more than [80%](http://www.gartner.com/document/3446217) of enterprise apps running Java on Linux or .Net on Windows, Kubernetes is previewing capabilities that extends its reach to the mass majority of enterprise workloads.&nbsp;
 
@@ -66,7 +68,6 @@ Support for Windows Server-based containers is in alpha release mode for Kuberne
 To get started with Kubernetes on Windows Server 2016, please visit the [GitHub guide](/docs/getting-started-guides/windows/) for more details.  
 If you want to help with Windows Server support, then please connect with the [Windows Server SIG](https://github.com/kubernetes/community/blob/master/sig-windows/README.md) or connect directly with Michael Michael, the SIG lead, on [GitHub](https://github.com/michmike).&nbsp;  
 
-_--[Michael Michael](https://twitter.com/michmike77), Senior Director of Product Management, Apprenda&nbsp;_  
 
 
 


### PR DESCRIPTION
Split out from PR https://github.com/kubernetes/website/pull/45957

This PR extends the changes made in PR https://github.com/kubernetes/website/pull/45865 and implements those changes to all the 2016 blog files as per the recommendation in https://github.com/kubernetes/website/pull/45865#issuecomment-2054036103. The primary change involves relocating author details into the metadata within the front matter.

Useful Link
[Preview Blog Summary Page](https://deploy-preview-46772--kubernetes-io-main-staging.netlify.app/blog)