### PR TITLE
[zh] update content/zh-cn/examples/pods/security/hello-apparmor.yaml

### DIFF
--- a/content/zh-cn/examples/pods/security/hello-apparmor.yaml
+++ b/content/zh-cn/examples/pods/security/hello-apparmor.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: hello-apparmor
-  annotations:
-    # 告知 Kubernetes 去应用 AppArmor 配置 "k8s-apparmor-example-deny-write"。
-    # 请注意，如果节点上运行的 Kubernetes 不是 1.4 或更高版本，此注解将被忽略。
-    container.apparmor.security.beta.kubernetes.io/hello: localhost/k8s-apparmor-example-deny-write
 spec:
+  securityContext:
+    appArmorProfile:
+      type: Localhost
+      localhostProfile: k8s-apparmor-example-deny-write
   containers:
   - name: hello
     image: busybox:1.28


### PR DESCRIPTION
Update AppArmor configuration to:
`content/zh-cn/examples/pods/security/hello-apparmor.yaml`

Prior to Kubernetes v1.30, AppArmor was specified through annotations. After Kubernetes v1.30, it needs to be configured in securityContext. The original **hello-apparmor.yaml** file still uses annotations to configure AppArmor, which has been updated to use securityContext configuration.