### PR TITLE
[ja] Translate reference/setup-tools/kubeadm/kubeadm-config into Japanese 

### DIFF
--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/_index.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Kubeadm Generated"
+weight: 10
+toc_hide: true
+---
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
@@ -23,7 +23,7 @@ kubeadm config images list [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: true</td>
+<td colspan="2">--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: true</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>trueならば、テンプレートの中にフィールドやマップキーが見つからない場合に、テンプレート内のエラーを無視します。golangまたはjsonpathを出力フォーマットとした場合にのみ適用されます。</p></td>
@@ -37,7 +37,7 @@ kubeadm config images list [flags]
 </tr>
 
 <tr>
-<td colspan="2">-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "text"</td>
+<td colspan="2">-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "text"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>出力フォーマット。次のいずれか: text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.</p></td>
@@ -47,7 +47,7 @@ kubeadm config images list [flags]
 <td colspan="2">--feature-gates string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>様々な機能に対するフィーチャーゲートを記述するkey=valueペアのセット。オプション:<br/>EtcdLearnerMode=true|false (BETA - 既定値=true)<br/>PublicKeysECDSA=true|false (DEPRECATED - 既定値=false)<br/>RootlessControlPlane=true|false (ALPHA - 既定値=false)<br/>UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 既定値=false)<br/>WaitForAllControlPlaneComponents=true|false (ALPHA - 既定値=false)</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>様々な機能に対するフィーチャーゲートを記述するkey=valueペアのセット。オプション:<br/>EtcdLearnerMode=true|false (BETA - デフォルト値=true)<br/>PublicKeysECDSA=true|false (DEPRECATED - デフォルト値=false)<br/>RootlessControlPlane=true|false (ALPHA - デフォルト値=false)<br/>UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - デフォルト値=false)<br/>WaitForAllControlPlaneComponents=true|false (ALPHA - デフォルト値=false)</p></td>
 </tr>
 
 <tr>
@@ -58,14 +58,14 @@ kubeadm config images list [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "registry.k8s.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンのイメージをプルするコンテナレジストリを選択します。</p></td>
 </tr>
 
 <tr>
-<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "stable-1"</td>
+<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "stable-1"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンの特定のKubernetesバージョンを選択します。</p></td>
@@ -93,10 +93,10 @@ kubeadm config images list [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
@@ -1,0 +1,113 @@
+
+
+kubeadmが使用するイメージの一覧を出力します。
+設定ファイルはイメージやイメージリポジトリをカスタマイズする際に使用されます。
+
+### 概要
+
+
+kubeadmが使用するイメージの一覧を出力します。
+設定ファイルはイメージやイメージリポジトリをカスタマイズする際に使用されます。
+
+```
+kubeadm config images list [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: true</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>trueならば、テンプレートの中にフィールドやマップキーが見つからない場合に、テンプレート内のエラーを無視します。golangまたはjsonpathを出力フォーマットとした場合にのみ適用されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>kubeadmの設定ファイルのパス。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "text"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>出力フォーマット。次のいずれか: text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--feature-gates string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>様々な機能に対するフィーチャーゲートを記述するkey=valueペアのセット。オプション:<br/>EtcdLearnerMode=true|false (BETA - 既定値=true)<br/>PublicKeysECDSA=true|false (DEPRECATED - 既定値=false)<br/>RootlessControlPlane=true|false (ALPHA - 既定値=false)<br/>UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 既定値=false)<br/>WaitForAllControlPlaneComponents=true|false (ALPHA - 既定値=false)</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>listのヘルプ</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "registry.k8s.io"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンのイメージをプルするコンテナレジストリを選択します。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "stable-1"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンの特定のKubernetesバージョンを選択します。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--show-managed-fields</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>trueならば、JSONまたはYAMLフォーマットでmanagedFieldsを省略せずにオブジェクトを出力します。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
@@ -38,7 +38,7 @@ kubeadm config images pull [flags]
 <td colspan="2">--feature-gates string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>様々な機能に対するフィーチャーゲートを記述するkey=valueペアのセット。オプション:<br/>EtcdLearnerMode=true|false (BETA - 既定値=true)<br/>PublicKeysECDSA=true|false (DEPRECATED - 既定値=false)<br/>RootlessControlPlane=true|false (ALPHA - 既定値=false)<br/>UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 既定値=false)<br/>WaitForAllControlPlaneComponents=true|false (ALPHA - 既定値=false)</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>様々な機能に対するフィーチャーゲートを記述するkey=valueペアのセット。オプション:<br/>EtcdLearnerMode=true|false (BETA - デフォルト値=true)<br/>PublicKeysECDSA=true|false (DEPRECATED - デフォルト値=false)<br/>RootlessControlPlane=true|false (ALPHA - デフォルト値=false)<br/>UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - デフォルト値=false)<br/>WaitForAllControlPlaneComponents=true|false (ALPHA - デフォルト値=false)</p></td>
 </tr>
 
 <tr>
@@ -49,14 +49,14 @@ kubeadm config images pull [flags]
 </tr>
 
 <tr>
-<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "registry.k8s.io"</td>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "registry.k8s.io"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンのイメージをプルするコンテナレジストリを選択します。</p></td>
 </tr>
 
 <tr>
-<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "stable-1"</td>
+<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "stable-1"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンの特定のKubernetesバージョンを選択します。</p></td>
@@ -77,10 +77,10 @@ kubeadm config images pull [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_pull.md
@@ -1,0 +1,97 @@
+
+
+kubeadmによって使用されるイメージをプルします。
+
+### 概要
+
+
+kubeadmによって使用されるイメージをプルします。
+
+```
+kubeadm config images pull [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>kubeadmの設定ファイルのパス。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--cri-socket string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>接続するCRIソケットへのパス。空の場合、kubeadmはこの値を自動検出しようとします。このオプションは、複数のCRIがインストールされているか、標準ではないCRIソケットがある場合のみ使用してください。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--feature-gates string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>様々な機能に対するフィーチャーゲートを記述するkey=valueペアのセット。オプション:<br/>EtcdLearnerMode=true|false (BETA - 既定値=true)<br/>PublicKeysECDSA=true|false (DEPRECATED - 既定値=false)<br/>RootlessControlPlane=true|false (ALPHA - 既定値=false)<br/>UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 既定値=false)<br/>WaitForAllControlPlaneComponents=true|false (ALPHA - 既定値=false)</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>pullのヘルプ</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "registry.k8s.io"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンのイメージをプルするコンテナレジストリを選択します。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--kubernetes-version string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "stable-1"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>コントロールプレーンの特定のKubernetesバージョンを選択します。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_migrate.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_migrate.md
@@ -1,0 +1,93 @@
+
+
+ファイルから古いバージョンのAPIタイプのkubeadmの設定を読み込み、新しいバージョンの同等の設定オブジェクトを出力します。
+
+### 概要
+
+
+
+このコマンドは、古いバージョンの設定オブジェクトを、サポートされている最新のバージョンに変換します。
+これはクラスターを何も触ることなく、CLIツール内に閉じています。
+kubeadmのこのバージョンでは、次のAPIバージョンがサポートされています:
+- kubeadm.k8s.io/v1beta3
+
+さらに、kubeadmはバージョン"kubeadm.k8s.io/v1beta3"の設定しか出力できませんが、両方の種類を読むことができます。
+このため、どのバージョンを--old-configパラメーターに渡したとしても、APIオブジェクトは読み込まれ、デシリアライズ、デフォルト化、変換、検証、再シリアライズされて、標準出力または--new-configで指定されたファイルに出力されます。
+
+言い換えると、このコマンドの出力は、そのファイルを"kubeadm init"に渡した時にkubeadmが実際に内部で読むものとなります。
+
+
+```
+kubeadm config migrate [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--allow-experimental-api</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>実験的な未リリースのAPIへの移行を許可します。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>migrateのヘルプ</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--new-config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>新しいAPIバージョンを使用して得られた同等の内容のkubeadm設定ファイルのパス。この設定はオプションで、指定しない場合は標準出力に出力されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--old-config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>古いAPIバージョンを使用している、変換対象のkubeadm設定ファイルのパス。このフラグは必須です。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_migrate.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_migrate.md
@@ -73,10 +73,10 @@ kubeadm config migrate [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
@@ -1,0 +1,64 @@
+
+
+設定を出力します
+
+### 概要
+
+
+
+このコマンドは、指定されたサブコマンドに対する設定を出力します。
+詳細については次を参照してください: https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#section-directories
+
+```
+kubeadm config print [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>printのヘルプ</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print.md
@@ -1,6 +1,6 @@
 
 
-設定を出力します
+設定を出力します。
 
 ### 概要
 
@@ -44,10 +44,10 @@ kubeadm config print [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
@@ -1,14 +1,14 @@
 
 
-`kubeadm init`で使用可能な既定の初期設定を出力します。
+`kubeadm init`で使用できるデフォルトのInitConfigurationを出力します。
 
 ### 概要
 
 
 
-このコマンドは、'kubeadm init'で使用される既定の初期設定のオブジェクトを出力します。
+このコマンドは、'kubeadm init'で使用されるデフォルトのInitConfigurationオブジェクトを出力します。
 
-Bootstrap Tokenフィールドのような機密性が高い値は、検証をパスしますが、実際にトークンを生成する計算は実行されないように、"abcdef.0123456789abcdef"のようなプレースホルダーの値に置き換えられることに注意してください。
+Bootstrap Tokenフィールドのような機密性が高い値は、実際にトークンを生成する計算は実行しませんが、検証をパスするために"abcdef.0123456789abcdef"のようなプレースホルダーの値に置き換えられることに注意してください。
 
 
 ```
@@ -28,7 +28,7 @@ kubeadm config print init-defaults [flags]
 <td colspan="2">--component-configs strings</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>既定値を出力するコンポーネントの設定APIオブジェクトのカンマ区切りのリスト。利用可能な値: [KubeProxyConfiguration KubeletConfiguration]。このフラグが設定されない場合は、どのコンポーネントの設定も出力されません。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>デフォルト値を出力するコンポーネントの設定APIオブジェクトのカンマ区切りのリスト。利用可能な値: [KubeProxyConfiguration KubeletConfiguration]。このフラグが設定されていない場合は、どのコンポーネントの設定も出力されません。</p></td>
 </tr>
 
 <tr>
@@ -53,10 +53,10 @@ kubeadm config print init-defaults [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_init-defaults.md
@@ -1,0 +1,73 @@
+
+
+`kubeadm init`で使用可能な既定の初期設定を出力します。
+
+### 概要
+
+
+
+このコマンドは、'kubeadm init'で使用される既定の初期設定のオブジェクトを出力します。
+
+Bootstrap Tokenフィールドのような機密性が高い値は、検証をパスしますが、実際にトークンを生成する計算は実行されないように、"abcdef.0123456789abcdef"のようなプレースホルダーの値に置き換えられることに注意してください。
+
+
+```
+kubeadm config print init-defaults [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--component-configs strings</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>既定値を出力するコンポーネントの設定APIオブジェクトのカンマ区切りのリスト。利用可能な値: [KubeProxyConfiguration KubeletConfiguration]。このフラグが設定されない場合は、どのコンポーネントの設定も出力されません。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>init-defaultsのヘルプ</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
@@ -1,0 +1,66 @@
+
+
+`kubeadm join`で使用可能な既定の参加の設定を出力します。
+
+### 概要
+
+
+
+このコマンドは`kubeadm join`で使用可能な既定の参加の設定のオブジェクトを出力します。
+
+Bootstrap Tokenフィールドのような機密性が高い値は、検証はパスしますが、実際にトークンを生成する計算は実行されないように、"abcdef.0123456789abcdef"のようなプレースホルダーの値に置き換えられることに注意してください。
+
+
+```
+kubeadm config print join-defaults [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>join-defaultsのヘルプ</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_print_join-defaults.md
@@ -1,14 +1,14 @@
 
 
-`kubeadm join`で使用可能な既定の参加の設定を出力します。
+`kubeadm join`で使用できるデフォルトのJoinConfigurationを出力します。
 
 ### 概要
 
 
 
-このコマンドは`kubeadm join`で使用可能な既定の参加の設定のオブジェクトを出力します。
+このコマンドは`kubeadm join`で使用されるデフォルトのJoinConfigurationオブジェクトを出力します
 
-Bootstrap Tokenフィールドのような機密性が高い値は、検証はパスしますが、実際にトークンを生成する計算は実行されないように、"abcdef.0123456789abcdef"のようなプレースホルダーの値に置き換えられることに注意してください。
+Bootstrap Tokenフィールドのような機密性が高い値は、実際にトークンを生成する計算は実行しませんが、検証をパスするために"abcdef.0123456789abcdef"のようなプレースホルダーの値に置き換えられることに注意してください。
 
 
 ```
@@ -46,10 +46,10 @@ kubeadm config print join-defaults [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_validate.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_validate.md
@@ -1,0 +1,85 @@
+
+
+kubeadm設定APIを含むファイルを読み込み、検証に問題があれば報告します。
+
+### 概要
+
+
+
+このコマンドはkubeadm設定APIファイルを検証して、警告やエラーがあれば報告します。
+エラーが無い場合は終了ステータスはゼロ、それ以外の場合はゼロ以外の値となります。
+不明なAPIフィールドのようなアンマーシャリングできない問題については、エラーが発生します。
+不明なAPIバージョンや不正な値を持つフィールドについてもエラーとなります。
+入力ファイルの内容によっては、その他のエラーや警告が報告されることもあります。
+
+このバージョンのkubeadmでは、次のAPIバージョンがサポートされています:
+- kubeadm.k8s.io/v1beta3
+
+
+```
+kubeadm config validate [flags]
+```
+
+### オプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--allow-experimental-api</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>実験的な未リリースのAPIの検証を許可する。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>kubeadm設定ファイルへのパス。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>validateのヘルプ</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+### 親コマンドから継承されたオプション
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>[実験的]'実際の'ホストのルートファイルシステムのパス。</p></td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_validate.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_validate.md
@@ -8,7 +8,7 @@ kubeadm設定APIを含むファイルを読み込み、検証に問題があれ�
 
 このコマンドはkubeadm設定APIファイルを検証して、警告やエラーがあれば報告します。
 エラーが無い場合は終了ステータスはゼロ、それ以外の場合はゼロ以外の値となります。
-不明なAPIフィールドのようなアンマーシャリングできない問題については、エラーが発生します。
+不明なAPIフィールドのようなデータ変換できない問題については、エラーが発生します。
 不明なAPIバージョンや不正な値を持つフィールドについてもエラーとなります。
 入力ファイルの内容によっては、その他のエラーや警告が報告されることもあります。
 
@@ -65,10 +65,10 @@ kubeadm config validate [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;既定値: "/etc/kubernetes/admin.conf"</td>
+<td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;デフォルト値: "/etc/kubernetes/admin.conf"</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと対話する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>クラスターと通信する時に使用するkubeconfigファイル。フラグが設定されていない場合は、標準的な場所の中から既存のkubeconfigファイルが検索されます。</p></td>
 </tr>
 
 <tr>

--- a/content/ja/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -1,0 +1,61 @@
+---
+title: kubeadm config
+content_type: concept
+weight: 50
+---
+
+<!-- overview -->
+`kubeadm init`の実行中、kubeadmはクラスターに対して、`kube-system`名前空間内の`kubeadm-config`という名前のConfigMapに`ClusterConfiguration`オブジェクトをアップロードします。
+この設定は`kubeadm join`、`kubeadm reset`および`kubeadm upgrade`の実行中に読み込まれます。
+
+`kubeadm config print`によって、kubeadmが`kubeadm init`や`kubeadm join`で使用する、既定の静的な設定を表示することができます。
+
+{{< note >}}
+コマンドの出力は一例として提供されるものです。
+このコマンドの出力を手動で編集して、自身のセットアップに合わせる必要があります。
+よくわからないフィールドは削除してください。
+kubeadmはホストを調べて実行時にそれらの既定値を設定しようとします。
+{{< /note >}}
+
+`init`と`join`のより詳細な情報については、[設定ファイルを使ったkubeadm initの利用](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file)、または[設定ファイルを使ったkubeadm joinの利用](/docs/reference/setup-tools/kubeadm/kubeadm-join/#config-file)を参照してください。
+
+kubeadmの設定APIの使用法に関するより詳細な情報については、[kubeadm APIを使ったコンポーネントのカスタマイズ](/ja/docs/setup/production-environment/tools/kubeadm/control-plane-flags)を参照してください。
+
+廃止されたAPIバージョンを含んだ古い設定ファイルを、サポートされた、新しいAPIバージョンに変換する際には、`kubeadm config migrate`コマンドを使用することができます。
+
+設定ファイルを検証するためには、`kubeadm config validate`を使用することができます。
+
+kubeadmが必要とするイメージを表示、取得するために、`kbueadm config images list`や`kubeadm config images pull`を使用することができます。
+
+<!-- body -->
+## kubeadm config print {#cmd-config-print}
+
+{{< include "generated/kubeadm_config_print.md" >}}
+
+## kubeadm config print init-defaults {#cmd-config-print-init-defaults}
+
+{{< include "generated/kubeadm_config_print_init-defaults.md" >}}
+
+## kubeadm config print join-defaults {#cmd-config-print-join-defaults}
+
+{{< include "generated/kubeadm_config_print_join-defaults.md" >}}
+
+## kubeadm config migrate {#cmd-config-migrate}
+
+{{< include "generated/kubeadm_config_migrate.md" >}}
+
+## kubeadm config validate {#cmd-config-validate}
+
+{{< include "generated/kubeadm_config_validate.md" >}}
+
+## kubeadm config images list {#cmd-config-images-list}
+
+{{< include "generated/kubeadm_config_images_list.md" >}}
+
+## kubeadm config images pull {#cmd-config-images-pull}
+
+{{< include "generated/kubeadm_config_images_pull.md" >}}
+
+## {{% heading "whatsnext" %}}
+
+* [kubeadm upgrade](/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/)を使用すると、Kubernetesクラスターを最新のバージョンにアップグレードすることができます

--- a/content/ja/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/ja/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -8,20 +8,20 @@ weight: 50
 `kubeadm init`の実行中、kubeadmはクラスターに対して、`kube-system`名前空間内の`kubeadm-config`という名前のConfigMapに`ClusterConfiguration`オブジェクトをアップロードします。
 この設定は`kubeadm join`、`kubeadm reset`および`kubeadm upgrade`の実行中に読み込まれます。
 
-`kubeadm config print`によって、kubeadmが`kubeadm init`や`kubeadm join`で使用する、既定の静的な設定を表示することができます。
+`kubeadm config print`によって、kubeadmが`kubeadm init`や`kubeadm join`で使用する、デフォルトの静的な設定を表示することができます。
 
 {{< note >}}
 コマンドの出力は一例として提供されるものです。
-このコマンドの出力を手動で編集して、自身のセットアップに合わせる必要があります。
-よくわからないフィールドは削除してください。
-kubeadmはホストを調べて実行時にそれらの既定値を設定しようとします。
+自身のセットアップに合わせるためには、コマンドの出力を手動で編集する必要があります。
+不明確なフィールドは削除してください。
+kubeadmは実行時にホストを調べ、そのフィールドにデフォルト値を設定しようとします。
 {{< /note >}}
 
 `init`と`join`のより詳細な情報については、[設定ファイルを使ったkubeadm initの利用](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file)、または[設定ファイルを使ったkubeadm joinの利用](/docs/reference/setup-tools/kubeadm/kubeadm-join/#config-file)を参照してください。
 
 kubeadmの設定APIの使用法に関するより詳細な情報については、[kubeadm APIを使ったコンポーネントのカスタマイズ](/ja/docs/setup/production-environment/tools/kubeadm/control-plane-flags)を参照してください。
 
-廃止されたAPIバージョンを含んだ古い設定ファイルを、サポートされた、新しいAPIバージョンに変換する際には、`kubeadm config migrate`コマンドを使用することができます。
+非推奨のAPIバージョンを含んだ古い設定ファイルを、サポートされた新しいAPIバージョンに変換する際には、`kubeadm config migrate`コマンドを使用することができます。
 
 設定ファイルを検証するためには、`kubeadm config validate`を使用することができます。
 


### PR DESCRIPTION
Fixes #40420 

Preview: https://deploy-preview-46887--kubernetes-io-main-staging.netlify.app/ja/docs/reference/setup-tools/kubeadm/kubeadm-config/
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
