### PR TITLE
Re-add ABAC deprecation status note

### DIFF
--- a/content/en/docs/reference/access-authn-authz/abac.md
+++ b/content/en/docs/reference/access-authn-authz/abac.md
@@ -14,6 +14,11 @@ Attribute-based access control (ABAC) defines an access control paradigm whereby
 to users through the use of policies which combine attributes together.
 
 <!-- body -->
+{{< note >}}
+{{< feature-state state="deprecated" for_k8s_version="1.6" >}}
+The ABAC Authorization feature has been considered deprecated from the Kubernetes 1.6 release.
+{{< /note >}}
+
 ## Policy File Format
 
 To enable `ABAC` mode, specify `--authorization-policy-file=SOME_FILENAME` and `--authorization-mode=ABAC`


### PR DESCRIPTION
This was handled in the past:  
https://github.com/kubernetes/website/issues/13021   
https://github.com/kubernetes/website/pull/13067/files

But the current page does not mention this:
https://kubernetes.io/docs/reference/access-authn-authz/abac/

So I have added back that note.  