### PR TITLE
Register annotation autoscaling.alpha.kubernetes.io/behavior as deprecated

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -580,6 +580,14 @@ receiving traffic for the Service from the moment the kubelet starts all contain
 and marks it _Running_, til the kubelet stops all containers and deletes the pod from
 the API server.
 
+### autoscaling.alpha.kubernetes.io/behavior (deprecated)
+
+Type: Annotation
+
+Used on: HorizontalPodAutoscaler
+
+This annotation was used to configure the scaling behavior of the Horizontal Pod Autoscaler (HPA) in earlier Kubernetes versions. It allowed to specify how the HPA should scale pods up or down, including setting stabilization windows and scaling policies.
+
 ### kubernetes.io/hostname {#kubernetesiohostname}
 
 Type: Label


### PR DESCRIPTION


<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
 * `autoscaling.alpha.kubernetes.io/behavior` annotation was not registered earlier with this PR is it registered in https://kubernetes.io/docs/reference/labels-annotations-taints/ and its marked as deprecated 
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #47874