### PR TITLE
kubeadm: add note about a bug in the PublicKeysECDSA FG

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -174,7 +174,9 @@ as a learner and promoted to a voting member only after the etcd data are fully 
 `PublicKeysECDSA`
 : Can be used to create a cluster that uses ECDSA certificates instead of the default RSA algorithm.
 Renewal of existing ECDSA certificates is also supported using `kubeadm certs renew`, but you cannot
-switch between the RSA and ECDSA algorithms on the fly or during upgrades.
+switch between the RSA and ECDSA algorithms on the fly or during upgrades. Kubernetes
+{{< skew currentVersion >}} has a bug where keys in generated kubeconfig files are set use RSA
+despite the feature gate being enabled.
 
 `RootlessControlPlane`
 : Setting this flag configures the kubeadm deployed control plane component static Pod containers


### PR DESCRIPTION
The PublicKeysECDSA has been poorly tested and supported and apparently it had a bug where keys in kubeconfig files were using RSA even if the FG was true. (even the FG name is misleading...)

Add note about that in the FG section of the kubeadm init doc.

xref https://github.com/kubernetes/kubeadm/issues/3072