### PR TITLE
mark ZeroLimitedNominalConcurrencyShares as removed

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/zero-limited-nominal-concurrency-shares.md
@@ -13,6 +13,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.30"
+    toVersion: "1.31"
+
+removed: true
 ---
 Allow [priority & fairness](/docs/concepts/cluster-administration/flow-control/)
 in the API server to use a zero value for the `nominalConcurrencyShares` field of


### PR DESCRIPTION
k/k: https://github.com/kubernetes/kubernetes/pull/126894
/hold