### PR TITLE
Improve blog article summaries presentation with translator metadata in front matter

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -587,6 +587,8 @@ other = """<p>Items on this page refer to third party products or projects that 
 [thirdparty_message_vendor]
 other = """Items on this page refer to vendors external to Kubernetes. The Kubernetes project authors aren't responsible for those third-party products or projects. To add a vendor, product or project to this list, read the <a href="/docs/contribute/style/content-guide/#third-party-content">content guide</a> before submitting a change. <a href="#third-party-content-disclaimer">More information.</a>"""
 
+[translated_by]
+other = "Translated By"
 
 [ui_search_placeholder]
 other = "Search this site"

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -1,0 +1,23 @@
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<div class="td-byline mb-4">
+		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
+    {{ with .Params.translator }}{{ T "translated_by" }} <b>{{ . | markdownify }}</b> |{{ end }}
+		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
+	</div>
+	<header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+			{{ partial "reading-time.html" . }}
+		{{ end }}
+	</header>
+	{{ .Content }}
+	{{ if (.Site.Params.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+		<br />
+	{{ end }}
+
+	{{ partial "pager.html" . }}
+</div>


### PR DESCRIPTION
close #47223

## Feature Description

- Add "translator" metadata to the blog's front matter, just like the [author metadata](https://github.com/kubernetes/website/pull/45865)
    - The display remains unchanged for languages that do not require a "translator", like in the English, or where the "translator" metadata is not set

Here is a simple example. This is already working well in Preview - and has already been used by zh-cn - see [`content/zh-cn/blog/_posts
`](https://github.com/kubernetes/website/tree/main/content/zh-cn/blog/_posts)

```yaml
slug: 
title: 
date:
author: >
  Author-Name (Affiliation)
translator: >
  Translator-Name (Affiliation)
```

### Useful links

- EN: [Preview New Blog Summary Page](https://deploy-preview-47270--kubernetes-io-main-staging.netlify.app/blog/) (not changed)
- EN: [Preview a Blog Article page](https://deploy-preview-47270--kubernetes-io-main-staging.netlify.app/blog/2024/06/06/10-years-of-kubernetes/) (not changed)
- ZH-CN: [Preview New Blog Summary Page](https://deploy-preview-47270--kubernetes-io-main-staging.netlify.app/zh-cn/blog/)
- ZH-CN: [Preview a Blog Article page](https://deploy-preview-47270--kubernetes-io-main-staging.netlify.app/zh-cn/blog/2024/06/06/10-years-of-kubernetes/)
