### PR TITLE
Add deprecation warnings for enforce-mountable-secrets annotation

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -666,16 +666,11 @@ Therefore, one Pod does not have access to the Secrets of another Pod.
 
 ### Configure least-privilege access to Secrets
 
-To enhance the security measures around Secrets, Kubernetes provides a mechanism: you can
-annotate a ServiceAccount as `kubernetes.io/enforce-mountable-secrets: "true"`.
-
-For more information, you can refer to the [documentation about this annotation](/docs/concepts/security/service-accounts/#enforce-mountable-secrets).
+To enhance the security measures around Secrets, use separate namespaces to isolate access to mounted secrets.
 
 {{< warning >}}
 Any containers that run with `privileged: true` on a node can access all
 Secrets used on that node.
-
-`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
 {{< /warning >}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -674,6 +674,8 @@ For more information, you can refer to the [documentation about this annotation]
 {{< warning >}}
 Any containers that run with `privileged: true` on a node can access all
 Secrets used on that node.
+
+`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
 {{< /warning >}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/security/secrets-good-practices.md
+++ b/content/en/docs/concepts/security/secrets-good-practices.md
@@ -62,15 +62,8 @@ recommendations include:
 *  Implement audit rules that alert on specific events, such as concurrent
    reading of multiple Secrets by a single user
 
-#### Additional ServiceAccount annotations for Secret management
-
-You can also use the `kubernetes.io/enforce-mountable-secrets` annotation on
-a ServiceAccount to enforce specific rules on how Secrets are used in a Pod.
-For more details, see the [documentation on this annotation](/docs/reference/labels-annotations-taints/#enforce-mountable-secrets).
-
-{{< warning >}}
-`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
-{{< /warning >}}
+#### Restrict Access for Secrets
+Use separate namespaces to isolate access to mounted secrets.
 
 ### Improve etcd management policies
 

--- a/content/en/docs/concepts/security/secrets-good-practices.md
+++ b/content/en/docs/concepts/security/secrets-good-practices.md
@@ -68,6 +68,10 @@ You can also use the `kubernetes.io/enforce-mountable-secrets` annotation on
 a ServiceAccount to enforce specific rules on how Secrets are used in a Pod.
 For more details, see the [documentation on this annotation](/docs/reference/labels-annotations-taints/#enforce-mountable-secrets).
 
+{{< warning >}}
+`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
+{{< /warning >}}
+
 ### Improve etcd management policies
 
 Consider wiping or shredding the durable storage used by `etcd` once it is

--- a/content/en/docs/concepts/security/service-accounts.md
+++ b/content/en/docs/concepts/security/service-accounts.md
@@ -197,11 +197,13 @@ or using a custom mechanism such as an [authentication webhook](/docs/reference/
 You can also use TokenRequest to obtain short-lived tokens for your external application.
 {{< /note >}}
 
-### Restricting access to Secrets {#enforce-mountable-secrets}
+### Restricting access to Secrets (deprecated) {#enforce-mountable-secrets}
 
-{{< warning >}}
-`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
-{{< /warning >}}
+{{< feature-state for_k8s_version="v1.32" state="deprecated" >}}
+
+{{< note >}}
+`kubernetes.io/enforce-mountable-secrets` is deprecated since Kubernetes v1.32. Use separate namespaces to isolate access to mounted secrets.
+{{< /note >}}
 
 Kubernetes provides an annotation called `kubernetes.io/enforce-mountable-secrets`
 that you can add to your ServiceAccounts. When this annotation is applied,

--- a/content/en/docs/concepts/security/service-accounts.md
+++ b/content/en/docs/concepts/security/service-accounts.md
@@ -199,6 +199,10 @@ You can also use TokenRequest to obtain short-lived tokens for your external app
 
 ### Restricting access to Secrets {#enforce-mountable-secrets}
 
+{{< warning >}}
+`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
+{{< /warning >}}
+
 Kubernetes provides an annotation called `kubernetes.io/enforce-mountable-secrets`
 that you can add to your ServiceAccounts. When this annotation is applied,
 the ServiceAccount's secrets can only be mounted on specified types of resources,

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -789,6 +789,10 @@ Regarding the annotation `kubernetes.io/enforce-mountable-secrets`: While the an
 its enforcement also extends to other ways Secrets are used in the context of a Pod.
 Therefore, it is crucial to ensure that all the referenced secrets are correctly specified in the ServiceAccount.
 
+{{< warning >}}
+`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
+{{< /warning >}}
+
 ### StorageObjectInUseProtection
 
 **Type**: Mutating.

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -785,13 +785,7 @@ The Kubernetes project strongly recommends enabling this admission controller.
 You should enable this admission controller if you intend to make any use of Kubernetes
 `ServiceAccount` objects.
 
-Regarding the annotation `kubernetes.io/enforce-mountable-secrets`: While the annotation's name suggests it only concerns the mounting of Secrets,
-its enforcement also extends to other ways Secrets are used in the context of a Pod.
-Therefore, it is crucial to ensure that all the referenced secrets are correctly specified in the ServiceAccount.
-
-{{< warning >}}
-`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
-{{< /warning >}}
+To enhance the security measures around Secrets, use separate namespaces to isolate access to mounted secrets.
 
 ### StorageObjectInUseProtection
 

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -806,6 +806,10 @@ This annotation is used for describing specific behaviour of given object.
 
 ### kubernetes.io/enforce-mountable-secrets {#enforce-mountable-secrets}
 
+{{< warning >}}
+`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
+{{< /warning >}}
+
 Type: Annotation
 
 Example: `kubernetes.io/enforce-mountable-secrets: "true"`

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -804,17 +804,17 @@ Used on: All Objects
 
 This annotation is used for describing specific behaviour of given object.
 
-### kubernetes.io/enforce-mountable-secrets {#enforce-mountable-secrets}
-
-{{< warning >}}
-`kubernetes.io/enforce-mountable-secrets` is deprecated in v1.32+. Use separate namespaces to isolate access to mounted secrets.
-{{< /warning >}}
+### kubernetes.io/enforce-mountable-secrets (deprecated) {#enforce-mountable-secrets}
 
 Type: Annotation
 
 Example: `kubernetes.io/enforce-mountable-secrets: "true"`
 
 Used on: ServiceAccount
+
+{{< note >}}
+`kubernetes.io/enforce-mountable-secrets` is deprecated since Kubernetes v1.32. Use separate namespaces to isolate access to mounted secrets.
+{{< /note >}}
 
 The value for this annotation must be **true** to take effect.
 When you set this annotation  to "true", Kubernetes enforces the following rules for


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Add warnings for deprecated `kubernetes.io/enforce-mountable-secrets `annotation. Encourage the use of separate namespaces when isolation is desired.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

/sig auth
/cc @liggitt