### PR TITLE
Tweak script to update release info page

### DIFF
--- a/content/en/releases/release.md
+++ b/content/en/releases/release.md
@@ -11,7 +11,7 @@ This content is auto-generated and links may not function. The source of the doc
 {{% /pageinfo %}}
 <!-- Localization note: omit the pageinfo block when localizing -->
 
-# Targeting enhancements, Issues and PRs to Release Milestones
+## Targeting enhancements, Issues and PRs to Release Milestones
 
 This document is focused on Kubernetes developers and contributors who need to
 create an enhancement, issue, or pull request which targets a specific release

--- a/content/en/releases/release.md
+++ b/content/en/releases/release.md
@@ -3,12 +3,13 @@ title: Kubernetes Release Cycle
 type: docs
 auto_generated: true
 ---
+<!-- THIS CONTENT IS AUTO-GENERATED via https://github.com/kubernetes/website/blob/main/scripts/releng/update-release-info.sh -->
 
-<!-- THIS CONTENT IS AUTO-GENERATED via ./scripts/releng/update-release-info.sh in kubernetes/website -->
-
-{{< warning >}}
-This content is auto-generated and links may not function. The source of the document is located [here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md).
-{{< /warning >}}
+{{% pageinfo color="light" %}}
+This content is auto-generated and links may not function. The source of the document is located
+[here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md).
+{{% /pageinfo %}}
+<!-- Localization note: omit the pageinfo block when localizing -->
 
 # Targeting enhancements, Issues and PRs to Release Milestones
 

--- a/scripts/releng/update-release-info.sh
+++ b/scripts/releng/update-release-info.sh
@@ -10,10 +10,18 @@ auto_generated: true
 ---
 <!-- THIS CONTENT IS AUTO-GENERATED via https://github.com/kubernetes/website/blob/main/scripts/releng/update-release-info.sh -->
 
-{{< warning >}}
-This content is auto-generated and links may not function. The source of the document is located [here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md).
-{{< /warning >}}
+{{% pageinfo color="light" %}}
+This content is auto-generated and links may not function. The source of the document is located
+[here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md).
+{{% /pageinfo %}}
+<!-- Localization note: omit the pageinfo block when localizing -->
 
 EOF
 
 curl --retry 3 https://raw.githubusercontent.com/kubernetes/community/master/contributors/devel/sig-release/release.md >> content/en/releases/release.md
+
+printf "\nDone" 1>&2
+printf "\n" 1>&2 # ensure a new line
+
+printf "You should now 'git add -p' the changes to %q.\n" content/en/releases/release.md
+printf "Some changes require manual checking.\n"


### PR DESCRIPTION
Update the script for fetching [Kubernetes Release Cycle](https://kubernetes.io/releases/release/) and updating it.

- Change the warning to a `pageinfo` shortcode
  - We reserve warning shortcodes for dangerous, never-do-this kind of advice
- Update the fetched page to match
- Change the first heading to a level 2 (the page title becomes a level 1 heading)

/sig release