### PR TITLE
Updates v1.31 hugo.toml to include latest patches ahead of release

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -191,25 +191,25 @@ url = "https://kubernetes.io"
 
 [[params.versions]]
 version = "v1.30"
-githubbranch = "v1.30.0"
+githubbranch = "v1.30.3"
 docsbranch = "release-1.30"
 url = "https://v1-30.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.29"
-githubbranch = "v1.29.3"
+githubbranch = "v1.29.7"
 docsbranch = "release-1.29"
 url = "https://v1-29.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.28"
-githubbranch = "v1.28.8"
+githubbranch = "v1.28.12"
 docsbranch = "release-1.28"
 url = "https://v1-28.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.27"
-githubbranch = "v1.27.12"
+githubbranch = "v1.27.16"
 docsbranch = "release-1.27"
 url = "https://v1-27.docs.kubernetes.io"
 


### PR DESCRIPTION
Updates the site configuration (hugo.toml) for dev-1.31 ahead of v1.31 release date.

#### Note:
This PR satisfies the [Update the site configuration files for future release](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#update-the-site-configuration-files-for-future-release) task in the Release Docs handbook, adding the latest patch versions into the site config so that will get merged into `main` once we release. I will update the handbook with a link to this example to make this clear in later release cycles.
Thanks!
cc: @chanieljdan @salaxander @Princesso @katcosgrove @reylejano 