### PR TITLE
fix typo in self subject access review

### DIFF
--- a/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
@@ -4,7 +4,7 @@ api_metadata:
   import: "k8s.io/api/authorization/v1"
   kind: "SelfSubjectAccessReview"
 content_type: "api_reference"
-description: "SelfSubjectAccessReview checks whether or the current user can perform an action."
+description: "SelfSubjectAccessReview checks whether or not the current user can perform an action."
 title: "SelfSubjectAccessReview"
 weight: 2
 auto_generated: true
@@ -28,7 +28,7 @@ guide. You can file document formatting bugs against the
 
 ## SelfSubjectAccessReview {#SelfSubjectAccessReview}
 
-SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
+SelfSubjectAccessReview checks whether or not the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
 
 <hr>
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Seems like a glitch when comparing to the other similiar resources:

![image](https://github.com/user-attachments/assets/92aeb279-68df-4b9f-9f9b-1116706bcdb4)

Source: https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/
