### PR TITLE
Fix: improve clarity and formatting in liveness, readiness, and startup probes documentation

### DIFF
--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -16,22 +16,21 @@ Kubernetes has various types of probes:
 
 ## Liveness probe
 
-Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock, when an application is running, but unable to make progress.
+Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock when an application is running but unable to make progress.
 
 If a container fails its liveness probe repeatedly, the kubelet restarts the container.
 
-Liveness probes do not wait for readiness probes to succeed. If you want to wait before
-executing a liveness probe you can either define `initialDelaySeconds`, or use a
+Liveness probes do not wait for readiness probes to succeed. If you want to wait before executing a liveness probe, you can either define `initialDelaySeconds` or use a
 [startup probe](#startup-probe).
 
 
 ## Readiness probe
 
-Readiness probes determine when a container is ready to start accepting traffic. This is useful when waiting for an application to perform time-consuming initial tasks, such as establishing network connections, loading files, and warming caches. 
+Readiness probes determine when a container is ready to start accepting traffic. This is useful when waiting for an application to perform time-consuming initial tasks, such as establishing network connections, loading files, and warming caches.
 
 If the readiness probe returns a failed state, Kubernetes removes the pod from all matching service endpoints.
 
-Readiness probes runs on the container during its whole lifecycle.
+Readiness probes run on the container during its whole lifecycle.
 
 
 ## Startup probe

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -340,7 +340,7 @@ startupProbe:
 ```
 
 Thanks to the startup probe, the application will have a maximum of 5 minutes
-(30 * 10 = 300s) to finish its startup.
+(30 \* 10 = 300s) to finish its startup.
 Once the startup probe has succeeded once, the liveness probe takes over to
 provide a fast response to container deadlocks.
 If the startup probe never succeeds, the container is killed after 300s and
@@ -495,9 +495,9 @@ startupProbe:
 ```
 
 {{< note >}}
-When the kubelet probes a Pod using HTTP, it only follows redirects if the redirect   
+When the kubelet probes a Pod using HTTP, it only follows redirects if the redirect
 is to the same host. If the kubelet receives 11 or more redirects during probing, the probe is considered successful
-and a related Event is created:  
+and a related Event is created:
 
 ```none
 Events:
@@ -508,7 +508,7 @@ Events:
   Normal   Pulled        24m                     kubelet            Successfully pulled image "docker.io/kennethreitz/httpbin" in 5m12.402735213s
   Normal   Created       24m                     kubelet            Created container httpbin
   Normal   Started       24m                     kubelet            Started container httpbin
- Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects  
+ Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects
 ```
 
 If the kubelet receives a redirect where the hostname is different from the request, the outcome of the probe is treated as successful and kubelet creates an event to report the redirect failure.

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -340,7 +340,7 @@ startupProbe:
 ```
 
 Thanks to the startup probe, the application will have a maximum of 5 minutes
-(30 \* 10 = 300s) to finish its startup.
+(30 * 10 = 300s) to finish its startup.
 Once the startup probe has succeeded once, the liveness probe takes over to
 provide a fast response to container deadlocks.
 If the startup probe never succeeds, the container is killed after 300s and


### PR DESCRIPTION

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This pull request includes several minor changes to the documentation in the Kubernetes project, specifically focusing on improving the clarity and correctness of the text.

Documentation improvements:

* Corrected the phrasing in the description of liveness probes to improve readability (`content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md`).
* Fixed the grammar in the explanation of readiness probes to ensure proper verb agreement (`content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md`).
* Adjusted the formatting of a mathematical expression in the startup probe documentation to enhance clarity (`content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md`).

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: N/A