### PR TITLE
Fix v1.29 docs incorrectly not marked as stale

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -147,7 +147,7 @@ latest = "v1.30"
 version = "v1.29"
 githubbranch = "v1.29.3"
 docsbranch = "release-1.29"
-deprecated = false
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 


### PR DESCRIPTION
This pull request updates the `hugo.toml` configuration file in the **release-1.29** branch by setting the `deprecated` field from 'false' to 'true'. This change will trigger a deprecation banner in the v1.29 documentation, alerting users that docs support for this version has ended.

Please be aware that the current latest release is **v1.30**  _(as of the time this PR was created)_.

[Preview v1.29 Docs](https://deploy-preview-47395--k8s-v1-29.netlify.app/docs/home/) | [Existing v1.29 Docs](https://v1-29.docs.kubernetes.io/docs/home/)