### PR TITLE
Disentangle CRD additional printer columns & field selector sections

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1630,6 +1630,45 @@ my-new-cron-object   * * * * *   1          7s
 The `NAME` column is implicit and does not need to be defined in the CustomResourceDefinition.
 {{< /note >}}
 
+
+#### Priority
+
+Each column includes a `priority` field. Currently, the priority
+differentiates between columns shown in standard view or wide view (using the `-o wide` flag).
+
+- Columns with priority `0` are shown in standard view.
+- Columns with priority greater than `0` are shown only in wide view.
+
+#### Type
+
+A column's `type` field can be any of the following (compare
+[OpenAPI v3 data types](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#dataTypes)):
+
+- `integer` – non-floating-point numbers
+- `number` – floating point numbers
+- `string` – strings
+- `boolean` – `true` or `false`
+- `date` – rendered differentially as time since this timestamp.
+
+If the value inside a CustomResource does not match the type specified for the column,
+the value is omitted. Use CustomResource validation to ensure that the value
+types are correct.
+
+#### Format
+
+A column's `format` field can be any of the following:
+
+- `int32`
+- `int64`
+- `float`
+- `double`
+- `byte`
+- `date`
+- `date-time`
+- `password`
+
+The column's `format` controls the style used when `kubectl` prints the value.
+
 ### Field selectors
 
 [Field Selectors](/docs/concepts/overview/working-with-objects/field-selectors/)
@@ -1719,44 +1758,6 @@ Should output:
 NAME       COLOR  SIZE
 example2   blue   M
 ```
-
-#### Priority
-
-Each column includes a `priority` field. Currently, the priority
-differentiates between columns shown in standard view or wide view (using the `-o wide` flag).
-
-- Columns with priority `0` are shown in standard view.
-- Columns with priority greater than `0` are shown only in wide view.
-
-#### Type
-
-A column's `type` field can be any of the following (compare
-[OpenAPI v3 data types](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#dataTypes)):
-
-- `integer` – non-floating-point numbers
-- `number` – floating point numbers
-- `string` – strings
-- `boolean` – `true` or `false`
-- `date` – rendered differentially as time since this timestamp.
-
-If the value inside a CustomResource does not match the type specified for the column,
-the value is omitted. Use CustomResource validation to ensure that the value
-types are correct.
-
-#### Format
-
-A column's `format` field can be any of the following:
-
-- `int32`
-- `int64`
-- `float`
-- `double`
-- `byte`
-- `date`
-- `date-time`
-- `password`
-
-The column's `format` controls the style used when `kubectl` prints the value.
 
 ### Subresources
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Through PR #45155 the additional printer columns & field selector sections got mixed up. This PR fixes that

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
