### PR TITLE
Updates v1.27 hugo.toml for 1.31 release

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -138,10 +138,10 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.30"
+latest = "v1.31"
 
 version = "v1.27"
-githubbranch = "v1.27.12"
+githubbranch = "v1.27.16"
 docsbranch = "release-1.27"
 deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
@@ -180,26 +180,32 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.30"
-githubbranch = "v1.30.0"
+version = "v1.31"
+githubbranch = "v1.31.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
+version = "v1.30"
+githubbranch = "v1.30.3"
+docsbranch = "release-1.30"
+url = "https://v1-30.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.29"
-githubbranch = "v1.29.3"
+githubbranch = "v1.29.7"
 docsbranch = "release-1.29"
 url = "https://v1-29.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.28"
-githubbranch = "v1.28.8"
+githubbranch = "v1.28.12"
 docsbranch = "release-1.28"
 url = "https://v1-28.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.27"
-githubbranch = "v1.27.12"
+githubbranch = "v1.27.16"
 docsbranch = "release-1.27"
 url = "https://v1-27.docs.kubernetes.io"
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -209,12 +209,6 @@ githubbranch = "v1.27.16"
 docsbranch = "release-1.27"
 url = "https://v1-27.docs.kubernetes.io"
 
-[[params.versions]]
-version = "v1.26"
-githubbranch = "v1.26.15"
-docsbranch = "release-1.26"
-url = "https://v1-26.docs.kubernetes.io"
-
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.


### PR DESCRIPTION
Updating site configuration files (hugo.toml) for release v1.31.

/hold until v1.31 release day.

cc: @drewhagen @chanieljdan @salaxander 