### PR TITLE
[zh] Add coordinated-leader-election.md and related 2 pages

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/leases.md
+++ b/content/zh-cn/docs/concepts/architecture/leases.md
@@ -67,6 +67,14 @@ Kubernetes 也使用 Lease 确保在任何给定时间某个组件只有一个�
 这些组件只应有一个实例激活运行，而其他实例待机。
 
 <!--
+Read [coordinated leader election](/docs/concepts/cluster-administration/coordinated-leader-election)
+to learn about how Kubernetes builds on the Lease API to select which component instance
+acts as leader.
+-->
+参阅[协调领导者选举](/zh-cn/docs/concepts/cluster-administration/coordinated-leader-election)以了解
+Kubernetes 如何基于 Lease API 来选择哪个组件实例充当领导者。
+
+<!--
 ## API server identity
 -->
 ## API 服务器身份   {#api-server-identity}
@@ -93,12 +101,12 @@ kube-apiserver 拥有的租约。你还可以使用标签选择算符 `apiserver
 ```shell
 kubectl -n kube-system get lease -l apiserver.kubernetes.io/identity=kube-apiserver
 ```
+
 ```
 NAME                                        HOLDER                                                                           AGE
 apiserver-07a5ea9b9b072c4a5f3d1c3702        apiserver-07a5ea9b9b072c4a5f3d1c3702_0c8914f7-0f35-440e-8676-7844977d3a05        5m33s
 apiserver-7be9e061c59d368b3ddaf1376e        apiserver-7be9e061c59d368b3ddaf1376e_84f2a85d-37c1-4b14-b6b9-603e62e4896f        4m23s
 apiserver-1dfef752bcb36637d2763d1868        apiserver-1dfef752bcb36637d2763d1868_c5ffa286-8a9a-45d4-91e7-61118ed58d2e        4m43s
-
 ```
 
 <!--
@@ -115,6 +123,7 @@ hostname used by kube-apisever by checking the value of the `kubernetes.io/hostn
 ```shell
 kubectl -n kube-system get lease apiserver-07a5ea9b9b072c4a5f3d1c3702 -o yaml
 ```
+
 ```yaml
 apiVersion: coordination.k8s.io/v1
 kind: Lease

--- a/content/zh-cn/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -1,0 +1,76 @@
+---
+title: 协调领导者选举
+content_type: concept
+weight: 200
+---
+<!--
+reviewers:
+- jpbetz
+title: Coordinated Leader Election
+content_type: concept
+weight: 200
+-->
+
+<!-- overview -->
+
+{{< feature-state feature_gate_name="CoordinatedLeaderElection" >}}
+
+<!--
+Kubernetes {{< skew currentVersion >}} includes an alpha feature that allows {{<
+glossary_tooltip text="control plane" term_id="control-plane" >}} components to
+deterministically select a leader via _coordinated leader election_.
+This is useful to satisfy Kubernetes version skew constraints during cluster upgrades.
+Currently, the only builtin selection strategy is `OldestEmulationVersion`,
+preferring the leader with the lowest emulation version, followed by binary
+version, followed by creation timestamp.
+-->
+Kubernetes {{< skew currentVersion >}} 包含一个 Alpha 特性，
+允许{{< glossary_tooltip text="控制平面" term_id="control-plane" >}}组件通过**协调领导者选举**确定性地选择一个领导者。
+这对于在集群升级期间满足 Kubernetes 版本偏差约束非常有用。
+目前，唯一内置的选择策略是 `OldestEmulationVersion`，
+此策略会优先选择最低仿真版本作为领导者，其次按二进制版本选择领导者，最后会按创建时间戳选择领导者。
+
+<!--
+## Enabling coordinated leader election
+
+Ensure that `CoordinatedLeaderElection` [feature
+gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled
+when you start the {{< glossary_tooltip text="API Server"
+term_id="kube-apiserver" >}}: and that the `coordination.k8s.io/v1alpha1` API group is
+enabled.
+-->
+## 启用协调领导者选举   {#enabling-coordinated-leader-election}
+
+确保你在启动 {{< glossary_tooltip text="API 服务器" term_id="kube-apiserver" >}}时
+`CoordinatedLeaderElection` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)被启用，
+并且 `coordination.k8s.io/v1alpha1` API 组被启用。
+
+<!--
+This can be done by setting flags `--feature-gates="CoordinatedLeaderElection=true"` and
+`--runtime-config="coordination.k8s.io/v1alpha1=true"`.
+-->
+此操作可以通过设置 `--feature-gates="CoordinatedLeaderElection=true"`
+和 `--runtime-config="coordination.k8s.io/v1alpha1=true"` 标志来完成。
+
+<!--
+## Component configuration
+
+Provided that you have enabled the `CoordinatedLeaderElection` feature gate _and_  
+have the `coordination.k8s.io/v1alpha1` API group enabled, compatible control plane  
+components automatically use the LeaseCandidate and Lease APIs to elect a leader  
+as needed.
+-->
+## 组件配置   {#component-configuration}
+
+前提是你已启用 `CoordinatedLeaderElection` 特性门控**并且**
+启用了 `coordination.k8s.io/v1alpha1` API 组，
+兼容的控制平面组件会自动使用 LeaseCandidate 和 Lease API 根据需要选举领导者。
+
+<!--
+For Kubernetes {{< skew currentVersion >}}, two control plane components  
+(kube-controller-manager and kube-scheduler) automatically use coordinated  
+leader election when the feature gate and API group are enabled.
+-->
+对于 Kubernetes {{< skew currentVersion >}}，
+当特性门控和 API 组被启用时，
+两个控制平面组件（kube-controller-manager 和 kube-scheduler）会自动使用协调领导者选举。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/coordinated-leader-election.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/coordinated-leader-election.md
@@ -1,0 +1,18 @@
+---
+title: CoordinatedLeaderElection
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.31"
+---
+
+<!--
+Enables the behaviors supporting the LeaseCandidate API, and also enables
+coordinated leader election for the Kubernetes control plane, deterministically.
+-->
+启用支持 LeaseCandidate API 的行为，并且以确定性的方式为 Kubernetes 控制平面启用协调领导者选举。


### PR DESCRIPTION
Added new zh text in:
```
content/zh-cn/docs/concepts/architecture/leases.md
content/zh-cn/docs/concepts/cluster-administration/coordinated-leader-election.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/coordinated-leader-election.md
```
See [preview](https://deploy-preview-47486--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/cluster-administration/coordinated-leader-election/).