### PR TITLE
Update code snippet yaml formatting

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/en/docs/concepts/cluster-administration/system-metrics.md
@@ -49,10 +49,10 @@ kind: ClusterRole
 metadata:
   name: prometheus
 rules:
-  - nonResourceURLs:
-      - "/metrics"
-    verbs:
-      - get
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 ```
 
 ## Metric lifecycle

--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -150,7 +150,6 @@ CPU and 128MiB of memory. You can say the Pod has a request of 0.5 CPU and 128
 MiB of memory, and a limit of 1 CPU and 256MiB of memory.
 
 ```yaml
----
 apiVersion: v1
 kind: Pod
 metadata:
@@ -438,9 +437,9 @@ spec:
     - name: ephemeral
       mountPath: "/tmp"
   volumes:
-    - name: ephemeral
-      emptyDir:
-        sizeLimit: 500Mi
+  - name: ephemeral
+    emptyDir:
+      sizeLimit: 500Mi
 ```
 
 ### How Pods with ephemeral-storage requests are scheduled

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -61,18 +61,17 @@ Suppose a Kubernetes cluster is running a device plugin that advertises resource
 on certain nodes. Here is an example of a pod requesting this resource to run a demo workload:
 
 ```yaml
----
 apiVersion: v1
 kind: Pod
 metadata:
   name: demo-pod
 spec:
   containers:
-    - name: demo-container-1
-      image: registry.k8s.io/pause:2.0
-      resources:
-        limits:
-          hardware-vendor.example/foo: 2
+  - name: demo-container-1
+    image: registry.k8s.io/pause:2.0
+    resources:
+      limits:
+        hardware-vendor.example/foo: 2
 #
 # This Pod needs 2 of the hardware-vendor.example/foo devices
 # and can only schedule onto a Node that's able to satisfy

--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -156,11 +156,11 @@ metadata:
   name: cuda-test
 spec:
   containers:
-    - name: cuda-test
-      image: "registry.k8s.io/cuda-vector-add:v0.1"
-      resources:
-        limits:
-          nvidia.com/gpu: 1
+  - name: cuda-test
+    image: "registry.k8s.io/cuda-vector-add:v0.1"
+    resources:
+      limits:
+        nvidia.com/gpu: 1
   nodeSelector:
     accelerator: nvidia-tesla-p100
 ```

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -200,19 +200,19 @@ apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 
 profiles:
-  - schedulerName: default-scheduler
-  - schedulerName: foo-scheduler
-    pluginConfig:
-      - name: NodeAffinity
-        args:
-          addedAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: scheduler-profile
-                  operator: In
-                  values:
-                  - foo
+- schedulerName: default-scheduler
+- schedulerName: foo-scheduler
+  pluginConfig:
+  - name: NodeAffinity
+    args:
+      addedAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: scheduler-profile
+              operator: In
+              values:
+              - foo
 ```
 
 The `addedAffinity` is applied to all Pods that set `.spec.schedulerName` to `foo-scheduler`, in addition to the
@@ -442,7 +442,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
       # ensure that pods associated with this tenant land on the correct node pool
       - matchLabelKeys:
-          - tenant
+        - tenant
         topologyKey: node-pool
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -51,7 +51,6 @@ The Pod API includes a field, `spec.topologySpreadConstraints`. The usage of thi
 the following:
 
 ```yaml
----
 apiVersion: v1
 kind: Pod
 metadata:
@@ -59,14 +58,14 @@ metadata:
 spec:
   # Configure a topology spread constraint
   topologySpreadConstraints:
-    - maxSkew: <integer>
-      minDomains: <integer> # optional
-      topologyKey: <string>
-      whenUnsatisfiable: <string>
-      labelSelector: <object>
-      matchLabelKeys: <list> # optional; beta since v1.27
-      nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-      nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+  - maxSkew: <integer>
+    minDomains: <integer> # optional
+    topologyKey: <string>
+    whenUnsatisfiable: <string>
+    labelSelector: <object>
+    matchLabelKeys: <list> # optional; beta since v1.27
+    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
   ### other Pod fields go here
 ```
 
@@ -519,15 +518,15 @@ apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 
 profiles:
-  - schedulerName: default-scheduler
-    pluginConfig:
-      - name: PodTopologySpread
-        args:
-          defaultConstraints:
-            - maxSkew: 1
-              topologyKey: topology.kubernetes.io/zone
-              whenUnsatisfiable: ScheduleAnyway
-          defaultingType: List
+- schedulerName: default-scheduler
+  pluginConfig:
+  - name: PodTopologySpread
+    args:
+      defaultConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      defaultingType: List
 ```
 ### Built-in default constraints {#internal-default-constraints}
 
@@ -569,12 +568,12 @@ apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 
 profiles:
-  - schedulerName: default-scheduler
-    pluginConfig:
-      - name: PodTopologySpread
-        args:
-          defaultConstraints: []
-          defaultingType: List
+- schedulerName: default-scheduler
+  pluginConfig:
+  - name: PodTopologySpread
+    args:
+      defaultConstraints: []
+      defaultingType: List
 ```
 
 ## Comparison with podAffinity and podAntiAffinity {#comparison-with-podaffinity-podantiaffinity}

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -160,8 +160,8 @@ spec:
   containers:
   - image: busybox:1.28
     command:
-      - sleep
-      - "3600"
+    - sleep
+    - "3600"
     name: busybox
 ---
 apiVersion: v1
@@ -176,8 +176,8 @@ spec:
   containers:
   - image: busybox:1.28
     command:
-      - sleep
-      - "3600"
+    - sleep
+    - "3600"
     name: busybox
 ```
 
@@ -260,8 +260,8 @@ spec:
   containers:
   - image: busybox:1.28
     command:
-      - sleep
-      - "3600"
+    - sleep
+    - "3600"
     imagePullPolicy: IfNotPresent
     name: busybox
   restartPolicy: Always

--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -48,17 +48,17 @@ metadata:
     kubernetes.io/service-name: example
 addressType: IPv4
 ports:
-  - name: http
-    protocol: TCP
-    port: 80
+- name: http
+  protocol: TCP
+  port: 80
 endpoints:
-  - addresses:
-      - "10.1.2.3"
-    conditions:
-      ready: true
-    hostname: pod-1
-    nodeName: node-1
-    zone: us-west2-a
+- addresses:
+  - "10.1.2.3"
+  conditions:
+    ready: true
+  hostname: pod-1
+  nodeName: node-1
+  zone: us-west2-a
 ```
 
 By default, the control plane creates and manages EndpointSlices to have no

