### PR TITLE
Document OCI volume sources / KEP-4639

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/image-volume.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/image-volume.md
@@ -1,0 +1,14 @@
+---
+title: ImageVolume
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.31"
+---
+Allow using the [`image`](/docs/concepts/storage/volumes/) volume source in a Pod.
+This volume source lets you mount a container image as a read-only volume.

--- a/content/en/docs/tasks/configure-pod-container/image-volumes.md
+++ b/content/en/docs/tasks/configure-pod-container/image-volumes.md
@@ -1,0 +1,72 @@
+---
+title: Use an Image Volume With a Pod
+reviewers:
+content_type: task
+weight: 210
+min-kubernetes-server-version: v1.31
+---
+
+<!-- overview -->
+
+{{< feature-state feature_gate_name="ImageVolume" >}}
+
+This page shows how to configure a pod using image volumes. This allows you to
+mount content from OCI registries inside containers.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+- The container runtime needs to support the image volumes feature
+- You need to exec commands in the host
+- You need to be able to exec into pods
+- You need to enable the `ImageVolume` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+
+<!-- steps -->
+
+## Run a Pod that uses an image volume {#create-pod}
+
+An image volume for a pod is enabled setting the `volumes.[*].image` field of `.spec`
+to a valid reference and consuming it in the `volumeMounts` of the container. For example:
+
+{{% code_sample file="pods/image-volumes.yaml" %}}
+
+1. Create the pod on your cluster:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/image-volumes.yaml
+   ```
+
+1. Attach to the container:
+
+   ```shell
+   kubectl attach -it image-volume bash
+   ```
+
+Run this command:
+
+```shell
+cat /volume/dir/file
+```
+
+The output is similar to:
+
+```shell
+1
+```
+
+Also run:
+
+```shell
+cat /volume/file
+```
+
+The output is similar to:
+
+```shell
+2
+```
+
+## Further reading
+
+- [`image` volumes](/docs/concepts/storage/volumes/#image)

--- a/content/en/examples/pods/image-volumes.yaml
+++ b/content/en/examples/pods/image-volumes.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: image-volume
+spec:
+  containers:
+  - name: shell
+    command: ["sleep", "infinity"]
+    image: debian
+    volumeMounts:
+    - name: volume
+      mountPath: /volume
+  volumes:
+  - name: volume
+    image:
+      reference: quay.io/crio/artifact:v1
+      pullPolicy: IfNotPresent


### PR DESCRIPTION
Adding a simple task to deploy image volumes. I assume most of the details will be generated from the API (https://github.com/kubernetes/kubernetes/pull/125660).

Refers to https://github.com/kubernetes/enhancements/issues/4639

Preview:
- https://deploy-preview-46946--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/image-volumes
- https://deploy-preview-46946--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/volumes/#image