### PR TITLE
[KEP-4006] - Docs for PortForward over WebSockets Feature Gates (Beta)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/port-forward-websockets.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/port-forward-websockets.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.30"
+    toVersion: "1.30"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.31"
 ---
 Allow WebSocket streaming of the
 portforward sub-protocol (`port-forward`) from clients requesting


### PR DESCRIPTION
* Updates control plane feature flag: PortForwardWebsockets to Beta
* Updates `kubectl` feature flag: KUBECTL_PORT_FORWARD_WEBSOCKETS to Beta

https://github.com/kubernetes/enhancements/issues/4006