### PR TITLE
Ready case studies shortcode for Docsy

### DIFF
--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -3,22 +3,20 @@
 {{ errorf "[%s] No case-studies section found. Create content/%s/case-studies/_index.md"  $.Page.Lang $.Page.Lang }}
 {{ else }}
 {{ $caseStudiesPages := where $caseStudiesSection.Pages "Params.featured" true | first 4 }}
-<section id="talkToUs">
-  <div class="main-section">
-    <h3  style="text-align: center"><a href="/case-studies/" style="color: #3371E3; font-weight: 400">{{ $caseStudiesSection.LinkTitle }}</a></h3>
-    <div id="caseStudiesWrapper">
+<section class="case-studies">
+    <h3><a href="{{ $caseStudiesSection.RelPermalink }}">{{ $caseStudiesSection.LinkTitle }}</a></h3>
+    <div class="case-study-list">
       {{ range $caseStudiesPages }}
-			{{ $logo := .Resources.GetMatch "**{feature,logo}*.svg" }}
-			{{ if not $logo }}
-				{{ $logo = .Resources.GetMatch "**logo*.png" }}
-			{{ end }}
-      <div>
-        {{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ .Title }}">{{ end }}
-        <p>"{{ .Params.quote | truncate 100 }}"</p>
-        <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
-      </div>
-      {{ end }}  
+          {{ $logo := .Resources.GetMatch "**{feature,logo}*.svg" }}
+          {{ if not $logo }}
+              {{ $logo = .Resources.GetMatch "**logo*.png" }}
+          {{ end }}
+          <div>
+            {{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ .Title }}">{{ end }}
+            <p>"{{ .Params.quote | truncate 100 }}"</p>
+            <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
+          </div>
+      {{ end }}
     </div>
-  </div>
 </section>
 {{ end }}


### PR DESCRIPTION
Revise a shortcode that renders a selection of case studies.

This changes the HTML on the site landing page(s), not the rendering within the Case Studies section.

Here's a [preview](https://deploy-preview-48560--kubernetes-io-main-staging.netlify.app/)
 
Helps with issue #41171

/area web-development

