### PR TITLE
Remove incorrect/vague explanation of probe config

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -397,9 +397,8 @@ liveness and readiness checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started before startup,
   liveness or readiness probes are initiated. If a startup  probe is defined, liveness and
-  readiness probe delays do not begin until the startup probe has succeeded. If the value of
-  `periodSeconds` is greater than `initialDelaySeconds` then the `initialDelaySeconds` will be
-  ignored. Defaults to 0 seconds. Minimum value is 0.
+  readiness probe delays do not begin until the startup probe has succeeded. Defaults to 0
+  seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
   The minimum value is 1.
   While a container is not Ready, the `ReadinessProbe` may be executed at times other than

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -397,8 +397,10 @@ liveness and readiness checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started before startup,
   liveness or readiness probes are initiated. If a startup  probe is defined, liveness and
-  readiness probe delays do not begin until the startup probe has succeeded. Defaults to 0
-  seconds. Minimum value is 0.
+  readiness probe delays do not begin until the startup probe has succeeded.
+  `initialDelaySeconds` will block probes, but `periodSeconds` remains active. The probe may
+  be initiated at a time after `initialDelaySeconds` has elapsed.
+  Defaults to 0 seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
   The minimum value is 1.
   While a container is not Ready, the `ReadinessProbe` may be executed at times other than

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -396,10 +396,12 @@ have a number of fields that you can use to more precisely control the behavior 
 liveness and readiness checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started before startup,
-  liveness or readiness probes are initiated. If a startup  probe is defined, liveness and
+  liveness or readiness probes are initiated. If a startup probe is defined, liveness and
   readiness probe delays do not begin until the startup probe has succeeded.
-  `initialDelaySeconds` will block probes, but `periodSeconds` remains active. The probe may
-  be initiated at a time after `initialDelaySeconds` has elapsed.
+  An `initialDelaySeconds` value greater than 0 will delay when the first probe starts. If
+  the value of `periodSeconds` is greater than `initialDelaySeconds` then `periodSeconds`
+  intervals remain effective. For example, if `initialDelaySeconds` is set to 10, but
+  `periodSeconds` is set to 20, periodic probes will still begin after an initial 20 seconds.
   Defaults to 0 seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
   The minimum value is 1.

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -396,13 +396,10 @@ have a number of fields that you can use to more precisely control the behavior 
 liveness and readiness checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started before startup,
-  liveness or readiness probes are initiated. If a startup probe is defined, liveness and
-  readiness probe delays do not begin until the startup probe has succeeded.
-  An `initialDelaySeconds` value greater than 0 will delay when the first probe starts. If
-  the value of `periodSeconds` is greater than `initialDelaySeconds` then `periodSeconds`
-  intervals remain effective. For example, if `initialDelaySeconds` is set to 10, but
-  `periodSeconds` is set to 20, periodic probes will still begin after an initial 20 seconds.
-  Defaults to 0 seconds. Minimum value is 0.
+  liveness or readiness probes are effective. If a startup probe is defined, liveness and
+  readiness probe delays do not begin until the startup probe has succeeded. If the value of
+  `periodSeconds` is greater than `initialDelaySeconds` then the `initialDelaySeconds` will
+  be included in the first period interval. Defaults to 0 seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
   The minimum value is 1.
   While a container is not Ready, the `ReadinessProbe` may be executed at times other than


### PR DESCRIPTION
### Description

Remove the incorrect/vague explanation of `initialDelaySeconds` with `periodSeconds` relation in configure probes. It misleads understanding of`initialDelaySeconds` and `periodSeconds` behavior.
Page: [Configure Liveness, Readiness, Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).

### Issue

Closes: #48519 