### PR TITLE
Document labels, annotations and taints for JobSet

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2332,6 +2332,126 @@ Starting in v1.16, this annotation was removed in favor of
 [Pod Priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/).
 {{< /note >}}
 
+### jobset.sigs.k8s.io/jobset-name
+
+Type: Label
+
+Example:  `jobset.sigs.k8s.io/jobset-name: "my-jobset"`
+
+Used on: Jobs, Pods
+
+This label is used to store the name of the JobSet to which a job or pod belongs.
+
+### jobset.sigs.k8s.io/replicatedjob-replicas
+
+Type: Annotation
+
+Example: `jobset.sigs.k8s.io/replicatedjob-replicas: "5"`
+
+Used on: ReplicatedJobs
+
+This annotation specifies the number of replicas for a ReplicatedJob.
+
+### jobset.sigs.k8s.io/replicatedjob-name
+
+Type: Label
+
+Example: `jobset.sigs.k8s.io/replicatedjob-name: "my-replicatedjob"`
+
+Used on: Jobs
+
+This label is used to index into a job's labels and retrieve the name of the parent ReplicatedJob.
+
+### jobset.sigs.k8s.io/job-index
+
+Type: Annotation
+
+Example: `jobset.sigs.k8s.io/job-index: "0"`
+
+Used on: Jobs
+
+ This annotation stores the index of the job within the ReplicatedJob.
+
+### jobset.sigs.k8s.io/job-key
+
+Type: Label
+
+Example: `jobset.sigs.k8s.io/job-key: "my-job-key"`
+
+Used on: Jobs
+
+This label provides a unique key for the job.
+
+### job-name
+
+Type: Label
+
+Example: `job-name: "my-job"`
+
+Used on: Jobs
+
+This label stores the name of the job.
+
+### alpha.jobset.sigs.k8s.io/exclusive-topology
+
+Type: Annotation
+
+Example: `alpha.jobset.sigs.k8s.io/exclusive-topology: "zone"`
+
+Used on: JobSets, ReplicatedJobs
+
+ This annotation can be set on a JobSet or a ReplicatedJob template to ensure exclusive job placement per topology group.
+
+### alpha.jobset.sigs.k8s.io/node-selector
+
+Type: Annotation
+
+Example: `alpha.jobset.sigs.k8s.io/node-selector: ""`
+
+Used on: JobSets
+
+This annotation acts as a flag. When set, the JobSet controller injects nodeSelectors for the JobSetNameKey label to ensure exclusive job placement per topology.
+
+### alpha.jobset.sigs.k8s.io/namespaced-job
+
+Type: Annotation
+
+Example: `alpha.jobset.sigs.k8s.io/namespaced-job: "true"`
+
+Used on: Jobs
+
+This annotation indicates that the job is namespaced.
+
+### alpha.jobset.sigs.k8s.io/no-schedule
+
+Type: Annotation
+
+Example: `alpha.jobset.sigs.k8s.io/no-schedule: "true"`
+
+Used on: Jobs
+
+This annotation prevents the job from being scheduled.
+
+### jobset.sigs.k8s.io/jobset-controller
+
+Type: Label
+
+Example: `jobset.sigs.k8s.io/jobset-controller: "jobset-controller"`
+
+Used on: Jobs
+
+This label is used for the `managedBy` field to indicate that the job is managed by the built-in JobSet controller.
+
+### jobset.sigs.k8s.io/coordinator
+
+Type: Annotation, Label
+
+Example: `jobset.sigs.k8s.io/coordinator: "coordinator-endpoint"`
+
+Used on: Jobs, Pods
+
+This annotation/label is used on Jobs and Pods to store a stable network endpoint where the coordinator pod can be reached if the JobSet spec defines the `.spec.coordinator` field.
+
 ## Annotations used for audit
 
 <!-- sorted by annotation -->

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2340,7 +2340,8 @@ Example:  `jobset.sigs.k8s.io/jobset-name: "my-jobset"`
 
 Used on: Jobs, Pods
 
-This label is used to store the name of the JobSet to which a job or pod belongs.
+This label is used to store the name of the JobSet to which a Job or Pod belongs.
+JobSet is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/replicatedjob-replicas
 
@@ -2351,6 +2352,7 @@ Example: `jobset.sigs.k8s.io/replicatedjob-replicas: "5"`
 Used on: ReplicatedJobs
 
 This annotation specifies the number of replicas for a ReplicatedJob.
+ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/replicatedjob-name
 
@@ -2360,7 +2362,8 @@ Example: `jobset.sigs.k8s.io/replicatedjob-name: "my-replicatedjob"`
 
 Used on: Jobs
 
-This label is used to index into a job's labels and retrieve the name of the parent ReplicatedJob.
+This label is used to index into a Job's labels and retrieve the name of the parent ReplicatedJob.
+ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/job-index
 
