### PR TITLE
Fix trafficDistribution status in Service v1

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -207,7 +207,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
 - **trafficDistribution** (string)
 
-  TrafficDistribution offers a way to express preferences for how traffic is distributed to Service endpoints. Implementations can use this field as a hint, but are not required to guarantee strict adherence. If the field is not set, the implementation will apply its default routing strategy. If set to "PreferClose", implementations should prioritize endpoints that are topologically close (e.g., same zone). This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+  TrafficDistribution offers a way to express preferences for how traffic is distributed to Service endpoints. Implementations can use this field as a hint, but are not required to guarantee strict adherence. If the field is not set, the implementation will apply its default routing strategy. If set to "PreferClose", implementations should prioritize endpoints that are topologically close (e.g., same zone). This is an beta field and requires enabling ServiceTrafficDistribution feature.
 
 
 


### PR DESCRIPTION
The `trafficDistribution` field in Service has been graduated to Beta, however the upstream comment wasn't fixed when we generate the API reference for v1.31 (or more precisely, v1.30.0).
This nit has been fixed in https://github.com/kubernetes/kubernetes/pull/127117, and the change is effective in the 1.30 release branch.

This PR fixes the generated contents. 

closes: #47776