### PR TITLE
[ja] Translate content/en/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md into Japanese

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -1,0 +1,109 @@
+---
+title: Podスケジューリング準備状態
+content_type: concept
+weight: 40
+---
+
+<!-- overview -->
+
+{{< feature-state for_k8s_version="v1.30" state="stable" >}}
+
+Podは1度作成されると、スケジュールの準備ができたとみなされます。Kubernetesのスケジューラーは、すべての保留中のPodを配置するためのノードを見つけることに最善を尽くします。しかし実際のケースでは、一部のPodが「必要なリソースを満たさない」状態に長期間とどまることがあります。このようなPodは、実際にはスケジューラー（およびCluster AutoScalerのようなダウンストリームのインテグレーター）を不必要に混乱させます。
+
+Podの`.spec.schedulingGates`を指定したり削除することで、Podがスケジューリングの対象になるタイミングを制御できます。
+
+<!-- body -->
+
+## PodにschedulingGatesを設定する
+
+`schedulingGates`のフィールドは、文字列のリストで構成されており、各文字列はPodがスケジューリング可能とみなされる前に満たすべき条件を表します。このフィールドは、Pod 作成時のみ初期化できます(クライアントによる作成時、または Admission webhook による変更時)。作成後、個々のschedulingGateは順序不同で削除できますが、新しいschedulingGateを追加することはできません。
+
+{{< figure src="/docs/images/podSchedulingGates.svg" alt="pod-scheduling-gates-diagram" caption="Figure. Pod SchedulingGates" class="diagram-large" link="https://mermaid.live/edit#pako:eNplkktTwyAUhf8KgzuHWpukaYszutGlK3caFxQuCVMCGSDVTKf_XfKyPlhxz4HDB9wT5lYAptgHFuBRsdKxenFMClMYFIdfUdRYgbiD6ItJTEbR8wpEq5UpUfnDTf-5cbPoJjcbXdcaE61RVJIiqJvQ_Y30D-OCt-t3tFjcR5wZayiVnIGmkv4NiEfX9jijKTmmRH5jf0sRugOP0HyHUc1m6KGMFP27cM28fwSJDluPpNKaXqVJzmFNfHD2APRKSjnNFx9KhIpmzSfhVls3eHdTRrwG8QnxKfEZUUNeYTDBNbiaKRF_5dSfX-BQQQ0FpnEqQLJWhwIX5hyXsjbYl85wTINrgeC2EZd_xFQy7b_VJ6GCdd-itkxALE84dE3fAqXyIUZya6Qqe711OspVCI2ny2Vv35QqVO3-htt66ZWomAvVcZcv8yTfsiSFfJOydZoKvl_ttjLJVlJsblcJw-czwQ0zr9ZeqGDgeR77b2jD8xdtjtDn" >}}
+
+## 使用例
+
+Podをスケジューリングする準備ができていないと示すには、次のように1つ以上のスケジューリングゲートを使って作成します。
+
+{{% code_sample file="pods/pod-with-scheduling-gates.yaml" %}}
+
+Podの作成後、Podの状態を確認するには、以下のようにします。
+
+```bash
+kubectl get pod test-pod
+```
+
+出力から`SchedulingGated`状態であることがわかります。
+
+```none
+NAME       READY   STATUS            RESTARTS   AGE
+test-pod   0/1     SchedulingGated   0          7s
+```
+
+また、`schedulingGates`フィールドを実行して確認することもできます。
+
+```bash
+kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
+```
+
+出力は以下のようになります。
+
+```none
+[{"name":"example.com/foo"},{"name":"example.com/bar"}]
+```
+
+このPodがスケジューリング可能であることをスケジューラに通知するには、変更したマニフェストを再適用することで、その`schedulingGates`を完全に削除できます。
+
+{{% code_sample file="pods/pod-without-scheduling-gates.yaml" %}}
+
+`schedulingGates`が削除されているかどうかは、実行することで確認できます。
+
+```bash
+kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
+```
+
+出力は、空であることが期待されます。そして、以下のように実行することで最新の状態をチェックすることができます。
+
+```bash
+kubectl get pod test-pod -o wide
+```
+
+test-podがCPU/メモリーリソースを要求していないのであれば、予想通り、このポッドのステータスは、以前の`SchedulingGated`から`Running`に遷移するでしょう。
+
+```none
+NAME       READY   STATUS    RESTARTS   AGE   IP         NODE
+test-pod   1/1     Running   0          15s   10.0.0.4   node-2
+```
+
+## Observability
+
+The metric `scheduler_pending_pods` comes with a new label `"gated"` to distinguish whether a Pod
+has been tried scheduling but claimed as unschedulable, or explicitly marked as not ready for
+scheduling. You can use `scheduler_pending_pods{queue="gated"}` to check the metric result.
+
+## Mutable Pod scheduling directives
+
+You can mutate scheduling directives of Pods while they have scheduling gates, with certain constraints.
+At a high level, you can only tighten the scheduling directives of a Pod. In other words, the updated
+directives would cause the Pods to only be able to be scheduled on a subset of the nodes that it would
+previously match. More concretely, the rules for updating a Pod's scheduling directives are as follows:
+
+1. For `.spec.nodeSelector`, only additions are allowed. If absent, it will be allowed to be set.
+
+2. For `spec.affinity.nodeAffinity`, if nil, then setting anything is allowed.
+
+3. If `NodeSelectorTerms` was empty, it will be allowed to be set.
+   If not empty, then only additions of `NodeSelectorRequirements` to `matchExpressions`
+   or `fieldExpressions` are allowed, and no changes to existing `matchExpressions`
+   and `fieldExpressions` will be allowed. This is because the terms in
+   `.requiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms`, are ORed
+   while the expressions in `nodeSelectorTerms[].matchExpressions` and
+   `nodeSelectorTerms[].fieldExpressions` are ANDed.
+
+4. For `.preferredDuringSchedulingIgnoredDuringExecution`, all updates are allowed.
+   This is because preferred terms are not authoritative, and so policy controllers
+   don't validate those terms.
+
+
+## {{% heading "whatsnext" %}}
+
+* Read the [PodSchedulingReadiness KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/3521-pod-scheduling-readiness) for more details

