### PR TITLE
Signpost to API reference for StorageClass

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -5,6 +5,9 @@ reviewers:
 - thockin
 - msau42
 title: Storage Classes
+api_metadata:
+- apiVersion: "storage.k8s.io/v1"
+  kind: "StorageClass"
 content_type: concept
 weight: 40
 ---


### PR DESCRIPTION
This PR adds metadata in the front matter of the `/docs/concepts/storage/storage-classes.md` file. With this change, the StorageClass API reference link is prominently displayed at the top of the meta links _(alongside "Edit this page" and "Create an Issue")_ on "Storage Classes" concept page.

[Updated Preview Page](https://deploy-preview-48162--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/storage-classes/)