--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -278,7 +278,6 @@ resource for that API.
 For example:
 
 ```yaml
----
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
@@ -327,7 +326,6 @@ Here is an example of an IngressClass that refers to parameters that are
 namespaced:
 
 ```yaml
----
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:

--- a/content/en/docs/concepts/services-networking/service-traffic-policy.md
+++ b/content/en/docs/concepts/services-networking/service-traffic-policy.md
@@ -48,9 +48,9 @@ spec:
   selector:
     app.kubernetes.io/name: MyApp
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 9376
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
   internalTrafficPolicy: Local
 ```
 

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -115,9 +115,9 @@ spec:
   selector:
     app.kubernetes.io/name: MyApp
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 9376
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
 ```
 
 Applying this manifest creates a new Service named "my-service" with the default
@@ -160,8 +160,8 @@ spec:
   - name: nginx
     image: nginx:stable
     ports:
-      - containerPort: 80
-        name: http-web-svc
+    - containerPort: 80
+      name: http-web-svc
 
 ---
 apiVersion: v1
@@ -219,10 +219,10 @@ metadata:
   name: my-service
 spec:
   ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 9376
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 9376
 ```
 
 Because this Service has no selector, the corresponding EndpointSlice (and
@@ -242,15 +242,15 @@ metadata:
     kubernetes.io/service-name: my-service
 addressType: IPv4
 ports:
-  - name: http # should match with the name of the service port defined above
-    appProtocol: http
-    protocol: TCP
-    port: 9376
+- name: http # should match with the name of the service port defined above
+  appProtocol: http
+  protocol: TCP
+  port: 9376
 endpoints:
-  - addresses:
-      - "10.4.5.6"
-  - addresses:
-      - "10.1.2.3"
+- addresses:
+  - "10.4.5.6"
+- addresses:
+  - "10.1.2.3"
 ```
 
 #### Custom EndpointSlices
@@ -388,14 +388,14 @@ spec:
   selector:
     app.kubernetes.io/name: MyApp
   ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 9376
-    - name: https
-      protocol: TCP
-      port: 443
-      targetPort: 9377
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 9376
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 9377
 ```
 
 {{< note >}}
@@ -513,14 +513,14 @@ spec:
   selector:
     app.kubernetes.io/name: MyApp
   ports:
-    - port: 80
-      # By default and for convenience, the `targetPort` is set to
-      # the same value as the `port` field.
-      targetPort: 80
-      # Optional field
-      # By default and for convenience, the Kubernetes control plane
-      # will allocate a port from a range (default: 30000-32767)
-      nodePort: 30007
+  - port: 80
+    # By default and for convenience, the `targetPort` is set to
+    # the same value as the `port` field.
+    targetPort: 80
+    # Optional field
+    # By default and for convenience, the Kubernetes control plane
+    # will allocate a port from a range (default: 30000-32767)
+    nodePort: 30007
 ```
 
 #### Reserve Nodeport ranges to avoid collisions  {#avoid-nodeport-collisions}
@@ -578,9 +578,9 @@ spec:
   selector:
     app.kubernetes.io/name: MyApp
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 9376
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
   clusterIP: 10.0.171.239
   type: LoadBalancer
 status:
@@ -1048,12 +1048,12 @@ spec:
   selector:
     app.kubernetes.io/name: MyApp
   ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 49152
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 49152
   externalIPs:
-    - 198.51.100.32
+  - 198.51.100.32
 ```
 
 {{< note >}}

--- a/content/en/docs/concepts/services-networking/topology-aware-routing.md
+++ b/content/en/docs/concepts/services-networking/topology-aware-routing.md
@@ -95,19 +95,19 @@ metadata:
     kubernetes.io/service-name: example-svc
 addressType: IPv4
 ports:
-  - name: http
-    protocol: TCP
-    port: 80
+- name: http
+  protocol: TCP
+  port: 80
 endpoints:
-  - addresses:
-      - "10.1.2.3"
-    conditions:
-      ready: true
-    hostname: pod-1
-    zone: zone-a
-    hints:
-      forZones:
-        - name: "zone-a"
+- addresses:
+  - "10.1.2.3"
+  conditions:
+    ready: true
+  hostname: pod-1
+  zone: zone-a
+  hints:
+    forZones:
+    - name: "zone-a"
 ```
 
 ### kube-proxy {#implementation-kube-proxy}

--- a/content/en/docs/concepts/storage/dynamic-provisioning.md
+++ b/content/en/docs/concepts/storage/dynamic-provisioning.md
@@ -93,7 +93,7 @@ metadata:
   name: claim1
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   storageClassName: fast
   resources:
     requests:

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -571,12 +571,12 @@ spec:
     storage: 5Gi
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: slow
   mountOptions:
-    - hard
-    - nfsvers=4.1
+  - hard
+  - nfsvers=4.1
   nfs:
     path: /tmp
     server: 172.17.0.2
@@ -794,7 +794,7 @@ metadata:
   name: myclaim
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   volumeMode: Filesystem
   resources:
     requests:
@@ -804,7 +804,7 @@ spec:
     matchLabels:
       release: "stable"
     matchExpressions:
-      - {key: environment, operator: In, values: [dev]}
+    - {key: environment, operator: In, values: [dev]}
 ```
 
 ### Access Modes
@@ -927,15 +927,15 @@ metadata:
   name: mypod
 spec:
   containers:
-    - name: myfrontend
-      image: nginx
-      volumeMounts:
-      - mountPath: "/var/www/html"
-        name: mypd
+  - name: myfrontend
+    image: nginx
+    volumeMounts:
+    - mountPath: "/var/www/html"
+      name: mypd
   volumes:
-    - name: mypd
-      persistentVolumeClaim:
-        claimName: myclaim
+  - name: mypd
+    persistentVolumeClaim:
+      claimName: myclaim
 ```
 
 ### A Note on Namespaces
@@ -977,7 +977,7 @@ spec:
   capacity:
     storage: 10Gi
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   volumeMode: Block
   persistentVolumeReclaimPolicy: Retain
   fc:
@@ -995,7 +995,7 @@ metadata:
   name: block-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   volumeMode: Block
   resources:
     requests:
@@ -1011,17 +1011,17 @@ metadata:
   name: pod-with-block-volume
 spec:
   containers:
-    - name: fc-container
-      image: fedora:26
-      command: ["/bin/sh", "-c"]
-      args: [ "tail -f /dev/null" ]
-      volumeDevices:
-        - name: data
-          devicePath: /dev/xvda
-  volumes:
+  - name: fc-container
+    image: fedora:26
+    command: ["/bin/sh", "-c"]
+    args: [ "tail -f /dev/null" ]
+    volumeDevices:
     - name: data
