### PR TITLE
Update assign-pod-node.md

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -634,8 +634,8 @@ The following operators can only be used with `nodeAffinity`.
 
 |    Operator    |    Behaviour    |
 | :------------: | :-------------: |
-| `Gt` | The field value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
-| `Lt` | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
+| `Lt` | The field value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
+| `Gt` | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
 
 
 {{<note>}}


### PR DESCRIPTION
This pull request corrects the descriptions for the Gt (greater than) and Lt (less than) operators in the Kubernetes documentation. The previous descriptions were inaccurate and have been updated to reflect the correct behavior.



