### PR TITLE
Amend English resource management and contribution docs to be clearer

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -276,7 +276,7 @@ If you are administering a cluster or namespace, you can also set
 you may also want to define a [LimitRange](/docs/concepts/policy/limit-range/)
 for additional enforcement.
 If you specify a `spec.containers[].resources.limits.memory` for each Pod,
-then the muximum size of an `emptyDir` volume will be the pod's memory limit.
+then the maximum size of an `emptyDir` volume will be the pod's memory limit.
 
 As an alternative, a cluster administrator can enforce size limits for
 `emptyDir` volumes in new Pods using a policy mechanism such as

--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -213,7 +213,7 @@ Figure 2. Working from a local fork to make your changes.
 
 ### Create a branch
 
-1. Decide which branch base to your work on:
+1. Decide which branch to base your work on:
 
    - For improvements to existing content, use `upstream/main`.
    - For new content about existing features, use `upstream/main`.


### PR DESCRIPTION
### Description

This PR amends the upstream documentation to improve clarity.

This involves fixing a typo in the resource management documentation, and a case of out-of-order words in the contribution docs.

These clarity issues are also present in the `zh-cn` localizations, however, I'll address those separately on approval, as per the [docs](https://kubernetes.io/docs/contribute/localization/#suggest-changes).

Relevant docs:
- https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#memory-backed-emptydir
- https://kubernetes.io/docs/contribute/new-content/open-a-pr/#create-a-branch