### PR TITLE
Replaced elided with omitted

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -263,7 +263,7 @@ token:          ...
 ```
 
 {{< note >}}
-The content of `token` is elided here.
+The content of `token` is omitted here.
 
 Take care not to display the contents of a `kubernetes.io/service-account-token`
 Secret somewhere that your terminal / computer screen could be seen by an onlooker.


### PR DESCRIPTION
The word `omitted` is likely more appropriate than `elided` here.    `elided` refers more to speech than writing.