### PR TITLE
KEP-3619: fix typo in the feature blog to be published on 2024-08-22

### DIFF
--- a/content/en/blog/_posts/2024-08-22-Fine-grained-SupplementalGroups-control/index.md
+++ b/content/en/blog/_posts/2024-08-22-Fine-grained-SupplementalGroups-control/index.md
@@ -90,7 +90,7 @@ uid=1000 gid=3000 groups=3000,4000
 
 You can see `Strict` policy can exclude group `50000` from `groups`! 
 
-Thus, ensuring `supplementalGroupsPolicy: Merge` (enforced by some policy mechanism) helps prevent the implicit supplementary groups in a Pod.
+Thus, ensuring `supplementalGroupsPolicy: Strict` (enforced by some policy mechanism) helps prevent the implicit supplementary groups in a Pod.
 
 {{<note>}}
 Actually, this is not enough because container with sufficient privileges / capability can change its process identity. Please see the following section for details.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

- This PR just fixes a typo in the KEP-3619 feature blog that will be published on 2024-08-22.
- This is a follow up PR for #46921 

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
