### PR TITLE
kubeadm-init: mark EtcdLearnerMode as GA

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -156,7 +156,7 @@ List of feature gates:
 Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
 `ControlPlaneKubeletLocalMode` | `false` | 1.31 | - | -
-`EtcdLearnerMode` | `true` | 1.27 | 1.29 | -
+`EtcdLearnerMode` | `true` | 1.27 | 1.29 | 1.32
 `PublicKeysECDSA` | `false` | 1.19 | - | -
 `WaitForAllControlPlaneComponents` | `false` | 1.30 | - | -
 {{< /table >}}


### PR DESCRIPTION
change for 1.32

xref
- https://github.com/kubernetes/kubeadm/issues/1793
- https://github.com/kubernetes/kubernetes/pull/126374