### PR TITLE
Fix broken link in 'AnonymousAuthConfigurableEndpoints' feature gate file

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/anonymous-auth-configurable-endpoints.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/anonymous-auth-configurable-endpoints.md
@@ -10,5 +10,5 @@ stages:
     defaultValue: false
     fromVersion: "1.31"
 ---
-Enable [configurable endpoints for anonymous auth](/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-onfiguration) 
+Enable [configurable endpoints for anonymous auth](/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration) 
 for the API server.


### PR DESCRIPTION
Fixes the broken link to https://kubernetes.io//docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration in `AnonymousAuthConfigurableEndpoints` feature gate description [file](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/command-line-tools-reference/feature-gates/anonymous-auth-configurable-endpoints.md).

```diff
- https://kubernetes.io//docs/reference/access-authn-authz/authentication/#anonymous-authenticator-onfiguration
+ https://kubernetes.io//docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
```