--- a/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -8,7 +8,7 @@ weight: 40
 
 {{< feature-state for_k8s_version="v1.30" state="stable" >}}
 
-Podは1度作成されると、スケジュールの準備ができたとみなされます。Kubernetesのスケジューラーは、すべての保留中のPodを配置するためのノードを見つけることに最善を尽くします。しかし実際のケースでは、一部のPodが「必要なリソースを満たさない」状態に長期間とどまることがあります。このようなPodは、実際にはスケジューラー（およびCluster AutoScalerのようなダウンストリームのインテグレーター）を不必要に混乱させます。
+Podは1度作成されると、スケジュールの準備ができたとみなされます。Kubernetesのスケジューラーは、すべての保留中のPodを配置するためにノードを見つけることに最善を尽くします。しかし実際のケースでは、一部のPodが「必要なリソースを満たさない」状態に長期間とどまることがあります。このようなPodは、実際にはスケジューラー（およびCluster AutoScalerのようなダウンストリームのインテグレーター）を不必要に混乱させます。
 
 Podの`.spec.schedulingGates`を指定したり削除することで、Podがスケジューリングの対象になるタイミングを制御できます。
 
@@ -16,17 +16,17 @@ Podの`.spec.schedulingGates`を指定したり削除することで、Podがス
 
 ## PodにschedulingGatesを設定する
 
