### PR TITLE
fix(tain-and-toleration.md): fix the unfinished sentence

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -78,7 +78,7 @@ The default value for `operator` is `Equal`.
 
 A toleration "matches" a taint if the keys are the same and the effects are the same, and:
 
-* the `operator` is `Exists` (in which case no `value` should be specified), or
+* the `operator` is `Exists` (in which case no `value` should be specified), and the key should included
 * the `operator` is `Equal` and the values should be equal.
 
 {{< note >}}

--- a/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -129,12 +129,12 @@ The default value for `operator` is `Equal`.
 <!--
 A toleration "matches" a taint if the keys are the same and the effects are the same, and:
 
-* the `operator` is `Exists` (in which case no `value` should be specified), or
+* the `operator` is `Exists` (in which case no `value` should be specified), and the key should included
 * the `operator` is `Equal` and the values should be equal.
 -->
 一个容忍度和一个污点相“匹配”是指它们有一样的键名和效果，并且：
 
-* 如果 `operator` 是 `Exists`（此时容忍度不能指定 `value`），或者
+* 如果 `operator` 是 `Exists`（此时容忍度不能指定 `value`），则键的值需要被包含
 * 如果 `operator` 是 `Equal`，则它们的值应该相等。
 
 {{< note >}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
change the unfinished sentence "he `operator` is `Exists` (in which case no `value` should be specified), or " to 
"the `operator` is `Exists` (in which case no `value` should be specified), and the key should included"

And change the language:zh  md too

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
https://github.com/kubernetes/website/issues/47737
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #