### PR TITLE
Remove duplicate feature-state shortcode in CRD task

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1645,7 +1645,6 @@ may also be used with field selectors when included in the `spec.versions[*].sel
 
 #### Selectable fields for custom resources {#crd-selectable-fields}
 
-{{< feature-state state="alpha" for_k8s_version="v1.30" >}}
 {{< feature-state feature_gate_name="CustomResourceFieldSelectors" >}}
 
 You need to enable the `CustomResourceFieldSelectors`


### PR DESCRIPTION
This PR addresses the issue of duplicated `feature-state` shortcodes in the [Extend the Kubernetes API with CustomResourceDefinitions page (here)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields). The manually driven feature-state shortcode has been removed in favor of the dynamically derived one that updates based on feature gate description file changes.

[Fixed Preview Page (here)](https://deploy-preview-47046--kubernetes-io-main-staging.netlify.app/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields) | [Problematic Current Page (here) ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields)