### PR TITLE
Drop unused Hugo layout partial

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,8 +1,0 @@
-{{ partial "page-meta-links.html" . }}
-{{ if not .Params.notoc }}
-{{ with .TableOfContents }}
-{{ if ge (len .) 100 }}
-{{ . }}
-{{ end }}
-{{ end }}
-{{ end }}


### PR DESCRIPTION
The `toc.html` (table of contents) layout partial is unused; drop it.

This is a different change from PR #48364

/area web-development
/kind cleanup