### PR TITLE
Fix volume-attributes-classes.md feature gate requirements

### DIFF
--- a/content/en/docs/concepts/storage/volume-attributes-classes.md
+++ b/content/en/docs/concepts/storage/volume-attributes-classes.md
@@ -23,7 +23,7 @@ Kubernetes itself is un-opinionated about what these classes represent.
 This is a beta feature and disabled by default.
 
 If you want to test the feature whilst it's beta, you need to enable the `VolumeAttributesClass`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the kube-controller-manager
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the kube-controller-manager, kube-scheduler,
 and the kube-apiserver. You use the `--feature-gates` command line argument:
 
 ```


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR adds `kube-scheduler` as an additional component that requires the `VolumeAttributesClass` feature-gate. This is a change from the alpha -> beta version of this feature due to [kubernetes/kubernetes#121902](https://github.com/kubernetes/kubernetes/pull/121902).

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #