### PR TITLE
Tweak deprecation warnings to align with Docsy

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -409,38 +409,27 @@ body.cid-community {
   }
 }
 
-#caseStudies body > #deprecation-warning, body.cid-casestudies > #deprecation-warning, body.cid-community > #deprecation-warning {
-    display: inline-block;
-    vertical-align: top;
-    position: relative;
-    background-color: #326ce5; // Kubernetes blue
-    color: #fff;
+body.cid-casestudies, body.cid-community, body.cid-partners {
+  section#deprecation-warning {
     padding: 0;
     margin: 0;
     width: 100vw;
+
+    border-top: solid 1em #326ce5;
+    border-bottom: solid 1em #326ce5;
+
+    // Center the pageinfo
+    padding-left: calc(max(1rem, (100vw - 60rem) / 2));
+    padding-right: calc(max(1rem, (100vw - 60rem) / 2));
+  }
+  /* Ensure color overrides */
+  section#deprecation-warning, section#deprecation-warning > .pageinfo.deprecation-warning {
+    background-color: #326ce5; // Kubernetes blue
+    color: #fff;
+  }
 }
-#caseStudies body > #deprecation-warning, body.cid-casestudies > #deprecation-warning {
-    padding-top: 32px;
-}
+
 body.cid-partners {
-    > #deprecation-warning {
-        padding: 0;
-        margin-right: 0;
-        margin-left: 0;
-        margin-top: 0;
-        width: 100vw;
-        > .content {
-            width: 100%;
-            max-width: initial;
-            margin-right: 0;
-            margin-left: 0;
-            margin-top: 0;
-            padding-left: 5vw;
-            padding-right: 5vw;
-            padding-top: 2rem;
-            padding-bottom: 2rem;
-        }
-    }
     /*  SECTIONS  */
     .section {
         clear: both;

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -441,6 +441,9 @@ other = "Options"
 [outdated_blog__message]
 other = "This article is more than one year old. Older articles may contain outdated content. Check that the information in the page has not become incorrect since its publication."
 
+[page_deprecated]
+other = "(stale page)"
+
 [patch_release]
 other = "Patch Release"
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -148,7 +148,7 @@ latest = "v1.31"
 version = "v1.31"
 githubbranch = "main"
 docsbranch = "main"
-deprecated = false
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,15 +24,15 @@
 		</section>
 		{{ block "post-hero" . }}
     </header>
-      {{ block "deprecated" . }}
-        {{ if or .IsHome ( eq .Params.cid "partners" ) ( eq .Params.cid "community" ) }}
-          {{ partial "deprecation-warning.html" . }}
-        {{ end }}
-      {{ end }}
     {{ end }}
 		{{ end }}
     <div class="td-outer">
       <main role="main" class="td-main" {{ if (or (ne .FirstSection "case-studies") (not .IsSection) ) }}data-pagefind-body{{ end }}>
+        {{ block "deprecation_warning" . }}
+          {{ if or .IsHome ( eq .Params.cid "partners" ) ( eq .Params.cid "community" ) }}
+            {{ partial "deprecation-warning.html" . }}
+          {{ end }}
+        {{ end }}
         {{ block "main" . }}{{ end }}
       </main>
     </div>

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -37,6 +37,9 @@
               RSS <i class="fa fa-rss ml-2 "></i>
             </a>
             {{ end -}}
+            {{ block "deprecation_warning" . }}
+              {{ partial "deprecation-warning.html" . }}
+            {{ end }}
             {{ block "main" . }}{{ end }}
           </main>
           <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -12,7 +12,6 @@ have blog posts -->
 {{ $pageGroups := $pag.PageGroups}}
 {{ if eq $pag.PageNumber 1 }}
 {{ end }}
-{{ partial "deprecation-warning.html" . }}
 <div class="row">
 	<div class="col-12">
 		{{ range $pageGroups }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,4 +1,3 @@
 {{ define "main" }}
-{{ partial "deprecation-warning.html" . }}
 {{ .Render "content" }}
 {{ end }}

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -12,7 +12,6 @@
 <section id="mainContent">
 	<div class="main-section">
 		<div class="content">
-		{{ partial "deprecation-warning.html" . }}
 			<div class="case-studies">
 				{{ range $featured }}
 				{{ template "case-study-featured-block" (dict "ctx" $ "page" .) }}

--- a/layouts/case-studies/single-baseof.html
+++ b/layouts/case-studies/single-baseof.html
@@ -5,7 +5,9 @@
 	</head>
         <body{{ with .Page.Params.body_class }} class="{{ . }}"{{ end }}>
 		{{ partial "navbar.html" . }}
+		{{ block "deprecation_warning.html" . }}
 		{{ partial "deprecation-warning.html" . }}
+		{{ end }}
 		<div data-pagefind-body>
 		{{ block "main" . }}{{ end }}
 		</div>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -24,6 +24,9 @@
           <!--main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main"-->
           <main role="main" class="col-xl-8" {{ if ne .Params.cid "docsHome" }}data-pagefind-body{{ end }}{{ if (and .IsPage .Params.description ) }} data-pagefind-meta="description:{{ .Params.description }}"{{ end }}>
               {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+              {{ block "deprecation_warning" . }}
+                {{ partial "deprecation-warning.html" . }}
+              {{ end }}
               {{ block "outdated_content" . }}
                 {{ partial "docs/outdated_content.html" . }}
               {{ end }}

--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -3,7 +3,6 @@
 {{ end }}
 
 {{ define "main" }}
-{{ partial "deprecation-warning.html" . }}
 <h1>{{ .Title }}</h1>
 <p>{{ T "layouts_docs_glossary_description" }}</p>
 <div id="tag-container">

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -6,7 +6,6 @@
 {{- end -}}
 {{- end -}}
     <div class="td-content">
-        {{- partial "deprecation-warning.html" . -}}
         {{ $hasContent := false }}
         {{ with .File }}
             {{ if ne .Filename "" }}

--- a/layouts/docs/release-info.html
+++ b/layouts/docs/release-info.html
@@ -6,7 +6,7 @@
   {{ range where .Site.Pages "Section" "releases" }}
     {{ if not .IsNode }}
       <div class="entry">
-        <h5><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+        <h5><a href="{{ .RelPermalink }}">{{ .Title }}</a> {{ T "page_deprecated" }}</h5>
       </div>
     {{ end }}
   {{ end }}

--- a/layouts/docs/release-info.html
+++ b/layouts/docs/release-info.html
@@ -2,7 +2,6 @@
 {{ if not .Site.Params.deprecated }}
   {{ .Content }}
 {{ else }}
-{{ partial "deprecation-warning.html" . }}
 <div class="section-index">
   {{ range where .Site.Pages "Section" "releases" }}
     {{ if not .IsNode }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-{{ partial "deprecation-warning.html" . }}
     <div class="td-content">
     {{- if .HasShortcode "kat-button" -}}
     <div class="pageinfo pageinfo-secondary">

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -5,7 +5,7 @@
       {{ T "deprecation_title" }} {{ .Param "version" }}
     </h3>
     <p> Kubernetes {{ .Param "version" }} {{ T "deprecation_warning" }}
-      <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
+      <a href="{{ site.Params.currentUrl }}{{ .RelPermalink }}">{{ T "latest_version" }}</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
Follow up to #47411 

- Ready the deprecation warning mechanism for when we want to align with upstream Docsy

Since #47411, I changed my thinking about where we should put the warning info.

Intended to help with #41171.

/area web-development