### PR TITLE
[SidecarContainer] provide sidecar best practices hints about exit code

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -97,6 +97,12 @@ maintain sidecar containers without affecting the primary application.
 Sidecar containers share the same network and storage namespaces with the primary
 container. This co-location allows them to interact closely and share resources.
 
+From Kubernetes perspective, sidecars graceful termination is less important. 
+When other containers took all alloted graceful termination time, sidecar containers
+will receive the `SIGTERM` following with `SIGKILL` faster than may be expected. 
+So exit codes different from `0` (`0` indicates successful exit), for sidecar containers are normal
+on Pod termination and should be generally ignored by the external tooling.
+
 ## Differences from init containers
 
 Sidecar containers work alongside the main container, extending its functionality and

--- a/content/en/docs/tutorials/configuration/pod-sidecar-containers.md
+++ b/content/en/docs/tutorials/configuration/pod-sidecar-containers.md
@@ -69,6 +69,8 @@ Using Kubernetes' native support for sidecar containers provides several benefit
    special care is needed to handle this situation.
 4. Also, with Jobs, built-in sidecar containers would keep being restarted once they are done, even if regular containers would not with Pod's `restartPolicy: Never`.
 
+See [differences from init containers](/docs/concepts/workloads/pods/sidecar-containers/#differences-from-application-containers) to learn more about it.
+
 ## Adopting built-in sidecar containers
 
 The `SidecarContainers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is in beta state starting from Kubernetes version 1.29 and is enabled by default.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This is a follow up from https://github.com/kubernetes/enhancements/issues/753#issuecomment-2332796992

We need to improve the page https://kubernetes.io/docs/tutorials/configuration/pod-sidecar-containers/ with the best practices on how to implement sidecar containers. Things like exiting with 0 on SIGTERM

### Issue

Closes: https://github.com/kubernetes/website/issues/47823