### PR TITLE
Update German install-kubectl-linux.md

### DIFF
--- a/content/de/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/de/docs/tasks/tools/install-kubectl-linux.md
@@ -167,7 +167,7 @@ Falls es benötigt wird, kann es angelegt werden. Hierzu sollte es danach von je
 1. Hinzufügen des Kubernetes `yum` Repository. Wenn eine andere Kubernetes Version als {{< param "version" >}} installiert werden soll, muss {{< param "version" >}} im unteren Block durch die gewünschte Version ersetzt werden.
 
    ```bash
-   # This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
+   # Bestehende Inhalte in /etc/yum.repos.d/kubernetes.repo werden überschrieben
    cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
    [kubernetes]
    name=Kubernetes
@@ -180,7 +180,7 @@ Falls es benötigt wird, kann es angelegt werden. Hierzu sollte es danach von je
 {{< note >}}
 Wenn ein andere minor Version von kubectl installiert werden soll muss `/etc/yum.repos.d/kubernetes.repo` angepasst werden
 bevor `yum install` ausgeführt wird. Eine genauere Beschreibung findet sich hier
-[Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+[Wechseln des Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}
 
 2. Installieren von kubectl mit Hilfe von `yum`:
@@ -195,7 +195,7 @@ bevor `yum install` ausgeführt wird. Eine genauere Beschreibung findet sich hie
 1. Hinzufügen des Kubernetes `zypper` Repository. Wenn eine andere Kubernetes Version als {{< param "version" >}} installiert werden soll, muss {{< param "version" >}} im unteren Block durch die gewünschte Version ersetzt werden.
 
    ```bash
-   # This overwrites any existing configuration in /etc/zypp/repos.d/kubernetes.repo
+   # Bestehende Inhalte in /etc/zypp/repos.d/kubernetes.repo werden überschrieben
    cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
    [kubernetes]
    name=Kubernetes
@@ -209,7 +209,7 @@ bevor `yum install` ausgeführt wird. Eine genauere Beschreibung findet sich hie
 {{< note >}}
 Wenn ein andere minor Version von kubectl installiert werden soll muss `/etc/zypp/repos.d/kubernetes.repo` angepasst werden
 bevor `zypper update` ausgeführt wird. Eine genauere Beschreibung findet sich hier
-[Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+[Wechseln des Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}
 
    2. Install kubectl using `zypper`:

--- a/content/de/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/de/docs/tasks/tools/install-kubectl-linux.md
@@ -207,7 +207,7 @@ bevor `yum install` ausgeführt wird. Eine genauere Beschreibung findet sich hie
    ```
 
 {{< note >}}
-Wenn ein andere minor Version von kubectl installiert werden soll muss `/etc/zypp/repos.d/kubernetes.repo` angepasst werden
+Wenn eine andere minor Version von kubectl installiert werden soll muss `/etc/zypp/repos.d/kubernetes.repo` angepasst werden
 bevor `zypper update` ausgeführt wird. Eine genauere Beschreibung findet sich hier
 [Wechseln des Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}

--- a/content/de/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/de/docs/tasks/tools/install-kubectl-linux.md
@@ -163,17 +163,60 @@ Falls es benötigt wird, kann es angelegt werden. Hierzu sollte es danach von je
 {{% /tab %}}
 
 {{% tab name="Red Hat-basierte Distributionen" %}}
-```bash
-cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-sudo yum install -y kubectl
-```
+
+1. Hinzufügen des Kubernetes `yum` Repository. Wenn eine andere Kubernetes Version als {{< param "version" >}} installiert werden soll, muss {{< param "version" >}} im unteren Block durch die gewünschte Version ersetzt werden.
+
+   ```bash
+   # This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
+   cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   EOF
+   ```
+{{< note >}}
+Wenn ein andere minor Version von kubectl installiert werden soll muss `/etc/yum.repos.d/kubernetes.repo` angepasst werden
+bevor `yum install` ausgeführt wird. Eine genauere Beschreibung findet sich hier
+[Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+{{< /note >}}
+
+2. Installieren von kubectl mit Hilfe von `yum`:
+
+   ```bash
+   sudo yum install -y kubectl
+   ```
+
+{{% /tab %}}
+
+{{% tab name="SUSE-basierte Distributionen" %}}
+1. Hinzufügen des Kubernetes `zypper` Repository. Wenn eine andere Kubernetes Version als {{< param "version" >}} installiert werden soll, muss {{< param "version" >}} im unteren Block durch die gewünschte Version ersetzt werden.
+
+   ```bash
+   # This overwrites any existing configuration in /etc/zypp/repos.d/kubernetes.repo
+   cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   EOF
+   ```
+
+{{< note >}}
+Wenn ein andere minor Version von kubectl installiert werden soll muss `/etc/zypp/repos.d/kubernetes.repo` angepasst werden
+bevor `zypper update` ausgeführt wird. Eine genauere Beschreibung findet sich hier
+[Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+{{< /note >}}
+
+   2. Install kubectl using `zypper`:
+
+      ```bash
+      sudo zypper install -y kubectl
+      ```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/de/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/de/docs/tasks/tools/install-kubectl-linux.md
@@ -178,7 +178,7 @@ Falls es benötigt wird, kann es angelegt werden. Hierzu sollte es danach von je
    EOF
    ```
 {{< note >}}
-Wenn ein andere minor Version von kubectl installiert werden soll muss `/etc/yum.repos.d/kubernetes.repo` angepasst werden
+Wenn eine andere minor Version von kubectl installiert werden soll muss `/etc/yum.repos.d/kubernetes.repo` angepasst werden
 bevor `yum install` ausgeführt wird. Eine genauere Beschreibung findet sich hier
 [Wechseln des Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}


### PR DESCRIPTION
The German installation instructions for RedHat were outdated and do not currently work.

This replaced `packages.cloud.google.com` with the current `pkgs.k8s.io` urls. 
Also adds SUSE installation instructions in german language.

I found no active german localization branch so I opened this PR on the main branch. If there is a better branch please let me know.
