### PR TITLE
[zh] Sync an API doc: persistent-volume-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "PersistentVolume (PV) 是管理员制备的一个存储资源。"
 title: "PersistentVolume"
-weight: 5
+weight: 7
 ---
 <!--
 api_metadata:
@@ -16,7 +16,8 @@ api_metadata:
 content_type: "api_reference"
 description: "PersistentVolume (PV) is a storage resource provisioned by an administrator."
 title: "PersistentVolume"
-weight: 5
+weight: 7
+auto_generated: true
 -->
 
 `apiVersion: v1`
@@ -39,15 +40,13 @@ https://kubernetes.io/zh-cn/docs/concepts/storage/persistent-volumes
 
 <!--
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
   Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeSpec" >}}">PersistentVolumeSpec</a>)
+
   spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-
-- **status** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeStatus" >}}">PersistentVolumeStatus</a>)
-  status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
 -->
-
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
   标准的对象元数据。更多信息：
@@ -58,12 +57,18 @@ https://kubernetes.io/zh-cn/docs/concepts/storage/persistent-volumes
   spec 定义了集群所拥有的持久卷的规约。由管理员进行制备。更多信息：
   https://kubernetes.io/zh-cn/docs/concepts/storage/persistent-volumes#persistent-volumes
 
+<!--
+- **status** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeStatus" >}}">PersistentVolumeStatus</a>)
+
+  status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+-->
 - **status** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeStatus" >}}">PersistentVolumeStatus</a>)
 
   status 表示持久卷的当前信息/状态。该值由系统填充，只读。更多信息：
   https://kubernetes.io/zh-cn/docs/concepts/storage/persistent-volumes#persistent-volumes
 
 ## PersistentVolumeSpec {#PersistentVolumeSpec}
+
 <!--
 PersistentVolumeSpec is the specification of a persistent volume.
 -->
@@ -73,6 +78,9 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **accessModes** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
   accessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
 
 - **capacity** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
@@ -80,6 +88,8 @@ PersistentVolumeSpec 是持久卷的规约。
   capacity is the description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
 -->
 - **accessModes** ([]string)
+
+  **原子：将在合并期间被替换**
 
   accessModes 包含可以挂载卷的所有方式。更多信息：
   https://kubernetes.io/zh-cn/docs/concepts/storage/persistent-volumes#access-modes
@@ -95,9 +105,11 @@ PersistentVolumeSpec 是持久卷的规约。
   claimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding
 
 - **mountOptions** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
   mountOptions is the list of mount options, e.g. ["ro", "soft"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options
 -->
-
 - **claimRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
 
   claimRef 是 PersistentVolume 和 PersistentVolumeClaim 之间双向绑定的一部分。
@@ -106,18 +118,20 @@ PersistentVolumeSpec 是持久卷的规约。
 
 - **mountOptions** ([]string)
 
+  **原子：将在合并期间被替换**
+
   mountOptions 是挂载选项的列表，例如 ["ro", "soft"]。
   针对此字段无合法性检查——如果某选项无效，则只是挂载会失败。更多信息：
   https://kubernetes.io/zh-cn/docs/concepts/storage/persistent-volumes/#mount-options
 
 <!--
 - **nodeAffinity** (VolumeNodeAffinity)
+
   nodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume.
 
   <a name="VolumeNodeAffinity"></a>
   *VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.*
 -->
-
 - **nodeAffinity** (VolumeNodeAffinity)
 
   nodeAffinity 定义可以从哪些节点访问此卷的约束限制。此字段会影响调度使用此卷的 Pod。
@@ -127,26 +141,13 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **nodeAffinity.required** (NodeSelector)
+
     required specifies hard node constraints that must be met.
 
     <a name="NodeSelector"></a>
     *A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.*
-
-    - **nodeAffinity.required.nodeSelectorTerms** ([]NodeSelectorTerm), required
-
-      Required. A list of node selector terms. The terms are ORed.
-
-      <a name="NodeSelectorTerm"></a>
-      *A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.*
-
-      - **nodeAffinity.required.nodeSelectorTerms.matchExpressions** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
-
-        A list of node selector requirements by node's labels.
-
-      - **nodeAffinity.required.nodeSelectorTerms.matchFields** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
-
-        A list of node selector requirements by node's fields.
   -->
+
   - **nodeAffinity.required** (NodeSelector)
 
     required 指定必须满足的硬性节点约束。
@@ -155,7 +156,20 @@ PersistentVolumeSpec 是持久卷的规约。
     **节点选择器表示在一组节点上一个或多个标签查询结果的并集；
     也就是说，它表示由节点选择器条件表示的选择器的逻辑或计算结果。**
 
+    <!--
+    - **nodeAffinity.required.nodeSelectorTerms** ([]NodeSelectorTerm), required
+
+      *Atomic: will be replaced during a merge*
+      
+      Required. A list of node selector terms. The terms are ORed.
+
+      <a name="NodeSelectorTerm"></a>
+      *A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.*
+    -->
+
     - **nodeAffinity.required.nodeSelectorTerms** ([]NodeSelectorTerm)，必需
+
+      **原子：将在合并期间被替换**
 
       必需。节点选择器条件的列表。这些条件是逻辑或的计算结果。
 
@@ -163,11 +177,29 @@ PersistentVolumeSpec 是持久卷的规约。
       **一个 null 或空的节点选择器条件不会与任何对象匹配。这些条件会按逻辑与的关系来计算。
       TopologySelectorTerm 类别实现了 NodeSelectorTerm 的子集。**
 
+      <!--
       - **nodeAffinity.required.nodeSelectorTerms.matchExpressions** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+        *Atomic: will be replaced during a merge*
+        
+        A list of node selector requirements by node's labels.
+
+      - **nodeAffinity.required.nodeSelectorTerms.matchFields** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+        *Atomic: will be replaced during a merge*
+        
+        A list of node selector requirements by node's fields.
+      -->
+      
+      - **nodeAffinity.required.nodeSelectorTerms.matchExpressions** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+        **原子：将在合并期间被替换**
 
         基于节点标签所设置的节点选择器要求的列表。
 
       - **nodeAffinity.required.nodeSelectorTerms.matchFields** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+        **原子：将在合并期间被替换**
 
         基于节点字段所设置的节点选择器要求的列表。
 
@@ -176,7 +208,6 @@ PersistentVolumeSpec 是持久卷的规约。
 
   persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
 -->
-
 - **persistentVolumeReclaimPolicy** (string)
 
   persistentVolumeReclaimPolicy 定义当从持久卷声明释放持久卷时会发生什么。
@@ -187,38 +218,54 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **storageClassName** (string)
+
   storageClassName is the name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.
 
-- **volumeMode** (string)
-  volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
--->
+- **volumeAttributesClassName** (string)
 
+  Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process. This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
+-->
 - **storageClassName** (string)
 
   storageClassName 是这个持久卷所属于的 StorageClass 的名称。
   空值意味着此卷不属于任何 StorageClass。
 
+- **volumeAttributesClassName** (string)
+
+  此持久卷所属的 VolumeAttributesClass 的名称。不能为空。
+  当此字段未设置时，表示此卷不属于任何 VolumeAttributesClass。
+  此字段是可变更的，在某个卷已被成功更新为新类后可以由 CSI 驱动更改此字段。对于未绑定的 PersistentVolume，
+  volumeAttributesClassName 将在绑定过程中与未绑定的 PersistentVolumeClaim 进行匹配。
+  这是一个 Beta 字段，需要启用 VolumeAttributesClass 特性（默认关闭）。
+
+<!--
+- **volumeMode** (string)
+
+  volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
+-->
 - **volumeMode** (string)
 
   volumeMode 定义一个卷是带着已格式化的文件系统来使用还是保持在原始块状态来使用。
   当 spec 中未包含此字段时，意味着取值为 Filesystem。
 
 ### Local
+
 <!--
 - **hostPath** (HostPathVolumeSource)
+
   hostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 
   <a name="HostPathVolumeSource"></a>
   *Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.*
 
   - **hostPath.path** (string), required
+
     path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 
   - **hostPath.type** (string)
 
     type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 -->
-
 - **hostPath** (HostPathVolumeSource)
 
   hostPath 表示主机上的目录，由开发或测试人员进行制备。hostPath 仅对单节点开发和测试有用！
@@ -247,13 +294,13 @@ PersistentVolumeSpec 是持久卷的规约。
   *Local represents directly-attached storage with node affinity (Beta feature)*
 
   - **local.path** (string), required
+
     path of the full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
 
   - **local.fsType** (string)
 
     fsType is the filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a filesystem if unspecified.
 -->
-
 - **local** (LocalVolumeSource)
 
   local 表示具有节点亲和性的直连式存储。
@@ -274,8 +321,8 @@ PersistentVolumeSpec 是持久卷的规约。
 <!--
 ### Persistent volumes
 
-
 - **awsElasticBlockStore** (AWSElasticBlockStoreVolumeSource)
+
   awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 
   <a name="AWSElasticBlockStoreVolumeSource"></a>
@@ -343,7 +390,6 @@ PersistentVolumeSpec 是持久卷的规约。
   <a name="AzureDiskVolumeSource"></a>
   *AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.*
 -->
-
 - **azureDisk** (AzureDiskVolumeSource)
 
   azureDisk 表示主机上挂载的 Azure Data Disk 并绑定挂载到 Pod 上。
@@ -353,26 +399,16 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **azureDisk.diskName** (string), required
+
     diskName is the Name of the data disk in the blob storage
 
   - **azureDisk.diskURI** (string), required
+
     diskURI is the URI of data disk in the blob storage
 
   - **azureDisk.cachingMode** (string)
 
     cachingMode is the Host Caching mode: None, Read Only, Read Write.
-
-  - **azureDisk.fsType** (string)
-
-    fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-
-  - **azureDisk.kind** (string)
-
-    kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
-
-  - **azureDisk.readOnly** (boolean)
-
-    readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
   -->
 
   - **azureDisk.diskName** (string)，必需
@@ -387,6 +423,20 @@ PersistentVolumeSpec 是持久卷的规约。
 
     cachingMode 是主机缓存（Host Caching）模式：None、Read Only、Read Write。
 
+  <!--
+  - **azureDisk.fsType** (string)
+
+    fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **azureDisk.kind** (string)
+
+    kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+  - **azureDisk.readOnly** (boolean)
+
+    readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+  -->
+
   - **azureDisk.fsType** (string)
 
     fsType 是要挂载的文件系统类型。必须是主机操作系统所支持的文件系统类型之一。
@@ -395,9 +445,11 @@ PersistentVolumeSpec 是持久卷的规约。
   - **azureDisk.kind** (string)
 
     kind 预期值包括：
+
     - Shared：每个存储帐户多个 Blob 磁盘；
     - Dedicated：每个存储帐户单个 Blob 磁盘；
     - Managed：azure 托管的数据盘（仅托管的可用性集合中）。
+    
     默认为 Shared。
 
   - **azureDisk.readOnly** (boolean)
@@ -408,13 +460,24 @@ PersistentVolumeSpec 是持久卷的规约。
 - **azureFile** (AzureFilePersistentVolumeSource)
 
   azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
   <a name="AzureFilePersistentVolumeSource"></a>
   *AzureFile represents an Azure File Service mount on the host and bind mount to the pod.*
+-->
+- **azureFile** (AzureFilePersistentVolumeSource)
 
+  azureDisk 表示主机上挂载并绑定挂载到 Pod 上的 Azure File Service。
+
+  <a name="AzureFilePersistentVolumeSource"></a>
+  **azureFile 表示主机上挂载的并绑定挂载到 Pod 上的 Azure File Service。**
+
+  <!--
   - **azureFile.secretName** (string), required
+
     secretName is the name of secret that contains Azure Storage Account Name and Key
 
   - **azureFile.shareName** (string), required
+
     shareName is the azure Share Name
 
   - **azureFile.readOnly** (boolean)
@@ -424,14 +487,7 @@ PersistentVolumeSpec 是持久卷的规约。
   - **azureFile.secretNamespace** (string)
 
     secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
--->
-
-- **azureFile** (AzureFilePersistentVolumeSource)
-
-  azureDisk 表示主机上挂载的 Azure File Service 并绑定挂载到 Pod 上。
-
-  <a name="AzureFilePersistentVolumeSource"></a>
-  **azureFile 表示主机上挂载的 Azure File Service 并绑定挂载到 Pod 上。**
+  -->
 
   - **azureFile.secretName** (string)，必需
 
@@ -457,7 +513,6 @@ PersistentVolumeSpec 是持久卷的规约。
   <a name="CephFSPersistentVolumeSource"></a>
   *Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.*
 -->
-
 - **cephfs** (CephFSPersistentVolumeSource)
 
   cephfs 表示在主机上挂载的 Ceph FS，该文件系统挂载与 Pod 的生命周期相同。
@@ -467,24 +522,32 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **cephfs.monitors** ([]string), required
-    monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
+    *Atomic: will be replaced during a merge*
+    
+    monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+  -->
+
+  - **cephfs.monitors** ([]string)，必需
+
+    **原子：将在合并期间被替换**
+
+    monitors 是必需的。monitors 是 Ceph 监测组件的集合。更多信息：
+    https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  <!--
   - **cephfs.path** (string)
 
     path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
 
   - **cephfs.readOnly** (boolean)
+
     readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
   - **cephfs.secretFile** (string)
 
     secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   -->
-
-  - **cephfs.monitors** ([]string)，必需
-
-    monitors 是必需的。monitors 是 Ceph 监测的集合。更多信息：
-    https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
   - **cephfs.path** (string)
 
@@ -509,9 +572,11 @@ PersistentVolumeSpec 是持久卷的规约。
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **cephfs.secretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **cephfs.secretRef.namespace** (string)
+
       namespace defines the space within which the secret name must be unique.
 
   - **cephfs.user** (string)
@@ -548,7 +613,6 @@ PersistentVolumeSpec 是持久卷的规约。
   <a name="CinderPersistentVolumeSource"></a>
   *Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.*
 -->
-
 - **cinder** (CinderPersistentVolumeSource)
 
   cinder 表示 kubelet 主机上挂接和挂载的 Cinder 卷。更多信息：
@@ -560,6 +624,7 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **cinder.volumeID** (string), required
+
     volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 
   - **cinder.fsType** (string)
@@ -567,6 +632,7 @@ PersistentVolumeSpec 是持久卷的规约。
     fsType Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 
   - **cinder.readOnly** (boolean)
+
     readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   -->
 
@@ -589,12 +655,14 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **cinder.secretRef** (SecretReference)
+
     secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack.
 
     <a name="SecretReference"></a>
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **cinder.secretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **cinder.secretRef.namespace** (string)
@@ -619,12 +687,14 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **csi** (CSIPersistentVolumeSource)
+
   csi represents storage that is handled by an external CSI driver (Beta feature).
 
   <a name="CSIPersistentVolumeSource"></a>
   *Represents storage that is managed by an external CSI volume driver (Beta feature)*
 
   - **csi.driver** (string), required
+
     driver is the name of the driver to use for this volume. Required.
 
   - **csi.volumeHandle** (string), required
@@ -691,9 +761,11 @@ PersistentVolumeSpec 是持久卷的规约。
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **csi.controllerPublishSecretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **csi.controllerPublishSecretRef.namespace** (string)
+
       namespace defines the space within which the secret name must be unique.
   -->
 
@@ -722,7 +794,7 @@ PersistentVolumeSpec 是持久卷的规约。
 
   - **csi.nodeExpandSecretRef** (SecretReference)
 
-    nodeExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeExpandVolume call. This is a beta field which is enabled default by CSINodeExpandSecret feature gate. This field is optional, may be omitted if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+    nodeExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeExpandVolume call. This field is optional, may be omitted if no secret is required. If the secret object contains more than one secret, all secrets are passed.
 
     <a name="SecretReference"></a>
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
@@ -743,8 +815,7 @@ PersistentVolumeSpec 是持久卷的规约。
   - **csi.nodeExpandSecretRef** (SecretReference)
 
     nodeExpandSecretRef 是对包含敏感信息的 Secret 对象的引用，
-    从而传递到 CSI 驱动以完成 CSI NodeExpandVolume 和 NodeUnpublishVolume 调用。
-    这是一个 Beta 字段，通过 CSINodeExpandSecret 特性门控默认启用。
+    从而传递到 CSI 驱动以完成 CSI NodeExpandVolume 调用。
     此字段是可选的，且如果不需要 Secret，则此字段可以为空。
     如果 Secret 对象包含多个 Secret，则所有 Secret 被传递。
 
@@ -869,14 +940,6 @@ PersistentVolumeSpec 是持久卷的规约。
   - **fc.readOnly** (boolean)
 
     readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
-
-  - **fc.targetWWNs** ([]string)
-
-    targetWWNs is Optional: FC target worldwide names (WWNs)
-
-  - **fc.wwids** ([]string)
-
-    wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
   -->
 
   - **fc.fsType** (string)
@@ -893,11 +956,29 @@ PersistentVolumeSpec 是持久卷的规约。
     readOnly 是可选的。默认为 false（读/写）。
     此处 readOnly 将在 VolumeMounts 中强制设置 readOnly。
 
+  <!--
   - **fc.targetWWNs** ([]string)
+
+    *Atomic: will be replaced during a merge*
+    
+    targetWWNs is Optional: FC target worldwide names (WWNs)
+
+  - **fc.wwids** ([]string)
+
+    *Atomic: will be replaced during a merge*
+    
+    wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+  -->
+
+  - **fc.targetWWNs** ([]string)
+
+    **原子：将在合并期间被替换**
 
     targetWWNs 是可选的。FC 目标全球名称（WWN）。
 
   - **fc.wwids** ([]string)
+
+    **原子：将在合并期间被替换**
 
     wwids 是可选的。FC 卷全球识别号（wwids）。
     必须设置 wwids 或 targetWWNs 及 lun 的组合，但不能同时设置两者。
@@ -910,7 +991,6 @@ PersistentVolumeSpec 是持久卷的规约。
   <a name="FlexPersistentVolumeSource"></a>
   *FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.*
 -->
-
 - **flexVolume** (FlexPersistentVolumeSource)
 
   flexVolume 表示使用基于 exec 的插件制备/挂接的通用卷资源。
@@ -920,9 +1000,11 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **flexVolume.driver** (string), required
+
     driver is the name of the driver to use for this volume.
 
   - **flexVolume.fsType** (string)
+
     fsType is the Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 
   - **flexVolume.options** (map[string]string)
@@ -961,6 +1043,7 @@ PersistentVolumeSpec 是持久卷的规约。
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **flexVolume.secretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **flexVolume.secretRef.namespace** (string)
@@ -986,19 +1069,20 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **flocker** (FlockerVolumeSource)
+
   flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running
 
   <a name="FlockerVolumeSource"></a>
   *Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.*
 
   - **flocker.datasetName** (string)
+
     datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
 
   - **flocker.datasetUUID** (string)
 
     datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
 -->
-
 - **flocker** (FlockerVolumeSource)
 
   flocker 表示挂接到 kubelet 的主机并暴露给 Pod 供其使用的 Flocker 卷。
@@ -1018,6 +1102,7 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **gcePersistentDisk** (GCEPersistentDiskVolumeSource)
+
   gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
   <a name="GCEPersistentDiskVolumeSource"></a>
@@ -1025,7 +1110,6 @@ PersistentVolumeSpec 是持久卷的规约。
 
   A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.*
 -->
-
 - **gcePersistentDisk** (GCEPersistentDiskVolumeSource)
 
   gcePersistentDisk 表示挂接到 kubelet 的主机随后暴露给 Pod 的一个 GCE Disk 资源。
@@ -1040,15 +1124,19 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **gcePersistentDisk.pdName** (string), required
+
     pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
   - **gcePersistentDisk.fsType** (string)
+
     fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
   - **gcePersistentDisk.partition** (int32)
+
     partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
   - **gcePersistentDisk.readOnly** (boolean)
+
     readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
   -->
 
@@ -1078,17 +1166,16 @@ PersistentVolumeSpec 是持久卷的规约。
 - **glusterfs** (GlusterfsPersistentVolumeSource)
 
   glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md
--->
 
+  <a name="GlusterfsPersistentVolumeSource"></a>
+  *Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.*
+-->
 - **glusterfs** （GlusterfsPersistentVolumeSource）
 
   glusterfs 表示关联到主机并暴露给 Pod 的 Glusterfs 卷。由管理员配置。
   更多信息：https://examples.k8s.io/volumes/glusterfs/README.md
 
   <a name="GlusterfsPersistentVolumeSource"></a>
-  <!--
-  *Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.*
-  -->
   **表示在 Pod 生命周期内一直存在的 Glusterfs 挂载卷。Glusterfs 卷不支持属主管理或 SELinux 重标记。**
 
   <!--
@@ -1137,7 +1224,6 @@ PersistentVolumeSpec 是持久卷的规约。
   iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.
 
   <a name="ISCSIPersistentVolumeSource"></a>
-
   *ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.*
 -->
 
@@ -1150,12 +1236,15 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **iscsi.iqn** (string), required
+
     iqn is Target iSCSI Qualified Name.
 
   - **iscsi.lun** (int32), required
+
     lun is iSCSI Target Lun number.
 
   - **iscsi.targetPortal** (string), required
+
     targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
   -->
 
@@ -1182,6 +1271,7 @@ PersistentVolumeSpec 是持久卷的规约。
     chapAuthSession defines whether support iSCSI Session CHAP authentication
 
   - **iscsi.fsType** (string)
+
     fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
   -->
 
@@ -1205,10 +1295,13 @@ PersistentVolumeSpec 是持久卷的规约。
     initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \<target portal>:\<volume name> will be created for the connection.
 
   - **iscsi.iscsiInterface** (string)
+
     iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
 
   - **iscsi.portals** ([]string)
 
+    *Atomic: will be replaced during a merge*
+    
     portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
 
   - **iscsi.readOnly** (boolean)
@@ -1227,6 +1320,8 @@ PersistentVolumeSpec 是持久卷的规约。
 
   - **iscsi.portals** ([]string)
 
+    **原子：将在合并期间被替换**
+
     portals 是 iSCSI 目标门户列表（iSCSI Target Portal List）。
     如果不是默认端口（通常是 TCP 端口 860 和 3260），则 Portal 为 IP 或 ip_addr:port。
 
@@ -1243,6 +1338,7 @@ PersistentVolumeSpec 是持久卷的规约。
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **iscsi.secretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **iscsi.secretRef.namespace** (string)
@@ -1267,22 +1363,24 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **nfs** (NFSVolumeSource)
+
   nfs represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
   <a name="NFSVolumeSource"></a>
   *Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.*
 
   - **nfs.path** (string), required
+
     path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
   - **nfs.server** (string), required
+
     server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
   - **nfs.readOnly** (boolean)
 
     readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 -->
-
 - **nfs** (NFSVolumeSource)
 
   nfs 表示主机上挂载的 NFS。由管理员进行制备。更多信息：
@@ -1308,18 +1406,20 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **photonPersistentDisk** (PhotonPersistentDiskVolumeSource)
+
   photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
 
   <a name="PhotonPersistentDiskVolumeSource"></a>
   *Represents a Photon Controller persistent disk resource.*
 
   - **photonPersistentDisk.pdID** (string), required
+
     pdID is the ID that identifies Photon Controller persistent disk
 
   - **photonPersistentDisk.fsType** (string)
+
     fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 -->
-
 - **photonPersistentDisk** (PhotonPersistentDiskVolumeSource)
 
   photonPersistentDisk 表示 kubelet 主机上挂接和挂载的 PhotonController 持久磁盘。
@@ -1338,21 +1438,24 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **portworxVolume** (PortworxVolumeSource)
+
   portworxVolume represents a portworx volume attached and mounted on kubelets host machine
 
   <a name="PortworxVolumeSource"></a>
   *PortworxVolumeSource represents a Portworx volume resource.*
 
   - **portworxVolume.volumeID** (string), required
+
     volumeID uniquely identifies a Portworx volume
 
   - **portworxVolume.fsType** (string)
+
     fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
 
   - **portworxVolume.readOnly** (boolean)
+
     readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 -->
-
 - **portworxVolume** (PortworxVolumeSource)
 
   portworxVolume 表示 kubelet 主机上挂接和挂载的 portworx 卷。
@@ -1382,12 +1485,13 @@ PersistentVolumeSpec 是持久卷的规约。
   *Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.*
 
   - **quobyte.registry** (string), required
+
     registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
 
   - **quobyte.volume** (string), required
+
     volume is a string that references an already created Quobyte volume by name.
 -->
-
 - **quobyte** (QuobyteVolumeSource)
 
   quobyte 表示在共享 Pod 生命周期的主机上挂载的 Quobyte。
@@ -1406,15 +1510,19 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **quobyte.group** (string)
+
     group to map volume access to Default is no group
 
   - **quobyte.readOnly** (boolean)
+
     readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
 
   - **quobyte.tenant** (string)
+
     tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
 
   - **quobyte.user** (string)
+
     user to map volume access to Defaults to serivceaccount user
   -->
 
@@ -1436,15 +1544,20 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **rbd** (RBDPersistentVolumeSource)
+
   rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
 
   <a name="RBDPersistentVolumeSource"></a>
   *Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.*
 
   - **rbd.image** (string), required
+
     image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 
   - **rbd.monitors** ([]string), required
+
+    *Atomic: will be replaced during a merge*
+    
     monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 -->
 
@@ -1463,6 +1576,8 @@ PersistentVolumeSpec 是持久卷的规约。
 
   - **rbd.monitors** ([]string)，必需
 
+    **原子：将在合并期间被替换**
+
     monitors 是 Ceph 监测的集合。更多信息：
     https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 
@@ -1472,12 +1587,15 @@ PersistentVolumeSpec 是持久卷的规约。
     fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 
   - **rbd.keyring** (string)
+
     keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 
   - **rbd.pool** (string)
+
     pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 
   - **rbd.readOnly** (boolean)
+
     readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   -->
 
@@ -1511,12 +1629,15 @@ PersistentVolumeSpec 是持久卷的规约。
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **rbd.secretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **rbd.secretRef.namespace** (string)
+
       namespace defines the space within which the secret name must be unique.
 
   - **rbd.user** (string)
+
     user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   -->
 
@@ -1550,6 +1671,7 @@ PersistentVolumeSpec 是持久卷的规约。
   *ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume*
 
   - **scaleIO.gateway** (string), required
+
     gateway is the host address of the ScaleIO API Gateway.
 -->
 
@@ -1566,15 +1688,18 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **scaleIO.secretRef** (SecretReference), required
+
     secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
 
     <a name="SecretReference"></a>
     *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
 
     - **scaleIO.secretRef.name** (string)
+
       name is unique within a namespace to reference a secret resource.
 
     - **scaleIO.secretRef.namespace** (string)
+
       namespace defines the space within which the secret name must be unique.
   -->
 
@@ -1595,15 +1720,19 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **scaleIO.system** (string), required
+
     system is the name of the storage system as configured in ScaleIO.
 
   - **scaleIO.fsType** (string)
+
     fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
 
   - **scaleIO.protectionDomain** (string)
+
     protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
 
   - **scaleIO.readOnly** (boolean)
+
     readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
   -->
 
@@ -1626,15 +1755,19 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **scaleIO.sslEnabled** (boolean)
+
     sslEnabled is the flag to enable/disable SSL communication with Gateway, default false
 
   - **scaleIO.storageMode** (string)
+
     storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
 
   - **scaleIO.storagePool** (string)
+
     storagePool is the ScaleIO Storage Pool associated with the protection domain.
 
   - **scaleIO.volumeName** (string)
+
     volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
   -->
 
@@ -1657,18 +1790,20 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **storageos** (StorageOSPersistentVolumeSource)
+
   storageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://examples.k8s.io/volumes/storageos/README.md
 
   <a name="StorageOSPersistentVolumeSource"></a>
   *Represents a StorageOS persistent volume resource.*
 
   - **storageos.fsType** (string)
+
     fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 
   - **storageos.readOnly** (boolean)
+
     readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
 -->
-
 - **storageos** (StorageOSPersistentVolumeSource)
 
   storageOS 表示一个 StorageOS 卷，该卷被挂接到 kubelet 的主机并挂载到 Pod 中。更多信息：
@@ -1688,12 +1823,15 @@ PersistentVolumeSpec 是持久卷的规约。
 
   <!--
   - **storageos.secretRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
     secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
 
   - **storageos.volumeName** (string)
+
     volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
 
   - **storageos.volumeNamespace** (string)
+
     volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
   -->
 
@@ -1715,24 +1853,28 @@ PersistentVolumeSpec 是持久卷的规约。
 
 <!--
 - **vsphereVolume** (VsphereVirtualDiskVolumeSource)
+
   vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
 
   <a name="VsphereVirtualDiskVolumeSource"></a>
   *Represents a vSphere volume resource.*
 
   - **vsphereVolume.volumePath** (string), required
+
     volumePath is the path that identifies vSphere volume vmdk
 
   - **vsphereVolume.fsType** (string)
+
     fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 
   - **vsphereVolume.storagePolicyID** (string)
+
     storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
 
   - **vsphereVolume.storagePolicyName** (string)
+
     storagePolicyName is the storage Policy Based Management (SPBM) profile name.
 -->
-
 - **vsphereVolume** (VsphereVirtualDiskVolumeSource)
 
   vsphereVolume 表示 kubelet 主机上挂接和挂载的 vSphere 卷。
@@ -1770,8 +1912,7 @@ PersistentVolumeStatus 是持久卷的当前状态。
 - **lastPhaseTransitionTime** (Time)
 
   lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically
-  resets to current time everytime a volume phase transitions. This is an alpha field and requires
-  enabling PersistentVolumeLastPhaseTransitionTime feature.
+  resets to current time everytime a volume phase transitions.
 
   <a name="Time"></a>
   *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.
@@ -1780,22 +1921,23 @@ PersistentVolumeStatus 是持久卷的当前状态。
 - **lastPhaseTransitionTime** (Time)
 
   lastPhaseTransitionTime 是从一个阶段转换到另一个阶段的时间，每次卷阶段转换时都会自动重置为当前时间。
-  这是一个 Alpha 字段，需要启用 PersistentVolumeLastPhaseTransitionTime 特性。
 
   <a name="Time"></a>
   **Time 是 time.Time 的包装器，支持正确编组为 YAML 和 JSON，它为 time 包提供的许多工厂方法提供了包装器。**
 
 <!--
 - **message** (string)
+
   message is a human-readable message indicating details about why the volume is in this state.
 
 - **phase** (string)
+
   phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
 
 - **reason** (string)
+
   reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
 -->
-
 - **message** (string)
 
   message 是一条人类可读的消息，指明有关卷为何处于此状态的详细信息。
@@ -1810,6 +1952,7 @@ PersistentVolumeStatus 是持久卷的当前状态。
   reason 是一个描述任何故障的简短 CamelCase 字符串，用于机器解析并在 CLI 中整齐地显示。
 
 ## PersistentVolumeList {#PersistentVolumeList}
+
 <!--
 PersistentVolumeList is a list of PersistentVolume items.
 -->
@@ -1823,12 +1966,13 @@ PersistentVolumeList 是 PersistentVolume 各项的列表。
 
 <!--
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
   Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
 - **items** ([]<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>), required
+
   items is a list of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 -->
-
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
 
   标准的列表元数据。更多信息：
@@ -1849,7 +1993,9 @@ PersistentVolumeList 是 PersistentVolume 各项的列表。
 <hr>
 
 ### `get` 读取指定的 PersistentVolume
+
 #### HTTP 请求
+
 GET /api/v1/persistentvolumes/{name}
 
 <!--
@@ -1860,9 +2006,10 @@ GET /api/v1/persistentvolumes/{name}
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **pretty** (**查询参数**): string
 
@@ -1872,6 +2019,7 @@ GET /api/v1/persistentvolumes/{name}
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 401: Unauthorized
@@ -1881,7 +2029,9 @@ GET /api/v1/persistentvolumes/{name}
 #### HTTP Request
 -->
 ### `get` 读取指定的 PersistentVolume 的状态
+
 #### HTTP 请求
+
 GET /api/v1/persistentvolumes/{name}/status
 
 <!--
@@ -1892,9 +2042,10 @@ GET /api/v1/persistentvolumes/{name}/status
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **pretty** (**查询参数**): string
 
@@ -1904,6 +2055,7 @@ GET /api/v1/persistentvolumes/{name}/status
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 401: Unauthorized
@@ -1913,7 +2065,9 @@ GET /api/v1/persistentvolumes/{name}/status
 #### HTTP Request
 -->
 ### `list` 列出或观测类别为 PersistentVolume 的对象
+
 #### HTTP 请求
+
 GET /api/v1/persistentvolumes
 
 <!--
@@ -1930,6 +2084,7 @@ GET /api/v1/persistentvolumes
 - **watch** (*in query*): boolean
 -->
 #### 参数
+
 - **allowWatchBookmarks** (**查询参数**): boolean
 
   <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
@@ -1978,6 +2133,7 @@ GET /api/v1/persistentvolumes
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeList" >}}">PersistentVolumeList</a>): OK
 
 401: Unauthorized
