### PR TITLE
Add /sys/devices/virtual/powercap to Masked Paths

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -498,6 +498,7 @@ them. The list of masked and read-only paths are as follows:
   - `/proc/sched_debug`
   - `/proc/scsi`
   - `/sys/firmware`
+  - `/sys/devices/virtual/powercap`
 
 - Read-Only Paths:
   - `/proc/bus`


### PR DESCRIPTION
Add `/sys/devices/virtual/powercap` to Masked Paths in security-context.md

The document does not reflect the following:
ref https://github.com/kubernetes/kubernetes/pull/125970

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
