### PR TITLE
Improve local container development experience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM docker.io/library/debian:bookworm AS builder
 
 LABEL maintainer="Kubernetes Authors https://github.com/kubernetes/website"
 LABEL description="Image for building and serving a the Kubernetes website"
-LABEL version="1.0"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
- Followup to #48741
- Dockerfile improvements inspried by @sftim via https://github.com/kubernetes/website/pull/48722/files,
  built from `debian:bookworm`
- Builds image using the version of Node.js specified in the `netlify.toml` file
- Makefile improvements:
  - `HUGO` and `HUGO_ARGS`, which supports use cases link invoking a container serve with `HUGO_ARGS="--gc"` helping when the serve just hangs.
  - Container builds from the same targets as local builds. Specify the target via `BUILD`