### PR TITLE
Ready Landscape shortcode for vanilla Docsy

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -91,10 +91,6 @@
 <script defer src="{{ "js/release_binaries.js" | relURL }}"></script>
 {{- end -}}
 
-{{- if .HasShortcode "cncf-landscape" -}}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js" integrity="sha384-hHTwgxzjpO1G1NI0wMHWQYUxnGtpWyDjVSZrFnDrlWa5OL+DFY57qnDWw/5WSJOl" crossorigin="anonymous"></script>
-{{- end -}}
-
 <!-- Enable zoom-on-click for figures that opt in to this -->
 {{- if .HasShortcode "figure" -}}
 <script defer src="{{ "js/zoom.js" | relURL }}"></script>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -9,3 +9,7 @@
 <script defer src="{{ $sortableTableJs.RelPermalink }}"></script>
   {{- end -}}
 {{- end -}}
+
+{{- if .HasShortcode "cncf-landscape" -}}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js" integrity="sha384-hHTwgxzjpO1G1NI0wMHWQYUxnGtpWyDjVSZrFnDrlWa5OL+DFY57qnDWw/5WSJOl" crossorigin="anonymous"></script>
+{{- end -}}


### PR DESCRIPTION
Move the shortcode support for the CNCF landscape shortcode. This readies us to make the site align with vanilla Docsy.

Helps with https://github.com/kubernetes/website/issues/41171

### Example

- [Current](http://k8s.io/partners)
- [Preview](https://deploy-preview-46780--kubernetes-io-main-staging.netlify.app/partners)
