### PR TITLE
Updating english docs to default to American spellings

### DIFF
--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -46,7 +46,7 @@ when new servers are created in your cloud infrastructure. The node controller o
 hosts running inside your tenancy with the cloud provider. The node controller performs the following functions:
 
 1. Update a Node object with the corresponding server's unique identifier obtained from the cloud provider API.
-1. Annotating and labelling the Node object with cloud-specific information, such as the region the node
+1. Annotating and labeling the Node object with cloud-specific information, such as the region the node
    is deployed into and the resources (CPU, memory, etc) that it has available.
 1. Obtain the node's hostname and network addresses.
 1. Verifying the node's health. In case a node becomes unresponsive, this controller checks with

--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -106,7 +106,7 @@ to learn more.
 
 When Kubernetes deletes an owner object, the dependents left behind are called
 *orphan* objects. By default, Kubernetes deletes dependent objects. To learn how
-to override this behaviour, see [Delete owner objects and orphan dependents](/docs/tasks/administer-cluster/use-cascading-deletion/#set-orphan-deletion-policy).
+to override this behavior, see [Delete owner objects and orphan dependents](/docs/tasks/administer-cluster/use-cascading-deletion/#set-orphan-deletion-policy).
 
 ## Garbage collection of unused containers and images {#containers-images}
 

--- a/content/en/docs/concepts/architecture/mixed-version-proxy.md
+++ b/content/en/docs/concepts/architecture/mixed-version-proxy.md
@@ -75,7 +75,7 @@ loads a special filter that does the following:
 * When a resource request reaches an API server that cannot serve that API
   (either because it is at a version pre-dating the introduction of the API or the API is turned off on the API server)
   the API server attempts to send the request to a peer API server that can serve the requested API.
-  It does so by identifying API groups / versions / resources that the local server doesn't recognise,
+  It does so by identifying API groups / versions / resources that the local server doesn't recognize,
   and tries to proxy those requests to a peer API server that is capable of handling the request.
 * If the peer API server fails to respond, the _source_ API server responds with 503 ("Service Unavailable") error.
 

--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -319,7 +319,7 @@ memorySwap:
   Only Pods of Burstable QoS are permitted to employ swap.
 
 If configuration for `memorySwap` is not specified and the feature gate is
-enabled, by default the kubelet will apply the same behaviour as the
+enabled, by default the kubelet will apply the same behavior as the
 `NoSwap` setting.
 
 With `LimitedSwap`, Pods that do not fall under the Burstable QoS classification (i.e.

--- a/content/en/docs/concepts/cluster-administration/logging.md
+++ b/content/en/docs/concepts/cluster-administration/logging.md
@@ -378,6 +378,6 @@ of Kubernetes.
 
 * Read about [Kubernetes system logs](/docs/concepts/cluster-administration/system-logs/)
 * Learn about [Traces For Kubernetes System Components](/docs/concepts/cluster-administration/system-traces/)
-* Learn how to [customise the termination message](/docs/tasks/debug/debug-application/determine-reason-pod-failure/#customizing-the-termination-message)
+* Learn how to [customize the termination message](/docs/tasks/debug/debug-application/determine-reason-pod-failure/#customizing-the-termination-message)
   that Kubernetes records when a Pod fails
 

--- a/content/en/docs/concepts/cluster-administration/node-shutdown.md
+++ b/content/en/docs/concepts/cluster-administration/node-shutdown.md
@@ -71,7 +71,7 @@ Graceful node shutdown feature is configured with two
 
 {{< note >}}
 
-There are cases when Node termination was cancelled by the system (or perhaps manually
+There are cases when Node termination was canceled by the system (or perhaps manually
 by an administrator). In either of those situations the Node will return to the `Ready` state.
 However, Pods which already started the process of termination will not be restored by kubelet
 and will need to be re-scheduled.
@@ -248,7 +248,7 @@ which states that `ControllerUnpublishVolume` "**must** be called after all
 `NodeUnstageVolume` and `NodeUnpublishVolume` on the volume are called and succeed".
 In such circumstances, volumes on the node in question might encounter data corruption.
 
-The forced storage detach behaviour is optional; users might opt to use the "Non-graceful
+The forced storage detach behavior is optional; users might opt to use the "Non-graceful
 node shutdown" feature instead.
 
 Force storage detach on timeout can be disabled by setting the `disable-force-detach-on-timeout`

--- a/content/en/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/en/docs/concepts/cluster-administration/system-metrics.md
@@ -155,7 +155,7 @@ lack of resources, and compare actual usage to the pod's request.
 
 The kube-scheduler identifies the resource [requests and limits](/docs/concepts/configuration/manage-resources-containers/)
 configured for each Pod; when either a request or limit is non-zero, the kube-scheduler reports a
-metrics timeseries. The time series is labelled by:
+metrics timeseries. The time series is labeled by:
 
 - namespace
 - pod name

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -544,7 +544,7 @@ which strategy the kubelet uses. The default strategy is `Watch`.
 
 Updates to Secrets can be either propagated by an API watch mechanism (the default), based on
 a cache with a defined time-to-live, or polled from the cluster API server on each kubelet
-synchronisation loop.
+synchronization loop.
 
 As a result, the total delay from the moment when the Secret is updated to the moment
 when new keys are projected to the Pod can be as long as the kubelet sync period + cache

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -34,7 +34,7 @@ Images can also include a registry hostname; for example: `fictional.registry.ex
 and possibly a port number as well; for example: `fictional.registry.example:10443/imagename`.
 
 If you don't specify a registry hostname, Kubernetes assumes that you mean the [Docker public registry](https://hub.docker.com/).
-You can change this behaviour by setting default image registry in 
+You can change this behavior by setting default image registry in 
 [container runtime](/docs/setup/production-environment/container-runtimes/) configuration.
 
 After the image name part you can add a _tag_ or _digest_ (in the same way you would when using with commands

--- a/content/en/docs/concepts/extend-kubernetes/_index.md
+++ b/content/en/docs/concepts/extend-kubernetes/_index.md
@@ -115,7 +115,7 @@ clients that access it.
 #### Key to the figure
 
 1. Users often interact with the Kubernetes API using `kubectl`. [Plugins](#client-extensions)
-   customise the behaviour of clients. There are generic extensions that can apply to different clients,
+   customize the behavior of clients. There are generic extensions that can apply to different clients,
    as well as specific ways to extend `kubectl`.
 
 1. The API server handles all requests. Several types of extension points in the API server allow
@@ -265,7 +265,7 @@ durable external storage, or provide ephemeral storage, or they might offer a re
 to information using a filesystem paradigm.
 
 Kubernetes also includes support for [FlexVolume](/docs/concepts/storage/volumes/#flexvolume) plugins,
-which are deprecated since Kubernetes v1.23 (in favour of CSI).
+which are deprecated since Kubernetes v1.23 (in favor of CSI).
 
 FlexVolume plugins allow users to mount volume types that aren't natively supported by Kubernetes. When
 you run a Pod that relies on FlexVolume storage, the kubelet calls a binary plugin to mount the volume.

--- a/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
@@ -18,7 +18,7 @@ The additional APIs can either be ready-made solutions such as a
 The aggregation layer is different from
 [Custom Resource Definitions](/docs/concepts/extend-kubernetes/api-extension/custom-resources/),
 which are a way to make the {{< glossary_tooltip term_id="kube-apiserver" text="kube-apiserver" >}}
-recognise new kinds of object.
+recognize new kinds of object.
 
 <!-- body -->
 

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/_index.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/_index.md
@@ -16,7 +16,7 @@ fabric that links Pods together.
   read-only interface to information using a filesystem paradigm.
 
   Kubernetes also includes support for [FlexVolume](/docs/concepts/storage/volumes/#flexvolume)
-  plugins, which are deprecated since Kubernetes v1.23 (in favour of CSI).
+  plugins, which are deprecated since Kubernetes v1.23 (in favor of CSI).
 
   FlexVolume plugins allow users to mount volume types that aren't natively
   supported by Kubernetes. When you run a Pod that relies on FlexVolume

--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -32,7 +32,7 @@ to automate deploying and running workloads, *and* you can automate how
 Kubernetes does that.
 
 Kubernetes' {{< glossary_tooltip text="operator pattern" term_id="operator-pattern" >}}
-concept lets you extend the cluster's behaviour without modifying the code of Kubernetes
+concept lets you extend the cluster's behavior without modifying the code of Kubernetes
 itself by linking {{< glossary_tooltip text="controllers" term_id="controller" >}} to
 one or more custom resources. Operators are clients of the Kubernetes API that act as
 controllers for a [Custom Resource](/docs/concepts/extend-kubernetes/api-extension/custom-resources/).

--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -97,7 +97,7 @@ Kubernetes:
 * Does not deploy source code and does not build your application. Continuous Integration,
   Delivery, and Deployment (CI/CD) workflows are determined by organization cultures and
   preferences as well as technical requirements.
-* Does not provide application-level services, such as middleware (for example, message buses),
+* Does not provide application-level services, such as middleware (for example, message busses),
   data-processing frameworks (for example, Spark), databases (for example, MySQL), caches, nor
   cluster storage systems (for example, Ceph) as built-in services. Such components can run on
   Kubernetes, and/or can be accessed by applications running on Kubernetes through portable

--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -148,7 +148,7 @@ kubectl api-resources --namespaced=true
 kubectl api-resources --namespaced=false
 ```
 
-## Automatic labelling
+## Automatic labeling
 
 {{< feature-state for_k8s_version="1.22" state="stable" >}}
 

--- a/content/en/docs/concepts/policy/node-resource-managers.md
+++ b/content/en/docs/concepts/policy/node-resource-managers.md
@@ -9,7 +9,7 @@ weight: 50
 
 <!-- overview -->
 
-In order to support latency-critical and high-throughput workloads, Kubernetes offers a suite of Resource Managers. The managers aim to co-ordinate and optimise node's resources alignment for pods configured with a specific requirement for CPUs, devices, and memory (hugepages) resources. 
+In order to support latency-critical and high-throughput workloads, Kubernetes offers a suite of Resource Managers. The managers aim to co-ordinate and optimize node's resources alignment for pods configured with a specific requirement for CPUs, devices, and memory (hugepages) resources. 
 
 <!-- body -->
 

--- a/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -26,7 +26,7 @@ large Kubernetes clusters.
 
 <!-- body -->
 
-In large clusters, you can tune the scheduler's behaviour balancing
+In large clusters, you can tune the scheduler's behavior balancing
 scheduling outcomes between latency (new Pods are placed quickly) and
 accuracy (the scheduler rarely makes poor placement decisions).
 

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -264,7 +264,7 @@ ingress or egress traffic.
 ## Network traffic filtering
 
 NetworkPolicy is defined for [layer 4](https://en.wikipedia.org/wiki/OSI_model#Layer_4:_Transport_layer)
-connections (TCP, UDP, and optionally SCTP). For all the other protocols, the behaviour may vary
+connections (TCP, UDP, and optionally SCTP). For all the other protocols, the behavior may vary
 across network plugins.
 
 {{< note >}}
@@ -273,7 +273,7 @@ protocol NetworkPolicies.
 {{< /note >}}
 
 When a `deny all` network policy is defined, it is only guaranteed to deny TCP, UDP and SCTP
-connections. For other protocols, such as ARP or ICMP, the behaviour is undefined.
+connections. For other protocols, such as ARP or ICMP, the behavior is undefined.
 The same applies to allow rules: when a specific pod is allowed as ingress source or egress destination,
 it is undefined what happens with (for example) ICMP packets. Protocols such as ICMP may be allowed by some
 network plugins and denied by others.
@@ -395,7 +395,7 @@ but cannot reach Pod B until a few seconds later.
 
 ## NetworkPolicy and `hostNetwork` pods
 
-NetworkPolicy behaviour for `hostNetwork` pods is undefined, but it should be limited to 2 possibilities:
+NetworkPolicy behavior for `hostNetwork` pods is undefined, but it should be limited to 2 possibilities:
 
 - The network plugin can distinguish `hostNetwork` pod traffic from all other traffic
   (including being able to distinguish traffic from different `hostNetwork` pods on

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -103,7 +103,7 @@ view or modify Service definitions using the Kubernetes API. Usually
 you use a tool such as `kubectl` to make those API calls for you.
 
 For example, suppose you have a set of Pods that each listen on TCP port 9376
-and are labelled as `app.kubernetes.io/name=MyApp`. You can define a Service to
+and are labeled as `app.kubernetes.io/name=MyApp`. You can define a Service to
 publish that TCP listener:
 
 ```yaml

--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -255,7 +255,7 @@ the StatefulSet.
 {{< feature-state for_k8s_version="v1.28" state="beta" >}}
 
 When the StatefulSet {{<glossary_tooltip text="controller" term_id="controller">}} creates a Pod,
-the new Pod is labelled with `apps.kubernetes.io/pod-index`. The value of this label is the ordinal index of
+the new Pod is labeled with `apps.kubernetes.io/pod-index`. The value of this label is the ordinal index of
 the Pod. This label allows you to route traffic to a particular pod index, filter logs/metrics
 using the pod index label, and more. Note the feature gate `PodIndexLabel` must be enabled for this
 feature, and it is enabled by default.

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -258,7 +258,7 @@ restarts them with an exponential backoff delay (10s, 20s, 40s, …), that is ca
 300 seconds (5 minutes). Once a container has executed for 10 minutes without any
 problems, the kubelet resets the restart backoff timer for that container.
 [Sidecar containers and Pod lifecycle](/docs/concepts/workloads/pods/sidecar-containers/#sidecar-containers-and-pod-lifecycle)
-explains the behaviour of `init containers` when specify `restartpolicy` field on it.
+explains the behavior of `init containers` when specify `restartpolicy` field on it.
 
 
 ## Pod conditions

--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -302,7 +302,7 @@ be useful for debugging.
 
 {{< note >}}
 The commands below use Docker as default container engine. Set the `CONTAINER_ENGINE` environment
-variable to override this behaviour.
+variable to override this behavior.
 {{< /note >}}
 
 1. Build the container image locally  

--- a/content/en/docs/contribute/participate/issue-wrangler.md
+++ b/content/en/docs/contribute/participate/issue-wrangler.md
@@ -8,7 +8,7 @@ weight: 20
 
 Alongside the [PR Wrangler](/docs/contribute/participate/pr-wranglers), formal approvers,
 reviewers and members of SIG Docs take week-long shifts
-[triaging and categorising issues](/docs/contribute/review/for-approvers/#triage-and-categorize-issues)
+[triaging and categorizing issues](/docs/contribute/review/for-approvers/#triage-and-categorize-issues)
 for the repository.
 
 <!-- body -->

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -1135,7 +1135,7 @@ Sometimes it's useful to know which admission webhooks are frequently rejecting 
 reason for a rejection.
 
 The API server exposes a Prometheus counter metric recording admission webhook rejections. The
-metrics are labelled to identify the causes of webhook rejection(s):
+metrics are labeled to identify the causes of webhook rejection(s):
 
 - `name`: the name of the webhook that rejected a request.
 - `operation`: the operation type of the request, can be one of `CREATE`,

--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -46,7 +46,7 @@ for a number of reasons:
   username that represents a user represents the same user.
   In Kubernetes, service accounts are namespaced: two different namespaces can
   contain ServiceAccounts that have identical names.
-- Typically, a cluster's user accounts might be synchronised from a corporate
+- Typically, a cluster's user accounts might be synchronized from a corporate
   database, where new user account creation requires special privileges and is
   tied to complex business processes. By contrast, service account creation is
   intended to be more lightweight, allowing cluster users to create service accounts

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/service-node-exclusion.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/service-node-exclusion.md
@@ -24,4 +24,4 @@ stages:
 removed: true
 ---
 Enable the exclusion of nodes from load balancers created by a cloud provider.
-A node is eligible for exclusion if labelled with "`node.kubernetes.io/exclude-from-external-load-balancers`".
+A node is eligible for exclusion if labeled with "node.kubernetes.io/exclude-from-external-load-balancers".

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -231,7 +231,7 @@ kubelet [flags]
 <td colspan="2">--cpu-manager-policy-options string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">A set of 'key=value' CPU manager policy options to use, to fine tune their behaviour. If not supplied, keep the default behaviour. (DEPRECATED: This parameter should be set via the config file specified by the kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">A set of 'key=value' CPU manager policy options to use, to fine tune their behavior. If not supplied, keep the default behavior. (DEPRECATED: This parameter should be set via the config file specified by the kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
 </tr>
 
 <tr>
@@ -847,7 +847,7 @@ WindowsHostNetwork=true|false (ALPHA - default=true)<br/>
 <td colspan="2">--protect-kernel-defaults</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults. (DEPRECATED: This parameter should be set via the config file specified by the kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">Default kubelet behavior for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults. (DEPRECATED: This parameter should be set via the config file specified by the kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
 </tr>
 
 <tr>
@@ -1063,7 +1063,7 @@ Insecure values:
 <td colspan="2">--topology-manager-policy-options string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">A set of &lt;key&gt;=&lt;value&gt; topology manager policy options to use, to fine tune their behaviour. If not supplied, keep the default behaviour. (DEPRECATED: This parameter should be set via the config file specified by the kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">A set of &lt;key&gt;=&lt;value&gt; topology manager policy options to use, to fine tune their behavior. If not supplied, keep the default behavior. (DEPRECATED: This parameter should be set via the config file specified by the kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)</td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -845,7 +845,7 @@ Default: &quot;None&quot;</p>
 </td>
 <td>
    <p>cpuManagerPolicyOptions is a set of key=value which 	allows to set extra options
-to fine tune the behaviour of the cpu manager policies.
+to fine tune the behavior of the cpu manager policies.
 Requires  both the &quot;CPUManager&quot; and &quot;CPUManagerPolicyOptions&quot; feature gates to be enabled.
 Default: nil</p>
 </td>
@@ -904,7 +904,7 @@ that topology manager requests and hint providers generate. Valid values include
 </td>
 <td>
    <p>TopologyManagerPolicyOptions is a set of key=value which allows to set extra options
-to fine tune the behaviour of the topology manager policies.
+to fine tune the behavior of the topology manager policies.
 Requires  both the &quot;TopologyManager&quot; and &quot;TopologyManagerPolicyOptions&quot; feature gates to be enabled.
 Default: nil</p>
 </td>

--- a/content/en/docs/reference/instrumentation/metrics.md
+++ b/content/en/docs/reference/instrumentation/metrics.md
@@ -1692,7 +1692,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">backoffLimit</span><span class="metric_label">status</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_job_pods_creation_total</div>
-	<div class="metric_help">`The number of Pods created by the Job controller labelled with a reason for the Pod creation., This metric also distinguishes between Pods created using different PodReplacementPolicy settings., Possible values of the "reason" label are:, "new", "recreate_terminating_or_failed", "recreate_failed"., Possible values of the "status" label are:, "succeeded", "failed".`</div>
+	<div class="metric_help">`The number of Pods created by the Job controller labeled with a reason for the Pod creation., This metric also distinguishes between Pods created using different PodReplacementPolicy settings., Possible values of the "reason" label are:, "new", "recreate_terminating_or_failed", "recreate_failed"., Possible values of the "status" label are:, "succeeded", "failed".`</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -843,7 +843,7 @@ PersistentVolumeSpec is the specification of a persistent volume.
 
   - **storageos.volumeNamespace** (string)
 
-    volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+    volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behavior. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
 
 - **vsphereVolume** (VsphereVirtualDiskVolumeSource)
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
@@ -882,7 +882,7 @@ Volume represents a named volume in a pod that may be accessed by any container 
 
   - **storageos.volumeNamespace** (string)
 
-    volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+    volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behavior. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
 
 - **vsphereVolume** (VsphereVirtualDiskVolumeSource)
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -522,7 +522,7 @@ JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-sc
   1) `granular`:
        These maps are actual maps (key-value pairs) and each fields are independent
        from each other (they can each be manipulated by separate actors). This is
-       the default behaviour for all maps.
+       the default behavior for all maps.
   2) `atomic`: the list is treated as a single entity, like a scalar.
        Atomic maps will be entirely replaced when updated.
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
@@ -127,7 +127,7 @@ NetworkPolicySpec provides the specification of a NetworkPolicy
       port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
     - **ingress.ports.endPort** (int32)
 
@@ -198,7 +198,7 @@ NetworkPolicySpec provides the specification of a NetworkPolicy
       port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
     - **egress.ports.endPort** (int32)
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1.md
@@ -65,14 +65,14 @@ PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
   An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
 
   <a name="IntOrString"></a>
-  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
 - **minAvailable** (IntOrString)
 
   An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
 
   <a name="IntOrString"></a>
-  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+  *IntOrString is a type that can hold an int32 or a string. When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type. This allows you to have, for example, a JSON field that can accept a name or number.*
 
 - **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -84,7 +84,7 @@ ServiceSpec describes the attributes that a user creates on a service.
     Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
 
     <a name="IntOrString"></a>
-    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
   - **ports.protocol** (string)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
@@ -95,14 +95,14 @@ DaemonSetSpec is the specification of a daemon set.
       The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
     - **updateStrategy.rollingUpdate.maxUnavailable** (IntOrString)
 
       The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
 - **revisionHistoryLimit** (int32)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
@@ -101,14 +101,14 @@ DeploymentSpec is the specification of the desired behavior of the Deployment.
       The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
     - **strategy.rollingUpdate.maxUnavailable** (IntOrString)
 
       The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
 - **revisionHistoryLimit** (int32)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1.md
@@ -44,7 +44,7 @@ configuration of a horizontal pod autoscaler.
 
 - **spec** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
 
-  spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+  spec defines the behavior of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 
 - **status** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2.md
@@ -44,7 +44,7 @@ HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, wh
 
 - **spec** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
 
-  spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+  spec is the specification for the behavior of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 
 - **status** (<a href="{{< ref "../workload-resources/horizontal-pod-autoscaler-v2#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -122,7 +122,7 @@ JobSpec describes how the job execution will look like.
 
 - **podFailurePolicy** (PodFailurePolicy)
 
-  Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+  Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behavior applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
 
   <a name="PodFailurePolicy"></a>
   *PodFailurePolicy describes how failed pods influence the backoffLimit.*

--- a/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
@@ -1690,7 +1690,7 @@ LifecycleHandler defines a specific action that should be taken in a lifecycle h
     Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 
     <a name="IntOrString"></a>
-    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
   - **httpGet.host** (string)
 
@@ -1744,7 +1744,7 @@ LifecycleHandler defines a specific action that should be taken in a lifecycle h
     Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 
     <a name="IntOrString"></a>
-    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
   - **tcpSocket.host** (string)
 
@@ -2053,7 +2053,7 @@ Probe describes a health check to be performed against a container to determine 
     Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 
     <a name="IntOrString"></a>
-    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
   - **httpGet.host** (string)
 
@@ -2096,7 +2096,7 @@ Probe describes a health check to be performed against a container to determine 
     Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
 
     <a name="IntOrString"></a>
-    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
   - **tcpSocket.host** (string)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
@@ -103,7 +103,7 @@ A StatefulSetSpec is the specification of a StatefulSet.
       The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0. Defaults to 1. This field is alpha-level and is only honored by servers that enable the MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it will be counted towards MaxUnavailable.
 
       <a name="IntOrString"></a>
-      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+      *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshaling and unmarshaling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
 
     - **updateStrategy.rollingUpdate.partition** (int32)
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -615,7 +615,7 @@ Example: `kubernetes.io/description: "Description of K8s object."`
 
 Used on: All Objects
 
-This annotation is used for describing specific behaviour of given object.
+This annotation is used for describing specific behavior of given object.
 
 ### kubernetes.io/enforce-mountable-secrets {#enforce-mountable-secrets}
 

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -672,7 +672,7 @@ same-zone traffic. However, there are key differences in their approaches:
 
 If the `service.kubernetes.io/topology-mode` annotation is set to `Auto`, it
 will take precedence over `trafficDistribution`. (The annotation may be deprecated
-in the future in favour of the `trafficDistribution` field).
+in the future in favor of the `trafficDistribution` field).
 
 ### Interaction with Traffic Policies
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -148,7 +148,7 @@ You will install these packages on all of your machines:
 kubeadm **will not** install or manage `kubelet` or `kubectl` for you, so you will
 need to ensure they match the version of the Kubernetes control plane you want
 kubeadm to install for you. If you do not, there is a risk of a version skew occurring that
-can lead to unexpected, buggy behaviour. However, _one_ minor version skew between the
+can lead to unexpected, buggy behavior. However, _one_ minor version skew between the
 kubelet and the control plane is supported, but the kubelet version may never exceed the API
 server version. For example, the kubelet running 1.7.0 should be fully compatible with a 1.8.0 API server,
 but not vice versa.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -105,7 +105,7 @@ for more details.
 
 ### Workflow when using `kubeadm init`
 
-When you call `kubeadm init`, the kubelet configuration is marshalled to disk
+When you call `kubeadm init`, the kubelet configuration is marshaled to disk
 at `/var/lib/kubelet/config.yaml`, and also uploaded to a `kubelet-config` ConfigMap in the `kube-system`
 namespace of the cluster. A kubelet configuration file is also written to `/etc/kubernetes/kubelet.conf`
 with the baseline cluster-wide configuration for all kubelets in the cluster. This configuration file
@@ -126,7 +126,7 @@ In addition to the flags used when starting the kubelet, the file also contains 
 parameters such as the cgroup driver and whether to use a different container runtime socket
 (`--cri-socket`).
 
-After marshalling these two files to disk, kubeadm attempts to run the following two
+After marshaling these two files to disk, kubeadm attempts to run the following two
 commands, if you are using systemd:
 
 ```bash

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -66,7 +66,7 @@ can take care of retaining the existing CoreDNS configuration automatically.
 
 ## Tuning CoreDNS
 
-When resource utilisation is a concern, it may be useful to tune the
+When resource utilization is a concern, it may be useful to tune the
 configuration of CoreDNS. For more details, check out the
 [documentation on scaling CoreDNS](https://github.com/coredns/deployment/blob/master/kubernetes/Scaling_CoreDNS.md).
 

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -272,8 +272,8 @@ The following policy options exist for the static `CPUManager` policy:
 If the `full-pcpus-only` policy option is specified, the static policy will always allocate full physical cores.
 By default, without this option, the static policy allocates CPUs using a topology-aware best-fit allocation.
 On SMT enabled systems, the policy can allocate individual virtual cores, which correspond to hardware threads.
-This can lead to different containers sharing the same physical cores; this behaviour in turn contributes
-to the [noisy neighbours problem](https://en.wikipedia.org/wiki/Cloud_computing_issues#Performance_interference_and_noisy_neighbors).
+This can lead to different containers sharing the same physical cores; this behavior in turn contributes
+to the [noisy neighbors problem](https://en.wikipedia.org/wiki/Cloud_computing_issues#Performance_interference_and_noisy_neighbors).
 With the option enabled, the pod will be admitted by the kubelet only if the CPU request of all its containers
 can be fulfilled by allocating full physical cores.
 If the pod does not pass the admission, it will be put in Failed state with the message `SMTAlignmentError`.

--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -331,7 +331,7 @@ deciphers the data key, and finally recovers the plain text. Communication betwe
 and the KMS requires in-transit protection, such as TLS.
 
 Using envelope encryption creates dependence on the key encryption key, which is not stored in Kubernetes.
-In the KMS case, an attacker who intends to get unauthorised access to the plaintext
+In the KMS case, an attacker who intends to get unauthorized access to the plaintext
 values would need to compromise etcd **and** the third-party KMS provider.
 
 ### Protection for encryption keys

--- a/content/en/docs/tasks/administer-cluster/memory-manager.md
+++ b/content/en/docs/tasks/administer-cluster/memory-manager.md
@@ -132,7 +132,7 @@ A dedicated set of flags can be used for this purpose to set the total amount of
 for a node. This pre-configured value is subsequently utilized to calculate
 the real amount of node's "allocatable" memory available to pods.
 
-The Kubernetes scheduler incorporates "allocatable" to optimise pod scheduling process.
+The Kubernetes scheduler incorporates "allocatable" to optimize pod scheduling process.
 The foregoing flags include `--kube-reserved`, `--system-reserved` and `--eviction-threshold`.
 The sum of their values will account for the total amount of reserved memory.
 
@@ -446,7 +446,7 @@ comprises these two NUMA nodes, i.e. `0` and `1` indexed NUMA nodes.
 Notice that the management of groups is handled in a relatively complex manner, and
 further elaboration is provided in Memory Manager KEP in [this][1] and [this][3] sections.
 
-In order to analyse memory resources available in a group,the corresponding entries from
+In order to analyze memory resources available in a group,the corresponding entries from
 NUMA nodes belonging to the group must be added up.
 
 For example, the total amount of free "conventional" memory in the group can be computed

--- a/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -52,7 +52,7 @@ Successfully running cloud-controller-manager requires some changes to your clus
   must be specified. Otherwise, it should not be specified.
 
 Keep in mind that setting up your cluster to use cloud controller manager will
-change your cluster behaviour in a few ways:
+change your cluster behavior in a few ways:
 
 * Components that specify `--cloud-provider=external` will add a taint
  `node.cloudprovider.kubernetes.io/uninitialized` with an effect `NoSchedule`

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -69,7 +69,7 @@ The Topology Manager currently:
 
 If these conditions are met, the Topology Manager will align the requested resources.
 
-In order to customise how this alignment is carried out, the Topology Manager provides two
+In order to customize how this alignment is carried out, the Topology Manager provides two
 distinct knobs: `scope` and `policy`.
 
 The `scope` defines the granularity at which you would like resource alignment to be performed

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -16,7 +16,7 @@ to authenticate to the
 
 A _service account_ provides an identity for processes that run in a Pod,
 and maps to a ServiceAccount object. When you authenticate to the API
-server, you identify yourself as a particular _user_. Kubernetes recognises
+server, you identify yourself as a particular _user_. Kubernetes recognizes
 the concept of a user, however, Kubernetes itself does **not** have a User
 API.
 

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -80,7 +80,7 @@ kubectl create secret generic regcred \
 ```
 
 If you need more control (for example, to set a namespace or a label on the new
-secret) then you can customise the Secret before storing it.
+secret) then you can customize the Secret before storing it.
 Be sure to:
 
 - set the name of the data item to `.dockerconfigjson`

--- a/content/en/docs/tasks/configure-pod-container/user-namespaces.md
+++ b/content/en/docs/tasks/configure-pod-container/user-namespaces.md
@@ -46,7 +46,7 @@ this is true when user namespaces are used.
 {{< note >}}
 The feature gate to enable user namespaces was previously named
 `UserNamespacesStatelessPodsSupport`, when only stateless pods were supported.
-Only Kubernetes v1.25 through to v1.27 recognise `UserNamespacesStatelessPodsSupport`.
+Only Kubernetes v1.25 through to v1.27 recognize `UserNamespacesStatelessPodsSupport`.
 {{</ note >}}
 
 The cluster that you're using **must** include at least one node that meets the

--- a/content/en/docs/tasks/debug/_index.md
+++ b/content/en/docs/tasks/debug/_index.md
@@ -79,7 +79,7 @@ before asking a new one!
 Many people from the Kubernetes community hang out on Kubernetes Slack in the `#kubernetes-users` channel.
 Slack requires registration; you can [request an invitation](https://slack.kubernetes.io),
 and registration is open to everyone). Feel free to come and ask any and all questions.
-Once registered, access the [Kubernetes organisation in Slack](https://kubernetes.slack.com)
+Once registered, access the [Kubernetes organization in Slack](https://kubernetes.slack.com)
 via your web browser or via Slack's own dedicated app.
 
 Once you are registered, browse the growing list of channels for various subjects of

--- a/content/en/docs/tasks/extend-kubernetes/socks5-proxy-access-api.md
+++ b/content/en/docs/tasks/extend-kubernetes/socks5-proxy-access-api.md
@@ -33,7 +33,7 @@ Figure 1 represents what you're going to achieve in this task.
 * The Kubernetes server/API is hosted on a remote server.
 * You will use SSH client and server software to create a secure SOCKS5 tunnel between the local and
   the remote server. The HTTPS traffic between the client and the Kubernetes API will flow over the SOCKS5
-  tunnel, which is itself tunnelled over SSH.
+  tunnel, which is itself tunneled over SSH.
 
 {{< mermaid >}}
 graph LR;

--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -285,7 +285,7 @@ you can check on all Pods for these templated Jobs with a single command.
 
 {{< note >}}
 The label key `jobgroup` is not special or reserved.
-You can pick your own labelling scheme.
+You can pick your own labeling scheme.
 There are [recommended labels](/docs/concepts/overview/working-with-objects/common-labels/#labels)
 that you can use if you wish.
 {{< /note >}}

--- a/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -81,7 +81,7 @@ kubectl label nodes node2 accelerator=other-gpu-k915
 That label key `accelerator` is just an example; you can use
 a different label key if you prefer.
 
-## Automatic node labelling {#node-labeller}
+## Automatic node labeling {#node-labeller}
 
 As an administrator, you can automatically discover and label all your GPU enabled nodes
 by deploying Kubernetes [Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery) (NFD).

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -381,7 +381,7 @@ and [the walkthrough for using external metrics](/docs/tasks/run-application/hor
 If you use the `v2` HorizontalPodAutoscaler API, you can use the `behavior` field
 (see the [API reference](/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec))
 to configure separate scale-up and scale-down behaviors.
-You specify these behaviours by setting `scaleUp` and / or `scaleDown`
+You specify these behaviors by setting `scaleUp` and / or `scaleDown`
 under the `behavior` field.
 
 You can specify a _stabilization window_ that prevents [flapping](#flapping)

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -1186,7 +1186,7 @@ Once the checks are good, Kubernetes updates `app-1` and finally `app-2`.
 If you added two more Pods, Kubernetes would set up `app-3` and wait for that to become healthy before deploying
 `app-4`.
 
-Because this is the default setting, you've already practised using it.
+Because this is the default setting, you've already practiced using it.
 
 ### Parallel Pod management
 


### PR DESCRIPTION
### Description

Updating the English docs to use the US-based spellings. 
Reference: https://kubernetes.io/docs/contribute/style/style-guide/#language

More details about EkLine.io [here](https://ekline.atlassian.net/wiki/external/MDJmNWI3MjBkMzE4NGQyMzhlYjkxNjUwNDVhYjBlOGQ)