### PR TITLE
[zh-cn] sync bootstrap-tokens container-runtime-interface cri

### DIFF
--- a/content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -184,13 +184,13 @@ authenticate to the API server as a bearer token.
 <!--
 The `expiration` field controls the expiry of the token. Expired tokens are
 rejected when used for authentication and ignored during ConfigMap signing.
-The expiry value is encoded as an absolute UTC time using RFC3339. Enable the
+The expiry value is encoded as an absolute UTC time using [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339). Enable the
 `tokencleaner` controller to automatically delete expired tokens.
 -->
 `expiration` 字段控制令牌的失效期。过期的令牌在用于身份认证时会被拒绝，在用于
 ConfigMap 签名时会被忽略。
-过期时间值是遵循 RFC3339 进行编码的 UTC 时间。
-启用 TokenCleaner 控制器会自动删除过期的令牌。
+过期时间值是遵循 [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339)
+进行编码的 UTC 时间。启用 TokenCleaner 控制器会自动删除过期的令牌。
 
 <!--
 ## Token Management with kubeadm

--- a/content/zh-cn/docs/reference/glossary/container-runtime-interface.md
+++ b/content/zh-cn/docs/reference/glossary/container-runtime-interface.md
@@ -33,11 +33,11 @@ The main protocol for the communication between the {{< glossary_tooltip text="k
 <!-- 
 The Kubernetes Container Runtime Interface (CRI) defines the main
 [gRPC](https://grpc.io) protocol for the communication between the
-[node components](/docs/concepts/overview/components/#node-components)
+[node components](/docs/concepts/architecture/#node-components)
 {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} and
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}.
 -->
 Kubernetes 容器运行时接口（Container Runtime Interface；CRI）定义了主要 [gRPC](https://grpc.io) 协议，
-用于[节点组件](/zh-cn/docs/concepts/overview/components/#node-components)
+用于[节点组件](/zh-cn/docs/concepts/architecture/#node-components)
 {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}
 和{{< glossary_tooltip text="容器运行时" term_id="container-runtime" >}}之间的通信。

--- a/content/zh-cn/docs/reference/glossary/cri.md
+++ b/content/zh-cn/docs/reference/glossary/cri.md
@@ -2,7 +2,7 @@
 title: 容器运行时接口（Container Runtime Interface；CRI）
 id: cri
 date: 2019-03-07
-full_link: /zh-cn/docs/concepts/overview/components/#container-runtime
+full_link: /zh-cn/docs/concepts/architecture/#container-runtime
 short_description: >
   一组与 kubelet 集成的容器运行时 API 
 
@@ -15,7 +15,7 @@ tags:
 title: Container runtime interface (CRI)
 id: cri
 date: 2019-03-07
-full_link: /docs/concepts/overview/components/#container-runtime
+full_link: /docs/concepts/architecture/#container-runtime
 short_description: >
     An API for container runtimes to integrate with kubelet
 


### PR DESCRIPTION
content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
content/zh-cn/docs/reference/glossary/container-runtime-interface.md
content/zh-cn/docs/reference/glossary/cri.md