### PR TITLE
[zh-cn] sync role-binding-v1 daemon-set-v1

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
@@ -82,15 +82,20 @@ RoleBinding 通过 Subjects 和所在的命名空间信息添加主体信息。
   - **roleRef.name** (string)，必需
     
     name 是被引用的资源的名称
-<!--
+
+- **subjects** ([]Subject)
+  <!--
+  *Atomic: will be replaced during a merge*
+
   Subjects holds references to the objects the role applies to.
   <a name="Subject"></a>
   *Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.*
 
   - **subjects.kind** (string), required
     Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
--->
-- **subjects** ([]Subject)
+  -->
+
+  **原子性：合并期间将被替换**
   
   subjects 包含角色所适用的对象的引用。
   

--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
@@ -6,7 +6,7 @@ api_metadata:
 content_type: "api_reference"
 description: "DaemonSet 表示守护进程集的配置。"
 title: "DaemonSet"
-weight: 8
+weight: 9
 ---
 
 <!--
@@ -17,7 +17,7 @@ kind: "DaemonSet"
 content_type: "api_reference"
 description: "DaemonSet represents the configuration of a daemon set."
 title: "DaemonSet"
-weight: 8
+weight: 9
 auto_generated: true
 -->
 
@@ -308,10 +308,14 @@ DaemonSetStatus 表示守护进程集的当前状态。
 - **conditions** ([]DaemonSetCondition)
 
   *Patch strategy: merge on key `type`*
+
+  *Map: unique values on key type will be kept during a merge*
 -->
 - **conditions** ([]DaemonSetCondition)
 
   **补丁策略：根据 `type` 键合并**
+
+  **Map：键 `type` 的唯一值将在合并期间保留**
 
   <!-- 
   Represents the latest available observations of a DaemonSet's current state.


### PR DESCRIPTION
content/zh-cn/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
content/zh-cn/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md