@@ -2370,7 +2373,8 @@ Example: `jobset.sigs.k8s.io/job-index: "0"`
 
 Used on: Jobs
 
- This annotation stores the index of the job within the ReplicatedJob.
+This annotation stores the index of the Job within the ReplicatedJob.
+ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/job-key
 
@@ -2382,16 +2386,6 @@ Used on: Jobs
 
 This label provides a unique key for the job.
 
-### job-name
-
-Type: Label
-
-Example: `job-name: "my-job"`
-
-Used on: Jobs
-
-This label stores the name of the job.
-
 ### alpha.jobset.sigs.k8s.io/exclusive-topology
 
 Type: Annotation
@@ -2400,7 +2394,8 @@ Example: `alpha.jobset.sigs.k8s.io/exclusive-topology: "zone"`
 
 Used on: JobSets, ReplicatedJobs
 
- This annotation can be set on a JobSet or a ReplicatedJob template to ensure exclusive job placement per topology group.
+You can set this annotation on a JobSet or a ReplicatedJob template to ensure exclusive job placement per topology group.
+JobSet and ReplicaSet are extension APIs that you can deploy into your Kubernetes cluster.
 
 ### alpha.jobset.sigs.k8s.io/node-selector
 
@@ -2410,7 +2405,7 @@ Example: `alpha.jobset.sigs.k8s.io/node-selector: ""`
 
 Used on: JobSets
 
-This annotation acts as a flag. When set, the JobSet controller injects nodeSelectors for the JobSetNameKey label to ensure exclusive job placement per topology.
+This annotation acts as a flag. When set, the JobSet controller injects nodeSelectors for the `JobSetNameKey` label (e.g., `jobset.sigs.k8s.io/jobset-name`) to ensure exclusive job placement per topology.
 
 ### alpha.jobset.sigs.k8s.io/namespaced-job
 
@@ -2424,23 +2419,14 @@ This annotation indicates that the job is namespaced.
 
 ### alpha.jobset.sigs.k8s.io/no-schedule
 
-Type: Annotation
+Type: Taint
 
-Example: `alpha.jobset.sigs.k8s.io/no-schedule: "true"`
+Example: `alpha.jobset.sigs.k8s.io/no-schedule: NoSchedule`
 
-Used on: Jobs
+Used on: Nodes
 
-This annotation prevents the job from being scheduled.
-
-### jobset.sigs.k8s.io/jobset-controller
-
-Type: Label
-
-Example: `jobset.sigs.k8s.io/jobset-controller: "jobset-controller"`
-
-Used on: Jobs
-
-This label is used for the `managedBy` field to indicate that the job is managed by the built-in JobSet controller.
+The JobSet controller uses this taint to support its node labeling exclusive placement strategy.
+JobSet is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/coordinator
 
@@ -2450,7 +2436,9 @@ Example: `jobset.sigs.k8s.io/coordinator: "coordinator-endpoint"`
 
 Used on: Jobs, Pods
 
-This annotation/label is used on Jobs and Pods to store a stable network endpoint where the coordinator pod can be reached if the JobSet spec defines the `.spec.coordinator` field.
+This annotation/label is used on Jobs and Pods to store a stable network endpoint where the coordinator
+pod can be reached if the JobSet spec defines the `.spec.coordinator` field.
+JobSet is an extension API that you can deploy into your Kubernetes cluster.
 
 ## Annotations used for audit
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2334,84 +2334,81 @@ Starting in v1.16, this annotation was removed in favor of
 
 ### jobset.sigs.k8s.io/jobset-name
 
-Type: Label
+Type: Label, Annotation
 
 Example:  `jobset.sigs.k8s.io/jobset-name: "my-jobset"`
 
 Used on: Jobs, Pods
 
