### PR TITLE
Update DisableKubeletCloudCredentialProviders feature gate for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta 
     defaultValue: true
     fromVersion: "1.29"     
+    toVersion: "1.30"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.31"
+
 ---
 Disable the in-tree functionality in kubelet
 to authenticate to a cloud provider container registry for image pull credentials.


### PR DESCRIPTION
The `DisableKubeletCloudCredentialProviders` feature has been GA'ed in v1.31.
