### PR TITLE
Fixed minimum feasible nodes value (50->100)

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -103,9 +103,9 @@ percentageOfNodesToScore: 50
 
 `percentageOfNodesToScore` must be a value between 1 and 100 with the default
 value being calculated based on the cluster size. There is also a hardcoded
-minimum value of 50 nodes.
+minimum value of 100 nodes.
 
-{{< note >}}In clusters with less than 50 feasible nodes, the scheduler still
+{{< note >}}In clusters with less than 100 feasible nodes, the scheduler still
 checks all the nodes because there are not enough feasible nodes to stop
 the scheduler's search early.
 


### PR DESCRIPTION
### Why change?

We need to update the value in the document to correspond to the source code.

In the source code, the hardcoded minimum number of nodes is 100,
https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/scheduler/schedule_one.go#L54

and scheduler checks all nodes if feasible nodes is less than 100.
https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/scheduler/schedule_one.go#L679-L681
