### PR TITLE
Mark v1.30 docs as stale

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -147,7 +147,7 @@ latest = "v1.31"
 version = "v1.30"
 githubbranch = "v1.30.3"
 docsbranch = "release-1.30"
-deprecated = false
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 


### PR DESCRIPTION
This pull request updates the hugo.toml configuration file in the release-1.30 branch to trigger a deprecation banner in the v1.30 documentation now that v1.31 is latest and main doc version.

Closes https://github.com/kubernetes/website/issues/47514