-      persistentVolumeClaim:
-        claimName: block-pvc
+      devicePath: /dev/xvda
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: block-pvc
 ```
 
 {{< note >}}
@@ -1079,7 +1079,7 @@ spec:
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -1103,7 +1103,7 @@ spec:
     name: existing-src-pvc-name
     kind: PersistentVolumeClaim
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -1194,7 +1194,7 @@ spec:
     kind: ExampleDataSource
     apiGroup: example.storage.k8s.io
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi

--- a/content/en/docs/concepts/storage/volume-pvc-datasource.md
+++ b/content/en/docs/concepts/storage/volume-pvc-datasource.md
@@ -53,8 +53,8 @@ that references an existing PVC in the same namespace.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-    name: clone-of-pvc-1
-    namespace: myns
+  name: clone-of-pvc-1
+  namespace: myns
 spec:
   accessModes:
   - ReadWriteOnce

--- a/content/en/docs/concepts/storage/volume-snapshots.md
+++ b/content/en/docs/concepts/storage/volume-snapshots.md
@@ -241,7 +241,7 @@ kind: VolumeSnapshotContent
 metadata:
   name: new-snapshot-content-test
   annotations:
-    - snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"
+  - snapshot.storage.kubernetes.io/allow-volume-mode-change: "true"
 spec:
   deletionPolicy: Delete
   driver: hostpath.csi.k8s.io

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -167,19 +167,19 @@ metadata:
   name: configmap-pod
 spec:
   containers:
-    - name: test
-      image: busybox:1.28
-      command: ['sh', '-c', 'echo "The app is running!" && tail -f /dev/null']
-      volumeMounts:
-        - name: config-vol
-          mountPath: /etc/config
-  volumes:
+  - name: test
+    image: busybox:1.28
+    command: ['sh', '-c', 'echo "The app is running!" && tail -f /dev/null']
+    volumeMounts:
     - name: config-vol
-      configMap:
-        name: log-config
-        items:
-          - key: log_level
-            path: log_level
+      mountPath: /etc/config
+  volumes:
+  - name: config-vol
+    configMap:
+      name: log-config
+      items:
+      - key: log_level
+        path: log_level
 ```
 
 The `log-config` ConfigMap is mounted as a volume, and all contents stored in
@@ -914,26 +914,26 @@ kind: Pod
 metadata:
   name: my-lamp-site
 spec:
-    containers:
-    - name: mysql
-      image: mysql
-      env:
-      - name: MYSQL_ROOT_PASSWORD
-        value: "rootpasswd"
-      volumeMounts:
-      - mountPath: /var/lib/mysql
-        name: site-data
-        subPath: mysql
-    - name: php
-      image: php:7.0-apache
-      volumeMounts:
-      - mountPath: /var/www/html
-        name: site-data
-        subPath: html
-    volumes:
-    - name: site-data
-      persistentVolumeClaim:
-        claimName: my-lamp-site-data
+  containers:
+  - name: mysql
+    image: mysql
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: "rootpasswd"
+    volumeMounts:
+    - mountPath: /var/lib/mysql
+      name: site-data
+      subPath: mysql
+  - name: php
+    image: php:7.0-apache
+    volumeMounts:
+    - mountPath: /var/www/html
+      name: site-data
+      subPath: html
+  volumes:
+  - name: site-data
+    persistentVolumeClaim:
+      claimName: my-lamp-site-data
 ```
 
 ### Using subPath with expanded environment variables {#using-subpath-expanded-environment}

--- a/content/en/docs/concepts/windows/user-guide.md
+++ b/content/en/docs/concepts/windows/user-guide.md
@@ -39,7 +39,6 @@ The example YAML file below deploys a simple webserver application running insid
 Create a manifest named `win-webserver.yaml` with the contents below:
 
 ```yaml
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -48,9 +47,9 @@ metadata:
     app: win-webserver
 spec:
   ports:
-    # the port that this service should serve on
-    - port: 80
-      targetPort: 80
+  # the port that this service should serve on
+  - port: 80
+    targetPort: 80
   selector:
     app: win-webserver
   type: NodePort
@@ -72,15 +71,15 @@ spec:
         app: win-webserver
       name: win-webserver
     spec:
-     containers:
+      containers:
       - name: windowswebserver
         image: mcr.microsoft.com/windows/servercore:ltsc2019
         command:
         - powershell.exe
         - -command
         - "<#code used from https://gist.github.com/19WAS85/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callerCounts = @{} ; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$clientIP = $$context.Request.RemoteEndPoint.Address ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ;  ;$$count = 1 ;$$k=$$callerCounts.Get_Item($$clientIP) ;if ($$k -ne $$null) { $$count += $$k } ;$$callerCounts.Set_Item($$clientIP, $$count) ;$$ip=(Get-NetAdapter | Get-NetIpAddress); $$header='<html><body><H1>Windows Container Web Server</H1>' ;$$callerCountsString='' ;$$callerCounts.Keys | % { $$callerCountsString+='<p>IP {0} callerCount {1} ' -f $$ip[1].IPAddress,$$callerCounts.Item($$_) } ;$$footer='</body></html>' ;$$content='{0}{1}{2}' -f $$header,$$callerCountsString,$$footer ;Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "
-     nodeSelector:
-      kubernetes.io/os: windows
+      nodeSelector:
+        kubernetes.io/os: windows
 ```
 
 {{< note >}}

--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -224,7 +224,6 @@ At this point, those init containers will be waiting to discover {{< glossary_to
 Here's a configuration you can use to make those Services appear:
 
 ```yaml
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -253,8 +253,8 @@ requests to store new Events. The cluster admin can specify event rate limits by
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
-  - name: EventRateLimit
-    path: eventconfig.yaml
+- name: EventRateLimit
+  path: eventconfig.yaml
 ...
 ```
 
@@ -272,13 +272,13 @@ Below is a sample `eventconfig.yaml` for such a configuration:
 apiVersion: eventratelimit.admission.k8s.io/v1alpha1
 kind: Configuration
 limits:
-  - type: Namespace
-    qps: 50
-    burst: 100
-    cacheSize: 2000
-  - type: User
-    qps: 10
-    burst: 50
+- type: Namespace
+  qps: 50
+  burst: 100
+  cacheSize: 2000
+- type: User
+  qps: 10
+  burst: 50
 ```
 
 See the [EventRateLimit Config API (v1alpha1)](/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/)
