### PR TITLE
Style unfixed vulnerabilities in bold

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -341,6 +341,12 @@ footer {
 
 /* DOCS */
 
+table tr.cve-status-open, table tr.cve-status-unknown {
+  > td.cve-item-summary {
+    font-weight: bold;
+  }
+}
+
 .launch-cards {
   padding: 0;
   display: grid;

--- a/layouts/shortcodes/cve-feed.html
+++ b/layouts/shortcodes/cve-feed.html
@@ -45,9 +45,9 @@
   </thead>
   <tbody>
   {{ range $feed.items }}
-  <tr>
-    <td><a href="{{ .url }}">{{ .id | htmlEscape | safeHTML }}</a></td>
-    <td>{{ .summary | htmlEscape | safeHTML }}</td>
+  <tr class="cve-status-{{.status}}">
+    <td class="cve-item-id"><a href="{{ .url }}">{{ .id | htmlEscape | safeHTML }}</a></td>
+    <td class="cve-item-summary">{{ .summary | htmlEscape | safeHTML }}</td>
     <td><a href="{{ .url }}">#{{ ._kubernetes_io.issue_number }}</a></td>
   </tr>
   {{ end }}


### PR DESCRIPTION
For the [CVE feed](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/) page, use bold for any vulnerability that hasn't been fixed. [Preview](https://deploy-preview-46996--kubernetes-io-main-staging.netlify.app/docs/reference/issues-security/official-cve-feed/).

Relies on changes from https://github.com/kubernetes/sig-security/pull/115