### PR TITLE
Replace tr -d \n with base64 -w 0 option

### DIFF
--- a/content/en/blog/_posts/2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md
+++ b/content/en/blog/_posts/2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md
@@ -367,7 +367,7 @@ Now install your favourite CNI and the control-plane node will become ready.
 
 For example, to install Weave Net, run this command:
 ```shell
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
 ```
 
 Next we'll set up worker nodes.

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -537,7 +537,7 @@ Some points to note:
   You can get the content using this command: 
 
   ```shell
-  cat myuser.csr | base64 | tr -d "\n"
+  cat myuser.csr |base64 -w 0
   ```
 
 

--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -123,7 +123,7 @@ kind: CertificateSigningRequest
 metadata:
   name: my-svc.my-namespace
 spec:
-  request: $(cat server.csr | base64 | tr -d '\n')
+  request: $(cat server.csr | base64 -w 0)
   signerName: example.com/serving
   usages:
   - digital signature

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -415,7 +415,7 @@ Weave Net paramètre le mode hairpin par défaut. Cela permet aux pods de se con
 s'ils ne connaissent pas leur Pod IP.
 
 ```shell
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
 ```
 {{% /tab %}}
 

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -181,7 +181,7 @@ d’autres nœuds du control plane au cluster.
 1.  Activez l'extension CNI Weave:
 
     ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
     ```
 
 1.  Tapez ce qui suit et observez les pods des composants démarrer:
@@ -315,7 +315,7 @@ donnée par` kubeadm init` sur le premier noeud. Ça devrait ressembler a quelqu
 1.  Appliquer le plugin CNI Weave:
 
     ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
     ```
 
 ### Étapes pour le reste des nœuds du control plane

--- a/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -361,7 +361,7 @@ Weave Net menyalakan mode _hairpin_ secara bawaan. Hal ini mengizinkan Pod untuk
 jika mereka tidak tahu PodIP miliknya.
 
 ```shell
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
 ```
 {{% /tab %}}
 

--- a/content/id/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -162,7 +162,7 @@ opsi. Kebutuhan klastermu mungkin membutuhkan konfigurasi berbeda.
     Pada contoh berikut kami menggunakan Weave Net:
 
     ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
     ```
 
 3.  Tulis perintah berikut dan saksikan Pod komponen-komponen _control plane_ mulai dinyalakan:
@@ -256,7 +256,7 @@ Langkah-langkah berikut sama dengan pengaturan pada etcd bertumpuk:
 3.  Pasang _plugin_ CNI pilihanmu. Contoh berikut ini untuk Weave Net:
 
     ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
     ```
 
 ### Langkah selanjutnya untuk Node _control plane_ lainnya

--- a/content/id/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/id/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -105,7 +105,7 @@ kind: CertificateSigningRequest
 metadata:
   name: my-svc.my-namespace
 spec:
-  request: $(cat server.csr | base64 | tr -d '\n')
+  request: $(cat server.csr | base64 -w 0)
   usages:
   - digital signature
   - key encipherment

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -133,7 +133,7 @@ weight: 60
     Weave Netを使用する場合の例:
 
     ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
     ```
 
 1.  以下のコマンドを入力し、コンポーネントのPodが起動するのを確認します:
@@ -220,7 +220,7 @@ kubeadmバージョン1.15以降、複数のコントロールプレーンノー
 1.  使用するCNIプラグインを適用します。以下はWeave CNIの場合です:
 
     ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 -w 0)"
     ```
 
 ### 残りのコントロールプレーンノードの手順

--- a/content/ko/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/ko/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -123,7 +123,7 @@ kind: CertificateSigningRequest
 metadata:
   name: my-svc.my-namespace
 spec:
-  request: $(cat server.csr | base64 | tr -d '\n')
+  request: $(cat server.csr | base64 -w 0)
   signerName: example.com/serving
   usages:
   - digital signature

--- a/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -956,7 +956,7 @@ Some points to note:
   要得到该值，可以执行命令：
 
   ```shell
-  cat myuser.csr | base64 | tr -d "\n"
+  cat myuser.csr |base64 -w 0
   ```
 
 <!--

--- a/content/zh-cn/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/zh-cn/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -191,7 +191,7 @@ kind: CertificateSigningRequest
 metadata:
   name: my-svc.my-namespace
 spec:
-  request: $(cat server.csr | base64 | tr -d '\n')
+  request: $(cat server.csr | base64 -w 0)
   signerName: example.com/serving
   usages:
   - digital signature


### PR DESCRIPTION
### Description

I've often seen the given examples that used base64 to encode the piped stream, but felt that piping that through `tr -d '\n'` to remove newlines is unnecessary.
base64 itself has an option that takes care of it - `-w 0`
So I've essentially replaced all such instances in docs.