### PR TITLE
Update the release schedule after August patch releases

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -15,10 +15,13 @@ schedules:
 - endOfLifeDate: "2025-06-28"
   maintenanceModeStartDate: "2025-04-28"
   next:
-    cherryPickDeadline: "2024-08-09"
+    cherryPickDeadline: "2024-09-06"
+    release: 1.30.5
+    targetDate: "2024-09-10"
+  previousPatches:
+  - cherryPickDeadline: "2024-08-09"
     release: 1.30.4
     targetDate: "2024-08-14"
-  previousPatches:
   - cherryPickDeadline: "2024-07-12"
     release: 1.30.3
     targetDate: "2024-07-16"
@@ -35,10 +38,13 @@ schedules:
 - endOfLifeDate: "2025-02-28"
   maintenanceModeStartDate: "2024-12-28"
   next:
-    cherryPickDeadline: "2024-08-09"
+    cherryPickDeadline: "2024-09-06"
+    release: 1.29.9
+    targetDate: "2024-09-10"
+  previousPatches:
+  - cherryPickDeadline: "2024-08-09"
     release: 1.29.8
     targetDate: "2024-08-14"
-  previousPatches:
   - cherryPickDeadline: "2024-07-12"
     release: 1.29.7
     targetDate: "2024-07-16"
@@ -67,10 +73,13 @@ schedules:
 - endOfLifeDate: "2024-10-28"
   maintenanceModeStartDate: "2024-08-28"
   next:
-    cherryPickDeadline: "2024-08-09"
+    cherryPickDeadline: "2024-09-06"
+    release: 1.28.14
+    targetDate: "2024-09-10"
+  previousPatches:
+  - cherryPickDeadline: "2024-08-09"
     release: 1.28.13
     targetDate: "2024-08-14"
-  previousPatches:
   - cherryPickDeadline: "2024-07-12"
     release: 1.28.12
     targetDate: "2024-07-16"
@@ -113,9 +122,9 @@ schedules:
   release: "1.28"
   releaseDate: "2023-08-15"
 upcoming_releases:
-- cherryPickDeadline: "2024-08-09"
-  targetDate: "2024-08-14"
 - cherryPickDeadline: "2024-09-06"
   targetDate: "2024-09-10"
 - cherryPickDeadline: "2024-10-11"
   targetDate: "2024-10-15"
+- cherryPickDeadline: "2024-11-08"
+  targetDate: "2024-11-12"


### PR DESCRIPTION
This PR updates the schedule to reflect the August patch release. 

This was generated with:

```
schedule-builder -uc data/releases/schedule.yaml
```

