### PR TITLE
[zh] Sync resource-claim-template-v1alpha3.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/resource-claim-template-v1alpha3.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/resource-claim-template-v1alpha3.md
@@ -1,39 +1,43 @@
 ---
 api_metadata:
-  apiVersion: "resource.k8s.io/v1alpha2"
-  import: "k8s.io/api/resource/v1alpha2"
+  apiVersion: "resource.k8s.io/v1alpha3"
+  import: "k8s.io/api/resource/v1alpha3"
   kind: "ResourceClaimTemplate"
 content_type: "api_reference"
 description: "ResourceClaimTemplate 用于生成 ResourceClaim 对象。"
-title: "ResourceClaimTemplate v1alpha2"
-weight: 16
+title: "ResourceClaimTemplate v1alpha3"
+weight: 17
 ---
 <!--
 api_metadata:
-  apiVersion: "resource.k8s.io/v1alpha2"
-  import: "k8s.io/api/resource/v1alpha2"
+  apiVersion: "resource.k8s.io/v1alpha3"
+  import: "k8s.io/api/resource/v1alpha3"
   kind: "ResourceClaimTemplate"
 content_type: "api_reference"
 description: "ResourceClaimTemplate is used to produce ResourceClaim objects."
-title: "ResourceClaimTemplate v1alpha2"
-weight: 16
+title: "ResourceClaimTemplate v1alpha3"
+weight: 17
 auto_generated: true
 -->
 
-`apiVersion: resource.k8s.io/v1alpha2`
+`apiVersion: resource.k8s.io/v1alpha3`
 
-`import "k8s.io/api/resource/v1alpha2"`
+`import "k8s.io/api/resource/v1alpha3"`
 
 ## ResourceClaimTemplate {#ResourceClaimTemplate}
 
 <!--
 ResourceClaimTemplate is used to produce ResourceClaim objects.
+
+This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
 -->
 ResourceClaimTemplate 用于生成 ResourceClaim 对象。
 
+这是一个 Alpha 类型的特性，需要启用 DynamicResourceAllocation 特性门控。
+
 <hr>
 
-- **apiVersion**: resource.k8s.io/v1alpha2
+- **apiVersion**: resource.k8s.io/v1alpha3
 
 - **kind**: ResourceClaimTemplate
 
@@ -45,13 +49,13 @@ ResourceClaimTemplate 用于生成 ResourceClaim 对象。
   标准的对象元数据。
 
 <!--
-- **spec** (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplateSpec" >}}">ResourceClaimTemplateSpec</a>), required
+- **spec** (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplateSpec" >}}">ResourceClaimTemplateSpec</a>), required
 
   Describes the ResourceClaim that is to be generated.
   
   This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
 -->
-- **spec** (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplateSpec" >}}">ResourceClaimTemplateSpec</a>), 必需
+- **spec** (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplateSpec" >}}">ResourceClaimTemplateSpec</a>)，必需
 
   描述要生成的 ResourceClaim。
 
@@ -67,20 +71,22 @@ ResourceClaimTemplateSpec 包含针对 ResourceClaim 的元数据和字段。
 <hr>
 
 <!--
