### PR TITLE
Specify likely etcd restart steps for etcdctl-based restore.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -447,7 +447,10 @@ either be a snapshot file from a previous backup operation, or from a remaining
    ```
 
    If `<data-dir-location>` is the same folder as before, delete it and stop the etcd process before restoring the cluster. 
+
    Otherwise, change etcd configuration and restart the etcd process after restoration to have it use the new data directory.
+   Usually, this means `/etc/kubernetes/manifests/etcd.yaml`'s `volumes.hostPath.path` for `name: etc-data` becomes `<data-dir-location>`.
+   Next, `kubectl -n kube-system delete pod <name-of-etcd-pod>` or `systemctl restart kubelet.service` or both may be needed.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -447,10 +447,9 @@ either be a snapshot file from a previous backup operation, or from a remaining
    ```
 
    If `<data-dir-location>` is the same folder as before, delete it and stop the etcd process before restoring the cluster. 
-
-   Otherwise, change etcd configuration and restart the etcd process after restoration to have it use the new data directory.
-   Usually, this means `/etc/kubernetes/manifests/etcd.yaml`'s `volumes.hostPath.path` for `name: etc-data` becomes `<data-dir-location>`.
-   Next, `kubectl -n kube-system delete pod <name-of-etcd-pod>` or `systemctl restart kubelet.service` or both may be needed.
+   Otherwise, change etcd configuration and restart the etcd process after restoration to have it use the new data directory:
+   first change  `/etc/kubernetes/manifests/etcd.yaml`'s `volumes.hostPath.path` for `name: etcd-data`  to `<data-dir-location>`,
+   then execute `kubectl -n kube-system delete pod <name-of-etcd-pod>` or `systemctl restart kubelet.service` (or both).
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
For many, maybe most, installations of etcd, when etcd is restored with etcdctl, when the etcd pod YAML is edited to point at a new restore location, the pod will also need to be restarted and the kubelet restarted in order for etcd to become fully operational again with the new backup. Some basic guidance is provided for use of the (legacy) etcdctl instructions as a reminder.