### PR TITLE
[ja] kubectl debian install guide does not mention gnupg at all

### DIFF
--- a/content/ja/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ja/docs/tasks/tools/install-kubectl-linux.md
@@ -124,7 +124,7 @@ Linuxへkubectlをインストールするには、次の方法があります:
    ```shell
    sudo apt-get update
    # apt-transport-httpsはダミーパッケージの可能性があります。その場合、そのパッケージはスキップできます
-   sudo apt-get install -y apt-transport-https ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    ```
 
 2. Kubernetesパッケージリポジトリの公開署名キーをダウンロードしてください。


### PR DESCRIPTION
en PR https://github.com/kubernetes/website/pull/45814/files