### PR TITLE
Update node version to latest LTS

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"
 
 [build.environment]
-NODE_VERSION = "20.11.0"
+NODE_VERSION = "20.17.0"
 HUGO_VERSION = "0.121.2"
 
 [context.production.environment]


### PR DESCRIPTION
Updated netlify.toml, Node 2.11.0 -> Node 2.17.0 - latest as of 21/08/2024.

See the [official Nodejs blog](https://nodejs.org/en/blog/release/v20.17.0) to know more about the new features included in this release.