### PR TITLE
Adding mirror of election blog post

### DIFF
--- a/content/en/blog/_posts/2024-10-02-steering-committee-results-2024.md
+++ b/content/en/blog/_posts/2024-10-02-steering-committee-results-2024.md
@@ -1,0 +1,62 @@
+---
+layout: blog
+title: "Announcing the 2024 Steering Committee Election Results"
+slug: steering-committee-results-2024
+canonicalUrl: https://www.kubernetes.dev/blog/2024/10/02/steering-committee-results-2024
+date: 2024-10-02
+author: >
+  Bridget Kromhout
+---
+
+
+The [2024 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2024) is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in 2024. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
+
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+
+Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
+
+## Results
+
+Congratulations to the elected committee members whose two year terms begin immediately (listed in alphabetical order by GitHub handle):
+
+* **Antonio Ojea ([@aojea](https://github.com/aojea)), Google**
+* **Benjamin Elder ([@BenTheElder](https://github.com/bentheelder)), Google**
+* **Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert)), Red Hat**
+
+They join continuing members:
+
+* **Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco**
+* **Paco Xu 徐俊杰 ([@pacoxu](https://github.com/pacoxu)), DaoCloud**
+* **Patrick Ohly ([@pohly](https://github.com/pohly)), Intel**
+* **Maciej Szulik ([@soltysh](https://github.com/soltysh)), Defense Unicorns**
+
+Benjamin Elder is a returning Steering Committee Member.
+
+## Big Thanks!
+
+Thank you and congratulations on a successful election to this round’s election officers:
+
+* Bridget Kromhout ([@bridgetkromhout](https://github.com/bridgetkromhout))
+* Christoph Blecker ([@cblecker](https://github.com/cblecker))
+* Priyanka Saggu ([@Priyankasaggu11929](https://github.com/Priyankasaggu11929))
+
+
+Thanks to the Emeritus Steering Committee Members. Your service is appreciated by the community:
+
+* Bob Killen ([@mrbobbytables](https://github.com/mrbobbytables))
+* Nabarun Pal ([@palnabarun](https://github.com/palnabarun))
+
+
+And thank you to all the candidates who came forward to run for election.
+
+## Get Involved with the Steering Committee
+
+This governing body, like all of Kubernetes, is open to all. You can follow along with Steering Committee [meeting notes](https://bit.ly/k8s-steering-wd) and weigh in by filing an issue or creating a PR against their [repo](https://github.com/kubernetes/steering). They have an open meeting on [the first Monday at 8am PT of every month](https://github.com/kubernetes/steering). They can also be contacted at their public mailing list steering@kubernetes.io.
+
+You can see what the Steering Committee meetings are all about by watching past meetings on the [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM).
+
+If you want to meet some of the newly elected Steering Committee members, join us for the Steering AMA at the [Kubernetes Contributor Summit North America 2024 in Salt Lake City](https://www.kubernetes.dev/events/2024/kcsna/schedule/#steering-ama).
+
+---
+
+_This post was adapted from one written by the [Contributor Comms Subproject](https://github.com/kubernetes/community/tree/master/communication/contributor-comms). If you want to write stories about the Kubernetes community, learn more about us._

--- a/content/en/blog/_posts/2024-10-02-steering-committee-results-2024.md
+++ b/content/en/blog/_posts/2024-10-02-steering-committee-results-2024.md
@@ -9,7 +9,7 @@ author: >
 ---
 
 
-The [2024 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2024) is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in 2024. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
+The [2024 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2024) is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in 2024. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
 This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
 

--- a/content/en/blog/_posts/2024-10-02-steering-committee-results-2024.md
+++ b/content/en/blog/_posts/2024-10-02-steering-committee-results-2024.md
@@ -3,7 +3,7 @@ layout: blog
 title: "Announcing the 2024 Steering Committee Election Results"
 slug: steering-committee-results-2024
 canonicalUrl: https://www.kubernetes.dev/blog/2024/10/02/steering-committee-results-2024
-date: 2024-10-02
+date: 2024-10-02T15:10:00-05:00
 author: >
   Bridget Kromhout
 ---
@@ -32,7 +32,7 @@ They join continuing members:
 
 Benjamin Elder is a returning Steering Committee Member.
 
-## Big Thanks!
+## Big thanks!
 
 Thank you and congratulations on a successful election to this round’s election officers:
 
@@ -49,13 +49,13 @@ Thanks to the Emeritus Steering Committee Members. Your service is appreciated b
 
 And thank you to all the candidates who came forward to run for election.
 
-## Get Involved with the Steering Committee
+## Get involved with the Steering Committee
 
 This governing body, like all of Kubernetes, is open to all. You can follow along with Steering Committee [meeting notes](https://bit.ly/k8s-steering-wd) and weigh in by filing an issue or creating a PR against their [repo](https://github.com/kubernetes/steering). They have an open meeting on [the first Monday at 8am PT of every month](https://github.com/kubernetes/steering). They can also be contacted at their public mailing list steering@kubernetes.io.
 
 You can see what the Steering Committee meetings are all about by watching past meetings on the [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM).
 
-If you want to meet some of the newly elected Steering Committee members, join us for the Steering AMA at the [Kubernetes Contributor Summit North America 2024 in Salt Lake City](https://www.kubernetes.dev/events/2024/kcsna/schedule/#steering-ama).
+If you want to meet some of the newly elected Steering Committee members, join us for the [Steering AMA](https://www.kubernetes.dev/events/2024/kcsna/schedule/#steering-ama) at the Kubernetes Contributor Summit North America 2024 in Salt Lake City.
 
 ---
 


### PR DESCRIPTION
Adding mirror of election blog post; merge only after reconciling with any updates that happen before https://github.com/kubernetes/contributor-site/pull/535 is merged.


/hold