### PR TITLE
[zh] update service-resources/service-v1.md

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -8,7 +8,6 @@ description: "Service 是软件服务（例如 mysql）的命名抽象，包含�
 title: Service
 weight: 1
 ---
-
 <!--
 api_metadata:
   apiVersion: "v1"
@@ -26,10 +25,10 @@ auto_generated: true
 `import "k8s.io/api/core/v1”`
 
 ## Service {#Service}
+
 <!--
 Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
 -->
-
 Service 是软件服务（例如 mysql）的命名抽象，包含代理要侦听的本地端口（例如 3306）和一个选择算符，
 选择算符用来确定哪些 Pod 将响应通过代理发送的请求。
 
@@ -45,8 +44,8 @@ Service 是软件服务（例如 mysql）的命名抽象，包含代理要侦听
   Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   -->
 
-  标准的对象元数据。
-  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  标准的对象元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../service-resources/service-v1#ServiceSpec" >}}">ServiceSpec</a>)
 
@@ -63,12 +62,12 @@ Service 是软件服务（例如 mysql）的命名抽象，包含代理要侦听
   Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   -->
 
-  最近观察到的 Service 状态。由系统填充。只读。
-  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  最近观察到的 Service 状态。由系统填充。只读。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 ## ServiceSpec {#ServiceSpec}
 
-<!-- 
+<!--
 ServiceSpec describes the attributes that a user creates on a service. 
 -->
 ServiceSpec 描述用户在服务上创建的属性。
@@ -77,18 +76,18 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **selector** (map[string]string)
 
-  <!-- 
+  <!--
   Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/ 
   -->
 
   将 Service 流量路由到具有与此 selector 匹配的标签键值对的 Pod。
   如果为空或不存在，则假定该服务有一个外部进程管理其端点，Kubernetes 不会修改该端点。
-  仅适用于 ClusterIP、NodePort 和 LoadBalancer 类型。如果类型为 ExternalName，则忽略。
-  更多信息： https://kubernetes.io/docs/concepts/services-networking/service/
+  仅适用于 ClusterIP、NodePort 和 LoadBalancer 类型。如果类型为 ExternalName，则忽略。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/
 
 - **ports** ([]ServicePort)
 
-  <!-- 
+  <!--
   *Patch strategy: merge on key `port`*
   
   *Map: unique values on keys `port, protocol` will be kept during a merge*
@@ -99,17 +98,17 @@ ServiceSpec 描述用户在服务上创建的属性。
   *ServicePort contains information on service's port.*
   -->
 
-  **Patch strategy：基于键 `type` 合并**
+  **补丁策略：基于键 `type` 合并**
 
   **Map：合并时将保留 type 键的唯一值**
 
-  此 Service 公开的端口列表。
-  更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  此 Service 公开的端口列表。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
 
   <a name="ServicePort"></a>
   **ServicePort 包含有关 ServicePort 的信息。**
 
-  <!-- 
+  <!--
   - **ports.port** (int32), required
 
     The port that will be exposed by this service.
@@ -135,8 +134,8 @@ ServiceSpec 描述用户在服务上创建的属性。
     如果此值是一个字符串，将在目标 Pod 的容器端口中作为命名端口进行查找。
     如果未指定字段，则使用 `port` 字段的值（直接映射）。
     对于 clusterIP 为 None 的服务，此字段将被忽略，
-    应忽略不设或设置为 `port` 字段的取值。
-    更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+    应忽略不设或设置为 `port` 字段的取值。更多信息：
+    https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#defining-a-service
 
     <a name="IntOrString"></a>
     **IntOrString 是一种可以保存 int32 或字符串的类型。
@@ -145,7 +144,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
   - **ports.protocol** (string)
 
-    <!-- 
+    <!--
     The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP. 
     -->
 
@@ -153,7 +152,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
   - **ports.name** (string)
 
-    <!-- 
+    <!--
     The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service. 
     -->
 
@@ -164,7 +163,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
   - **ports.nodePort** (int32)
 
-    <!-- 
+    <!--
     The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport 
     -->
 
@@ -172,8 +171,8 @@ ServiceSpec 描述用户在服务上创建的属性。
     通常由系统分配。如果指定了一个在范围内且未使用的值，则将使用该值，否则操作将失败。
     如果在创建的 Service 需要该端口时未指定该字段，则会分配端口。
     如果在创建不需要该端口的 Service时指定了该字段，则会创建失败。
