### PR TITLE
clarify container kill/restart scenario

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-qos.md
+++ b/content/en/docs/concepts/workloads/pods/pod-qos.md
@@ -105,7 +105,7 @@ mechanisms that both provide controls over quality of service.
 
 Certain behavior is independent of the QoS class assigned by Kubernetes. For example:
 
-* Any Container exceeding a resource limit will be killed and restarted by the kubelet without
+* Any Container exceeding a memory limit will be killed and restarted by the kubelet without
   affecting other Containers in that Pod.
 
 * If a Container exceeds its resource request and the node it runs on faces


### PR DESCRIPTION
**What this PR does / why we need it:**
* In the **Pod Quality of Service Classes** documentation page, there is a section: [Some behavior is independent of QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#class-independent-behavior) does not clearly mention when the Kubelet kills or restarts a container. Since the Kubelet restarts containers only when they exceed memory limits, this PR adds clarity on that aspect.