### PR TITLE
Clarify PDB `maxUnavailable` only works if all pods have same controller

### DIFF
--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -124,7 +124,7 @@ for policy/v1 an empty selector matches every pod in the namespace.
 
 You can specify only one of `maxUnavailable` and `minAvailable` in a single `PodDisruptionBudget`.
 `maxUnavailable` can only be used to control the eviction of pods
-that have an associated controller managing them. In the examples below, "desired replicas"
+that all have the same associated controller managing them. In the examples below, "desired replicas"
 is the `scale` of the controller managing the pods being selected by the
 `PodDisruptionBudget`.
 


### PR DESCRIPTION
### Description

Tighten the wording around the situations in which the `maxUnavailable` field of `PodDisruptionBudget` can be used.

The `maxUnavailable` field does not work as expected if the pods matched by the `selector` are managed by multiple different controllers.
