### PR TITLE
Emphasize that some kubeadm node setup commands run on control plane

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-linux-nodes.md
@@ -39,6 +39,7 @@ To specify an IPv6 tuple for `<control-plane-host>:<control-plane-port>`, IPv6 a
 If you do not have the token, you can get it by running the following command on the control plane node:
 
 ```bash
+# Run this on a control plane node
 sudo kubeadm token list
 ```
 
@@ -57,6 +58,7 @@ current token has expired, you can create a new token by running the following c
 control plane node:
 
 ```bash
+# Run this on a control plane node
 sudo kubeadm token create
 ```
 
@@ -70,6 +72,7 @@ If you don't have the value of `--discovery-token-ca-cert-hash`, you can get it 
 following commands on the control plane node:
 
 ```bash
+# Run this on a control plane node
 sudo cat /etc/kubernetes/pki/ca.crt | openssl x509 -pubkey  | openssl rsa -pubin -outform der 2>/dev/null | \
    openssl dgst -sha256 -hex | sed 's/^.* //'
 ```

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -83,7 +83,8 @@ To specify an IPv6 tuple for `<control-plane-host>:<control-plane-port>`, IPv6 a
 If you do not have the token, you can get it by running the following command on the control plane node:
 
 ```bash
-kubeadm token list
+# Run this on a control plane node
+sudo kubeadm token list
 ```
 
 The output is similar to this:
@@ -101,7 +102,8 @@ current token has expired, you can create a new token by running the following c
 control plane node:
 
 ```bash
-kubeadm token create
+# Run this on a control plane node
+sudo kubeadm token create
 ```
 
 The output is similar to this:


### PR DESCRIPTION
We have two new pages about node setup. I expect that these will be popular, and also that some people will file issues about their confusion without having read the page properly. For some commands, you run them in a different shell on a different server that is part of the control plane.

Our readers are often smart, but they are also in a hurry.

- Make it extra clear that you need to run some commands in a different shell.
- Also be consistent about expecting use of `sudo`.

/sig cluster-lifecycle
/language en

Follows PR #47888