### PR TITLE
Add feature gate AllowInsecureKubeletCertificateSigningRequests for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/AllowInsecureKubeletCertificateSigningRequests.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/AllowInsecureKubeletCertificateSigningRequests.md
@@ -1,0 +1,15 @@
+---
+title: AllowInsecureKubeletCertificateSigningRequests
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.31"
+---
+Disable node admission validation of CSRs for kubelet signers where CN=system:node:$nodeName.
+


### PR DESCRIPTION
The AllowInsecureKubeletCSR feature gate was missing.