### PR TITLE
Delay August patch releases one day

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -9,7 +9,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-08-09"
     release: 1.30.4
-    targetDate: "2024-08-13"
+    targetDate: "2024-08-14"
   previousPatches:
   - cherryPickDeadline: "2024-07-12"
     release: 1.30.3
@@ -29,7 +29,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-08-09"
     release: 1.29.8
-    targetDate: "2024-08-13"
+    targetDate: "2024-08-14"
   previousPatches:
   - cherryPickDeadline: "2024-07-12"
     release: 1.29.7
@@ -61,7 +61,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-08-09"
     release: 1.28.13
-    targetDate: "2024-08-13"
+    targetDate: "2024-08-14"
   previousPatches:
   - cherryPickDeadline: "2024-07-12"
     release: 1.28.12
@@ -106,7 +106,7 @@ schedules:
   releaseDate: "2023-08-15"
 upcoming_releases:
 - cherryPickDeadline: "2024-08-09"
-  targetDate: "2024-08-13"
+  targetDate: "2024-08-14"
 - cherryPickDeadline: "2024-09-06"
   targetDate: "2024-09-10"
 - cherryPickDeadline: "2024-10-11"


### PR DESCRIPTION
### Description

This PR updates the schedule to delay the August patch releases by one day due to the 1.31 release occurring the same day. 
