### PR TITLE
Correcting Style Guide Headings and Titles section

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -511,7 +511,7 @@ Use pound or hash signs (`#`) for non-blog post content. | Use underlines (`---`
 Use sentence case for headings in the page body. For example, **Extend kubectl with plugins** | Use title case for headings in the page body. For example, **Extend Kubectl With Plugins**
 Use title case for the page title in the front matter. For example, `title: Kubernetes API Server Bypass Risks` | Use sentence case for page titles in the front matter. For example, don't use `title: Kubernetes API server bypass risks`
 Place relevant links in the body copy. | Include hyperlinks (`<a href=""></a>`) in headings.
-Use proper heading markers (`---` or `===`) to indicate headings. | Use **bold** text or other indicators to split paragraphs.
+Use pound or hash signs (`#`) to indicate headings. | Use **bold** text or other indicators to split paragraphs.
 {{< /table >}}
 
 ### Paragraphs


### PR DESCRIPTION

### Description

Correcting headings style guide recommendation in Headings & Titles section (use `#` not `---` or `===`) to be consistent with earlier guidance.

### Issue

Follow up to: https://github.com/kubernetes/website/pull/48667