-`schedulingGates`のフィールドは、文字列のリストで構成されており、各文字列はPodがスケジューリング可能とみなされる前に満たすべき条件を表します。このフィールドは、Pod 作成時のみ初期化できます(クライアントによる作成時、または Admission webhook による変更時)。作成後、個々のschedulingGateは順序不同で削除できますが、新しいschedulingGateを追加することはできません。
+`schedulingGates`のフィールドは、文字列のリストで構成されており、各文字列はPodがスケジューリング可能とみなされる前に満たすべき条件を表します。このフィールドは、Pod作成時のみ初期化できます(クライアントによる作成時、またはAdmission webhookによる変更時)。作成後、個々のschedulingGateは順序不同で削除できますが、新しいschedulingGateを追加することはできません。
 
 {{< figure src="/docs/images/podSchedulingGates.svg" alt="pod-scheduling-gates-diagram" caption="Figure. Pod SchedulingGates" class="diagram-large" link="https://mermaid.live/edit#pako:eNplkktTwyAUhf8KgzuHWpukaYszutGlK3caFxQuCVMCGSDVTKf_XfKyPlhxz4HDB9wT5lYAptgHFuBRsdKxenFMClMYFIdfUdRYgbiD6ItJTEbR8wpEq5UpUfnDTf-5cbPoJjcbXdcaE61RVJIiqJvQ_Y30D-OCt-t3tFjcR5wZayiVnIGmkv4NiEfX9jijKTmmRH5jf0sRugOP0HyHUc1m6KGMFP27cM28fwSJDluPpNKaXqVJzmFNfHD2APRKSjnNFx9KhIpmzSfhVls3eHdTRrwG8QnxKfEZUUNeYTDBNbiaKRF_5dSfX-BQQQ0FpnEqQLJWhwIX5hyXsjbYl85wTINrgeC2EZd_xFQy7b_VJ6GCdd-itkxALE84dE3fAqXyIUZya6Qqe711OspVCI2ny2Vv35QqVO3-htt66ZWomAvVcZcv8yTfsiSFfJOydZoKvl_ttjLJVlJsblcJw-czwQ0zr9ZeqGDgeR77b2jD8xdtjtDn" >}}
 
 ## 使用例
 
-Podをスケジューリングする準備ができていないと示すには、次のように1つ以上のスケジューリングゲートを使って作成します。
+Podがスケジューリングされる準備ができていないと示すには、次のように1つ以上のスケジューリングゲートを使って作成します。
 
 {{% code_sample file="pods/pod-with-scheduling-gates.yaml" %}}
 
-Podの作成後、Podの状態を確認するには、以下のようにします。
+Podの作成後、状態を確認するには、以下のようにします。
 
 ```bash
 kubectl get pod test-pod
@@ -39,7 +39,7 @@ NAME       READY   STATUS            RESTARTS   AGE
 test-pod   0/1     SchedulingGated   0          7s
 ```
 
-また、`schedulingGates`フィールドを実行して確認することもできます。
+また、`schedulingGates`フィールドから確認することもできます。
 
 ```bash
 kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
@@ -51,23 +51,23 @@ kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
 [{"name":"example.com/foo"},{"name":"example.com/bar"}]
 ```
 
-このPodがスケジューリング可能であることをスケジューラーに通知するには、変更したマニフェストを再適用することで、その`schedulingGates`を完全に削除できます。
+このPodがスケジューリング可能であることをスケジューラーに知らせるには、変更したマニフェストを再適用することで、`schedulingGates`を完全に削除できます。
 
 {{% code_sample file="pods/pod-without-scheduling-gates.yaml" %}}
 
-`schedulingGates`が削除されているかどうかは、実行することで確認できます。
+`schedulingGates`が削除されているかは、以下のように確認できます。
 
 ```bash
 kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
 ```
 
-出力は、空であることが期待されます。そして、以下のように実行することで最新の状態をチェックすることができます。
+出力は、空であることが期待されます。そして、以下のように実行することで最新の状態を確認することができます。
 
 ```bash
 kubectl get pod test-pod -o wide
 ```
 
