### PR TITLE
[zh] Sync kubeadm-reset and kubeadm-reset-phase and its dependencies

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/_index.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/_index.md
@@ -18,10 +18,17 @@ The "reset" command executes the following phases:
 -->
 "reset" 命令执行以下阶段：
 
+<!--
 ```
 preflight              Run reset pre-flight checks
 remove-etcd-member     Remove a local etcd member.
 cleanup-node           Run cleanup node.
+```
+-->
+```
+preflight              重置预检
+remove-etcd-member     移除本地 etcd 成员
+cleanup-node           清理节点
 ```
 
 ```
@@ -33,7 +40,7 @@ kubeadm reset [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -50,10 +57,10 @@ kubeadm reset [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The path to the directory where the certificates are stored. If specified, clean this directory.
 -->
-<p>
 存储证书的目录路径。如果已指定，则需要清空此目录。
 </p>
 </td>
@@ -66,10 +73,10 @@ The path to the directory where the certificates are stored. If specified, clean
 <td>
 </td>
 <td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Cleanup the &quot;/etc/kubernetes/tmp&quot; directory
 -->
-<p>
 清理 &quot;/etc/kubernetes/tmp&quot; 目录。
 </p>
 </td>
@@ -202,7 +209,7 @@ List of phases to be skipped
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -216,9 +223,9 @@ List of phases to be skipped
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
 -->
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase.md
@@ -6,7 +6,6 @@ Use this command to invoke single phase of the reset workflow
 <!--
 ### Synopsis
 -->
-
 ### 概要
 
 <!--
@@ -19,7 +18,7 @@ Use this command to invoke single phase of the reset workflow
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -31,10 +30,10 @@ Use this command to invoke single phase of the reset workflow
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 help for phase
 -->
-<p>
 phase 操作的帮助命令。
 </p>
 </td>
@@ -48,7 +47,7 @@ phase 操作的帮助命令。
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -60,11 +59,11 @@ phase 操作的帮助命令。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
--->
 <p>
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
+-->
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase_cleanup-node.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase_cleanup-node.md
@@ -22,7 +22,7 @@ kubeadm reset phase cleanup-node [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -39,10 +39,10 @@ kubeadm reset phase cleanup-node [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The path to the directory where the certificates are stored. If specified, clean this directory.
 -->
-<p>
 存储证书的目录路径。如果已指定，则需要清空此目录。
 </p>
 </td>
@@ -55,10 +55,10 @@ The path to the directory where the certificates are stored. If specified, clean
 <td>
 </td>
 <td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Cleanup the &quot;/etc/kubernetes/tmp&quot; directory
 -->
-<p>
 清理 &quot;/etc/kubernetes/tmp&quot; 目录。
 </p>
 </td>
@@ -69,11 +69,12 @@ Cleanup the &quot;/etc/kubernetes/tmp&quot; directory
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.
 -->
-<p>
-要连接的 CRI 套接字的路径。如果为空，则 kubeadm 将尝试自动检测此值；仅当安装了多个 CRI 或具有非标准 CRI 套接字时，才使用此选项。
+要连接的 CRI 套接字的路径。如果为空，则 kubeadm 将尝试自动检测此值；
+仅当安装了多个 CRI 或具有非标准 CRI 套接字时，才使用此选项。
 </p>
 </td>
 </tr>
@@ -85,10 +86,10 @@ Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this
 <td>
 </td>
 <td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Don't apply any changes; just output what would be done.
 -->
-<p>
 不做任何更改；只输出将要执行的操作。
 </p>
 </td>
@@ -99,10 +100,10 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 help for cleanup-node
 -->
-<p>
 cleanup-node 操作的帮助命令。
 </p>
 </td>
@@ -116,7 +117,7 @@ cleanup-node 操作的帮助命令。
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -128,11 +129,11 @@ cleanup-node 操作的帮助命令。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
--->
 <p>
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
+-->
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase_preflight.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase_preflight.md
@@ -23,7 +23,7 @@ kubeadm reset phase preflight [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -35,10 +35,10 @@ kubeadm reset phase preflight [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Don't apply any changes; just output what would be done.
 -->
-<p>
 不做任何更改；只输出将要执行的操作。
 </p>
 </td>
@@ -88,7 +88,7 @@ Don't apply any changes; just output what would be done.
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -100,10 +100,12 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
 -->
-<p>[实验] 指向 '真实' 宿主机根文件系统的路径。</p>
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
+</p>
 </td>
 </tr>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase_remove-etcd-member.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_reset/kubeadm_reset_phase_remove-etcd-member.md
@@ -1,7 +1,7 @@
 <!--
 Remove a local etcd member.
 -->
-删除本地 etcd 成员。
+移除本地 etcd 成员。
 
 <!--
 ### Synopsis
@@ -11,7 +11,7 @@ Remove a local etcd member.
 <!--
 Remove a local etcd member for a control plane node.
 -->
-删除控制平面节点的本地 etcd 成员。
+移除控制平面节点的本地 etcd 成员。
 
 ```
 kubeadm reset phase remove-etcd-member [flags]
