### PR TITLE
kubeadm: start using v1beta4 in all docs

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
@@ -144,8 +144,8 @@ install them selectively.
 {{< tab name="kube-proxy" include="generated/kubeadm_init_phase_addon_kube-proxy.md" />}}
 {{< /tabs >}}
 
-For more details on each field in the `v1beta3` configuration you can navigate to our
-[API reference pages.](/docs/reference/config-api/kubeadm-config.v1beta3/)
+For more details on each field in the `v1beta4` configuration you can navigate to our
+[API reference pages.](/docs/reference/config-api/kubeadm-config.v1beta4/)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -133,7 +133,7 @@ If your configuration is not using the latest version it is **recommended** that
 the [kubeadm config migrate](/docs/reference/setup-tools/kubeadm/kubeadm-config/) command.
 
 For more information on the fields and usage of the configuration you can navigate to our
-[API reference page](/docs/reference/config-api/kubeadm-config.v1beta3/).
+[API reference page](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 ### Using kubeadm init with feature gates {#feature-gates}
 
@@ -143,7 +143,7 @@ of the cluster. Feature gates are removed after a feature graduates to GA.
 
 To pass a feature gate you can either use the `--feature-gates` flag for
 `kubeadm init`, or you can add items into the `featureGates` field when you pass
-a [configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-ClusterConfiguration)
+a [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-ClusterConfiguration)
 using `--config`.
 
 Passing [feature gates for core Kubernetes components](/docs/reference/command-line-tools-reference/feature-gates)
@@ -321,7 +321,7 @@ kubeadm init phase upload-certs --upload-certs --config=SOME_YAML_FILE
 ```
 {{< note >}}
 A predefined `certificateKey` can be provided in `InitConfiguration` when passing the
-[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/) with `--config`.
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/) with `--config`.
 {{< /note >}}
 
 If a predefined certificate key is not passed to `kubeadm init` and

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -182,7 +182,7 @@ In case the discovery file does not contain credentials, the TLS discovery token
 
 #### Use of custom kubelet credentials with `kubeadm join`
 
-To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap 
+To allow `kubeadm join` to use predefined kubelet credentials and skip client TLS bootstrap
 and CSR approval for a new node:
 
 1. From a working control plane node in the cluster that has `/etc/kubernetes/pki/ca.key`
@@ -317,7 +317,7 @@ If your configuration is not using the latest version it is **recommended** that
 the [kubeadm config migrate](/docs/reference/setup-tools/kubeadm/kubeadm-config/#cmd-config-migrate) command.
 
 For more information on the fields and usage of the configuration you can navigate to our
-[API reference](/docs/reference/config-api/kubeadm-config.v1beta3/).
+[API reference](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -14,7 +14,7 @@ and kube-proxy you can use `KubeletConfiguration` and `KubeProxyConfiguration`, 
 
 All of these options are possible via the kubeadm configuration API.
 For more details on each field in the configuration you can navigate to our
-[API reference pages](/docs/reference/config-api/kubeadm-config.v1beta3/).
+[API reference pages](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 {{< note >}}
 Customizing the CoreDNS deployment of kubeadm is currently not supported. You must manually
@@ -42,7 +42,7 @@ The components are defined using the following structures:
 - `scheduler`
 - `etcd`
 
-These structures contain a common `extraArgs` field, that consists of `key: value` pairs.
+These structures contain a common `extraArgs` field, that consists of `name` / `value` pairs.
 To override a flag for a control plane component:
 
 1.  Add the appropriate `extraArgs` to your configuration.
@@ -72,14 +72,15 @@ For details, see the [reference documentation for kube-apiserver](/docs/referenc
 Example usage:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: v1.16.0
 apiServer:
   extraArgs:
-    anonymous-auth: "false"
-    enable-admission-plugins: AlwaysPullImages,DefaultStorageClass
-    audit-log-path: /home/johndoe/audit.log
+  - name: "enable-admission-plugins"
+    value: "AlwaysPullImages,DefaultStorageClass"
+  - name: "audit-log-path"
+    value: "/home/johndoe/audit.log"
 ```
 
 ### ControllerManager flags
@@ -89,13 +90,15 @@ For details, see the [reference documentation for kube-controller-manager](/docs
 Example usage:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: v1.16.0
 controllerManager:
   extraArgs:
-    cluster-signing-key-file: /home/johndoe/keys/ca.key
-    deployment-controller-sync-period: "50"
+  - name: "cluster-signing-key-file"
+    value: "/home/johndoe/keys/ca.key"
+  - name: "deployment-controller-sync-period"
+    value: "50"
 ```
 
 ### Scheduler flags
@@ -105,12 +108,13 @@ For details, see the [reference documentation for kube-scheduler](/docs/referenc
 Example usage:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: v1.16.0
 scheduler:
   extraArgs:
-    config: /etc/kubernetes/scheduler-config.yaml
+  - name: "config"
+    value: "/etc/kubernetes/scheduler-config.yaml"
   extraVolumes:
     - name: schedulerconfig
       hostPath: /home/johndoe/schedconfig.yaml
@@ -126,12 +130,13 @@ For details, see the [etcd server documentation](https://etcd.io/docs/).
 Example usage:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 etcd:
   local:
     extraArgs:
-      election-timeout: 1000
+    - name: "election-timeout"
+      value: 1000
 ```
 
 ## Customizing with patches {#patches}
@@ -145,7 +150,7 @@ is written to disk.
 You can pass this file to `kubeadm init` with `--config <YOUR CONFIG YAML>`:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 patches:
   directory: /home/user/somedir
@@ -159,7 +164,7 @@ separated by `---`.
 You can pass this file to `kubeadm join` with `--config <YOUR CONFIG YAML>`:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 patches:
   directory: /home/user/somedir
@@ -206,7 +211,7 @@ For additional details see [Configuring each kubelet in your cluster using kubea
 To customize kube-proxy you can pass a `KubeProxyConfiguration` next your `ClusterConfiguration` or
 `InitConfiguration` to `kubeadm init` separated by `---`.
 
-For more details you can navigate to our [API reference pages](/docs/reference/config-api/kubeadm-config.v1beta3/).
+For more details you can navigate to our [API reference pages](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 {{< note >}}
 kubeadm deploys kube-proxy as a {{< glossary_tooltip text="DaemonSet" term_id="daemonset" >}}, which means

--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -116,7 +116,7 @@ to a Kubernetes component, the component may exit with an error.
 
 To configure the API server advertise address for control plane nodes created with both
 `init` and `join`, the flag `--apiserver-advertise-address` can be used.
-Preferably, this option can be set in the [kubeadm API](/docs/reference/config-api/kubeadm-config.v1beta3)
+Preferably, this option can be set in the [kubeadm API](/docs/reference/config-api/kubeadm-config.v1beta4)
 as `InitConfiguration.localAPIEndpoint` and `JoinConfiguration.controlPlane.localAPIEndpoint`.
 
 For kubelets on all nodes, the `--node-ip` option can be passed in
@@ -335,8 +335,8 @@ See a list of add-ons that implement the
 
 
 Please refer to the [Installing Addons](/docs/concepts/cluster-administration/addons/#networking-and-network-policy)
-page for a non-exhaustive list of networking addons supported by Kubernetes. 
-You can install a Pod network add-on with the following command on the 
+page for a non-exhaustive list of networking addons supported by Kubernetes.
+You can install a Pod network add-on with the following command on the
 control-plane node or a node that has the kubeconfig credentials:
 
 ```bash
@@ -578,7 +578,7 @@ match the kubeadm version with the versions of the control plane components, kub
 kubeadm can be used with Kubernetes components that are the same version as kubeadm
 or one version older. The Kubernetes version can be specified to kubeadm by using the
 `--kubernetes-version` flag of `kubeadm init` or the
-[`ClusterConfiguration.kubernetesVersion`](/docs/reference/config-api/kubeadm-config.v1beta3/)
+[`ClusterConfiguration.kubernetesVersion`](/docs/reference/config-api/kubeadm-config.v1beta4/)
 field when using `--config`. This option will control the versions
 of kube-apiserver, kube-controller-manager, kube-scheduler and kube-proxy.
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -50,25 +50,26 @@ kubeadm init --pod-network-cidr=10.244.0.0/16,2001:db8:42:0::/56 --service-cidr=
 ```
 
 To make things clearer, here is an example kubeadm
-[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/)
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)
 `kubeadm-config.yaml` for the primary dual-stack control plane node.
 
 ```yaml
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:
   podSubnet: 10.244.0.0/16,2001:db8:42:0::/56
   serviceSubnet: 10.96.0.0/16,2001:db8:42:1::/112
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: "10.100.0.1"
   bindPort: 6443
 nodeRegistration:
   kubeletExtraArgs:
-    node-ip: 10.100.0.2,fd00:1:2:3::2
+  - name: "node-ip"
+    value: "10.100.0.2,fd00:1:2:3::2"
 ```
 
 `advertiseAddress` in InitConfiguration specifies the IP address that the API Server
@@ -92,11 +93,11 @@ The `--apiserver-advertise-address` flag does not support dual-stack.
 
 Before joining a node, make sure that the node has IPv6 routable network interface and allows IPv6 forwarding.
 
-Here is an example kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/)
+Here is an example kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)
 `kubeadm-config.yaml` for joining a worker node to the cluster.
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
@@ -107,14 +108,15 @@ discovery:
     # change auth info above to match the actual token and CA certificate hash for your cluster
 nodeRegistration:
   kubeletExtraArgs:
-    node-ip: 10.100.0.3,fd00:1:2:3::3
+  - name: "node-ip"
+    value: "10.100.0.2,fd00:1:2:3::3"
 ```
 
-Also, here is an example kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/)
+Also, here is an example kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)
 `kubeadm-config.yaml` for joining another control plane node to the cluster.
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 controlPlane:
   localAPIEndpoint:
@@ -129,8 +131,8 @@ discovery:
     # change auth info above to match the actual token and CA certificate hash for your cluster
 nodeRegistration:
   kubeletExtraArgs:
-    node-ip: 10.100.0.4,fd00:1:2:3::4
-
+  - name: "node-ip"
+    value: "10.100.0.2,fd00:1:2:3::4"
 ```
 
 `advertiseAddress` in JoinConfiguration.controlPlane specifies the IP address that the
@@ -149,11 +151,11 @@ You can deploy a single-stack cluster that has the dual-stack networking feature
 {{< /note >}}
 
 To make things more clear, here is an example kubeadm
-[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/)
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)
 `kubeadm-config.yaml` for the single-stack control plane node.
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:
   podSubnet: 10.244.0.0/16
@@ -164,4 +166,4 @@ networking:
 
 * [Validate IPv4/IPv6 dual-stack](/docs/tasks/network/validate-dual-stack) networking
 * Read about [Dual-stack](/docs/concepts/services-networking/dual-stack/) cluster networking
-* Learn more about the kubeadm [configuration format](/docs/reference/config-api/kubeadm-config.v1beta3/)
+* Learn more about the kubeadm [configuration format](/docs/reference/config-api/kubeadm-config.v1beta4/)

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -173,7 +173,7 @@ option. Your cluster requirements may need a different configuration.
 
    {{< note >}}
    The `kubeadm init` flags `--config` and `--certificate-key` cannot be mixed, therefore if you want
-   to use the [kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta3/)
+   to use the [kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta4/)
    you must add the `certificateKey` field in the appropriate config locations
    (under `InitConfiguration` and `JoinConfiguration: controlPlane`).
    {{< /note >}}
@@ -291,7 +291,7 @@ in the kubeadm config file.
 
    ```yaml
    ---
-   apiVersion: kubeadm.k8s.io/v1beta3
+   apiVersion: kubeadm.k8s.io/v1beta4
    kind: ClusterConfiguration
    kubernetesVersion: stable
    controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT" # change this (see below)

--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -126,14 +126,14 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
    NAME=${NAMES[$i]}
    cat << EOF > /tmp/${HOST}/kubeadmcfg.yaml
    ---
-   apiVersion: "kubeadm.k8s.io/v1beta3"
+   apiVersion: "kubeadm.k8s.io/v1beta4"
    kind: InitConfiguration
    nodeRegistration:
        name: ${NAME}
    localAPIEndpoint:
        advertiseAddress: ${HOST}
    ---
-   apiVersion: "kubeadm.k8s.io/v1beta3"
+   apiVersion: "kubeadm.k8s.io/v1beta4"
    kind: ClusterConfiguration
    etcd:
        local:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -274,7 +274,7 @@ Error from server: Get https://10.19.0.41:10250/containerLogs/default/mysql-ddc6
   When using DigitalOcean, it can be the public one (assigned to `eth0`) or
   the private one (assigned to `eth1`) should you want to use the optional
   private network. The `kubeletExtraArgs` section of the kubeadm
-  [`NodeRegistrationOptions` structure](/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-NodeRegistrationOptions)
+  [`NodeRegistrationOptions` structure](/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-NodeRegistrationOptions)
   can be used for this.
 
   Then restart `kubelet`:
@@ -352,7 +352,7 @@ Alternatively, you can try separating the `key=value` pairs like so:
 `--apiserver-extra-args "enable-admission-plugins=LimitRanger,enable-admission-plugins=NamespaceExists"`
 but this will result in the key `enable-admission-plugins` only having the value of `NamespaceExists`.
 
-A known workaround is to use the kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/).
+A known workaround is to use the kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 ## kube-proxy scheduled before node is initialized by cloud-controller-manager
 
@@ -408,33 +408,36 @@ FlexVolume was deprecated in the Kubernetes v1.23 release.
 {{< /note >}}
 
 To workaround this issue, you can configure the flex-volume directory using the kubeadm
-[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/).
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 On the primary control-plane Node (created using `kubeadm init`), pass the following
 file using `--config`:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+  - name: "volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 controllerManager:
   extraArgs:
-    flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+  - name: "flex-volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 ```
 
 On joining Nodes:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+  - name: "volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 ```
 
 Alternatively, you can modify `/etc/fstab` to make the `/usr` mount writeable, but please

--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -48,7 +48,7 @@ A minimal example of configuring the field explicitly:
 ```yaml
 # kubeadm-config.yaml
 kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kubernetesVersion: v1.21.0
 ---
 kind: KubeletConfiguration

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -238,15 +238,17 @@ To activate the built-in signer, you must pass the `--cluster-signing-cert-file`
 `--cluster-signing-key-file` flags.
 
 If you're creating a new cluster, you can use a kubeadm
-[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/):
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/):
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 controllerManager:
   extraArgs:
-    cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
-    cluster-signing-key-file: /etc/kubernetes/pki/ca.key
+  - name: "cluster-signing-cert-file"
+    value: "/etc/kubernetes/pki/ca.crt"
+  - name: "cluster-signing-key-file"
+    value: "/etc/kubernetes/pki/ca.key"
 ```
 
 ### Create certificate signing requests (CSR)
@@ -286,7 +288,7 @@ To configure the kubelets in a new kubeadm cluster to obtain properly signed ser
 certificates you must pass the following minimal configuration to `kubeadm init`:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -357,7 +359,7 @@ Sharing the `admin.conf` with additional users is **not recommended**!
 Instead, you can use the [`kubeadm kubeconfig user`](/docs/reference/setup-tools/kubeadm/kubeadm-kubeconfig)
 command to generate kubeconfig files for additional users.
 The command accepts a mixture of command line flags and
-[kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta3/) options.
+[kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta4/) options.
 The generated kubeconfig will be written to stdout and can be piped to a file using
 `kubeadm kubeconfig user ... > somefile.conf`.
 
@@ -365,7 +367,7 @@ Example configuration file that can be used with `--config`:
 
 ```yaml
 # example.yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 # Will be used as the target "cluster" in the kubeconfig
 clusterName: "kubernetes"
@@ -412,7 +414,7 @@ directory for kubeconfig files is `/etc/kubernetes`. These defaults can be
 overridden with the flags `--cert-dir` and `--kubeconfig-dir`, respectively.
 
 To pass custom options to `kubeadm certs generate-csr` use the `--config` flag,
-which accepts a [kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta3/)
+which accepts a [kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta4/)
 file, similarly to commands such as `kubeadm init`. Any specification such
 as extra SANs and custom IP addresses must be stored in the same configuration
 file and used for all relevant kubeadm commands by passing it as `--config`.

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
@@ -60,7 +60,7 @@ component configuration and avoid introducing typos and YAML indentation mistake
 #### Updating the `ClusterConfiguration`
 
 During cluster creation and upgrade, kubeadm writes its
-[`ClusterConfiguration`](/docs/reference/config-api/kubeadm-config.v1beta3/)
+[`ClusterConfiguration`](/docs/reference/config-api/kubeadm-config.v1beta4/)
 in a ConfigMap called `kubeadm-config` in the `kube-system` namespace.
 
 To change a particular option in the `ClusterConfiguration` you can edit the ConfigMap with this command:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -49,9 +49,10 @@ The upgrade workflow at high level is the following:
 - All containers are restarted after upgrade, because the container spec hash value is changed.
 - To verify that the kubelet service has successfully restarted after the kubelet has been upgraded,
   you can execute `systemctl status kubelet` or view the service logs with `journalctl -xeu kubelet`.
-- Usage of the `--config` flag of `kubeadm upgrade` with
-  [kubeadm configuration API types](/docs/reference/config-api/kubeadm-config.v1beta3)
-  with the purpose of reconfiguring the cluster is not recommended and can have unexpected results. Follow the steps in
+- `kubeadm upgrade` supports `--config` with a
+[`UpgradeConfiguration` API type](/docs/reference/config-api/kubeadm-config.v1beta4) which can
+be used to configure the upgrade process.
+- `kubeadm upgrade` does not support reconfiguration of an existing cluster. Follow the steps in
   [Reconfiguring a kubeadm cluster](/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure) instead.
 
 ### Considerations when upgrading etcd
@@ -161,13 +162,7 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    For more information see the [certificate management guide](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs).
    {{</ note >}}
 
-   {{< note >}}
-   If `kubeadm upgrade plan` shows any component configs that require manual upgrade, users must provide
-   a config file with replacement configs to `kubeadm upgrade apply` via the `--config` command line flag.
-   Failing to do so will cause `kubeadm upgrade apply` to exit with an error and not perform an upgrade.
-   {{</ note >}}
-
-1. Choose a version to upgrade to, and run the appropriate command. For example:
+   1. Choose a version to upgrade to, and run the appropriate command. For example:
 
    ```shell
    # replace x with the patch version you picked for this upgrade
@@ -309,7 +304,7 @@ manually restored in `/etc/kubernetes/manifests`. If for some reason there is no
 and post-upgrade manifest file for a certain component, a backup file for it will not be written.
 
 {{< note >}}
-After the cluster upgrade using kubeadm, the backup directory `/etc/kubernetes/tmp` will remain and 
+After the cluster upgrade using kubeadm, the backup directory `/etc/kubernetes/tmp` will remain and
 these backup files will need to be cleared manually.
 {{</ note >}}
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -162,7 +162,7 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    For more information see the [certificate management guide](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs).
    {{</ note >}}
 
-   1. Choose a version to upgrade to, and run the appropriate command. For example:
+1. Choose a version to upgrade to, and run the appropriate command. For example:
 
    ```shell
    # replace x with the patch version you picked for this upgrade


### PR DESCRIPTION
- make some updates to --config on upgrade, as now it supports an v1beta4,UpgradeConfiguration and there is no possibility to reconfigure using --config on upgrade anymore.
- start using v1beta4 in all examples, the v1beta4 API page is already generated but needs update for 1.31.


xref https://github.com/kubernetes/kubeadm/issues/2890