### PR TITLE
Update AWS EBS Storage Class Example

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -290,7 +290,8 @@ parameters:
   type: io1
   iopsPerGB: "50"
   encrypted: "true"
-  tagSpecification: "key1=value1"
+  tagSpecification_1: "key1=value1"
+  tagSpecification_2: "key2=value2"
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.ebs.csi.aws.com/zone
@@ -298,7 +299,7 @@ allowedTopologies:
     - us-east-2c
 ```
 
-- `tagSpecification`: Tags to be applied on dynamically provisioned ebs volumes through AWS_EBS_CSI_DRIVER (in v1.6.0 and later).
+- `tagSpecification`: Tags to be applied on dynamically provisioned ebs volumes using this prefix. For more details, refer to the [AWS EBS CSI Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md) documentation.
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -299,7 +299,8 @@ allowedTopologies:
     - us-east-2c
 ```
 
-- `tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes. For more details, refer to the [AWS_EBS_CSI_Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md) documentation.
+`tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes.
+For more details, refer to [AWS_EBS_CSI_Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md).
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -300,7 +300,6 @@ allowedTopologies:
 ```
 
 `tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes.
-For more details, refer to [AWS_EBS_CSI_Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md).
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -290,12 +290,16 @@ parameters:
   type: io1
   iopsPerGB: "50"
   encrypted: "true"
+  tagSpecification_1: "key1=value1"
+  tagSpecification_2: "key2=hello world"
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.ebs.csi.aws.com/zone
     values:
     - us-east-2c
 ```
+
+- `tagSpecification`: Tags to be applied on the dynamically provisioned volumes.
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -299,7 +299,7 @@ allowedTopologies:
     - us-east-2c
 ```
 
-- `tagSpecification`: Tags to be applied on dynamically provisioned ebs volumes using this prefix. For more details, refer to the [AWS EBS CSI Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md) documentation.
+- `tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes. For more details, refer to the [AWS EBS CSI Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md) documentation.
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -290,8 +290,7 @@ parameters:
   type: io1
   iopsPerGB: "50"
   encrypted: "true"
-  tagSpecification_1: "key1=value1"
-  tagSpecification_2: "key2=hello world"
+  tagSpecification: "key1=value1"
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.ebs.csi.aws.com/zone
@@ -299,7 +298,7 @@ allowedTopologies:
     - us-east-2c
 ```
 
-- `tagSpecification`: Tags to be applied on dynamically provisioned ebs volumes.
+- `tagSpecification`: Tags to be applied on dynamically provisioned ebs volumes through AWS_EBS_CSI_DRIVER (in v1.6.0 and later).
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -299,7 +299,7 @@ allowedTopologies:
     - us-east-2c
 ```
 
-- `tagSpecification`: Tags to be applied on the dynamically provisioned volumes.
+- `tagSpecification`: Tags to be applied on dynamically provisioned ebs volumes.
 
 ### NFS
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -299,7 +299,7 @@ allowedTopologies:
     - us-east-2c
 ```
 
-- `tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes. For more details, refer to the [AWS EBS CSI Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md) documentation.
+- `tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes. For more details, refer to the [AWS_EBS_CSI_Driver StorageClass Tagging](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md) documentation.
 
 ### NFS
 


### PR DESCRIPTION
This PR updates the example of StorageClass for the AWS EBS CSI driver by adding the following **previously available but undocumented in k8s** tag specifications:

- `tagSpecification: "key1=value1"`

The tags will be applied to dynamically provisioned EBS volumes for better resource tracking and management. 

