### PR TITLE
Update docker-cli-to-kubectl.md, add the missing newline

### DIFF
--- a/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -15,6 +15,7 @@ You can use the Kubernetes command line tool `kubectl` to interact with the API 
 ## docker run
 
 To run an nginx Deployment and expose the Deployment, see [kubectl create deployment](/docs/reference/generated/kubectl/kubectl-commands#-em-deployment-em-).
+
 docker:
 
 ```shell


### PR DESCRIPTION
Add the missing newline before `docker`
<img width="781" alt="截屏2024-08-08 16 20 47" src="https://github.com/user-attachments/assets/53a6fe13-57cd-4953-8128-32145c1bd799">
