### PR TITLE
[ar] Fix build error due to bad tooltip label

### DIFF
--- a/content/ar/docs/setup/_index.md
+++ b/content/ar/docs/setup/_index.md
@@ -47,6 +47,6 @@ card:
 - اختيار [بيئة تشغيل الحاويات](/docs/setup/production-environment/container-runtimes/) لعنقودك الجديد.
 - التعرف على [أفضل الممارسات](/docs/concepts/overview/what-is-kubernetes/) لكوبرناتيز.
 
-تم تصميم كوبرناتيز {{< glossary_tooltip term_id="مستوى-التحكم" text="control plane" >}} ليعمل علي أنظمه لينكس. بإمكانك تشغيل أنظمة أخرى (مثل ويندوز) داخل العنقود بعد إعداده.
+تم تصميم كوبرناتيز {{< glossary_tooltip term_id="control-plane" text="صطح التحكم" >}} ليعمل علي أنظمه لينكس. بإمكانك تشغيل أنظمة أخرى (مثل ويندوز) داخل العنقود بعد إعداده.
 
 - تعرف على كيفية [تشغيل نظام ويندوز داخل حاويات كوبرناتيز](/docs/setup/production-environment/windows/user-guide-windows-containers/).

--- a/content/ar/docs/setup/_index.md
+++ b/content/ar/docs/setup/_index.md
@@ -47,6 +47,6 @@ card:
 - اختيار [بيئة تشغيل الحاويات](/docs/setup/production-environment/container-runtimes/) لعنقودك الجديد.
 - التعرف على [أفضل الممارسات](/docs/concepts/overview/what-is-kubernetes/) لكوبرناتيز.
 
-تم تصميم كوبرناتيز {{< glossary_tooltip term_id="control-plane" text="صطح التحكم" >}} ليعمل علي أنظمه لينكس. بإمكانك تشغيل أنظمة أخرى (مثل ويندوز) داخل العنقود بعد إعداده.
+تم تصميم كوبيرنيتيس {{< glossary_tooltip term_id="control-plane" text="مستوى التحكم" >}} ليعمل علي أنظمه لينكس. بإمكانك تشغيل أنظمة أخرى (مثل ويندوز) داخل العنقود بعد إعداده.
 
 - تعرف على كيفية [تشغيل نظام ويندوز داخل حاويات كوبرناتيز](/docs/setup/production-environment/windows/user-guide-windows-containers/).


### PR DESCRIPTION
### Description

This commit will fix a build error due to what seems to be a typo, where the term_id and text field for a glossary tooltip were switched.

### Issue

See [this](https://app.netlify.com/sites/kubernetes-io-ar-staging/deploys/66db07e0492a630008d1f77f) build failure in #47819 