### PR TITLE
Fix text not visible in case studies page

### DIFF
--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -39,6 +39,10 @@
     font-weight: 300 !important;
 }
 
+.gridPage .case-study .quote{
+    color: rgb(26,26,26);
+ }
+
 .gridPage #mainContent {
     padding: 0;
 }


### PR DESCRIPTION

### Description

Texts are not visible in case-studies page .

<img width="1233" alt="Screenshot 2024-11-26 at 1 47 25 AM" src="https://github.com/user-attachments/assets/51f513b3-a530-42e7-a6c7-aac800c17195">
<img width="1225" alt="Screenshot 2024-11-26 at 1 47 35 AM" src="https://github.com/user-attachments/assets/9f386a7e-8476-4793-a86b-d63102da8d9d">



### Test

<img width="1234" alt="Screenshot 2024-11-26 at 1 47 50 AM" src="https://github.com/user-attachments/assets/62682cf8-6438-451a-afb3-6f1c4130b90d">


Closes: #48770