### PR TITLE
glossary: Fix PDB tooltip text

### DIFF
--- a/content/en/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/en/docs/reference/glossary/pod-disruption-budget.md
@@ -4,7 +4,7 @@ title: Pod Disruption Budget
 full-link: /docs/concepts/workloads/pods/disruptions/
 date: 2019-02-12
 short_description: >
- An object that limits the number of {{< glossary_tooltip text="Pods" term_id="pod" >}} of a replicated application, that are down simultaneously from voluntary disruptions.
+ An object that limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions.
 
 aka:
  - PDB
@@ -17,8 +17,8 @@ tags:
 
  A [Pod Disruption Budget](/docs/concepts/workloads/pods/disruptions/) allows an 
  application owner to create an object for a replicated application, that ensures 
- a certain number or percentage of Pods with an assigned label will not be voluntarily
- evicted at any point in time.
+ a certain number or percentage of {{< glossary_tooltip text="Pods" term_id="pod" >}}
+ with an assigned label will not be voluntarily evicted at any point in time.
 
 <!--more--> 
 


### PR DESCRIPTION

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The tooltip text for the Pod Disruption Budget term renders incorrectly due to the templating of the "Pod" term within the `short_description`. This can be observed by hovering the cursor over the "PodDisruptionBudget" term on the following page: https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/

<img width="640" alt="Screenshot 2024-10-28 at 15 37 55" src="https://github.com/user-attachments/assets/771687d0-5744-4e63-bea3-d62ef11fbba6">

Fix the issue by replacing the templated text with the literal word "Pod" for the English and Chinese versions of the documentation. Also slightly modify the wording to align with the full description on the following page: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #