### PR TITLE
[zh-cn] sync components disruptions validating-webhook-configuration-v1

### DIFF
--- a/content/zh-cn/docs/concepts/overview/components.md
+++ b/content/zh-cn/docs/concepts/overview/components.md
@@ -3,7 +3,7 @@ title: Kubernetes 组件
 content_type: concept
 description: >
   组成 Kubernetes 集群的关键组件概述。
-weight: 30
+weight: 10
 card:
   title: 集群组件
   name: concepts
@@ -16,7 +16,7 @@ title: Kubernetes Components
 content_type: concept
 description: >
   An overview of the key components that make up a Kubernetes cluster.
-weight: 30
+weight: 10
 card:
   title: Components of a cluster
   name: concepts
@@ -39,7 +39,8 @@ card:
 <!--
 ## Core Components
 
-A Kubernetes cluster consists of a control plane and one or more worker nodes. Here's a brief overview of the main components:
+A Kubernetes cluster consists of a control plane and one or more worker nodes.
+Here's a brief overview of the main components:
 -->
 ## 核心组件
 
@@ -63,7 +64,7 @@ Manage the overall state of the cluster:
 : Runs {{< glossary_tooltip text="controllers" term_id="controller" >}} to implement Kubernetes API behavior.
 
 [cloud-controller-manager](/docs/concepts/architecture/#cloud-controller-manager) (optional)
-: Integrates with underlying cloud provider(s)
+: Integrates with underlying cloud provider(s).
 -->
 ## 控制平面组件（Control Plane Components）    {#control-plane-components}
 
@@ -93,11 +94,12 @@ Run on every node, maintaining running pods and providing the Kubernetes runtime
 : Ensures that Pods are running, including their containers.
 
 [kube-proxy](/docs/concepts/architecture/#kube-proxy) (optional)
-: Maintains network rules on nodes to implement {{< glossary_tooltip text="Services" term_id="service" >}}
+: Maintains network rules on nodes to implement {{< glossary_tooltip text="Services" term_id="service" >}}.
 
 
 [Container runtime](/docs/concepts/architecture/#container-runtime)
-: Software responsible for running containers. Read [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more.
+: Software responsible for running containers. Read
+  [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more.
 -->
 ## Node 组件  {#node-components}
 
@@ -158,9 +160,12 @@ Addons extend the functionality of Kubernetes. A few important examples include:
 <!--
 ## Flexibility in Architecture
 
-Kubernetes allows for flexibility in how these components are deployed and managed. The architecture can be adapted to various needs, from small development environments to large-scale production deployments.
+Kubernetes allows for flexibility in how these components are deployed and managed.
+The architecture can be adapted to various needs, from small development environments
+to large-scale production deployments.
 
-For more detailed information about each component and various ways to configure your cluster architecture, see the [Cluster Architecture](/docs/concepts/architecture/) page.
+For more detailed information about each component and various ways to configure your
+cluster architecture, see the [Cluster Architecture](/docs/concepts/architecture/) page.
 -->
 ## 架构灵活性    {#flexibility-in-architecture}
 

--- a/content/zh-cn/docs/concepts/workloads/pods/disruptions.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/disruptions.md
@@ -443,25 +443,16 @@ can happen, according to:
 -->
 ## Pod 干扰状况 {#pod-disruption-conditions}
 
-{{< feature-state for_k8s_version="v1.26" state="beta" >}}
-
-{{< note >}}
-<!-- 
-In order to use this behavior, you must have the `PodDisruptionConditions`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-enabled in your cluster.
--->
-要使用此行为，你必须在集群中启用 `PodDisruptionConditions`
-[特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)。
-{{< /note >}}
+{{< feature-state feature_gate_name="PodDisruptionConditions" >}}
 
 <!--
-When enabled, a dedicated Pod `DisruptionTarget` [condition](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions) is added to indicate
+A dedicated Pod `DisruptionTarget` [condition](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions)
+is added to indicate
 that the Pod is about to be deleted due to a {{<glossary_tooltip term_id="disruption" text="disruption">}}.
 The `reason` field of the condition additionally
 indicates one of the following reasons for the Pod termination:
 -->
-启用后，会给 Pod 添加一个 `DisruptionTarget`
+Pod 会被添加一个 `DisruptionTarget`
 [状况](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions)，
 用来表明该 Pod 因为发生{{<glossary_tooltip term_id="disruption" text="干扰">}}而被删除。
 状况中的 `reason` 字段进一步给出 Pod 终止的原因，如下：
@@ -501,11 +492,15 @@ Taint Manager（`kube-controller-manager` 中节点生命周期控制器的一�
 
 <!--
 `TerminationByKubelet`
-: Pod has been terminated by the kubelet, because of either {{<glossary_tooltip term_id="node-pressure-eviction" text="node pressure eviction">}} or the [graceful node shutdown](/docs/concepts/architecture/nodes/#graceful-node-shutdown).
+: Pod has been terminated by the kubelet, because of either {{<glossary_tooltip term_id="node-pressure-eviction" text="node pressure eviction">}},
+  the [graceful node shutdown](/docs/concepts/architecture/nodes/#graceful-node-shutdown),
+  or preemption for [system critical pods](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
 -->
 `TerminationByKubelet`
 : Pod
-由于{{<glossary_tooltip term_id="node-pressure-eviction" text="节点压力驱逐">}}或[节点体面关闭](/zh-cn/docs/concepts/architecture/nodes/#graceful-node-shutdown)而被
+由于{{<glossary_tooltip term_id="node-pressure-eviction" text="节点压力驱逐">}}、
+[节点体面关闭](/zh-cn/docs/concepts/architecture/nodes/#graceful-node-shutdown)
+或[系统关键 Pod](/zh-cn/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)的抢占而被
 kubelet 终止。
 
 <!--
@@ -533,11 +528,10 @@ Pod 的干扰可能会被中断。控制平面可能会重新尝试继续干扰�
 {{< /note >}}
 
 <!--
-When the `PodDisruptionConditions` feature gate is enabled,
-along with cleaning up the pods, the Pod garbage collector (PodGC) will also mark them as failed if they are in a non-terminal
+Along with cleaning up the pods, the Pod garbage collector (PodGC) will also mark them as failed if they are in a non-terminal
 phase (see also [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)).
 -->
-当 `PodDisruptionConditions` 特性门控被启用时，在清理 Pod 的同时，如果这些 Pod 处于非终止阶段，
+在清理 Pod 的同时，如果这些 Pod 处于非终止阶段，
 则 Pod 垃圾回收器 (PodGC) 也会将这些 Pod 标记为失效
 （另见 [Pod 垃圾回收](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)）。
 

--- a/content/zh-cn/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可在不更改对象的情况下接受或拒绝对象请求"
 title: "ValidatingWebhookConfiguration"
-weight: 3
+weight: 4
 ---
 
 <!-- 
@@ -17,7 +17,7 @@ api_metadata:
 content_type: "api_reference"
 description: "ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it."
 title: "ValidatingWebhookConfiguration"
-weight: 3
+weight: 4
 -->
 
 `apiVersion: admissionregistration.k8s.io/v1`
@@ -51,6 +51,8 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
 - **webhooks** ([]ValidatingWebhook)
 
   *Patch strategy: merge on key `name`*
+
+  *Map: unique values on key name will be kept during a merge*
   
   Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -61,6 +63,8 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
 - **webhooks** ([]ValidatingWebhook)
 
   **补丁策略：根据 `name` 键执行合并操作**
+
+  **Map：name 键的唯一值将在合并期间保留**
   
   webhooks 是 Webhook 以及受影响的资源和操作的列表。
 
@@ -69,11 +73,15 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
 
   <!-- 
   - **webhooks.admissionReviewVersions** ([]string), required
+  
+    *Atomic: will be replaced during a merge*
 
     AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. 
   -->
 
   - **webhooks.admissionReviewVersions** ([]string), 必需
+
+    **Atomic：将在合并期间被替换**
 
     admissionReviewVersions 是 Webhook 期望的首选 `AdmissionReview` 版本的有序列表。 
     API 服务器将尝试使用它支持的列表中的第一个版本。如果 API 服务器不支持此列表中指定的版本，则此对象将验证失败。 
@@ -266,13 +274,9 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
      - 如果 failurePolicy=Ignore，忽略错误并跳过该 webhook。
 
   <!--
-  This is an beta feature and managed by the AdmissionWebhookMatchConditions feature gate.
-  
   <a name="MatchCondition"></a>
   *MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.*
   -->
-  这是一个 Beta 功能特性，由 AdmissionWebhookMatchConditions 特性门控管理。
-
   <a name="MatchCondition"></a>
   **MatchCondition 表示将请求发送到 Webhook 之前必须满足的条件。**
 
@@ -432,6 +436,8 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
 
   <!-- 
   - **webhooks.rules** ([]RuleWithOperations)
+  
+    *Atomic: will be replaced during a merge*
 
     Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects. 
 
@@ -440,6 +446,8 @@ ValidatingWebhookConfiguration 描述准入 Webhook 的配置，该 Webhook 可�
   -->
 
   - **webhooks.rules** ([]RuleWithOperations)
+
+    **Atomic：将在合并期间被替换**
 
     rules 描述了 Webhook 关心的资源/子资源上有哪些操作。Webhook 关心操作是否匹配**任何**rules。
     但是，为了防止 ValidatingAdmissionWebhooks 和 MutatingAdmissionWebhooks 将集群置于只能完全禁用插件才能恢复的状态，
@@ -559,29 +567,46 @@ ValidatingWebhookConfigurationList 是 ValidatingWebhookConfiguration 的列表�
 
 <hr>
 
-- **apiVersion**: admissionregistration.k8s.io/v1
-
-- **kind**: ValidatingWebhookConfigurationList
-
-<!-- 
-- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
-
-  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 
--->
-
-- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
-
-  标准的对象元数据，更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds。
-
-<!-- 
+<!--
 - **items** ([]<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>), required
-
-  List of ValidatingWebhookConfiguration. 
+ 
+  List of ValidatingWebhookConfiguration.
 -->
 
 - **items** ([]<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>), 必需
-
+ 
   ValidatingWebhookConfiguration 列表。
+  
+<!--
+- **apiVersion** (string)
+
+  APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-->
+
+  apiVersion 定义对象表示的版本化模式。服务器应将已识别的模式转换为最新的内部值，并可能拒绝未识别的值。
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+<!--
+- **kind** (string)
+
+  Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-->
+- **kind**（string）
+
+  kind 是一个字符串值，表示此对象表示的 REST 资源。服务器可以从客户端提交请求的端点推断出资源类别。
+  无法更新。采用驼峰式命名。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+
+<!--
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-->
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  标准的列表元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 <!-- 
 ## Operations {#Operations}  


### PR DESCRIPTION
content/zh-cn/docs/concepts/overview/components.md
content/zh-cn/docs/concepts/workloads/pods/disruptions.md
content/zh-cn/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md