### PR TITLE
Link to PVC API reference from "Persistent Volumes" concept page

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -9,6 +9,8 @@ title: Persistent Volumes
 api_metadata:
 - apiVersion: "v1"
   kind: "PersistentVolume"
+- apiVersion: "k8s.io/api/core/v1"
+  kind: "PersistentVolumeClaim"
 feature:
   title: Storage orchestration
   description: >

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -9,7 +9,7 @@ title: Persistent Volumes
 api_metadata:
 - apiVersion: "v1"
   kind: "PersistentVolume"
-- apiVersion: "k8s.io/api/core/v1"
+- apiVersion: "v1"
   kind: "PersistentVolumeClaim"
 feature:
   title: Storage orchestration


### PR DESCRIPTION
Contains update to add a link to the right hand navigation of
https://kubernetes.io/docs/concepts/storage/persistent-volumes/ that links to the API reference for PersistentVolumeClaim.
Verification link https://deploy-preview-48391--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/persistent-volumes/
Closes #48334