### PR TITLE
Remove init container example from sidecar container documentation.

### DIFF
--- a/content/bn/examples/application/deployment-sidecar.yaml
+++ b/content/bn/examples/application/deployment-sidecar.yaml
@@ -21,7 +21,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /opt
-      initContainers:
         - name: logshipper
           image: alpine:latest
           restartPolicy: Always


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The yaml has init container field which is tailing the logs generated by the application but its not working as sidecar container if its an init container.  How come the logs will be tailed if its running as init container and running before the application container 'tail -F /opt/logs.txt'.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #