### PR TITLE
[zh-cn]Update the description of how to access the dashboard

### DIFF
--- a/content/zh-cn/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -115,13 +115,13 @@ by running the following command:
 你可以使用 `kubectl` 命令行工具来启用 Dashboard 访问，命令如下：
 
 ```
-kubectl proxy
+kubectl proxy --port=8001
 ```
 
 <!--
-Kubectl will make Dashboard available at [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/).
+Kubectl will make Dashboard available at [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/).
 -->
-kubectl 会使得 Dashboard 可以通过 [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/) 访问。
+kubectl 会使得 Dashboard 可以通过 [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/) 访问。
 
 <!--
 The UI can _only_ be accessed from the machine where the command is executed. See `kubectl proxy --help` for more options.


### PR DESCRIPTION
### Description
Update `http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/` to `http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/`

ref:
- https://github.com/kubernetes/dashboard/blob/master/docs/user/accessing-dashboard/README.md#kubectl-proxy
- https://github.com/kubernetes/website/pull/48205#issuecomment-2395044667