### PR TITLE
Redirect legacy Windows node setup URLs to new page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -430,10 +430,10 @@
 /docs/setup/on-premises-vm/dcos/     /docs/setup/production-environment/on-premises-vm/dcos/   301
 /docs/setup/on-premises-vm/ovirt/     /docs/setup/production-environment/on-premises-vm/ovirt/   301
 /docs/setup/windows/intro-windows-in-kubernetes/   /docs/concepts/windows/intro/  301
-/docs/setup/windows/user-guide-windows-nodes/    /docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/  301
+/docs/setup/windows/user-guide-windows-nodes/    /docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/ 301
 /docs/setup/production-environment/windows/user-guide-windows-containers/     /docs/concepts/windows/user-guide/   301
-/docs/setup/production-environment/windows/user-guide-windows-nodes/  /docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/  301
-/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/     /docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/   301
+/docs/setup/production-environment/windows/user-guide-windows-nodes/  /docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/ 301
+/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/     /docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/ 301
 /docs/setup/windows/user-guide-windows-containers/   /docs/concepts/windows/user-guide/   301
 /docs/setup/production-environment/windows/intro-windows-in-kubernetes/     /docs/concepts/windows/intro/   301
 /docs/setup/production-environment/windows/     /docs/concepts/windows/   301


### PR DESCRIPTION
We have a page about Windows node setup. If there are legacy links or bookmarks, send people to the new page.

[_example_](https://deploy-preview-47912--kubernetes-io-main-staging.netlify.app/docs/setup/windows/user-guide-windows-nodes/)

Follows #47888

/sig windows
/kind cleanup

Done for English only