### PR TITLE
Fix version info for DRAControlPlaneController feature in v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DRAControlPlaneController.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DRAControlPlaneController.md
@@ -8,7 +8,7 @@ _build:
 stages:
   - stage: alpha
     defaultValue: false
-    fromVersion: "1.26"
+    fromVersion: "1.31"
 ---
 Enables support for resources with custom parameters and a lifecycle
 that is independent of a Pod. Allocation of resources is handled


### PR DESCRIPTION
The DRAControlPlaneController feature gate was actually introduced in v1.31, although the huge effort behind the scene commenced from v1.26. We document the feature's history rather than the KEP behind it.
