### PR TITLE
Fix field name for ListMeta in API reference

### DIFF
--- a/content/en/docs/reference/kubernetes-api/workload-resources/resource-slice-v1alpha3.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/resource-slice-v1alpha3.md
@@ -218,7 +218,7 @@ ResourceSliceList is a collection of ResourceSlices.
 
   Items is the list of resource ResourceSlices.
 
-- **listMeta** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
 
   Standard list metadata
 


### PR DESCRIPTION
The ListMeta stanza in the ResourceSliceList type was incorrectly customized to be `listMeta` when v1.30 was released. This problem has been fixed in https://github.com/kubernetes/kubernetes/pull/126749.

This PR updates the field name accordingly.
