### PR TITLE
fix: kubelet allowedUnsafeSysctls docs to represent a list

### DIFF
--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -1370,9 +1370,9 @@ Default: [&quot;pods&quot;]</p>
 <code>[]string</code>
 </td>
 <td>
-   <p>A comma separated whitelist of unsafe sysctls or sysctl patterns (ending in <code>*</code>).
+   <p>allowedUnsafeSysctls is the list of unsafe sysctls or sysctl patterns (ending in <code>*</code>).
 Unsafe sysctl groups are <code>kernel.shm*</code>, <code>kernel.msg*</code>, <code>kernel.sem</code>, <code>fs.mqueue.*</code>,
-and <code>net.*</code>. For example: &quot;<code>kernel.msg*,net.ipv4.route.min_pmtu</code>&quot;
+and <code>net.*</code>. For example: <code>[&quot;kernel.msg*&quot;, &quot;net.ipv4.route.min_pmtu&quot;]</code>
 Default: []</p>
 </td>
 </tr>


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
it's no longer a comma separated list once it's part of kubelet config file

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #