### PR TITLE
Fix permissions for "Update schedule.yaml" CD job

### DIFF
--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   create-pull-request:
     name: Create PR (if required)
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.repository == 'kubernetes/website'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This fixes the permissions required for the job, which fails like: https://github.com/kubernetes/website/actions/runs/10444771187

cc @kubernetes/release-engineering 