### PR TITLE
Adding a blog post for windows memory pressure eviction

### DIFF
--- a/content/en/blog/_posts/2024-12-11-windows-memory-pressure-eviction.md
+++ b/content/en/blog/_posts/2024-12-11-windows-memory-pressure-eviction.md
@@ -2,7 +2,8 @@
 layout: blog
 title: "Windows Memory Pressure Eviction"
 slug: windows-memory-pressure-eviction
-date: TBD
+date: 2024-12-11
+draft: true
 author: >
   Mark Rossetti (Microsoft)
 ---
@@ -48,7 +49,7 @@ on a Windows node:
 By default, Windows nodes have a "hard" eviction threshold of 500Mi
 (kubelet setting `--eviction-hard=memory.available<500Mi`).
 This means that if the system's availble commit memory is less than 500 Mi,
-the Kubelet will try to evict pods.
+the kubelet will try to evict pods.
 
 For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds,
 refer to the official Kubernetes documentation on [memory-pressure-eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -1,0 +1,85 @@
+---
+layout: blog
+title: "Windows Memory Pressure Eviction"
+slug: windows-memory-pressure-eviction
+canonicalUrl: TBD
+date: TBD
+author: >
+  Mark Rossetti (Microsoft)
+---
+
+In Kubernetes 1.31, support for memory-pressure based eviction was added for Windows nodes.
+
+This post describes what these changes mean for you and how they may differ from usage on Linux nodes.
+
+## How Memory Pressure Eviction Works on Windows Nodes
+
+Kubernetes nodes can be configured to report memory pressure when the available memory falls below a defined threshold (either a percentage of the total node memory or a specific value). When this signal is raised, the kubelet attempts to evict pods to maintain stability on the node.
+
+For Windows, the available memory is derived from the node's global memory commit levels, which are queried through the [GetPerformanceInfo()](https://](https://learn.microsoft.com/windows/win32/api/psapi/nf-psapi-getperformanceinfo)) system call. Available memory is calculated by subtracting the node's global `CommitTotal` (the amount of memory committed by all processes on the node) from the `CommitLimit` (the total amount of virtual memory that can be committed without extending the page file(s) on the node).
+
+> Important note: The `CommitLimit` (capacity) can change dynamically based on current memory usage if Windows is configured to automatically adjust page file sizes, which is the default behavior on Windows Client machines.
+
+This approach differs from Linux, where available memory is reported based on **Working Set** memory usage.
+
+## Why Use Commit Memory on Windows?
+
+Before diving into the reasons for using commit memory on Windows for eviction signalling, it's helpful to understand the difference between **Working Set** and **Commit** memory.
+
+**Working Set** memory represents the amount of physical memory currently used by processes. It includes the pages of memory that are actively in use and exludes memory pages that have been swapped out to disk (if paging is enabled).
+
+**Commit** memory, on the other hand, represents the total amount of virtual memory that has been reserved by processes - including memory that has been swapped out to disk. When memory is "committed", it means that the system has allocated the backing storage (either physical RAM or space in the paging file(s)) to ensure that the memory will be available if needed.
+
+Using global commit levels to measure available memory on Windows was implemented for two key reasons:
+
+1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit** (not WorkingSet) **memory**. Windows memory management enforces limits on processes based on the total amount of memory committed, not just the memory in use. 
+This also means that memory limits specified for containers in Kubernetes Pods are enforced on the total amount of virtual memory committed by all processes in the container. Consistenty in how memory usage is tracked and enforced is essential for workload stability.
+
+2. **Paging (swap) is automatically enabled on Windows**, and it plays an essential role in the operating system's memory management. Disabling paging is not recommended because it can lead to system instability.
+
+## Eviction Thresholds
+
+By default, Windows nodes have a default "hard" eviction threadhold of `--eviction-hard=memory.available<500Mi`. This means that if the system's availalbe memory is less than 500 Mi the Kubelet will try and start evicting pods.
+
+For more information on configuring memory-pressure based eviction and understanding the eviction signals and threadhols, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
+
+
+## Monitoring Commit Memory for Windows nodes
+
+Understanding the distinction between **Working Set** and **Commit** memory and being able to monitor both is critical for maintaining the stability of individual Pod workloads and the entire Windows node.
+
+Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its Commit limit, even when the WorkingSet appears to be well within the expected bounds. This discrepancy can lead to confusion.
+
+Starting with v1.31, Windows nodes now report the global `CommitTotal` and `CommitLimit` for each node through the `/stats/summary` API endpoint. This information is available under the `windows-global-commit-memory` syscontainer.
+
+```json=
+kubectl get --raw http://{cluster-endpoint}/api/v1/nodes/{node-name}/proxy/stats/summary
+
+{
+ "node": {
+  "nodeName": "{node-name},
+  "systemContainers": [
+   ...
+   {
+    "name": "windows-global-commit-memory",
+    "startTime": "2024-10-02T19:14:33Z",
+    "memory": {
+     "time": "2024-10-02T19:14:33Z",
+     "availableBytes": 4563402752,
+     "usageBytes": 1212754432
+    }
+   }
+  ...
+  ],
+}
+
+```
+
+
+Additionally, exposing the Commit usage for individial Pods and Containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
+
+[windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on Commit memory usage.
+
+## Additional Resources
+
+To gain a deeper understanding of how memory is managed on Windows, you may also find this article on [Physical and Virtual Memory in Windows 10](https://answers.microsoft.com/en-us/windows/forum/all/physical-and-virtual-memory-in-windows-10/e36fb5bc-9ac8-49af-951c-e7d39b979938) helpful.

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -49,7 +49,7 @@ For more information on configuring memory-pressure based eviction and understan
 
 Understanding the distinction between _Working Set_ and _Commit_ memory and being able to monitor both is critical for maintaining the stability of individual Pod workloads and the entire Windows node.
 
-Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its `CommitLimit`, even when the WorkingSet appears to be well within the expected bounds. This discrepancy can lead to confusion.
+Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its `CommitLimit`, even when the _WorkingSet_ memory usage appears to be well within the expected bounds. This discrepancy can lead to confusion.
 
 Starting with v1.31, Windows nodes now report the global `CommitTotal` and `CommitLimit` for each node through the `/stats/summary` API endpoint. This information is available under the `windows-global-commit-memory` syscontainer API resource.
 
@@ -78,7 +78,7 @@ kubectl get --raw http://<cluster-endpoint>/api/v1/nodes/<node-name>/proxy/stats
 
 Additionally, exposing the _Commit_ memory usage for individial Pods and Containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
 
-[windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on _Commit_ memory usage today.
+[windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on _Commit_ memory usage for Pods and containers today.
 
 ## Additional resources
 

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -40,7 +40,7 @@ This also means that memory limits specified for containers in Kubernetes Pods a
 
 ## Eviction thresholds
 
-By default, Windows nodes have a default "hard" eviction threshold of `--eviction-hard=memory.available<500Mi`. This means that if the system's availalbe memory is less than 500 Mi the Kubelet will try and start evicting pods.
+By default, Windows nodes have a "hard" eviction threshold of 500Mi (kubelet setting `--eviction-hard=memory.available<500Mi`). This means that if the system's availble commit memory is less than 500 Mi the Kubelet will try and start evicting pods.
 
 For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
 
@@ -76,7 +76,7 @@ kubectl get --raw http://<cluster-endpoint>/api/v1/nodes/<node-name>/proxy/stats
 
 ```
 
-Additionally, exposing the _Commit_ memory usage for individial Pods and Containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
+Additionally, exposing the _Commit_ memory usage for individial Pods and containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
 
 [windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on _Commit_ memory usage for Pods and containers today.
 

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -34,7 +34,9 @@ _Commit_ memory, on the other hand, represents the total amount of virtual memor
 There are two reasons to using the global commit levels for measuring the available memory
 on a Windows node:
 
-1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit** (not WorkingSet) **memory**. Windows memory management enforces limits on processes based on the total amount of memory committed, not just the memory in use. 
+1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit (not WorkingSet) memory**.
+   Windows memory management enforces limits on processes based on the total amount of memory committed,
+   not just the memory in use. 
 This also means that memory limits specified for containers in Kubernetes Pods are enforced on the total amount of virtual memory committed by all processes in the container. Consistency in how memory usage is tracked and enforced is essential for workload stability.
 
 2. **Paging (swap) is automatically enabled on Windows**, and it plays an essential role in the operating system's memory management. Disabling paging is not recommended because it can lead to system instability.

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -34,7 +34,7 @@ _Commit_ memory, on the other hand, represents the total amount of virtual memor
 There are two reasons to using the global commit levels for measuring the available memory
 on a Windows node:
 
-1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit (not WorkingSet) memory**.
+1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit (not Working Set) memory**.
    Windows memory management enforces limits on processes based on the total amount of memory committed,
    not just the memory in use. 
    This also means that memory limits specified for containers in Kubernetes Pods are enforced
@@ -58,9 +58,9 @@ refer to the official Kubernetes documentation on [memory-pressure-eviction](/do
 
 Understanding the distinction between _Working Set_ and _Commit_ memory and being able to monitor both is critical for maintaining the stability of individual Pod workloads and the entire Windows node.
 
-Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its `CommitLimit`, even when the _WorkingSet_ memory usage appears to be well within the expected bounds. This discrepancy can lead to confusion.
+Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its `CommitLimit`, even when the _Working Set_ memory usage appears to be well within the expected bounds. This discrepancy can lead to confusion.
 
-Starting with v1.31, Windows nodes now report the global `CommitTotal` and `CommitLimit` for each node through the `/stats/summary` API endpoint. This information is available under the `windows-global-commit-memory` syscontainer API resource.
+Starting with v1.31, Windows nodes report the global `CommitTotal` and `CommitLimit` for each node through the `/stats/summary` API endpoint. This information is available under the `windows-global-commit-memory` named object in the `systemContainers` collection:
 
 ```json=
 kubectl get --raw http://<cluster-endpoint>/api/v1/nodes/<node-name>/proxy/stats/summary
@@ -85,7 +85,7 @@ kubectl get --raw http://<cluster-endpoint>/api/v1/nodes/<node-name>/proxy/stats
 
 ```
 
-Additionally, exposing the _Commit_ memory usage for individial Pods and containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
+Additionally, exposing the _Commit_ memory usage for individial Pods and containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-less, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
 
 [windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on _Commit_ memory usage for Pods and containers today.
 

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -37,7 +37,9 @@ on a Windows node:
 1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit (not WorkingSet) memory**.
    Windows memory management enforces limits on processes based on the total amount of memory committed,
    not just the memory in use. 
-This also means that memory limits specified for containers in Kubernetes Pods are enforced on the total amount of virtual memory committed by all processes in the container. Consistency in how memory usage is tracked and enforced is essential for workload stability.
+   This also means that memory limits specified for containers in Kubernetes Pods are enforced
+   on the total amount of virtual memory committed by all processes in the container. 
+   Consistency in how memory usage is tracked and enforced is essential for workload stability.
 
 2. **Paging (swap) is automatically enabled on Windows**, and it plays an essential role in the operating system's memory management. Disabling paging is not recommended because it can lead to system instability.
 

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -50,7 +50,8 @@ By default, Windows nodes have a "hard" eviction threshold of 500Mi
 This means that if the system's availble commit memory is less than 500 Mi,
 the Kubelet will try to evict pods.
 
-For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
+For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds,
+refer to the official Kubernetes documentation on [memory-pressure-eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
 
 
 ## Monitoring commit memory for Windows nodes

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -45,7 +45,10 @@ on a Windows node:
 
 ## Eviction thresholds
 
-By default, Windows nodes have a "hard" eviction threshold of 500Mi (kubelet setting `--eviction-hard=memory.available<500Mi`). This means that if the system's availble commit memory is less than 500 Mi the Kubelet will try and start evicting pods.
+By default, Windows nodes have a "hard" eviction threshold of 500Mi
+(kubelet setting `--eviction-hard=memory.available<500Mi`).
+This means that if the system's availble commit memory is less than 500 Mi,
+the Kubelet will try to evict pods.
 
 For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
 

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -31,7 +31,8 @@ _Working Set_ memory represents the amount of physical memory currently used by 
 
 _Commit_ memory, on the other hand, represents the total amount of virtual memory that has been reserved by processes - including memory that has been swapped out to disk. When memory is "committed", it means that the system has allocated the backing storage (either physical RAM or space in the paging file(s)) to ensure that the memory will be available if needed.
 
-Using global commit levels to measure available memory on Windows was implemented for two key reasons:
+There are two reasons to using the global commit levels for measuring the available memory
+on a Windows node:
 
 1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit** (not WorkingSet) **memory**. Windows memory management enforces limits on processes based on the total amount of memory committed, not just the memory in use. 
 This also means that memory limits specified for containers in Kubernetes Pods are enforced on the total amount of virtual memory committed by all processes in the container. Consistency in how memory usage is tracked and enforced is essential for workload stability.

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -27,20 +27,20 @@ This approach differs from Linux, where available memory is reported based on _W
 
 Before diving into the reasons for using commit memory on Windows for eviction signalling, it's helpful to understand the difference between _Working Set_ and _Commit_ memory.
 
-_Working Set_ memory represents the amount of physical memory currently used by processes. It includes the pages of memory that are actively in use and exludes memory pages that have been swapped out to disk (if paging is enabled).
+_Working Set_ memory represents the amount of physical memory currently used by processes. It includes the pages of memory that are actively in use and excludes memory pages that have been swapped out to disk (if paging is enabled).
 
 _Commit_ memory, on the other hand, represents the total amount of virtual memory that has been reserved by processes - including memory that has been swapped out to disk. When memory is "committed", it means that the system has allocated the backing storage (either physical RAM or space in the paging file(s)) to ensure that the memory will be available if needed.
 
 Using global commit levels to measure available memory on Windows was implemented for two key reasons:
 
 1. **Memory limits for containers in Pods running on Windows nodes are enforced using Commit** (not WorkingSet) **memory**. Windows memory management enforces limits on processes based on the total amount of memory committed, not just the memory in use. 
-This also means that memory limits specified for containers in Kubernetes Pods are enforced on the total amount of virtual memory committed by all processes in the container. Consistenty in how memory usage is tracked and enforced is essential for workload stability.
+This also means that memory limits specified for containers in Kubernetes Pods are enforced on the total amount of virtual memory committed by all processes in the container. Consistency in how memory usage is tracked and enforced is essential for workload stability.
 
 2. **Paging (swap) is automatically enabled on Windows**, and it plays an essential role in the operating system's memory management. Disabling paging is not recommended because it can lead to system instability.
 
 ## Eviction thresholds
 
-By default, Windows nodes have a default "hard" eviction threadhold of `--eviction-hard=memory.available<500Mi`. This means that if the system's availalbe memory is less than 500 Mi the Kubelet will try and start evicting pods.
+By default, Windows nodes have a default "hard" eviction threshold of `--eviction-hard=memory.available<500Mi`. This means that if the system's availalbe memory is less than 500 Mi the Kubelet will try and start evicting pods.
 
 For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
 
@@ -58,7 +58,7 @@ kubectl get --raw http://<cluster-endpoint>/api/v1/nodes/<node-name>/proxy/stats
 
 {
  "node": {
-  "nodeName": "{node-name},
+  "nodeName": "<node-name>",
   "systemContainers": [
    ...
    {

--- a/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
+++ b/content/en/blog/_posts/Windows-Memory-Pressure-Eviction.md
@@ -2,7 +2,6 @@
 layout: blog
 title: "Windows Memory Pressure Eviction"
 slug: windows-memory-pressure-eviction
-canonicalUrl: TBD
 date: TBD
 author: >
   Mark Rossetti (Microsoft)
@@ -10,25 +9,27 @@ author: >
 
 In Kubernetes 1.31, support for memory-pressure based eviction was added for Windows nodes.
 
-This post describes what these changes mean for you and how they may differ from usage on Linux nodes.
+This post provides an in-depth look at how memory-pressure-based evictions are implemented for Windows nodes in Kubernetes and highlights key differences from implementations on Linux-based systems.
 
-## How Memory Pressure Eviction Works on Windows Nodes
+## How memory pressure eviction works on Windows nodes
 
-Kubernetes nodes can be configured to report memory pressure when the available memory falls below a defined threshold (either a percentage of the total node memory or a specific value). When this signal is raised, the kubelet attempts to evict pods to maintain stability on the node.
+Kubernetes nodes can be configured to report memory pressure when the available memory falls below a defined threshold (either a percentage of the total node memory or a specific value). When this signal is raised, the kubelet attempts to evict Pods to maintain stability on the node.
 
-For Windows, the available memory is derived from the node's global memory commit levels, which are queried through the [GetPerformanceInfo()](https://](https://learn.microsoft.com/windows/win32/api/psapi/nf-psapi-getperformanceinfo)) system call. Available memory is calculated by subtracting the node's global `CommitTotal` (the amount of memory committed by all processes on the node) from the `CommitLimit` (the total amount of virtual memory that can be committed without extending the page file(s) on the node).
+For Windows, the available memory is derived from the node's global memory commit levels, which are queried through the [GetPerformanceInfo()](https://learn.microsoft.com/windows/win32/api/psapi/nf-psapi-getperformanceinfo) system call. Available memory is calculated by subtracting the node's global `CommitTotal` (the amount of memory committed by all processes on the node) from the `CommitLimit` (the total amount of virtual memory that can be committed without extending the page file(s) on the node).
 
-> Important note: The `CommitLimit` (capacity) can change dynamically based on current memory usage if Windows is configured to automatically adjust page file sizes, which is the default behavior on Windows Client machines.
+{{< note >}}
+The `CommitLimit` (capacity) can change dynamically based on current memory usage if Windows is configured to automatically adjust page file sizes, which is the default behavior on Windows Client machines.
+{{< /note >}}
 
-This approach differs from Linux, where available memory is reported based on **Working Set** memory usage.
+This approach differs from Linux, where available memory is reported based on _Working Set_ memory usage.
 
-## Why Use Commit Memory on Windows?
+## Why use commit memory on Windows?
 
-Before diving into the reasons for using commit memory on Windows for eviction signalling, it's helpful to understand the difference between **Working Set** and **Commit** memory.
+Before diving into the reasons for using commit memory on Windows for eviction signalling, it's helpful to understand the difference between _Working Set_ and _Commit_ memory.
 
-**Working Set** memory represents the amount of physical memory currently used by processes. It includes the pages of memory that are actively in use and exludes memory pages that have been swapped out to disk (if paging is enabled).
+_Working Set_ memory represents the amount of physical memory currently used by processes. It includes the pages of memory that are actively in use and exludes memory pages that have been swapped out to disk (if paging is enabled).
 
-**Commit** memory, on the other hand, represents the total amount of virtual memory that has been reserved by processes - including memory that has been swapped out to disk. When memory is "committed", it means that the system has allocated the backing storage (either physical RAM or space in the paging file(s)) to ensure that the memory will be available if needed.
+_Commit_ memory, on the other hand, represents the total amount of virtual memory that has been reserved by processes - including memory that has been swapped out to disk. When memory is "committed", it means that the system has allocated the backing storage (either physical RAM or space in the paging file(s)) to ensure that the memory will be available if needed.
 
 Using global commit levels to measure available memory on Windows was implemented for two key reasons:
 
@@ -37,23 +38,23 @@ This also means that memory limits specified for containers in Kubernetes Pods a
 
 2. **Paging (swap) is automatically enabled on Windows**, and it plays an essential role in the operating system's memory management. Disabling paging is not recommended because it can lead to system instability.
 
-## Eviction Thresholds
+## Eviction thresholds
 
 By default, Windows nodes have a default "hard" eviction threadhold of `--eviction-hard=memory.available<500Mi`. This means that if the system's availalbe memory is less than 500 Mi the Kubelet will try and start evicting pods.
 
-For more information on configuring memory-pressure based eviction and understanding the eviction signals and threadhols, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
+For more information on configuring memory-pressure based eviction and understanding the eviction signals and thresholds, refer to the official Kubernetes documentation on [memory-pressure-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds).
 
 
-## Monitoring Commit Memory for Windows nodes
+## Monitoring commit memory for Windows nodes
 
-Understanding the distinction between **Working Set** and **Commit** memory and being able to monitor both is critical for maintaining the stability of individual Pod workloads and the entire Windows node.
+Understanding the distinction between _Working Set_ and _Commit_ memory and being able to monitor both is critical for maintaining the stability of individual Pod workloads and the entire Windows node.
 
-Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its Commit limit, even when the WorkingSet appears to be well within the expected bounds. This discrepancy can lead to confusion.
+Currently, `kubectl top` continues to report Working Set memory. As a result, a Pod may be evicted for exceeding its memory requests or encounter memory allocation failures due to exceeding its `CommitLimit`, even when the WorkingSet appears to be well within the expected bounds. This discrepancy can lead to confusion.
 
-Starting with v1.31, Windows nodes now report the global `CommitTotal` and `CommitLimit` for each node through the `/stats/summary` API endpoint. This information is available under the `windows-global-commit-memory` syscontainer.
+Starting with v1.31, Windows nodes now report the global `CommitTotal` and `CommitLimit` for each node through the `/stats/summary` API endpoint. This information is available under the `windows-global-commit-memory` syscontainer API resource.
 
 ```json=
-kubectl get --raw http://{cluster-endpoint}/api/v1/nodes/{node-name}/proxy/stats/summary
+kubectl get --raw http://<cluster-endpoint>/api/v1/nodes/<node-name>/proxy/stats/summary
 
 {
  "node": {
@@ -75,11 +76,10 @@ kubectl get --raw http://{cluster-endpoint}/api/v1/nodes/{node-name}/proxy/stats
 
 ```
 
+Additionally, exposing the _Commit_ memory usage for individial Pods and Containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
 
-Additionally, exposing the Commit usage for individial Pods and Containers through the `/stats/summary` API is being worked on as part of the [cAdvisor-les, CRI-full Container and Pod Stats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2371-cri-pod-container-stats/README.md) enhancement.
+[windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on _Commit_ memory usage today.
 
-[windows-exporter](https://github.com/prometheus-community/windows_exporter) can also be configured to monitor and report on Commit memory usage.
-
-## Additional Resources
+## Additional resources
 
 To gain a deeper understanding of how memory is managed on Windows, you may also find this article on [Physical and Virtual Memory in Windows 10](https://answers.microsoft.com/en-us/windows/forum/all/physical-and-virtual-memory-in-windows-10/e36fb5bc-9ac8-49af-951c-e7d39b979938) helpful.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Support for memory-pressure based eviction for Windows nodes was added in K8s v1.31. 
Documentation on k8s.io website was added with https://github.com/kubernetes/website/pull/47306 but would also like to publish a blog post to cover some of the more Windows specific behaviors

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

/sig windows
