### PR TITLE
[zh] Sync kubeadm-token.md and its dependent files

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/_index.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/_index.md
@@ -17,16 +17,13 @@ This command manages bootstrap tokens. It is optional and needed only for advanc
 In short, bootstrap tokens are used for establishing bidirectional trust between a client and a server.
 A bootstrap token can be used when a client (for example a node that is about to join the cluster) needs
 to trust the server it is talking to. Then a bootstrap token with the "signing" usage can be used.
--->
-简而言之，引导令牌（bootstrap token）用于在客户端和服务器之间建立双向信任。
-当客户端（例如，即将加入集群的节点）需要时，可以使用引导令牌相信正在与之通信的服务器。
-然后可以使用具有 “签名” 的引导令牌。
-
-<!--
 bootstrap tokens can also function as a way to allow short-lived authentication to the API Server
 (the token serves as a way for the API Server to trust the client), for example for doing the TLS Bootstrap.
 -->
-引导令牌还可以作为一种允许对 API 服务器进行短期身份验证的方法（令牌用作 API 服务器信任客户端的方式），例如用于执行 TLS 引导程序。
+简而言之，引导令牌（Bootstrap Token）用于在客户端和服务器之间建立双向信任。
+当客户端（例如，即将加入集群的节点）需要信任所通信的服务器时，可以使用引导令牌。
+这时可以使用具有 “signing” 用途的引导令牌。引导令牌还可以作为一种允许对 API
+服务器进行短期身份验证的方法（令牌用作 API 服务器信任客户端的方式），例如用于执行 TLS 引导程序。
 
 <!--
 What is a bootstrap token more exactly?
@@ -34,7 +31,7 @@ What is a bootstrap token more exactly?
  - A bootstrap token must be of the form "[a-z0-9]{6}.[a-z0-9]{16}". The former part is the public token ID,
    while the latter is the Token Secret and it must be kept private at all circumstances!
  - The name of the Secret must be named "bootstrap-token-(token-id)".
- -->
+-->
 引导令牌准确来说是什么？
 
 - 它是位于 kube-system 命名空间中类型为 “bootstrap.kubernetes.io/token” 的一个 Secret。
@@ -43,10 +40,10 @@ What is a bootstrap token more exactly?
 
 <!--
 You can read more about bootstrap tokens here:
-  /docs/admin/bootstrap-tokens/
+  https://kubernetes.io/docs/admin/bootstrap-tokens/
 -->
 你可以在此处阅读有关引导令牌（bootstrap token）的更多信息：
