### PR TITLE
Fix typo of selector-selector

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/ttlafterfinished.md
+++ b/content/en/docs/concepts/workloads/controllers/ttlafterfinished.md
@@ -57,7 +57,7 @@ You can set the TTL seconds at any time. Here are some examples for setting the
   to detect changes to the `.status` of the Job and only set a TTL when the Job
   is being marked as completed.
 * Write your own controller to manage the cleanup TTL for Jobs that match a particular
-  {{< glossary_tooltip term_id="selector" text="selector-selector" >}}.
+  {{< glossary_tooltip term_id="selector" text="selector" >}}.
 
 ## Caveats
 


### PR DESCRIPTION

### Description

I don't believe that `selector-selector` is an actual k8s term. This appears to be the only usage of the term throughout the English localization of the docs, so I imagine it was just a typo introduced in https://github.com/kubernetes/website/pull/37595.

### Issue

No corresponding issue created