### PR TITLE
Replace resources.ToCSS with css.Sass due to deprecation of the former

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -36,7 +36,7 @@
 
 {{- if .Params.case_study_styles }}
   {{ $cssOutput := "css/case-studies.css" }}
-  {{ $caseStudiesCSS := resources.Get "scss/_case-studies.scss" | resources.ToCSS }}
+  {{ $caseStudiesCSS := resources.Get "scss/_case-studies.scss" | css.Sass }}
   {{ if $inServerMode }}
     <link rel="stylesheet" href="{{ $caseStudiesCSS.RelPermalink }}">
   {{ else }}


### PR DESCRIPTION
### Description

> Start building sites … 
hugo v0.134.2+extended darwin/arm64 BuildDate=2024-09-10T10:46:33Z VendorInfo=brew
> 
>WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #