### PR TITLE
Add “duration” to glossary

### DIFF
--- a/content/en/docs/reference/glossary/duration.md
+++ b/content/en/docs/reference/glossary/duration.md
@@ -1,0 +1,12 @@
+---
+title: Duration
+id: duratoion
+date: 2024-10-05
+full_link:
+short_description: >
+  A time interval specified as a string in the format accepted by Go's [time.Duration](https://pkg.go.dev/time), allowing for flexible time specifications using various units like seconds, minutes, and hours.
+aka:
+tags:
+- fundamental
+---
+ In Kubernetes APIs, a duration must be non-negative and is typically expressed with a suffix (e.g., `5s` for five seconds or `1m30s` for one minute and thirty seconds).

--- a/content/en/docs/reference/glossary/duration.md
+++ b/content/en/docs/reference/glossary/duration.md
@@ -1,6 +1,6 @@
 ---
 title: Duration
-id: duratoion
+id: duration
 date: 2024-10-05
 full_link:
 short_description: >
@@ -9,4 +9,6 @@ aka:
 tags:
 - fundamental
 ---
- In Kubernetes APIs, a duration must be non-negative and is typically expressed with a suffix (e.g., `5s` for five seconds or `1m30s` for one minute and thirty seconds).
+In Kubernetes APIs, a duration must be non-negative and is typically expressed with a suffix. 
+For example, `5s` for five seconds or `1m30s` for one minute and thirty seconds
+

--- a/content/en/docs/reference/glossary/duration.md
+++ b/content/en/docs/reference/glossary/duration.md
@@ -10,5 +10,5 @@ tags:
 - fundamental
 ---
 In Kubernetes APIs, a duration must be non-negative and is typically expressed with a suffix. 
-For example, `5s` for five seconds or `1m30s` for one minute and thirty seconds
+For example, `5s` for five seconds or `1m30s` for one minute and thirty seconds.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

* This PR adds a glossary entry for **Duration** to clarify its usage in Kubernetes APIs. 
* The entry defines a duration as a time interval specified in Go's `time.Duration` format, highlights the requirement for non-negativity, and provides examples of valid expressions. 
* This addition aims to enhance user understanding of duration fields within the Kubernetes API.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #47909