### PR TITLE
[zh] Sync evented-pleg and kubelet-pod-resources-dynamic-resources

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/evented-pleg.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/evented-pleg.md
@@ -8,11 +8,7 @@ _build:
 stages:
   - stage: alpha
     defaultValue: false
-    fromVersion: "1.26"
-    toVersion: "1.26"
-  - stage: beta
-    defaultValue: false
-    fromVersion: "1.27"
+    fromVersion: "1.25"
 ---
 <!--
 Enable support for the kubelet to receive container life cycle events from the

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamic-resources.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamic-resources.md
@@ -15,7 +15,7 @@ stages:
 Extend the kubelet's pod resources gRPC endpoint to
 to include resources allocated in `ResourceClaims` via `DynamicResourceAllocation` API.
 See [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources) for more details.
-with informations about the allocatable resources, enabling clients to properly
+with information about the allocatable resources, enabling clients to properly
 track the free compute resources on a node.
 -->
 扩展 kubelet 的 Pod 资源 gRPC 端点以包括通过


### PR DESCRIPTION
Sync 2 feature gates:

```
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/evented-pleg.md
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-pod-resources-dynamic-resources.md
```