### PR TITLE
sort yaml examples pod storage

### DIFF
--- a/content/en/examples/pods/storage/projected-clustertrustbundle.yaml
+++ b/content/en/examples/pods/storage/projected-clustertrustbundle.yaml
@@ -4,12 +4,14 @@ metadata:
   name: sa-ctb-name-test
 spec:
   containers:
-  - name: container-test
+  - command:
+    - sleep
+    - "3600"
     image: busybox
-    command: ["sleep", "3600"]
+    name: container-test
     volumeMounts:
-    - name: token-vol
-      mountPath: "/root-certificates"
+    - mountPath: /root-certificates
+      name: token-vol
       readOnly: true
   serviceAccountName: default
   volumes:
@@ -20,9 +22,9 @@ spec:
           name: example
           path: example-roots.pem
       - clusterTrustBundle:
-          signerName: "example.com/mysigner"
           labelSelector:
             matchLabels:
               version: live
-          path: mysigner-roots.pem
           optional: true
+          path: mysigner-roots.pem
+          signerName: example.com/mysigner

--- a/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
+++ b/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
@@ -4,33 +4,35 @@ metadata:
   name: volume-test
 spec:
   containers:
-  - name: container-test
+  - command:
+    - sleep
+    - "3600"
     image: busybox:1.28
-    command: ["sleep", "3600"]
+    name: container-test
     volumeMounts:
-    - name: all-in-one
-      mountPath: "/projected-volume"
+    - mountPath: /projected-volume
+      name: all-in-one
       readOnly: true
   volumes:
   - name: all-in-one
     projected:
       sources:
       - secret:
-          name: mysecret
           items:
-            - key: username
-              path: my-group/my-username
+          - key: username
+            path: my-group/my-username
+          name: mysecret
       - downwardAPI:
           items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "cpu_limit"
-              resourceFieldRef:
-                containerName: container-test
-                resource: limits.cpu
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: container-test
+              resource: limits.cpu
       - configMap:
-          name: myconfigmap
           items:
-            - key: config
-              path: my-group/my-config
+          - key: config
+            path: my-group/my-config
+          name: myconfigmap

--- a/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
+++ b/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
@@ -4,25 +4,27 @@ metadata:
   name: volume-test
 spec:
   containers:
-  - name: container-test
+  - command:
+    - sleep
+    - "3600"
     image: busybox:1.28
-    command: ["sleep", "3600"]
+    name: container-test
     volumeMounts:
-    - name: all-in-one
-      mountPath: "/projected-volume"
+    - mountPath: /projected-volume
+      name: all-in-one
       readOnly: true
   volumes:
   - name: all-in-one
     projected:
       sources:
       - secret:
+          items:
+          - key: username
+            path: my-group/my-username
           name: mysecret
-          items:
-            - key: username
-              path: my-group/my-username
       - secret:
-          name: mysecret2
           items:
-            - key: password
-              path: my-group/my-password
-              mode: 511
+          - key: password
+            mode: 511
+            path: my-group/my-password
+          name: mysecret2

--- a/content/en/examples/pods/storage/projected-service-account-token.yaml
+++ b/content/en/examples/pods/storage/projected-service-account-token.yaml
@@ -4,12 +4,14 @@ metadata:
   name: sa-token-test
 spec:
   containers:
-  - name: container-test
+  - command:
+    - sleep
+    - "3600"
     image: busybox:1.28
-    command: ["sleep", "3600"]
+    name: container-test
     volumeMounts:
-    - name: token-vol
-      mountPath: "/service-account"
+    - mountPath: /service-account
+      name: token-vol
       readOnly: true
   serviceAccountName: default
   volumes:

--- a/content/en/examples/pods/storage/projected.yaml
+++ b/content/en/examples/pods/storage/projected.yaml
@@ -4,14 +4,14 @@ metadata:
   name: test-projected-volume
 spec:
   containers:
-  - name: test-projected-volume
-    image: busybox:1.28
-    args:
+  - args:
     - sleep
     - "86400"
