### PR TITLE
[ja] fix for link formatting in the blog post

### DIFF
--- a/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
+++ b/content/ja/blog/_posts/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
@@ -166,7 +166,7 @@ Kubernetesでのサービスネットワークの実装は、サービスネッ�
 
 CiliumはeBPFテクノロジーに基づいており、Linuxネットワークスタックを効率的にオフロードできるため、iptablesベースの従来の方法と比較してパフォーマンスとセキュリティが向上します。
 
-実際には、CiliumとKube-OVNを簡単に[統合]((https://kube-ovn.readthedocs.io/zh-cn/stable/en/advance/with-cilium/))することが可能です。
+実際には、CiliumとKube-OVNを簡単に[統合](https://kube-ovn.readthedocs.io/zh-cn/stable/en/advance/with-cilium/)することが可能です。
 これにより、仮想マシン向けにシームレスでマルチテナントのネットワーキングを提供する統合ソリューションを実現することができます。
 また、高度なネットワークポリシーと統合されたサービスネットワーク機能も提供されます。
 


### PR DESCRIPTION
This PR corrects a typo in the link in the Japanese blog post. I came across this error while trying to experiment with [Link render hooks](https://gohugo.io/render-hooks/links/) to improve multilingual support.