-test-podがCPU/メモリーリソースを要求していないのであれば、予想通り、このポッドのステータスは、以前の`SchedulingGated`から`Running`に遷移するでしょう。
+test-podがCPU/メモリーリソースを要求しないので、このポッドのステータスは、以前の`SchedulingGated`から`Running`に遷移することが予想されます。
 
 ```none
 NAME       READY   STATUS    RESTARTS   AGE   IP         NODE
@@ -80,25 +80,17 @@ test-pod   1/1     Running   0          15s   10.0.0.4   node-2
 
 ## 変更可能なPodのスケジューリング命令
 
-Podのスケジューリング命令は、Podがスケジューリングゲートを持っている間は、一定の制約のもとで変更できます。高いレベルでは、Podのスケジューリング命令を強化することしかできません。言い換えると、更新された命令は、Podが以前マッチしていたノードのサブセットでしかスケジューリングできなくなります。より具体的には、Podのスケジューリング命令を更新するルールは以下のようになります。
+Podにスケジューリングゲートが設定されている間、Podのスケジューリング命令は、一定の制約のもとで変更できます。高いレベルでは、Podのスケジューリング命令を強化することしかできません。言い換えると、更新された命令は、Podが以前マッチしていたノードのサブセットでしかスケジューリングできなくなります。より具体的には、Podのスケジューリング命令を更新するルールは以下のようになります。
 
-1. For `.spec.nodeSelector`, only additions are allowed. If absent, it will be allowed to be set.
+1. `.spec.nodeSelector`は、追加のみが許可されます。 存在しない場合は設定が許可されます。
 
-2. For `spec.affinity.nodeAffinity`, if nil, then setting anything is allowed.
+2. `spec.affinity.nodeAffinity`は、空の場合、何でも設定できます。
 
-3. If `NodeSelectorTerms` was empty, it will be allowed to be set.
-   If not empty, then only additions of `NodeSelectorRequirements` to `matchExpressions`
-   or `fieldExpressions` are allowed, and no changes to existing `matchExpressions`
-   and `fieldExpressions` will be allowed. This is because the terms in
-   `.requiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms`, are ORed
-   while the expressions in `nodeSelectorTerms[].matchExpressions` and
-   `nodeSelectorTerms[].fieldExpressions` are ANDed.
+3. `NodeSelectorTerms`が空の場合、設定が許可されます。 空でない場合は、`matchExpressions`または`fieldExpressions`への`NodeSelectorRequirements`の追加のみが許可され、既存の`matchExpressions`および`fieldExpressions`への変更は許可されません。これは、`.requiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms`の項目が OR で結合されるのに対し、`nodeSelectorTerms[].matchExpressions`および`nodeSelectorTerms[].fieldExpressions`の項目は AND で結合されるためです。
 
-4. For `.preferredDuringSchedulingIgnoredDuringExecution`, all updates are allowed.
-   This is because preferred terms are not authoritative, and so policy controllers
-   don't validate those terms.
+4. `.preferredDuringSchedulingIgnoredDuringExecution`は、すべての更新が許可されます。これは、優先項目の権威がないため、ポリシーコントローラーがこれらの用語を検証しないためです。
 
 
 ## {{% heading "whatsnext" %}}
 
-* Read the [PodSchedulingReadiness KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/3521-pod-scheduling-readiness) for more details
+* 詳しくは[PodSchedulingReadiness KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/3521-pod-scheduling-readiness) をお読みください。

--- a/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -51,7 +51,7 @@ kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
 [{"name":"example.com/foo"},{"name":"example.com/bar"}]
 ```
 
-このPodがスケジューリング可能であることをスケジューラに通知するには、変更したマニフェストを再適用することで、その`schedulingGates`を完全に削除できます。
+このPodがスケジューリング可能であることをスケジューラーに通知するには、変更したマニフェストを再適用することで、その`schedulingGates`を完全に削除できます。
 
 {{% code_sample file="pods/pod-without-scheduling-gates.yaml" %}}
 
