### PR TITLE
Clarify image change restart behavior for sidecar containers

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -121,6 +121,9 @@ Init containers stop before the main containers start up, so init containers can
 exchange messages with the app container in a Pod. Any data passing is one-way
 (for example, an init container can put information inside an `emptyDir` volume).
 
+Changing the image of a sidecar container will not cause the Pod to restart, but will
+trigger a container restart.
+
 ## Resource sharing within containers
 
 {{< comment >}}


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Clarify that only chaging the image of a sidecar container will not restart the pod.

Previously had contradicting information:

`Altering an init container image field is equivalent to restarting the Pod.`
and
`The Pod will not be restarted when the init container image is changed,`

xref: https://github.com/kubernetes/kubernetes/issues/121333