### PR TITLE
[ko] Update outdated files in dev-1.27-ko.1 (M127-M137)

### DIFF
--- a/content/ko/docs/tasks/administer-cluster/change-default-storage-class.md
+++ b/content/ko/docs/tasks/administer-cluster/change-default-storage-class.md
@@ -1,6 +1,7 @@
 ---
 title: 기본 스토리지클래스(StorageClass) 변경하기
 content_type: task
+weight: 90
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/ko/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -1,6 +1,7 @@
 ---
 title: 퍼시스턴트볼륨 반환 정책 변경하기
 content_type: task
+weight: 100
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/cluster-upgrade.md
+++ b/content/ko/docs/tasks/administer-cluster/cluster-upgrade.md
@@ -99,4 +99,4 @@ kubectl convert -f pod.yaml --output-version v1
 업그레이드 중에 장치 할당이 계속 성공적으로 완료되도록 하려면
 장치 플러그인을 업그레이드해야 한다.
 
-[API 호환성](docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md/#api-compatibility) 및 [Kubelet 장치 매니저 API 버전](docs/reference/node/device-plugin-api-versions.md)을 참조한다.
+[API 호환성](/ko/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#api-호환성) 및 [Kubelet 장치 매니저 API 버전](/docs/reference/node/device-plugin-api-versions/)을 참조한다.

--- a/content/ko/docs/tasks/administer-cluster/coredns.md
+++ b/content/ko/docs/tasks/administer-cluster/coredns.md
@@ -4,6 +4,7 @@
 title: 서비스 디스커버리를 위해 CoreDNS 사용하기
 min-kubernetes-server-version: v1.9
 content_type: task
+weight: 380
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/ko/docs/tasks/administer-cluster/declare-network-policy.md
@@ -5,6 +5,7 @@
 title: 네트워크 폴리시(Network Policy) 선언하기
 min-kubernetes-server-version: v1.8
 content_type: task
+weight: 180
 ---
 <!-- overview -->
 이 문서는 사용자가 쿠버네티스 [네트워크폴리시 API](/ko/docs/concepts/services-networking/network-policies/)를 사용하여 파드(Pod)가 서로 통신하는 방법을 제어하는 네트워크 폴리시를 선언하는데 도움을 준다.

--- a/content/ko/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/ko/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -1,6 +1,7 @@
 ---
 title: 클러스터에서 DNS 서비스 오토스케일
 content_type: task
+weight: 80
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/enable-disable-api.md
+++ b/content/ko/docs/tasks/administer-cluster/enable-disable-api.md
@@ -1,6 +1,7 @@
 ---
 title: 쿠버네티스 API 활성화 혹은 비활성화하기
 content_type: task
+weight: 200
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/extended-resource-node.md
+++ b/content/ko/docs/tasks/administer-cluster/extended-resource-node.md
@@ -1,8 +1,8 @@
 ---
 title: 노드에 대한 확장 리소스 알리기
 content_type: task
+weight: 70
 ---
-
 
 <!-- overview -->
 
@@ -10,16 +10,9 @@ content_type: task
 확장 리소스를 통해 클러스터 관리자는 쿠버네티스에게
 알려지지 않은 노드-레벨 리소스를 알릴 수 있다.
 
-
-
-
 ## {{% heading "prerequisites" %}}
 
-
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-
-
 
 <!-- steps -->
 
@@ -38,7 +31,7 @@ HTTP PATCH 요청을 보낸다. 예를 들어, 노드 중 하나에 4개의 동�
 가정한다. 다음은 노드에 4개의 동글 리소스를 알리는 PATCH 요청의
 예이다.
 
-```shell
+```
 PATCH /api/v1/nodes/<your-node-name>/status HTTP/1.1
 Accept: application/json
 Content-Type: application/json-patch+json
@@ -68,9 +61,9 @@ kubectl proxy
 
 ```shell
 curl --header "Content-Type: application/json-patch+json" \
---request PATCH \
---data '[{"op": "add", "path": "/status/capacity/example.com~1dongle", "value": "4"}]' \
-http://localhost:8001/api/v1/nodes/<your-node-name>/status
+  --request PATCH \
+  --data '[{"op": "add", "path": "/status/capacity/example.com~1dongle", "value": "4"}]' \
+  http://localhost:8001/api/v1/nodes/<your-node-name>/status
 ```
 
 {{< note >}}
@@ -99,9 +92,9 @@ kubectl describe node <your-node-name>
 
 ```yaml
 Capacity:
- cpu:  2
- memory:  2049008Ki
- example.com/dongle:  4
+  cpu:  2
+  memory:  2049008Ki
+  example.com/dongle:  4
 ```
 
 이제, 애플리케이션 개발자는 특정 개수의 동글을 요청하는 파드를
@@ -132,8 +125,8 @@ example.com/special-storage와 같은 특별한 스토리지의 이름을 생성
 
 ```yaml
 Capacity:
- ...
- example.com/special-storage: 8
+  ...
+  example.com/special-storage: 8
 ```
 
 이 특별한 스토리지에 대한 임의 요청을 허용하려면,
@@ -142,8 +135,8 @@ Capacity:
 
 ```yaml
 Capacity:
- ...
- example.com/special-storage:  800Gi
+  ...
+  example.com/special-storage:  800Gi
 ```
 
 그런 다음 컨테이너는 최대 800Gi의 임의 바이트 수의 특별한 스토리지를 요청할 수 있다.
@@ -177,9 +170,9 @@ kubectl proxy
 
 ```shell
 curl --header "Content-Type: application/json-patch+json" \
---request PATCH \
---data '[{"op": "remove", "path": "/status/capacity/example.com~1dongle"}]' \
-http://localhost:8001/api/v1/nodes/<your-node-name>/status
+  --request PATCH \
+  --data '[{"op": "remove", "path": "/status/capacity/example.com~1dongle"}]' \
+  http://localhost:8001/api/v1/nodes/<your-node-name>/status
 ```
 
 동글 알림이 제거되었는지 확인한다.
@@ -190,17 +183,13 @@ kubectl describe node <your-node-name> | grep dongle
 
 (출력이 보이지 않아야 함)
 
-
-
-
 ## {{% heading "whatsnext" %}}
-
 
 ### 애플리케이션 개발자를 위한 문서
 
-* [컨테이너에 확장 리소스 할당하기](/ko/docs/tasks/configure-pod-container/extended-resource/)
+- [컨테이너에 확장 리소스 할당하기](/ko/docs/tasks/configure-pod-container/extended-resource/)
 
 ### 클러스터 관리자를 위한 문서
 
-* [네임스페이스에 대한 메모리의 최소 및 최대 제약 조건 구성](/ko/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/)
-* [네임스페이스에 대한 CPU의 최소 및 최대 제약 조건 구성](/ko/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)
+- [네임스페이스에 대한 메모리의 최소 및 최대 제약 조건 구성](/ko/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/)
+- [네임스페이스에 대한 CPU의 최소 및 최대 제약 조건 구성](/ko/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Related Issue: #41631

Updated outdated files in `content/en/docs/tasks/administer-cluster/`.

**11 files to be modified**

M127, M128은 이미 변경 사항이 적용되어 있습니다. https://github.com/kubernetes/website/issues/41631#issuecomment-1678902282
그리고 M134는 단순 영문 오탈자 수정입니다.

- [x] M127. `content/en/docs/tasks/administer-cluster/access-cluster-api.md` | 1(+XS) 0(-)
- [x] M128. `content/en/docs/tasks/administer-cluster/certificates.md` | 2(+XS) 2(-)
- [x] M129. `content/en/docs/tasks/administer-cluster/change-default-storage-class.md` | 1(+XS) 0(-)
- [x] M130. `content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md` | 1(+XS) 0(-)
- [x] M131. `content/en/docs/tasks/administer-cluster/cluster-upgrade.md` | 2(+XS) 1(-)
- [x] M132. `content/en/docs/tasks/administer-cluster/coredns.md` | 1(+XS) 0(-)
- [x] M133. `content/en/docs/tasks/administer-cluster/declare-network-policy.md` | 1(+XS) 0(-)
- [x] M134. `content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md` | 2(+XS) 1(-)
- [x] M135. `content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md` | 1(+XS) 0(-)
- [x] M136. `content/en/docs/tasks/administer-cluster/enable-disable-api.md` | 2(+XS) 1(-)
- [x] M137. `content/en/docs/tasks/administer-cluster/extended-resource-node.md` | 14(+S) 28(-)