### PR TITLE
Fix type parameter in example

### DIFF
--- a/content/en/blog/_posts/2023-12-15-volume-attributes-class/index.md
+++ b/content/en/blog/_posts/2023-12-15-volume-attributes-class/index.md
@@ -68,7 +68,7 @@ If you would like to see the feature in action and verify it works fine in your 
      name: csi-sc-example
    provisioner: pd.csi.storage.gke.io
    parameters:
-     disk-type: "hyperdisk-balanced"
+     type: "hyperdisk-balanced"
    volumeBindingMode: WaitForFirstConsumer
    ```
 


### PR DESCRIPTION
### Description

The blog post doesn't match how the field actually works and trying to use the blog post content as-is results in a failure.
