### PR TITLE
(zh-cn) Update an invalid date in its front matter in blog

### DIFF
--- a/content/zh-cn/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md
+++ b/content/zh-cn/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes 1.17：稳定"
-date: 2019-12-09T13：00：00-08：00
+date: 2019-12-09T13:00:00-08:00
 slug: kubernetes-1-17-release-announcement
 evergreen: true
 ---


### PR DESCRIPTION
As requested in issue https://github.com/kubernetes/website/issues/48754 updated `content/zh-cn/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md` has an invalid date in its front matter.


Error to solve  when full error message I got when trying to run make serve with Hugo 

`ERROR the "date" front matter field is not a parsable date: see /Users/sreeram/OSS/kube/kubernetes-website/content/zh-cn/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md`


I have put the same value of date as in English version of same files I found https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md?plain=1



Sovles part 2 of https://github.com/kubernetes/website/issues/48754