### PR TITLE
Create new task for building basic daemon set

### DIFF
--- a/content/en/docs/tasks/manage-daemon/create-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/create-daemon-set.md
@@ -1,0 +1,65 @@
+---
+title: Building a Basic DaemonSet  
+content_type: task  
+weight: 5  
+---
+<!-- overview -->
+
+This page demonstrates how to build a basic {{< glossary_tooltip text="DaemonSet" term_id="daemonset" >}} that runs a Pod on every node in a Kubernetes cluster.
+It covers a simple use case of mounting a file from the host, logging its contents using
+an [init container](/docs/concepts/workloads/pods/init-containers/), and utilizing a pause container.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+A Kubernetes cluster with at least two nodes (one control plane node and one worker node) to demonstrate the behavior of DaemonSets.
+
+## Define the DaemonSet
+
+In this task, a basic DaemonSet is created which ensures that the copy of a Pod is scheduled on every node.
+The Pod will use an init container to read and log the contents of `/etc/machine-id` from the host,
+while the main container will be a `pause` container, which keeps the Pod running.
+
+{{% code_sample file="application/basic-daemonset.yaml" %}}
+
+1. Create a DaemonSet based on the (YAML) manifest:
+
+  ```shell
+  kubectl apply -f https://k8s.io/examples/application/basic-daemonset.yaml
+  ```
+
+1. Once applied, you can verify that the DaemonSet is running a Pod on every node in the cluster:
+
+  ```shell
+  kubectl get pods -o wide
+  ```
+
+  The output will list one Pod per node, similar to:
+
+  ```
+  NAME                                READY   STATUS    RESTARTS   AGE    IP       NODE
+  example-daemonset-xxxxx             1/1     Running   0          5m     x.x.x.x  node-1
+  example-daemonset-yyyyy             1/1     Running   0          5m     x.x.x.x  node-2
+  ```
+
+1. You can inspect the contents of the logged `/etc/machine-id` file by checking the log directory mounted from the host:
+
+  ```shell
+  kubectl exec <pod-name> -- cat /var/log/machine-id.log
+  ```
+  
+  Where `<pod-name>` is the name of one of your Pods.
+
+## {{% heading "cleanup" %}}
+
+  ```
+  kubectl delete --cascade=foreground --ignore-not-found --now daemonsets/example-daemonset
+  ```
+
+This simple DaemonSet example introduces key components like init containers and host path volumes,
+which can be expanded upon for more advanced use cases. For more details refer to
+[DaemonSet](/docs/concepts/workloads/controllers/daemonset/).
+
+
+

--- a/content/en/examples/application/basic-daemonset.yaml
+++ b/content/en/examples/application/basic-daemonset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-daemonset
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: example
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: example
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause
+      initContainers:
+      - name: log-machine-id
+        image: busybox:1.37
+        command: ['sh', '-c', 'cat /etc/machine-id > /var/log/machine-id.log']
+        volumeMounts:
+        - name: machine-id
+          mountPath: /etc/machine-id
+          readOnly: true
+        - name: log-dir
+          mountPath: /var/log
+      volumes:
+      - name: machine-id
+        hostPath:
+          path: /etc/machine-id
+          type: File
+      - name: log-dir
+        hostPath:
+          path: /var/log


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
* This PR adds a new page to the Kubernetes documentation under the "Manage Daemon" tasks section. The new guide provides a step-by-step process for creating a basic DaemonSet that:

    * Mounts `/etc/machine-id` from the host as a read-only volume. 
    * Logs the machine ID using an init container.
    * Uses a pause container as the main container.

* This guide helps users understand how to get started with DaemonSets, focusing on key features like init containers and host path volumes. The task is designed to demonstrate a simple, functional DaemonSet running on all nodes in a cluster, providing an easy-to-follow introduction to DaemonSets.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #48438