### PR TITLE
[zh] Sync feature-gates/*.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
@@ -6,17 +6,20 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
+  - stage: alpha
     defaultValue: false
     fromVersion: "1.18"
     toVersion: "1.19"
   - stage: beta
     defaultValue: true
     fromVersion: "1.20"
-    toVersion: "1.28"    
+    toVersion: "1.28"
   - stage: stable
     defaultValue: true
-    fromVersion: "1.29" 
+    fromVersion: "1.29"
+    toVersion: "1.30"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-rbd.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-rbd.md
@@ -6,24 +6,30 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
+  - stage: alpha
     defaultValue: false
     fromVersion: "1.23"
     toVersion: "1.27"
   - stage: deprecated
     defaultValue: false
-    fromVersion: "1.28"  
+    fromVersion: "1.28"
+    toVersion: "1.30"
+
+removed: true
 ---
+
 <!--
 Enables shims and translation logic to route volume
 operations from the RBD in-tree plugin to Ceph RBD CSI plugin. Requires
 CSIMigration and csiMigrationRBD feature flags enabled and Ceph CSI plugin
-installed and configured in the cluster. This flag has been deprecated in
-favor of the `InTreePluginRBDUnregister` feature flag which prevents the registration of
-in-tree RBD plugin.
+installed and configured in the cluster.
+
+This feature gate was deprecated in favor of the `InTreePluginRBDUnregister` feature gate,
+which prevents the registration of in-tree RBD plugin.
 -->
 启用封装和转换逻辑，将卷操作从 RBD 的内嵌插件路由到 Ceph RBD CSI 插件。
 此特性要求 CSIMigration 和 csiMigrationRBD 特性标志均被启用，
 且集群中安装并配置了 Ceph CSI 插件。
-此标志已被弃用，以鼓励使用 `InTreePluginRBDUnregister` 特性标志。
+
+此特性门控已被弃用，以鼓励使用 `InTreePluginRBDUnregister` 特性门控。
 后者会禁止注册内嵌的 RBD 插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-rbd-unregister.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-rbd-unregister.md
@@ -6,17 +6,19 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
+  - stage: alpha
     defaultValue: false
     fromVersion: "1.23"
     toVersion: "1.27"
   - stage: deprecated
     defaultValue: false
-    fromVersion: "1.28"  
+    fromVersion: "1.28"
+    toVersion: "1.30"
+
+removed: true
 ---
 
 <!--
-Stops registering the RBD in-tree plugin in kubelet
-and volume controllers.
+Stops registering the RBD in-tree plugin within kubelet and volume controllers.
 -->
 在 kubelet 和卷控制器上关闭注册 RBD 内嵌插件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-ready-pods.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-ready-pods.md
@@ -6,17 +6,20 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
+  - stage: alpha
     defaultValue: false
     fromVersion: "1.23"
     toVersion: "1.23"
   - stage: beta
     defaultValue: true
-    fromVersion: "1.24"  
-    toVersion: "1.28" 
+    fromVersion: "1.24"
+    toVersion: "1.28"
   - stage: stable
     defaultValue: true
-    fromVersion: "1.29"  
+    fromVersion: "1.29"
+    toVersion: "1.30"
+
+removed: true
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/skip-read-only-validation-gce.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/skip-read-only-validation-gce.md
@@ -6,16 +6,18 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
+  - stage: alpha
     defaultValue: false
     fromVersion: "1.28"
     toVersion: "1.28"
   - stage: deprecated
     defaultValue: true
-    fromVersion: "1.29"  
+    fromVersion: "1.29"
+    toVersion: "1.30"
+
+removed: true
 ---
 <!--
-Skip validation for GCE, will enable in the
-next version.
+Skip validation that GCE PersistentDisk volumes are in read-only mode.
 -->
-跳过对 GCE 的验证，将在下个版本中启用。
+跳过对 GCE PersistentDisk 卷处于只读模式的验证。


### PR DESCRIPTION
Sync with en #48436 

```
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/api-priority-and-fairness.md
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/csi-migration-rbd.md
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/in-tree-plugin-rbd-unregister.md
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/job-ready-pods.md
modified:   content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/skip-read-only-validation-gce.md
```