### PR TITLE
Mark TopologyManagerPolicyOptions as GA in v1.32

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/topology-manager-policy-options.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/topology-manager-policy-options.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.28"
+    toVersion: "1.31"
+  - stage: stable
+    defaultValue: true    
+    fromVersion: "1.32"
+
 ---
 Enable [fine-tuning](/docs/tasks/administer-cluster/topology-manager/#topology-manager-policy-options)
 of topology manager policies.

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -221,14 +221,9 @@ You can toggle groups of options on and off based upon their maturity level usin
 * `TopologyManagerPolicyBetaOptions` default enabled. Enable to show beta-level options.
 * `TopologyManagerPolicyAlphaOptions` default disabled. Enable to show alpha-level options.
 
-You will still have to enable each option using the `TopologyManagerPolicyOptions` kubelet option.
-
 ### `prefer-closest-numa-nodes` (beta) {#policy-option-prefer-closest-numa-nodes}
 
-The `prefer-closest-numa-nodes` option is beta since Kubernetes 1.28. In Kubernetes {{< skew currentVersion >}}
-this policy option is visible by default provided that the `TopologyManagerPolicyOptions` and
-`TopologyManagerPolicyBetaOptions` [feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
-are enabled.
+The `prefer-closest-numa-nodes` option is GA'ed since Kubernetes 1.32.
 
 The Topology Manager is not aware by default of NUMA distances, and does not take them into account when making
 Pod admission decisions. This limitation surfaces in multi-socket, as well as single-socket multi NUMA systems,


### PR DESCRIPTION
The `prefer-closest-numa-nodes` option is also GA'ed in v1.32. See upstream PR for details.

Upstream PR: https://github.com/kubernetes/kubernetes/pull/128124
Status: merged