### PR TITLE
Tweak and use glossary entry for duration

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -149,20 +149,15 @@ until disk usage reaches the `LowThresholdPercent` value.
 As a beta feature, you can specify the maximum time a local image can be unused for,
 regardless of disk usage. This is a kubelet setting that you configure for each node.
 
-To configure the setting, you need to set a value for the `imageMaximumGCAge` 
+To configure the setting, you need to set a value for the `imageMaximumGCAge`
 field in the kubelet configuration file.
 
-The value is specified as a Kubernetes _duration_; 
-Valid time units for the `imageMaximumGCAge` field in the kubelet configuration file are:
-- "ns" for nanoseconds
-- "us" or "µs" for microseconds
-- "ms" for milliseconds
-- "s" for seconds
-- "m" for minutes
-- "h" for hours
+The value is specified as a Kubernetes {{< glossary_tooltip text="duration" term_id="duration" >}}.
+See [duration](/docs/reference/glossary/?all=true#term-duration) in the glossary
+for more details.
 
 For example, you can set the configuration field to `12h45m`,
-which means 12 hours and 45 minutes. 
+which means 12 hours and 45 minutes.
 
 {{< note >}}
 This feature does not track image usage across kubelet restarts. If the kubelet

--- a/content/en/docs/reference/glossary/duration.md
+++ b/content/en/docs/reference/glossary/duration.md
@@ -4,11 +4,21 @@ id: duration
 date: 2024-10-05
 full_link:
 short_description: >
-  A time interval specified as a string in the format accepted by Go's [time.Duration](https://pkg.go.dev/time), allowing for flexible time specifications using various units like seconds, minutes, and hours.
-aka:
+  A string value representing an amount of time.
 tags:
 - fundamental
 ---
-In Kubernetes APIs, a duration must be non-negative and is typically expressed with a suffix. 
-For example, `5s` for five seconds or `1m30s` for one minute and thirty seconds.
+A string value representing an amount of time.
 
+<!--more-->
+
+The format of a (Kubernetes) duration is based on the
+[`time.Duration`](https://pkg.go.dev/time#Duration) type from the Go programming language.
+
+In Kubernetes APIs that use durations, the value is expressed as series of a non-negative
+integers combined with a time unit suffix. You can have more than one time quantity and
+the duration is the sum of those time quantities.
+The valid time units are "ns", "µs" (or "us"), "ms", "s", "m", and "h".
+
+For example: `5s` represents a duration of five seconds, and `1m30s` represents a duration
+of one minute and thirty seconds.


### PR DESCRIPTION
- Revise wording of https://kubernetes.io/docs/reference/glossary/?all=true#term-duration
- Use the glossary entry where appropriate (one place, I think)