### PR TITLE
[zh-cn] sync cluster-role-v1 role-v1 replication-controller-v1

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
@@ -48,6 +48,7 @@ ClusterRole 是一个集群级别的 PolicyRule 逻辑分组，
   <a name="AggregationRule"></a>
   *AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole*
   - **aggregationRule.clusterRoleSelectors** ([]<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+    *Atomic: will be replaced during a merge*
     ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
 -->
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
@@ -63,63 +64,95 @@ ClusterRole 是一个集群级别的 PolicyRule 逻辑分组，
   **aggregationRule 描述如何定位并聚合其它 ClusterRole 到此 ClusterRole。**
   
   - **aggregationRule.clusterRoleSelectors** ([]<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
-    
+
+    **原子：将在合并期间被替换**
+  
     clusterRoleSelectors 包含一个选择器的列表，用于查找 ClusterRole 并创建规则。
     如果发现任何选择器匹配的 ClusterRole，将添加其对应的权限。
 
 <!--
 - **rules** ([]PolicyRule)
+
+  *Atomic: will be replaced during a merge*
+
   Rules holds all the PolicyRules for this ClusterRole
 
   <a name="PolicyRule"></a>
   *PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.*
 
   - **rules.apiGroups** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 
   - **rules.resources** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     Resources is a list of resources this rule applies to. '*' represents all resources.
 -->
 - **rules** ([]PolicyRule)
-  
+
+  **原子：将在合并期间被替换**
+
   rules 包含了这个 ClusterRole 的所有 PolicyRule。
   
   <a name="PolicyRule"></a>
   **PolicyRule 包含描述一个策略规则的信息，但不包含该规则适用于哪个主体或适用于哪个命名空间的信息。**
   
   - **rules.apiGroups** ([]string)
-    
+
+    **原子：将在合并期间被替换**
+
     apiGroups 是包含资源的 apiGroup 的名称。
     如果指定了多个 API 组，则允许针对任何 API 组中的其中一个枚举资源来请求任何操作。
     "" 表示核心 API 组，“*” 表示所有 API 组。
   
   - **rules.resources** ([]string)
-    
+
+    **原子：将在合并期间被替换**
+
     resources 是此规则所适用的资源的列表。“*” 表示所有资源。
 
   <!--
   - **rules.verbs** ([]string), required
+  
+    *Atomic: will be replaced during a merge*
+
     Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
   - **rules.resourceNames** ([]string)
+  
+    *Atomic: will be replaced during a merge*
+
     ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
   - **rules.nonResourceURLs** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
   -->
 
   - **rules.verbs** ([]string)，必需
-    
+
+    **原子：将在合并期间被替换**
+
     verbs 是适用于此规则中所包含的所有 ResourceKinds 的动作。
     “*” 表示所有动作。
   
   - **rules.resourceNames** ([]string)
-    
+
+    **原子：将在合并期间被替换** 
+
     resourceNames 是此规则所适用的资源名称白名单，可选。
     空集合意味着允许所有资源。
   
   - **rules.nonResourceURLs** ([]string)
-    
+
+    **原子：将在合并期间被替换** 
+
     nonResourceURLs 是用户应有权访问的一组部分 URL。
     允许使用 “*”，但仅能作为路径中最后一段且必须用于完整的一段，
     因为非资源 URL 没有划分命名空间。

--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/role-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/role-v1.md
@@ -39,62 +39,95 @@ Role 是一个按命名空间划分的 PolicyRule 逻辑分组，可以被 RoleB
 
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
-  标准的对象元数据。
-<!--
-Standard object's metadata.
+  <!--
+  Standard object's metadata.
+  -->
 
+  标准的对象元数据。
+
+<!--
 - **rules** ([]PolicyRule)
+
+  *Atomic: will be replaced during a merge*
+
   Rules holds all the PolicyRules for this Role
 
   <a name="PolicyRule"></a>
   *PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.*
 
   - **rules.apiGroups** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 
   - **rules.resources** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     Resources is a list of resources this rule applies to. '*' represents all resources.
 
   - **rules.verbs** ([]string), required
+
+    *Atomic: will be replaced during a merge*
+
     Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
   - **rules.resourceNames** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
   - **rules.nonResourceURLs** ([]string)
+
+    *Atomic: will be replaced during a merge*
+
     NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 -->  
 
 - **rules** ([]PolicyRule)
-  
+
+  **原子：将在合并期间被替换**
+
   rules 包含了这个 Role 的所有 PolicyRule。
-  
+
   <a name="PolicyRule"></a>
   **PolicyRule 包含描述一个策略规则的信息，但不包含该规则适用于哪个主体或适用于哪个命名空间的信息。**
-  
+
   - **rules.apiGroups** ([]string)
-    
+
+    **原子：将在合并期间被替换**
+  
     apiGroups 是包含资源的 apiGroup 的名称。
     如果指定了多个 API 组，则允许对任何 API 组中的其中一个枚举资源来请求任何操作。
     "" 表示核心 API 组，“*” 表示所有 API 组。
   
   - **rules.resources** ([]string)
-    
+
+    **原子：将在合并期间被替换**
+
     resources 是此规则所适用的资源的列表。
     “*” 表示所有资源。
 
   - **rules.verbs** ([]string)，必需
-    
+
+    **原子：将在合并期间被替换**
+
     verbs 是适用于此规则中所包含的所有 ResourceKinds 的动作。
     “*” 表示所有动作。
   
   - **rules.resourceNames** ([]string)
-    
+
+    **原子：将在合并期间被替换**
+  
     resourceNames 是此规则所适用的资源名称白名单，可选。
     空集合意味着允许所有资源。
   
   - **rules.nonResourceURLs** ([]string)
-    
+
+    **原子：将在合并期间被替换**
+  
     nonResourceURLs 是用户应有权访问的一组部分 URL。
     允许使用 “*”，但仅能作为路径中最后一段且必须用于完整的一段，
     因为非资源 URL 没有划分命名空间。

--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/replication-controller-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/replication-controller-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "ReplicationController 表示一个副本控制器的配置。"
 title: "ReplicationController"
-weight: 3
+weight: 4
 ---
 <!--
 api_metadata:
@@ -16,7 +16,7 @@ api_metadata:
 content_type: "api_reference"
 description: "ReplicationController represents the configuration of a replication controller."
 title: "ReplicationController"
-weight: 3
+weight: 4
 auto_generated: true
 -->
 
@@ -168,7 +168,9 @@ ReplicationControllerStatus 表示一个副本控制器的当前状态。
 - **conditions** ([]ReplicationControllerCondition)
 
   *Patch strategy: merge on key `type`*
-  
+
+  *Map: unique values on key type will be kept during a merge*
+
   Represents the latest available observations of a replication controller's current state.
 
   <a name="ReplicationControllerCondition"></a>
@@ -177,7 +179,9 @@ ReplicationControllerStatus 表示一个副本控制器的当前状态。
 - **conditions** ([]ReplicationControllerCondition)
   
   **补丁策略：按照键 `type` 合并**
-  
+
+  **Map：键 `type` 的唯一值将在合并期间保留**
+ 
   表示副本控制器当前状态的最新可用观测值。
   
   <a name="ReplicationControllerCondition"></a>


### PR DESCRIPTION
content/zh-cn/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
content/zh-cn/docs/reference/kubernetes-api/authorization-resources/role-v1.md
content/zh-cn/docs/reference/kubernetes-api/workload-resources/replication-controller-v1.md