### PR TITLE
Fix syntax in update-schedule GitHub action

### DIFF
--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This fixes the incorrect action syntax of the job.

cc @kubernetes/release-engineering 

Follow-up on https://github.com/kubernetes/website/pull/45762