### PR TITLE
Container build: use npm ci over packages files and fix build cmd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 **
+!package.json
+!package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN apk add --no-cache \
     git \
     openssh-client \
     rsync \
-    npm && \
-    npm install -D autoprefixer postcss-cli
+    npm
 
 RUN mkdir -p /var/hugo && \
     addgroup -Sg 1000 hugo && \
@@ -43,6 +42,8 @@ RUN mkdir -p /var/hugo && \
 COPY --from=0 /go/bin/hugo /usr/local/bin/hugo
 
 WORKDIR /src
+COPY package.json package-lock.json ./
+RUN npm ci
 
 USER hugo:hugo
 


### PR DESCRIPTION
In addition to fixing the issue named below, this PR has the **container use the project's specified NPM dependencies**, rather than using a separate list, keeping things DRY.

- Fixes #48739
- Updates Dockerfile to:
  - Copy the project's `package.json package-lock.json` files
  - Run `npm ci` ... so that Hugo commands from the container use the same NPM packages we do in local development.
- Fixes `container-build`, and changes the command so that it **writes to the local `public` folder**, making it **easier to debug** generated files (without this change, the container build command fails because it can't write to `./public` -- which means the only other alternative would be to write to another container-only folder such as `/tmp/public`, but I think that the solution proposed here is better).