### PR TITLE
cleanup(search): drop some bing search leftovers

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -19,28 +19,6 @@
         s.parentNode.insertBefore(gcse, s);
     }
 
-    window.getPaginationAnchors = (pages) => {
-        var pageAnchors = '', searchTerm  = window.location.search.split("=")[1].split("&")[0].replace(/%20/g, ' ');
-        var currentPage = window.location.search.split("=")[2];
-        currentPage = (!currentPage) ?  1 : currentPage.split("&")[0];
-
-        for(var i = 1; i <= 10; i++){
-            if(i > pages) break;
-            pageAnchors += '<a class="bing-page-anchor" href="/search/?q='+searchTerm+'&page='+i+'">';
-            pageAnchors += (currentPage == i) ? '<b>'+i+'</b>' : i;
-            pageAnchors += '</a>';
-        }
-        return pageAnchors;
-    }
-
-    window.getResultMarkupString = (ob) => {
-        return '<div class="bing-result">'
-            + '<div class="bing-result-name"><a href="'+ob.url+'">'+ob.name+'</a></div>'
-            + '<div class="bing-result-url">'+ob.displayUrl+'</div>'
-            + '<div class="bing-result-snippet">'+ob.snippet+'</div>'
-            +'</div>';
-    }
-
     window.renderPageFindSearchResults = () => {
         let urlParams = new URLSearchParams(window.location.search);
         let searchTerm = urlParams.get("q") || "";


### PR DESCRIPTION
The only usage of these functions was here, we dropped it when switching to PageFind

https://github.com/kubernetes/website/commit/9d2317aa156e65dcdedd5eb79585d2af5f0d8658#diff-f355db8e18a5352f796b8030582fdf862ec9a7ea193ca4cf71de7df9e7386db1L69-L70

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
