### PR TITLE
Document device_ownership_from_security_context=true for Containerd v2

### DIFF
--- a/content/en/blog/_posts/2021-11-09-non-root-containers-and-devices.md
+++ b/content/en/blog/_posts/2021-11-09-non-root-containers-and-devices.md
@@ -135,11 +135,21 @@ deployments break, an opt-in config entry in both containerd and CRI-O to enable
 defaults to `false` and must be enabled to use the feature.
 
 ## See non-root containers using devices after the fix
-To demonstrate the new behavior, let's use a Data Plane Development Kit (DPDK) application using hardware accelerators, Kubernetes CPU manager, and HugePages as an example. The cluster runs containerd with:
+To demonstrate the new behavior, let's use a Data Plane Development Kit (DPDK) application using hardware accelerators, Kubernetes CPU manager, and HugePages as an example. The cluster runs
+
+Containerd v1 with:
 
 ```toml
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = true
+```
+
+Containerd v2 with:
+
+```toml
+[plugins]
+  [plugins."io.containerd.cri.v1.runtime"]
     device_ownership_from_security_context = true
 ```
 


### PR DESCRIPTION
Hi, in the [Cozystack](github.com/aenix-io/cozystack) project, we recently upgraded to Containerd v2 and noticed that the old option is no longer functioning. It has now been moved to a different section. I'd like to update the documentation to help others quickly find the solution.

I prepared a set of fixes:
- Original issue https://github.com/aenix-io/cozystack/issues/397
- CDI docs: https://github.com/kubevirt/containerized-data-importer/pull/3452
- Kubernetes docs: https://github.com/kubernetes/website/pull/48198

Cheers