-- **spec** (<a href="{{< ref "#ResourceClaimTemplateSpec" >}}">ResourceClaimSpec</a>), required
+- **spec** (<a href="{{< ref "../workload-resources/resource-claim-v1alpha3#ResourceClaimSpec" >}}">ResourceClaimSpec</a>), required
 
   Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here.
 -->
-*spec** (<a href="{{< ref "#ResourceClaimTemplateSpec" >}}">ResourceClaimSpec</a>), 必需
+- **spec** (<a href="{{< ref "../workload-resources/resource-claim-v1alpha3#ResourceClaimSpec" >}}">ResourceClaimSpec</a>)，必需
 
   ResourceClaim 的规约。整个内容将不加修改地复制到从模板创建的 ResourceClaim 中。
   与 ResourceClaim 中相同的字段在此处也是有效的。
 
+<!--
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
-  <!--
   ObjectMeta may contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
-  -->
+-->
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
   ObjectMeta 可以包含创建 PVC 时将要复制到其中的标签和注解。
   不允许设置其他字段，并且即便设置了也会在验证期间被拒绝。
 
@@ -93,7 +99,7 @@ ResourceClaimTemplateList 是申领模板的集合。
 
 <hr>
 
-- **apiVersion**: resource.k8s.io/v1alpha2
+- **apiVersion**: resource.k8s.io/v1alpha3
 
 - **kind**: ResourceClaimTemplateList
 
@@ -105,11 +111,11 @@ ResourceClaimTemplateList 是申领模板的集合。
   标准的列表元数据。
 
 <!--
-- **items** ([]<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>), required
+- **items** ([]<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>), required
 
   Items is the list of resource claim templates.
 -->
-- **items** ([]<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>), 必需
+- **items** ([]<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>)，必需
 
   items 是资源申领模板的列表。
 
@@ -130,7 +136,7 @@ ResourceClaimTemplateList 是申领模板的集合。
 
 #### HTTP 请求
 
-GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates/{name}
+GET /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates/{name}
 
 <!--
 #### Parameters
@@ -149,11 +155,11 @@ GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 -->
 #### 参数
 
-- **name** (**路径参数**): string, 必需
+- **name** (**路径参数**): string，必需
 
-  name of the ResourceClaimTemplate
+  ResourceClaimTemplate 的名称。
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
@@ -166,7 +172,7 @@ GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
 
 401: Unauthorized
 
@@ -179,7 +185,7 @@ GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 
 #### HTTP 请求
 
-GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
+GET /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates
 
 <!--
 #### Parameters
@@ -234,7 +240,7 @@ GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 -->
 #### 参数
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
@@ -287,7 +293,7 @@ GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplateList" >}}">ResourceClaimTemplateList</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplateList" >}}">ResourceClaimTemplateList</a>): OK
 
 401: Unauthorized
 
@@ -300,7 +306,7 @@ GET /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 
 #### HTTP 请求
 
-GET /apis/resource.k8s.io/v1alpha2/resourceclaimtemplates
+GET /apis/resource.k8s.io/v1alpha3/resourceclaimtemplates
 
 <!--
 #### Parameters
@@ -400,7 +406,7 @@ GET /apis/resource.k8s.io/v1alpha2/resourceclaimtemplates
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplateList" >}}">ResourceClaimTemplateList</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplateList" >}}">ResourceClaimTemplateList</a>): OK
 
 401: Unauthorized
 
@@ -413,7 +419,7 @@ GET /apis/resource.k8s.io/v1alpha2/resourceclaimtemplates
 
 #### HTTP 请求
 
-POST /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
+POST /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates
 
 <!--
 #### Parameters
@@ -422,7 +428,7 @@ POST /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplate
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>, required
+- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>, required
 
 - **dryRun** (*in query*): string
 
@@ -442,11 +448,11 @@ POST /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplate
 -->
 #### 参数
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>, 必需
+- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>，必需
 
 - **dryRun** (**查询参数**): string
 
@@ -469,11 +475,11 @@ POST /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplate
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
 
-201 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Created
+201 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Created
 
-202 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Accepted
+202 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Accepted
 
 401: Unauthorized
 
@@ -486,7 +492,7 @@ POST /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplate
 
 #### HTTP 请求
 
-PUT /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates/{name}
+PUT /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates/{name}
 
 <!--
 #### Parameters
@@ -499,7 +505,7 @@ PUT /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>, required
+- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>, required
 
 - **dryRun** (*in query*): string
 
@@ -519,15 +525,15 @@ PUT /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 -->
 #### 参数
 
-- **name** (**路径参数**): string, 必需
+- **name** (**路径参数**): string，必需
 
-  name of the ResourceClaimTemplate
+  ResourceClaimTemplate 的名称。
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>, 必需
+- **body**: <a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>，必需
 
 - **dryRun** (**查询参数**): string
 
@@ -550,9 +556,9 @@ PUT /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
 
-201 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Created
+201 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Created
 
 401: Unauthorized
 
@@ -565,7 +571,7 @@ PUT /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
 
 #### HTTP 请求
 
-PATCH /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates/{name}
+PATCH /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates/{name}
 
 <!--
 #### Parameters
@@ -602,15 +608,15 @@ PATCH /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplat
 -->
 #### 参数
 
-- **name** (**路径参数**): string, 必需
+- **name** (**路径参数**): string，必需
 
-  name of the ResourceClaimTemplate
+  ResourceClaimTemplate 的名称。
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, 必需
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，必需
 
 - **dryRun** (**查询参数**): string
 
@@ -637,9 +643,9 @@ PATCH /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplat
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
 
-201 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Created
+201 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Created
 
 401: Unauthorized
 
@@ -652,7 +658,7 @@ PATCH /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplat
 
 #### HTTP 请求
 
-DELETE /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates/{name}
+DELETE /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates/{name}
 
 <!--
 #### Parameters
@@ -685,11 +691,11 @@ DELETE /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtempla
 -->
 #### 参数
 
-- **name** (**路径参数**): string, 必需
+- **name** (**路径参数**): string，必需
 
-  name of the ResourceClaimTemplate
+  ResourceClaimTemplate 的名称。
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
@@ -716,9 +722,9 @@ DELETE /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtempla
 -->
 #### 响应
 
-200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
+200 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): OK
 
-202 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha2#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Accepted
+202 (<a href="{{< ref "../workload-resources/resource-claim-template-v1alpha3#ResourceClaimTemplate" >}}">ResourceClaimTemplate</a>): Accepted
 
 401: Unauthorized
 
@@ -731,7 +737,7 @@ DELETE /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtempla
 
 #### HTTP 请求
 
-DELETE /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtemplates
+DELETE /apis/resource.k8s.io/v1alpha3/namespaces/{namespace}/resourceclaimtemplates
 
 <!--
 #### Parameters
@@ -792,7 +798,7 @@ DELETE /apis/resource.k8s.io/v1alpha2/namespaces/{namespace}/resourceclaimtempla
 -->
 #### 参数
 
-- **namespace** (**路径参数**): string, 必需
+- **namespace** (**路径参数**): string，必需
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 


### PR DESCRIPTION
Update this api doc from v1alpha2 to v1alpha3:

```
deleted: content/zh-cn/docs/reference/kubernetes-api/workload-resources/resource-claim-template-v1alpha2.md
added: content/zh-cn/docs/reference/kubernetes-api/workload-resources/resource-claim-template-v1alpha3.md
```
See [preview](https://deploy-preview-47779--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/workload-resources/resource-claim-template-v1alpha3/).