### PR TITLE
Release 1.29-kubeadm: add note about a bug in the PublicKeysECDSA feature gate

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -176,7 +176,8 @@ as a learner and promoted to a voting member only after the etcd data are fully 
 `PublicKeysECDSA`
 : Can be used to create a cluster that uses ECDSA certificates instead of the default RSA algorithm.
 Renewal of existing ECDSA certificates is also supported using `kubeadm certs renew`, but you cannot
-switch between the RSA and ECDSA algorithms on the fly or during upgrades.
+switch between the RSA and ECDSA algorithms on the fly or during upgrades. Kubernetes {{< skew currentVersion >}} has
+a bug where keys in generated kubeconfig files are set use RSA despite the feature gate being enabled.
 
 `RootlessControlPlane`
 : Setting this flag configures the kubeadm deployed control plane component static Pod containers


### PR DESCRIPTION
Add note about that in the PublicKeysECDSA section of the kubeadm init doc.

xref https://github.com/kubernetes/website/issues/46799