### PR TITLE
Update feature gate DisableCloudProviders for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableCloudProviders.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableCloudProviders.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta 
     defaultValue: true
     fromVersion: "1.29"    
+    toVersion": "1.30"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.31"
+
 ---
 Disables any functionality in `kube-apiserver`,
 `kube-controller-manager` and `kubelet` related to the `--cloud-provider`


### PR DESCRIPTION
The `DisableCloudProviders` feature gate has actually been GA'ed in v1.31.