### PR TITLE
Taints in kubernetes.io and k8s.io namespace are also reserved

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -13,7 +13,7 @@ card:
 
 <!-- overview -->
 
-Kubernetes reserves all labels and annotations in the `kubernetes.io` and `k8s.io` namespaces.
+Kubernetes reserves all labels, annotations and taints in the `kubernetes.io` and `k8s.io` namespaces.
 
 This document serves both as a reference to the values and as a coordination point for assigning values.
 


### PR DESCRIPTION
### Description

I assume this is an oversight in the phrasing. If taints are in fact **not** reserved, this still should change, but then I suppose it would not be a documentation issue only.
