### PR TITLE
[zh] Fix rendering error caused by {{< glossary >}} in concepts/architecture/#kubelet

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/_index.md
+++ b/content/zh-cn/docs/concepts/architecture/_index.md
@@ -147,6 +147,15 @@ Node components run on every node, maintaining running pods and providing the Ku
 
 {{< glossary_definition term_id="kubelet" length="all" >}}
 
+<!--
+### kube-proxy (optional) {#kube-proxy}
+
+If you use a [network plugin](#network-plugins) that implements packet forwarding for Services
+by itself, and providing equivalent behavior to kube-proxy, then you do not need to run
+kube-proxy on the nodes in your cluster.
+
+### Container runtime
+-->
 ### kube-proxy（可选）  {#kube-proxy}
 
 {{< glossary_definition term_id="kube-proxy" length="all" >}}

--- a/content/zh-cn/docs/concepts/architecture/_index.md
+++ b/content/zh-cn/docs/concepts/architecture/_index.md
@@ -147,16 +147,6 @@ Node components run on every node, maintaining running pods and providing the Ku
 
 {{< glossary_definition term_id="kubelet" length="all" >}}
 
-<!--
-### kube-proxy (optional) {#kube-proxy}
-
-{{< glossary_definition term_id="kube-proxy" length="all" >}}
-If you use a [network plugin](#network-plugins) that implements packet forwarding for Services
-by itself, and providing equivalent behavior to kube-proxy, then you do not need to run
-kube-proxy on the nodes in your cluster.
-
-### Container runtime
--->
 ### kube-proxy（可选）  {#kube-proxy}
 
 {{< glossary_definition term_id="kube-proxy" length="all" >}}


### PR DESCRIPTION
Previously,
<img width="946" alt="Screenshot 2024-09-05 at 8 36 56 PM" src="https://github.com/user-attachments/assets/42743c32-c02d-4496-898a-8e5de69aeea8">

After
<img width="946" alt="Screenshot 2024-09-05 at 8 36 48 PM" src="https://github.com/user-attachments/assets/df3fc8f2-6f22-4371-b120-60590fa53626">

The after change version matches English version as well, https://kubernetes.io/docs/concepts/architecture/#kubelet