### PR TITLE
Clarify cluster diagram as one possible reference architecture

### DIFF
--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -5,7 +5,9 @@ description: >
   The architectural concepts behind Kubernetes.
 ---
 
-{{< figure src="/images/docs/kubernetes-cluster-architecture.svg" alt="Components of Kubernetes" caption="**Note:** This diagram presents an example reference architecture of a Kubernetes cluster. The actual distribution of components can vary based on specific cluster setups and requirements." class="diagram-large" >}}
+{{< figure src="/images/docs/kubernetes-cluster-architecture.svg" alt="The control plane (kube-apiserver, etcd, kube-controller-manager, kube-scheduler) and several nodes. Each node is running a kubelet and kube-proxy." 
+title="Kubernetes cluster components"
+caption="**Note:** This diagram presents an example reference architecture for a Kubernetes cluster. The actual distribution of components can vary based on specific cluster setups and requirements." class="diagram-large" >}}
 
 ### Understanding Cluster Component Distribution
 

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -5,7 +5,7 @@ description: >
   The architectural concepts behind Kubernetes.
 ---
 
-A Kubernetes cluster consists of a set of worker machines, called nodes, that run containerized applications. Every cluster has at least one worker node.
+A Kubernetes cluster consists of a control plane plus a set of worker machines, called nodes, that run containerized applications. Every cluster needs at least one worker node in order to run Pods.
 
 The worker node(s) host the Pods that are the components of the application workload. The control plane manages the worker nodes and the Pods in the cluster. In production environments, the control plane usually runs across multiple computers and a cluster usually runs multiple nodes, providing fault-tolerance and high availability.
 
@@ -15,7 +15,7 @@ This document outlines the various components you need to have for a complete an
 title="Kubernetes cluster components"
 caption="**Note:** This diagram presents an example reference architecture for a Kubernetes cluster. The actual distribution of components can vary based on specific cluster setups and requirements." class="diagram-large" >}}
 
-## Control Plane Components
+## Control plane components
 
 The control plane's components make global decisions about the cluster (for example, scheduling), as well as detecting and responding to cluster events (for example, starting up a new {{< glossary_tooltip text="pod" term_id="pod">}} when a Deployment's `{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
 
@@ -60,7 +60,7 @@ The following controllers can have cloud provider dependencies:
 - Route controller: For setting up routes in the underlying cloud infrastructure
 - Service controller: For creating, updating and deleting cloud provider load balancers
 
-## Node Components
+## Node components
 
 Node components run on every node, maintaining running pods and providing the Kubernetes runtime environment.
 
@@ -68,9 +68,12 @@ Node components run on every node, maintaining running pods and providing the Ku
 
 {{< glossary_definition term_id="kubelet" length="all" >}}
 
-### kube-proxy
+### kube-proxy (optional) {#kube-proxy)
 
 {{< glossary_definition term_id="kube-proxy" length="all" >}}
+If you use a [network plugin](#network-plugins) that implements packet forwarding for Services
+by itself, and providing equivalent behavior to kube-proxy), then you do not need to run
+kube-proxy on the nodes in your cluster.
 
 ### Container runtime
 
@@ -94,7 +97,7 @@ Containers started by Kubernetes automatically include this DNS server in their 
 
 [Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in the cluster, as well as the cluster itself.
 
-### Container Resource Monitoring
+### Container resource monitoring
 
 [Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/) records generic time-series metrics about containers in a central database, and provides a UI for browsing that data.
 
@@ -102,7 +105,7 @@ Containers started by Kubernetes automatically include this DNS server in their 
 
 A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for saving container logs to a central log store with a search/browsing interface.
 
-### Network Plugins
+### Network plugins
 
 [Network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins) are software components that implement the container network interface (CNI) specification. They are responsible for allocating IP addresses to pods and enabling them to communicate with each other within the cluster.
 
@@ -110,7 +113,7 @@ A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechan
 
 While the core components of Kubernetes remain consistent, the way they are deployed and managed can vary. Understanding these variations is crucial for designing and maintaining Kubernetes clusters that meet specific operational needs.
 
-### Control Plane Deployment Options
+### Control plane deployment options
 
 The control plane components can be deployed in several ways:
 
@@ -128,7 +131,7 @@ The control plane components can be deployed in several ways:
   <dd>Cloud providers often abstract away the control plane, managing its components as part of their service offering.</dd>
 </dl>
 
-### Workload Placement Considerations
+### Workload placement considerations
 
 The placement of workloads, including the control plane components, can vary based on cluster size, performance requirements, and operational policies:
 
@@ -136,13 +139,13 @@ The placement of workloads, including the control plane components, can vary bas
 - Larger production clusters often dedicate specific nodes to control plane components, separating them from user workloads.
 - Some organizations run critical add-ons or monitoring tools on control plane nodes.
 
-### Cluster Management Tools
+### Cluster management tools
 
 Tools like kubeadm, kops, and Kubespray offer different approaches to deploying and managing clusters, each with its own method of component layout and management.
 
 The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs, balancing factors such as operational complexity, performance, and management overhead.
 
-### Customization and Extensibility
+### Customization and extensibility
 
 Kubernetes architecture allows for significant customization:
 

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -9,7 +9,7 @@ description: >
 title="Kubernetes cluster components"
 caption="**Note:** This diagram presents an example reference architecture for a Kubernetes cluster. The actual distribution of components can vary based on specific cluster setups and requirements." class="diagram-large" >}}
 
-### Understanding Cluster Component Distribution
+## Components of a Kubernetes cluster
 
 A Kubernetes cluster consists of a control plane and some nodes. The diagram shows an example of what's involved.
 

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -100,7 +100,7 @@ Containers started by Kubernetes automatically include this DNS server in their 
 
 ### Cluster-level Logging
 
-A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for saving container logs to a central log store with search/browsing interface.
+A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for saving container logs to a central log store with a search/browsing interface.
 
 ### Network Plugins
 
@@ -146,7 +146,7 @@ The flexibility of Kubernetes architecture allows organizations to tailor their 
 
 Kubernetes architecture allows for significant customization:
 
-- Custom schedulers can be deployed alongside or instead of the default scheduler.
+- Custom schedulers can be deployed to work alongside the default Kubernetes scheduler or to replace it entirely.
 - API servers can be extended with CustomResourceDefinitions and API Aggregation.
 - Cloud providers can integrate deeply with Kubernetes using the cloud-controller-manager.
 

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -5,24 +5,162 @@ description: >
   The architectural concepts behind Kubernetes.
 ---
 
-{{< figure src="/images/docs/kubernetes-cluster-architecture.svg" alt="The control plane (kube-apiserver, etcd, kube-controller-manager, kube-scheduler) and several nodes. Each node is running a kubelet and kube-proxy." 
+A Kubernetes cluster consists of a set of worker machines, called nodes, that run containerized applications. Every cluster has at least one worker node.
+
+The worker node(s) host the Pods that are the components of the application workload. The control plane manages the worker nodes and the Pods in the cluster. In production environments, the control plane usually runs across multiple computers and a cluster usually runs multiple nodes, providing fault-tolerance and high availability.
+
+This document outlines the various components you need to have for a complete and working Kubernetes cluster.
+
+{{< figure src="/images/docs/kubernetes-cluster-architecture.svg" alt="The control plane (kube-apiserver, etcd, kube-controller-manager, kube-scheduler) and several nodes. Each node is running a kubelet and kube-proxy."
 title="Kubernetes cluster components"
 caption="**Note:** This diagram presents an example reference architecture for a Kubernetes cluster. The actual distribution of components can vary based on specific cluster setups and requirements." class="diagram-large" >}}
 
-## Components of a Kubernetes cluster
+## Control Plane Components
 
-A Kubernetes cluster consists of a control plane and some nodes. The diagram shows an example of what's involved.
+The control plane's components make global decisions about the cluster (for example, scheduling), as well as detecting and responding to cluster events (for example, starting up a new {{< glossary_tooltip text="pod" term_id="pod">}} when a Deployment's `{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
 
-- **Control Plane Components:** The control plane refers to a collection of critical components that manage the cluster's core functionality. These include the API server, scheduler, controller manager, and etcd (for cluster state storage).
+Control plane components can be run on any machine in the cluster. However, for simplicity, setup scripts typically start all control plane components on the same machine, and do not run user containers on this machine. See [Creating Highly Available clusters with kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/) for an example control plane setup that runs across multiple machines.
 
-- **Node Components:** Both control plane nodes and worker nodes typically run kubelet (the node agent) and kube-proxy (for network proxying). These components are essential for node operation but are not always considered part of the core control plane.
+### kube-apiserver
 
-- **Deployment Variations:** In production environments, there are many possible setups:
-  - Control plane components might run on dedicated nodes or be distributed across cluster nodes.
-  - They could be deployed as static Pods, managed by systemd, or handled by cluster management tools.
-  - In some cases, especially with managed Kubernetes services, the control plane might be abstracted away from direct user management.
+{{< glossary_definition term_id="kube-apiserver" length="all" >}}
 
-- **Workload Placement:** Depending on the cluster's size and configuration, you might deploy workloads on control plane nodes, especially for cluster management tasks, monitoring, or trusted applications.
+### etcd
 
-The flexibility of Kubernetes allows you to adapt the architecture to your specific needs, resource constraints, and business requirements.
+{{< glossary_definition term_id="etcd" length="all" >}}
 
+### kube-scheduler
+
+{{< glossary_definition term_id="kube-scheduler" length="all" >}}
+
+### kube-controller-manager
+
+{{< glossary_definition term_id="kube-controller-manager" length="all" >}}
+
+There are many different types of controllers. Some examples of them are:
+
+- Node controller: Responsible for noticing and responding when nodes go down.
+- Job controller: Watches for Job objects that represent one-off tasks, then creates Pods to run those tasks to completion.
+- EndpointSlice controller: Populates EndpointSlice objects (to provide a link between Services and Pods).
+- ServiceAccount controller: Create default ServiceAccounts for new namespaces.
+
+The above is not an exhaustive list.
+
+### cloud-controller-manager
+
+{{< glossary_definition term_id="cloud-controller-manager" length="short" >}}
+
+The cloud-controller-manager only runs controllers that are specific to your cloud provider. If you are running Kubernetes on your own premises, or in a learning environment inside your own PC, the cluster does not have a cloud controller manager.
+
+As with the kube-controller-manager, the cloud-controller-manager combines several logically independent control loops into a single binary that you run as a single process. You can scale horizontally (run more than one copy) to improve performance or to help tolerate failures.
+
+The following controllers can have cloud provider dependencies:
+
+- Node controller: For checking the cloud provider to determine if a node has been deleted in the cloud after it stops responding
+- Route controller: For setting up routes in the underlying cloud infrastructure
+- Service controller: For creating, updating and deleting cloud provider load balancers
+
+## Node Components
+
+Node components run on every node, maintaining running pods and providing the Kubernetes runtime environment.
+
+### kubelet
+
+{{< glossary_definition term_id="kubelet" length="all" >}}
+
+### kube-proxy
+
+{{< glossary_definition term_id="kube-proxy" length="all" >}}
+
+### Container runtime
+
+{{< glossary_definition term_id="container-runtime" length="all" >}}
+
+## Addons
+
+Addons use Kubernetes resources ({{< glossary_tooltip term_id="daemonset" >}}, {{< glossary_tooltip term_id="deployment" >}}, etc) to implement cluster features. Because these are providing cluster-level features, namespaced resources for addons belong within the `kube-system` namespace.
+
+Selected addons are described below; for an extended list of available addons, please see [Addons](/docs/concepts/cluster-administration/addons/).
+
+### DNS
+
+While the other addons are not strictly required, all Kubernetes clusters should have [cluster DNS](/docs/concepts/services-networking/dns-pod-service/), as many examples rely on it.
+
+Cluster DNS is a DNS server, in addition to the other DNS server(s) in your environment, which serves DNS records for Kubernetes services.
+
+Containers started by Kubernetes automatically include this DNS server in their DNS searches.
+
+### Web UI (Dashboard)
+
+[Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in the cluster, as well as the cluster itself.
+
+### Container Resource Monitoring
+
+[Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/) records generic time-series metrics about containers in a central database, and provides a UI for browsing that data.
+
+### Cluster-level Logging
+
+A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for saving container logs to a central log store with search/browsing interface.
+
+### Network Plugins
+
+[Network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins) are software components that implement the container network interface (CNI) specification. They are responsible for allocating IP addresses to pods and enabling them to communicate with each other within the cluster.
+
+## Architecture Variations
+
+While the core components of Kubernetes remain consistent, the way they are deployed and managed can vary. Understanding these variations is crucial for designing and maintaining Kubernetes clusters that meet specific operational needs.
+
+### Control Plane Deployment Options
+
+The control plane components can be deployed in several ways:
+
+<dl>
+  <dt>Traditional deployment</dt>
+  <dd>Control plane components run directly on dedicated machines or VMs, often managed as systemd services.</dd>
+
+  <dt>Static Pods</dt>
+  <dd>Control plane components are deployed as static Pods, managed by the kubelet on specific nodes. This is a common approach used by tools like kubeadm.</dd>
+
+  <dt>Self-hosted</dt>
+  <dd>The control plane runs as Pods within the Kubernetes cluster itself, managed by Deployments or other Kubernetes primitives.</dd>
+
+  <dt>Managed Kubernetes services</dt>
+  <dd>Cloud providers often abstract away the control plane, managing its components as part of their service offering.</dd>
+</dl>
+
+### Workload Placement Considerations
+
+The placement of workloads, including the control plane components, can vary based on cluster size, performance requirements, and operational policies:
+
+- In smaller or development clusters, control plane components and user workloads might run on the same nodes.
+- Larger production clusters often dedicate specific nodes to control plane components, separating them from user workloads.
+- Some organizations run critical add-ons or monitoring tools on control plane nodes.
+
+### Cluster Management Tools
+
+Tools like kubeadm, kops, and Kubespray offer different approaches to deploying and managing clusters, each with its own method of component layout and management.
+
+The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs, balancing factors such as operational complexity, performance, and management overhead.
+
+### Customization and Extensibility
+
+Kubernetes architecture allows for significant customization:
+
+- Custom schedulers can be deployed alongside or instead of the default scheduler.
+- API servers can be extended with CustomResourceDefinitions and API Aggregation.
+- Cloud providers can integrate deeply with Kubernetes using the cloud-controller-manager.
+
+The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs, balancing factors such as operational complexity, performance, and management overhead.
+
+## {{% heading "whatsnext" %}}
+
+Learn more about the following:
+
+- [Nodes](/docs/concepts/architecture/nodes/) and [their communication](/docs/concepts/architecture/control-plane-node-communication/)
+  with the control plane.
+- Kubernetes [controllers](/docs/concepts/architecture/controller/).
+- [kube-scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) which is the default scheduler for Kubernetes.
+- Etcd's official [documentation](https://etcd.io/docs/).
+- Several [container runtimes](/docs/setup/production-environment/container-runtimes/) in Kubernetes.
+- Integrating with cloud providers using [cloud-controller-manager](/docs/concepts/architecture/cloud-controller/).
+- [kubectl](/docs/reference/generated/kubectl/kubectl-commands) commands.

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -9,7 +9,7 @@ description: >
 
 ### Understanding Cluster Component Distribution
 
-While the diagram provides a simplified overview, it's important to understand the flexibility of Kubernetes architecture:
+A Kubernetes cluster consists of a control plane and some nodes. The diagram shows an example of what's involved.
 
 - **Control Plane Components:** The control plane refers to a collection of critical components that manage the cluster's core functionality. These include the API server, scheduler, controller manager, and etcd (for cluster state storage).
 

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -68,11 +68,11 @@ Node components run on every node, maintaining running pods and providing the Ku
 
 {{< glossary_definition term_id="kubelet" length="all" >}}
 
-### kube-proxy (optional) {#kube-proxy)
+### kube-proxy (optional) {#kube-proxy}
 
 {{< glossary_definition term_id="kube-proxy" length="all" >}}
 If you use a [network plugin](#network-plugins) that implements packet forwarding for Services
-by itself, and providing equivalent behavior to kube-proxy), then you do not need to run
+by itself, and providing equivalent behavior to kube-proxy, then you do not need to run
 kube-proxy on the nodes in your cluster.
 
 ### Container runtime
@@ -109,7 +109,7 @@ A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechan
 
 [Network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins) are software components that implement the container network interface (CNI) specification. They are responsible for allocating IP addresses to pods and enabling them to communicate with each other within the cluster.
 
-## Architecture Variations
+## Architecture variations
 
 While the core components of Kubernetes remain consistent, the way they are deployed and managed can vary. Understanding these variations is crucial for designing and maintaining Kubernetes clusters that meet specific operational needs.
 
@@ -117,19 +117,17 @@ While the core components of Kubernetes remain consistent, the way they are depl
 
 The control plane components can be deployed in several ways:
 
-<dl>
-  <dt>Traditional deployment</dt>
-  <dd>Control plane components run directly on dedicated machines or VMs, often managed as systemd services.</dd>
+Traditional deployment
+: Control plane components run directly on dedicated machines or VMs, often managed as systemd services.
 
-  <dt>Static Pods</dt>
-  <dd>Control plane components are deployed as static Pods, managed by the kubelet on specific nodes. This is a common approach used by tools like kubeadm.</dd>
+Static Pods
+: Control plane components are deployed as static Pods, managed by the kubelet on specific nodes. This is a common approach used by tools like kubeadm.
 
-  <dt>Self-hosted</dt>
-  <dd>The control plane runs as Pods within the Kubernetes cluster itself, managed by Deployments or other Kubernetes primitives.</dd>
+Self-hosted
+: The control plane runs as Pods within the Kubernetes cluster itself, managed by Deployments and StatefulSets or other Kubernetes primitives.
 
-  <dt>Managed Kubernetes services</dt>
-  <dd>Cloud providers often abstract away the control plane, managing its components as part of their service offering.</dd>
-</dl>
+Managed Kubernetes services
+: Cloud providers often abstract away the control plane, managing its components as part of their service offering.
 
 ### Workload placement considerations
 

--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -5,4 +5,22 @@ description: >
   The architectural concepts behind Kubernetes.
 ---
 
-{{< figure src="/images/docs/kubernetes-cluster-architecture.svg" alt="Components of Kubernetes" caption="Kubernetes cluster architecture" class="diagram-large" >}}
+{{< figure src="/images/docs/kubernetes-cluster-architecture.svg" alt="Components of Kubernetes" caption="**Note:** This diagram presents an example reference architecture of a Kubernetes cluster. The actual distribution of components can vary based on specific cluster setups and requirements." class="diagram-large" >}}
+
+### Understanding Cluster Component Distribution
+
+While the diagram provides a simplified overview, it's important to understand the flexibility of Kubernetes architecture:
+
+- **Control Plane Components:** The control plane refers to a collection of critical components that manage the cluster's core functionality. These include the API server, scheduler, controller manager, and etcd (for cluster state storage).
+
+- **Node Components:** Both control plane nodes and worker nodes typically run kubelet (the node agent) and kube-proxy (for network proxying). These components are essential for node operation but are not always considered part of the core control plane.
+
+- **Deployment Variations:** In production environments, there are many possible setups:
+  - Control plane components might run on dedicated nodes or be distributed across cluster nodes.
+  - They could be deployed as static Pods, managed by systemd, or handled by cluster management tools.
+  - In some cases, especially with managed Kubernetes services, the control plane might be abstracted away from direct user management.
+
+- **Workload Placement:** Depending on the cluster's size and configuration, you might deploy workloads on control plane nodes, especially for cluster management tasks, monitoring, or trusted applications.
+
+The flexibility of Kubernetes allows you to adapt the architecture to your specific needs, resource constraints, and business requirements.
+

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -4,8 +4,7 @@ reviewers:
 title: Kubernetes Components
 content_type: concept
 description: >
-  A Kubernetes cluster consists of the components that are a part of the control
-  plane and a set of machines called nodes.
+  An overview of the key components that make up a Kubernetes cluster.
 weight: 30
 card: 
   title: Components of a cluster
@@ -14,140 +13,73 @@ card:
 ---
 
 <!-- overview -->
-When you deploy Kubernetes, you get a cluster.
-{{< glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
 
-This document outlines the various components you need to have for
-a complete and working Kubernetes cluster.
+This page provides a high-level overview of the essential components that make up a Kubernetes cluster.
 
 {{< figure src="/images/docs/components-of-kubernetes.svg" alt="Components of Kubernetes" caption="The components of a Kubernetes cluster" class="diagram-large" clicktozoom="true" >}}
 
 <!-- body -->
-## Control Plane Components
 
-The control plane's components make global decisions about the cluster (for example, scheduling),
-as well as detecting and responding to cluster events (for example, starting up a new
-{{< glossary_tooltip text="pod" term_id="pod">}} when a Deployment's
-`{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
+## Core Components
 
-Control plane components can be run on any machine in the cluster. However,
-for simplicity, setup scripts typically start all control plane components on
-the same machine, and do not run user containers on this machine. See
-[Creating Highly Available clusters with kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/)
-for an example control plane setup that runs across multiple machines.
+A Kubernetes cluster consists of a control plane and one or more worker nodes. Here's a brief overview of the main components:
 
-### kube-apiserver
+### Control Plane Components
 
-{{< glossary_definition term_id="kube-apiserver" length="all" >}}
+Manage the overall state of the cluster:
 
-### etcd
+<dl>
+  <dt>kube-apiserver</dt>
+  <dd>The API server that exposes the Kubernetes API</dd>
 
-{{< glossary_definition term_id="etcd" length="all" >}}
+  <dt>etcd</dt>
+  <dd>Consistent and highly-available key value store for all cluster data</dd>
 
-### kube-scheduler
+  <dt>kube-scheduler</dt>
+  <dd>Assigns Pods to Nodes</dd>
 
-{{< glossary_definition term_id="kube-scheduler" length="all" >}}
+  <dt>kube-controller-manager</dt>
+  <dd>Runs controller processes</dd>
 
-### kube-controller-manager
+  <dt>cloud-controller-manager</dt>
+  <dd>Integrates with underlying cloud providers</dd>
+</dl>
 
-{{< glossary_definition term_id="kube-controller-manager" length="all" >}}
+### Node Components
 
-There are many different types of controllers. Some examples of them are:
+Run on every node, maintaining running pods and providing the Kubernetes runtime environment:
 
-  * Node controller: Responsible for noticing and responding when nodes go down.
-  * Job controller: Watches for Job objects that represent one-off tasks, then creates
-    Pods to run those tasks to completion.
-  * EndpointSlice controller: Populates EndpointSlice objects (to provide a link between Services and Pods).
-  * ServiceAccount controller: Create default ServiceAccounts for new namespaces.
+<dl>
+  <dt>kubelet</dt>
+  <dd>Ensures that containers are running in a Pod</dd>
 
-The above is not an exhaustive list.
+  <dt>kube-proxy</dt>
+  <dd>Maintains network rules on nodes</dd>
 
-### cloud-controller-manager
-
-{{< glossary_definition term_id="cloud-controller-manager" length="short" >}}
-
-The cloud-controller-manager only runs controllers that are specific to your cloud provider.
-If you are running Kubernetes on your own premises, or in a learning environment inside your
-own PC, the cluster does not have a cloud controller manager.
-
-As with the kube-controller-manager, the cloud-controller-manager combines several logically
-independent control loops into a single binary that you run as a single process. You can
-scale horizontally (run more than one copy) to improve performance or to help tolerate failures.
-
-The following controllers can have cloud provider dependencies:
-
-  * Node controller: For checking the cloud provider to determine if a node has been deleted in the cloud after it stops responding
-  * Route controller: For setting up routes in the underlying cloud infrastructure
-  * Service controller: For creating, updating and deleting cloud provider load balancers
-
-## Node Components
-
-Node components run on every node, maintaining running pods and providing the Kubernetes runtime environment.
-
-### kubelet
-
-{{< glossary_definition term_id="kubelet" length="all" >}}
-
-### kube-proxy
-
-{{< glossary_definition term_id="kube-proxy" length="all" >}}
-
-### Container runtime
-
-{{< glossary_definition term_id="container-runtime" length="all" >}}
+  <dt>Container runtime</dt>
+  <dd>Software responsible for running containers</dd>
+</dl>
 
 ## Addons
 
-Addons use Kubernetes resources ({{< glossary_tooltip term_id="daemonset" >}},
-{{< glossary_tooltip term_id="deployment" >}}, etc)
-to implement cluster features. Because these are providing cluster-level features, namespaced resources
-for addons belong within the `kube-system` namespace.
+Addons extend the functionality of Kubernetes. A few important examples include:
 
-Selected addons are described below; for an extended list of available addons, please
-see [Addons](/docs/concepts/cluster-administration/addons/).
+<dl>
+  <dt>DNS</dt>
+  <dd>For cluster-wide DNS resolution</dd>
 
-### DNS
+  <dt>Web UI (Dashboard)</dt>
+  <dd>For cluster management via a web interface</dd>
 
-While the other addons are not strictly required, all Kubernetes clusters should have
-[cluster DNS](/docs/concepts/services-networking/dns-pod-service/), as many examples rely on it.
+  <dt>Container Resource Monitoring</dt>
+  <dd>For collecting and storing container metrics</dd>
 
-Cluster DNS is a DNS server, in addition to the other DNS server(s) in your environment,
-which serves DNS records for Kubernetes services.
+  <dt>Cluster-level Logging</dt>
+  <dd>For saving container logs to a central log store</dd>
+</dl>
 
-Containers started by Kubernetes automatically include this DNS server in their DNS searches.
+## Flexibility in Architecture
 
-### Web UI (Dashboard)
+Kubernetes allows for flexibility in how these components are deployed and managed. The architecture can be adapted to various needs, from small development environments to large-scale production deployments.
 
-[Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose,
-web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications
-running in the cluster, as well as the cluster itself.
-
-### Container Resource Monitoring
-
-[Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)
-records generic time-series metrics
-about containers in a central database, and provides a UI for browsing that data.
-
-### Cluster-level Logging
-
-A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for
-saving container logs to a central log store with search/browsing interface.
-
-### Network Plugins
-
-[Network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins) are software
-components that implement the container network interface (CNI) specification. They are responsible for
-allocating IP addresses to pods and enabling them to communicate with each other within the cluster.
-
-
-## {{% heading "whatsnext" %}}
-
-Learn more about the following:
-   * [Nodes](/docs/concepts/architecture/nodes/) and [their communication](/docs/concepts/architecture/control-plane-node-communication/)
-     with the control plane.
-   * Kubernetes [controllers](/docs/concepts/architecture/controller/).
-   * [kube-scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) which is the default scheduler for Kubernetes.
-   * Etcd's official [documentation](https://etcd.io/docs/).
-   * Several [container runtimes](/docs/setup/production-environment/container-runtimes/) in Kubernetes.
-   * Integrating with cloud providers using [cloud-controller-manager](/docs/concepts/architecture/cloud-controller/).
-   * [kubectl](/docs/reference/generated/kubectl/kubectl-commands) commands.
+For more detailed information about each component and various ways to configure your cluster architecture, see the [Cluster Architecture](/docs/concepts/architecture/) page.

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -54,10 +54,13 @@ Run on every node, maintaining running pods and providing the Kubernetes runtime
 : Maintains network rules on nodes to implement {{< glossary_tooltip text="Services" term_id="service" >}}
 
 [Container runtime](/docs/concepts/architecture/#container-runtime)
-: Software responsible for running containers. Read [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more. {{% thirdparty-content single="true" %}}
+: Software responsible for running containers. Read [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more.
+
+
+{{% thirdparty-content single="true" %}}
 
 Your cluster may require additional software on each node; for example, you might also
-run systemd on a Linux node to supervise local components.
+run [systemd](https://systemd.io/) on a Linux node to supervise local components.
 
 ## Addons
 

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -28,55 +28,52 @@ A Kubernetes cluster consists of a control plane and one or more worker nodes. H
 
 Manage the overall state of the cluster:
 
-<dl>
-  <dt>kube-apiserver</dt>
-  <dd>The API server that exposes the Kubernetes API</dd>
+[kube-apiserver](/docs/concepts/architecture/#kube-apiserver)
+: The core component server that exposes the Kubernetes HTTP API
 
-  <dt>etcd</dt>
-  <dd>Consistent and highly-available key value store for all cluster data</dd>
+[etcd](/docs/concepts/architecture/#etcd)
+: Consistent and highly-available key value store for all API server data
 
-  <dt>kube-scheduler</dt>
-  <dd>Assigns Pods to Nodes</dd>
+[kube-scheduler](/docs/concepts/architecture/#kube-scheduler)
+: Looks for Pods not yet bound to a node, and assigns each Pod to a suitable node.
 
-  <dt>kube-controller-manager</dt>
-  <dd>Runs controller processes</dd>
+[kube-controller-manager](/docs/concepts/architecture/#kube-controller-manager)
+: Runs {{< glossary_tooltip text="controllers" term_id="controller" >}} to implement Kubernetes API behavior.
 
-  <dt>cloud-controller-manager</dt>
-  <dd>Integrates with underlying cloud providers</dd>
-</dl>
+[cloud-controller-manager](/docs/concepts/architecture/#cloud-controller-manager) (optional)
+: Integrates with underlying cloud provider(s)
 
 ### Node Components
 
 Run on every node, maintaining running pods and providing the Kubernetes runtime environment:
 
-<dl>
-  <dt>kubelet</dt>
-  <dd>Ensures that containers are running in a Pod</dd>
+[kubelet](/docs/concepts/architecture/#kubelet)
+: Ensures that Pods are running, including their containers.
 
-  <dt>kube-proxy</dt>
-  <dd>Maintains network rules on nodes</dd>
+[kube-proxy](/docs/concepts/architecture/#kube-proxy) (optional)
+: Maintains network rules on nodes to implement {{< glossary_tooltip text="Services" term_id="service" >}}
 
-  <dt>Container runtime</dt>
-  <dd>Software responsible for running containers</dd>
-</dl>
+[Container runtime](/docs/concepts/architecture/#container-runtime)
+: Software responsible for running containers. Read [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more. {{% thirdparty-content single="true" %}}
+
+Your cluster may require additional software on each node; for example, you might also
+run systemd on a Linux node to supervise local components.
 
 ## Addons
 
 Addons extend the functionality of Kubernetes. A few important examples include:
 
-<dl>
-  <dt>DNS</dt>
-  <dd>For cluster-wide DNS resolution</dd>
+[DNS](/docs/concepts/architecture/#dns)
+: For cluster-wide DNS resolution
 
-  <dt>Web UI (Dashboard)</dt>
-  <dd>For cluster management via a web interface</dd>
+[Web UI](/docs/concepts/architecture/#web-ui-dashboard) (Dashboard)
+: For cluster management via a web interface
 
-  <dt>Container Resource Monitoring</dt>
-  <dd>For collecting and storing container metrics</dd>
+[Container Resource Monitoring](/docs/concepts/architecture/#container-resource-monitoring)
+: For collecting and storing container metrics
 
-  <dt>Cluster-level Logging</dt>
-  <dd>For saving container logs to a central log store</dd>
-</dl>
+[Cluster-level Logging](/docs/concepts/architecture/#cluster-level-logging)
+: For saving container logs to a central log store
 
 ## Flexibility in Architecture
 


### PR DESCRIPTION
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This PR addresses the concerns raised in issue #47111 regarding the potential misunderstanding of component distribution in Kubernetes clusters, particularly the presence of kubelet and kube-proxy on control plane nodes.

![image](https://github.com/user-attachments/assets/d4da9b57-2d1f-48c4-a47e-3a7c209d83b3)

[Before](https://kubernetes.io/docs/concepts/architecture/)
[After](https://deploy-preview-47164--kubernetes-io-main-staging.netlify.app/docs/concepts/architecture/)

I'm not entirely sure how much additional detail is appropriate for this introductory page on cluster architecture. I'm open to removing certain details for brevity if needed. Feedback on the level of detail and which points are most crucial to keep would be greatly appreciated. Also if there is anything I have gotten wrong about cluster architecture, please feel free to correct me.