### PR TITLE
Change date for October 2024 releases

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -9,7 +9,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-10-11"
     release: 1.31.2
-    targetDate: "2024-10-15"
+    targetDate: "2024-10-22"
   previousPatches:
   - cherryPickDeadline: "2024-09-06"
     release: 1.31.1
@@ -23,7 +23,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-10-11"
     release: 1.30.6
-    targetDate: "2024-10-15"
+    targetDate: "2024-10-22"
   previousPatches:
   - cherryPickDeadline: "2024-09-06"
     release: 1.30.5
@@ -49,7 +49,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-10-11"
     release: 1.29.10
-    targetDate: "2024-10-15"
+    targetDate: "2024-10-22"
   previousPatches:
   - cherryPickDeadline: "2024-09-06"
     release: 1.29.9
@@ -87,7 +87,7 @@ schedules:
   next:
     cherryPickDeadline: "2024-10-11"
     release: 1.28.15
-    targetDate: "2024-10-15"
+    targetDate: "2024-10-22"
   previousPatches:
   - cherryPickDeadline: "2024-09-06"
     release: 1.28.14
@@ -138,7 +138,7 @@ schedules:
   releaseDate: "2023-08-15"
 upcoming_releases:
 - cherryPickDeadline: "2024-10-11"
-  targetDate: "2024-10-15"
+  targetDate: "2024-10-22"
 - cherryPickDeadline: "2024-11-08"
   targetDate: "2024-11-12"
 - cherryPickDeadline: "2024-12-06"


### PR DESCRIPTION
The October patch releases have been delayed for October 22, 2024, as stated in https://groups.google.com/a/kubernetes.io/g/dev/c/ycnFVQwOlz8/m/o_ML2JsNAAAJ

This PR updates the schedule file to reflect that.

/assign @jeremyrickard @puerco 
cc @kubernetes/release-engineering 