@@ -1987,7 +2143,9 @@ GET /api/v1/persistentvolumes
 #### HTTP Request
 -->
 ### `create` 创建 PersistentVolume
+
 #### HTTP 请求
+
 POST /api/v1/persistentvolumes
 
 <!--
@@ -1999,7 +2157,9 @@ POST /api/v1/persistentvolumes
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>，必需
+
 - **dryRun** (**查询参数**): string
 
   <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
@@ -2020,6 +2180,7 @@ POST /api/v1/persistentvolumes
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
@@ -2033,7 +2194,9 @@ POST /api/v1/persistentvolumes
 #### HTTP Request
 -->
 ### `update` 替换指定的 PersistentVolume
+
 #### HTTP 请求
+
 PUT /api/v1/persistentvolumes/{name}
 
 <!--
@@ -2047,9 +2210,10 @@ PUT /api/v1/persistentvolumes/{name}
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>，必需
 
@@ -2073,6 +2237,7 @@ PUT /api/v1/persistentvolumes/{name}
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
@@ -2084,7 +2249,9 @@ PUT /api/v1/persistentvolumes/{name}
 #### HTTP Request
 -->
 ### `update` 替换指定的 PersistentVolume 的状态
+
 #### HTTP 请求
+
 PUT /api/v1/persistentvolumes/{name}/status
 
 <!--
