### PR TITLE
Mark Windows node support as beta

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -6,6 +6,8 @@ weight: 50
 
 <!-- overview -->
 
+{{< feature-state for_k8s_version="v1.18" state="beta" >}}
+
 This page explains how to add Windows worker nodes to a kubeadm cluster.
 
 ## {{% heading "prerequisites" %}}


### PR DESCRIPTION
Support for Windows nodes set up with kubeadm is beta; make that clearer.

/sig windows
/sig cluster-lifecycle
/language en

Relevant to https://github.com/kubernetes/enhancements/issues/995