### PR TITLE
Update release schedule with dec '04 patches

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,10 +7,13 @@ schedules:
 - endOfLifeDate: "2025-10-28"
   maintenanceModeStartDate: "2025-08-28"
   next:
-    cherryPickDeadline: "2024-11-15"
+    cherryPickDeadline: "2024-12-06"
+    release: 1.31.4
+    targetDate: "2024-12-10"
+  previousPatches:
+  - cherryPickDeadline: "2024-11-15"
     release: 1.31.3
     targetDate: "2024-11-19"
-  previousPatches:
   - cherryPickDeadline: "2024-10-11"
     release: 1.31.2
     targetDate: "2024-10-22"
@@ -24,10 +27,13 @@ schedules:
 - endOfLifeDate: "2025-06-28"
   maintenanceModeStartDate: "2025-04-28"
   next:
-    cherryPickDeadline: "2024-11-15"
+    cherryPickDeadline: "2024-12-06"
+    release: 1.30.8
+    targetDate: "2024-12-10"
+  previousPatches:
+  - cherryPickDeadline: "2024-11-15"
     release: 1.30.7
     targetDate: "2024-11-19"
-  previousPatches:
   - cherryPickDeadline: "2024-10-11"
     release: 1.30.6
     targetDate: "2024-10-22"
@@ -53,10 +59,13 @@ schedules:
 - endOfLifeDate: "2025-02-28"
   maintenanceModeStartDate: "2024-12-28"
   next:
-    cherryPickDeadline: "2024-11-15"
+    cherryPickDeadline: "2024-12-06"
+    release: 1.29.12
+    targetDate: "2024-12-10"
+  previousPatches:
+  - cherryPickDeadline: "2024-11-15"
     release: 1.29.11
     targetDate: "2024-11-19"
-  previousPatches:
   - cherryPickDeadline: "2024-10-11"
     release: 1.29.10
     targetDate: "2024-10-22"
@@ -92,9 +101,9 @@ schedules:
   release: "1.29"
   releaseDate: "2023-12-13"
 upcoming_releases:
-- cherryPickDeadline: "2024-11-15"
-  targetDate: "2024-11-19"
 - cherryPickDeadline: "2024-12-06"
   targetDate: "2024-12-10"
 - cherryPickDeadline: "2025-01-10"
   targetDate: "2025-01-14"
+- cherryPickDeadline: "2025-02-07"
+  targetDate: "2025-02-11"


### PR DESCRIPTION
### Description

Update the release schedule to reflect the latest patches.


Generated using schedule builder:

```
[puerco@babieco website] on  main 🦆❯ schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml 
INFO Validating options                           
INFO Reading schedule file: data/releases/schedule.yaml 
INFO Parsing schedule                             
INFO Updating schedule                            
INFO Adding release schedule: &{Release:1.31.4 CherryPickDeadline:2024-12-06 TargetDate:2024-12-10 Note:} 
INFO Adding release schedule: &{Release:1.30.8 CherryPickDeadline:2024-12-06 TargetDate:2024-12-10 Note:} 
INFO Adding release schedule: &{Release:1.29.12 CherryPickDeadline:2024-12-06 TargetDate:2024-12-10 Note:} 
INFO Skipping outdated upcoming release for 2024-11-19 
INFO Using existing upcoming release for 2024-12-10 
INFO Using existing upcoming release for 2025-01-14 
INFO Adding new upcoming release for February 2025 
INFO Got 3 new upcoming releases, not adding any more 
INFO Writing end of life branches: data/releases/eol.yaml 
INFO Wrote schedule YAML to: data/releases/schedule.yaml 

```

/cc @kubernetes/release-managers 

### Issue

None
