### PR TITLE
Add feature gate StrictCostEnforcementForWebhooks for v1.31

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForWebhooks.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForWebhooks.md
@@ -1,0 +1,15 @@
+---
+title: StrictCostEnforcementForWebhooks
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta 
+    defaultValue: false
+    fromVersion: "1.31"
+---
+This is used to apply strict CEL cost validation for `matchonditions` in webhooks.
+


### PR DESCRIPTION
The feature gate was missing in the docs for v1.31.
