### PR TITLE
Fix up topology manager reference

### DIFF
--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -35,7 +35,7 @@ responsible for these optimizations.
 
 <!-- steps -->
 
-## How Topology Manager Works
+## How topology manager works
 
 Prior to the introduction of Topology Manager, the CPU and Device Manager in Kubernetes make
 resource allocation decisions independently of each other.  This can result in undesirable
@@ -60,7 +60,7 @@ the pod can be accepted or rejected from the node based on the selected hint.
 The hint is then stored in the Topology Manager for use by the *Hint Providers* when making the
 resource allocation decisions.
 
-## Topology Manager Scopes and Policies
+## Topology manager scopes and policies
 
 The Topology Manager currently:
 
@@ -89,7 +89,7 @@ Manager should be enabled and proper Memory Manager policy should be configured 
 [Memory Manager](/docs/tasks/administer-cluster/memory-manager/) documentation.
 {{< /note >}}
 
-### Topology Manager Scopes
+## Topology manager scopes
 
 The Topology Manager can deal with the alignment of resources in a couple of distinct scopes:
 
@@ -100,7 +100,7 @@ Either option can be selected at a time of the kubelet startup, by setting the
 `topologyManagerScope` in the
 [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/).
 
-### container scope
+### `container` scope
 
 The `container` scope is used by default. You can also explicitly set the
 `topologyManagerScope` to `container` in the
@@ -114,7 +114,7 @@ the Topology Manager performs an arbitrary alignment of individual containers to
 The notion of grouping the containers was endorsed and implemented on purpose in the following
 scope, for example the `pod` scope.
 
