### PR TITLE
Fix table rendering issue inside admonition blocks

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1470,3 +1470,14 @@ section.k8s-birthday-override:has(div.k8s-birthday-override.revert-to-previous i
   display: none;
   visibility: hidden;
 }
+
+/* Apply site-wide table styles for tables in alert callouts (note, caution, warning) */
+.alert {
+  &.alert-info, &.alert-caution, &.alert-danger {
+    > table {
+    @extend .table-striped;
+    @extend .table-responsive;
+    @extend .table;
+    }
+  }
+}

--- a/content/en/docs/test.md
+++ b/content/en/docs/test.md
@@ -370,7 +370,12 @@ Notes catch the reader's attention without a sense of urgency.
 
 You can have multiple paragraphs and block-level elements inside an admonition.
 
-| Or | a | table |
+You can also add tables to organize and highlight key information.
+
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------- | -------- |
+| Data 1   | Data A   | Info X   |
+| Data 2   | Data B   | Info Y   |
 {{< /note >}}
 
 {{< caution >}}


### PR DESCRIPTION
This PR addresses the issue where tables inside alert callouts _(note, caution, warning)_ were not rendering correctly due to missing styles. 

The proposed fix applies the same styling classes used for tables across the site to tables within alert callouts (notes, cautions, warnings), ensuring that they are consistently styled and properly displayed.

Fixes https://github.com/kubernetes/website/issues/37500

[Preview Fixed Table Rendering](https://deploy-preview-47365--kubernetes-io-main-staging.netlify.app/docs/test/#admonitions) | [Current Page with rendering issue](https://kubernetes.io/docs/test/#admonitions)

/area web-development