### PR TITLE
Link from cluster operator glossary entry to operator pattern page

### DIFF
--- a/content/en/docs/reference/glossary/cluster-operator.md
+++ b/content/en/docs/reference/glossary/cluster-operator.md
@@ -17,6 +17,6 @@ tags:
 Their primary responsibility is keeping a cluster up and running, which may involve periodic maintenance activities or upgrades.<br>
 
 {{< note >}}
-Cluster operators are different from the [Operator pattern](https://www.openshift.com/learn/topics/operators) that extends the Kubernetes API.
+Cluster operators are different from the [Operator pattern](/docs/concepts/extend-kubernetes/operator/) that extends the Kubernetes API.
 {{< /note >}}
 


### PR DESCRIPTION

### Description

If you expand https://kubernetes.io/docs/reference/glossary/?user-type=true#term-cluster-operator you see a link to the operator pattern, but it's an off site link back from before I wrote https://kubernetes.io/docs/concepts/extend-kubernetes/operator/

We should change that glossary entry so that it links to https://kubernetes.io/docs/concepts/extend-kubernetes/operator/ instead. 

### Issue

Closes: #48404 