-### pod scope
+### `pod` scope
 
 To select the `pod` scope, set `topologyManagerScope` in the [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/) to `pod`.`
 
@@ -150,7 +150,7 @@ is present among possible allocations. Reconsider the example above:
 To recap, Topology Manager first computes a set of NUMA nodes and then tests it against Topology
 Manager policy, which either leads to the rejection or admission of the pod.
 
-### Topology Manager Policies
+## Topology manager policies
 
 Topology Manager supports four allocation policies. You can set a policy via a Kubelet flag,
 `--topology-manager-policy`. There are four supported policies:
@@ -166,11 +166,11 @@ the policy, is reflecting requirements of the entire pod, and thus each containe
 will result with **the same** topology alignment decision.
 {{< /note >}}
 
-### none policy {#policy-none}
+### `none` policy {#policy-none}
 
 This is the default policy and does not perform any topology alignment.
 
-### best-effort policy {#policy-best-effort}
+### `best-effort` policy {#policy-best-effort}
 
 For each container in a Pod, the kubelet, with `best-effort` topology management policy, calls
 each Hint Provider to discover their resource availability. Using this information, the Topology
@@ -180,7 +180,7 @@ preferred, Topology Manager will store this and admit the pod to the node anyway
 The *Hint Providers* can then use this information when making the
 resource allocation decision.
 
-### restricted policy {#policy-restricted}
+### `restricted` policy {#policy-restricted}
 
 For each container in a Pod, the kubelet, with `restricted` topology management policy, calls each
 Hint Provider to discover their resource availability.  Using this information, the Topology
@@ -196,7 +196,7 @@ have the `Topology Affinity` error.
 If the pod is admitted, the *Hint Providers* can then use this information when making the
 resource allocation decision.
 
-### single-numa-node policy {#policy-single-numa-node}
+### `single-numa-node` policy {#policy-single-numa-node}
 
 For each container in a Pod, the kubelet, with `single-numa-node` topology management policy,
 calls each Hint Provider to discover their resource availability.  Using this information, the
@@ -211,7 +211,7 @@ reschedule the pod. It is recommended to use a Deployment with replicas to trigg
 the Pod.An external control loop could be also implemented to trigger a redeployment of pods
 that have the `Topology Affinity` error.
 
-### Topology manager policy options
+## Topology manager policy options
 
 Support for the Topology Manager policy options requires `TopologyManagerPolicyOptions`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to be enabled
@@ -251,7 +251,7 @@ The following policy options exists:
   Future, potential improvements to Kubernetes may improve Pod admission performance and the high
   latency that happens as the number of NUMA nodes increases.
 
-### Pod Interactions with Topology Manager Policies
+## Pod interactions with topology manager policies
 
 Consider the containers in the following pod specs:
 
@@ -360,7 +360,7 @@ Using this information the Topology Manager calculates the optimal hint for the 
 this information, which will be used by the Hint Providers when they are making their resource
 assignments.
 
-### Known Limitations
+## Known limitations
 
 1. The maximum number of NUMA nodes that Topology Manager allows is 8. With more than 8 NUMA nodes
    there will be a state explosion when trying to enumerate the possible NUMA affinities and

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -96,12 +96,15 @@ The Topology Manager can deal with the alignment of resources in a couple of dis
 * `container` (default)
 * `pod`
 
-Either option can be selected at a time of the kubelet startup, with `--topology-manager-scope`
-flag.
+Either option can be selected at a time of the kubelet startup, by setting the
+`topologyManagerScope` in the
+[kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/).
 
 ### container scope
 
-The `container` scope is used by default.
+The `container` scope is used by default. You can also explicitly set the
+`topologyManagerScope` to `container` in the
+[kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/).
 
 Within this scope, the Topology Manager performs a number of sequential resource alignments, i.e.,
 for each container (in a pod) a separate alignment is computed. In other words, there is no notion
@@ -113,7 +116,7 @@ scope, for example the `pod` scope.
 
 ### pod scope
 
-To select the `pod` scope, start the kubelet with the command line option `--topology-manager-scope=pod`.
+To select the `pod` scope, set `topologyManagerScope` in the [kubelet configuration file](/docs/tasks/administer-cluster/kubelet-config-file/) to `pod`.`
 
 This scope allows for grouping all containers in a pod to a common set of NUMA nodes. That is, the
 Topology Manager treats a pod as a whole and attempts to allocate the entire pod (all containers)

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -78,13 +78,13 @@ carry out the alignment (e.g. `best-effort`, `restricted`, `single-numa-node`, e
 Details on the various `scopes` and `policies` available today can be found below.
 
 {{< note >}}
-To align CPU resources with other requested resources in a Pod Spec, the CPU Manager should be
+To align CPU resources with other requested resources in a Pod spec, the CPU Manager should be
 enabled and proper CPU Manager policy should be configured on a Node.
 See [control CPU Management Policies](/docs/tasks/administer-cluster/cpu-management-policies/).
 {{< /note >}}
 
 {{< note >}}
-To align memory (and hugepages) resources with other requested resources in a Pod Spec, the Memory
+To align memory (and hugepages) resources with other requested resources in a Pod spec, the Memory
 Manager should be enabled and proper Memory Manager policy should be configured on a Node. Examine
 [Memory Manager](/docs/tasks/administer-cluster/memory-manager/) documentation.
 {{< /note >}}


### PR DESCRIPTION
Improve the v1.31 version of https://k8s.io/docs/tasks/administer-cluster/topology-manager/
- Write headings in sentence case per [style guide](https://kubernetes.io/docs/contribute/style/style-guide/)
- Revise the guidance about setting topology manager policy options
  - Give each item a bookmarkable heading
  - Overall rewording
- Recommend configuring kubelet via its configuration file; command line arguments are largely deprecated
- Write the technical text of headings in backticks (eg `pod` scope not pod scope)

This is basically reference content. A future PR may move the page inside https://k8s.io/docs/reference/node/; for now, let's not do that part.

[Before](https://kubernetes-io-vnext-staging.netlify.app/docs/tasks/administer-cluster/topology-manager/) _vs_ [after](https://deploy-preview-47318--kubernetes-io-main-staging.netlify.app/docs/tasks/administer-cluster/topology-manager/); notice the revised right-hand navigation.

/sig docs
/language en

@LaurentGoderre FYI