### PR TITLE
Removed weavework-scope url from the doc

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -96,8 +96,6 @@ installation instructions. The list does not try to be exhaustive.
 
 * [Dashboard](https://github.com/kubernetes/dashboard#kubernetes-dashboard)
   is a dashboard web interface for Kubernetes.
-* [Weave Scope](https://www.weave.works/documentation/scope-latest-installing/#k8s) is a
-  tool for visualizing your containers, Pods, Services and more.
 
 ## Infrastructure
 


### PR DESCRIPTION
### Description

Since Weavework has been closed (#45482) its URL mentioned  has been removed from docs.

Issue: #47421 