### PR TITLE
Localize accessibility text in sidebar nav

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -597,6 +597,9 @@ other = "Changelog"
 [seealso_heading]
 other = "See Also"
 
+[sidebar_toggle_nav]
+other = "Toggle section navigation"
+
 [subscribe_button]
 other = "Subscribe"
 

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -4,14 +4,14 @@
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fa-solid fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fa-solid fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="{{ T "sidebar_toggle_nav" }}">
     </button>
   </form>
   {{ else -}}
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fa-solid fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fa-solid fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="{{ T "sidebar_toggle_nav" }}">
     </button>
   </form>
   </div>


### PR DESCRIPTION
Allow localizing labels that are used in the sidebar navigation to help accessibility.

Helps with https://github.com/kubernetes/website/issues/49298

Split out from https://github.com/kubernetes/website/pull/48721
/area localization
/area web-development

We could also contribute this to Docsy