@@ -22,7 +22,7 @@ kubeadm reset phase remove-etcd-member [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -63,7 +63,7 @@ remove-etcd-member 操作的帮助命令。
 <!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
 -->
-与集群通信时使用的 Kubeconfig 文件。如果未设置该标志，则可以在默认位置中查找现有的 Kubeconfig 文件。
+与集群通信时使用的 kubeconfig 文件。如果未设置该标志，则可以在默认位置中查找现有的 kubeconfig 文件。
 </p>
 </td>
 </tr>
@@ -76,7 +76,7 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -90,9 +90,9 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
 -->
-[实验] 到'真实'主机根文件系统的路径。
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset-phase.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset-phase.md
@@ -1,13 +1,12 @@
 ---
 title: kubeadm reset phase
-content_type: concept
 weight: 90
+content_type: concept
 ---
-
 <!--
 title: kubeadm reset phase
-content_type: concept
 weight: 90
+content_type: concept
 -->
 
 <!--
@@ -16,20 +15,20 @@ Hence, you can let kubeadm do some of the work and you can fill in the gaps
 if you wish to apply customization.
 -->
 `kubeadm reset phase` 使你能够调用 `reset` 过程的基本原子步骤。
-因此，如果希望执行自定义操作，可以让 kubeadm 做一些工作，然后由用户来补足剩余操作。
+因此，如果希望执行自定义操作，你可以让 kubeadm 做一些工作，然后由用户来补足剩余操作。
 
 <!--
 `kubeadm reset phase` is consistent with the [kubeadm reset workflow](/docs/reference/setup-tools/kubeadm/kubeadm-reset/#reset-workflow),
 and behind the scene both use the same code.
 -->
 `kubeadm reset phase` 与
-[kubeadm reset 工作流程](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset/#reset-workflow)
-一致，后台都使用相同的代码。
+[kubeadm reset 工作流程](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset/#reset-workflow)一致，
+后台都使用相同的代码。
 
 ## kubeadm reset phase {#cmd-reset-phase}
 
 {{< tabs name="tab-phase" >}}
-{{< tab name="phase" include="generated/kubeadm_reset_phase.md" />}}
+{{< tab name="phase" include="generated/kubeadm_reset/kubeadm_reset_phase.md" />}}
 {{< /tabs >}}
 
 ## kubeadm reset phase preflight {#cmd-reset-phase-preflight}
@@ -40,7 +39,7 @@ Using this phase you can execute preflight checks on a node that is being reset.
 使用此阶段，你可以在要重置的节点上执行启动前检查阶段。
 
 {{< tabs name="tab-preflight" >}}
-{{< tab name="preflight" include="generated/kubeadm_reset_phase_preflight.md" />}}
+{{< tab name="preflight" include="generated/kubeadm_reset/kubeadm_reset_phase_preflight.md" />}}
 {{< /tabs >}}
 
 <!--
@@ -51,10 +50,10 @@ Using this phase you can execute preflight checks on a node that is being reset.
 <!--
 Using this phase you can remove this control-plane node's etcd member from the etcd cluster.
 -->
-使用此阶段，你可以从 etcd 集群中删除此控制平面节点的 etcd 成员。
+使用此阶段，你可以从 etcd 集群中移除此控制平面节点的 etcd 成员。
 
 {{< tabs name="tab-remove-etcd-member" >}}
-{{< tab name="remove-etcd-member" include="generated/kubeadm_reset_phase_remove-etcd-member.md" />}}
+{{< tab name="remove-etcd-member" include="generated/kubeadm_reset/kubeadm_reset_phase_remove-etcd-member.md" />}}
 {{< /tabs >}}
 
 <!--
@@ -68,7 +67,7 @@ Using this phase you can perform cleanup on this node.
 使用此阶段，你可以在此节点上执行清理工作。
 
 {{< tabs name="tab-cleanup-node" >}}
-{{< tab name="cleanup-node" include="generated/kubeadm_reset_phase_cleanup-node.md" />}}
+{{< tab name="cleanup-node" include="generated/kubeadm_reset/kubeadm_reset_phase_cleanup-node.md" />}}
 {{< /tabs >}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -13,14 +13,15 @@ weight: 60
 -->
 
 <!-- overview -->
+
 <!--
 Performs a best effort revert of changes made by `kubeadm init` or `kubeadm join`.
 -->
 该命令尽力还原由 `kubeadm init` 或 `kubeadm join` 所做的更改。
 
-
 <!-- body -->
-{{< include "generated/kubeadm_reset.md" >}}
+
+{{< include "generated/kubeadm_reset/_index.md" >}}
 
 <!--
 ### Reset workflow {#reset-workflow}
@@ -46,7 +47,7 @@ the `kubeadm join` and `kubeadm init` phase runners.
 <!--
 ### External etcd clean up
 -->
-### 外部 etcd 清理
+### 外部 etcd 清理   {#external-etcd-clean-up}
 
 <!--
 `kubeadm reset` will not delete any etcd data if external etcd is used. This means that if you run `kubeadm init` again using the same etcd endpoints, you will see state from previous clusters.
@@ -75,7 +76,7 @@ If you have your `kube-apiserver` configured with the `--shutdown-delay-duration
 you can run the following commands to attempt a graceful shutdown for the running API server Pod,
 before you run `kubeadm reset`:
 -->
-### 体面关闭 kube-apiserver
+### 体面关闭 kube-apiserver   {#graceful-kube-apiserver-shutdown}
 
 如果你为 `kube-apiserver` 配置了 `--shutdown-delay-duration` 标志，
 你可以在运行 `kubeadm reset` 之前，运行以下命令尝试体面关闭正在运行的 API 服务器 Pod：
@@ -91,5 +92,7 @@ timeout 60 sh -c 'while pgrep kube-apiserver >/dev/null; do sleep 1; done' || tr
 * [kubeadm init](/docs/reference/setup-tools/kubeadm/kubeadm-init/) to bootstrap a Kubernetes control-plane node
 * [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/) to bootstrap a Kubernetes worker node and join it to the cluster
 -->
-* 参考 [kubeadm init](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init/) 来初始化 Kubernetes 主节点。
-* 参考 [kubeadm join](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-join/) 来初始化 Kubernetes 工作节点并加入集群。
+* 参考 [kubeadm init](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init/)
+  来初始化 Kubernetes 控制平面节点。
+* 参考 [kubeadm join](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-join/)
+  来初始化 Kubernetes 工作节点并加入集群。


### PR DESCRIPTION
Update zh text in:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset-phase.md
```
and their dependent files.

See [preview](https://deploy-preview-47707--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-reset/).