### PR TITLE
Promote RetryGenerateName to GA in 1.32

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -32,7 +32,7 @@ of the same resource. API resources are distinguished by their API group, resour
 In cases when objects represent a physical entity, like a Node representing a physical host, when the host is re-created under the same name without deleting and re-creating the Node, Kubernetes treats the new host as the old one, which may lead to inconsistencies.
 {{< /note >}}
 
-The server may generate a name when `generateName` is provided in a resource create request instead of `name`.
+The server may generate a name when `generateName` is provided instead of `name` in a resource create request.
 When `generateName` is used, the provided value is used as a name prefix, which server appends a generated suffix
 to. Even though the name is generated, it may conflict with existing names resulting in a HTTP 409 resopnse. This
 became far less likely to happen in Kubernetes v1.31 and later, since the server will make up to 8 attempt to generate a

--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -32,6 +32,12 @@ of the same resource. API resources are distinguished by their API group, resour
 In cases when objects represent a physical entity, like a Node representing a physical host, when the host is re-created under the same name without deleting and re-creating the Node, Kubernetes treats the new host as the old one, which may lead to inconsistencies.
 {{< /note >}}
 
+The server may generate a name when `generateName` is provided in a resource create request instead of `name`.
+When `generateName` is used, the provided value is used as a name prefix, which server appends a generated suffix
+to. Even though the name is generated, it may conflict with existing names resulting in a HTTP 409 resopnse. This
+became far less likely to happen in Kubernetes v1.31 and later, since the server will make up to 8 attempt to generate a
+unique name before returning a HTTP 409 response.
+
 Below are four types of commonly used name constraints for resources.
 
 ### DNS Subdomain Names

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/retry-generate-name.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/retry-generate-name.md
@@ -9,6 +9,14 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.30"
+    toVersion: "1.31"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.31"
+    toVersion: "1.32"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.32"
 ---
 Enables retrying of object creation when the
 {{< glossary_tooltip text="API server" term_id="kube-apiserver" >}}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/retry-generate-name.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/retry-generate-name.md
@@ -9,11 +9,11 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.30"
-    toVersion: "1.31"
+    toVersion: "1.30"
   - stage: beta
     defaultValue: true
     fromVersion: "1.31"
-    toVersion: "1.32"
+    toVersion: "1.31"
   - stage: stable
     defaultValue: true
     fromVersion: "1.32"


### PR DESCRIPTION
### Description

Promote the RetryGenerateName feature to GA

/sig api-machinery

/hold
until https://github.com/kubernetes/kubernetes/pull/127093 merges