-    当更新 Service 时，如果不再需要此字段（例如，将类型从 NodePort 更改为 ClusterIP），这个字段将被擦除。
-    更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    当更新 Service 时，如果不再需要此字段（例如，将类型从 NodePort 更改为 ClusterIP），这个字段将被擦除。更多信息：
+    https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#type-nodeport
 
   - **ports.appProtocol** (string)
 
@@ -182,6 +181,7 @@ ServiceSpec 描述用户在服务上创建的属性。
     richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax.
     Valid values are either:
     -->
+
     此端口的应用协议，用作实现的提示，为他们理解的协议提供更丰富的行为。此字段遵循标准
     Kubernetes 标签语法，有效值包括：
     
@@ -208,7 +208,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **type** (string)
 
-  <!-- 
+  <!--
   type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types 
   -->
 
@@ -219,18 +219,18 @@ ServiceSpec 描述用户在服务上创建的属性。
   如果 clusterIP 为 `None`，则不分配虚拟 IP，并且 Endpoints 作为一组端点而不是虚拟 IP 发布。
   `NodePort` 建立在 ClusterIP 之上，并在每个节点上分配一个端口，该端口路由到与 clusterIP 相同的 Endpoints。
   `LoadBalancer` 基于 NodePort 构建并创建一个外部负载均衡器（如果当前云支持），该负载均衡器路由到与 clusterIP 相同的 Endpoints。
-  `externalName` 将此 Service 别名为指定的 externalName。其他几个字段不适用于 ExternalName Service。
-  更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  `externalName` 将此 Service 别名为指定的 externalName。其他几个字段不适用于 ExternalName Service。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#publishing-services-service-types
 
 - **ipFamilies** ([]string)
 
-  <!-- 
+  <!--
   *Atomic: will be replaced during a merge* 
   -->
 
   **原子: 将在合并期间被替换**
 
-  <!-- 
+  <!--
   IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName. 
   -->
 
@@ -252,7 +252,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **ipFamilyPolicy** (string)
 
-  <!-- 
+  <!--
   IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName. 
   -->
 
@@ -266,7 +266,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **clusterIP** (string)
 
-  <!-- 
+  <!--
   clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies 
   -->
 
@@ -278,17 +278,18 @@ ServiceSpec 描述用户在服务上创建的属性。
   clusterIP 为 “None” 时会生成“无头服务”（无虚拟 IP），这在首选直接 Endpoint 连接且不需要代理时很有用。
   仅适用于 ClusterIP、NodePort、和 LoadBalancer 类型的服务。
   如果在创建 ExternalName 类型的 Service 时指定了 clusterIP，则创建将失败。
-  更新 Service type 为 ExternalName 时，clusterIP 会被移除。
-  更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  更新 Service type 为 ExternalName 时，clusterIP 会被移除。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
 
 - **clusterIPs** ([]string)
 
-  <!-- 
+  <!--
   *Atomic: will be replaced during a merge* 
   -->
+
   **原子: 将在合并期间被替换**
 
-  <!-- 
+  <!--
   ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
   -->
 
@@ -303,18 +304,18 @@ ServiceSpec 描述用户在服务上创建的属性。
   更新 Service type 为 ExternalName 时，该字段将被移除。如果未指定此字段，则将从 clusterIP 字段初始化。
   如果指定 clusterIPs，客户端必须确保 clusterIPs[0] 和 clusterIP 一致。
 
-  <!-- 
+  <!--
   This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies 
   -->
 
   clusterIPs 最多可包含两个条目（双栈系列，按任意顺序）。
   这些 IP 必须与 ipFamilies 的值相对应。
-  clusterIP 和 ipFamilies 都由 ipFamilyPolicy 管理。
-  更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  clusterIP 和 ipFamilies 都由 ipFamilyPolicy 管理。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
 
 - **externalIPs** ([]string)
 
-  <!-- 
+  <!--
   *Atomic: will be replaced during a merge*
   
   externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system. 
@@ -328,19 +329,20 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **sessionAffinity** (string)
 
-  <!-- 
+  <!--
   Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies 
   -->
 
   支持 “ClientIP” 和 “None”。用于维护会话亲和性。
-  启用基于客户端 IP 的会话亲和性。必须是 ClientIP 或 None。默认为 None。
-  更多信息： https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  启用基于客户端 IP 的会话亲和性。必须是 ClientIP 或 None。默认为 None。更多信息：
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
 
 - **loadBalancerIP** (string)
 
