### PR TITLE
Fix JSONPath syntax in kubectl explain documentation

### DIFF
--- a/content/en/docs/reference/kubectl/generated/kubectl_explain/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_explain/_index.md
@@ -26,7 +26,9 @@ Describe fields and structure of various resources.
 
  This command describes the fields associated with each supported API resource. Fields are identified via a simple JSONPath identifier:
 
-        &lt;type&gt;.&lt;fieldName&gt;[.&lt;fieldName&gt;]
+```
+<type>.<fieldName>[.<fieldName>]
+```
         
  Information about each field is retrieved from the server in OpenAPI format.
 


### PR DESCRIPTION
This pull request addresses an inaccuracy in the JSONPath syntax explanation for the kubectl explain command in the Kubernetes website documentation.

### Current Issue:

The current documentation incorrectly uses &lt;type&gt;.&lt;fieldName&gt;[.&lt;fieldName&gt;] as the JSONPath syntax for accessing fields within Kubernetes resources.

### Proposed Fix:

This PR corrects the syntax to the following:
```
$.<type>.<fieldName>[.<fieldName>]
```
This change ensures an accurate representation of how to navigate nested structures within resources using JSONPath with `kubectl explain`.

Please review this pull request and consider merging it to improve the clarity of the `kubectl explain` documentation.

Thanks!