### PR TITLE
[ja] Delete Localization READMEs section in localized README

### DIFF
--- a/content/ja/README.md
+++ b/content/ja/README.md
@@ -5,7 +5,6 @@
 このリポジトリには、[KubernetesのWebサイトとドキュメント](https://kubernetes.io/)をビルドするために必要な全アセットが格納されています。あなたの貢献をお待ちしています！
 
 - [ドキュメントに貢献する](#contributing-to-the-docs)
-- [翻訳された`README.md`一覧](#localization-readmemds)
 
 ## リポジトリの使い方
 

--- a/content/ja/README.md
+++ b/content/ja/README.md
@@ -201,18 +201,6 @@ Kubernetesのドキュメントへの貢献に関する詳細については以�
 | -------------------------- | -------------------------- | -------------------------- |
 | Sreeram Venkitesh                | @sreeram.venkitesh                      | @sreeram-venkitesh              |
 
-## 翻訳された`README.md`一覧 {#localization-readmemds}
-
-| Language  | Language |
-|---|---|
-|[中国語](README-zh.md)|[韓国語](README-ko.md)|
-|[フランス語](README-fr.md)|[ポーランド語](README-pl.md)|
-|[ドイツ語](README-de.md)|[ポルトガル語](README-pt.md)|
-|[ヒンディー語](README-hi.md)|[ロシア語](README-ru.md)|
-|[インドネシア語](README-id.md)|[スペイン語](README-es.md)|
-|[イタリア語](README-it.md)|[ウクライナ語](README-uk.md)|
-|[日本語](README-ja.md)|[ベトナム語](README-vi.md)|
-
 ### 行動規範
 
 Kubernetesコミュニティへの参加については、[CNCFの行動規範](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ja.md)によって管理されています。


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

ref. https://github.com/kubernetes/website/pull/47763#issuecomment-2400322169

- Delete Localization READMEs section in localized README
    - Now, these links don't work well

/kind cleanup
/approve

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #