### PR TITLE
KEP-4358: Custom Resource Field Selectors: Promote to Beta

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -313,11 +313,6 @@ may also be used with field selectors when included in the `spec.versions[*].sel
 
 {{< feature-state feature_gate_name="CustomResourceFieldSelectors" >}}
 
-You need to enable the `CustomResourceFieldSelectors`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to
-use this behavior, which then applies to all CustomResourceDefinitions in your
-cluster.
-
 The `spec.versions[*].selectableFields` field of a {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} may be used to
 declare which other fields in a custom resource may be used in field selectors.
 The following example adds the `.spec.color` and `.spec.size` fields as

--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -314,7 +314,9 @@ may also be used with field selectors when included in the `spec.versions[*].sel
 {{< feature-state feature_gate_name="CustomResourceFieldSelectors" >}}
 
 The `spec.versions[*].selectableFields` field of a {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} may be used to
-declare which other fields in a custom resource may be used in field selectors.
+declare which other fields in a custom resource may be used in field selectors
+with the feature of `CustomResourceFieldSelectors`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) (This feature gate is enabled by default since Kubernetes v1.31).
 The following example adds the `.spec.color` and `.spec.size` fields as
 selectable fields.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
@@ -9,6 +9,9 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.30"  
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.31"  
 ---
 
 Enable `selectableFields` in the

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/custom-resource-field-selectors.md
@@ -9,6 +9,7 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.30"  
+    toVersion: "1.30"
   - stage: beta
     defaultValue: true
     fromVersion: "1.31"  

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1647,6 +1647,10 @@ may also be used with field selectors when included in the `spec.versions[*].sel
 
 {{< feature-state feature_gate_name="CustomResourceFieldSelectors" >}}
 
+For Kubernetes {{< skew currentVersion >}} the ability to define field selectors for
+custom resources is available by default (enabled by default since Kubernetes v1.31);
+you can disable it for your cluster  by turning off the `CustomResourceFieldSelectors`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 The `spec.versions[*].selectableFields` field of a {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} may be used to
 declare which other fields in a custom resource may be used in field selectors.
 The following example adds the `.spec.color` and `.spec.size` fields as

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1645,13 +1645,7 @@ may also be used with field selectors when included in the `spec.versions[*].sel
 
 #### Selectable fields for custom resources {#crd-selectable-fields}
 
-{{< feature-state state="alpha" for_k8s_version="v1.30" >}}
 {{< feature-state feature_gate_name="CustomResourceFieldSelectors" >}}
-
-You need to enable the `CustomResourceFieldSelectors`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to
-use this behavior, which then applies to all CustomResourceDefinitions in your
-cluster.
 
 The `spec.versions[*].selectableFields` field of a {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} may be used to
 declare which other fields in a custom resource may be used in field selectors.

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1652,7 +1652,9 @@ custom resources is available by default (enabled by default since Kubernetes v1
 you can disable it for your cluster  by turning off the `CustomResourceFieldSelectors`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 The `spec.versions[*].selectableFields` field of a {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}} may be used to
-declare which other fields in a custom resource may be used in field selectors.
+declare which other fields in a custom resource may be used in field selectors
+with the feature of `CustomResourceFieldSelectors`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) (This feature gate is enabled by default since Kubernetes v1.31).
 The following example adds the `.spec.color` and `.spec.size` fields as
 selectable fields.
 


### PR DESCRIPTION
Update feature gate to reflect that this is in beta starting with 1.31 and is enabled by default.

This feature was accurately documented for alpha in https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/ and https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/, so we don't need to change any other documentation.