### PR TITLE
[pl] Delete Localization READMEs section in localized README

### DIFF
--- a/content/pl/README.md
+++ b/content/pl/README.md
@@ -146,18 +146,6 @@ Więcej informacji na temat współpracy przy tworzeniu dokumentacji znajdziesz 
 - [Styl pisania dokumentacji](http://kubernetes.io/docs/contribute/style/style-guide/)
 - [Lokalizacja dokumentacji Kubernetesa](https://kubernetes.io/docs/contribute/localization/)
 
-## Różne wersje językowe `README.md`
-
-| Język  | Język |
-|---|---|
-| [angielski](README.md)       | [francuski](README-fr.md)    |
-| [koreański](README-ko.md)    | [niemiecki](README-de.md)    |
-| [portugalski](README-pt.md)  | [hindi](README-hi.md)        |
-| [hiszpański](README-es.md)   | [indonezyjski](README-id.md) |
-| [chiński](README-zh.md)      | [japoński](README-ja.md)     |
-| [wietnamski](README-vi.md)   | [rosyjski](README-ru.md)     |
-| [włoski](README-it.md)       | [ukraiński](README-uk.md)    |
-
 ## Zasady postępowania
 
 Udział w działaniach społeczności Kubernetesa jest regulowany przez [Kodeks postępowania CNCF](https://github.com/cncf/foundation/blob/master/code-of-conduct-languages/pl.md).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

ref. https://github.com/kubernetes/website/pull/47763#issuecomment-2400322169

- Delete Localization READMEs section in localized README
    - Now, these links don't work well

/kind cleanup

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #