### PR TITLE
Safe Sysctl 1.32 sync: net.ipv4.rmem and net.ipv4.wmem

### DIFF
--- a/content/en/docs/reference/node/kernel-version-requirements.md
+++ b/content/en/docs/reference/node/kernel-version-requirements.md
@@ -32,6 +32,8 @@ Code: https://github.com/kubernetes/kubernetes/blob/00236ae0d73d2455a2470469ed10
 - `net.ipv4.tcp_keepalive_intvl` (since Kubernetes 1.29, needs kernel 4.5+);
 - `net.ipv4.tcp_keepalive_probes` (since Kubernetes 1.29, needs kernel 4.5+);
 - `net.ipv4.tcp_syncookies` (namespaced since kernel 4.6+).
+- `net.ipv4.tcp_rmem` (since Kubernetes 1.32, needs kernel 4.15+).
+- `net.ipv4.tcp_wmem` (since Kubernetes 1.32, needs kernel 4.15+).
 - `net.ipv4.vs.conn_reuse_mode` (used in `ipvs` proxy mode, needs kernel 4.1+);
 
 ### kube proxy `nftables` proxy mode

--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -81,6 +81,8 @@ The following sysctls are supported in the _safe_ set:
 - `net.ipv4.tcp_fin_timeout` (since Kubernetes 1.29, needs kernel 4.6+);
 - `net.ipv4.tcp_keepalive_intvl` (since Kubernetes 1.29, needs kernel 4.5+);
 - `net.ipv4.tcp_keepalive_probes` (since Kubernetes 1.29, needs kernel 4.5+).
+- `net.ipv4.tcp_rmem` (since Kubernetes 1.32, needs kernel 4.15+).
+- `net.ipv4.tcp_wmem` (since Kubernetes 1.32, needs kernel 4.15+).
 
 {{< note >}}
 There are some exceptions to the set of safe sysctls:


### PR DESCRIPTION
This should be merged after https://github.com/kubernetes/kubernetes/pull/127489 was merged.

xref https://github.com/kubernetes/kubernetes/issues/125234