### PR TITLE
Fix: Small typo on node.kubernetes.io/out-of-service taint

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1609,7 +1609,7 @@ to determine if the node condition and taint should be added/removed.
 
 Type: Taint
 
-Example: `node.kubernetes.io/out-of-service:NoExecute`
+Example: `node.kubernetes.io/out-of-service: "NoExecute"`
 
 Used on: Node
 


### PR DESCRIPTION
Just a really small typo fix...