### PR TITLE
Update NVIDIA GPU scheduling link

### DIFF
--- a/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -125,4 +125,4 @@ spec:
 #### GPU vendor implementations
 
 - [Intel](https://intel.github.io/intel-device-plugins-for-kubernetes/cmd/gpu_plugin/README.html)
-- [NVIDIA](https://github.com/NVIDIA/gpu-feature-discovery/#readme)
+- [NVIDIA](https://github.com/NVIDIA/k8s-device-plugin)


### PR DESCRIPTION
### Description

The link to the NVIDIA GPU vendor implementation reference for the scheduling-gpus page was pointing at their gpu-feature-discovery repo. This repo is deprecated and the work has moved to the k8s-device-plugin repo.

Luckily the old repo has a migration notice that leads folks to the new location, so they ultimately are able to get the information they are looking for. This updates the link to take out the extra step of visiting the old repo first.