### PR TITLE
KEP-4540: CPUManager strict-cpu-reservation policy option documentation

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -268,6 +268,7 @@ The following policy options exist for the static `CPUManager` policy:
 * `distribute-cpus-across-numa` (alpha, hidden by default) (1.23 or higher)
 * `align-by-socket` (alpha, hidden by default) (1.25 or higher)
 * `distribute-cpus-across-cores` (alpha, hidden by default) (1.31 or higher)
+* `strict-cpu-reservation` (alpha, hidden by default) (1.32 or higher)
 
 If the `full-pcpus-only` policy option is specified, the static policy will always allocate full physical cores.
 By default, without this option, the static policy allocates CPUs using a topology-aware best-fit allocation.
@@ -318,7 +319,6 @@ the benefit of reducing contention diminishes. Conversely, default behavior
 can help in reducing inter-core communication overhead, potentially providing
 better performance under high load conditions.
 
-
 The `full-pcpus-only` option can be enabled by adding `full-pcpus-only=true` to
 the CPUManager policy options.
 Likewise, the `distribute-cpus-across-numa` option can be enabled by adding
@@ -334,3 +334,12 @@ The `distribute-cpus-across-cores` option can be enabled by adding
 `distribute-cpus-across-cores=true` to the `CPUManager` policy options.
 It cannot be used with `full-pcpus-only` or `distribute-cpus-across-numa` policy
 options together at this moment.
+
+The `strict-cpu-reservation` option can be enabled by adding `strict-cpu-reservation=true` to
+the CPUManager policy options.
+
+If the `strict-cpu-reservation` policy option is enabled, the static policy will not allow
+workloads to use the CPU cores specified in `reservedSystemCPUs`.
+The `reservedSystemCPUs` defines an explicit CPU set for OS system daemons and kubernetes
+system daemons. More details of this parameter can be found on the
+[Explicitly Reserved CPU List](/docs/tasks/administer-cluster/reserve-compute-resources) page.

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -335,11 +335,18 @@ The `distribute-cpus-across-cores` option can be enabled by adding
 It cannot be used with `full-pcpus-only` or `distribute-cpus-across-numa` policy
 options together at this moment.
 
-The `strict-cpu-reservation` option can be enabled by adding `strict-cpu-reservation=true` to
-the CPUManager policy options.
+The `reservedSystemCPUs` parameter in [KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/),
+or the deprecated kubelet command line option `--reserved-cpus`, defines an explicit CPU set for OS system daemons
+and kubernetes system daemons.  More details of this parameter can be found on the
+[Explicitly Reserved CPU List](/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list) page.
+
+By default this isolation is implemented only for guaranteed pods with integer CPU requests not for burstable and best-effort pods
+(and guaranteed pods with fractional CPU requests). Admission is only comparing the cpu requests against the allocatable cpus.
+Since the cpu limit are higher than the request, the default behaviour allows burstable and best-effort pods to use up the capacity
+of `reservedSystemCPUs` and cause host OS services to starve in real life deployments.
 
 If the `strict-cpu-reservation` policy option is enabled, the static policy will not allow
-workloads to use the CPU cores specified in `reservedSystemCPUs`.
-The `reservedSystemCPUs` defines an explicit CPU set for OS system daemons and kubernetes
-system daemons. More details of this parameter can be found on the
-[Explicitly Reserved CPU List](/docs/tasks/administer-cluster/reserve-compute-resources) page.
+any workload to use the CPU cores specified in `reservedSystemCPUs`.
+
+The `strict-cpu-reservation` option can be enabled by adding `strict-cpu-reservation=true` to
+the CPUManager policy options followed by removing the `/var/lib/kubelet/cpu_manager_state` file and restart kubelet.

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -342,7 +342,7 @@ and kubernetes system daemons.  More details of this parameter can be found on t
 
 By default this isolation is implemented only for guaranteed pods with integer CPU requests not for burstable and best-effort pods
 (and guaranteed pods with fractional CPU requests). Admission is only comparing the cpu requests against the allocatable cpus.
-Since the cpu limit are higher than the request, the default behaviour allows burstable and best-effort pods to use up the capacity
+Since the cpu limit is higher than the request, the default behaviour allows burstable and best-effort pods to use up the capacity
 of `reservedSystemCPUs` and cause host OS services to starve in real life deployments.
 
 If the `strict-cpu-reservation` policy option is enabled, the static policy will not allow


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

KEP-4540: CPUManager strict-cpu-reservation policy option documentation

### Issue

https://github.com/kubernetes/enhancements/issues/4540

Kubelet PR:
https://github.com/kubernetes/kubernetes/pull/127483

Closes: https://github.com/kubernetes/enhancements/issues/4540