### PR TITLE
Improve limitrange documentation

### DIFF
--- a/content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml
+++ b/content/en/examples/concepts/policy/limit-range/problematic-limit-range.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: cpu-resource-constraint
+  namespace: default # when unspecified this will be created in default namespace.
 spec:
   limits:
   - default: # this section defines default limits


### PR DESCRIPTION
Fixing issue 46899 by adding namespace field in the examples in limitrange k8s doc
https://kubernetes.io/docs/concepts/policy/limit-range/ 
