### PR TITLE
[dev-1.31] KEP-3619: Fine-grained SupplementalGroups control

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/supplemental-groups-policy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/supplemental-groups-policy.md
@@ -1,0 +1,14 @@
+---
+title: SupplementalGroupsPolicy
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.31"
+---
+Enables support for fine-grained SupplementalGroups control.
+For more details, see [Configure fine-grained SupplementalGroups control for a Pod](/content/en/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy).

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -162,8 +162,7 @@ exit
 
 ### Implicit group memberships defined in `/etc/group` in the container image
 
-By default, kubernetes merges group information for the container's primary user defined in
-`/etc/group` in the container image.
+By default, kubernetes merges group information from the Pod with information defined in `/etc/group` in the container image.
 
 {{% code_sample file="pods/security/security-context-5.yaml" %}}
 
@@ -198,11 +197,10 @@ $ id
 The output is similar to this:
 
 ```none
-uid=1000(user-defined-in-image) gid=3000 groups=3000,4000,50000(group-defined-in-image)
+uid=1000 gid=3000 groups=3000,4000,50000
 ```
 
-You can see `groups` includes group ID `50000`. This is because the user (`uid=1000(user-defined-in-image)`)
-belongs to the group `group-defined-in-image(gid=50000)` which is defined in `/etc/group` in the container image.
+You can see `groups` includes group ID `50000`. This is because the user (`uid=1000`), which is defined in the image, belongs to the group (`gid=50000`), which is defined in `/etc/group` inside the container image.
 
 Check the `/etc/group` in the container image:
 
@@ -210,10 +208,11 @@ Check the `/etc/group` in the container image:
 $ cat /etc/group
 ```
 
-You can see the group entry that `user-defined-in-image(uid=1000)` belongs to `group-defined-in-image(gid=50000)`.
+You can see that uid `1000` belongs to group `50000`.
 
 ```none
 ...
+user-defined-in-image:x:1000:
 group-defined-in-image:x:50000:user-defined-in-image
 ```
 
@@ -272,7 +271,7 @@ kubectl exec -it security-context-demo -- id
 The output is similar to this:
 
 ```none
-uid=1000(user-defined-in-image) gid=3000 groups=3000,4000
+uid=1000 gid=3000 groups=3000,4000
 ```
 
 See the Pod's status:

--- a/content/en/examples/pods/security/security-context-5.yaml
+++ b/content/en/examples/pods/security/security-context-5.yaml
@@ -6,17 +6,10 @@ spec:
   securityContext:
     runAsUser: 1000
     runAsGroup: 3000
-    fsGroup: 2000
     supplementalGroups: [4000]
-  volumes:
-  - name: sec-ctx-vol
-    emptyDir: {}
   containers:
   - name: sec-ctx-demo
-    image: busybox:1.28
+    image: registry.k8s.io/e2e-test-images/agnhost:2.45
     command: [ "sh", "-c", "sleep 1h" ]
-    volumeMounts:
-    - name: sec-ctx-vol
-      mountPath: /data/demo
     securityContext:
       allowPrivilegeEscalation: false

--- a/content/en/examples/pods/security/security-context-6.yaml
+++ b/content/en/examples/pods/security/security-context-6.yaml
@@ -6,17 +6,11 @@ spec:
   securityContext:
     runAsUser: 1000
     runAsGroup: 3000
-    fsGroup: 2000
     supplementalGroups: [4000]
-  volumes:
-  - name: sec-ctx-vol
-    emptyDir: {}
+    supplementalGroupsPolicy: Strict
   containers:
   - name: sec-ctx-demo
-    image: busybox:1.28
+    image: registry.k8s.io/e2e-test-images/agnhost:2.45
     command: [ "sh", "-c", "sleep 1h" ]
-    volumeMounts:
-    - name: sec-ctx-vol
-      mountPath: /data/demo
     securityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR adds a user-facing document for https://github.com/kubernetes/enhancements/issues/3619 in [Configure a Security Context for a Pod or Container](https://deploy-preview-46920--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/security-context/)
- "Implicit group membership in /etc/group in the container image" section is added to clarify the motivation of this KEP.
- "Configure fine-grained SupplementalGroups control for a Pod" section is introduced to explain feature gates and policies. This section also describes the Node's `.status.containerStatuses[].user.linux` field.

----

For:

- https://github.com/kubernetes/enhancements/issues/3619

Depends on:

- k/k
  - [x] https://github.com/kubernetes/kubernetes/pull/117842
  - [x] https://github.com/kubernetes/kubernetes/pull/125470
- contained: 
  - [x] https://github.com/containerd/containerd/pull/9737
  - [x] https://github.com/containerd/containerd/pull/10410
- CRI-O Update PR(s): 
  - [x] https://github.com/cri-o/cri-o/pull/8268
  - [x] https://github.com/cri-o/cri-o/pull/8386
