### PR TITLE
Clarify image pull secret documentation

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -261,7 +261,7 @@ Credentials can be provided in several ways:
   - all pods can use any images cached on a node
   - requires root access to all nodes to set up
 - Specifying ImagePullSecrets on a Pod
-  - only pods which provide own keys can access the private registry
+  - only pods which provide their own keys can access the private registry
 - Vendor-specific or local extensions
   - if you're using a custom node configuration, you (or your cloud
     provider) can implement your mechanism for authenticating the node

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -239,7 +239,7 @@ Events:
 ## Using images from multiple registries
 
 A pod can have multiple containers, each container image can be from a different registry.
-You can use multiple pull secrets with one pod, and pull secrets can contain multiple credentials.
+You can use multiple `imagePullSecrets` with one pod, and each can contain multiple credentials.
 
 The image pull will be attempted using each credential that matches the registry.
 If no credentials match the registry, the image pull will be attempted without authorization.

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -227,8 +227,6 @@ kubectl describe pod private-reg
 
 If you then see an event with the reason set to `FailedToRetrieveImagePullSecret`,
 Kubernetes can't find a Secret with name (`regcred`, in this example).
-If you specify that a Pod needs image pull credentials, the kubelet checks that it can
-access that Secret before attempting to pull the image.
 
 Make sure that the Secret you have specified exists, and that its name is spelled properly.
 ```shell
@@ -237,6 +235,14 @@ Events:
        ------                                -------
   ...  FailedToRetrieveImagePullSecret  ...  Unable to retrieve some image pull secrets (<regcred>); attempting to pull the image may not succeed.
 ```
+
+## Using images from multiple registries
+
+A pod can have multiple containers, each container image can be from a different registry.
+You can use multiple pull secrets with one pod, and pull secrets can contain multiple credentials.
+
+The image pull will be attempted using each credential that matches the registry.
+If no credentials match the registry, the image pull will be attempted without authorization.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -242,7 +242,7 @@ A pod can have multiple containers, each container image can be from a different
 You can use multiple `imagePullSecrets` with one pod, and each can contain multiple credentials.
 
 The image pull will be attempted using each credential that matches the registry.
-If no credentials match the registry, the image pull will be attempted without authorization.
+If no credentials match the registry, the image pull will be attempted without authorization or using custom runtime specific configuration.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The statement about missing pull secrets is incorrect, the kubelet will still attempt to pull the image if a pull secret is missing.

Added some information about how multiple pull secrets are handled.

### Issue

Closes: n/a