### PR TITLE
Update the multi tenancy docs to remove reference to archived project

### DIFF
--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -463,7 +463,6 @@ listed below.
 #### Multi-team tenancy
 
 * [Capsule](https://github.com/clastix/capsule)
-* [Kiosk](https://github.com/loft-sh/kiosk)
 
 #### Multi-customer tenancy
 


### PR DESCRIPTION
### Description

This change removes a reference to the kiosk project from the multi tenancy page as this project appears to have been archived by its owners.

