### PR TITLE
Clarify expiration time for service accounts and tokens of pods pending deletion despite finalizers

### DIFF
--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -75,8 +75,9 @@ stored as extra 'private claims' in the issued JWT.
 
 When a bound token is presented to the kube-apiserver, the service account authenticator
 will extract and verify these claims.
-If the referenced object or the service account is pending deletion (for example, due to finalizers),
-the request will not be authenticated after 1 minute of the `.metadata.deletionTimestamp`.
+If the referenced object or the ServiceAccount is pending deletion (for example, due to finalizers),
+then for any instant that is 60 seconds (or more) after the `.metadata.deletionTimestamp` date,
+authentication with that token would fail.
 If the referenced object no longer exists (or its `metadata.uid` does not match),
 the request will not be authenticated.
 

--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -75,6 +75,8 @@ stored as extra 'private claims' in the issued JWT.
 
 When a bound token is presented to the kube-apiserver, the service account authenticator
 will extract and verify these claims.
+If the referenced object or the service account is pending deletion (for example, due to finalizers),
+the request will not be authenticated after 1 minute of the `.metadata.deletionTimestamp`.
 If the referenced object no longer exists (or its `metadata.uid` does not match),
 the request will not be authenticated.
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -59,8 +59,10 @@ When a Pod authenticates as a ServiceAccount, its level of access depends on the
 in use.
 
 The API credentials are automatically revoked when the Pod is deleted, even if
-finalizers are in place. In particular, the API credentials are revoked after 1
-minute of the `.metadata.deletionTimestamp`, which includes the grace period.
+finalizers are in place. In particular, the API credentials are revoked 60 seconds
+beyond the `.metadata.deletionTimestamp` set on the Pod (the deletion timestamp
+is typically the time that the **delete** request was accepted plus the Pod's
+termination grace period).
 
 ### Opt out of API credential automounting
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -58,6 +58,10 @@ When a Pod authenticates as a ServiceAccount, its level of access depends on the
 [authorization plugin and policy](/docs/reference/access-authn-authz/authorization/#authorization-modules)
 in use.
 
+The API credentials are automatically revoked when the Pod is deleted, even if
+finalizers are in place. In particular, the API credentials are revoked after 1
+minute of the `.metadata.deletionTimestamp`, which includes the grace period.
+
 ### Opt out of API credential automounting
 
 If you don't want the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The doc about finalizers doesn't give any information about the fact that the API server considers a deleted service account or a deleted pod's token invalid after 1 minute the DeletionTimestamp.

ref: https://github.com/openshift/kubernetes/blob/76463e21d4dec90b4d49975b182a13e1fdb6b20a/pkg/serviceaccount/claims.go#L176-L197 https://github.com/openshift/kubernetes/blob/76463e21d4dec90b4d49975b182a13e1fdb6b20a/pkg/serviceaccount/claims.go#L216-L234

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #47403