### PR TITLE
Adding warning tags and line wrapping

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -170,6 +170,13 @@ Kubernetes cluster. To make the `hello-node` Container accessible from outside t
 Kubernetes virtual network, you have to expose the Pod as a
 Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 
+{{< warning >}}
+The agnhost container has a `/shell` endpoint, which is useful 
+for debugging, but dangerous to expose to the public internet. 
+Do not run this on an internet-facing cluster, or a production 
+cluster.
+{{< /warning >}}
+
 1. Expose the Pod to the public internet using the `kubectl expose` command:
 
     ```shell


### PR DESCRIPTION
Adding a warning about `kubectl expose` on `agnhost` and incorporating feedback to wrap the lines.

This PR is based on the original work done by @cjcullen in [PR #46140](https://github.com/kubernetes/website/pull/46140). Thanks to @cjcullen for the initial implementation and @Shubham82 for the feedback on line wrapping [PR #46140-comment](https://github.com/kubernetes/website/pull/46140#discussion_r1588795257).

Per the request from @sftim on Slack (see [Slack post](https://kubernetes.slack.com/archives/C1J0BPD2M/p1718732770418679)), this new PR has been created to address the same changes with appropriate line wrapping.