### PR TITLE
Set (partial) release information for v1.31

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -142,9 +142,9 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.30"
+latest = "v1.31"
 
-version = "v1.30"
+version = "v1.31"
 githubbranch = "main"
 docsbranch = "main"
 deprecated = false
@@ -184,10 +184,16 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.30"
-githubbranch = "v1.30.0"
+version = "v1.31"
+githubbranch = "v1.31.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
+
+[[params.versions]]
+version = "v1.30"
+githubbranch = "v1.30.0"
+docsbranch = "release-1.30"
+url = "https://v1-30.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.29"
@@ -206,12 +212,6 @@ version = "v1.27"
 githubbranch = "v1.27.12"
 docsbranch = "release-1.27"
 url = "https://v1-27.docs.kubernetes.io"
-
-[[params.versions]]
-version = "v1.26"
-githubbranch = "v1.26.15"
-docsbranch = "release-1.26"
-url = "https://v1-26.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Set the v1.31 release branch to be for Kubernetes v1.31

This change does **not** cover [`/data/releases`](https://github.com/kubernetes/website/tree/main/data/releases), which also needs doing.

/sig release