### PR TITLE
Remove deprecated note on  "Set up a High Availability etcd Cluster with kubeadm" page

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -9,11 +9,6 @@ weight: 70
 <!-- overview -->
 
 {{< note >}}
-While kubeadm is being used as the management tool for external etcd nodes
-in this guide, please note that kubeadm does not plan to support certificate rotation
-or upgrades for such nodes. The long-term plan is to empower the tool
-[etcdadm](https://github.com/kubernetes-sigs/etcdadm) to manage these
-aspects.
 {{< /note >}}
 
 By default, kubeadm runs a local etcd instance on each control plane node.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -8,7 +8,6 @@ weight: 70
 
 <!-- overview -->
 
-{{< /note >}}
 
 By default, kubeadm runs a local etcd instance on each control plane node.
 It is also possible to treat the etcd cluster as external and provision

--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -8,7 +8,6 @@ weight: 70
 
 <!-- overview -->
 
-{{< note >}}
 {{< /note >}}
 
 By default, kubeadm runs a local etcd instance on each control plane node.


### PR DESCRIPTION
Removed the note from the https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/ page as given solution in comment https://github.com/kubernetes/website/issues/47818#issuecomment-2334088987

Closes https://github.com/kubernetes/website/issues/47818