### PR TITLE
fix apt repo urls in german kubectl install guide

### DIFF
--- a/content/de/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/de/docs/tasks/tools/install-kubectl-linux.md
@@ -127,7 +127,7 @@ Um kubectl auf Linux zu installieren, gibt es die folgenden Möglichkeiten:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y ca-certificates curl
+   sudo apt-get install -y ca-certificates curl gnupg
    ```
 
    Falls Debian 9 (stretch) oder älter genutzt wird, müssen zusätzlich das Paket `apt-transport-https` installiert werden:
@@ -136,16 +136,20 @@ Um kubectl auf Linux zu installieren, gibt es die folgenden Möglichkeiten:
    sudo apt-get install -y apt-transport-https
    ```
 
-2. Den öffentlichen Google Cloud Signaturschlüssel herunterladen:
+2. Den öffentlichen Signaturschlüssel für die Kubernetes Repositories herunterladen:
 
    ```shell
-   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+   # Falls der Ordner `/etc/apt/keyrings` nicht existiert, sollte er vor dem curl Kommando erstellt werden, siehe folgende Zeile
+   # sudo mkdir -p -m 755 /etc/apt/keyrings
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+   sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # nicht privilegierten APT Applikationen den Lesezugriff auf diesen Keyring erlauben
    ```
 
-3. Kubernetes zum `apt` Repository:
+3. Kubernetes `apt` Repository hinzufügen:
 
    ```shell
-   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # dies hilft tools wie command-not-found korrekt zu funktionieren
    ```
 
 4. Den `apt` Paketindex mit dem neuen Repository updaten und kubectl installieren:


### PR DESCRIPTION
### Description

The kubectl install guide for linux (debian) will contain the correct shell scripts and repository urls in the german documentation.

There is no open german localization branch as far as I can tell.