### PR TITLE
Add feature gate StrictCostEnforcementForVAP for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForVAP.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForVAP.md
@@ -1,0 +1,17 @@
+---
+title: StrictCostEnforcementForVAP
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta 
+    defaultValue: false
+    fromVersion: "1.31"
+---
+This is used to apply strict CEL cost validation for ValidatingAdmissionPolicy.
+The strict cost is specific for the extended library whose cost is defined under
+k8s/apiserver/pkg/cel/library.
+


### PR DESCRIPTION
The feature gate was missing in the docs for v1.31.