### PR TITLE
Update High Availability etcd ClusterConfiguration snippet for v1beta4

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -142,13 +142,20 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
            peerCertSANs:
            - "${HOST}"
            extraArgs:
-               initial-cluster: ${NAMES[0]}=https://${HOSTS[0]}:2380,${NAMES[1]}=https://${HOSTS[1]}:2380,${NAMES[2]}=https://${HOSTS[2]}:2380
-               initial-cluster-state: new
-               name: ${NAME}
-               listen-peer-urls: https://${HOST}:2380
-               listen-client-urls: https://${HOST}:2379
-               advertise-client-urls: https://${HOST}:2379
-               initial-advertise-peer-urls: https://${HOST}:2380
+           - name: initial-cluster
+             value: ${NAMES[0]}=https://${HOSTS[0]}:2380,${NAMES[1]}=https://${HOSTS[1]}:2380,${NAMES[2]}=https://${HOSTS[2]}:2380
+           - name: initial-cluster-state
+             value: new
+           - name: name
+             value: ${NAME}
+           - name: listen-peer-urls
+             value: https://${HOST}:2380
+           - name: listen-client-urls
+             value: https://${HOST}:2379
+           - name: advertise-client-urls
+             value: https://${HOST}:2379
+           - name: initial-advertise-peer-urls
+             value: https://${HOST}:2380
    EOF
    done
    ```


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The docs have been updated to use `v1beta4` but the structure of `extraArgs` is still `v1beta3`. The produces an error when running, `failed to unmarshal into []Arg`.

This PR updates the docs to use the correct `v1beta4` `extraArgs` structure.

### Issue

Closes: #47668