### PR TITLE
docs: fix borken hyperlink in pod-sidecar-containers.md

### DIFF
--- a/content/en/docs/tutorials/configuration/pod-sidecar-containers.md
+++ b/content/en/docs/tutorials/configuration/pod-sidecar-containers.md
@@ -44,8 +44,7 @@ The concept of sidecar containers is not new and there are multiple implementati
 As well as sidecar containers that you, the person defining the Pod, want to run, you can also find
 that some {{< glossary_tooltip text="addons" term_id="addons" >}} modify Pods -  before the Pods
 start running - so that there are extra sidecar containers. The mechanisms to _inject_ those extra
-sidecars are often [mutating webhooks](/docs/reference/access-authn-authz/admission-controllers/
-#mutatingadmissionwebhook).
+sidecars are often [mutating webhooks](/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook).
 For example, a service mesh addon might inject a sidecar that configures mutual TLS and encryption
 in transit between different Pods.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

There's a broken hyperlink in the red box. It appears that Markdown does not support a line break (br) within a link. :P

![image](https://github.com/user-attachments/assets/0f0224b0-2b2a-47df-9ff1-af7dbb1964c1)

### Issue

Closes: None