### PR TITLE
Add AppArmorFields feature gate to v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/AppArmorFields.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/AppArmorFields.md
@@ -1,0 +1,18 @@
+---
+title: AppArmorFields
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.30"
+    toVersion: "1.30"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.31"
+---
+Enable AppArmor related security context settings.
+See [AppArmor Tutorial](/docs/tutorials/security/apparmor/) for more details.


### PR DESCRIPTION
The `AppArmorFields` feature was introduced in v1.30 as a Beta feature (enabled by default), but it was not documented.