### PR TITLE
nftables kube-proxy blog post for 1.31

### DIFF
--- a/content/en/blog/_posts/2024-08-XX-nftables-kube-proxy.md
+++ b/content/en/blog/_posts/2024-08-XX-nftables-kube-proxy.md
@@ -1,0 +1,8 @@
+---
+layout: blog
+title: "NFTables mode for kube-proxy"
+date: 2024-08-XX
+slug: nftables-kube-proxy
+author: >
+  Dan Winship (Red Hat)
+---


### PR DESCRIPTION
Placeholder for a 1.31 blog post about kube-proxy's nftables mode, which will now be beta.
