### PR TITLE
Update docs for kube proxy status deprecation

### DIFF
--- a/content/en/blog/_posts/2024-07-19-kubernetes-1.31-deprecations-and-removals.md
+++ b/content/en/blog/_posts/2024-07-19-kubernetes-1.31-deprecations-and-removals.md
@@ -48,12 +48,13 @@ Please see [Kubernetes issue #125689](https://github.com/kubernetes/kubernetes/i
 
 ### Deprecation of `status.nodeInfo.kubeProxyVersion` field for Nodes ([KEP 4004](https://github.com/kubernetes/enhancements/issues/4004))
 
-The `.status.nodeInfo.kubeProxyVersion` field of Nodes is being deprecated in Kubernetes v1.31,
-and will be removed in a later release.
-It's being deprecated because the value of this field wasn't (and isn't) accurate.
+**Update**: *This section was edited post-publication due to changes resulting from https://issue.k8s.io/126720*
+
+The `.status.nodeInfo.kubeProxyVersion` field of Nodes was deprecated in Kubernetes v1.29,
+and will not be populated starting in Kubernetes v1.33, because the value of this field wasn't (and isn't) accurate.
 This field is set by the kubelet, which does not have reliable information about the kube-proxy version or whether kube-proxy is running. 
 
-The `DisableNodeKubeProxyVersion` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) will be set to `true` in by default in v1.31 and the kubelet will no longer attempt to set the `.status.kubeProxyVersion` field for its associated Node.
+The `DisableNodeKubeProxyVersion` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) will be set to `true` in by default in v1.33 and the kubelet will no longer attempt to set the `.status.kubeProxyVersion` field for its associated Node.
 
 ### Removal of all in-tree integrations with cloud providers
 

--- a/content/en/blog/_posts/2024-08-13-Kubernetes-v1-31-Release.md
+++ b/content/en/blog/_posts/2024-08-13-Kubernetes-v1-31-Release.md
@@ -269,12 +269,13 @@ Please see [Kubernetes issue #125689](https://github.com/kubernetes/kubernetes/i
 
 #### Deprecation of `status.nodeInfo.kubeProxyVersion` field for Nodes ([KEP 4004](https://github.com/kubernetes/enhancements/issues/4004))
 
-The `.status.nodeInfo.kubeProxyVersion` field of Nodes has been deprecated in Kubernetes v1.31,
-and will be removed in a later release.
-It's being deprecated because the value of this field wasn't (and isn't) accurate.
+**Update**: *This section was edited post-publication due to changes resulting from https://issue.k8s.io/126720*
+
+The `.status.nodeInfo.kubeProxyVersion` field of Nodes was deprecated in Kubernetes v1.29,
+and will not be populated starting in Kubernetes v1.33, because the value of this field wasn't (and isn't) accurate.
 This field is set by the kubelet, which does not have reliable information about the kube-proxy version or whether kube-proxy is running. 
 
-The `DisableNodeKubeProxyVersion` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) will be set to `true` in by default in v1.31 and the kubelet will no longer attempt to set the `.status.kubeProxyVersion` field for its associated Node.
+The `DisableNodeKubeProxyVersion` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) will be set to `true` in by default in v1.33 and the kubelet will no longer attempt to set the `.status.kubeProxyVersion` field for its associated Node.
 
 #### Removal of all in-tree integrations with cloud providers
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/disable-node-kube-proxy-version.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/disable-node-kube-proxy-version.md
@@ -9,9 +9,13 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.29"
-    toVersion: "1.30"
+    toVersion: "1.31.0"
   - stage: beta
     defaultValue: true
-    fromVersion: "1.31"
+    fromVersion: "1.31.0"
+    toVersion: "1.31.1"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.31.1"
 ---
 Disable setting the `kubeProxyVersion` field of the Node.


### PR DESCRIPTION
### Description

Update docs to reflect adjusted enablement schedule for the DisableNodeKubeProxyVersion gate.

xref https://github.com/kubernetes/kubernetes/pull/126720 and https://github.com/kubernetes/enhancements/issues/4004#issuecomment-2291482423


/cc @thockin @HirazawaUi

I'd like input from the docs team on how to update content in existing blog posts to be accurate while clearing indicating that it was edited