### PR TITLE
Change dnsutils from jessie-dnsutils to agnhost

### DIFF
--- a/content/bn/examples/admin/dns/dnsutils.yaml
+++ b/content/bn/examples/admin/dns/dnsutils.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
-    command:
-      - sleep
-      - "infinity"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
     imagePullPolicy: IfNotPresent
   restartPolicy: Always

--- a/content/en/examples/admin/dns/dnsutils.yaml
+++ b/content/en/examples/admin/dns/dnsutils.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
-    command:
-      - sleep
-      - "infinity"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
     imagePullPolicy: IfNotPresent
   restartPolicy: Always

--- a/content/id/examples/admin/dns/dnsutils.yaml
+++ b/content/id/examples/admin/dns/dnsutils.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
-    command:
-      - sleep
-      - "3600"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
     imagePullPolicy: IfNotPresent
   restartPolicy: Always

--- a/content/zh-cn/examples/admin/dns/dnsutils.yaml
+++ b/content/zh-cn/examples/admin/dns/dnsutils.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
-    command:
-      - sleep
-      - "infinity"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
     imagePullPolicy: IfNotPresent
   restartPolicy: Always


### PR DESCRIPTION
### Description

The jessie-dnsutils image is not maintained, but agnhost is and has all the same tools.

Closes: https://github.com/kubernetes/kubernetes/issues/126936

/cc @BenTheElder 