@@ -331,8 +331,8 @@ Reference the ImagePolicyWebhook configuration file from the file provided to th
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
-  - name: ImagePolicyWebhook
-    path: imagepolicyconfig.yaml
+- name: ImagePolicyWebhook
+  path: imagepolicyconfig.yaml
 ...
 ```
 
@@ -342,14 +342,14 @@ Alternatively, you can embed the configuration directly in the file:
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
-  - name: ImagePolicyWebhook
-    configuration:
-      imagePolicy:
-        kubeConfigFile: <path-to-kubeconfig-file>
-        allowTTL: 50
-        denyTTL: 50
-        retryBackoff: 500
-        defaultAllow: true
+- name: ImagePolicyWebhook
+  configuration:
+    imagePolicy:
+      kubeConfigFile: <path-to-kubeconfig-file>
+      allowTTL: 50
+      denyTTL: 50
+      retryBackoff: 500
+      defaultAllow: true
 ```
 
 The ImagePolicyWebhook config file must reference a

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -553,13 +553,13 @@ Match create requests for all resources (but not subresources) in all API groups
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    rules:
-      - operations: ["CREATE"]
-        apiGroups: ["*"]
-        apiVersions: ["*"]
-        resources: ["*"]
-        scope: "*"
+- name: my-webhook.example.com
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["*"]
+    scope: "*"
 ```
 
 Match update requests for all `status` subresources in all API groups and versions:
@@ -568,13 +568,13 @@ Match update requests for all `status` subresources in all API groups and versio
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    rules:
-      - operations: ["UPDATE"]
-        apiGroups: ["*"]
-        apiVersions: ["*"]
-        resources: ["*/status"]
-        scope: "*"
+- name: my-webhook.example.com
+  rules:
+  - operations: ["UPDATE"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["*/status"]
+    scope: "*"
 ```
 
 ### Matching requests: objectSelector
@@ -629,18 +629,18 @@ that does not have a "runlevel" label of "0" or "1":
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    namespaceSelector:
-      matchExpressions:
-        - key: runlevel
-          operator: NotIn
-          values: ["0","1"]
-    rules:
-      - operations: ["CREATE"]
-        apiGroups: ["*"]
-        apiVersions: ["*"]
-        resources: ["*"]
-        scope: "Namespaced"
+- name: my-webhook.example.com
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values: ["0","1"]
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["*"]
+    scope: "Namespaced"
 ```
 
 This example shows a validating webhook that matches a `CREATE` of any namespaced resource inside
@@ -650,18 +650,18 @@ a namespace that is associated with the "environment" of "prod" or "staging":
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    namespaceSelector:
-      matchExpressions:
-        - key: environment
-          operator: In
-          values: ["prod","staging"]
-    rules:
-      - operations: ["CREATE"]
-        apiGroups: ["*"]
-        apiVersions: ["*"]
-        resources: ["*"]
-        scope: "Namespaced"
+- name: my-webhook.example.com
+  namespaceSelector:
+    matchExpressions:
+    - key: environment
+      operator: In
+      values: ["prod","staging"]
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["*"]
+    scope: "Namespaced"
 ```
 
 See [labels concept](/docs/concepts/overview/working-with-objects/labels)
@@ -735,52 +735,52 @@ Here is an example illustrating a few different uses for match conditions:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    matchPolicy: Equivalent
-    rules:
-      - operations: ['CREATE','UPDATE']
-        apiGroups: ['*']
-        apiVersions: ['*']
-        resources: ['*']
-    failurePolicy: 'Ignore' # Fail-open (optional)
-    sideEffects: None
-    clientConfig:
-      service:
-        namespace: my-namespace
-        name: my-webhook
-      caBundle: '<omitted>'
-    # You can have up to 64 matchConditions per webhook
-    matchConditions:
-      - name: 'exclude-leases' # Each match condition must have a unique name
-        expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")' # Match non-lease resources.
-      - name: 'exclude-kubelet-requests'
-        expression: '!("system:nodes" in request.userInfo.groups)' # Match requests made by non-node users.
-      - name: 'rbac' # Skip RBAC requests, which are handled by the second webhook.
-        expression: 'request.resource.group != "rbac.authorization.k8s.io"'
-  
-  # This example illustrates the use of the 'authorizer'. The authorization check is more expensive
-  # than a simple expression, so in this example it is scoped to only RBAC requests by using a second
-  # webhook. Both webhooks can be served by the same endpoint.
-  - name: rbac.my-webhook.example.com
-    matchPolicy: Equivalent
-    rules:
-      - operations: ['CREATE','UPDATE']
-        apiGroups: ['rbac.authorization.k8s.io']
-        apiVersions: ['*']
-        resources: ['*']
-    failurePolicy: 'Fail' # Fail-closed (the default)
-    sideEffects: None
-    clientConfig:
-      service:
-        namespace: my-namespace
-        name: my-webhook
-      caBundle: '<omitted>'
-    # You can have up to 64 matchConditions per webhook
-    matchConditions:
-      - name: 'breakglass'
-        # Skip requests made by users authorized to 'breakglass' on this webhook.
-        # The 'breakglass' API verb does not need to exist outside this check.
-        expression: '!authorizer.group("admissionregistration.k8s.io").resource("validatingwebhookconfigurations").name("my-webhook.example.com").check("breakglass").allowed()'
+- name: my-webhook.example.com
+  matchPolicy: Equivalent
+  rules:
+  - operations: ['CREATE','UPDATE']
+    apiGroups: ['*']
+    apiVersions: ['*']
+    resources: ['*']
+  failurePolicy: 'Ignore' # Fail-open (optional)
+  sideEffects: None
+  clientConfig:
+    service:
+      namespace: my-namespace
+      name: my-webhook
+    caBundle: '<omitted>'
+  # You can have up to 64 matchConditions per webhook
+  matchConditions:
+  - name: 'exclude-leases' # Each match condition must have a unique name
+    expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")' # Match non-lease resources.
+  - name: 'exclude-kubelet-requests'
+    expression: '!("system:nodes" in request.userInfo.groups)' # Match requests made by non-node users.
+  - name: 'rbac' # Skip RBAC requests, which are handled by the second webhook.
+    expression: 'request.resource.group != "rbac.authorization.k8s.io"'
+
+# This example illustrates the use of the 'authorizer'. The authorization check is more expensive
+# than a simple expression, so in this example it is scoped to only RBAC requests by using a second
+# webhook. Both webhooks can be served by the same endpoint.
+- name: rbac.my-webhook.example.com
+  matchPolicy: Equivalent
+  rules:
+  - operations: ['CREATE','UPDATE']
+    apiGroups: ['rbac.authorization.k8s.io']
+    apiVersions: ['*']
+    resources: ['*']
+  failurePolicy: 'Fail' # Fail-closed (the default)
+  sideEffects: None
+  clientConfig:
+    service:
+      namespace: my-namespace
+      name: my-webhook
+    caBundle: '<omitted>'
+  # You can have up to 64 matchConditions per webhook
+  matchConditions:
+  - name: 'breakglass'
+    # Skip requests made by users authorized to 'breakglass' on this webhook.
+    # The 'breakglass' API verb does not need to exist outside this check.
+    expression: '!authorizer.group("admissionregistration.k8s.io").resource("validatingwebhookconfigurations").name("my-webhook.example.com").check("breakglass").allowed()'
 ```
 
 {{< note >}}
@@ -913,8 +913,8 @@ Here is an example of a validating webhook indicating it has no side effects on 
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    sideEffects: NoneOnDryRun
+- name: my-webhook.example.com
+  sideEffects: NoneOnDryRun
 ```
 
 ### Timeouts
