### PR TITLE
KEP-4568: Resilient Watch Cache Initialization: Add feature gate docs

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/resilient-watch-cache-initialization.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/resilient-watch-cache-initialization.md
@@ -1,0 +1,14 @@
+---
+title: ResilientWatchCacheInitialization
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta 
+    defaultValue: true
+    fromVersion: "1.31"
+---
+Enables resilient watchcache initialization to avoid controlplane overload.


### PR DESCRIPTION
KEP: [Resilient Watchcache Initialization](https://github.com/kubernetes/enhancements/issues/4568)

cc @wojtek-t I don't know if we need any docs for this feature, but I got pinged about getting a placeholder docs PR in place so I took the liberty of creating this.  Feel free to comment or take it over.