### PR TITLE
Add feature gate DisableAllocatorDualWrite for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableAllocatorDualWrite.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableAllocatorDualWrite.md
@@ -1,0 +1,17 @@
+---
+title: DisableAllocatorDualWrite
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.31"
+---
+The API server may enable the `MultiCIDRServiceAllocator` feature in order to support live migration
+from the old bitmap ClusterIP allocators to the new IPAddress allocators.
+The API server performs a dual-write on both allocators. This feature gate disables the dual write
+on the new Cluster IP allocators.
+


### PR DESCRIPTION
This PR adds a feature gate that failed to be documented in v1.31.