### PR TITLE
Update configure-liveness-readiness-startup-probes.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -206,17 +206,17 @@ can't it is considered a failure.
 {{% code_sample file="pods/probe/tcp-liveness-readiness.yaml" %}}
 
 As you can see, configuration for a TCP check is quite similar to an HTTP check.
-This example uses both readiness and liveness probes. The kubelet will send the
-first readiness probe 15 seconds after the container starts. This will attempt to
-connect to the `goproxy` container on port 8080. If the probe succeeds, the Pod
-will be marked as ready. The kubelet will continue to run this check every 10
+This example uses both readiness and liveness probes. The kubelet will run the 
+first liveness probe 15 seconds after the container starts. This will attempt to 
+connect to the `goproxy` container on port 8080. If the liveness probe fails, the 
+container will be restarted. The kubelet will continue to run this check every 10
 seconds.
 
-In addition to the readiness probe, this configuration includes a liveness probe.
-The kubelet will run the first liveness probe 15 seconds after the container
-starts. Similar to the readiness probe, this will attempt to connect to the
-`goproxy` container on port 8080. If the liveness probe fails, the container
-will be restarted.
+In addition to the liveness probe, this configuration includes a readiness probe.
+The kubelet will run the first readiness probe 15 seconds after the container
+starts. Similar to the liveness probe, this will attempt to connect to the
+`goproxy` container on port 8080. If the readiness probe fails, the container
+will be marked unready and will not receive traffic from any services.
 
 To try the TCP liveness check, create a Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -215,8 +215,9 @@ seconds.
 In addition to the liveness probe, this configuration includes a readiness probe.
 The kubelet will run the first readiness probe 15 seconds after the container
 starts. Similar to the liveness probe, this will attempt to connect to the
-`goproxy` container on port 8080. If the readiness probe fails, the container
-will be marked unready and will not receive traffic from any services.
+`goproxy` container on port 8080. If the probe succeeds, the Pod will be marked 
+as ready and will receive traffic from services. If the readiness probe fails, 
+the pod will be marked unready and will not receive traffic from any services.
 
 To try the TCP liveness check, create a Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -206,18 +206,19 @@ can't it is considered a failure.
 {{% code_sample file="pods/probe/tcp-liveness-readiness.yaml" %}}
 
 As you can see, configuration for a TCP check is quite similar to an HTTP check.
-This example uses both readiness and liveness probes. The kubelet will run the 
-first liveness probe 15 seconds after the container starts. This will attempt to 
-connect to the `goproxy` container on port 8080. If the liveness probe fails, the 
-container will be restarted. The kubelet will continue to run this check every 10
-seconds.
+This example uses both readiness and liveness probes. The kubelet will run the
+first liveness probe 15 seconds after the container starts. This will attempt to
+connect to the `goproxy` container on port 8080. If the liveness probe fails,
+the container will be restarted. The kubelet will continue to run this check
+every 10 seconds.
 
-In addition to the liveness probe, this configuration includes a readiness probe.
-The kubelet will run the first readiness probe 15 seconds after the container
-starts. Similar to the liveness probe, this will attempt to connect to the
-`goproxy` container on port 8080. If the probe succeeds, the Pod will be marked 
-as ready and will receive traffic from services. If the readiness probe fails, 
-the pod will be marked unready and will not receive traffic from any services.
+In addition to the liveness probe, this configuration includes a readiness
+probe. The kubelet will run the first readiness probe 15 seconds after the
+container starts. Similar to the liveness probe, this will attempt to connect to
+the `goproxy` container on port 8080. If the probe succeeds, the Pod will be
+marked as ready and will receive traffic from services. If the readiness probe
+fails, the pod will be marked unready and will not receive traffic from any
+services.
 
 To try the TCP liveness check, create a Pod:
 
@@ -304,13 +305,12 @@ livenessProbe:
 
 ## Protect slow starting containers with startup probes {#define-startup-probes}
 
-Sometimes, you have to deal with legacy applications that might require
-an additional startup time on their first initialization.
-In such cases, it can be tricky to set up liveness probe parameters without
-compromising the fast response to deadlocks that motivated such a probe.
-The trick is to set up a startup probe with the same command, HTTP or TCP
-check, with a `failureThreshold * periodSeconds` long enough to cover the
-worst case startup time.
+Sometimes, you have to deal with applications that require additional startup
+time on their first initialization. In such cases, it can be tricky to set up
+liveness probe parameters without compromising the fast response to deadlocks
+that motivated such a probe. The solution is to set up a startup probe with the
+same command, HTTP or TCP check, with a `failureThreshold * periodSeconds` long
+enough to cover the worst case startup time.
 
 So, the previous example would become:
 
@@ -393,7 +393,7 @@ liveness and readiness checks:
 * `initialDelaySeconds`: Number of seconds after the container has started before startup,
   liveness or readiness probes are initiated. If a startup  probe is defined, liveness and
   readiness probe delays do not begin until the startup probe has succeeded. If the value of
-  `periodSeconds` is greater than `initialDelaySeconds` then the `initialDelaySeconds` would be
+  `periodSeconds` is greater than `initialDelaySeconds` then the `initialDelaySeconds` will be
   ignored. Defaults to 0 seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
   The minimum value is 1.


### PR DESCRIPTION
### Changes
* Flip the order in which liveness and readiness probes are discussed in the TCP liveness probe section, because that makes more sense (the item in the section title first, the extra item after it)
* Some phrasing / language improvements in other sections

View the edited section as rendered markdown: https://github.com/sankalp-khare/website/blob/patch-1/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md#define-a-tcp-liveness-probe

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
