### PR TITLE
[ja] Update manage-resources-containers.md

### DIFF
--- a/content/ja/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/ja/docs/concepts/configuration/manage-resources-containers.md
@@ -13,24 +13,24 @@ feature:
 {{< glossary_tooltip term_id="pod" >}}を指定する際に、{{< glossary_tooltip text="コンテナ" term_id="container" >}}が必要とする各リソースの量をオプションで指定することができます。
 指定する最も一般的なリソースはCPUとメモリ(RAM)ですが、他にもあります。
 
-Pod内のコンテナのリソース*要求*を指定すると、スケジューラはこの情報を使用して、どのNodeにPodを配置するかを決定します。コンテナに*制限*ソースを指定すると、kubeletはその制限を適用し、実行中のコンテナが設定した制限を超えてリソースを使用することができないようにします。また、kubeletは、少なくともそのシステムリソースのうち、*要求*の量を、そのコンテナが使用するために特別に確保します。
+Pod内のコンテナのリソース*requests*を指定すると、スケジューラはこの情報を使用して、どのNodeにPodを配置するかを決定します。コンテナに*limits*ソースを指定すると、kubeletはそのlimitsを適用し、実行中のコンテナが設定したlimitsを超えてリソースを使用することができないようにします。また、kubeletは、少なくともそのシステムリソースのうち、*requests*の量を、そのコンテナが使用するために特別に確保します。
 
 <!-- body -->
 
-## 要求と制限 {#requests-and-limits}
+## requestsとlimits {#requests-and-limits}
 
-Podが動作しているNodeに利用可能なリソースが十分にある場合、そのリソースの`要求`が指定するよりも多くのリソースをコンテナが使用することが許可されます
-ただし、コンテナはそのリソースの`制限`を超えて使用することはできません。
+Podが動作しているNodeに利用可能なリソースが十分にある場合、そのリソースの`requests`が指定するよりも多くのリソースをコンテナが使用することが許可されます
+ただし、コンテナはそのリソースの`limits`を超えて使用することはできません。
 
-たとえば、コンテナに256MiBの`メモリー`要求を設定し、そのコンテナが8GiBのメモリーを持つNodeにスケジュールされたPod内に存在し、他のPodが存在しない場合、コンテナはより多くのRAMを使用しようとする可能性があります。
+たとえば、コンテナに256MiBの`メモリー`requestsを設定し、そのコンテナが8GiBのメモリーを持つNodeにスケジュールされたPod内に存在し、他のPodが存在しない場合、コンテナはより多くのRAMを使用しようとする可能性があります。
 
-そのコンテナに4GiBの`メモリー`制限を設定すると、kubelet(および{{< glossary_tooltip text="コンテナランタイム" term_id="container-runtime" >}}) が制限を適用します。ランタイムは、コンテナが設定済みのリソース制限を超えて使用するのを防ぎます。例えば、コンテナ内のプロセスが、許容量を超えるメモリを消費しようとすると、システムカーネルは、メモリ不足(OOM)エラーで、割り当てを試みたプロセスを終了します。
+そのコンテナに4GiBの`メモリー`limitsを設定すると、kubelet(および{{< glossary_tooltip text="コンテナランタイム" term_id="container-runtime" >}}) がlimitsを適用します。ランタイムは、コンテナが設定済みのリソースlimitsを超えて使用するのを防ぎます。例えば、コンテナ内のプロセスが、許容量を超えるメモリを消費しようとすると、システムカーネルは、メモリ不足(OOM)エラーで、割り当てを試みたプロセスを終了します。
 
-制限は、違反が検出されるとシステムが介入するように事後的に、またはコンテナが制限を超えないようにシステムが防ぐように強制的に、実装できます。
-異なるランタイムは、同じ制限を実装するために異なる方法をとることができます。
+limitsは、違反が検出されるとシステムが介入するように事後的に、またはコンテナがlimitsを超えないようにシステムが防ぐように強制的に、実装できます。
+異なるランタイムは、同じlimitsを実装するために異なる方法をとることができます。
 
 {{< note >}}
