### PR TITLE
Revert updates for KEP-4191: Split Image Filesystem promotion to Beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-separate-disk-gc.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/kubelet-separate-disk-gc.md
@@ -9,11 +9,6 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.29"
-    toVersion: "1.30"
-  - stage: beta
-    defaultValue: true
-    fromVersion: "1.31"
 ---
-The split image filesystem feature enables kubelet to perform garbage collection
-of images (read-only layers) and/or containers (writeable layers) deployed on
-separate filesystems.
+Enable kubelet to garbage collect container images and containers
+even when those are on a separate filesystem.


### PR DESCRIPTION
This PR reverts the doc changes related to KEP-4191 that were merged as part of https://github.com/kubernetes/website/pull/47228 without the upstream changes being merged. 

/cc tengqm 

