### PR TITLE
improving documented auth annotation decision

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
+++ b/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
@@ -76,7 +76,8 @@ for more information.
 
 Example: `authorization.k8s.io/decision: "forbid"`
 
-This annotation indicates whether or not a request was authorized in Kubernetes audit logs.
+Value must be **forbid** or **allow**. This annotation indicates whether or not a request
+was authorized in Kubernetes audit logs.
 
 See [Auditing](/docs/tasks/debug/debug-cluster/audit/) for more information.
 


### PR DESCRIPTION
The audit annotation authorization.k8s.io/decision `authorization.k8s.io/decision` should have valid values listed in description.
Adding the same in the description of the annotation and  as per this [comment](https://github.com/kubernetes/website/pull/47448/commits/efaca25ffb37712fec8fc69a54940c798ac301c7#r1723527238)
Page to be updated: https://kubernetes.io/docs/reference/labels-annotations-taints/audit-annotations/

