### PR TITLE
Fix a link in labels-annotations-taints/_index.md

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1217,13 +1217,12 @@ Example: `nginx.ingress.kubernetes.io/configuration-snippet: "  more_set_headers
 
 Used on: Ingress
 
-You can use this annotation to set extra configuration on an Ingress that 
-uses the [NGINX Ingress Controller] (https://github.com/kubernetes/ingress-nginx/)
+You can use this annotation to set extra configuration on an Ingress that
+uses the [NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx/).
 The `configuration-snippet` annotation is ignored
 by default since version 1.9.0 of the ingress controller.
-The NGINX ingress controller setting `allow-snippet-annotations.` 
-has to be explicitly enabled to
-use this annotation.
+The NGINX ingress controller setting `allow-snippet-annotations.`
+has to be explicitly enabled to use this annotation.
 Enabling the annotation can be dangerous in a multi-tenant cluster, as it can lead people with otherwise
 limited permissions being able to retrieve all Secrets in the cluster.
 


### PR DESCRIPTION
Fix a 404 link caused by a redundant markdown space.

[Before](https://kubernetes.io/docs/reference/labels-annotations-taints/#nginx-ingress-kubernetes-io-configuration-snippet) | [After](https://deploy-preview-47491--kubernetes-io-main-staging.netlify.app/docs/reference/labels-annotations-taints/#nginx-ingress-kubernetes-io-configuration-snippet)