### PR TITLE
Remove an invalid published date in front matter of blog

### DIFF
--- a/content/en/blog/_posts/2018-01-00-Reporting-Errors-Using-Kubernetes-Events.md
+++ b/content/en/blog/_posts/2018-01-00-Reporting-Errors-Using-Kubernetes-Events.md
@@ -1,7 +1,6 @@
 ---
 title: "Reporting Errors from Control Plane to Applications Using Kubernetes Events"
 date: 2018-01-25
-published: true
 slug: reporting-errors-using-kubernetes-events
 url: /blog/2018/01/Reporting-Errors-Using-Kubernetes-Events
 author: >


### PR DESCRIPTION
As requested in issue https://github.com/kubernetes/website/issues/48754 removed an invalid published date in front matter of `content/en/blog/_posts/2018-01-00-Reporting-Errors-Using-Kubernetes-Events.md`.

Sovles part 1 of https://github.com/kubernetes/website/issues/48754