### PR TITLE
KEP-4191: Split Image Filesystem promotion to Beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-separate-disk-gc.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-separate-disk-gc.md
@@ -9,6 +9,11 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.29"
+    toVersion: "1.30"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.31"
 ---
-Enable kubelet to garbage collect container images and containers
-even when those are on a separate filesystem.
+The split image filesystem feature enables kubelet to perform garbage collection
+of images (read-only layers) and/or containers (writeable layers) deployed on
+separate filesystems.


### PR DESCRIPTION
- One-line PR description: Promote [KEP-4191](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4191-split-image-filesystem/README.md?rgh-link-date=2024-06-03T08%3A18%3A51Z) "Split Image Filesystem" to Beta, update references to the `KubeletSeparateDiskGC` feature gate.

- Issue link: https://github.com/kubernetes/enhancements/issues/4191

- Other comments:

Starting from the upcoming Kubernetes release v1.31, the feature will be enabled by default, allowing users to deploy split image and container filesystems without enabling the feature gate to benefit from the new functionality.

Thus, update the documentation that references the `KubeletSeparateDiskGC` feature gate, ensuring that its state post-Beta promotion will be correctly reflected.

Related:

- https://github.com/kubernetes/website/pull/46951
- https://github.com/kubernetes/kubernetes/pull/126205