### PR TITLE
Update kube-apiserver.md

### DIFF
--- a/content/en/docs/reference/glossary/kube-apiserver.md
+++ b/content/en/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API server
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/concepts/overview/components/#kube-apiserver
+full_link: /docs/concepts/architecture/#kube-apiserver
 short_description: >
   Control plane component that serves the Kubernetes API.
 


### PR DESCRIPTION
The current link the glossary entry points to non-existence page and section. Corrected the link to points to correct location.

In the exiting page https://kubernetes.io/docs/concepts/cluster-administration/flow-control/ the 'kube-apiserver' tooltip is taking to page with wrong section.

After this change it will be fixed. 

Preview Page link https://deploy-preview-47743--kubernetes-io-main-staging.netlify.app/docs/concepts/cluster-administration/flow-control/ 
(Click the tooltip in second line of the intro section to see the new link in action)