### PR TITLE
[pt] Bump cri-tools version to v1.30.0

### DIFF
--- a/content/pt-br/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/pt-br/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -292,7 +292,7 @@ sudo mkdir -p "$DOWNLOAD_DIR"
 Instale o crictl (utilizado pelo kubeadm e pela Interface do Agente de execução do Kubelet (CRI))
 
 ```bash
-CRICTL_VERSION="v1.28.0"
+CRICTL_VERSION="v1.30.0"
 ARCH="amd64"
 curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | sudo tar -C $DOWNLOAD_DIR -xz
 ```


### PR DESCRIPTION
en PR https://github.com/kubernetes/website/pull/46577/files