### PR TITLE
Clarify meaning of `periodSeconds` in probes.

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -394,7 +394,7 @@ liveness and readiness checks:
   readiness probe delays do not begin until the startup probe has succeeded. If the value of
   `periodSeconds` is greater than `initialDelaySeconds` then the `initialDelaySeconds` would be
   ignored. Defaults to 0 seconds. Minimum value is 0.
-* `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
+* `periodSeconds`: Number of seconds between probes. Default to 10 seconds.
   The minimum value is 1.
 * `timeoutSeconds`: Number of seconds after which the probe times out.
   Defaults to 1 second. Minimum value is 1.


### PR DESCRIPTION
Previous description of `periodSeconds` implies that a new probe will trigger regardless of whether the previous probe hasn't finished or timed-out.

This poses questions such as those:

1. [Kubernetes Health Check: timeoutSeconds exceeds periodSeconds](https://stackoverflow.com/questions/66687912/kubernetes-health-check-timeoutseconds-exceeds-periodseconds)
2. [Kubernetes Health Probe periodSeconds Clarification](https://stackoverflow.com/questions/77801283/kubernetes-health-probe-periodseconds-clarification)

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
