### PR TITLE
Update pod disruption condition to align with the implementation

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -254,7 +254,9 @@ indicates one of the following reasons for the Pod termination:
 : Pod, that is bound to a no longer existing Node, is due to be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection).
 
 `TerminationByKubelet`
-: Pod has been terminated by the kubelet, because of either {{<glossary_tooltip term_id="node-pressure-eviction" text="node pressure eviction">}} or the [graceful node shutdown](/docs/concepts/architecture/nodes/#graceful-node-shutdown).
+: Pod has been terminated by the kubelet, because of either {{<glossary_tooltip term_id="node-pressure-eviction" text="node pressure eviction">}},
+  the [graceful node shutdown](/docs/concepts/architecture/nodes/#graceful-node-shutdown),
+  or preemption for [system critical pods](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
 
 {{< note >}}
 A Pod disruption might be interrupted. The control plane might re-attempt to


### PR DESCRIPTION
### Description

Add "or preemption for system critical pods" to align the docs with the actual implementation. 

### Issue

This was done in https://github.com/kubernetes/kubernetes/pull/117586

It is also already reflected in the KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures#beta: "Add DisruptionTarget condition for pods which are preempted by Kubelet to make room for critical pods. Also, backport this fix to 1.26 and 1.27 release branches, and update the user-facing documentation to reflect this change."