### PR TITLE
Move misplaced comment outside YAML block in storageclass-aws-ebs.yaml

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -248,6 +248,8 @@ Here is an example StorageClass for the AWS EBS CSI driver:
 
 {{% code_sample language="yaml" file="storage/storageclass/storageclass-aws-ebs.yaml" %}}
 
+`tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes.
+
 ### AWS EFS
 
 To configure AWS EFS storage, you can use the out-of-tree [AWS_EFS_CSI_DRIVER](https://github.com/kubernetes-sigs/aws-efs-csi-driver).

--- a/content/en/examples/storage/storageclass/storageclass-aws-ebs.yaml
+++ b/content/en/examples/storage/storageclass/storageclass-aws-ebs.yaml
@@ -16,4 +16,3 @@ allowedTopologies:
   - key: topology.ebs.csi.aws.com/zone
     values:
     - us-east-2c
-

--- a/content/en/examples/storage/storageclass/storageclass-aws-ebs.yaml
+++ b/content/en/examples/storage/storageclass/storageclass-aws-ebs.yaml
@@ -17,4 +17,3 @@ allowedTopologies:
     values:
     - us-east-2c
 
-# `tagSpecification`: Tags with this prefix are applied to dynamically provisioned EBS volumes.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR corrects a formatting issue in the `StorageClass` YAML configuration where a comment about `tagSpecification` was mistakenly included inside the YAML block. The comment is now moved outside the YAML block for better clarity.

### Changes Made
- Moved the comment about `tagSpecification` outside the YAML block.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #