### PR TITLE
registering apiserver.latency.k8s.io/total annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
+++ b/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
@@ -72,11 +72,19 @@ violated from the PodSecurity enforcement.
 See [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
 for more information.
 
+## apiserver.latency.k8s.io/total
+
+Example: `apiserver.latency.k8s.io/total: "573.018706ms"`
+
+This value shows total latency incurred in components within the apiserver. Please note that the latency is recorded in
+annotation only when the total latency of the given request exceeds 500ms; This is in keeping with the
+traces in rest/handlers for create, delete, update, get, list, and delete collection.
+
 ## authorization.k8s.io/decision
 
 Example: `authorization.k8s.io/decision: "forbid"`
 
-This annotation indicates whether or not a request was authorized in Kubernetes audit logs.
+Value must be **forbid** or **allow**. This annotation indicates whether or not a request was authorized in Kubernetes audit logs.
 
 See [Auditing](/docs/tasks/debug/debug-cluster/audit/) for more information.
 


### PR DESCRIPTION

Documented apiserver.latency.k8s.io/total annotation in page https://kubernetes.io/docs/reference/labels-annotations-taints/audit-annotations/
also added values details in `authorization.k8s.io/decision` annotation.
Partially Fixes: #29479