### PR TITLE
mark feature-gate MinDomainsInPodTopologySpread as removed

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -99,7 +99,7 @@ your cluster. Those fields are:
   <!-- OK to remove this note once v1.29 Kubernetes is out of support -->
   {{< note >}}
   Before Kubernetes v1.30, the `minDomains` field was only available if the
-  `MinDomainsInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+  `MinDomainsInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates-removed/)
   was enabled (default since v1.28). In older Kubernetes clusters it might be explicitly
   disabled or the field might not be available.
   {{< /note >}}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/min-domains-in-pod-topology-spread.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/min-domains-in-pod-topology-spread.md
@@ -21,6 +21,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.30"
+    toVersion: "1.31"
+
+removed: true
 ---
 Enable `minDomains` in
 [Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/).


### PR DESCRIPTION
k/k: https://github.com/kubernetes/kubernetes/pull/126863

/hold
/cc @sanposhiho 

/cc @sftim

The content of generated references is out of date. The latest commit is last year. 

- website: https://github.com/carlory/website/blob/MinDomainsInPodTopologySpread/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md#L241
- api: https://github.com/carlory/kubernetes/blob/MinDomainsInPodTopologySpread/staging/src/k8s.io/api/core/v1/types.go#L4226

![image](https://github.com/user-attachments/assets/4d3e9d91-d05c-490a-b201-878e24bae6f4)