-コンテナが自身のメモリー制限を指定しているが、メモリー要求を指定していない場合、Kubernetesは制限に一致するメモリー要求を自動的に割り当てます。同様に、コンテナが自身のCPU制限を指定しているが、CPU要求を指定していない場合、Kubernetesは制限に一致するCPU要求を自動的に割り当てます。
+コンテナが自身のメモリーlimitsを指定しているが、メモリーrequestsを指定していない場合、Kubernetesはlimitsに一致するメモリーrequestsを自動的に割り当てます。同様に、コンテナが自身のCPUlimitsを指定しているが、CPUrequestsを指定していない場合、Kubernetesはlimitsに一致するCPU requestsを自動的に割り当てます。
 {{< /note >}}
 
 ## リソースタイプ {#resource-types}
@@ -41,7 +41,7 @@ CPUは計算処理を表し、[Kubernetes CPUs](#meaning-of-cpu)の単位で指�
 Kubernetes v1.14以降を使用している場合は、*huge page*リソースを指定することができます。
 Huge PageはLinux固有の機能であり、Nodeのカーネルはデフォルトのページサイズよりもはるかに大きいメモリブロックを割り当てます。
 
-たとえば、デフォルトのページサイズが4KiBのシステムでは、`hugepages-2Mi: 80Mi`という制限を指定できます。
+たとえば、デフォルトのページサイズが4KiBのシステムでは、`hugepages-2Mi: 80Mi`というlimitsを指定できます。
 コンテナが40を超える2MiBの巨大ページ(合計80 MiB)を割り当てようとすると、その割り当ては失敗します。
 
 {{< note >}}
@@ -50,11 +50,11 @@ Huge PageはLinux固有の機能であり、Nodeのカーネルはデフォル�
 {{< /note >}}
 
 CPUとメモリーは、まとめて*コンピュートリソース*または単に*リソース*と呼ばれます。
-コンピューティングリソースは、要求され、割り当てられ、消費され得る測定可能な量です。
+コンピューティングリソースは、requestsされ、割り当てられ、消費され得る測定可能な量です。
 それらは[API resources](/ja/docs/concepts/overview/kubernetes-api/)とは異なります。
 Podや[Services](/ja/docs/concepts/services-networking/service/)などのAPIリソースは、Kubernetes APIサーバーを介して読み取りおよび変更できるオブジェクトです。
 
-## Podとコンテナのリソース要求と制限 {#resource-requests-and-limits-of-pod-and-container}
+## Podとコンテナのリソースrequestsとlimits {#resource-requests-and-limits-of-pod-and-container}
 
 Podの各コンテナは、次の1つ以上を指定できます。
 
@@ -65,29 +65,29 @@ Podの各コンテナは、次の1つ以上を指定できます。
 * `spec.containers[].resources.requests.memory`
 * `spec.containers[].resources.requests.hugepages-<size>`
 
-要求と制限はそれぞれのコンテナでのみ指定できますが、このPodリソースの要求と制限の関係性について理解すると便利です。
-特定のリソースタイプの*Podリソース要求/制限*は、Pod内の各コンテナに対するそのタイプのリソース要求/制限の合計です。
+requestsとlimitsはそれぞれのコンテナでのみ指定できますが、このPodリソースのrequestsとlimitsの関係性について理解すると便利です。
+特定のリソースタイプの*Podリソースrequests/limits*は、Pod内の各コンテナに対するそのタイプのリソースrequests/limitsの合計です。
 
 ## Kubernetesにおけるリソースの単位 {#resource-units-in-kubernetes}
 
 ### CPUの意味 {#meaning-of-cpu}
 
-CPUリソースの制限と要求は、*cpu*単位で測定されます。
+CPUリソースのlimitsとrequestsは、*cpu*単位で測定されます。
 Kuberenetesにおける1つのCPUは、クラウドプロバイダーの**1 vCPU/コア**およびベアメタルのインテルプロセッサーの**1 ハイパースレッド**に相当します。
 
-要求を少数で指定することもできます。
-`spec.containers[].resources.requests.cpu`が`0.5`のコンテナは、1CPUを要求するコンテナの半分のCPUが保証されます。
+requestsを少数で指定することもできます。
+`spec.containers[].resources.requests.cpu`が`0.5`のコンテナは、1CPUをrequestsするコンテナの半分のCPUが保証されます。
 `0.1`という表現は`100m`という表現と同等であり、`100ミリCPU`と読み替えることができます。
 `100ミリコア`という表現も、同じことを意味しています。
-`0.1`のような小数点のある要求はAPIによって`100m`に変換され、`1m`より細かい精度は許可されません。
+`0.1`のような小数点のあるrequestsはAPIによって`100m`に変換され、`1m`より細かい精度は許可されません。
 このため、`100m`の形式が推奨されます。
 
-CPUは常に相対量としてではなく、絶対量として要求されます。
-0.1は、シングルコア、デュアルコア、あるいは48コアマシンのどのCPUに対してでも、同一の量を要求します。
+CPUは常に相対量としてではなく、絶対量としてrequestsされます。
+0.1は、シングルコア、デュアルコア、あるいは48コアマシンのどのCPUに対してでも、同一の量をrequestsします。
 
 ### メモリーの意味 {#meaning-of-memory}
 
-`メモリー`の制限と要求はバイト単位で測定されます。
+`メモリー`のlimitsとrequestsはバイト単位で測定されます。
 E、P、T、G、M、Kのいずれかのサフィックスを使用して、メモリーを整数または固定小数点数として表すことができます。
 また、Ei、Pi、Ti、Gi、Mi、Kiのような2の累乗の値を使用することもできます。
 たとえば、以下はほぼ同じ値を表しています。
@@ -98,8 +98,8 @@ E、P、T、G、M、Kのいずれかのサフィックスを使用して、メ�
 
 例を見てみましょう。
 次のPodには2つのコンテナがあります。
-各コンテナには、0.25cpuおよび64MiB(2<sup>26</sup>バイト)のメモリー要求と、0.5cpuおよび128MiBのメモリー制限があります
-Podには0.5cpuと128MiBのメモリー要求があり、1cpuと256MiBのメモリ制限があると言えます。
+各コンテナには、0.25cpuおよび64MiB(2<sup>26</sup>バイト)のメモリーrequestsと、0.5cpuおよび128MiBのメモリーlimitsがあります
+Podには0.5cpuと128MiBのメモリーrequestsがあり、1cpuと256MiBのメモリlimitsがあると言えます。
 
 ```yaml
 apiVersion: v1
@@ -128,17 +128,17 @@ spec:
         cpu: "500m"
 ```
 
-## リソース要求を含むPodがどのようにスケジュールされるか {#how-pods-with-resource-requests-are-scheduled}
+## リソースrequestsを含むPodがどのようにスケジュールされるか {#how-pods-with-resource-requests-are-scheduled}
 
 Podを作成すると、KubernetesスケジューラーはPodを実行するNodeを選択します。
 各Nodeには、リソースタイプごとに最大容量があります。それは、Podに提供できるCPUとメモリの量です。
-スケジューラーは、リソースタイプごとに、スケジュールされたコンテナのリソース要求の合計がNodeの容量より少ないことを確認します。
+スケジューラーは、リソースタイプごとに、スケジュールされたコンテナのリソースrequestsの合計がNodeの容量より少ないことを確認します。
 Node上の実際のメモリーまたはCPUリソースの使用率は非常に低いですが、容量チェックが失敗した場合、スケジューラーはNodeにPodを配置しないことに注意してください。
-これにより、例えば日々のリソース要求のピーク時など、リソース利用が増加したときに、Nodeのリソース不足から保護されます。
+これにより、例えば日々のリソースrequestsのピーク時など、リソース利用が増加したときに、Nodeのリソース不足から保護されます。
 
-## リソース制限のあるPodがどのように実行されるか {#how-pods-with-resource-limits-are-run}
+## リソースlimitsのあるPodがどのように実行されるか {#how-pods-with-resource-limits-are-run}
 
-kubeletがPodのコンテナを開始すると、CPUとメモリーの制限がコンテナランタイムに渡されます。
+kubeletがPodのコンテナを開始すると、CPUとメモリーのlimitsがコンテナランタイムに渡されます。
 
 Dockerを使用する場合:
 
@@ -156,15 +156,15 @@ Dockerを使用する場合:
 
 - `spec.containers[].resources.limits.memory`は整数に変換され、`docker run`コマンドの[`--memory`](https://docs.docker.com/engine/reference/run/#/user-memory-constraints)フラグの値として使用されます。
 
-コンテナがメモリー制限を超過すると、終了する場合があります。
+コンテナがメモリーlimitsを超過すると、終了する場合があります。
 コンテナが再起動可能である場合、kubeletは他のタイプのランタイム障害と同様にコンテナを再起動します。
 
-コンテナがメモリー要求を超過すると、Nodeのメモリーが不足するたびにそのPodが排出される可能性があります。
+コンテナがメモリーrequestsを超過すると、Nodeのメモリーが不足するたびにそのPodが排出される可能性があります。
 
-コンテナは、長時間にわたってCPU制限を超えることが許可される場合と許可されない場合があります。
+コンテナは、長時間にわたってCPUlimitsを超えることが許可される場合と許可されない場合があります。
 ただし、CPUの使用量が多すぎるために、コンテナが強制終了されることはありません。
 
-コンテナをスケジュールできないか、リソース制限が原因で強制終了されているかどうかを確認するには、[トラブルシューティング](#troubleshooting)のセクションを参照してください。
+コンテナをスケジュールできないか、リソースlimitsが原因で強制終了されているかどうかを確認するには、[トラブルシューティング](#troubleshooting)のセクションを参照してください。
 
 ### コンピュートリソースとメモリーリソースの使用量を監視する {#monitoring-compute-memory-resource-usage}
 
@@ -190,7 +190,7 @@ Nodeに障害が発生すると、そのエフェメラルストレージ内の�
 アプリケーションは、ローカルのエフェメラルストレージにパフォーマンスのサービス品質保証(ディスクのIOPSなど)を期待することはできません。
 {{< /caution >}}
 
-ベータ版の機能として、Kubernetesでは、Podが消費するローカルのエフェメラルストレージの量を追跡、予約、制限することができます。
+ベータ版の機能として、Kubernetesでは、Podが消費するローカルのエフェメラルストレージの量を追跡、予約、limitsすることができます。
 
 ### ローカルエフェメラルストレージの設定 {#configurations-for-local-ephemeral-storage}
 
@@ -229,20 +229,20 @@ kubeletは、ローカルストレージの使用量を測定できます。
 - `LocalStorageCapacityIsolation`[フィーチャーゲート](/ja/docs/reference/command-line-tools-reference/feature-gates/)が有効になっています。(デフォルトでオンになっています。)
 - そして、ローカルのエフェメラルストレージ用にサポートされている構成の1つを使用してNodeをセットアップします。
 
-別の構成を使用している場合、kubeletはローカルのエフェメラルストレージにリソース制限を適用しません。
+別の構成を使用している場合、kubeletはローカルのエフェメラルストレージにリソースlimitsを適用しません。
 
 {{< note >}}
 kubeletは、`tmpfs`のemptyDirボリュームをローカルのエフェメラルストレージとしてではなく、コンテナメモリーとして追跡します。
 {{< /note >}}
 
-### ローカルのエフェメラルストレージの要求と制限設定 {#setting-requests-and-limits-for-local-ephemeral-storage}
+### ローカルのエフェメラルストレージのrequestsとlimits設定 {#setting-requests-and-limits-for-local-ephemeral-storage}
 
 ローカルのエフェメラルストレージを管理するためには _ephemeral-storage_ パラメーターを利用することができます。
 Podの各コンテナは、次の1つ以上を指定できます。
 * `spec.containers[].resources.limits.ephemeral-storage`
 * `spec.containers[].resources.requests.ephemeral-storage`
 
-`ephemeral-storage`の制限と要求はバイト単位で記します。
+`ephemeral-storage`のlimitsとrequestsはバイト単位で記します。
 ストレージは、次のいずれかの接尾辞を使用して、通常の整数または固定小数点数として表すことができます。
 E、P、T、G、M、K。Ei、Pi、Ti、Gi、Mi、Kiの2のべき乗を使用することもできます。
 たとえば、以下はほぼ同じ値を表しています。
@@ -252,9 +252,9 @@ E、P、T、G、M、K。Ei、Pi、Ti、Gi、Mi、Kiの2のべき乗を使用す�
 ```
 
 次の例では、Podに2つのコンテナがあります。
-各コンテナには、2GiBのローカルのエフェメラルストレージ要求があります。
-各コンテナには、4GiBのローカルのエフェメラルストレージ制限があります。
-したがって、Podには4GiBのローカルのエフェメラルストレージの要求と、8GiBのローカルのエフェメラルストレージ制限があります。
+各コンテナには、2GiBのローカルのエフェメラルストレージrequestsがあります。
+各コンテナには、4GiBのローカルのエフェメラルストレージlimitsがあります。
+したがって、Podには4GiBのローカルのエフェメラルストレージのrequestsと、8GiBのローカルのエフェメラルストレージlimitsがあります。
 
 ```yaml
 apiVersion: v1
@@ -288,13 +288,13 @@ spec:
       emptyDir: {}
 ```
 
-### エフェメラルストレージを要求するPodのスケジュール方法 {#how-pods-with-ephemeral-storage-requests-are-scheduled}
+### エフェメラルストレージをrequestsするPodのスケジュール方法 {#how-pods-with-ephemeral-storage-requests-are-scheduled}
 
 Podを作成すると、KubernetesスケジューラーはPodを実行するNodeを選択します。
 各Nodeには、Podに提供できるローカルのエフェメラルストレージの上限があります。
 詳細については、[Node割り当て可能](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)を参照してください。
 
-スケジューラーは、スケジュールされたコンテナのリソース要求の合計がNodeの容量より少なくなるようにします。
+スケジューラーは、スケジュールされたコンテナのリソースrequestsの合計がNodeの容量より少なくなるようにします。
 
 ### エフェメラルストレージの消費管理 {#resource-emphemeralstorage-consumption}
 
@@ -306,14 +306,14 @@ kubeletがローカルのエフェメラルストレージをリソースとし�
 
 Podが許可するよりも多くのエフェメラルストレージを使用している場合、kubeletはPodの排出をトリガーするシグナルを設定します。
 
-コンテナレベルの分離の場合、コンテナの書き込み可能なレイヤーとログ使用量がストレージの制限を超えると、kubeletはPodに排出のマークを付けます。
+コンテナレベルの分離の場合、コンテナの書き込み可能なレイヤーとログ使用量がストレージのlimitsを超えると、kubeletはPodに排出のマークを付けます。
 
-Podレベルの分離の場合、kubeletはPod内のコンテナの制限を合計し、Podの全体的なストレージ制限を計算します。
-このケースでは、すべてのコンテナからのローカルのエフェメラルストレージの使用量とPodの`emptyDir`ボリュームの合計がPod全体のストレージ制限を超過する場合、
+Podレベルの分離の場合、kubeletはPod内のコンテナのlimitsを合計し、Podの全体的なストレージlimitsを計算します。
+このケースでは、すべてのコンテナからのローカルのエフェメラルストレージの使用量とPodの`emptyDir`ボリュームの合計がPod全体のストレージlimitsを超過する場合、
 kubeletはPodをまた排出対象としてマークします。
 
 {{< caution >}}
-kubeletがローカルのエフェメラルストレージを測定していない場合、ローカルストレージの制限を超えるPodは、ローカルストレージのリソース制限に違反しても排出されません。
+kubeletがローカルのエフェメラルストレージを測定していない場合、ローカルストレージのlimitsを超えるPodは、ローカルストレージのリソースlimitsに違反しても排出されません。
 
 ただし、書き込み可能なコンテナレイヤー、Nodeレベルのログ、または`emptyDir`ボリュームのファイルシステムスペースが少なくなると、Nodeはローカルストレージが不足していると汚染{{< glossary_tooltip text="taints" term_id="taint" >}}し、この汚染は、汚染を特に許容しないPodの排出をトリガーします。
 
@@ -344,7 +344,7 @@ Kubernetesでは、プロジェクトクォータを有効にしてストレー�
 例えば、XFSやext4fsはプロジェクトクォータを提供しています。
 
 {{< note >}}
-プロジェクトクォータはストレージの使用状況を監視しますが、制限を強制するものではありません。
+プロジェクトクォータはストレージの使用状況を監視しますが、limitsを強制するものではありません。
 {{< /note >}}
 
 Kubernetesでは、`1048576`から始まるプロジェクトIDを使用します。
@@ -382,7 +382,7 @@ Kubernetesが使用しないようにする必要があります。
 
 拡張リソースを使用するためには、2つのステップが必要です。
 第一に、クラスターオペレーターは拡張リソースをアドバタイズする必要があります。
-第二に、ユーザーはPodで拡張リソースを要求する必要があります。
+第二に、ユーザーはPodで拡張リソースをrequestsする必要があります。
 
 ### 拡張リソースの管理 {#managing-extended-resources}
 
@@ -397,7 +397,7 @@ Nodeレベルの拡張リソースはNodeに関連付けられています。
 新しいNodeレベルの拡張リソースをアドバタイズするには、クラスターオペレーターはAPIサーバに`PATCH`HTTPリクエストを送信し、クラスター内のNodeの`status.capacity`に利用可能な量を指定します。
 この操作の後、ノードの`status.capacity`には新しいリソースが含まれます。
 `status.allocatable`フィールドは、kubeletによって非同期的に新しいリソースで自動的に更新されます。
-スケジューラはPodの適合性を評価する際にNodeの`status.allocatable`値を使用するため、Nodeの容量に新しいリソースを追加してから、そのNodeでリソースのスケジューリングを要求する最初のPodが現れるまでには、短い遅延が生じる可能性があることに注意してください。
+スケジューラはPodの適合性を評価する際にNodeの`status.allocatable`値を使用するため、Nodeの容量に新しいリソースを追加してから、そのNodeでリソースのスケジューリングをrequestsする最初のPodが現れるまでには、短い遅延が生じる可能性があることに注意してください。
 
 **例:**
 
@@ -427,7 +427,7 @@ JSON-Patchの操作パス値は、JSON-Pointerとして解釈されます。
 
 次のスケジューラーポリシーの構成は、クラスターレベルの拡張リソース"example.com/foo"がスケジューラー拡張機能によって処理されることを示しています。
 
-- スケジューラーは、Podが"example.com/foo"を要求した場合にのみ、Podをスケジューラー拡張機能に送信します。
+- スケジューラーは、Podが"example.com/foo"をrequestsした場合にのみ、Podをスケジューラー拡張機能に送信します。
 - `ignoredByScheduler`フィールドは、スケジューラがその`PodFitsResources`述語で"example.com/foo"リソースをチェックしないことを指定します。
 
 ```json
@@ -454,7 +454,7 @@ JSON-Patchの操作パス値は、JSON-Pointerとして解釈されます。
 ユーザーは、CPUやメモリのようにPodのスペックで拡張されたリソースを消費できます。
 利用可能な量以上のリソースが同時にPodに割り当てられないように、スケジューラーがリソースアカウンティングを行います。
 
-APIサーバーは、拡張リソースの量を整数の値で制限します。
+APIサーバーは、拡張リソースの量を整数の値でlimitsします。
 有効な数量の例は、`3`、`3000m`、`3Ki`です。
 無効な数量の例は、`0.5`、`1500m`です。
 
@@ -466,15 +466,15 @@ APIサーバーは、拡張リソースの量を整数の値で制限します�
 Podで拡張リソースを消費するには、コンテナ名の`spec.containers[].resources.limits`マップにキーとしてリソース名を含めます。
 
 {{< note >}}
-拡張リソースはオーバーコミットできないので、コンテナスペックに要求と制限の両方が存在する場合は等しくなければなりません。
+拡張リソースはオーバーコミットできないので、コンテナスペックにrequestsとlimitsの両方が存在する場合は等しくなければなりません。
 {{< /note >}}
 
-Podは、CPU、メモリ、拡張リソースを含むすべてのリソース要求が満たされた場合にのみスケジュールされます。
-リソース要求が満たされない限り、Podは`PENDING`状態のままです。
+Podは、CPU、メモリ、拡張リソースを含むすべてのリソースrequestsが満たされた場合にのみスケジュールされます。
+リソースrequestsが満たされない限り、Podは`PENDING`状態のままです。
 
 **例:**
 
-下のPodはCPUを2つ、"example.com/foo"(拡張リソース)を1つ要求しています。
+下のPodはCPUを2つ、"example.com/foo"(拡張リソース)を1つrequestsしています。
 
 ```yaml
 apiVersion: v1
@@ -516,7 +516,7 @@ Events:
 - クラスターにNodeを追加します。
 - 不要なポッドを終了して、保留中のPodのためのスペースを空けます。
 - PodがすべてのNodeよりも大きくないことを確認してください。
-  例えば、すべてのNodeが`cpu: 1`の容量を持っている場合、`cpu: 1.1`を要求するPodは決してスケジューリングされません。
+  例えば、すべてのNodeが`cpu: 1`の容量を持っている場合、`cpu: 1.1`をrequestsするPodは決してスケジューリングされません。
 
 Nodeの容量や割り当て量は`kubectl describe nodes`コマンドで調べることができる。
 例えば、以下のようになる。
@@ -551,7 +551,7 @@ Allocated resources:
   680m (34%)      400m (20%)    920Mi (12%)        1070Mi (14%)
 ```
 
-前述の出力では、Podが1120m以上のCPUや6.23Gi以上のメモリーを要求した場合、そのPodはNodeに収まらないことがわかります。
+前述の出力では、Podが1120m以上のCPUや6.23Gi以上のメモリーをrequestsした場合、そのPodはNodeに収まらないことがわかります。
 
 `Pods`セクションを見れば、どのPodがNode上でスペースを占有しているかがわかります。
 
@@ -559,13 +559,13 @@ Allocated resources:
 `allocatable`フィールド[NodeStatus](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#nodestatus-v1-core)は、Podに利用可能なリソースの量を与えます。
 詳細については、[ノード割り当て可能なリソース](https://git.k8s.io/design-proposals-archive/node/node-allocatable.md)を参照してください。
 
-[リソースクォータ](/docs/concepts/policy/resource-quotas/)機能は、消費できるリソースの総量を制限するように設定することができます。
+[リソースクォータ](/docs/concepts/policy/resource-quotas/)機能は、消費できるリソースの総量をlimitsするように設定することができます。
 名前空間と組み合わせて使用すると、1つのチームがすべてのリソースを占有するのを防ぐことができます。
 
 ### コンテナが終了した {#my-container-is-terminated}
 
 コンテナはリソース不足のため、終了する可能性があります。
-コンテナがリソース制限に達したために強制終了されているかどうかを確認するには、対象のPodで`kubectl describe pod`を呼び出します。
+コンテナがリソースlimitsに達したために強制終了されているかどうかを確認するには、対象のPodで`kubectl describe pod`を呼び出します。
 
 ```shell
 kubectl describe pod simmemleak-hra99
@@ -628,10 +628,10 @@ LastState: map[terminated:map[exitCode:137 reason:OOM Killed startedAt:2015-07-0
 
 * [コンテナとPodへのCPUリソースの割り当て](/ja/docs/tasks/configure-pod-container/assign-cpu-resource/)ハンズオンを行う
 
-* 要求と制限の違いの詳細については、[リソースQoS](https://git.k8s.io/design-proposals-archive/node/resource-qos.md)を参照する
+* requestsとlimitsの違いの詳細については、[リソースQoS](https://git.k8s.io/design-proposals-archive/node/resource-qos.md)を参照する
 
 * [コンテナ](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)APIリファレンスを読む
 
-* [リソース要求](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#resourcerequirements-v1-core)APIリファレンスを読む
+* [リソースrequests](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#resourcerequirements-v1-core)APIリファレンスを読む
 
 * XFSの[プロジェクトクォータ](http://xfs.org/docs/xfsdocs-xml-dev/XFS_User_Guide/tmp/en-US/html/xfs-quotas.html)について読む


### PR DESCRIPTION

### Issue

#48109
https://kubernetes.io/ja/docs/concepts/configuration/manage-resources-containers/

In this page, k8s manifest attributes limits and requests are translated 制限 and 要求
As a result, I think it's difficult to understand this article.
I think it's better without translating k8s manifest attributes limits and requests. How do you think?