@@ -934,8 +934,8 @@ Here is an example of a validating webhook with a custom timeout of 2 seconds:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-  - name: my-webhook.example.com
-    timeoutSeconds: 2
+- name: my-webhook.example.com
+  timeoutSeconds: 2
 ```
 
 The timeout for an admission webhook defaults to 10 seconds.

--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -253,7 +253,7 @@ metadata:
   name: build-robot
   namespace: default
 secrets:
-  - name: build-robot-secret # usually NOT present for a manually generated token                         
+- name: build-robot-secret # usually NOT present for a manually generated token                         
 ```
 
 Beginning from version 1.29, legacy ServiceAccount tokens that were generated
@@ -535,7 +535,7 @@ metadata:
   selfLink: /api/v1/namespaces/examplens/serviceaccounts/example-automated-thing
   uid: f23fd170-66f2-4697-b049-e1e266b7f835
 secrets:
-  - name: example-automated-thing-token-zyxwv
+- name: example-automated-thing-token-zyxwv
 ```
 
 Then, delete the Secret you now know the name of:

--- a/content/en/docs/reference/node/kubelet-config-directory-merging.md
+++ b/content/en/docs/reference/node/kubelet-config-directory-merging.md
@@ -70,8 +70,8 @@ kind: KubeletConfiguration
 port: 20250
 serializeImagePulls: false
 clusterDNS:
-  - "192.168.0.9"
-  - "192.168.0.8"
+- "192.168.0.9"
+- "192.168.0.8"
 ```
 
 Contents of a file in `--config-dir` directory:
@@ -79,9 +79,9 @@ Contents of a file in `--config-dir` directory:
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 clusterDNS:
-  - "192.168.0.2"
-  - "192.168.0.3"
-  - "192.168.0.5"
+- "192.168.0.2"
+- "192.168.0.3"
+- "192.168.0.5"
 ```
 
 The resulting configuration will be as follows:
@@ -91,9 +91,9 @@ kind: KubeletConfiguration
 port: 20250
 serializeImagePulls: false
 clusterDNS:
-  - "192.168.0.2"
-  - "192.168.0.3"
-  - "192.168.0.5"
+- "192.168.0.2"
+- "192.168.0.3"
+- "192.168.0.5"
 ```
 
 ### Maps, including Nested Structures

--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -92,15 +92,15 @@ or enable your own. For example:
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - plugins:
-      score:
-        disabled:
-        - name: PodTopologySpread
-        enabled:
-        - name: MyCustomPluginA
-          weight: 2
-        - name: MyCustomPluginB
-          weight: 1
+- plugins:
+    score:
+      disabled:
+      - name: PodTopologySpread
+      enabled:
+      - name: MyCustomPluginA
+        weight: 2
+      - name: MyCustomPluginB
+        weight: 1
 ```
 
 You can use `*` as name in the disabled array to disable all default plugins
@@ -194,15 +194,15 @@ disabled.
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: default-scheduler
-  - schedulerName: no-scoring-scheduler
-    plugins:
-      preScore:
-        disabled:
-        - name: '*'
-      score:
-        disabled:
-        - name: '*'
+- schedulerName: default-scheduler
+- schedulerName: no-scoring-scheduler
+  plugins:
+    preScore:
+      disabled:
+      - name: '*'
+    score:
+      disabled:
+      - name: '*'
 ```
 
 Pods that want to be scheduled according to a specific profile can include
@@ -245,11 +245,11 @@ points, the profile config looks like:
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: multipoint-scheduler
-    plugins:
-      multiPoint:
-        enabled:
-        - name: MyPlugin
+- schedulerName: multipoint-scheduler
+  plugins:
+    multiPoint:
+      enabled:
+      - name: MyPlugin
 ```
 
 This would equate to manually enabling `MyPlugin` for all of its extension
@@ -259,20 +259,20 @@ points, like so:
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: non-multipoint-scheduler
-    plugins:
-      preScore:
-        enabled:
-        - name: MyPlugin
-      score:
-        enabled:
-        - name: MyPlugin
-      preFilter:
-        enabled:
-        - name: MyPlugin
-      filter:
-        enabled:
-        - name: MyPlugin
+- schedulerName: non-multipoint-scheduler
+  plugins:
+    preScore:
+      enabled:
+      - name: MyPlugin
+    score:
+      enabled:
+      - name: MyPlugin
+    preFilter:
+      enabled:
+      - name: MyPlugin
+    filter:
+      enabled:
+      - name: MyPlugin
 ```
 
 One benefit of using `multiPoint` here is that if `MyPlugin` implements another
@@ -288,17 +288,17 @@ An example of this, disabling `Score` and `PreScore`, would be:
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: non-multipoint-scheduler
-    plugins:
-      multiPoint:
-        enabled:
-        - name: 'MyPlugin'
-      preScore:
-        disabled:
-        - name: '*'
-      score:
-        disabled:
-        - name: '*'
+- schedulerName: non-multipoint-scheduler
+  plugins:
+    multiPoint:
+      enabled:
+      - name: 'MyPlugin'
+    preScore:
+      disabled:
+      - name: '*'
+    score:
+      disabled:
+      - name: '*'
 ```
 
 Starting from `kubescheduler.config.k8s.io/v1beta3`, all [default plugins](#scheduling-plugins)
@@ -312,12 +312,12 @@ a weight of `1`. They can be reordered with different weights like so:
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: multipoint-scheduler
-    plugins:
-      score:
-        enabled:
-        - name: 'DefaultScore2'
-          weight: 5
+- schedulerName: multipoint-scheduler
+  plugins:
+    score:
+      enabled:
+      - name: 'DefaultScore2'
+        weight: 5
 ```
 
 In this example, it's unnecessary to specify the plugins in `MultiPoint` explicitly
@@ -347,22 +347,22 @@ A valid sample configuration for these plugins would be:
 apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: multipoint-scheduler
