### PR TITLE
Improve the test to decide which search results to serve

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -94,9 +94,7 @@
                 window.renderGoogleSearchResults()
             }
         } else if (getCookie("can_google") == "false") {
-            window.addEventListener('DOMContentLoaded', (event) => {
-                window.renderPageFindSearchResults()
-            });
+            window.renderPageFindSearchResults()
         } else {
             window.renderGoogleSearchResults()
         }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -80,20 +80,20 @@
     }
 
     async function runBlockedContentTest() {
-        if (getCookie("in_china") === "") {
+        if (getCookie("can_google") === "") {
             const isBlocked = await checkBlockedSite("https://www.google.com/favicon.ico");
             if ( isBlocked ) {
-                // Site is blocked so we think you are in China.
-                console.log("We think you ARE in China")
-                document.cookie = "in_china=true;" + path + expires
+                // Google is blocked.
+                console.log("Google is blocked")
+                document.cookie = "can_google=false;" + path + expires
                 window.renderPageFindSearchResults()
             } else {
-                // Site isn't blocked so we think you are NOT in China.
-                console.log("We think you are NOT in China")
-                document.cookie = "in_china=false;" + path + expires
+                // Google is not blocked.
+                console.log("Google is NOT blocked")
+                document.cookie = "can_google=true;" + path + expires
                 window.renderGoogleSearchResults()
             }
-        } else if (getCookie("in_china") == "true") {
+        } else if (getCookie("can_google") == "false") {
             window.addEventListener('DOMContentLoaded', (event) => {
                 window.renderPageFindSearchResults()
             });

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -69,9 +69,15 @@
     }
 
     async function checkBlockedSite(url) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => {
+          controller.abort();
+        }, 5000); // Timeout set to 5000ms (5 seconds)
+      
         try {
-            const response = await fetch(url, { method: 'HEAD', mode: 'no-cors' });
+            const response = await fetch(url, { method: 'HEAD', mode: 'no-cors', signal: controller.signal });
             // If we reach this point, the site is accessible (since mode: 'no-cors' doesn't allow us to check response.ok)
+            clearTimeout(timeout);
             return false;
         } catch (error) {
             // If an error occurs, it's likely the site is blocked

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -79,10 +79,10 @@
         }
     }
 
-    async function runBlockedContentTest() {
+    async function loadSearch() {
         if (getCookie("can_google") === "") {
-            const isBlocked = await checkBlockedSite("https://www.google.com/favicon.ico");
-            if ( isBlocked ) {
+            const isGoogleBlocked = await checkBlockedSite("https://www.google.com/favicon.ico");
+            if ( isGoogleBlocked ) {
                 // Google is blocked.
                 console.log("Google is blocked")
                 document.cookie = "can_google=false;" + path + expires
@@ -100,5 +100,5 @@
         }
     }
 
-    window.onload = runBlockedContentTest;
+    window.onload = loadSearch;
 


### PR DESCRIPTION
This addresses one of the issues that came from #47108

In deciding what search results to serve, we had previously been checking to see whether a user was in China using the ipinfo.io service. The problem, however, is that many people who are not in China are running privacy software that blocks this service and so they were incorrectly being deemed to be in China. This means that a lot of people would be getting PageFind search results when it would have been fine to serve them the Google search results.

Additionally, there are people in China who are using VPNs so _would_ be able to access Google search results but our system was instead serving them the inferior PageFind results.

This PR moves this test away from a geolocation of whether someone is in China and focuses instead on whether the user's browser can access Google. This is the only thing that matters anyway. If they can access Google, then they get the Google search results, otherwise it falls back to Pagefind search results.

For now, people can check the dev console to see debug output of either "Google is blocked" or "Google is NOT blocked" which will make testing easier. Before merge, we can remove these logs. After the first page load, a cookie is set and it will no longer perform the test, but you can try it again in an incognito window or by deleting the `can_google` cookie using dev tools.

It would be good to test this thoroughly with people inside and outside of China and have some people running privacy blocking plugins in their browsers. In all cases it should correctly determine whether you can access Google and will then serve the appropriate search results.