### PR TITLE
[bn] Reduce GracePeriod to 300 sec for deploying Cassandra with a Sta…

### DIFF
--- a/content/bn/examples/application/cassandra/cassandra-statefulset.yaml
+++ b/content/bn/examples/application/cassandra/cassandra-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: cassandra
     spec:
-      terminationGracePeriodSeconds: 1800
+      terminationGracePeriodSeconds: 500
       containers:
       - name: cassandra
         image: gcr.io/google-samples/cassandra:v13


### PR DESCRIPTION



Closes https://github.com/kubernetes/website/issues/47039
This change is already accepted and issue is resolved, raising the PR for bn
Issue:
The current command waits for the termination grace period of 1800 seconds (30 minutes), causing unnecessary delays for users.

Solution:
Reduced the terminationGracePeriodSeconds value to a shorter duration (e.g., 300 or 500 seconds) to avoid prolonged wait times.

Changes:

Updated the termination grace period from 1800 seconds to 500 seconds in the relevant command.
Impact:
This change will significantly reduce wait times during the execution of the command, improving user experience.
<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
