### PR TITLE
Promote LoadBalancerIPMode to GA

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -681,14 +681,11 @@ The value of `spec.loadBalancerClass` must be a label-style identifier,
 with an optional prefix such as "`internal-vip`" or "`example.com/internal-vip`".
 Unprefixed names are reserved for end-users.
 
-#### Specifying IPMode of load balancer status {#load-balancer-ip-mode}
+#### Load balancer IP address mode {#load-balancer-ip-mode}
 
 {{< feature-state feature_gate_name="LoadBalancerIPMode" >}}
 
-As a Beta feature in Kubernetes 1.30,
-a [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) 
-named `LoadBalancerIPMode` allows you to set the `.status.loadBalancer.ingress.ipMode` 
-for a Service with `type` set to `LoadBalancer`. 
+For a Service of `type: LoadBalancer`, a controller can set `.status.loadBalancer.ingress.ipMode`. 
 The `.status.loadBalancer.ingress.ipMode` specifies how the load-balancer IP behaves. 
 It may be specified only when the `.status.loadBalancer.ingress.ip` field is also specified.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/load-balancer-ip-mode.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/load-balancer-ip-mode.md
@@ -13,6 +13,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.30"
+    toVersion: "1.31"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.32"
 ---
 Allows setting `ipMode` for Services where `type` is set to `LoadBalancer`.
 See [Specifying IPMode of load balancer status](/docs/concepts/services-networking/service/#load-balancer-ip-mode)


### PR DESCRIPTION
Update the docs about promoting LoadBalancerIPMode to GA.

xref:
[KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding)
kubernetes/kubernetes#127348