### PR TITLE
Update CRI-O install link

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -265,7 +265,7 @@ and not require this setting on kubelet any longer.
 
 This section contains the necessary steps to install CRI-O as a container runtime.
 
-To install CRI-O, follow [CRI-O Install Instructions](https://github.com/cri-o/cri-o/blob/main/install.md#readme).
+To install CRI-O, follow [CRI-O Install Instructions](https://github.com/cri-o/packaging/blob/main/README.md#usage).
 
 #### cgroup driver
 


### PR DESCRIPTION
We now link to the packaging repository to keep the installation instructions up to date.

@kubernetes/sig-node-cri-o-test-maintainers PTAL

Refers to https://github.com/cri-o/cri-o/issues/8353