### PR TITLE
[uk] Delete Localization READMEs section in localized README

### DIFF
--- a/content/uk/README.md
+++ b/content/uk/README.md
@@ -188,18 +188,6 @@ sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 | -------------------------- | -------------------------- | -------------------------- |
 | Sreeram Venkitesh                | @sreeram.venkitesh                      | @sreeram-venkitesh              |
 
-## Локалізовані файли README
-
-| Мова                   | Мова                   |
-| -------------------------- | -------------------------- |
-| [Китайська](README-zh.md)    | [Корейська](README-ko.md)     |
-| [Французька](README-fr.md)     | [Польська](README-pl.md)     |
-| [Німецька](README-de.md)     | [Португальська](README-pt.md) |
-| [Хінді](README-hi.md)      | [Російська](README-ru.md)    |
-| [Індонезійська](README-id.md) | [Іспанська](README-es.md)    |
-| [Італійська](README-it.md)    | [Українська](README-uk.md)  |
-| [Японська](README-ja.md)   | [Вʼєтнамська](README-vi.md) |
-
 ## Кодекс поведінки
 
 Участь у спільноті Kubernetes регулюється [Кодексом поведінки CNCF](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

ref. https://github.com/kubernetes/website/pull/47763#issuecomment-2400322169

- Delete Localization READMEs section in localized README
    - Now, these links don't work well

/kind cleanup

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #