### PR TITLE
Update ports-and-protocols.md

### DIFF
--- a/content/en/docs/reference/networking/ports-and-protocols.md
+++ b/content/en/docs/reference/networking/ports-and-protocols.md
@@ -29,6 +29,7 @@ etcd cluster externally or on custom ports.
 | TCP      | Inbound   | 10250       | Kubelet API           | Self, Control plane     |
 | TCP      | Inbound   | 10256       | kube-proxy            | Self, Load balancers    |
 | TCP      | Inbound   | 30000-32767 | NodePort Services†    | All                     |
+| UDP      | Inbound   | 30000-32767 | NodePort Services†    | All                     |
 
 † Default port range for [NodePort Services](/docs/concepts/services-networking/service/).
 


### PR DESCRIPTION
### Description
The Ports and Protocols documentation currently describes the port range of 30000-32767 as being reserved only for TCP NodePort services. Kubernetes also uses this range for allocating UDP NodePort services, however this is undocumented

For a node port Service, Kubernetes additionally allocates a port (TCP, UDP or SCTP to match the protocol of the Service).
this is mention here about UDP protocols:https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport

### Issue
#47723