### PR TITLE
Fix misnamed field in CRD documentation

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -499,7 +499,7 @@ spec:
     webhook:
       # conversionReviewVersions indicates what ConversionReview versions are understood/preferred by the webhook.
       # The first version in the list understood by the API server is sent to the webhook.
-      # The webhook must respond with a ConversionResponse object in the same version it received.
+      # The webhook must respond with a ConversionReview object in the same version it received.
       conversionReviewVersions: ["v1","v1beta1"]
       clientConfig:
         service:

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -499,7 +499,7 @@ spec:
     webhook:
       # conversionReviewVersions indicates what ConversionReview versions are understood/preferred by the webhook.
       # The first version in the list understood by the API server is sent to the webhook.
-      # The webhook must respond with a ConversionReview object in the same version it received.
+      # The webhook must respond with a ConversionResponse object in the same version it received.
       conversionReviewVersions: ["v1","v1beta1"]
       clientConfig:
         service:
@@ -873,7 +873,7 @@ with the `response` stanza populated, serialized to JSON.
 If conversion succeeds, a webhook should return a `response` stanza containing the following fields:
 * `uid`, copied from the `request.uid` sent to the webhook
 * `result`, set to `{"status":"Success"}`
-* `convertedObjects`, containing all of the objects from `request.objects`, converted to `request.desiredVersion`
+* `convertedObjects`, containing all of the objects from `request.objects`, converted to `request.desiredAPIVersion`
 
 Example of a minimal successful response from a webhook:
 


### PR DESCRIPTION
- `request.desiredVersion` should be `request.desiredAPIVersion`. Ref - [types.go](https://github.com/kubernetes/kubernetes/blob/a3a49887ee73fa1108adac97a797dec02ccb00d4/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go#L495)

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
