### PR TITLE
Transalted the limitrange.md to Japanese

### DIFF
--- a/content/en/docs/reference/glossary/limitrange.md
+++ b/content/en/docs/reference/glossary/limitrange.md
@@ -4,7 +4,7 @@ id: limitrange
 date: 2019-04-15
 full_link:  /docs/concepts/policy/limit-range/
 short_description: >
-  Provides constraints to limit resource consumption per Containers or Pods in a namespace.
+  ネームスペース内のコンテナまたはポッドごとのリソース消費を制限するための制約を提供します。
 
 aka: 
 tags:
@@ -16,8 +16,7 @@ related:
  - container
 
 ---
- Provides constraints to limit resource consumption per {{< glossary_tooltip text="Containers" term_id="container" >}} or {{< glossary_tooltip text="Pods" term_id="pod" >}} in a namespace.
+{{< glossary_tooltip text="コンテナ" term_id="container" >}}または{{< glossary_tooltip text="ポッド" term_id="pod" >}}ごとのリソース消費を制限するための制約を提供します。
 
 <!--more--> 
-LimitRange limits the quantity of objects that can be created  by type, 
-as well as the amount of compute resources that may be requested/consumed by individual {{< glossary_tooltip text="Containers" term_id="container" >}} or {{< glossary_tooltip text="Pods" term_id="pod" >}} in a namespace.
+LimitRangeは、オブジェクトの作成可能な数量をタイプごとに制限し、また、ネームスペース内の個々の{{< glossary_tooltip text="コンテナ" term_id="container" >}}または{{< glossary_tooltip text="ポッド" term_id="pod" >}}が要求または消費できるコンピューティングリソースの量を制限します。


### PR DESCRIPTION
Issue: [#47684](https://github.com/kubernetes/website/issues/47684)

What This PR Does
This PR addresses the issue of translating the limitrange.md file from English to Japanese. The original English file is located in the content/en/docs/reference/glossary/limitrange.md path, and this translation provides the Japanese localization for the glossary term "LimitRange."

Why This Is Needed
The Kubernetes documentation aims to support a diverse global community. By translating this glossary term into Japanese, we help Japanese speakers better understand Kubernetes concepts in their native language. This is part of ongoing efforts to improve the accessibility and inclusiveness of Kubernetes documentation.