### PR TITLE
Fix typo in KEP-3619 blog published on 2024-08-22

### DIFF
--- a/content/en/blog/_posts/2024-08-22-Fine-grained-SupplementalGroups-control/index.md
+++ b/content/en/blog/_posts/2024-08-22-Fine-grained-SupplementalGroups-control/index.md
@@ -57,7 +57,7 @@ Thus, the group membership defined in `/etc/group` in the container image for th
 
 The _implicitly_ merged group information from `/etc/group` in the container image may cause some concerns particularly in accessing volumes (see [kubernetes/kubernetes#112879](https://issue.k8s.io/112879) for details) because file permission is controlled by uid/gid in Linux. Even worse, the implicit gids from `/etc/group` can not be detected/validated by any policy engines because there is no clue for the implicit group information in the manifest. This can also be a concern for Kubernetes security.
 
-## Fine-grined SupplementalGroups control in a Pod: `SupplementaryGroupsPolicy`
+## Fine-grained SupplementalGroups control in a Pod: `SupplementaryGroupsPolicy`
 
 To tackle the above problem, Kubernetes 1.31 introduces new field `supplementalGroupsPolicy` in Pod's `.spec.securityContext`.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->

### Description

This PR just fixes the typo in KEP-3619 Kubernetes feature blog to be published on 2024-08-22.
follows up #46921 

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->


<!--
### Issue

 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
Closes: #
-->

