### PR TITLE
Update customize-hosts-file-for-pods.md

### DIFF
--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -13,8 +13,7 @@ min-kubernetes-server-version: 1.7
 
 Adding entries to a Pod's `/etc/hosts` file provides Pod-level override of hostname resolution when DNS and other options are not applicable. You can add these custom entries with the HostAliases field in PodSpec.
 
-Modification not using HostAliases is not suggested because the file is managed by the kubelet and can be overwritten on during Pod creation/restart.
-
+Modification using the HostAliases field in the PodSpec is recommended because changes made in other ways may be overwritten by the kubelet during Pod creation or restart.
 
 <!-- steps -->
 


### PR DESCRIPTION
### Description
On this page: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
I found a sentence that is hard to understand because of the double negative.

The sentence is in the first paragraph:
"""
Modification not using HostAliases is not suggested because the file is managed by the kubelet and can be overwritten on during Pod creation/restart.
"""

It would be easier to read and understand by replacing the double negative:
"Modification using the HostAliases field in the PodSpec is recommended because changes made in other ways may be overwritten by the kubelet during Pod creation or restart."


### Issue
#47700