### PR TITLE
Fix broken hyperlink for 'prow plugins'

### DIFF
--- a/content/en/docs/contribute/participate/_index.md
+++ b/content/en/docs/contribute/participate/_index.md
@@ -67,7 +67,7 @@ automation uses information from `OWNERS` files.
 The Kubernetes project uses an automation tool called prow for automation
 related to GitHub issues and pull requests. The
 [Kubernetes website repository](https://github.com/kubernetes/website) uses
-two [prow plugins](https://github.com/kubernetes/test-infra/tree/master/prow/plugins):
+two [prow plugins](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins):
 
 - blunderbuss
 - approve


### PR DESCRIPTION
Resolved Invalid reference  for prow plugins in this page:https://kubernetes.io/docs/contribute/participate/

Fixes: #47494