### PR TITLE
[WIP] Add reference docs for pod PreStop hooks

### DIFF
--- a/content/en/docs/reference/lifecycle-events/_index.md
+++ b/content/en/docs/reference/lifecycle-events/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pod Lifecycle: Key Areas and Behaviors"
+title: "Pod Lifecycle Areas and Behaviors"
 content_type: reference
 weight: 30
 ---

--- a/content/en/docs/reference/lifecycle-events/_index.md
+++ b/content/en/docs/reference/lifecycle-events/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Pod Lifecycle: Key Areas and Behaviors"
+content_type: reference
+weight: 30
+---
+
+<!-- overview -->
+
+This reference explores the lifecycle phases of a Kubernetes Pod, categorized into key areas and behaviors to provide clarity on the nuances of Pod state transitions.
+
+For an overview of the Pod lifecycle, visit the [Pod Lifecycle Overview](docs/concepts/workloads/pods/pod-lifecycle/).
+
+<!-- body -->
+
+## Key Areas and Behaviors of the Pod Lifecycle
+
+The following are the key areas related to pod lifecycle management:
+
+- [Learn more about the behaviors related to Lifecycle Hooks](/docs/reference/lifecycle-events/hooks/) for managing tasks during container startup or shutdown.
+  - Lifecycle hooks like `PreStop` and `PostStart` allow you to execute commands or run HTTP requests at critical points in a container’s lifecycle. These hooks ensure proper initialization or graceful termination.
+
+<!--  
+- [Learn more about the behaviors related to Probes](/docs/reference/lifecycle-events/probes/) for container health and readiness checks.
+  - Probes like `liveness`, `readiness`, `startup` are used to monitor and manage container health and availability.These probes ensure that containers function correctly and are ready to handle traffic.
+-->

--- a/content/en/docs/reference/lifecycle-events/hooks/_index.md
+++ b/content/en/docs/reference/lifecycle-events/hooks/_index.md
@@ -1,0 +1,24 @@
+---
+title: Lifecycle Hooks Behaviors
+content_type: reference
+weight: 30
+---
+
+<!-- overview -->
+
+**lifecycle hooks** provide a way to trigger specific actions at crucial stages of a container's lifecycle. These hooks are useful for handling tasks such as performing tasks before the container shuts down or initiating tasks immediately after it starts.
+
+For a detailed overview of the lifecycle hooks, visit the [Lifecycle Hooks Overview](docs/concepts/containers/container-lifecycle-hooks/).
+
+
+<!-- body -->
+
+## Lifecycle Hooks Behaviors
+
+- [PreStop Hook Behaviors](/docs/reference/lifecycle-events/hooks/prestop)
+  - This `PreStop` hook runs a command or sends an HTTP request right before the container is terminated, allowing you to execute graceful shutdown steps.
+
+<!--
+- [PostStart Hook Behaviors](/docs/reference/lifecycle-events/hooks/poststart)
+  - This `PostStart` hook runs a command or sends an HTTP request right after the container starts, ideal for setting up resources or performing initialisation tasks.
+-->

