### PR TITLE
Include missing core object in glossary

### DIFF
--- a/content/en/docs/reference/glossary/network-policy.md
+++ b/content/en/docs/reference/glossary/network-policy.md
@@ -11,6 +11,7 @@ tags:
 - networking
 - architecture
 - extension
+- core-object
 ---
  A specification of how groups of Pods are allowed to communicate with each other and with other network endpoints.
 

--- a/content/en/docs/reference/glossary/node.md
+++ b/content/en/docs/reference/glossary/node.md
@@ -8,6 +8,7 @@ short_description: >
 
 aka:
 tags:
+- core-object
 - fundamental
 ---
  A node is a worker machine in Kubernetes.

--- a/content/en/docs/reference/glossary/pod-template.md
+++ b/content/en/docs/reference/glossary/pod-template.md
@@ -1,17 +1,28 @@
 ---
-title: Pod Template
+title: PodTemplate
 id: pod-template
 date: 2024-10-13
 short_description: >
-  A Pod Template defines template for creating pods.
+  A template for creating Pods.
 
 aka: 
+  - pod template
 tags:
 - core-object
 
 ---
-An API object that defines a template for creating {{< glossary_tooltip text="pod" term_id="pod" >}}, typically used in higher-level controllers.
+An API object that defines a template for creating {{< glossary_tooltip text="Pods" term_id="pod" >}}.
+The PodTemplate API is also embedded in API definitions for workload management, such as 
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}} or
+{{< glossary_tooltip text="StatefulSets" term_id="StatefulSet" >}}.
 
 <!--more--> 
 
-Pod Templates provide a specification that includes metadata, labels, and a pod's desired state, which is utilized by controllers like {{< glossary_tooltip text="deployment" term_id="deployment" >}} and {{< glossary_tooltip text="statefulset" term_id="statefulset" >}} to create and manage multiple {{< glossary_tooltip text="replicas" term_id="" >}} of {{< glossary_tooltip text="pod" term_id="pod" >}}.
+Pod templates allow you to define common metadata (such as labels, or a template for the name of a
+new Pod) as well as to specify a pod's desired state.
+[Workload management](/docs/concepts/workloads/controllers/) controllers use Pod templates
+(embedded into another object, such as a Deployment or StatefulSet)
+to define and manage one or more {{< glossary_tooltip text="Pods" term_id="pod" >}}.
+When there can be multiple Pods based on the same template, these are called
+{{< glossary_tooltip term_id="replica" text="replicas" >}}.
+Although you can create a PodTemplate object directly, you rarely need to do so.

--- a/content/en/docs/reference/glossary/pod-template.md
+++ b/content/en/docs/reference/glossary/pod-template.md
@@ -1,0 +1,17 @@
+---
+title: Pod Template
+id: pod-template
+date: 2024-10-13
+short_description: >
+  A Pod Template defines template for creating pods.
+
+aka: 
+tags:
+- core-object
+
+---
+An API object that defines a template for creating {{< glossary_tooltip text="pod" term_id="pod" >}}, typically used in higher-level controllers.
+
+<!--more--> 
+
+Pod Templates provide a specification that includes metadata, labels, and a pod's desired state, which is utilized by controllers like {{< glossary_tooltip text="deployment" term_id="deployment" >}} and {{< glossary_tooltip text="statefulset" term_id="statefulset" >}} to create and manage multiple {{< glossary_tooltip text="replicas" term_id="" >}} of {{< glossary_tooltip text="pod" term_id="pod" >}}.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
* This is the first part of resolving the issue regarding core objects in the Kubernetes glossary.
*  In this PR, I have included necessary API kinds that are built into Kubernetes as core objects, such as Node, PodTemplate, and NetworkPolicy.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

#45972