### PR TITLE
Update horizontal-pod-autoscale.md with additional keywords

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -563,7 +563,7 @@ the Deployment and / or StatefulSet be removed from their
 a change to that object is applied, for example via `kubectl apply -f
 deployment.yaml`, this will instruct Kubernetes to scale the current number of Pods
 to the value of the `spec.replicas` key. This may not be
-desired and could be troublesome when an HPA is active.
+desired and could be troublesome when an HPA is active, resulting in thrashing or flapping behavior.
 
 Keep in mind that the removal of `spec.replicas` may incur a one-time
 degradation of Pod counts as the default value of this key is 1 (reference


### PR DESCRIPTION
### Description

This PR adds additional keywords to the *Migrating Deployments and StatefulSets to horizontal autoscaling* section of the Horizontal Pod Autoscaler page to aid users in troubleshooting. This will help users who are not reading the documentation in its entirety but rather skimming it and searching for keywords.

This suggestion stems from an issue I had when troubleshooting a migration to HPA.

### Issue

N/A