### PR TITLE
Include CVE status in RSS feed

### DIFF
--- a/layouts/_default/cve-feed.rss.xml
+++ b/layouts/_default/cve-feed.rss.xml
@@ -42,7 +42,7 @@
       <pubDate>{{ time.Format "Mon, 02 Jan 2006 15:04:05 -0700" .date_published | safeHTML }}</pubDate>
       <guid>{{ .external_url }}</guid>
       <description>{{ htmlEscape .summary }}</description>
-      <status>{{ .status }}</status>
+      <category term="{{ .status }}" scheme="https://k8s.io/2024-06-27/cve-item-status" />
     </item>
     {{ end -}}
   </channel>

--- a/layouts/_default/cve-feed.rss.xml
+++ b/layouts/_default/cve-feed.rss.xml
@@ -42,6 +42,7 @@
       <pubDate>{{ time.Format "Mon, 02 Jan 2006 15:04:05 -0700" .date_published | safeHTML }}</pubDate>
       <guid>{{ .external_url }}</guid>
       <description>{{ htmlEscape .summary }}</description>
+      <status>{{ .status }}</status>
     </item>
     {{ end -}}
   </channel>


### PR DESCRIPTION
Includes the new CVE _status_ field for each item in the [RSS feed](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/#cve-feeds-1).

Relies on changes from [kubernetes/sig-security#115](https://github.com/kubernetes/sig-security/pull/115)
