### PR TITLE
KEP-4420: Retry Generate Name: Promote to beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/name-generation-retries.md
@@ -10,7 +10,10 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.30"
-
+    toVersion: "1.30"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.31"
 ---
 Enables retrying of object creation when the
 {{< glossary_tooltip text="API server" term_id="kube-apiserver" >}}


### PR DESCRIPTION
This is not a user visible feature. The change is that name generation is retried automatically by the apiserver if the randomly generated hash collides an existing name.  Name generation failures can still happen, and happen with the same error, but are far more rare.

For this reason, only a feature gate is being added to the documentation.