### PR TITLE
Document compatibility versions

### DIFF
--- a/content/en/releases/_index.md
+++ b/content/en/releases/_index.md
@@ -22,6 +22,24 @@ More information in the [version skew policy](/releases/version-skew-policy/) do
 
 <!-- body -->
 
+## Version Compatibility Mode (Version Emulation)
+
+Starting with Kubernetes v1.33, clusters can be configured to run in **Version Compatibility Mode**. This mode allows a newer Kubernetes version (e.g., v1.33) to emulate an older version (e.g., v1.31), ensuring compatibility with workloads, Helm charts, or tools that rely on specific Kubernetes versions.
+
+### Operational Overview
+
+In Version Compatibility Mode, the API server operates in accordance with the specifications of the emulated version. For example, when running a Kubernetes v1.33 cluster in compatibility mode for v1.31, the API adheres to v1.31's standards and behavior, while the underlying cluster remains on v1.33.
+
+### Use Cases
+
+- **Helm charts or workloads**: Suitable for workloads designed for a specific Kubernetes version, ensuring compatibility while testing or migrating to a newer release.
+- **Legacy API support**: Enables applications dependent on APIs that were modified or deprecated in newer versions to function without immediate changes.
+
+### Limitations
+
+- **Limited feature compatibility**: Certain features deprecated or removed in the newer version may not behave as expected, even when the API is emulating an older version.
+- **Partial compatibility**: Version Compatibility Mode ensures API compatibility, but other Kubernetes components and behaviors may still follow the newer version.
+
 ## Release History
 
 {{< release-data >}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

* This PR introduces documentation for Version Compatibility Mode in Kubernetes 1.33, which allows clusters to emulate older versions (e.g., running v1.33 as v1.31).

* Changes:
  * Added an overview of how the API server behaves in compatibility mode.
  * Included use cases demonstrating its benefits, such as compatibility with Helm charts and legacy APIs.
  * Outlined limitations and the need to reference the documentation of the emulated version.
  * This documentation is essential for users to understand the functionality and implications of this new feature.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #48171 