### PR TITLE
Remove reference to closed containerd issue in "Container Runtimes" page

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -256,9 +256,6 @@ sandbox image by setting the following config:
 
 You might need to restart `containerd` as well once you've updated the config file: `systemctl restart containerd`.
 
-Please note, that it is a best practice for kubelet to declare the matching `pod-infra-container-image`.
-If not configured, kubelet may attempt to garbage collect the `pause` image..
-
 ### CRI-O
 
 This section contains the necessary steps to install CRI-O as a container runtime.

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -257,9 +257,7 @@ sandbox image by setting the following config:
 You might need to restart `containerd` as well once you've updated the config file: `systemctl restart containerd`.
 
 Please note, that it is a best practice for kubelet to declare the matching `pod-infra-container-image`.
-If not configured, kubelet may attempt to garbage collect the `pause` image.
-There is ongoing work in [containerd to pin the pause image](https://github.com/containerd/containerd/issues/6352)
-and not require this setting on kubelet any longer.
+If not configured, kubelet may attempt to garbage collect the `pause` image..
 
 ### CRI-O
 


### PR DESCRIPTION
This PR corrects the documentation by removing a misleading reference to a closed containerd issue, ensuring the page accurately reflects the current information.

Closes https://github.com/kubernetes/website/issues/47343