### PR TITLE
[zh] Sync a feature gate: zero-limited-nominal-concurrency-shares.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
@@ -9,9 +9,13 @@ stages:
   - stage: beta 
     defaultValue: false
     fromVersion: "1.29"
+    toVersion: "1.29"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.30"
 ---
 <!--
-Allow [Priority & Fairness](/docs/concepts/cluster-administration/flow-control/)
+Allow [priority & fairness](/docs/concepts/cluster-administration/flow-control/)
 in the API server to use a zero value for the `nominalConcurrencyShares` field of
 the `limited` section of a priority level.
 -->


### PR DESCRIPTION
Sync with en text.

```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
```