@@ -74,18 +74,13 @@ NAME       READY   STATUS    RESTARTS   AGE   IP         NODE
 test-pod   1/1     Running   0          15s   10.0.0.4   node-2
 ```
 
-## Observability
+## 可観測性
 
-The metric `scheduler_pending_pods` comes with a new label `"gated"` to distinguish whether a Pod
-has been tried scheduling but claimed as unschedulable, or explicitly marked as not ready for
-scheduling. You can use `scheduler_pending_pods{queue="gated"}` to check the metric result.
+`scheduler_pending_pods`メトリックには、Podがスケジューリングされようとしているがスケジューリング不可能とされているのか、それとも明示的にスケジューリングの準備ができておらずマークされているのかを区別する新しいラベル`"gated"`があります。`scheduler_pending_pods{queue="gated"}`でメトリックの結果を確認できます。
 
-## Mutable Pod scheduling directives
+## 変更可能なPodのスケジューリング命令
 
-You can mutate scheduling directives of Pods while they have scheduling gates, with certain constraints.
-At a high level, you can only tighten the scheduling directives of a Pod. In other words, the updated
-directives would cause the Pods to only be able to be scheduled on a subset of the nodes that it would
-previously match. More concretely, the rules for updating a Pod's scheduling directives are as follows:
+Podのスケジューリング命令は、Podがスケジューリングゲートを持っている間は、一定の制約のもとで変更できます。高いレベルでは、Podのスケジューリング命令を強化することしかできません。言い換えると、更新された命令は、Podが以前マッチしていたノードのサブセットでしかスケジューリングできなくなります。より具体的には、Podのスケジューリング命令を更新するルールは以下のようになります。
 
 1. For `.spec.nodeSelector`, only additions are allowed. If absent, it will be allowed to be set.
 

--- a/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -1,5 +1,5 @@
 ---
-title: Podスケジューリング準備状態
+title: Podのスケジューリング準備
 content_type: concept
 weight: 40
 ---

--- a/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -8,15 +8,15 @@ weight: 40
 
 {{< feature-state for_k8s_version="v1.30" state="stable" >}}
 
-Podは1度作成されると、スケジュールの準備ができたとみなされます。Kubernetesのスケジューラーは、すべての保留中のPodを配置するためにノードを見つけることに最善を尽くします。しかし実際のケースでは、一部のPodが「必要なリソースを満たさない」状態に長期間とどまることがあります。このようなPodは、実際にはスケジューラー（およびCluster AutoScalerのようなダウンストリームのインテグレーター）を不必要に混乱させます。
+Podは1度作成されると、スケジュールの準備ができたとみなされます。Kubernetesのスケジューラーは、すべての保留中のPodを配置するためにノードを見つけることに最善を尽くします。しかし実際のケースでは、一部のPodが「必要なリソースを満たさない」状態に長期間とどまることがあります。このようなPodは、実際にはスケジューラー(およびCluster AutoScalerのようなダウンストリームのインテグレーター)を不必要に混乱させます。
 
-Podの`.spec.schedulingGates`を指定したり削除することで、Podがスケジューリングの対象になるタイミングを制御できます。
+Podの`.spec.schedulingGates`を指定したり削除したりすることで、Podがスケジューリングの対象になるタイミングを制御できます。
 
 <!-- body -->
 
 ## PodにschedulingGatesを設定する
 
-`schedulingGates`のフィールドは、文字列のリストで構成されており、各文字列はPodがスケジューリング可能とみなされる前に満たすべき条件を表します。このフィールドは、Pod作成時のみ初期化できます(クライアントによる作成時、またはAdmission webhookによる変更時)。作成後、個々のschedulingGateは順序不同で削除できますが、新しいschedulingGateを追加することはできません。
+`schedulingGates`のフィールドは、文字列のリストで構成されており、各文字列はPodがスケジューリング可能とみなされる前に満たすべき条件を表します。このフィールドは、Pod作成時のみ初期化できます(クライアントによる作成時、またはアドミッション中の変更時)。作成後、個々のschedulingGateは順序不同で削除できますが、新しいschedulingGateを追加することはできません。
 
 {{< figure src="/docs/images/podSchedulingGates.svg" alt="pod-scheduling-gates-diagram" caption="Pod スケジューリングゲートの図" class="diagram-large" link="https://mermaid.live/edit#pako:eNplkktTwyAUhf8KgzuHWpukaYszutGlK3caFxQuCVMCGSDVTKf_XfKyPlhxz4HDB9wT5lYAptgHFuBRsdKxenFMClMYFIdfUdRYgbiD6ItJTEbR8wpEq5UpUfnDTf-5cbPoJjcbXdcaE61RVJIiqJvQ_Y30D-OCt-t3tFjcR5wZayiVnIGmkv4NiEfX9jijKTmmRH5jf0sRugOP0HyHUc1m6KGMFP27cM28fwSJDluPpNKaXqVJzmFNfHD2APRKSjnNFx9KhIpmzSfhVls3eHdTRrwG8QnxKfEZUUNeYTDBNbiaKRF_5dSfX-BQQQ0FpnEqQLJWhwIX5hyXsjbYl85wTINrgeC2EZd_xFQy7b_VJ6GCdd-itkxALE84dE3fAqXyIUZya6Qqe711OspVCI2ny2Vv35QqVO3-htt66ZWomAvVcZcv8yTfsiSFfJOydZoKvl_ttjLJVlJsblcJw-czwQ0zr9ZeqGDgeR77b2jD8xdtjtDn" >}}
 
@@ -55,7 +55,7 @@ kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
 
 {{% code_sample file="pods/pod-without-scheduling-gates.yaml" %}}
 
-`schedulingGates`が削除されているかは、以下のように確認できます。
+`schedulingGates`が削除されているかどうかは、以下のように確認できます。
 
 ```bash
 kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
