### PR TITLE
Implementation of the Link Decorator function for processing localised links 🈂️

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,53 @@
+{{- $u := urls.Parse .Destination -}}
+{{- $href := $u.String -}}
+{{- $langCode := .Page.Site.Language.Lang -}}
+
+{{- if strings.HasPrefix $u.String "#" }}
+  {{- /* Anchor link in the document, leave unchanged */ -}}
+
+{{- else if $u.IsAbs -}}
+  {{- /* External link, leave unchanged */ -}}
+
+{{- else if strings.HasPrefix $u.Path (printf "/%s/" $langCode) -}}
+  {{- /* Internal link in the current language, leave unchanged */ -}}
+
+{{- else if strings.HasPrefix $u.Path "/" -}}
+  {{- $localizedPath := printf "/%s%s" $langCode $u.Path -}}
+  {{- with or
+    (.Page.GetPage $localizedPath)
+    (.Page.Resources.Get $localizedPath)
+    (resources.Get $localizedPath)
+  -}}
+    {{- $href = .RelPermalink -}}
+  {{- else -}}
+    {{- $path := strings.TrimPrefix "./" $u.Path }}
+    {{- with or
+      (.Page.GetPage $path)
+      (.Page.Resources.Get $path)
+      (resources.Get $path)
+    -}}
+      {{- $href = .RelPermalink -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if and $u.RawQuery (not (strings.Contains $href "?")) -}}
+    {{- $href = printf "%s?%s" $href $u.RawQuery -}}
+  {{- end -}}
+  {{- if and $u.Fragment (not (strings.Contains $href "#")) -}}
+    {{- $href = printf "%s#%s" $href $u.Fragment -}}
+  {{- end -}}
+
+{{- else -}}
+  {{- /* Other internal links, leave unchanged */ -}}
+
+{{- end -}}
+
+{{- $attributes := dict "href" $href "title" (.Title | transform.HTMLEscape) -}}
+<a
+  {{- range $k, $v := $attributes -}}
+    {{- if $v -}}
+      {{- printf " %s=%q" $k $v | safeHTMLAttr -}}
+    {{- end -}}
+  {{- end -}}
+  >{{ .Text | safeHTML }}</a>
+{{- /**/ -}}


### PR DESCRIPTION
### Description

I'm pleased to introduce the Link Decorator feature, which automatically transforms links in localised documents if the referenced documents have been localised. This feature eliminates the need to manually add language codes to links.

This was also inspired by the https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/_markup/render-link.html template, which is already included in Hugo.

### The logic is as follows

```mermaid
graph LR;

src_link("Link in a doc…")


src_link-->none_localized_link("… is not localized\n starts with `/…`")-->
check_for_localization{"if a localized\ndoc exists"}-- "yes, it is" -->add_lng_prefix("Add lang-code\nprefix to the link")

src_link-->indoc_link("… is in the same doc\nstarts with`#` symbol")
src_link-->already_localized_link("… is already localized\n starts with\n`/lang-code/…`")
src_link-->ext_link("…is an external link\nstarts with protocol\n [https:|mailto:|…] ")

ext_link & already_localized_link & indoc_link ---> asis("Keep it as is")
check_for_localization-- "no, it isn't" -->asis
```

The current approach fully implements the logic of link decoration by adding a language prefix to localised documents where it is not explicitly specified. Links with a hard-coded https://kubernetes.io/ or https://k8s.io/ are considered external and processed as such, even if there are localised versions of the link in the documentation. Handling such cases significantly complicates the code and processing time, and it is easier to correct such links directly in the text of documents.

I hope that the adoption of this PR will significantly improve the usability of the documentation and simplify the work of translators to maintain it.

### Issue

This effort was inspired by a previous discussion about adding language code manually when localising documents. — https://github.com/kubernetes/website/issues/18403


/hold Depends on: PR https://github.com/kubernetes/website/pull/47612 — Fixed flag deprecations and updated Hugo version to latest

/cc @sftim as per your request in [Slack](https://kubernetes.slack.com/archives/C1J0BPD2M/p1724247542463049?thread_ts=1724226266.705639&cid=C1J0BPD2M).

