### PR TITLE
[zh]: fix index error in content\zh-cn\docs\tutorials\hello-minikube.md

### DIFF
--- a/content/zh-cn/docs/tutorials/hello-minikube.md
+++ b/content/zh-cn/docs/tutorials/hello-minikube.md
@@ -246,7 +246,7 @@ Deployment 是管理 Pod 创建和扩展的推荐方法。
 <!--
 1. View application logs for a container in a pod (replace pod name with the one you got from `kubectl get pods`).
 -->
-1. 查看 Pod 中容器的应用程序日志（将 Pod 名称替换为你用 `kubectl get pods` 命令获得的名称）。
+6. 查看 Pod 中容器的应用程序日志（将 Pod 名称替换为你用 `kubectl get pods` 命令获得的名称）。
 
    {{< note >}}
    <!--


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->


<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

There is a index error in ```content\zh-cn\docs\tutorials\hello-minikube.md```.
![image](https://github.com/user-attachments/assets/b28fd047-b563-4c46-9803-39413e15179e)