-  <!-- 
+  <!--
   Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations. Using it is non-portable and it may not support dual-stack. Users are encouraged to use implementation-specific annotations when available.
   -->
+
   仅适用于服务类型：LoadBalancer。此功能取决于底层云提供商是否支持负载均衡器。
   如果云提供商不支持该功能，该字段将被忽略。
   已弃用：该字段信息不足，且其含义因实现而异。此字段是不可移植的，并且可能不支持双栈。。
@@ -348,7 +350,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **loadBalancerSourceRanges** ([]string)
 
-  <!-- 
+  <!--
   *Atomic: will be replaced during a merge*
   
   If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/ 
@@ -357,12 +359,12 @@ ServiceSpec 描述用户在服务上创建的属性。
   **原子：将在合并期间被替换**
 
   如果设置了此字段并且被平台支持，将限制通过云厂商的负载均衡器的流量到指定的客户端 IP。
-  如果云提供商不支持该功能，该字段将被忽略。
-  更多信息： https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+  如果云提供商不支持该功能，该字段将被忽略。更多信息：
+  https://kubernetes.io/zh-cn/docs/tasks/access-application-cluster/create-external-load-balancer/
 
 - **loadBalancerClass** (string)
 
-  <!-- 
+  <!--
   loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
   -->
 
@@ -377,7 +379,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **externalName** (string)
 
-  <!-- 
+  <!--
   externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName". 
   -->
 
@@ -387,9 +389,10 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **externalTrafficPolicy** (string)
 
-  <!-- 
+  <!--
   externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
   -->
+
   externalTrafficPolicy 描述了节点如何分发它们在 Service 的“外部访问”地址
   （NodePort、ExternalIP 和 LoadBalancer IP）接收到的服务流量。
   如果设置为 “Local”，代理将以一种假设外部负载均衡器将负责在节点之间服务流量负载均衡，
@@ -401,18 +404,20 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **internalTrafficPolicy** (string)
 
-  <!-- 
+  <!--
   InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
   -->
-  InternalTrafficPolicy 描述节点如何分发它们在 ClusterIP 上接收到的服务流量。
+
+  internalTrafficPolicy 描述节点如何分发它们在 ClusterIP 上接收到的服务流量。
   如果设置为 “Local”，代理将假定 Pod 只想与在同一节点上的服务端点通信，如果没有本地端点，它将丢弃流量。
   “Cluster” 默认将流量路由到所有端点（可能会根据拓扑和其他特性进行修改）。
 
 - **healthCheckNodePort** (int32)
 
-  <!-- 
+  <!--
   healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
   -->
+
   healthCheckNodePort 指定 Service 的健康检查节点端口。
   仅适用于 type 为 LoadBalancer 且 externalTrafficPolicy 设置为 Local 的情况。
   如果为此字段设定了一个值，该值在合法范围内且没有被使用，则使用所指定的值。
@@ -423,7 +428,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **publishNotReadyAddresses** (boolean)
 
-  <!-- 
+  <!--
   publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior. 
   -->
 
@@ -436,12 +441,13 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **sessionAffinityConfig** (SessionAffinityConfig)
 
-  <!-- 
+  <!--
   sessionAffinityConfig contains the configurations of session affinity.
 
   <a name="SessionAffinityConfig"></a>
   *SessionAffinityConfig represents the configurations of session affinity.*
   -->
+
   sessionAffinityConfig 包含会话亲和性的配置。
 
   <a name="SessionAffinityConfig"></a>
@@ -449,7 +455,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
   - **sessionAffinityConfig.clientIP** (ClientIPConfig)
 
-    <!-- 
+    <!--
     clientIP contains the configurations of Client IP based session affinity.
 
     <a name="ClientIPConfig"></a>
@@ -463,7 +469,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
     - **sessionAffinityConfig.clientIP.timeoutSeconds** (int32)
 
-      <!-- 
+      <!--
       timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && \<=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours). 
       -->
 
@@ -472,7 +478,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 - **allocateLoadBalancerNodePorts** (boolean)
 
-  <!-- 
+  <!--
   allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. 
   -->
 
@@ -495,7 +501,7 @@ ServiceSpec 描述用户在服务上创建的属性。
 
 ## ServiceStatus {#ServiceStatus}
 
