### PR TITLE
Add feature gate AllDNSOnlyNodeCSR for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/AllDNSOnlyNodeCSR.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/AllDNSOnlyNodeCSR.md
@@ -1,0 +1,14 @@
+---
+title: AllDNSOnlyNodeCSR
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.31"
+---
+Allow kubelet to request a certificate without any Node IP available, only with DNS names.
+


### PR DESCRIPTION
The AllDNSOnlyNodeCSR feature gate was missing from v1.31 docs. This PR fixes this problem.