-    plugins:
-      multiPoint:
-        enabled:
-        - name: 'CustomQueueSort'
-        - name: 'CustomPlugin1'
-          weight: 3
-        - name: 'CustomPlugin2'
-        disabled:
-        - name: 'DefaultQueueSort'
-      filter:
-        disabled:
-        - name: 'DefaultPlugin1'
-      score:
-        enabled:
-        - name: 'DefaultPlugin2'
+- schedulerName: multipoint-scheduler
+  plugins:
+    multiPoint:
+      enabled:
+      - name: 'CustomQueueSort'
+      - name: 'CustomPlugin1'
+        weight: 3
+      - name: 'CustomPlugin2'
+      disabled:
+      - name: 'DefaultQueueSort'
+    filter:
+      disabled:
+      - name: 'DefaultPlugin1'
+    score:
+      enabled:
+      - name: 'DefaultPlugin2'
 ```
 
 Note that there is no error for re-declaring a `MultiPoint` plugin in a specific
@@ -381,32 +381,32 @@ In versions of the config before `v1beta3`, without `multiPoint`, the above snip
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 profiles:
-  - schedulerName: multipoint-scheduler
-    plugins:
+- schedulerName: multipoint-scheduler
+  plugins:
 
-      # Disable the default QueueSort plugin
-      queueSort:
-        enabled:
-        - name: 'CustomQueueSort'
-        disabled:
-        - name: 'DefaultQueueSort'
+    # Disable the default QueueSort plugin
+    queueSort:
+      enabled:
+      - name: 'CustomQueueSort'
+      disabled:
+      - name: 'DefaultQueueSort'
 
-      # Enable custom Filter plugins
-      filter:
-        enabled:
-        - name: 'CustomPlugin1'
-        - name: 'CustomPlugin2'
-        - name: 'DefaultPlugin2'
-        disabled:
-        - name: 'DefaultPlugin1'
+    # Enable custom Filter plugins
+    filter:
+      enabled:
+      - name: 'CustomPlugin1'
+      - name: 'CustomPlugin2'
+      - name: 'DefaultPlugin2'
+      disabled:
+      - name: 'DefaultPlugin1'
 
-      # Enable and reorder custom score plugins
-      score:
-        enabled:
-        - name: 'DefaultPlugin2'
-          weight: 1
-        - name: 'DefaultPlugin1'
-          weight: 3
+    # Enable and reorder custom score plugins
+    score:
+      enabled:
+      - name: 'DefaultPlugin2'
+        weight: 1
+      - name: 'DefaultPlugin1'
+        weight: 3
 ```
 
 While this is a complicated example, it demonstrates the flexibility of `MultiPoint` config

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -97,7 +97,6 @@ becomes available.
 A simple example of an object created using Server-Side Apply could look like this:
 
 ```yaml
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -238,7 +237,6 @@ the body of the request that you submit.
 An example object with multiple managers could look like this:
 
 ```yaml
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -346,7 +344,6 @@ recommended to change a type from `atomic` to `map`/`set`/`granular`.
 Take for example, the custom resource:
 
 ```yaml
----
 apiVersion: example.com/v1
 kind: Foo
 metadata:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -116,11 +116,11 @@ scheduler:
   - name: "config"
     value: "/etc/kubernetes/scheduler-config.yaml"
   extraVolumes:
-    - name: schedulerconfig
-      hostPath: /home/johndoe/schedconfig.yaml
-      mountPath: /etc/kubernetes/scheduler-config.yaml
-      readOnly: true
-      pathType: "File"
+  - name: schedulerconfig
+    hostPath: /home/johndoe/schedconfig.yaml
+    mountPath: /etc/kubernetes/scheduler-config.yaml
+    readOnly: true
+    pathType: "File"
 ```
 
 ### Etcd flags

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -54,7 +54,6 @@ To make things clearer, here is an example kubeadm
 `kubeadm-config.yaml` for the primary dual-stack control plane node.
 
 ```yaml
----
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -43,12 +43,12 @@ kind: ClusterRole
 metadata:
   name: kubeadm:get-nodes
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -59,9 +59,9 @@ roleRef:
   kind: ClusterRole
   name: kubeadm:get-nodes
 subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:bootstrappers:kubeadm:default-node-token
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:kubeadm:default-node-token
 ```
 
 ## `ebtables` or some similar executable not found during installation

--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -52,8 +52,8 @@ spec:
   selector:
     app: example
   ports:
-    - port: 8765
-      targetPort: 9376
+  - port: 8765
+    targetPort: 9376
   type: LoadBalancer
 ```
 
@@ -150,8 +150,8 @@ spec:
   selector:
     app: example
   ports:
-    - port: 8765
-      targetPort: 9376
+  - port: 8765
+    targetPort: 9376
   externalTrafficPolicy: Local
   type: LoadBalancer
 ```

--- a/content/en/docs/tasks/administer-cluster/decrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/decrypt-data.md
@@ -96,35 +96,33 @@ entry in your encryption configuration file.
 
 For example, if your existing EncryptionConfiguration file reads:
 ```yaml
----
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
-  - resources:
-      - secrets
-    providers:
-      - aescbc:
-          keys:
-            # Do not use this (invalid) example key for encryption
-            - name: example
-              secret: 2KfZgdiq2K0g2YrYpyDYs9mF2LPZhQ==
+- resources:
+  - secrets
+  providers:
+  - aescbc:
+      keys:
+      # Do not use this (invalid) example key for encryption
+      - name: example
+        secret: 2KfZgdiq2K0g2YrYpyDYs9mF2LPZhQ==
 ```
 
 then change it to:
 
 ```yaml
----
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
-  - resources:
-      - secrets
-    providers:
-      - identity: {} # add this line
-      - aescbc:
-          keys:
-            - name: example
-              secret: 2KfZgdiq2K0g2YrYpyDYs9mF2LPZhQ==
+- resources:
+  - secrets
+  providers:
+  - identity: {} # add this line
+  - aescbc:
+      keys:
+      - name: example
+        secret: 2KfZgdiq2K0g2YrYpyDYs9mF2LPZhQ==
 ```
 
 and restart the kube-apiserver Pod on this node.

--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -424,22 +424,21 @@ who runs the kube-apiserver can read this configuration.
 Create a new encryption configuration file. The contents should be similar to:
 
 ```yaml
----
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
-  - resources:
-      - secrets
-      - configmaps
-      - pandas.awesome.bears.example
-    providers:
-      - aescbc:
-          keys:
-            - name: key1
-              # See the following text for more details about the secret value
-              secret: <BASE 64 ENCODED SECRET>
-      - identity: {} # this fallback allows reading unencrypted secrets;
-                     # for example, during initial migration
+- resources:
+  - secrets
+  - configmaps
+  - pandas.awesome.bears.example
+  providers:
+  - aescbc:
+      keys:
+      - name: key1
+        # See the following text for more details about the secret value
+        secret: <BASE 64 ENCODED SECRET>
+  - identity: {} # this fallback allows reading unencrypted secrets;
+                  # for example, during initial migration
 ```
 
 To create a new encryption key (that does not use KMS), see
