### PR TITLE
KEP-4832: add SchedulerAsyncPreemption to the doc

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/scheduler-async-preemption.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/scheduler-async-preemption.md
@@ -1,0 +1,15 @@
+---
+title: SchedulerAsyncPreemption
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.32"
+---
+
+Running some expensive operation within [the scheduler's preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/) asynchronously,
+which improves the scheduling latency when the preemption involves in.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/scheduler-async-preemption.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/scheduler-async-preemption.md
@@ -11,5 +11,6 @@ stages:
     fromVersion: "1.32"
 ---
 
-Running some expensive operation within [the scheduler's preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/) asynchronously,
-which improves the scheduling latency when the preemption involves in.
+Enable running some expensive operations within the scheduler, associated with
+[preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/), asynchronously.
+Asynchronous processing of preemption improves overall Pod scheduling latency.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Add KEP-4832 feature gate to the doc.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
KEP: https://github.com/kubernetes/enhancements/issues/4832