### PR TITLE
Fix CRD CEL transition rule error message example

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1247,8 +1247,7 @@ Unlike other rules, transition rules apply only to operations meeting the follow
   later update to the same object.
 
 Errors will be generated on CRD writes if a schema node contains a transition rule that can never be
-applied, e.g. "*path*: update rule *rule* cannot be set on schema because the schema or its parent
-schema is not mergeable".
+applied, e.g. "oldSelf cannot be used on the uncorrelatable portion of the schema within *path*".
 
 Transition rules are only allowed on _correlatable portions_ of a schema.
 A portion of the schema is correlatable if all `array` parent schemas are of type `x-kubernetes-list-type=map`;


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

This PR fixes the example message for CRD CEL transition rules in uncorrelatable paths.

Context: 
* Slack thread: https://kubernetes.slack.com/archives/C0EG7JC6T/p1718987516353139
* Corresponding line that produces the error: https://github.com/kubernetes/kubernetes/blob/d081fd56a2aba4663f11dd5e27dbcf64c0ec6638/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go#L1261