@@ -681,21 +680,20 @@ To disable encryption at rest, place the `identity` provider as the first
 entry in your encryption configuration file:
 
 ```yaml
----
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
-  - resources:
-      - secrets
-      # list any other resources here that you previously were
-      # encrypting at rest
-    providers:
-      - identity: {} # add this line
-      - aescbc:
-          keys:
-            - name: key1
-              secret: <BASE 64 ENCODED SECRET> # keep this in place
-                                               # make sure it comes after "identity"
+- resources:
+  - secrets
+  # list any other resources here that you previously were
+  # encrypting at rest
+  providers:
+  - identity: {} # add this line
+  - aescbc:
+      keys:
+      - name: key1
+        secret: <BASE 64 ENCODED SECRET> # keep this in place
+                                          # make sure it comes after "identity"
 ```
 
 Then run the following command to force decryption of all Secrets:

--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -46,10 +46,10 @@ address: "192.168.0.8"
 port: 20250
 serializeImagePulls: false
 evictionHard:
-    memory.available:  "100Mi"
-    nodefs.available:  "10%"
-    nodefs.inodesFree: "5%"
-    imagefs.available: "15%"
+  memory.available:  "100Mi"
+  nodefs.available:  "10%"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "15%"
 ```
 
 In this example, the kubelet is configured with the following settings:

--- a/content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md
@@ -64,57 +64,57 @@ kind: CredentialProviderConfig
 # for a single image, the results are combined. If providers return overlapping
 # auth keys, the value from the provider earlier in this list is used.
 providers:
-  # name is the required name of the credential provider. It must match the name of the
-  # provider executable as seen by the kubelet. The executable must be in the kubelet's
-  # bin directory (set by the --image-credential-provider-bin-dir flag).
-  - name: ecr-credential-provider
-    # matchImages is a required list of strings used to match against images in order to
-    # determine if this provider should be invoked. If one of the strings matches the
-    # requested image from the kubelet, the plugin will be invoked and given a chance
-    # to provide credentials. Images are expected to contain the registry domain
-    # and URL path.
-    #
-    # Each entry in matchImages is a pattern which can optionally contain a port and a path.
-    # Globs can be used in the domain, but not in the port or the path. Globs are supported
-    # as subdomains like '*.k8s.io' or 'k8s.*.io', and top-level-domains such as 'k8s.*'.
-    # Matching partial subdomains like 'app*.k8s.io' is also supported. Each glob can only match
-    # a single subdomain segment, so `*.io` does **not** match `*.k8s.io`.
-    #
-    # A match exists between an image and a matchImage when all of the below are true:
-    # - Both contain the same number of domain parts and each part matches.
-    # - The URL path of an matchImages must be a prefix of the target image URL path.
-    # - If the matchImages contains a port, then the port must match in the image as well.
-    #
-    # Example values of matchImages:
-    # - 123456789.dkr.ecr.us-east-1.amazonaws.com
-    # - *.azurecr.io
-    # - gcr.io
-    # - *.*.registry.io
-    # - registry.io:8080/path
-    matchImages:
-      - "*.dkr.ecr.*.amazonaws.com"
-      - "*.dkr.ecr.*.amazonaws.com.cn"
-      - "*.dkr.ecr-fips.*.amazonaws.com"
-      - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
-      - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
-    # defaultCacheDuration is the default duration the plugin will cache credentials in-memory
-    # if a cache duration is not provided in the plugin response. This field is required.
-    defaultCacheDuration: "12h"
-    # Required input version of the exec CredentialProviderRequest. The returned CredentialProviderResponse
-    # MUST use the same encoding version as the input. Current supported values are:
-    # - credentialprovider.kubelet.k8s.io/v1
-    apiVersion: credentialprovider.kubelet.k8s.io/v1
-    # Arguments to pass to the command when executing it.
-    # +optional
-    # args:
-    #   - --example-argument
-    # Env defines additional environment variables to expose to the process. These
-    # are unioned with the host's environment, as well as variables client-go uses
-    # to pass argument to the plugin.
-    # +optional
-    env:
-      - name: AWS_PROFILE
-        value: example_profile
+# name is the required name of the credential provider. It must match the name of the
+# provider executable as seen by the kubelet. The executable must be in the kubelet's
+# bin directory (set by the --image-credential-provider-bin-dir flag).
+- name: ecr-credential-provider
+  # matchImages is a required list of strings used to match against images in order to
+  # determine if this provider should be invoked. If one of the strings matches the
+  # requested image from the kubelet, the plugin will be invoked and given a chance
+  # to provide credentials. Images are expected to contain the registry domain
+  # and URL path.
+  #
+  # Each entry in matchImages is a pattern which can optionally contain a port and a path.
+  # Globs can be used in the domain, but not in the port or the path. Globs are supported
+  # as subdomains like '*.k8s.io' or 'k8s.*.io', and top-level-domains such as 'k8s.*'.
+  # Matching partial subdomains like 'app*.k8s.io' is also supported. Each glob can only match
+  # a single subdomain segment, so `*.io` does **not** match `*.k8s.io`.
+  #
+  # A match exists between an image and a matchImage when all of the below are true:
+  # - Both contain the same number of domain parts and each part matches.
+  # - The URL path of an matchImages must be a prefix of the target image URL path.
+  # - If the matchImages contains a port, then the port must match in the image as well.
+  #
+  # Example values of matchImages:
+  # - 123456789.dkr.ecr.us-east-1.amazonaws.com
+  # - *.azurecr.io
+  # - gcr.io
+  # - *.*.registry.io
+  # - registry.io:8080/path
+  matchImages:
+  - "*.dkr.ecr.*.amazonaws.com"
+  - "*.dkr.ecr.*.amazonaws.com.cn"
+  - "*.dkr.ecr-fips.*.amazonaws.com"
+  - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+  - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+  # defaultCacheDuration is the default duration the plugin will cache credentials in-memory
+  # if a cache duration is not provided in the plugin response. This field is required.
+  defaultCacheDuration: "12h"
+  # Required input version of the exec CredentialProviderRequest. The returned CredentialProviderResponse
+  # MUST use the same encoding version as the input. Current supported values are:
+  # - credentialprovider.kubelet.k8s.io/v1
+  apiVersion: credentialprovider.kubelet.k8s.io/v1
+  # Arguments to pass to the command when executing it.
+  # +optional
+  # args:
+  #   - --example-argument
+  # Env defines additional environment variables to expose to the process. These
+  # are unioned with the host's environment, as well as variables client-go uses
+  # to pass argument to the plugin.
+  # +optional
+  env:
+  - name: AWS_PROFILE
+    value: example_profile
 ```
 
 The `providers` field is a list of enabled plugins used by the kubelet. Each entry has a few required fields:

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -823,16 +823,16 @@ metadata:
   name: dapi-test-pod
 spec:
   containers:
