### PR TITLE
Register Annotation resource.kubernetes.io/pod-claim-name 

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -270,11 +270,12 @@ Type: Annotation
 
 Example: `resource.kubernetes.io/pod-claim-name: "my-pod-claim"`
 
-Used on: Pod
+Used on: ResourceClaim
 
 This annotation is assigned to generated ResourceClaims. 
-Its value corresponds to the `pod.spec.resourceClaims[].name` for which the ResourceClaim was created. 
-This annotation is utilized internally by the Kubernetes controller.
+Its value corresponds to the name of the resource claim in the `.spec` of any Pod(s) for which the ResourceClaim was created.
+This annotation is an internal implementation detail of [dynamic resource allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/).
+You should not need to read or modify the value of this annotation.
 
 ### cluster-autoscaler.kubernetes.io/safe-to-evict
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -264,6 +264,16 @@ in the StatefulSet topic for more details.
 Note the [PodIndexLabel](/docs/reference/command-line-tools-reference/feature-gates/)
 feature gate must be enabled for this label to be added to pods.
 
+### resource.kubernetes.io/pod-claim-name
+
+Type: Annotation
+
+Example: `resource.kubernetes.io/pod-claim-name: "my-pod-claim"`
+
+Used on: Pod
+
+This annotation is assigned to generated ResourceClaims. Its value corresponds to the `pod.spec.resourceClaims[].name` for which the ResourceClaim was created. This annotation is utilized internally by the Kubernetes controller.
+
 ### cluster-autoscaler.kubernetes.io/safe-to-evict
 
 Type: Annotation

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -272,7 +272,9 @@ Example: `resource.kubernetes.io/pod-claim-name: "my-pod-claim"`
 
 Used on: Pod
 
-This annotation is assigned to generated ResourceClaims. Its value corresponds to the `pod.spec.resourceClaims[].name` for which the ResourceClaim was created. This annotation is utilized internally by the Kubernetes controller.
+This annotation is assigned to generated ResourceClaims. 
+Its value corresponds to the `pod.spec.resourceClaims[].name` for which the ResourceClaim was created. 
+This annotation is utilized internally by the Kubernetes controller.
 
 ### cluster-autoscaler.kubernetes.io/safe-to-evict
 


### PR DESCRIPTION
Closes #47044 

**Problem**: The annotation `resource.kubernetes.io/pod-claim-name` is unregistered, but used in Kubernetes code.

**Changes**:  Registered the annotation, by mentioning it in [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/).

**Additional Information**:
Required for https://github.com/kubernetes/enhancements/issues/3063
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
