### PR TITLE
Fix: updated golang version to avoid breaking the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # change is that the Hugo version is now an overridable argument rather than a fixed
 # environment variable.
 
-FROM docker.io/library/golang:1.20-alpine
+FROM docker.io/library/golang:1.23.0-alpine3.20
 
 LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"
 
@@ -24,7 +24,7 @@ RUN mkdir $HOME/src && \
     cd "hugo-${HUGO_VERSION}" && \
     go install --tags extended
 
-FROM docker.io/library/golang:1.20-alpine
+FROM docker.io/library/golang:1.23.0-alpine3.20
 
 RUN apk add --no-cache \
     runuser \


### PR DESCRIPTION
One of my previous PRs, [this one](https://github.com/kubernetes/website/pull/47612), somehow broke the `make container-image` - the Docker build of the website image.

Seems like a Golang version 1.23.0+ is required for Hugo 0.133.0 to run but interestingly enough the pipeline for that broken PR went fine, including the Netlify build. This might be the occasion for improving the pipeline too (in a separated issue).

I hope this will trigger the pipeline in a way to really validate my fix.

Fixes #47673 

Thanks @sftim for catching this one.