### PR TITLE
Fix default CoreDNS TTL

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -112,7 +112,7 @@ The Corefile configuration includes the following [plugins](https://coredns.io/p
 * [kubernetes](https://coredns.io/plugins/kubernetes/): CoreDNS will reply to DNS queries
   based on IP of the Services and Pods. You can find [more details](https://coredns.io/plugins/kubernetes/)
   about this plugin on the CoreDNS website.
-  - `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.
+  - `ttl` allows you to set a custom TTL for responses. The default is 30 seconds.
     The minimum TTL allowed is 0 seconds, and the maximum is capped at 3600 seconds.
     Setting TTL to 0 will prevent records from being cached.  
   - The `pods insecure` option is provided for backward compatibility with `kube-dns`.


### PR DESCRIPTION
### Description

The default TTL is 30 seconds. I fixed the explanation to match the Corefile snippet above the text.

Ref: https://github.com/kubernetes/kubernetes/commit/f7f51fab2a01d2d529593934f43415fe3a93fd8f