### PR TITLE
Changed the command for Attaching to the shell container

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -40,7 +40,7 @@ Process namespace sharing is enabled using the `shareProcessNamespace` field of
 1. Attach to the `shell` container and run `ps`:
 
    ```shell
-   kubectl attach -it nginx -c shell
+   kubectl exec -it nginx -c shell -- /bin/sh
    ```
 
    If you don't see a command prompt, try pressing enter. In the container shell:


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
attaching doesn't work -
when i run kubectl attach -it nginx -c shell
I get

If you don't see a command prompt, try pressing enter.

and pressing enter doens't help

Proposed Solution : -
kubectl exec -it nginx -c shell -- /bin/sh
this command is working fine

### Issue
#46478