### PR TITLE
Add application/yaml section in api-concepts

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -126,15 +126,6 @@ virtual resource type would be used if that becomes necessary.
 
 Over HTTP, Kubernetes supports JSON and Protobuf wire encodings.
 
-{{% note %}}
-Although YAML is widely used to define Kubernetes manifests locally, Kubernetes does not
-support the [`application/yaml`](https://www.rfc-editor.org/rfc/rfc9512.html) media type
-for API operations.
-
-All JSON documents are valid YAML, so you can also use a JSON API response anywhere that is
-expecting a YAML input.
-{{% /note %}}
-
 By default, Kubernetes returns objects in [JSON serialization](#json-encoding), using the
 `application/json` media type. Although JSON is the default, clients may request the more
 efficient binary [Protobuf representation](#protobuf-encoding) for better performance at scale.
@@ -184,6 +175,39 @@ For example:
      "apiVersion": "v1",
      …
    }
+   ```
+
+### YAML resource encoding {#yaml-encoding}
+Kubernetes also supports the [`application/yaml`](https://www.rfc-editor.org/rfc/rfc9512.html) media type for both requests and responses. [`YAML`](https://yaml.org/) can be used for defining Kubernetes manifests and API interactions.
+
+For example:
+
+1. List all of the pods on a cluster in YAML format
+   ```
+   GET /api/v1/pods
+   Accept: application/yaml
+   ---
+   200 OK
+   Content-Type: application/yaml
+
+   … YAML encoded collection of Pods (PodList object)
+   ```
+
+1. Create a pod by sending YAML-encoded data to the server, requesting a YAML response:
+   ```
+   POST /api/v1/namespaces/test/pods
+   Content-Type: application/yaml
+   Accept: application/yaml
+   … YAML encoded Pod object
+   ---
+   200 OK
+   Content-Type: application/yaml
+
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: my-pod
+     …
    ```
 
 ### Kubernetes Protobuf encoding {#protobuf-encoding}

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -127,8 +127,8 @@ virtual resource type would be used if that becomes necessary.
 Over HTTP, Kubernetes supports JSON and Protobuf wire encodings.
 
 By default, Kubernetes returns objects in [JSON serialization](#json-encoding), using the
-`application/json` media type. Although JSON is the default, clients may request the more
-efficient binary [Protobuf representation](#protobuf-encoding) for better performance at scale.
+`application/json` media type. Although JSON is the default, clients may request a response in
+YAML, or use the more efficient binary [Protobuf representation](#protobuf-encoding) for better performance at scale.
 
 The Kubernetes API implements standard HTTP content type negotiation: passing an
 `Accept` header with a `GET` call will request that the server tries to return
@@ -186,7 +186,9 @@ For example:
    ```
    GET /api/v1/pods
    Accept: application/yaml
-   ---
+   ```
+   
+   ```
    200 OK
    Content-Type: application/yaml
 
@@ -199,7 +201,9 @@ For example:
    Content-Type: application/yaml
    Accept: application/yaml
    … YAML encoded Pod object
-   ---
+   ```
+   
+   ```
    200 OK
    Content-Type: application/yaml
 

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -152,7 +152,9 @@ For example:
 
    ```
    GET /api/v1/pods
-   ---
+   ```
+
+   ```
    200 OK
    Content-Type: application/json
 
@@ -166,7 +168,9 @@ For example:
    Content-Type: application/json
    Accept: application/json
    … JSON encoded Pod object
-   ---
+   ```
+
+   ```
    200 OK
    Content-Type: application/json
 
@@ -230,7 +234,9 @@ For example:
    ```
    GET /api/v1/pods
    Accept: application/vnd.kubernetes.protobuf
-   ---
+   ```
+
+   ```
    200 OK
    Content-Type: application/vnd.kubernetes.protobuf
 
@@ -245,7 +251,9 @@ For example:
    Content-Type: application/vnd.kubernetes.protobuf
    Accept: application/json
    … binary encoded Pod object
-   ---
+   ```
+
+   ```
    200 OK
    Content-Type: application/json
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
* Kubernetes API server supports [YAML](https://yaml.org/) (for encoding request bodies, or for a negotiated response format), but the documentation says it does not.
* In this PR new section for `application/yaml` is added and removed the note saying YAML for encoding request bodies is not supported.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #48317