### PR TITLE
Remove the object from glossary which are not part of core objects

### DIFF
--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -7,7 +7,6 @@ short_description: >
   Control plane component that integrates Kubernetes with third-party cloud providers.
 aka: 
 tags:
-- core-object
 - architecture
 - operation
 ---

--- a/content/en/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/en/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -8,7 +8,6 @@ short_description: >
 
 aka: 
 tags:
-- core-object
 - storage
 ---
  Allows users to request automatic creation of storage  {{< glossary_tooltip text="Volumes" term_id="volume" >}}.

--- a/content/en/docs/reference/glossary/qos-class.md
+++ b/content/en/docs/reference/glossary/qos-class.md
@@ -8,7 +8,6 @@ short_description: >
 
 aka: 
 tags:
-- core-object
 - fundamental
 - architecture
 related:

--- a/content/en/docs/reference/glossary/quantity.md
+++ b/content/en/docs/reference/glossary/quantity.md
@@ -8,7 +8,8 @@ short_description: >
 
 aka: 
 tags:
-- core-object
+- fundamental
+
 ---
  A whole-number representation of small or large numbers using [SI](https://en.wikipedia.org/wiki/International_System_of_Units) suffixes.
 

--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -8,7 +8,6 @@ short_description: >
 
 aka:
 tags:
-- core-object
 - fundamental
 ---
  A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups.

--- a/content/en/docs/reference/glossary/volume-plugin.md
+++ b/content/en/docs/reference/glossary/volume-plugin.md
@@ -8,7 +8,6 @@ short_description: >
 
 aka: 
 tags:
-- core-object
 - storage
 ---
  A Volume Plugin enables integration of storage within a {{< glossary_tooltip text="Pod" term_id="pod" >}}.

--- a/content/en/docs/reference/glossary/volume.md
+++ b/content/en/docs/reference/glossary/volume.md
@@ -8,7 +8,6 @@ short_description: >
 
 aka:
 tags:
-- core-object
 - fundamental
 ---
  A directory containing data, accessible to the {{< glossary_tooltip text="containers" term_id="container" >}} in a {{< glossary_tooltip term_id="pod" >}}.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
* This is the second part of resolving the issue regarding core objects in the Kubernetes glossary.
* First part of issue is PR #48318 for adding core objects in glossary.
* In this PR, I have removed objects that aren't core object kinds: 

    Quantity (not an API kind that you can create using kubectl etc)
    Dynamic Volume Provisioning (not an API kind at all)
    Cloud Controller Manager (a binary, not an API kind)
    Taint (a fundamental concept, but not an API kind)
    Volume (not an API kind that you can create using kubectl etc)
    Volume Plugin (not an API kind at all)
    QoS Class (not an API kind) 
* Issue - https://github.com/kubernetes/website/issues/45972
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

#45972