@@ -67,7 +67,7 @@ kubectl get pod test-pod -o jsonpath='{.spec.schedulingGates}'
 kubectl get pod test-pod -o wide
 ```
 
-test-podがCPU/メモリーリソースを要求しないので、このポッドのステータスは、以前の`SchedulingGated`から`Running`に遷移することが予想されます。
+test-podがCPU/メモリリソースを要求しないため、このPodのステータスは、以前の`SchedulingGated`から`Running`に遷移することが予想されます。
 
 ```none
 NAME       READY   STATUS    RESTARTS   AGE   IP         NODE
@@ -80,17 +80,17 @@ test-pod   1/1     Running   0          15s   10.0.0.4   node-2
 
 ## 変更可能なPodのスケジューリング命令
 
-Podにスケジューリングゲートが設定されている間、Podのスケジューリング命令は、一定の制約のもとで変更できます。高いレベルでは、Podのスケジューリング命令を強化することしかできません。言い換えると、更新された命令は、Podが以前マッチしていたノードのサブセットでしかスケジューリングできなくなります。より具体的には、Podのスケジューリング命令を更新するルールは以下のようになります。
+Podにスケジューリングゲートが設定されている間、Podのスケジューリング命令は、一定の制約のもとで変更できます。高いレベルでは、Podのスケジューリング命令を厳格にすることしかできません。言い換えると、更新された命令は、Podが以前マッチしていたノードのサブセットでしかスケジューリングできなくなります。より具体的には、Podのスケジューリング命令を更新するルールは以下のようになります。
 
 1. `.spec.nodeSelector`は、追加のみが許可されます。 存在しない場合は設定が許可されます。
 
 2. `spec.affinity.nodeAffinity`は、空の場合、何でも設定できます。
 
-3. `NodeSelectorTerms`が空の場合、設定が許可されます。 空でない場合は、`matchExpressions`または`fieldExpressions`への`NodeSelectorRequirements`の追加のみが許可され、既存の`matchExpressions`および`fieldExpressions`への変更は許可されません。これは、`.requiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms`の項目が OR で結合されるのに対し、`nodeSelectorTerms[].matchExpressions`および`nodeSelectorTerms[].fieldExpressions`の項目は AND で結合されるためです。
+3. `NodeSelectorTerms`が空の場合、設定が許可されます。 空でない場合は、`matchExpressions`または`fieldExpressions`への`NodeSelectorRequirements`の追加のみが許可され、既存の`matchExpressions`および`fieldExpressions`への変更は許可されません。これは、`.requiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms`の項目がORで結合されるのに対し、`nodeSelectorTerms[].matchExpressions`および`nodeSelectorTerms[].fieldExpressions`の項目はANDで結合されるためです。
 
-4. `.preferredDuringSchedulingIgnoredDuringExecution`は、すべての更新が許可されます。これは、優先項目の権威がないため、ポリシーコントローラーがこれらの用語を検証しないためです。
+4. `.preferredDuringSchedulingIgnoredDuringExecution`は、すべての更新が許可されます。これは、優先項目の権威がないため、ポリシーコントローラーがこれらの項目を検証しないためです。
 
 
 ## {{% heading "whatsnext" %}}
 
-* 詳しくは[PodSchedulingReadiness KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/3521-pod-scheduling-readiness) をお読みください。
+* 詳しくは[PodSchedulingReadiness KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/3521-pod-scheduling-readiness)をお読みください。

