### PR TITLE
Fix EncryptionConfiguration indentation

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/storage-version-migration.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/storage-version-migration.md
@@ -50,9 +50,9 @@ read [enable or disable a Kubernetes API](/docs/tasks/administer-cluster/enable-
     - secrets
     providers:
     - aescbc:
-      keys:
-      - name: key1
-        secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
   ```
 
   Make sure to enable automatic reload of encryption
@@ -77,13 +77,13 @@ read [enable or disable a Kubernetes API](/docs/tasks/administer-cluster/enable-
     - secrets
     providers:
     - aescbc:
-      keys:
-      - name: key2
-        secret: c2VjcmV0IGlzIHNlY3VyZSwgaXMgaXQ/
+        keys:
+        - name: key2
+          secret: c2VjcmV0IGlzIHNlY3VyZSwgaXMgaXQ/
     - aescbc:
-      keys:
-      - name: key1
-        secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
   ```
 
 - To ensure that previously created secret `my-secret` is re-encrypted


### PR DESCRIPTION
### Description

There was a mistake in the indentation of the EncryptionConfiguation. This commit fixes that. The correct indentation level for the "keys" can be seen in the reference docs here: https://kubernetes.io/docs/reference/config-api/apiserver-config.v1/#apiserver-config-k8s-io-v1-EncryptionConfiguration