-    - name: test-container
-      image: gcr.io/google_containers/busybox
-      command: ["/bin/sh", "-c", "env"]
-      env:
-        - name: SPECIAL_LEVEL_KEY
-          valueFrom:
-            configMapKeyRef:
-              name: a-config
-              key: akey
-              optional: true # mark the variable as optional
+  - name: test-container
+    image: gcr.io/google_containers/busybox
+    command: ["/bin/sh", "-c", "env"]
+    env:
+    - name: SPECIAL_LEVEL_KEY
+      valueFrom:
+        configMapKeyRef:
+          name: a-config
+          key: akey
+          optional: true # mark the variable as optional
   restartPolicy: Never
 ```
 
@@ -852,17 +852,17 @@ metadata:
   name: dapi-test-pod
 spec:
   containers:
-    - name: test-container
-      image: gcr.io/google_containers/busybox
-      command: ["/bin/sh", "-c", "ls /etc/config"]
-      volumeMounts:
-      - name: config-volume
-        mountPath: /etc/config
-  volumes:
+  - name: test-container
+    image: gcr.io/google_containers/busybox
+    command: ["/bin/sh", "-c", "ls /etc/config"]
+    volumeMounts:
     - name: config-volume
-      configMap:
-        name: no-config
-        optional: true # mark the source ConfigMap as optional
+      mountPath: /etc/config
+  volumes:
+  - name: config-volume
+    configMap:
+      name: no-config
+      optional: true # mark the source ConfigMap as optional
   restartPolicy: Never
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -360,7 +360,7 @@ metadata:
   namespace: default
   uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
 imagePullSecrets:
-  - name: myregistrykey
+- name: myregistrykey
 ```
 
 ### Verify that imagePullSecrets are set for new Pods

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -48,24 +48,24 @@ spec:
   group: stable.example.com
   # list of versions supported by this CustomResourceDefinition
   versions:
-    - name: v1
-      # Each version can be enabled/disabled by Served flag.
-      served: true
-      # One and only one version must be marked as the storage version.
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                cronSpec:
-                  type: string
-                image:
-                  type: string
-                replicas:
-                  type: integer
+  - name: v1
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer
   # either Namespaced or Cluster
   scope: Namespaced
   names:
@@ -627,26 +627,26 @@ metadata:
 spec:
   group: stable.example.com
   versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        # openAPIV3Schema is the schema for validating custom objects.
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                cronSpec:
-                  type: string
-                  pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
-                image:
-                  type: string
-                replicas:
-                  type: integer
-                  minimum: 1
-                  maximum: 10
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+                pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
+              image:
+                type: string
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 10
   scope: Namespaced
   names:
     plural: crontabs
@@ -1402,28 +1402,28 @@ metadata:
 spec:
   group: stable.example.com
   versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        # openAPIV3Schema is the schema for validating custom objects.
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                cronSpec:
-                  type: string
-                  pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
-                  default: "5 0 * * *"
-                image:
-                  type: string
-                replicas:
-                  type: integer
-                  minimum: 1
-                  maximum: 10
-                  default: 1
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+                pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
+                default: "5 0 * * *"
+              image:
+                type: string
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 10
+                default: 1
   scope: Namespaced
   names:
     plural: crontabs
@@ -1845,41 +1845,41 @@ metadata:
 spec:
   group: stable.example.com
   versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                cronSpec:
-                  type: string
-                image:
-                  type: string
-                replicas:
-                  type: integer
-            status:
-              type: object
-              properties:
-                replicas:
-                  type: integer
-                labelSelector:
-                  type: string
-      # subresources describes the subresources for custom resources.
-      subresources:
-        # status enables the status subresource.
-        status: {}
-        # scale enables the scale subresource.
-        scale:
-          # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
-          specReplicasPath: .spec.replicas
-          # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
-          statusReplicasPath: .status.replicas
-          # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector.
-          labelSelectorPath: .status.labelSelector
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer
+          status:
+            type: object
+            properties:
+              replicas:
+                type: integer
+              labelSelector:
+                type: string
+    # subresources describes the subresources for custom resources.
+    subresources:
+      # status enables the status subresource.
+      status: {}
+      # scale enables the scale subresource.
+      scale:
+        # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
+        specReplicasPath: .spec.replicas
+        # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
+        statusReplicasPath: .status.replicas
+        # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector.
+        labelSelectorPath: .status.labelSelector
   scope: Namespaced
   names:
     plural: crontabs
@@ -1961,22 +1961,22 @@ metadata:
 spec:
   group: stable.example.com
   versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                cronSpec:
-                  type: string
-                image:
-                  type: string
-                replicas:
-                  type: integer
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer
   scope: Namespaced
   names:
     plural: crontabs

--- a/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -57,11 +57,11 @@ metadata:
 spec:
   restartPolicy: OnFailure
   containers:
-    - name: example-vector-add
-      image: "registry.example/example-vector-add:v42"
-      resources:
-        limits:
-          gpu-vendor.example/example-gpu: 1 # requesting 1 GPU
+  - name: example-vector-add
+    image: "registry.example/example-vector-add:v42"
+    resources:
+      limits:
+        gpu-vendor.example/example-gpu: 1 # requesting 1 GPU
 ```
 
 ## Manage clusters with different types of GPUs


### PR DESCRIPTION
### Description

During my recent CKA certification training, I noticed that the formatting of some of the code snippet examples in the Kubernetes documentation (English) were inconsistent across the same object types.

For example, on the following page, the yaml formatting of the `Service` examples is inconsistent, and this can result in some extra work involved when copying these code snippets during CKA certification exam.

https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service

In the first code snippet example the `ports:` section attributes are indented with 2 spaces, whereas in the second code snippet example the attributes are inline and not indented,

First code snippet example:

```
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  selector:
    app.kubernetes.io/name: MyApp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
```

Second code snippet example:

```
...
---
apiVersion: v1
kind: Service
metadata:
  name: nginx-service
spec:
  selector:
    app.kubernetes.io/name: proxy
  ports:
  - name: name-of-service-port
    protocol: TCP
    port: 80
    targetPort: http-web-svc
```

Where there are indented attributes in the code snippet examples, I've updated the yaml formatting to show the relevant attributes inline across the Kubernetes documentation (English).