### PR TITLE
[ru] Delete Localization READMEs section in localized README

### DIFF
--- a/content/ru/README.md
+++ b/content/ru/README.md
@@ -121,18 +121,6 @@ sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 * [Руководство по оформлению документации](https://kubernetes.io/docs/contribute/style/style-guide/)
 * [Руководство по локализации Kubernetes](https://kubernetes.io/docs/contribute/localization/)
 
-# Файл `README.md` на других языках
-
-|           другие языки        |       другие языки            |
-|-------------------------------|-------------------------------|
-| [Английский](README.md)       | [Немецкий](README-de.md)      |
-| [Вьетнамский](README-vi.md)   | [Польский]( README-pl.md)     |
-| [Индонезийский](README-id.md) | [Португальский](README-pt.md) |
-| [Испанский](README-es.md)     | [Украинский](README-uk.md)    |
-| [Итальянский](README-it.md)   | [Французский](README-fr.md)   |
-| [Китайский](README-zh.md)     | [Хинди](README-hi.md)         |
-| [Корейский](README-ko.md)     | [Японский](README-ja.md)      |
-
 # Кодекс поведения
 
 Участие в сообществе Kubernetes регулируется [кодексом поведения CNCF](https://github.com/cncf/foundation/blob/master/code-of-conduct-languages/ru.md).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

ref. https://github.com/kubernetes/website/pull/47763#issuecomment-2400322169

- Delete Localization READMEs section in localized README
    - Now, these links don't work well

/kind cleanup

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #