### PR TITLE
Add AnonymousAuthConfigurableEndpoints feature gate for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/AnonymousAuthConfigurableEndpoints.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/AnonymousAuthConfigurableEndpoints.md
@@ -1,0 +1,14 @@
+---
+title: AnonymousAuthConfigurableEndpoints
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.31"  
+    
+---
+Allows to enable anonymous authentication/authorization for only certain API server endpoints.


### PR DESCRIPTION
The `AnonymousAuthConfigurableEndpoints` feature gate was missing in v1.31.