### PR TITLE
Clarify foreground deletion behavior of the GC controller in race and sync error conditions

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -82,13 +82,16 @@ owner object:
 * The object remains visible through the Kubernetes API until the deletion
   process is complete.
 
-After the owner object enters the deletion in progress state, the controller
-deletes the dependents. After deleting all the dependent objects, the controller
-deletes the owner object. At this point, the object is no longer visible in the
+After the owner object enters the *deletion in progress* state, the controller
+deletes dependents it knows about. After deleting all the dependent objects it knows about,
+the controller deletes the owner object. At this point, the object is no longer visible in the
 Kubernetes API.
 
 During foreground cascading deletion, the only dependents that block owner
-deletion are those that have the `ownerReference.blockOwnerDeletion=true` field.
+deletion are those that have the `ownerReference.blockOwnerDeletion=true` field
+and are in the garbage collection controller cache. The garbage collection controller
+cache may not contain objects whose resource type cannot be listed / watched successfully,
+or objects which are created concurrent with deletion of an owner object.
 See [Use foreground cascading deletion](/docs/tasks/administer-cluster/use-cascading-deletion/#use-foreground-cascading-deletion)
 to learn more.
 

--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -91,7 +91,7 @@ During foreground cascading deletion, the only dependents that block owner
 deletion are those that have the `ownerReference.blockOwnerDeletion=true` field
 and are in the garbage collection controller cache. The garbage collection controller
 cache may not contain objects whose resource type cannot be listed / watched successfully,
-or objects which are created concurrent with deletion of an owner object.
+or objects that are created concurrent with deletion of an owner object.
 See [Use foreground cascading deletion](/docs/tasks/administer-cluster/use-cascading-deletion/#use-foreground-cascading-deletion)
 to learn more.
 


### PR DESCRIPTION
### Description

Clarifies the best-effort nature of the garbage collector controller behavior honoring `blockOwnerDeletion` in sync error and race conditions scenarios.

/sig api-machinery
/assign @deads2k 

https://github.com/kubernetes/kubernetes/pull/125796 makes the best-effort nature even more clear in 1.32, but this was always best-effort and subject to races on creation, so we should document that.