### PR TITLE
Update statefulset.md

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -298,8 +298,7 @@ described [above](#deployment-and-scaling-guarantees).
 `Parallel` pod management tells the StatefulSet controller to launch or
 terminate all Pods in parallel, and to not wait for Pods to become Running
 and Ready or completely terminated prior to launching or terminating another
-Pod. This option only affects the behavior for scaling operations. Updates are not
-affected.
+Pod. This option only affects the behavior for scaling operations.
 
 
 ## Update strategies


### PR DESCRIPTION
Description
The documentation states that setting the podManagementPolicy to Parallel only affects scaling operations, not updates (like changes to the pod template). This suggests that during updates, pods should still be managed sequentially.

However, in practice, when you set podManagementPolicy to Parallel, updates are happening in parallel, meaning pods are updated without waiting for others to finish, which contradicts what the docs say.

Issue
https://github.com/kubernetes/website/issues/47085