### PR TITLE
[ja] Update blog content files to move translator details in front-matter

### DIFF
--- a/content/ja/blog/_posts/2024-01-23-image-filesystem.md
+++ b/content/ja/blog/_posts/2024-01-23-image-filesystem.md
@@ -5,9 +5,11 @@ date: 2024-01-23
 slug: kubernetes-separate-image-filesystem
 author: >
   Kevin Hannon (Red Hat)
+translator: >
+  Taisuke Okamoto (IDCフロンティア),
+  [Junya Okabe](https://github.com/Okabe-Junya) (筑波大学),
+  nasa9084 (LINEヤフー)
 ---
-
-**翻訳者:** Taisuke Okamoto (IDC Frontier Inc), Junya Okabe (University of Tsukuba), nasa9084 (LY Corporation)
 
 Kubernetesクラスターの稼働、運用する上でよくある問題は、ディスク容量が不足することです。
 ノードがプロビジョニングされる際には、コンテナイメージと実行中のコンテナのために十分なストレージスペースを確保することが重要です。

--- a/content/ja/blog/_posts/2024-02-22-k8s-book-club/index.md
+++ b/content/ja/blog/_posts/2024-02-22-k8s-book-club/index.md
@@ -7,8 +7,6 @@ author: >
   Frederico Muñoz (SAS Institute)
 ---
 
-**著者**: Frederico Muñoz (SAS Institute)
-
 Kubernetesとそれを取り巻く技術のエコシステム全体を学ぶことは、課題がないわけではありません。
 このインタビューでは、[AWSのCarlos Santana](https://www.linkedin.com/in/csantanapr/)さんに、コミュニティベースの学習体験を利用するために、彼がどのようにして[Kubernetesブッククラブ](https://community.cncf.io/kubernetes-virtual-book-club/)を作ったのか、その会がどのような活動をするのか、そしてどのようにして参加するのかについて伺います。
 

--- a/content/ja/blog/_posts/2024-03-07-cri-o-seccomp-oci-artifacts.md
+++ b/content/ja/blog/_posts/2024-03-07-cri-o-seccomp-oci-artifacts.md
@@ -5,9 +5,11 @@ date: 2024-03-07
 slug: cri-o-seccomp-oci-artifacts
 author: >
   Sascha Grunert
+translator: >
+  Taisuke Okamoto (IDCフロンティア),
+  atoato88 (NEC),
+  [Junya Okabe](https://github.com/Okabe-Junya) (筑波大学)
 ---
-
-**翻訳者:** Taisuke Okamoto (IDC Frontier Inc), atoato88 (NEC Corporation), Junya Okabe (University of Tsukuba)
 
 seccompはセキュアなコンピューティングモードを意味し、Linuxカーネルのバージョン2.6.12以降の機能として提供されました。
 これは、プロセスの特権をサンドボックス化し、ユーザースペースからカーネルへの呼び出しを制限するために使用できます。

--- a/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
+++ b/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
@@ -5,9 +5,10 @@ slug: diy-create-your-own-cloud-with-kubernetes-part-1
 date: 2024-04-05T07:30:00+00:00
 author: >
   Andrei Kvapil (Ænix)
+translator: >
+  [Taisuke Okamoto](https://github.com/b1gb4by) (IDCフロンティア),
+  [Junya Okabe](https://github.com/Okabe-Junya) (筑波大学)
 ---
-
-**翻訳者:** [Taisuke Okamoto](https://github.com/b1gb4by) (IDC Frontier Inc), [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba)
 
 Ænixでは、Kubernetesに対する深い愛着があり、近いうちにすべての最新テクノロジーがKubernetesの驚くべきパターンを活用し始めることを夢見ています。
 自分だけのクラウドを構築することを考えたことはありませんか？きっと考えたことがあるでしょう。

--- a/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
+++ b/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
@@ -5,9 +5,12 @@ slug: diy-create-your-own-cloud-with-kubernetes-part-2
 date: 2024-04-05T07:35:00+00:00
 author: >
   Andrei Kvapil (Ænix)
+translator: >
+  [Taisuke Okamoto](https://github.com/b1gb4by) ([IDCフロンティア](https://www.idcf.jp/)),
+  [Daiki Hayakawa(bells17)](https://github.com/bells17) ([3-shake](https://3-shake.com/)),
+  [atoato88](https://github.com/atoato88) ([NEC](https://jpn.nec.com/index.html)),
+  [Kaito Ii](https://github.com/kaitoii11) ([Hewlett Packard Enterprise](https://www.hpe.com/jp/ja/home.html))
 ---
-
-**翻訳者:** [Taisuke Okamoto](https://github.com/b1gb4by) ([IDC Frontier Inc.](https://www.idcf.jp/)), [Daiki Hayakawa(bells17)](https://github.com/bells17) ([3-shake Inc.](https://3-shake.com/en/)), [atoato88](https://github.com/atoato88) ([NEC Corporation](https://jpn.nec.com/index.html)),  [Kaito Ii](https://github.com/kaitoii11) ([Hewlett Packard Enterprise](https://www.hpe.com/jp/ja/home.html))
 
 Kubernetesエコシステムだけを使って自分だけのクラウドを構築する方法について、一連の記事を続けています。
 [前回の記事](/ja/blog/2024/04/05/diy-create-your-own-cloud-with-kubernetes-part-1/)では、Talos LinuxとFlux CDをベースにした基本的なKubernetes ディストリビューションの準備方法を説明しました。

--- a/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-3/index.md
+++ b/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-3/index.md
@@ -5,9 +5,11 @@ slug: diy-create-your-own-cloud-with-kubernetes-part-3
 date: 2024-04-05T07:40:00+00:00
 author: >
   Andrei Kvapil (Ænix)
+translator: >
+  [Taisuke Okamoto](https://github.com/b1gb4by) (IDCフロンティア),
+  [Daiki Hayakawa(bells17)](https://github.com/bells17) ([3-shake](https://3-shake.com/)),
+  [atoato88](https://github.com/atoato88) ([NEC](https://jpn.nec.com/index.html))
 ---
-
-**翻訳者:** [Taisuke Okamoto](https://github.com/b1gb4by) (IDC Frontier Inc), [Daiki Hayakawa(bells17)](https://github.com/bells17) ([3-shake Inc.](https://3-shake.com/en/)), [atoato88](https://github.com/atoato88) ([NEC Corporation](https://jpn.nec.com/index.html))
 
 Kubernetesの中でKubernetesを実行するという最も興味深いフェーズに近づいています。
 この記事では、KamajiやCluster APIなどのテクノロジーとそれらのKubeVirtとの統合について説明します。

--- a/content/ja/blog/_posts/2024-05-20-cloud-provider-migration.md
+++ b/content/ja/blog/_posts/2024-05-20-cloud-provider-migration.md
@@ -8,9 +8,10 @@ author: >
   Michelle Au (Google),
   Walter Fender (Google),
   Michael McCune (Red Hat)
+translator: >
+  Taisuke Okamoto (IDCフロンティア),
+  [Junya Okabe](https://github.com/Okabe-Junya) (筑波大学)
 ---
-
-**翻訳者:** Taisuke Okamoto (IDC Frontier Inc), [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba)
 
 Kubernetes v1.7以降、Kubernetesプロジェクトは、クラウドプロバイダーとの統合機能をKubernetesのコアコンポーネントから分離するという野心的な目標を追求してきました([KEP-2395](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md))。
 この統合機能はKubernetesの初期の開発と成長に重要な役割を果たしつつも、２つの重要な要因によってその分離が推進されました。

--- a/content/ja/blog/_posts/2024-05-21-sig-node-spotlight/index.md
+++ b/content/ja/blog/_posts/2024-05-21-sig-node-spotlight/index.md
@@ -6,9 +6,10 @@ canonicalUrl: https://www.kubernetes.dev/blog/2024/06/20/sig-node-spotlight-2024
 date: 2024-06-20
 author: >
   Arpit Agrawal
+translator: >
+  Taisuke Okamoto (IDCフロンティア),
+  [Junya Okabe](https://github.com/Okabe-Junya) (筑波大学)
 ---
-
-**翻訳者:** [Taisuke Okamoto](https://github.com/b1gb4by) (IDC Frontier Inc), [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba)
 
 コンテナオーケストレーションの世界で、[Kubernetes](/ja)は圧倒的な存在感を示しており、世界中で最も複雑で動的なアプリケーションの一部を動かしています。
 その裏では、Special Interest Groups(SIG)のネットワークがKubernetesの革新と安定性を牽引しています。

--- a/content/ja/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
+++ b/content/ja/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
@@ -10,8 +10,11 @@ author: >
   [Kaslin Fields](https://github.com/kaslin) (Google),
   [Tim Bannister](https://github.com/sftim) (The Scale Factory),
   and every contributor across the globe
+translator: >
+  [Junya Okabe](https://github.com/Okabe-Junya) (筑波大学),
+  [Daiki Hayakawa(bells17)](https://github.com/bells17) ([3-shake](https://3-shake.com/)),
+  [Kaito Ii](https://github.com/kaitoii11) (Hewlett Packard Enterprise)
 ---
-**翻訳者**: [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba), [Daiki Hayakawa(bells17)](https://github.com/bells17) ([3-shake Inc.](https://3-shake.com/en/)), [Kaito Ii](https://github.com/kaitoii11) (Hewlett Packard Enterprise)
 
 ![KCSEU 2024 group photo](kcseu2024.jpg)
 


### PR DESCRIPTION
## Change List

- In #47270, we're updating the blog to manage "translator(s)" as metadata. Some blogs localized into Japanese already have a "translator" set, so migrate those.

### Note

unhold this once #47270 is merged.

### useful links

- Blog Summary (not changed): [link](https://deploy-preview-47286--kubernetes-io-main-staging.netlify.app/ja/blog/)
- Blog Article page (add "Translate By"): [Before](https://kubernetes.io/ja/blog/2024/06/20/sig-node-spotlight-2024/) | [After](https://deploy-preview-47286--kubernetes-io-main-staging.netlify.app/ja/blog/2024/06/20/sig-node-spotlight-2024/)

/hold
