### PR TITLE
Update RemoveSelfLink feature gate for readability

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RemoveSelfLink.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RemoveSelfLink.md
@@ -1,5 +1,4 @@
 ---
-removed: true
 title: RemoveSelfLink
 content_type: feature_gate
 _build:
@@ -19,6 +18,8 @@ stages:
     defaultValue: true
     fromVersion: "1.24"  
     toVersion: "1.29"
+
+removed: true
 ---
 Sets the `.metadata.selfLink` field to blank (empty string) for all
 objects and collections. This field has been deprecated since the Kubernetes v1.16


### PR DESCRIPTION
Moving 'removed' entry to the end as an implicit convention.