### PR TITLE
[zh-cn]sync liveness-readiness-startup-probes configure-liveness-readiness-startup-probes

### DIFF
--- a/content/zh-cn/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/zh-cn/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -29,7 +29,7 @@ Kubernetes 提供了多种探针：
 <!--
 ## Liveness probe
 
-Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock, when an application is running, but unable to make progress.
+Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock when an application is running, but unable to make progress.
 -->
 ## 存活探针   {#liveness-probe}
 
@@ -42,8 +42,7 @@ If a container fails its liveness probe repeatedly, the kubelet restarts the con
 如果一个容器的存活探针失败多次，kubelet 将重启该容器。
 
 <!--
-Liveness probes do not wait for readiness probes to succeed. If you want to wait before
-executing a liveness probe you can either define `initialDelaySeconds`, or use a
+Liveness probes do not wait for readiness probes to succeed. If you want to wait before executing a liveness probe, you can either define `initialDelaySeconds`, or use a
 [startup probe](#startup-probe).
 -->
 存活探针不会等待就绪探针成功。
@@ -52,7 +51,7 @@ executing a liveness probe you can either define `initialDelaySeconds`, or use a
 <!--
 ## Readiness probe
 
-Readiness probes determine when a container is ready to start accepting traffic. This is useful when waiting for an application to perform time-consuming initial tasks, such as establishing network connections, loading files, and warming caches. 
+Readiness probes determine when a container is ready to start accepting traffic. This is useful when waiting for an application to perform time-consuming initial tasks, such as establishing network connections, loading files, and warming caches.
 -->
 ## 就绪探针   {#readiness-probe}
 
@@ -62,7 +61,7 @@ Readiness probes determine when a container is ready to start accepting traffic.
 <!--
 If the readiness probe returns a failed state, Kubernetes removes the pod from all matching service endpoints.
 
-Readiness probes runs on the container during its whole lifecycle.
+Readiness probes run on the container during its whole lifecycle.
 -->
 如果就绪探针返回的状态为失败，Kubernetes 会将该 Pod 从所有对应服务的端点中移除。
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -805,7 +805,7 @@ startupProbe:
 
 {{< note >}}
 <!--
-When the kubelet probes a Pod using HTTP, it only follows redirects if the redirect   
+When the kubelet probes a Pod using HTTP, it only follows redirects if the redirect
 is to the same host. If the kubelet receives 11 or more redirects during probing, the probe is considered successful
 and a related Event is created:
 -->
@@ -821,7 +821,7 @@ Events:
   Normal   Pulled        24m                     kubelet            Successfully pulled image "docker.io/kennethreitz/httpbin" in 5m12.402735213s
   Normal   Created       24m                     kubelet            Created container httpbin
   Normal   Started       24m                     kubelet            Started container httpbin
- Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects  
+ Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects
 ```
 
 <!--


### PR DESCRIPTION
content/zh-cn/docs/concepts/configuration/liveness-readiness-startup-probes.md