### PR TITLE
added a tabs for the Linux,  macOS and  Windows

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -260,11 +260,24 @@ This produces a signed serving certificate file, `ca-signed-server.pem`.
 
 Finally, populate the signed certificate in the API object's status:
 
-```shell
+{{< tabs name="Upload the signed certificate" >}}
+{{< tab name="Linux" codelang="bash" >}}
+    kubectl get csr my-svc.my-namespace -o json | \
+  jq '.status.certificate = "'$(base64 ca-signed-server.pem | tr -d '\n')'"' | \
+  kubectl replace --raw /apis/certificates.k8s.io/v1/certificatesigningrequests/my-svc.my-namespace/status -f -
+{{< /tab >}}
+{{< tab name="macOS" codelang="bash" >}}
+  kubectl get csr my-svc.my-namespace -o json | \
+  jq '.status.certificate = "'$(base64 -i ca-signed-server.pem | tr -d '\n')'"' | \
+  kubectl replace --raw /apis/certificates.k8s.io/v1/certificatesigningrequests/my-svc.my-namespace/status -f -
+{{< /tab >}}
+{{< tab name="Windows" codelang="bash" >}}
 kubectl get csr my-svc.my-namespace -o json | \
   jq '.status.certificate = "'$(base64 ca-signed-server.pem | tr -d '\n')'"' | \
   kubectl replace --raw /apis/certificates.k8s.io/v1/certificatesigningrequests/my-svc.my-namespace/status -f -
-```
+{{< /tab >}}
+{{< /tabs >}}
+
 
 {{< note >}}
 This uses the command line tool [`jq`](https://jqlang.github.io/jq/) to populate the base64-encoded


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
TLS certificate management task assumes Linux-style base64 command 
added a tabs for the Linux,  macOS and  Windows
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
#48586
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
