### PR TITLE
Use Docsy-friendly layout for community page

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -767,6 +767,14 @@ body.glossary {
   }
 }
 
+body.cid-community {
+  section.linkbox {
+    max-width: clamp(50%, calc(100em + 2vw), 100vw);
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 #caseStudies body > #deprecation-warning, body.cid-casestudies > #deprecation-warning, body.cid-community > #deprecation-warning {
     display: inline-block;
     vertical-align: top;

--- a/content/en/community/code-of-conduct.html
+++ b/content/en/community/code-of-conduct.html
@@ -1,0 +1,37 @@
+---
+title: Kubernetes Community Code of Conduct
+body_class: code-of-conduct
+---
+
+<a class="td-offset-anchor"></a>
+<section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
+    <div class="container text-center">
+        <span class="h4 mb-0">
+            <h1>Kubernetes Community Code of Conduct</h1>
+            <p>
+            Kubernetes follows the
+            <a href="https://github.com/cncf/foundation/blob/main/code-of-conduct.md">CNCF Code of Conduct</a>.
+            The text of the CNCF CoC is replicated below, as of
+            <a href="https://github.com/cncf/foundation/blob/71412bb029090d42ecbeadb39374a337bfb48a9c/code-of-conduct.md">commit 71412bb02</a>.
+            </p>
+            <p>
+            If you notice that this is out of date, please
+            <a href="https://github.com/kubernetes/website/issues/new">file an issue</a>.
+            </p>
+        </span>
+    </div>
+</section>
+
+<div id="cncf-code-of-conduct">
+{{< include "/static/cncf-code-of-conduct.md" >}}
+</div>
+
+<hr />
+
+<p>
+If you notice a violation of the Code of Conduct at an event or meeting, in
+Slack, or in another communication mechanism, reach out to
+the <a href="https://git.k8s.io/community/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a>.
+You can reach us by email at <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
+Your anonymity will be protected.
+</p>

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -34,8 +34,14 @@ other = "Cleaning up"
 [china_icp_license]
 other = "ICP license:"
 
-[community_events_calendar]
+[community_advice_guidelines]
+other = "You can also read about our {{ .link }}."
+
+[community_calendar_name]
 other = "Events Calendar"
+
+[community_contributor_site_name]
+other = "Contributor website"
 
 [community_forum_name]
 other = "Forum"

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -40,14 +40,24 @@ other = "You can also read about our {{ .link }}."
 [community_calendar_name]
 other = "Events Calendar"
 
+# Also cover [community_contribute] if localizing this site
+
 [community_contributor_site_name]
 other = "Contributor website"
+
+# Also cover [community_develop] if localizing this site
 
 [community_forum_name]
 other = "Forum"
 
 [community_github_name]
 other = "GitHub"
+
+# Also cover [community_introduce] if localizing this site
+
+# Also cover [community_join] if localizing this site
+
+# Also cover [community_learn] if localizing this site
 
 [community_server_fault_name]
 other = "Server Fault"
@@ -60,6 +70,8 @@ other = "Stack Overflow"
 
 [community_twitter_name]
 other = "X (formerly Twitter)"
+
+# Also cover [community_using] if localizing this site
 
 [community_x_name]
 other = "X (formerly Twitter)"

--- a/hugo.toml
+++ b/hugo.toml
@@ -127,6 +127,7 @@ id = "UA-00000000-0"
 copyright_k8s = "The Kubernetes Authors"
 copyright_linux = "Copyright © 2020 The Linux Foundation ®."
 
+contribution_guidelines_url = "https://www.kubernetes.dev/docs/contributor-cheatsheet/"
 # privacy_policy = "https://policies.google.com/privacy"
 
 # First one is picked as the Twitter card image if not set on page.
@@ -243,53 +244,46 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-	name = "User mailing list"
-	url = "https://discuss.kubernetes.io"
-	icon = "fa fa-envelope"
-	desc = "Discussion and help from your fellow users"
-
-[[params.links.user]]
-	name = "X(Twitter)"
-	url = "https://twitter.com/kubernetesio"
-	icon = "fab fa-x-twitter"
-	desc = "Follow us on X (formerly Twitter) to get the latest news!"
-
-[[params.links.user]]
-	name = "Calendar"
-	url = "https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io"
-	icon = "fas fa-calendar-alt"
-	desc = "Google Calendar for Kubernetes"
-
-[[params.links.user]]
-	name = "Youtube"
+	name_key = "community_youtube_name"
 	url = "https://youtube.com/kubernetescommunity"
 	icon = "fab fa-youtube"
-	desc = "Youtube community videos"
+
+[[params.links.user]]
+	name_key = "community_forum_name"
+	url = "https://discuss.kubernetes.io"
+	icon = "fa fa-envelope"
+
+[[params.links.user]]
+	name_key = "community_server_fault_name"
+	url = "https://serverfault.com/questions/tagged/kubernetes"
+	icon = "fab fa-stack-overflow"
+
+[[params.links.user]]
+	name_key = "community_x_name"
+	url = "https://twitter.com/kubernetesio"
+	icon = "fab fa-twitter"
+# Replace with fa-x-twitter once available
 
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
-	name = "GitHub"
+	name_key = "community_contributor_site_name"
+	url = "https://k8s.dev/"
+	icon = "fas fa-laptop-code"
+
+[[params.links.developer]]
+	name_key = "community_github_name"
 	url = "https://github.com/kubernetes/kubernetes"
 	icon = "fab fa-github"
-	desc = "Development takes place here!"
 
 [[params.links.developer]]
-	name = "Slack"
+	name_key = "community_slack_name"
 	url = "https://slack.k8s.io"
 	icon = "fab fa-slack"
-	desc = "Chat with other project developers"
 
 [[params.links.developer]]
-	name = "Contribute"
-	url = "https://git.k8s.io/community/contributors/guide"
-	icon = "fas fa-edit"
-	desc = "Contribute to the Kubernetes website"
-
-[[params.links.developer]]
-	name = "Stack Overflow"
-	url = "https://stackoverflow.com/questions/tagged/kubernetes"
-	icon = "fab fa-stack-overflow"
-	desc = "Practical questions and curated answers"
+	name_key = "community_calendar_name"
+	url = "https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io"
+	icon = "fas fa-calendar-alt"
 
 # Language definitions.
 

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,3 +1,0 @@
-{{ define "main" }}
-  {{ .Content }}
-{{ end }}

--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -1,0 +1,39 @@
+{{ $links := .Site.Params.links }}
+{{ $contributionGuidelines := "" }}
+{{- with index $links "community" -}}
+  {{ range . }}
+    {{ $contributionGuidelines := .url }}
+    {{ break }}
+  {{ end }}
+{{- end -}}
+
+<section class="row td-box td-box--4 td-box--gradient td-box--height-auto linkbox">
+    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+        <h2>{{ T "community_learn" }}</h2>
+        <p>{{ T "community_using" . }}</p>
+        {{ with index $links "user"}}
+        {{ template "community-links-list" . }}
+        {{ end }}
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+        <h2>{{ T "community_develop" }}</h2>
+        <p>{{ T "community_contribute" . }}</p>
+        {{ with index $links "developer"}}
+        {{ template "community-links-list" . }}
+        {{ end }}
+        {{ with .Site.Params.contribution_guidelines_url }}
+        <!-- https://k8s.dev/ did not support localization (as of 2024-08-12) -->
+        <p>{{ T "community_advice_guidelines" (dict "link" (printf "<a href=\"%s\" target=\"_blank\">%s</a>" . ( T "community_guideline" ) ) ) | safeHTML }}</p>
+        {{ end }}
+    </div>
+</section>
+
+{{ define "community-links-list" }}
+<ul>
+    {{ range . }}
+    <li title="{{ T .name_key }}">
+        <a target="_blank" rel="noopener" href="{{ .url }}"><i class="{{ .icon }}"></i> {{ T .name_key }}</a>
+    </li>
+    {{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
Adapt the existing page to work with (near-)vanilla Docsy.

Intended to help with https://github.com/kubernetes/website/issues/41171.

/area web-development

[Preview](https://deploy-preview-47415--kubernetes-io-main-staging.netlify.app/community/) | [existing](https://k8s.io/community)