### PR TITLE
KEP-4292: Remove custom profiling env var as it is GA now

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -351,14 +351,6 @@ kubectl [flags]
 </tr>
 
 <tr>
-<td colspan="2">KUBECTL_DEBUG_CUSTOM_PROFILE</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, custom flag will be enabled in kubectl debug. This flag is used to customize the pre-defined profiles.
-</td>
-</tr>
-
-<tr>
 <td colspan="2">KUBECTL_EXPLAIN_OPENAPIV3</td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR remove environment variable `KUBECTL_DEBUG_CUSTOM_PROFILE` from the docs for https://github.com/kubernetes/enhancements/issues/4292 as it is promoted to stable now.