### PR TITLE
fix: update the doc for metrics cardinality enforcement

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/en/docs/concepts/cluster-administration/system-metrics.md
@@ -183,7 +183,7 @@ disabled metrics (i.e. `--disabled-metrics=metric1,metric2`).
 ## Metric cardinality enforcement
 
 Metrics with unbounded dimensions could cause memory issues in the components they instrument. To
-limit resource use, you can use the `--allow-label-value` command line option to dynamically
+limit resource use, you can use the `--allow-metric-labels` command line option to dynamically
 configure an allow-list of label values for a metric.
 
 In alpha stage, the flag can only take in a series of mappings as metric label allow-list.
@@ -207,9 +207,8 @@ can specify the path to that configuration file using the `--allow-metric-labels
 line argument to a component. Here's an example of the contents of that configuration file:
 
 ```yaml
-allow-list:
-- "metric1,label2": "v1,v2,v3"
-- "metric2,label1": "v1,v2,v3"
+"metric1,label2": "v1,v2,v3"
+"metric2,label1": "v1,v2,v3"
 ```
 
 Additionally, the `cardinality_enforcement_unexpected_categorizations_total` meta-metric records the

--- a/content/en/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/en/docs/concepts/cluster-administration/system-metrics.md
@@ -193,13 +193,13 @@ Each mapping is of the format `<metric_name>,<label_name>=<allowed_labels>` wher
 The overall format looks like:
 
 ```
---allow-label-value <metric_name>,<label_name>='<allow_value1>, <allow_value2>...', <metric_name2>,<label_name>='<allow_value1>, <allow_value2>...', ...
+--allow-metric-labels <metric_name>,<label_name>='<allow_value1>, <allow_value2>...', <metric_name2>,<label_name>='<allow_value1>, <allow_value2>...', ...
 ```
 
 Here is an example:
 
 ```none
---allow-label-value number_count_metric,odd_number='1,3,5', number_count_metric,even_number='2,4,6', date_gauge_metric,weekend='Saturday,Sunday'
+--allow-metric-labels number_count_metric,odd_number='1,3,5', number_count_metric,even_number='2,4,6', date_gauge_metric,weekend='Saturday,Sunday'
 ```
 
 In addition to specifying this from the CLI, this can also be done within a configuration file. You


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR correct the doc for metrics cardinality enforcement
1. Use correct flag name as `allow-metric-labels` following the [flag definition](https://github.com/kubernetes/kubernetes/blob/c15581b277e9e42d830898357fdbd92dcf7981c6/staging/src/k8s.io/component-base/metrics/options.go#L81)
2. Use correct manifest pattern following the [flag process function](https://github.com/kubernetes/kubernetes/blob/c15581b277e9e42d830898357fdbd92dcf7981c6/staging/src/k8s.io/component-base/metrics/opts.go#L365 )
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #