### PR TITLE
Fix incorrect content type in API reference page

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -172,7 +172,7 @@ For example:
 
    ```
    POST /api/v1/namespaces/test/pods
-   Content-Type: json
+   Content-Type: application/json
    Accept: application/json
    … JSON encoded Pod object
    ---


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This is the changes made to the wrong content detail at https://kubernetes.io/docs/reference/using-api/api-concepts/#json-encoding

which was first incorrectly written as `Content-Type: json` and is now changed to `Content-Type: application/json`

### Issue



Closes: #48303 