### PR TITLE
Revise docs landing page (Docsy alignment)

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -94,7 +94,7 @@ footer {
 }
 
 main {
-  .button {
+  .button, .portal-button {
     display: inline-block;
     border-radius: 6px;
     padding: 6px 20px;

--- a/layouts/partials/docs/docs-portal-card.html
+++ b/layouts/partials/docs/docs-portal-card.html
@@ -20,12 +20,9 @@
         {{ end }}
     {{ end }}
     </ul>
-    {{ if .button }}
-      <br>
-      <button id="btn-concepts" class="button" onClick="location.href='{{ .button_path | relLangURL }}';" aria-label="{{ .title }}">{{ .button }}</button>
-      <br>
-      <br>
-    {{ end }}
+    {{- if .button -}}
+    <button class="portal-button" id="btn-{{ replace .title " " "-" | lower }}" onClick="location.href='{{ .button_path | relLangURL }}';" aria-label="{{ .title }}">{{ .button }}</button>
+    {{- end -}}
     </div>
 </div>
 {{ end }}


### PR DESCRIPTION
Drop some vestigial `<br>` elements from the docs portal page, and tweak how we do the styling.
Also avoid a repeated `id` value across different buttons.

Helps get us ready to use vanilla Docsy - see https://github.com/kubernetes/website/issues/41171

/area web-development
/priority backlog

[Before](https://k8s.io/docs) | [After](https://deploy-preview-47785--kubernetes-io-main-staging.netlify.app/docs/)