### PR TITLE
Drop Luc Perkins as Dockerfile maintainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 
 FROM docker.io/library/golang:1.23.0-alpine3.20
 
-LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"
-
 RUN apk add --no-cache \
     curl \
     gcc \


### PR DESCRIPTION
Luc no longer works for the CNCF. Drop the `maintainer` label on our container images.