### PR TITLE
Remove html tag escaping in chapter-single-definition.tmpl

### DIFF
--- a/api-ref-assets/templates/chapter-single-definition.tmpl
+++ b/api-ref-assets/templates/chapter-single-definition.tmpl
@@ -26,7 +26,7 @@ guide. You can file document formatting bugs against the
 {{if .Import}}`import "{{.Import}}"`{{end}}
 
 {{range .Sections}}
-{{.Description | replace "<" "\\<" }}
+{{.Description}}
 
 <hr>
 {{range .Fields}}

--- a/content/en/docs/reference/kubernetes-api/common-definitions/quantity.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/quantity.md
@@ -26,43 +26,37 @@ guide. You can file document formatting bugs against the
 `import "k8s.io/apimachinery/pkg/api/resource"`
 
 
-Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+<p>Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.</p>
+<p>The serialization format is:</p>
+<pre><code> &lt;quantity&gt;        ::= &lt;signedNumber&gt;&lt;suffix&gt;
 
-The serialization format is:
+  (Note that &lt;suffix&gt; may be empty, from the &quot;&quot; case in &lt;decimalSI&gt;.)
 
-``` \<quantity>        ::= \<signedNumber>\<suffix>
+&lt;digit&gt;           ::= 0 | 1 | ... | 9 &lt;digits&gt;          ::= &lt;digit&gt; | &lt;digit&gt;&lt;digits&gt; &lt;number&gt;          ::= &lt;digits&gt; | &lt;digits&gt;.&lt;digits&gt; | &lt;digits&gt;. | .&lt;digits&gt; &lt;sign&gt;            ::= &quot;+&quot; | &quot;-&quot; &lt;signedNumber&gt;    ::= &lt;number&gt; | &lt;sign&gt;&lt;number&gt; &lt;suffix&gt;          ::= &lt;binarySI&gt; | &lt;decimalExponent&gt; | &lt;decimalSI&gt; &lt;binarySI&gt;        ::= Ki | Mi | Gi | Ti | Pi | Ei
 
-	(Note that \<suffix> may be empty, from the "" case in \<decimalSI>.)
+  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
 
-\<digit>           ::= 0 | 1 | ... | 9 \<digits>          ::= \<digit> | \<digit>\<digits> \<number>          ::= \<digits> | \<digits>.\<digits> | \<digits>. | .\<digits> \<sign>            ::= "+" | "-" \<signedNumber>    ::= \<number> | \<sign>\<number> \<suffix>          ::= \<binarySI> | \<decimalExponent> | \<decimalSI> \<binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+&lt;decimalSI&gt;       ::= m | &quot;&quot; | k | M | G | T | P | E
 
-	(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
 
-\<decimalSI>       ::= m | "" | k | M | G | T | P | E
+&lt;decimalExponent&gt; ::= &quot;e&quot; &lt;signedNumber&gt; | &quot;E&quot; &lt;signedNumber&gt; 
+</code></pre>
+<p>No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.</p>
+<p>When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.</p>
+<p>Before serializing, Quantity will be put in &quot;canonical form&quot;. This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:</p>
+<ul>
+<li>No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.</li>
+</ul>
+<p>The sign will be omitted unless the number is negative.</p>
+<p>Examples:</p>
+<ul>
+<li>1.5 will be serialized as &quot;1500m&quot; - 1.5Gi will be serialized as &quot;1536Mi&quot;</li>
+</ul>
+<p>Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.</p>
+<p>Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)</p>
+<p>This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.</p>
 
-	(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
-
-\<decimalExponent> ::= "e" \<signedNumber> | "E" \<signedNumber> ```
-
-No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
-
-When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
-
-Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
-
-- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.
-
-The sign will be omitted unless the number is negative.
-
-Examples:
-
-- 1.5 will be serialized as "1500m" - 1.5Gi will be serialized as "1536Mi"
-
-Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
-
-Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
-
-This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
 
 <hr>
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This PR is part of a two-PR solution to address issue #35712: Code blocks not rendering properly in API Documentation (Quantity).

Current problem:
The Quantity description in the Kubernetes API documentation contains a code block that is not being rendered correctly. Instead of proper formatting, the code is displayed as a single line, making it difficult to read and understand.

Proposed solution:
This PR, along with a companion PR in the kubernetes-sigs/reference-docs repository, aims to improve the rendering of code blocks within the API documentation, specifically targeting the Quantity resource description.

Current status:
1. I've added a basic working example for the approach in the kubernetes-sigs/reference-docs repo.
2. This PR complements that change by removing an escaping operator for the Description field.

Known limitation:
The following lines are still rendered on a single line due to newline characters not being captured in the Swagger JSON:
```
// <digit>           ::= 0 | 1 | ... | 9
// <digits>          ::= <digit> | <digit><digits>
// <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits>
// <sign>            ::= "+" | "-"
// <signedNumber>    ::= <number> | <sign><number>
// <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI>
// <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
```

Seeking feedback:
I'm looking for input on whether this approach is the right direction to solve the issue. Specifically:
1. Is the proposed solution addressing the root cause of the rendering problem?
2. Are there any potential side effects or considerations I should be aware of?
3. How should we address the remaining issue with newline characters in the Swagger JSON?

Screenshots:
![image](https://github.com/kubernetes/website/assets/8540764/90209851-215b-487d-9629-f6939dc2d081)

Companion PRs:
https://github.com/kubernetes-sigs/reference-docs/pull/365

Any feedback or suggestions for improvement are greatly appreciated. Thank you for your time and input!