-<!-- 
+<!--
 ServiceStatus represents the current status of a service. 
 -->
 ServiceStatus 表示 Service 的当前状态。
@@ -504,7 +510,7 @@ ServiceStatus 表示 Service 的当前状态。
 
 - **conditions** ([]Condition)
 
-  <!-- 
+  <!--
   *Patch strategy: merge on key `type`*
 
   *Map: unique values on key type will be kept during a merge*
@@ -543,25 +549,25 @@ ServiceStatus 表示 Service 的当前状态。
     **Time 是 time.Time 的包装类，支持正确地序列化为 YAML 和 JSON。
     为 time 包提供的许多工厂方法提供了包装类。**
 
-  <!-- 
+  <!--
   - **conditions.message** (string), required
   -->
 
   - **conditions.message** (string)，必需
 
-    <!-- 
+    <!--
     message is a human readable message indicating details about the transition. This may be an empty string. 
     -->
 
     message 是人类可读的消息，有关转换的详细信息，可以是空字符串。
 
-  <!-- 
+  <!--
   - **conditions.reason** (string), required
   -->
 
   - **conditions.reason** (string)，必需
 
-    <!-- 
+    <!--
     reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty. 
     -->
   
@@ -569,33 +575,33 @@ ServiceStatus 表示 Service 的当前状态。
     特定条件类型的生产者可以定义该字段的预期值和含义，以及这些值是否被视为有保证的 API。
     该值应该是 CamelCase 字符串且不能为空。
 
-  <!-- 
+  <!--
   - **conditions.status** (string), required
   -->
 
   - **conditions.status** (string)，必需
 
-    <!-- 
+    <!--
     status of the condition, one of True, False, Unknown. 
     -->
 
     condition 的状态，True、False、Unknown 之一。
 
-  <!-- 
+  <!--
   - **conditions.type** (string), required
   -->
 
   - **conditions.type** (string)，必需
 
-    <!-- 
+    <!--
     type of condition in CamelCase or in foo.example.com/CamelCase. 
     -->
 
-    CamelCase 或 foo.example.com/CamelCase 中的条件类型。
+    condition 的类型，格式为 CamelCase 或 foo.example.com/CamelCase。
 
   - **conditions.observedGeneration** (int64)
 
-    <!-- 
+    <!--
     observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance. 
     -->
 
@@ -605,7 +611,7 @@ ServiceStatus 表示 Service 的当前状态。
 
 - **loadBalancer** (LoadBalancerStatus)
 
-  <!-- 
+  <!--
   LoadBalancer contains the current status of the load-balancer, if one is present.
 
   <a name="LoadBalancerStatus"></a>
@@ -619,7 +625,7 @@ ServiceStatus 表示 Service 的当前状态。
 
   - **loadBalancer.ingress** ([]LoadBalancerIngress)
 
-    <!-- 
+    <!--
     *Atomic: will be replaced during a merge*
     
     Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
@@ -637,7 +643,7 @@ ServiceStatus 表示 Service 的当前状态。
 
     - **loadBalancer.ingress.hostname** (string)
 
-      <!-- 
+      <!--
       Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)     
       -->
 
@@ -645,7 +651,7 @@ ServiceStatus 表示 Service 的当前状态。
 
     - **loadBalancer.ingress.ip** (string)
 
-      <!-- 
+      <!--
       IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers) 
       -->
 
@@ -659,6 +665,7 @@ ServiceStatus 表示 Service 的当前状态。
       Setting this to "Proxy" indicates that traffic is delivered to the node or pod with the destination set to the node's IP and node
       port or the pod's IP and port. Service implementations may use this information to adjust traffic routing.
       -->
+
       ipMode 指定负载平衡器 IP 的行为方式，并且只能在设置了 ip 字段时指定。
       将其设置为 `VIP` 表示流量将传送到节点，并将目标设置为负载均衡器的 IP 和端口。
       将其设置为 `Proxy` 表示将流量传送到节点或 Pod，并将目标设置为节点的 IP 和节点端口或 Pod 的 IP 和端口。
@@ -666,46 +673,47 @@ ServiceStatus 表示 Service 的当前状态。
 
     - **loadBalancer.ingress.ports** ([]PortStatus)
 
-      <!-- 
+      <!--
       *Atomic: will be replaced during a merge* 
       -->
 
-      **Atomic：将在合并期间被替换**
+      **原子：将在合并期间被替换**
 
