### PR TITLE
Update release schedule for v1.31

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,6 +4,14 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 schedules:
+- endOfLifeDate: "2025-10-28"
+  maintenanceModeStartDate: "2025-08-28"
+  next:
+    cherryPickDeadline: "2024-09-06"
+    release: 1.31.1
+    targetDate: "2024-09-11"
+  release: "1.31"
+  releaseDate: "2024-08-13"
 - endOfLifeDate: "2025-06-28"
   maintenanceModeStartDate: "2025-04-28"
   next:


### PR DESCRIPTION
Add an entry for v1.31 on the releases schedule, as described [here](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#update-releases-page-the-week-before-the-release)

cc: @katcosgrove @saschagrunert @drewhagen @salaxander @sftim 