### PR TITLE
Tweak long lines in cluster architecture and components

### DIFF
--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -5,9 +5,13 @@ description: >
   The architectural concepts behind Kubernetes.
 ---
 
-A Kubernetes cluster consists of a control plane plus a set of worker machines, called nodes, that run containerized applications. Every cluster needs at least one worker node in order to run Pods.
+A Kubernetes cluster consists of a control plane plus a set of worker machines, called nodes,
+that run containerized applications. Every cluster needs at least one worker node in order to run Pods.
 
-The worker node(s) host the Pods that are the components of the application workload. The control plane manages the worker nodes and the Pods in the cluster. In production environments, the control plane usually runs across multiple computers and a cluster usually runs multiple nodes, providing fault-tolerance and high availability.
+The worker node(s) host the Pods that are the components of the application workload.
+The control plane manages the worker nodes and the Pods in the cluster. In production
+environments, the control plane usually runs across multiple computers and a cluster
+usually runs multiple nodes, providing fault-tolerance and high availability.
 
 This document outlines the various components you need to have for a complete and working Kubernetes cluster.
 
@@ -17,9 +21,15 @@ caption="**Note:** This diagram presents an example reference architecture for a
 
 ## Control plane components
 
-The control plane's components make global decisions about the cluster (for example, scheduling), as well as detecting and responding to cluster events (for example, starting up a new {{< glossary_tooltip text="pod" term_id="pod">}} when a Deployment's `{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
+The control plane's components make global decisions about the cluster (for example, scheduling),
+as well as detecting and responding to cluster events (for example, starting up a new
+{{< glossary_tooltip text="pod" term_id="pod">}} when a Deployment's
+`{{< glossary_tooltip text="replicas" term_id="replica" >}}` field is unsatisfied).
 
-Control plane components can be run on any machine in the cluster. However, for simplicity, setup scripts typically start all control plane components on the same machine, and do not run user containers on this machine. See [Creating Highly Available clusters with kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/) for an example control plane setup that runs across multiple machines.
+Control plane components can be run on any machine in the cluster. However, for simplicity, setup scripts
+typically start all control plane components on the same machine, and do not run user containers on this machine.
+See [Creating Highly Available clusters with kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/)
+for an example control plane setup that runs across multiple machines.
 
 ### kube-apiserver
 
@@ -50,13 +60,18 @@ The above is not an exhaustive list.
 
 {{< glossary_definition term_id="cloud-controller-manager" length="short" >}}
 
-The cloud-controller-manager only runs controllers that are specific to your cloud provider. If you are running Kubernetes on your own premises, or in a learning environment inside your own PC, the cluster does not have a cloud controller manager.
+The cloud-controller-manager only runs controllers that are specific to your cloud provider.
+If you are running Kubernetes on your own premises, or in a learning environment inside your
+own PC, the cluster does not have a cloud controller manager.
 
-As with the kube-controller-manager, the cloud-controller-manager combines several logically independent control loops into a single binary that you run as a single process. You can scale horizontally (run more than one copy) to improve performance or to help tolerate failures.
+As with the kube-controller-manager, the cloud-controller-manager combines several logically
+independent control loops into a single binary that you run as a single process. You can scale
+horizontally (run more than one copy) to improve performance or to help tolerate failures.
 
 The following controllers can have cloud provider dependencies:
 
-- Node controller: For checking the cloud provider to determine if a node has been deleted in the cloud after it stops responding
+- Node controller: For checking the cloud provider to determine if a node has been
+  deleted in the cloud after it stops responding
 - Route controller: For setting up routes in the underlying cloud infrastructure
 - Service controller: For creating, updating and deleting cloud provider load balancers
 
@@ -81,37 +96,52 @@ kube-proxy on the nodes in your cluster.
 
 ## Addons
 
-Addons use Kubernetes resources ({{< glossary_tooltip term_id="daemonset" >}}, {{< glossary_tooltip term_id="deployment" >}}, etc) to implement cluster features. Because these are providing cluster-level features, namespaced resources for addons belong within the `kube-system` namespace.
+Addons use Kubernetes resources ({{< glossary_tooltip term_id="daemonset" >}},
+{{< glossary_tooltip term_id="deployment" >}}, etc) to implement cluster features.
+Because these are providing cluster-level features, namespaced resources for
+addons belong within the `kube-system` namespace.
 
-Selected addons are described below; for an extended list of available addons, please see [Addons](/docs/concepts/cluster-administration/addons/).
+Selected addons are described below; for an extended list of available addons,
+please see [Addons](/docs/concepts/cluster-administration/addons/).
 
 ### DNS
 
-While the other addons are not strictly required, all Kubernetes clusters should have [cluster DNS](/docs/concepts/services-networking/dns-pod-service/), as many examples rely on it.
+While the other addons are not strictly required, all Kubernetes clusters should have
+[cluster DNS](/docs/concepts/services-networking/dns-pod-service/), as many examples rely on it.
 
-Cluster DNS is a DNS server, in addition to the other DNS server(s) in your environment, which serves DNS records for Kubernetes services.
+Cluster DNS is a DNS server, in addition to the other DNS server(s) in your environment,
+which serves DNS records for Kubernetes services.
 
 Containers started by Kubernetes automatically include this DNS server in their DNS searches.
 
 ### Web UI (Dashboard)
 
-[Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in the cluster, as well as the cluster itself.
+[Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) is a general purpose,
+web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications
+running in the cluster, as well as the cluster itself.
 
 ### Container resource monitoring
 
-[Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/) records generic time-series metrics about containers in a central database, and provides a UI for browsing that data.
+[Container Resource Monitoring](/docs/tasks/debug/debug-cluster/resource-usage-monitoring/)
+records generic time-series metrics about containers in a central database, and provides a UI for browsing that data.
 
 ### Cluster-level Logging
 
-A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for saving container logs to a central log store with a search/browsing interface.
+A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible
+for saving container logs to a central log store with a search/browsing interface.
 
 ### Network plugins
 
-[Network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins) are software components that implement the container network interface (CNI) specification. They are responsible for allocating IP addresses to pods and enabling them to communicate with each other within the cluster.
+[Network plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins)
+are software components that implement the container network interface (CNI) specification.
+They are responsible for allocating IP addresses to pods and enabling them to communicate
+with each other within the cluster.
 
 ## Architecture variations
 
-While the core components of Kubernetes remain consistent, the way they are deployed and managed can vary. Understanding these variations is crucial for designing and maintaining Kubernetes clusters that meet specific operational needs.
+While the core components of Kubernetes remain consistent, the way they are deployed and
+managed can vary. Understanding these variations is crucial for designing and maintaining
+Kubernetes clusters that meet specific operational needs.
 
 ### Control plane deployment options
 
@@ -121,27 +151,33 @@ Traditional deployment
 : Control plane components run directly on dedicated machines or VMs, often managed as systemd services.
 
 Static Pods
-: Control plane components are deployed as static Pods, managed by the kubelet on specific nodes. This is a common approach used by tools like kubeadm.
+: Control plane components are deployed as static Pods, managed by the kubelet on specific nodes.
+  This is a common approach used by tools like kubeadm.
 
 Self-hosted
-: The control plane runs as Pods within the Kubernetes cluster itself, managed by Deployments and StatefulSets or other Kubernetes primitives.
+: The control plane runs as Pods within the Kubernetes cluster itself, managed by Deployments
+  and StatefulSets or other Kubernetes primitives.
 
 Managed Kubernetes services
 : Cloud providers often abstract away the control plane, managing its components as part of their service offering.
 
 ### Workload placement considerations
 
-The placement of workloads, including the control plane components, can vary based on cluster size, performance requirements, and operational policies:
+The placement of workloads, including the control plane components, can vary based on cluster size,
+performance requirements, and operational policies:
 
 - In smaller or development clusters, control plane components and user workloads might run on the same nodes.
-- Larger production clusters often dedicate specific nodes to control plane components, separating them from user workloads.
+- Larger production clusters often dedicate specific nodes to control plane components,
+  separating them from user workloads.
 - Some organizations run critical add-ons or monitoring tools on control plane nodes.
 
 ### Cluster management tools
 
-Tools like kubeadm, kops, and Kubespray offer different approaches to deploying and managing clusters, each with its own method of component layout and management.
+Tools like kubeadm, kops, and Kubespray offer different approaches to deploying and managing clusters,
+each with its own method of component layout and management.
 
-The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs, balancing factors such as operational complexity, performance, and management overhead.
+The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs,
+balancing factors such as operational complexity, performance, and management overhead.
 
 ### Customization and extensibility
 
@@ -151,13 +187,15 @@ Kubernetes architecture allows for significant customization:
 - API servers can be extended with CustomResourceDefinitions and API Aggregation.
 - Cloud providers can integrate deeply with Kubernetes using the cloud-controller-manager.
 
-The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs, balancing factors such as operational complexity, performance, and management overhead.
+The flexibility of Kubernetes architecture allows organizations to tailor their clusters to specific needs,
+balancing factors such as operational complexity, performance, and management overhead.
 
 ## {{% heading "whatsnext" %}}
 
 Learn more about the following:
 
-- [Nodes](/docs/concepts/architecture/nodes/) and [their communication](/docs/concepts/architecture/control-plane-node-communication/)
+- [Nodes](/docs/concepts/architecture/nodes/) and
+  [their communication](/docs/concepts/architecture/control-plane-node-communication/)
   with the control plane.
 - Kubernetes [controllers](/docs/concepts/architecture/controller/).
 - [kube-scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) which is the default scheduler for Kubernetes.

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -22,7 +22,8 @@ This page provides a high-level overview of the essential components that make u
 
 ## Core Components
 
-A Kubernetes cluster consists of a control plane and one or more worker nodes. Here's a brief overview of the main components:
+A Kubernetes cluster consists of a control plane and one or more worker nodes.
+Here's a brief overview of the main components:
 
 ### Control Plane Components
 
@@ -41,7 +42,7 @@ Manage the overall state of the cluster:
 : Runs {{< glossary_tooltip text="controllers" term_id="controller" >}} to implement Kubernetes API behavior.
 
 [cloud-controller-manager](/docs/concepts/architecture/#cloud-controller-manager) (optional)
-: Integrates with underlying cloud provider(s)
+: Integrates with underlying cloud provider(s).
 
 ### Node Components
 
@@ -51,11 +52,11 @@ Run on every node, maintaining running pods and providing the Kubernetes runtime
 : Ensures that Pods are running, including their containers.
 
 [kube-proxy](/docs/concepts/architecture/#kube-proxy) (optional)
-: Maintains network rules on nodes to implement {{< glossary_tooltip text="Services" term_id="service" >}}
+: Maintains network rules on nodes to implement {{< glossary_tooltip text="Services" term_id="service" >}}.
 
 [Container runtime](/docs/concepts/architecture/#container-runtime)
-: Software responsible for running containers. Read [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more.
-
+: Software responsible for running containers. Read
+  [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more.
 
 {{% thirdparty-content single="true" %}}
 
@@ -80,6 +81,9 @@ Addons extend the functionality of Kubernetes. A few important examples include:
 
 ## Flexibility in Architecture
 
-Kubernetes allows for flexibility in how these components are deployed and managed. The architecture can be adapted to various needs, from small development environments to large-scale production deployments.
+Kubernetes allows for flexibility in how these components are deployed and managed.
+The architecture can be adapted to various needs, from small development environments
+to large-scale production deployments.
 
-For more detailed information about each component and various ways to configure your cluster architecture, see the [Cluster Architecture](/docs/concepts/architecture/) page.
+For more detailed information about each component and various ways to configure your
+cluster architecture, see the [Cluster Architecture](/docs/concepts/architecture/) page.


### PR DESCRIPTION
Only wrap lone lines in the recently updated two pages:

```
content/en/docs/concepts/architecture/_index.md
content/en/docs/concepts/overview/components.md
```

No any text revised.