### PR TITLE
steering: Onboard/offboard members following 2024 election results

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -228,12 +228,12 @@ aliases:
     - MaxymVlasov
   # authoritative source: git.k8s.io/community/OWNERS_ALIASES
   committee-steering: # provide PR approvals for announcements
-    - bentheelder
+    - aojea
+    - BenTheElder
     - justaugustus
-    - mrbobbytables
     - pacoxu
-    - palnabarun
     - pohly
+    - saschagrunert
     - soltysh
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES
   sig-release-leads:


### PR DESCRIPTION
cc: @kubernetes/steering-committee 
ref: https://github.com/kubernetes/steering/issues/286
/assign @natalisucks @saschagrunert @divya-mohan0209 