### PR TITLE
Updates v1.30 hugo.toml for 1.31 release

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -196,7 +196,14 @@ docsbranch = "release-1.30"
 url = "https://v1-30.docs.kubernetes.io"
 
 [[params.versions]]
+version = "v1.30"
+githubbranch = "v1.30.3"
+docsbranch = "release-1.30"
+url = "https://v1-30.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.29"
+githubbranch = "v1.29.7"
 githubbranch = "v1.29.7"
 docsbranch = "release-1.29"
 url = "https://v1-29.docs.kubernetes.io"
@@ -209,6 +216,7 @@ url = "https://v1-28.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.27"
+githubbranch = "v1.27.16"
 githubbranch = "v1.27.16"
 docsbranch = "release-1.27"
 url = "https://v1-27.docs.kubernetes.io"


### PR DESCRIPTION
Updates v1.30 hugo.toml for 1.31 release

This PR updates the hugo.toml for v1.30 ahead of the v1.31 release.

Base branch will be updated from main to release-1.30 once that branch exists (to be created a day before release day).

/hold for v1.31 release day

cc: @chanieljdan @salaxander @katcosgrove @reylejano @Princesso 