### PR TITLE
Add CRI-O v1.31 blog post

### DIFF
--- a/content/en/blog/_posts/2024-09-18-cri-o-1.31.md
+++ b/content/en/blog/_posts/2024-09-18-cri-o-1.31.md
@@ -1,0 +1,104 @@
+---
+layout: blog
+title: "What's new in CRI-O 1.31"
+date: 2024-09-18
+slug: cri-o-1-31
+author: Sascha Grunert
+---
+
+The CRI-O maintainers are happy and proud to announce that CRI-O
+[v1.31.0](https://github.com/cri-o/cri-o/releases/tag/v1.31.0) has been
+released! This brand new version contains a large list of cool new features,
+bug fixes and smaller enhancements. I would like to take the opportunity to
+guide you through CRI-O's latest and greatest enhancements in the field of
+Kubernetes compliant container runtimes.
+
+### New features
+
+The CRI-O community voted to use the OCI runtime
+[crun](https://github.com/containers/crun) as new default in replacement to
+[runc](https://github.com/opencontainers/runc). That's actually not too new,
+because crun has been used as default runtime in the packages and static binary
+bundles for quite a while. The runtime offers an overall better performance and
+lower memory footprint than runc. It's efficiency in terms of faster container
+start times and lower memory usage makes it a more optimized runtime for modern
+workloads, for example when it comes to edge use cases as well as running
+WebAssembly (Wasm) workloads.
+
+CRI-O v1.31 also features support for fine-grained `SupplementalGroups`
+([KEP-3619](https://kep.k8s.io/3619)), which allow to control and track how
+supplemental groups are applied to a container process. If you like to learn
+more about the feature itself, then feel free to read through the [corresponding
+Kubernetes v1.31 blog post](/blog/2024/08/22/fine-grained-supplementalgroups-control).
+
+Beside that, the CRI-O maintainers also added support for the Kubernetes image
+volume source alpha feature ([KEP-4639](https://kep.k8s.io/4639)). This feature
+allows users to utilize OCI images and artifacts as custom volume source and
+mount them into containerized workloads. There is another [Kubernetes v1.31 blog
+post available](/blog/2024/08/16/kubernetes-1-31-image-volume-source) which
+covers more details about the functionality and usage of the feature.
+
+CRI-O now supports [sigstore](https://www.sigstore.dev)
+([cosign](https://github.com/sigstore/cosign)) signature verification for
+policies corresponding to a certain Kubernetes
+[namespace](/docs/concepts/overview/working-with-objects/namespaces). This
+means, that policies in the (default) directory
+`/etc/crio/policies/[NAMESPACE].json` will be validated for each pod of the
+corresponding `NAMESPACE`. This will also happen on container creation, which is
+a huge step forward in enforcing sigstore policies for a dedicated Kubernetes
+namespace in comparison to policies which only apply to the whole cluster
+itself.
+
+Beside the support for bigger Kubernetes features, CRI-O v1.31 ships a bunch of
+cool smaller enhancements, for example:
+
+- Adding a `--no-sync-log`/`no_sync_log` option to disable `fsync` on container
+  log rotation and container exit. This can improve performance at the cost of
+  potential data loss on machine crashes.
+- Respecting the image pull timeout set by the RPC context to potentially abort
+  an ongoing image pull.
+- Adding `/dev/net/tun` to the default allowed devices, which helps users to run
+  [Podman](https://podman.io) inside containers.
+- Showing the current runtime configuration in the CRI-O logs for maximum
+  transparency with respect to the loaded in-memory configuration.
+- Updating the type of checks the internal repair feature performs on CRI-O's
+  start-up following an unclean shutdown. This also features the new
+  `crio check` subcommand.
+- Updating the default pause image to v3.10 to stay up to date with Kubernetes
+  v1.31.
+- Adding support for [conmon-rs](https://github.com/containers/conmon-rs) >
+  v0.6.5, which is a replacement for the required container monitor
+  [conmon](https://github.com/containers/conmon).
+- Moving the tracing profile and endpoint listener to use 127.0.0.1 as the new
+  default to strengthen the security footprint of the project.
+- CRI-O now removes a container after it fails to start. This helps to prevent
+  copies of it from piling up until it succeeds.
+
+### Deprecations and removals
+
+It's worth to mention some deprecations and removals in CRI-O v1.31 which may
+affect existing users:
+
+- CRI-O v1.31 removed the `registries` config in `crio.image` as well as the
+  `--registry` CLI argument which have been already deprecated.
+- The device mapper storage driver is not supported any more.
+- The `crio config --migrate-defaults` subcommand has been removed (deprecated
+  in v1.28).
+
+### And more
+
+Beside features and removals, the CRI-O maintainers fixed bugs and addressed
+CVE's to ensure CRI-O's stability over the past releases. A full list of them
+can be found in the
+[official release notes](https://github.com/cri-o/cri-o/releases/tag/v1.31.0).
+
+**I would like to take this opportunity to give a huge shoutout to all
+contributors and maintainers of the CRI-O for this awesome job!** 🙌
+
+If you want to give CRI-O v1.31 a try, then feel free to head over to our
+official [packaging repository](https://github.com/cri-o/packaging?tab=readme-ov-file#stable-versions),
+which supports mostly all deb and rpm based distributions.
+
+If you have any questions or feedback, feel free to reach out using the
+Kubernetes Slack [#crio channel](https://kubernetes.slack.com/messages/CAZH62UR1)
+or create an issue in the [official repository](https://github.com/cri-o/cri-o/issues).


### PR DESCRIPTION
Creating a blog post about CRI-O v1.31.

cc @kubernetes/sig-node-cri-o-test-maintainers 


Preview: https://deploy-preview-47804--kubernetes-io-main-staging.netlify.app/blog/2024/09/18/cri-o-1-31