### PR TITLE
Document feature gate AllowInsecureKubeletCertificateSigningRequests

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-kubelet-certificate-signing-requests.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-kubelet-certificate-signing-requests.md
@@ -1,0 +1,15 @@
+---
+title: AllowInsecureKubeletCertificateSigningRequests
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.31"
+---
+Disable node admission validation of CSRs for kubelet signers where CN=system:node:$nodeName.
+

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-kubelet-certificate-signing-requests.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/allow-insecure-kubelet-certificate-signing-requests.md
@@ -11,5 +11,8 @@ stages:
     defaultValue: false
     fromVersion: "1.31"
 ---
-Disable node admission validation of CSRs for kubelet signers where CN=system:node:$nodeName.
+Disable node admission validation of
+[CertificateSigningRequests](/docs/reference/access-authn-authz/certificate-signing-requests/#certificate-signing-requests)
+for kubelet signers. Unless you disable this feature gate, Kubernetes enforces that new
+kubelet certificates have a `commonName` matching `system:node:$nodeName`.
 


### PR DESCRIPTION
v1.31 has a feature gate `AllowInsecureKubeletCertificateSigningRequests` that's not documented. Add it.

/sig auth