### PR TITLE
[zh-cn] Fix crontab expression in /controllers/cron-jobs.md translation

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/cron-jobs.md
@@ -130,7 +130,7 @@ The `.spec.schedule` field is required. The value of that field follows the [Cro
 <!--
 For example, `0 3 * * 1` means this task is scheduled to run weekly on a Monday at 3 AM.
 -->
-例如 `0 0 13 * 5` 表示此任务计划于每周一凌晨 3 点运行。
+例如 `0 3 * * 1` 表示此任务计划于每周一凌晨 3 点运行。
 
 <!--
 The format also includes extended "Vixie cron" step values. As explained in the


### PR DESCRIPTION
Fix incorrect crontab expression in Chinese translation of cron-jobs docs.

```
content/zh-cn/docs/concepts/workloads/controllers/cron-jobs.md
```