### PR TITLE
Add checkpoint subresource to Kublet authorization doc

### DIFF
--- a/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
@@ -65,12 +65,13 @@ DELETE    | delete
 
 The resource and subresource is determined from the incoming request's path:
 
-Kubelet API  | resource | subresource
--------------|----------|------------
-/stats/\*     | nodes    | stats
-/metrics/\*   | nodes    | metrics
-/logs/\*      | nodes    | log
-/spec/\*      | nodes    | spec
+Kubelet API         | resource | subresource
+--------------------|----------|------------
+/stats/\*           | nodes    | stats
+/metrics/\*         | nodes    | metrics
+/logs/\*            | nodes    | log
+/spec/\*            | nodes    | spec
+/checkpoint/\*      | nodes    | spec
 *all others* | nodes    | proxy
 
 The namespace and API group attributes are always an empty string, and

--- a/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
@@ -72,7 +72,7 @@ Kubelet API         | resource | subresource
 /logs/\*            | nodes    | log
 /spec/\*            | nodes    | spec
 /checkpoint/\*      | nodes    | spec
-*all others* | nodes    | proxy
+*all others*        | nodes    | proxy
 
 The namespace and API group attributes are always an empty string, and
 the resource name is always the name of the kubelet's `Node` API object.

--- a/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
@@ -71,7 +71,7 @@ Kubelet API         | resource | subresource
 /metrics/\*         | nodes    | metrics
 /logs/\*            | nodes    | log
 /spec/\*            | nodes    | spec
-/checkpoint/\*      | nodes    | spec
+/checkpoint/\*      | nodes    | checkpoint
 *all others*        | nodes    | proxy
 
 The namespace and API group attributes are always an empty string, and


### PR DESCRIPTION
### Description

This PR adds the `checkpoint` subresource to the kubelet authorization documentation which was introduced with kubernetes 1.25 as alpha, and graduated to beta in 1.30.

Preview: https://deploy-preview-48012--kubernetes-io-main-staging.netlify.app/docs/reference/access-authn-authz/kubelet-authn-authz/