--- a/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
+++ b/content/ja/docs/concepts/scheduling-eviction/pod-scheduling-readiness.md
@@ -18,7 +18,7 @@ Podの`.spec.schedulingGates`を指定したり削除することで、Podがス
 
 `schedulingGates`のフィールドは、文字列のリストで構成されており、各文字列はPodがスケジューリング可能とみなされる前に満たすべき条件を表します。このフィールドは、Pod作成時のみ初期化できます(クライアントによる作成時、またはAdmission webhookによる変更時)。作成後、個々のschedulingGateは順序不同で削除できますが、新しいschedulingGateを追加することはできません。
 
-{{< figure src="/docs/images/podSchedulingGates.svg" alt="pod-scheduling-gates-diagram" caption="Figure. Pod SchedulingGates" class="diagram-large" link="https://mermaid.live/edit#pako:eNplkktTwyAUhf8KgzuHWpukaYszutGlK3caFxQuCVMCGSDVTKf_XfKyPlhxz4HDB9wT5lYAptgHFuBRsdKxenFMClMYFIdfUdRYgbiD6ItJTEbR8wpEq5UpUfnDTf-5cbPoJjcbXdcaE61RVJIiqJvQ_Y30D-OCt-t3tFjcR5wZayiVnIGmkv4NiEfX9jijKTmmRH5jf0sRugOP0HyHUc1m6KGMFP27cM28fwSJDluPpNKaXqVJzmFNfHD2APRKSjnNFx9KhIpmzSfhVls3eHdTRrwG8QnxKfEZUUNeYTDBNbiaKRF_5dSfX-BQQQ0FpnEqQLJWhwIX5hyXsjbYl85wTINrgeC2EZd_xFQy7b_VJ6GCdd-itkxALE84dE3fAqXyIUZya6Qqe711OspVCI2ny2Vv35QqVO3-htt66ZWomAvVcZcv8yTfsiSFfJOydZoKvl_ttjLJVlJsblcJw-czwQ0zr9ZeqGDgeR77b2jD8xdtjtDn" >}}
+{{< figure src="/docs/images/podSchedulingGates.svg" alt="pod-scheduling-gates-diagram" caption="Pod スケジューリングゲートの図" class="diagram-large" link="https://mermaid.live/edit#pako:eNplkktTwyAUhf8KgzuHWpukaYszutGlK3caFxQuCVMCGSDVTKf_XfKyPlhxz4HDB9wT5lYAptgHFuBRsdKxenFMClMYFIdfUdRYgbiD6ItJTEbR8wpEq5UpUfnDTf-5cbPoJjcbXdcaE61RVJIiqJvQ_Y30D-OCt-t3tFjcR5wZayiVnIGmkv4NiEfX9jijKTmmRH5jf0sRugOP0HyHUc1m6KGMFP27cM28fwSJDluPpNKaXqVJzmFNfHD2APRKSjnNFx9KhIpmzSfhVls3eHdTRrwG8QnxKfEZUUNeYTDBNbiaKRF_5dSfX-BQQQ0FpnEqQLJWhwIX5hyXsjbYl85wTINrgeC2EZd_xFQy7b_VJ6GCdd-itkxALE84dE3fAqXyIUZya6Qqe711OspVCI2ny2Vv35QqVO3-htt66ZWomAvVcZcv8yTfsiSFfJOydZoKvl_ttjLJVlJsblcJw-czwQ0zr9ZeqGDgeR77b2jD8xdtjtDn" >}}
 
 ## 使用例
 
@@ -26,7 +26,7 @@ Podがスケジューリングされる準備ができていないと示すに�
 
 {{% code_sample file="pods/pod-with-scheduling-gates.yaml" %}}
 
-Podの作成後、状態を確認するには、以下のようにします。
+Podの作成後、状態を確認するには以下のようにします。
 
 ```bash
 kubectl get pod test-pod

--- a/content/ja/examples/pods/pod-with-scheduling-gates.yaml
+++ b/content/ja/examples/pods/pod-with-scheduling-gates.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  schedulingGates:
+  - name: example.com/foo
+  - name: example.com/bar
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.6

--- a/content/ja/examples/pods/pod-without-scheduling-gates.yaml
+++ b/content/ja/examples/pods/pod-without-scheduling-gates.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.6


### PR DESCRIPTION

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Closes: https://github.com/kubernetes/website/issues/44971