-This label is used to store the name of the JobSet to which a Job or Pod belongs.
-JobSet is an extension API that you can deploy into your Kubernetes cluster.
+This label/annotation is used to store the name of the JobSet to which a Job or Pod belongs.
+[JobSet](https://jobset.sigs.k8s.io) is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/replicatedjob-replicas
 
-Type: Annotation
+Type: Label, Annotation
 
 Example: `jobset.sigs.k8s.io/replicatedjob-replicas: "5"`
 
 Used on: ReplicatedJobs
 
-This annotation specifies the number of replicas for a ReplicatedJob.
-ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
+This label/annotation specifies the number of replicas for a ReplicatedJob.
 
 ### jobset.sigs.k8s.io/replicatedjob-name
 
-Type: Label
+Type: Label, Annotation
 
 Example: `jobset.sigs.k8s.io/replicatedjob-name: "my-replicatedjob"`
 
-Used on: Jobs
+Used on: Jobs, Pods
 
-This label is used to index into a Job's labels and retrieve the name of the parent ReplicatedJob.
+This label/annotation is used to index into a Job's labels and retrieve the name of the parent ReplicatedJob.
 ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/job-index
 
-Type: Annotation
+Type: Label, Annotation
 
 Example: `jobset.sigs.k8s.io/job-index: "0"`
 
-Used on: Jobs
+Used on: Jobs, Pods
 
-This annotation stores the index of the Job within the ReplicatedJob.
-ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
+This label/annotation is set by the JobSet controller on child Jobs and Pods. It contains the index of the Job replica within its parent ReplicatedJob.
 
 ### jobset.sigs.k8s.io/job-key
 
-Type: Label
+Type: Label, Annotation
 
-Example: `jobset.sigs.k8s.io/job-key: "my-job-key"`
+Example: `jobset.sigs.k8s.io/job-key=0f1e93893c4cb372080804ddb9153093cb0d20cefdd37f653e739c232d363feb`
 
-Used on: Jobs
+Used on: Jobs, Pods
 
-This label provides a unique key for the job.
+This label/annotation is set by the JobSet controller on child Jobs and Pods of a JobSet. The value will be the SHA256 hash of the namespaced Job name.
 
 ### alpha.jobset.sigs.k8s.io/exclusive-topology
 
-Type: Annotation
+Type: Label, Annotation
 
 Example: `alpha.jobset.sigs.k8s.io/exclusive-topology: "zone"`
 
 Used on: JobSets, ReplicatedJobs
 
-You can set this annotation on a JobSet or a ReplicatedJob template to ensure exclusive job placement per topology group.
-JobSet and ReplicaSet are extension APIs that you can deploy into your Kubernetes cluster.
+You can set this label/annotation on a [JobSet](https://jobset.sigs.k8s.io) or a ReplicatedJob template to ensure exclusive job placement per topology group.
 
 ### alpha.jobset.sigs.k8s.io/node-selector
 
-Type: Annotation
+Type: Label, Annotation
 
 Example: `alpha.jobset.sigs.k8s.io/node-selector-strategy=true`
 
-Used on: JObs ,Pods
+Used on: Jobs ,Pods
 
-This annotation can be applied to a JobSet. When it's set, the JobSet controller modifies the Jobs and their corresponding Pods by adding node selectors. This ensures exclusive job placement per topology domain, restricting the scheduling of these Pods to specific nodes based on the strategy.
+This label/annotation can be applied to a JobSet. When it's set, the JobSet controller modifies the Jobs and their corresponding Pods by adding node selectors. This ensures exclusive job placement per topology domain, restricting the scheduling of these Pods to specific nodes based on the strategy.
 
 ### alpha.jobset.sigs.k8s.io/namespaced-job
 
 Type: Annotation, Label
 
-Example: `alpha.jobset.sigs.k8s.io/namespaced-job:my-jobset-replicatedjob-A-0`
+Example: `alpha.jobset.sigs.k8s.io/default_myjobset-replicatedjob-0`
 
 Used on: Jobs, Pods
 
@@ -2425,20 +2422,18 @@ Example: `alpha.jobset.sigs.k8s.io/no-schedule: NoSchedule`
 
 Used on: Nodes
 
-The JobSet controller uses this taint to support its node labeling exclusive placement strategy.
-JobSet is an extension API that you can deploy into your Kubernetes cluster.
+The [JobSet](https://jobset.sigs.k8s.io) controller uses this taint to support its node labeling exclusive placement strategy.
 
 ### jobset.sigs.k8s.io/coordinator
 
 Type: Annotation, Label
 
-Example: `jobset.sigs.k8s.io/coordinator: "coordinator-endpoint"`
+Example: `jobset.sigs.k8s.io/coordinator: "myjobset-workers-0-0.headless-svc"`
 
 Used on: Jobs, Pods
 
 This annotation/label is used on Jobs and Pods to store a stable network endpoint where the coordinator
-pod can be reached if the JobSet spec defines the `.spec.coordinator` field.
-JobSet is an extension API that you can deploy into your Kubernetes cluster.
+pod can be reached if the [JobSet](https://jobset.sigs.k8s.io) spec defines the `.spec.coordinator` field.
 
 ## Annotations used for audit
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2361,7 +2361,7 @@ Example: `jobset.sigs.k8s.io/replicatedjob-name: "my-replicatedjob"`
 
 Used on: Jobs, Pods
 
-This label/annotation stores the name of the ReplicatedJob that this Job or Pod is part of.
+This label or annotation stores the name of the replicated job that this Job or Pod is part of.
 
 ### jobset.sigs.k8s.io/job-index
 
@@ -2381,7 +2381,8 @@ Example: `jobset.sigs.k8s.io/job-key=0f1e93893c4cb372080804ddb9153093cb0d20cefdd
 
 Used on: Jobs, Pods
 
-This label/annotation is set by the JobSet controller on child Jobs and Pods of a JobSet. The value will be the SHA256 hash of the namespaced Job name.
+The JobSet controller sets this label (and also an annotation with the same key)  on child Jobs and
+Pods of a JobSet. The value is the SHA256 hash of the namespaced Job name.
 
 ### alpha.jobset.sigs.k8s.io/exclusive-topology
 
@@ -2391,7 +2392,9 @@ Example: `alpha.jobset.sigs.k8s.io/exclusive-topology: "zone"`
 
 Used on: JobSets, ReplicatedJobs
 
-You can set this label/annotation on a [JobSet](https://jobset.sigs.k8s.io) or a ReplicatedJob template to ensure exclusive job placement per topology group.
+You can set this label/annotation on a [JobSet](https://jobset.sigs.k8s.io) to ensure exclusive Job
+placement per topology group. You can also define this label or annotation on a replicated job
+template. Read the documentation for JobSet to learn more.
 
 ### alpha.jobset.sigs.k8s.io/node-selector
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2401,21 +2401,21 @@ JobSet and ReplicaSet are extension APIs that you can deploy into your Kubernete
 
 Type: Annotation
 
-Example: `alpha.jobset.sigs.k8s.io/node-selector: ""`
+Example: `alpha.jobset.sigs.k8s.io/node-selector-strategy=true`
 
-Used on: JobSets
+Used on: JObs ,Pods
 
-This annotation acts as a flag. When set, the JobSet controller injects nodeSelectors for the `JobSetNameKey` label (e.g., `jobset.sigs.k8s.io/jobset-name`) to ensure exclusive job placement per topology.
+This annotation can be applied to a JobSet. When it's set, the JobSet controller modifies the Jobs and their corresponding Pods by adding node selectors. This ensures exclusive job placement per topology domain, restricting the scheduling of these Pods to specific nodes based on the strategy.
 
 ### alpha.jobset.sigs.k8s.io/namespaced-job
 
-Type: Annotation
+Type: Annotation, Label
 
-Example: `alpha.jobset.sigs.k8s.io/namespaced-job: "true"`
+Example: `alpha.jobset.sigs.k8s.io/namespaced-job:my-jobset-replicatedjob-A-0`
 
-Used on: Jobs
+Used on: Jobs, Pods
 
-This annotation indicates that the job is namespaced.
+The JobSet controller adds this label/annotation to Jobs and Pods that are part of a JobSet. It stores the namespaced Job name, which is used for logging and event management within the JobSet context.
 
 ### alpha.jobset.sigs.k8s.io/no-schedule
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2362,7 +2362,6 @@ Example: `jobset.sigs.k8s.io/replicatedjob-name: "my-replicatedjob"`
 Used on: Jobs, Pods
 
 This label/annotation is used to index into a Job's labels and retrieve the name of the parent ReplicatedJob.
-ReplicatedJob is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/job-index
 
@@ -2400,7 +2399,7 @@ Type: Label, Annotation
 
 Example: `alpha.jobset.sigs.k8s.io/node-selector-strategy=true`
 
-Used on: Jobs ,Pods
+Used on: Jobs, Pods
 
 This label/annotation can be applied to a JobSet. When it's set, the JobSet controller modifies the Jobs and their corresponding Pods by adding node selectors. This ensures exclusive job placement per topology domain, restricting the scheduling of these Pods to specific nodes based on the strategy.
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2340,7 +2340,7 @@ Example:  `jobset.sigs.k8s.io/jobset-name: "my-jobset"`
 
 Used on: Jobs, Pods
 
-This label/annotation is used to store the name of the JobSet to which a Job or Pod belongs.
+This label/annotation is used to store the name of the JobSet that a Job or Pod belongs to.
 [JobSet](https://jobset.sigs.k8s.io) is an extension API that you can deploy into your Kubernetes cluster.
 
 ### jobset.sigs.k8s.io/replicatedjob-replicas
@@ -2361,7 +2361,7 @@ Example: `jobset.sigs.k8s.io/replicatedjob-name: "my-replicatedjob"`
 
 Used on: Jobs, Pods
 
-This label/annotation is used to index into a Job's labels and retrieve the name of the parent ReplicatedJob.
+This label/annotation stores the name of the ReplicatedJob that this Job or Pod is part of.
 
 ### jobset.sigs.k8s.io/job-index
 


### PR DESCRIPTION
Adding labels and annotation for JobSet in https://github.com/kubernetes/website/blob/main/content/en/docs/reference/labels-annotations-taints/_index.md

Fixes #47373

/language en