--- a/content/en/docs/reference/lifecycle-events/hooks/prestop-postinsertion.md
+++ b/content/en/docs/reference/lifecycle-events/hooks/prestop-postinsertion.md
@@ -1,0 +1,91 @@
+---
+title: PreStop Hook Behaviors
+content_type: reference
+weight: 30
+auto_generated: true
+---
+
+## Prestop Behaviors
+
+The following behaviors describes the functionality of the `PreStop` hook. Each behavior ensures that the `PreStop` hook behaves as expected under different scenarios.
+
+---
+
+### PreStop Basic Behavior
+
+This behavior describes the basic functionality of the `PreStop` hook. It ensures that:
+- A specified command is executed during the graceful termination of a container.
+- The command completes its execution within the defined termination grace period before the container shuts down.
+
+<!-- prestop_basic_execution_test_starts -->
+
+When you have a PreStop hook defined on your container, it will execute before the container is terminated.
+
+Imagine You Have a Pod with the Following Specification:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-termination-grace-period
+spec:
+  containers:
+  - name: busybox
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
+    command:
+    - sleep
+    - "10000"
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - sh
+          - -c
+          - echo 'PreStop Hook Executed' > /tmp/prestop-hook-test.log
+    volumeMounts:
+    - mountPath: /tmp/prestop-hook-test.log
+      name: host-data
+  terminationGracePeriodSeconds: 30
+  volumes:
+  - name: host-data
+    hostPath:
+      path: /tmp/prestop-hook-test.log
+      type: FileOrCreate
+```
+
+The Pod should start successfully and run for a specified time.
+When the container is terminated, the PreStop hook will execute within the grace period.
+After the PreStop hook completes, the container terminates gracefully.
+
+The following log output confirms the successful execution of the PreStop hook:
+
+```
+PreStop Hook Executed
+```
+<!-- prestop_basic_execution_test_ends -->
+
+---
+
+### PreStop Failure Behavior
+
+This behavior describes how the `PreStop` hook behaves when issues arise during its execution. It ensures that:
+- The errors are managed during the execution of the `PreStop` hook.
+- shows failure affects the overall container shutdown process.
+
+<!-- prestop_basic_failure_test_starts -->
+<!-- Auto-generated test details, pod specifications, steps, and logs for PreStop Failure Handling will be inserted here. -->
+<!-- prestop_basic_failure_test_ends -->
+
+---
+
+### PreStop Hook Behavior Multiple Containers
+
+This behavior describes how the `PreStop` hook operates when multiple containers within the same Pod define hooks. It ensures:
+- The correct execution order of the hooks across containers.
+- Whether the hooks are executed sequentially or in parallel.
+
+<!-- prestop_multiple_containers_test_starts -->
+<!-- Auto-generated test details, pod specifications, steps, and logs for the PreStop Hook for Multiple Containers will be inserted here. -->
+<!-- prestop_multiple_containers_test_ends -->
+
+---

--- a/content/en/docs/reference/lifecycle-events/hooks/prestop.md
+++ b/content/en/docs/reference/lifecycle-events/hooks/prestop.md
@@ -1,0 +1,50 @@
+---
+title: PreStop Hook Behaviors
+content_type: reference
+weight: 30
+auto_generated: true
+---
+
+## Prestop Behaviors
+
+The following behaviors describes the functionality of the `PreStop` hook. Each behavior ensures that the `PreStop` hook behaves as expected under different scenarios.
+
+---
+
+### PreStop Basic Behavior
+
+This behavior describes the basic functionality of the `PreStop` hook. It ensures that:
+- A specified command is executed during the graceful termination of a container.
+- The command completes its execution within the defined termination grace period before the container shuts down.
+
+<!-- prestop_basic_execution_test_starts -->
+<!-- Auto-generated test details, pod specifications, steps, and logs for the PreStop Basic Behavior will be inserted here. -->
+<!-- prestop_basic_execution_test_ends -->
+
+---
+
+### PreStop Failure Behavior
+
+This behavior describes how the `PreStop` hook behaves when issues arise during its execution. It ensures that:
+- The errors are managed during the execution of the `PreStop` hook.
+- shows failure affects the overall container shutdown process.
+
+<!-- prestop_basic_failure_test_starts -->
+<!-- Auto-generated test details, pod specifications, steps, and logs for PreStop Failure Behavior will be inserted here. -->
+<!-- prestop_basic_failure_test_ends -->
+
+---
+
+### PreStop Hook Behavior Multiple Containers
+
+This behavior describes how the `PreStop` hook operates when multiple containers within the same Pod define hooks. It ensures:
+- The correct execution order of the hooks across containers.
+- Whether the hooks are executed sequentially or in parallel.
+
+<!-- prestop_multiple_containers_test_starts -->
+<!-- Auto-generated test details, pod specifications, steps, and logs for the PreStop Hook Behavior for Multiple Containers  will be inserted here. -->
+<!-- prestop_multiple_containers_test_ends -->
+
+---
+
+


### PR DESCRIPTION
**Description**

This PR introduces automated, testable documentation for Kubernetes Pod Lifecycle Behaviors, with a focus on PreStop hook behaviors. It leverages a Python script to dynamically populate placeholders in Markdown files with test-backed autogenerated documentation, covering the following:

Behavior Steps: Provides a clear understanding of the flow of lifecycle behaviors.
Behavior Logs: Displays expected logs to help end users validate complex behaviors.
Behavior Pod Specifications: Includes YAML configurations relevant to the behaviors being documented.

The script ensures consistent formatting and accuracy by using placeholders. Two Markdown files—`area.md` and `area-postinsertion.md` are included to validate the content before and after running the script.

**Issue**

Closes: [kubernetes/kubernetes#126369](https://github.com/kubernetes/kubernetes/issues/126369)