-      <!-- 
-      Ports is a list of records of service ports If used, every port defined in the service should have an entry in it       -->
+      <!--
+      Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+      -->
 
       ports 是 Service 的端口列表。如果设置了此字段，Service 中定义的每个端口都应该在此列表中。
 
       <a name="PortStatus"></a>
 
-      <!-- 
+      <!--
       - **loadBalancer.ingress.ports.port** (string), required
       -->
 
       - **loadBalancer.ingress.ports.port** (int32)，必需
 
-        <!-- 
+        <!--
         Port is the port number of the service port of which status is recorded here
         -->
 
         port 是所记录的服务端口状态的端口号。
 
-      <!-- 
+      <!--
       - **loadBalancer.ingress.ports.protocol** (string), required
       -->
 
       - **loadBalancer.ingress.ports.protocol** (string)，必需
 
-        <!-- 
+        <!--
         Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
         -->
 
-        protocol 是所记录的服务端口状态的协议。支持的值为：`TCP`、`UDP`、`SCTP`。
+        protocol 是所记录的服务端口状态的协议。支持的值为：“TCP”、“UDP”、“SCTP”。
 
       - **loadBalancer.ingress.ports.error** (string)
 
-        <!-- 
+        <!--
         Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
           CamelCase names
         - cloud provider specific error values must have names that comply with the
@@ -719,7 +727,7 @@ ServiceStatus 表示 Service 的当前状态。
 
 ## ServiceList {#ServiceList}
 
-<!-- 
+<!--
 ServiceList holds a list of services. 
 -->
 
@@ -733,14 +741,14 @@ ServiceList 包含一个 Service 列表。
 
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
 
-  <!-- 
+  <!--
   Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 
   -->
 
   标准的列表元数据。更多信息：
   https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
-<!-- 
+<!--
 - **items** ([]<a href="{{< ref "../service-resources/service-v1#Service" >}}">Service</a>), required
 
   List of services
@@ -749,7 +757,7 @@ ServiceList 包含一个 Service 列表。
 
   Service 列表。
 
-<!-- 
+<!--
 ## Operations {#Operations}
 -->
 
@@ -762,7 +770,6 @@ ServiceList 包含一个 Service 列表。
 
 #### HTTP Request
 -->
-
 ### `get` 读取指定的 Service
 
 #### HTTP 请求
@@ -807,7 +814,7 @@ GET /api/v1/namespaces/{namespace}/services/{name}
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `get` read status of the specified Service
 
 #### HTTP Request 
@@ -856,7 +863,7 @@ GET /api/v1/namespaces/{namespace}/services/{name}/status
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `list` list or watch objects of kind Service
 
 #### HTTP Request 
@@ -977,7 +984,7 @@ GET /api/v1/namespaces/{namespace}/services
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `list` list or watch objects of kind Service
 
 #### HTTP Request 
@@ -1090,7 +1097,7 @@ GET /api/v1/services
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `create` create a Service
 
 #### HTTP Request 
@@ -1163,7 +1170,7 @@ POST /api/v1/namespaces/{namespace}/services
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `update` replace the specified Service
 
 #### HTTP Request 
@@ -1242,7 +1249,7 @@ PUT /api/v1/namespaces/{namespace}/services/{name}
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `update` replace status of the specified Service
 
 #### HTTP Request 
@@ -1321,7 +1328,7 @@ PUT /api/v1/namespaces/{namespace}/services/{name}/status
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `patch` partially update the specified Service
 
 #### HTTP Request 
@@ -1408,7 +1415,7 @@ PATCH /api/v1/namespaces/{namespace}/services/{name}
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `patch` partially update status of the specified Service
 
 #### HTTP Request
@@ -1495,7 +1502,7 @@ PATCH /api/v1/namespaces/{namespace}/services/{name}/status
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `delete` delete a Service
 
 #### HTTP Request 
@@ -1574,7 +1581,7 @@ DELETE /api/v1/namespaces/{namespace}/services/{name}
 
 401: Unauthorized
 
-<!-- 
+<!--
 ### `deletecollection` delete collection of Service
 
 #### HTTP Request 


### PR DESCRIPTION
Performed actions below:

- Remove trailing spaces
- Replace url with zh-cn version if available
- Fix rendering issues by adding blank lines
- Some minor changes about translation

in
```
content/zh-cn/docs/reference/kubernetes-api/service-resources/service-v1.md
```