### PR TITLE
fixed: update the default value of parameter maxParallelImagePulls

### DIFF
--- a/content/zh-cn/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/zh-cn/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -1684,7 +1684,7 @@ Default: nil
    <p>maxParallelImagePulls 设置并行拉取镜像的最大数量。
 如果 serializeImagePulls 为 true，则无法设置此字段。
 把它设置为 nil 意味着没有限制。</p>
-   <p>默认值：true</p>
+   <p>默认值：nil</p>
 </td>
 </tr>
 <tr><td><code>evictionHard</code><br/>


### PR DESCRIPTION
fixed: update the default value of parameter maxParallelImagePulls
### Description
the original description:
MaxParallelImagePulls sets the maximum number of image pulls in parallel. This field cannot be set if SerializeImagePulls is true. Setting it to nil means no limit. Default: nil

### Issue
Translation error in Chinese version
