### PR TITLE
KEP-4193: beta promotion of ServiceAccountTokenNodeBinding feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/service-account-token-node-binding.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/service-account-token-node-binding.md
@@ -9,5 +9,9 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.29"
+    toVersion: "1.30"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.31"
 ---
-Controls whether the apiserver allows binding service account tokens to Node objects.
+Controls whether the API server allows binding service account tokens to Node objects.

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -184,12 +184,13 @@ ServiceAccount. You can request a specific token duration using the `--duration`
 command line argument to `kubectl create token` (the actual duration of the issued
 token might be shorter, or could even be longer).
 
+{{< feature-state feature_gate_name="ServiceAccountTokenNodeBinding" >}}
+
 When the `ServiceAccountTokenNodeBinding` and `ServiceAccountTokenNodeBindingValidation`
-features are enabled and the `KUBECTL_NODE_BOUND_TOKENS` environment variable is set to `true`,
-it is possible to create a service account token that is directly bound to a `Node`:
+features are enabled, it is possible to create a service account token that is directly bound to a `Node`:
 
 ```shell
-KUBECTL_NODE_BOUND_TOKENS=true kubectl create token build-robot --bound-object-kind Node --bound-object-name node-001 --bound-object-uid 123...456
+kubectl create token build-robot --bound-object-kind Node --bound-object-name node-001 --bound-object-uid 123...456
 ```
 
 The token will be valid until it expires or either the associated `Node` or service account are deleted.


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/issues/4193

Includes 1.31 updates for the ServiceAccountTokenNodeBinding feature gate portion of KEP-4193 (the only changes made in 1.31)

/sig auth
/cc @munnerz @ritazh 