### PR TITLE
Clarify whether CRDs are cluster scoped in multitenancy page

### DIFF
--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -423,7 +423,8 @@ Priority and Fairness, is also recommended.
 Namespace isolation is well-supported by Kubernetes, has a negligible resource cost, and provides
 mechanisms to allow tenants to interact appropriately, such as by allowing service-to-service
 communication. However, it can be difficult to configure, and it doesn't apply to Kubernetes resources
-that aren't namespaced, such as APIServices, StorageClasses, ClusterTrustBundles, or CustomResourceDefinitions (CRDs) themselves, though the custom resources they define can be namespaced.
+that aren't namespaced, such as APIServices, StorageClasses, ClusterTrustBundles.
+Note that CustomResourceDefinitions (CRDs) are cluster scoped, though the custom resources they define can be namespaced.
 
 Control plane virtualization allows for isolation of non-namespaced resources at the cost of
 somewhat higher resource usage and more difficult cross-tenant sharing. It is a good option when

--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -422,8 +422,7 @@ Priority and Fairness, is also recommended.
 
 Namespace isolation is well-supported by Kubernetes, has a negligible resource cost, and provides
 mechanisms to allow tenants to interact appropriately, such as by allowing service-to-service
-communication. However, it can be difficult to configure, and doesn't apply to Kubernetes
-resources that can't be namespaced, such as Custom Resource Definitions, Storage Classes, and Webhooks.
+communication. However, it can be difficult to configure, and it doesn't apply to resources that are cluster-scoped and not namespaced, such as Custom Resource Definitions (CRDs) themselves (though the custom resources they define can be namespaced), Storage Classes, and Webhooks.
 
 Control plane virtualization allows for isolation of non-namespaced resources at the cost of
 somewhat higher resource usage and more difficult cross-tenant sharing. It is a good option when

--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -422,7 +422,8 @@ Priority and Fairness, is also recommended.
 
 Namespace isolation is well-supported by Kubernetes, has a negligible resource cost, and provides
 mechanisms to allow tenants to interact appropriately, such as by allowing service-to-service
-communication. However, it can be difficult to configure, and it doesn't apply to resources that are cluster-scoped and not namespaced, such as Custom Resource Definitions (CRDs) themselves (though the custom resources they define can be namespaced), Storage Classes, and Webhooks.
+communication. However, it can be difficult to configure, and it doesn't apply to Kubernetes resources
+that aren't namespaced, such as APIServices, StorageClasses, ClusterTrustBundles, or CustomResourceDefinitions (CRDs) themselves, though the custom resources they define can be namespaced.
 
 Control plane virtualization allows for isolation of non-namespaced resources at the cost of
 somewhat higher resource usage and more difficult cross-tenant sharing. It is a good option when

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -563,6 +563,8 @@ spec:
   conversion:
     # the Webhook strategy instructs the API server to call an external webhook for any conversion between custom resources.
     strategy: Webhook
+    # Ensuring compatibility with v1 and v1beta1
+    conversionReviewVersions: ["v1", "v1beta1"]
     # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
     webhookClientConfig:
       service:
@@ -570,6 +572,7 @@ spec:
         name: example-conversion-webhook-server
         path: /crdconvert
       caBundle: "Ci0tLS0tQk...<base64-encoded PEM bundle>...tLS0K"
+      # Optionally configure mutual TLS authentication here
   # either Namespaced or Cluster
   scope: Namespaced
   names:
@@ -979,7 +982,7 @@ If conversion fails, a webhook should return a `response` stanza containing the 
 
 {{< warning >}}
 Failing conversion can disrupt read and write access to the custom resources,
-including the ability to update or delete the resources. Conversion failures 
+including the ability to update or delete the resources. Conversion failures
 should be avoided whenever possible, and should not be used to enforce validation
  constraints (use validation schemas or webhook admission instead).
 {{< /warning >}}

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -571,8 +571,8 @@ spec:
         namespace: default
         name: example-conversion-webhook-server
         path: /crdconvert
-      caBundle: "Ci0tLS0tQk...<base64-encoded PEM bundle>...tLS0K"
       # Optionally configure mutual TLS authentication here
+      caBundle: "Ci0tLS0tQk...<base64-encoded PEM bundle>...tLS0K"
   # either Namespaced or Cluster
   scope: Namespaced
   names:


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR updates the Kubernetes documentation to clarify the behavior of Custom Resource Definitions (CRDs) in the context of namespace isolation. The current wording incorrectly implies that namespace isolation does not apply to CRDs, without specifying that while CRDs are cluster-scoped, the resources they define can indeed be namespaced.

The revised sentence now reads:

_"However, it can be difficult to configure, and it doesn't apply to resources that are cluster-scoped and not namespaced, such as Custom Resource Definitions (CRDs) themselves (though the custom resources they define can be namespaced), Storage Classes, and Webhooks."_

This clarification will help users better understand the relationship between CRDs and namespace isolation.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #48112 