### PR TITLE
Update service.md

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -583,7 +583,7 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 9376
-  clusterIP: 10.0.171.239
+  loadBalancerIP: 10.0.171.239
   type: LoadBalancer
 status:
   loadBalancer:


### PR DESCRIPTION
Service type LoadBalancer has a property for clusterIP which should be loadBalancerIP for service type LoadBalancer.