### PR TITLE
KEP 4818: PodLifecycleSleepActionAllowZero

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -58,6 +58,10 @@ Resources consumed by the command are counted against the Container.
 * Sleep - Pauses the container for a specified duration. 
   This is a beta-level feature default enabled by the `PodLifecycleSleepAction` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/). 
 
+{{< note >}}
+Enable the `PodLifecycleSleepActionAllowZero` feature gate if you want to set a sleep duration of zero seconds (effectively a no-op) for your Sleep lifecycle hooks.
+{{< /note >}}
+
 ### Hook handler execution
 
 When a Container lifecycle management hook is called,

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/pod-lifecycle-sleep-action-allow-zero.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/pod-lifecycle-sleep-action-allow-zero.md
@@ -1,0 +1,14 @@
+---
+title: PodLifecycleSleepActionAllowZero
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.32"
+    toVersion: "1.32"
+---
+Enables setting zero value for the `sleep` action in Container lifecycle hooks.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/pod-lifecycle-sleep-action-allow-zero.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/pod-lifecycle-sleep-action-allow-zero.md
@@ -9,6 +9,5 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.32"
-    toVersion: "1.32"
 ---
-Enables setting zero value for the `sleep` action in Container lifecycle hooks.
+Enables setting zero value for the `sleep` action in [container lifecycle hooks](/docs/concepts/containers/container-lifecycle-hooks/).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Docs for [KEP 4818: Allow zero value for Sleep Action of PreStop Hook](https://github.com/kubernetes/enhancements/issues/4818). 

Related PRs
- Enhancements PR: https://github.com/kubernetes/enhancements/pull/4855
- Code PR: https://github.com/kubernetes/kubernetes/pull/127094

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue



<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: nil, part of https://github.com/kubernetes/enhancements/issues/4818