### PR TITLE
Regsitering Audit annotations

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
+++ b/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
@@ -31,7 +31,7 @@ request used a deprecated API version.
 
 Example: `k8s.io/removed-release: "1.22"`
 
-Value **must** be in the format "<major>.<minor>". It is set to target the removal release
+Value **must** be in the format "\<MAJOR>\.\<MINOR>\". It is set to target the removal release
 on requests made to deprecated API versions with a target removal release.
 
 ## pod-security.kubernetes.io/exempt
@@ -71,6 +71,30 @@ violated from the PodSecurity enforcement.
 
 See [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
 for more information.
+
+## apiserver.latency.k8s.io/etcd
+
+Example: `apiserver.latency.k8s.io/etcd: "4.730661757s"`
+
+This annotation indiactes the measure of latency incurred inside the storage layer,
+it accounts for the time it takes to send data to the etcd and get the complete response back.
+
+Please note that it does not include the time incurred in admission, or validation.
+
+## apiserver.latency.k8s.io/decode-response-object
+
+Example: `apiserver.latency.k8s.io/decode-response-object: "450.6649ns"`
+
+This annotation records the decoding time of response object.
+
+## apiserver.latency.k8s.io/apf-queue-wait
+
+Example: `apiserver.latency.k8s.io/apf-queue-wait: ""`
+
+This annotation records the time spent waiting in APF queue.
+
+See [API Priority and Fairness] (/docs/concepts/cluster-administration/flow-control/)
+for more information regarding the APF feature
 
 ## authorization.k8s.io/decision
 


### PR DESCRIPTION
adding annotation: 
- apiserver.latency.k8s.io/etcd, 
- apiserver.latency.k8s.io/decode-response-object, 
- apiserver.latency.k8s.io/apf-queue-wait

- Also corrected the description of annotation : k8s.io/removed-release
In the page [Audit Annotations](https://kubernetes.io/docs/reference/labels-annotations-taints/audit-annotations/)

Partially fixes: https://github.com/kubernetes/website/issues/29479