### PR TITLE
Update Source IP Tutorial: Replace Deprecated echoserver:1.4 with echoserver:1.10 for Compatibility

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -53,7 +53,7 @@ The image in the following command only runs on AMD64 architectures.
 {{< /note >}}
 
 ```shell
-kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.4
+kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.10
 ```
 The output is:
 ```


### PR DESCRIPTION
### Description

This PR updates the Docker image used in the [Source IP for Services tutorial](https://kubernetes.io/docs/tutorials/services/source-ip/) to `registry.k8s.io/echoserver:1.10`, replacing the deprecated version `1.4`. The existing image (`echoserver:1.4`) is no longer supported due to its use of Docker Image Format v1 and Docker Image manifest version 2, schema 1, which have been deprecated in Kubernetes. 

By updating to `echoserver:1.10`, this PR resolves image pull errors.

```plaintext
Warning  Failed     5m19s (x4 over 6m59s)  kubelet            Failed to pull image "registry.k8s.io/echoserver:1.4": [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release.
```

#### Changes made

Updated the image in the deployment command from `registry.k8s.io/echoserver:1.4` to `registry.k8s.io/echoserver:1.10`.

#### Impact

- Resolves the `ErrImagePull` issue in the tutorial caused by the deprecation of the older image format.
- Ensures compatibility with current Kubernetes releases.

#### Localization Note

The deprecated echoserver:1.4 image is also referenced in some localized documentation, such as the [Russian](https://kubernetes.io/ru/docs/setup/learning-environment/minikube/), [Japan](https://kubernetes.io/ja/docs/tutorials/services/source-ip/) and [Korean](https://kubernetes.io/ko/docs/tutorials/services/source-ip/) versions. It is recommended that these versions be updated as well to echoserver:1.10 for consistency across all languages.

### Issue

Closes: #