@@ -2098,9 +2265,10 @@ PUT /api/v1/persistentvolumes/{name}/status
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>，必需
 
@@ -2124,6 +2292,7 @@ PUT /api/v1/persistentvolumes/{name}/status
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
@@ -2135,7 +2304,9 @@ PUT /api/v1/persistentvolumes/{name}/status
 #### HTTP Request
 -->
 ### `patch` 部分更新指定的 PersistentVolume
+
 #### HTTP 请求
+
 PATCH /api/v1/persistentvolumes/{name}
 
 <!--
@@ -2150,9 +2321,10 @@ PATCH /api/v1/persistentvolumes/{name}
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，必需
 
@@ -2180,6 +2352,7 @@ PATCH /api/v1/persistentvolumes/{name}
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
@@ -2191,7 +2364,9 @@ PATCH /api/v1/persistentvolumes/{name}
 #### HTTP Request
 -->
 ### `patch` 部分更新指定的 PersistentVolume 的状态
+
 #### HTTP 请求
+
 PATCH /api/v1/persistentvolumes/{name}/status
 
 <!--
@@ -2206,9 +2381,10 @@ PATCH /api/v1/persistentvolumes/{name}/status
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>，必需
 
@@ -2236,6 +2412,7 @@ PATCH /api/v1/persistentvolumes/{name}/status
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
@@ -2247,7 +2424,9 @@ PATCH /api/v1/persistentvolumes/{name}/status
 #### HTTP Request
 -->
 ### `delete` 删除 PersistentVolume
+
 #### HTTP 请求
+
 DELETE /api/v1/persistentvolumes/{name}
 
 <!--
@@ -2261,9 +2440,10 @@ DELETE /api/v1/persistentvolumes/{name}
 - **propagationPolicy** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
-  PersistentVolume 的名称
+  PersistentVolume 的名称。
 
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 
@@ -2287,6 +2467,7 @@ DELETE /api/v1/persistentvolumes/{name}
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
 
 202 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Accepted
@@ -2298,7 +2479,9 @@ DELETE /api/v1/persistentvolumes/{name}
 #### HTTP Request
 -->
 ### `deletecollection` 删除 PersistentVolume 的集合
+
 #### HTTP 请求
+
 DELETE /api/v1/persistentvolumes
 
 <!--
@@ -2317,6 +2500,7 @@ DELETE /api/v1/persistentvolumes
 - **timeoutSeconds** (*in query*): integer
 -->
 #### 参数
+
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 
 - **continue** (**查询参数**): string
@@ -2371,6 +2555,7 @@ DELETE /api/v1/persistentvolumes
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
 
 401: Unauthorized


### PR DESCRIPTION
- Sync with en text
- Keep the style consistent

```
content/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
```
See [preview](https://deploy-preview-48046--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/)