+    image: busybox:1.28
+    name: test-projected-volume
     volumeMounts:
-    - name: all-in-one
-      mountPath: "/projected-volume"
+    - mountPath: /projected-volume
+      name: all-in-one
       readOnly: true
   volumes:
   - name: all-in-one

--- a/content/en/examples/pods/storage/pv-claim.yaml
+++ b/content/en/examples/pods/storage/pv-claim.yaml
@@ -3,9 +3,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: task-pv-claim
 spec:
-  storageClassName: manual
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 3Gi
+  storageClassName: manual

--- a/content/en/examples/pods/storage/pv-duplicate.yaml
+++ b/content/en/examples/pods/storage/pv-duplicate.yaml
@@ -1,22 +1,19 @@
-
 apiVersion: v1
 kind: Pod
 metadata:
   name: test
 spec:
   containers:
-    - name: test
-      image: nginx
-      volumeMounts:
-        # a mount for site-data
-        - name: config
-          mountPath: /usr/share/nginx/html
-          subPath: html
-        # another mount for nginx config
-        - name: config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+  - image: nginx
+    name: test
+    volumeMounts:
+    - mountPath: /usr/share/nginx/html
+      name: config
+      subPath: html
+    - mountPath: /etc/nginx/nginx.conf
+      name: config
+      subPath: nginx.conf
   volumes:
-    - name: config
-      persistentVolumeClaim:
-        claimName: test-nfs-claim
+  - name: config
+    persistentVolumeClaim:
+      claimName: test-nfs-claim

--- a/content/en/examples/pods/storage/pv-pod.yaml
+++ b/content/en/examples/pods/storage/pv-pod.yaml
@@ -3,18 +3,16 @@ kind: Pod
 metadata:
   name: task-pv-pod
 spec:
-  volumes:
-    - name: task-pv-storage
-      persistentVolumeClaim:
-        claimName: task-pv-claim
   containers:
-    - name: task-pv-container
-      image: nginx
-      ports:
-        - containerPort: 80
-          name: "http-server"
-      volumeMounts:
-        - mountPath: "/usr/share/nginx/html"
-          name: task-pv-storage
-
-
+  - image: nginx
+    name: task-pv-container
+    ports:
+    - containerPort: 80
+      name: http-server
+    volumeMounts:
+    - mountPath: /usr/share/nginx/html
+      name: task-pv-storage
+  volumes:
+  - name: task-pv-storage
+    persistentVolumeClaim:
+      claimName: task-pv-claim

--- a/content/en/examples/pods/storage/pv-volume.yaml
+++ b/content/en/examples/pods/storage/pv-volume.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: task-pv-volume
   labels:
     type: local
+  name: task-pv-volume
 spec:
-  storageClassName: manual
+  accessModes:
+  - ReadWriteOnce
   capacity:
     storage: 10Gi
-  accessModes:
-    - ReadWriteOnce
   hostPath:
-    path: "/mnt/data"
+    path: /mnt/data
+  storageClassName: manual

--- a/content/en/examples/pods/storage/redis.yaml
+++ b/content/en/examples/pods/storage/redis.yaml
@@ -4,11 +4,11 @@ metadata:
   name: redis
 spec:
   containers:
-  - name: redis
-    image: redis
+  - image: redis
+    name: redis
     volumeMounts:
-    - name: redis-storage
-      mountPath: /data/redis
+    - mountPath: /data/redis
+      name: redis-storage
   volumes:
-  - name: redis-storage
-    emptyDir: {}
+  - emptyDir: {}
+    name: redis-storage


### PR DESCRIPTION
Let's make documentation more human readable while sorting keys in example yaml files alphabetically. I wrote this [sort-yaml.go](https://gist.github.com/eumel8/ead695d37d6bffe728cab1f5098d96d8) to fullfill this half-automatically. I would continue to other example files if this PR is accepted. From user experience it's easier to review examples in a logical way with readings from a-z, but that can only be in my opinion :-)
