### PR TITLE
[pt-br] Update scheduling-eviction page based on the English version

### DIFF
--- a/content/pt-br/docs/concepts/scheduling-eviction/_index.md
+++ b/content/pt-br/docs/concepts/scheduling-eviction/_index.md
@@ -20,8 +20,11 @@ para que os Pods com maior prioridade possam ser escalonados nos nós. Remoção
 - [Restrições de Propagação da Topologia do Pod](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 - [Taints e Tolerâncias](/pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/)
 - [Framework do Escalonador](/docs/concepts/scheduling-eviction/scheduling-framework)
+- [Alocação Dinâmica de Recursos](/docs/concepts/scheduling-eviction/dynamic-resource-allocation)
 - [Refinando a Performance do Escalonador](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
 - [Empacotamento de Recursos para Recursos Estendidos](/docs/concepts/scheduling-eviction/resource-bin-packing/)
+- [Prontidão para Escalonamento de Pods](/docs/concepts/scheduling-eviction/pod-scheduling-readiness/)
+- [Descheduler](https://github.com/kubernetes-sigs/descheduler#descheduler-for-kubernetes)
 
 ## Disrupção do Pod
 


### PR DESCRIPTION
Description:

This PR updates the scheduling-eviction page in the Portuguese documentation (pt-br) to reflect the latest version of the page in English.

Note on Descheduler:

In addition to the main update, we chose to keep the term “Descheduler” instead of translating it to “desagendamento,” to preserve the reference to the official Kubernetes tool and avoid confusion that could arise from the translation.

Changes:

- Update of the page content/pt-br/docs/concepts/scheduling-eviction/_index.md
- Synchronization with the latest version of the English documentation

Related issue: #48426

--- 

Descrição:

Este PR atualiza a página scheduling-eviction na documentação em português (pt-br) para refletir a versão mais recente da página em inglês. 

**Nota sobre Descheduler:**

Além da atualização principal, optei por manter o termo “Descheduler” em vez de traduzi-lo para “desagendamento”, a fim de preservar a referência à ferramenta oficial do Kubernetes, evitando confusões que poderiam surgir com a tradução.

Mudanças:
	•	Atualização da página content/pt-br/docs/concepts/scheduling-eviction/_index.md
	•	Sincronização com a versão mais recente da documentação em inglês

Issue relacionada:
	•	Issue: #48426