-  /docs/admin/bootstrap-tokens/
+  https://kubernetes.io/zh-cn/docs/admin/bootstrap-tokens/
 
 ```
 kubeadm token [flags]
@@ -69,10 +66,10 @@ kubeadm token [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Whether to enable dry-run mode or not
 -->
-<p>
 是否启用 `dry-run` 模式。
 </p>
 </td>
@@ -83,10 +80,10 @@ Whether to enable dry-run mode or not
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 help for token
 -->
-<p>
 token 操作的帮助命令。
 </p>
 </td>
@@ -102,10 +99,10 @@ token 操作的帮助命令。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
 -->
-<p>
 与集群通信时使用的 kubeconfig 文件。如果未设置，则搜索一组标准位置以查找现有 kubeconfig 文件。
 </p>
 </td>
@@ -131,11 +128,11 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
--->
 <p>
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
+-->
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_create.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_create.md
@@ -57,10 +57,10 @@ When used together with '--print-join-command', print the full 'kubeadm join' fl
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Path to a kubeadm configuration file.
 -->
-<p>
 kubeadm 配置文件的路径。
 </p>
 </td>
@@ -71,10 +71,10 @@ kubeadm 配置文件的路径。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 A human friendly description of how this token is used.
 -->
-<p>
 针对令牌用途的人性化的描述。
 </p>
 </td>
@@ -92,10 +92,10 @@ A human friendly description of how this token is used.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Extra groups that this token will authenticate as when used for authentication. Must match "\\Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\\z"
 -->
-<p>
 此令牌用于身份验证时将对其他组进行身份验证。必须匹配 "\\Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\\z"
 </p>
 </td>
@@ -106,10 +106,10 @@ Extra groups that this token will authenticate as when used for authentication. 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 help for create
 -->
-<p>
 create 操作的帮助命令。
 </p>
 </td>
@@ -120,10 +120,10 @@ create 操作的帮助命令。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Instead of printing only the token, print the full 'kubeadm join' flag needed to join the cluster using the token.
 -->
-<p>
 不仅仅打印令牌，而是打印使用令牌加入集群所需的完整 'kubeadm join' 参数。
 </p>
 </td>
@@ -139,10 +139,10 @@ Instead of printing only the token, print the full 'kubeadm join' flag needed to
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The duration before the token is automatically deleted (e.g. 1s, 2m, 3h). If set to '0', the token will never expire
 -->
-<p>
 令牌有效时间，超过该时间令牌被自动删除。(例如：1s, 2m, 3h)。如果设置为 '0'，令牌将永远不过期。
 </p>
 </td>
@@ -158,11 +158,12 @@ The duration before the token is automatically deleted (e.g. 1s, 2m, 3h). If set
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Describes the ways in which this token can be used. You can pass --usages multiple times or provide a comma separated list of options. Valid options: [signing,authentication]
 -->
-<p>
-描述可以使用此令牌的方式。你可以多次使用 `--usages` 或者提供一个以逗号分隔的选项列表。合法选项有: [signing,authentication]
+描述可以使用此令牌的方式。你可以多次使用 `--usages` 或者提供一个以逗号分隔的选项列表。
+合法选项有：[signing,authentication]
 </p>
 </td>
 </tr>
@@ -187,10 +188,10 @@ Describes the ways in which this token can be used. You can pass --usages multip
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Whether to enable dry-run mode or not
 -->
-<p>
 是否启用 `dry-run` 运行模式。
 </p>
 </td>
@@ -206,10 +207,10 @@ Whether to enable dry-run mode or not
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
 -->
-<p>
 用于和集群通信的 kubeconfig 文件。如果它没有被设置，那么 kubeadm 将会搜索一个已经存在于标准路径的 kubeconfig 文件。
 </p>
 </td>
@@ -220,11 +221,11 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
--->
 <p>
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
+-->
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_delete.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_delete.md
@@ -39,10 +39,10 @@ kubeadm token delete [token-value] ...
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 help for delete
 -->
-<p>
 delete 操作的帮助命令。
 </p>
 </td>
@@ -68,10 +68,10 @@ delete 操作的帮助命令。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Whether to enable dry-run mode or not
 -->
-<p>
 是否启用 `dry-run` 运行模式。
 </p>
 </td>
@@ -87,10 +87,10 @@ Whether to enable dry-run mode or not
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
 -->
-<p>
 用于和集群通信的 kubeconfig 文件。如果它没有被设置，那么 kubeadm 将会搜索一个已经存在于标准路径的 kubeconfig 文件。
 </p>
 </td>
@@ -101,11 +101,11 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
--->
 <p>
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
+-->
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_generate.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_generate.md
@@ -1,5 +1,5 @@
 <!-- 
-Generate and print a bootstrap token, but do not create it on the server 
+Generate and print a bootstrap token, but do not create it on the server
 -->
 生成并打印一个引导令牌，但不要在服务器上创建它。
 
@@ -103,10 +103,12 @@ kubeadm token generate [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- 
-<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>  
+<p>
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
 -->
-<p>[实验] 指向 '真实' 宿主机根文件系统的路径。</p>
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
+</p>
 </td>
 </tr>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_list.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_token/kubeadm_token_list.md
@@ -37,10 +37,10 @@ kubeadm token list [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
 If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 -->
-<p>
 如果设置为 true，则在模板中缺少字段或哈希表的键时忽略模板中的任何错误。
 仅适用于 golang 和 jsonpath 输出格式。
 </p>
@@ -55,10 +55,10 @@ If true, ignore any errors in templates when a field or map key is missing in th
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--  
 Output format. One of: text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
 -->
-<p>
 输出格式：text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file 其中之一
 </p>
 </td>
@@ -69,8 +69,10 @@ Output format. One of: text|json|yaml|go-template|go-template-file|template|temp
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- help for list -->
 <p>
+<!--
+help for list
+-->
 list 操作的帮助命令。
 </p>
 </td>
@@ -129,10 +131,10 @@ Whether to enable dry-run mode or not
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
 -->
-<p>
 用于和集群通信的 kubeconfig 文件。如果它没有被设置，那么 kubeadm 将会搜索一个已经存在于标准路径的 kubeconfig 文件。
 </p>
 </td>
@@ -143,9 +145,11 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- [EXPERIMENTAL] The path to the 'real' host root filesystem.  -->
 <p>
-[实验] 指向 '真实' 宿主机根文件系统的路径。
+<!--
+The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
+-->
+到“真实”主机根文件系统的路径。这将导致 kubeadm 切换到所提供的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-token.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-token.md
@@ -3,53 +3,51 @@ title: kubeadm token
 content_type: concept
 weight: 70
 ---
-
 <!--
----
 reviewers:
-- mikedanese
 - luxas
 - jbeda
 title: kubeadm token
 content_type: concept
 weight: 70
----
 -->
 
 <!-- overview -->
+
 <!--
 Bootstrap tokens are used for establishing bidirectional trust between a node joining
-the cluster and a master node, as described in [authenticating with bootstrap tokens](/docs/reference/access-authn-authz/bootstrap-tokens/).
+the cluster and a control-plane node, as described in [authenticating with bootstrap tokens](/docs/reference/access-authn-authz/bootstrap-tokens/).
 -->
-
-如[使用引导令牌进行身份验证](/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens/)所描述的，引导令牌用于在即将加入集群的节点和主节点间建立双向认证。
+如[使用引导令牌进行身份验证](/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens/)所述，
+引导令牌用于在即将加入集群的节点和控制平面节点间建立双向认证。
 
 <!--
 `kubeadm init` creates an initial token with a 24-hour TTL. The following commands allow you to manage
 such a token and also to create and manage new ones.
 -->
-
 `kubeadm init` 创建了一个有效期为 24 小时的令牌，下面的命令允许你管理令牌，也可以创建和管理新的令牌。
-
-
 
 <!-- body -->
 ## kubeadm token create {#cmd-token-create}
-{{< include "generated/kubeadm_token_create.md" >}}
+
+{{< include "generated/kubeadm_token/kubeadm_token_create.md" >}}
 
 ## kubeadm token delete {#cmd-token-delete}
-{{< include "generated/kubeadm_token_delete.md" >}}
+
+{{< include "generated/kubeadm_token/kubeadm_token_delete.md" >}}
 
 ## kubeadm token generate {#cmd-token-generate}
-{{< include "generated/kubeadm_token_generate.md" >}}
+
+{{< include "generated/kubeadm_token/kubeadm_token_generate.md" >}}
 
 ## kubeadm token list {#cmd-token-list}
-{{< include "generated/kubeadm_token_list.md" >}}
 
+{{< include "generated/kubeadm_token/kubeadm_token_list.md" >}}
 
 ## {{% heading "whatsnext" %}}
 
 <!--
 * [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/) to bootstrap a Kubernetes worker node and join it to the cluster
 -->
-* [kubeadm join](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-join/) 引导 Kubernetes 工作节点并将其加入集群
+* [kubeadm join](/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-join/)
+  引导 Kubernetes 工作节点并将其加入集群


### PR DESCRIPTION
Update zh text in:

```
content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-token.md
```
and its dependent files.

See [preview](https://deploy-preview-47717--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-token/).