### PR TITLE
Drop unused Hugo shortcode

### DIFF
--- a/layouts/shortcodes/reference_docs.html
+++ b/layouts/shortcodes/reference_docs.html
@@ -1,1 +1,0 @@
-<a href="{{- printf "/docs/reference/generated/kubernetes-api/%s" site.Params.latest -}}" target="_blank">API reference docs</a>


### PR DESCRIPTION
None of our content uses the `reference_docs` shortcode any more. Drop it.

/area web-development
/kind cleanup