### PR TITLE
Fix inconsistent example (Kustomize)

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -102,17 +102,17 @@ kubectl get -k <directory-path> -o jsonpath='{.data}'
 The output is similar to:
 
 ```
-{ "password": "UyFCXCpkJHpEc2I9", "username": "YWRtaW4=" }
+{ "password": "MWYyZDFlMmU2N2Rm", "username": "YWRtaW4=" }
 ```
 
 ```
-echo 'UyFCXCpkJHpEc2I9' | base64 --decode
+echo 'MWYyZDFlMmU2N2Rm' | base64 --decode
 ```
 
 The output is similar to:
 
 ```
-S!B\*d$zDsb=
+1f2d1e2e67df
 ```
 
 For more information, refer to


### PR DESCRIPTION
Example show under [Managing Secrets using Kustomize](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kustomize/) page show setup with password=1f2d1e2e67df. But later in the document, it indicates wrong hash as UyFCXCpkJHpEc2I9 and pointed to a different password value S!B\*d$zDsb=.

This commit aligns the secret and hash value to 1f2d1e2e67df.