### PR TITLE
Remove duplicate description paragraph from scheduling index page

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/_index.md
+++ b/content/en/docs/concepts/scheduling-eviction/_index.md
@@ -2,12 +2,6 @@
 title: "Scheduling, Preemption and Eviction"
 weight: 95
 content_type: concept
-description: >
-  In Kubernetes, scheduling refers to making sure that Pods are matched to Nodes
-  so that the kubelet can run them. Preemption is the process of terminating 
-  Pods with lower Priority so that Pods with higher Priority can schedule on 
-  Nodes. Eviction is the process of proactively terminating one or more Pods on
-  resource-starved Nodes.
 no_list: true
 ---
 


### PR DESCRIPTION
The description and its proceeding text on the scheduling index page https://kubernetes.io/docs/concepts/scheduling-eviction/ are almost duplicated. The change in this PR is to remove one of the descrption block.

This will fix #48126 

Links:
- Page having duplicate content: https://kubernetes.io/docs/concepts/scheduling-eviction/
- Fixed Page after PR changes: https://deploy-preview-48132--kubernetes-io-main-staging.netlify.app/docs/concepts/scheduling-eviction 