### PR TITLE
Add `batch.kubernetes.io/cronjob-scheduled-timestamp` annotation information to CronJob page

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -216,6 +216,10 @@ are certain circumstances where two Jobs might be created, or no Job might be cr
 Kubernetes tries to avoid those situations, but does not completely prevent them. Therefore,
 the Jobs that you define should be _idempotent_.
 
+Starting with Kubernetes v1.32, CronJobs apply an annotation
+`batch.kubernetes.io/cronjob-scheduled-timestamp` to their created Jobs. This annotation
+indicates the originally scheduled creation time for the Job and is formatted in RFC3339.
+
 If `startingDeadlineSeconds` is set to a large value or left unset (the default)
 and if `concurrencyPolicy` is set to `Allow`, the Jobs will always run
 at least once.


### PR DESCRIPTION

### Description
Add `batch.kubernetes.io/cronjob-scheduled-timestamp` annotation information to CronJob page
 
### Issue
[kubernetes/enhancements#4026](https://github.com/kubernetes/enhancements/issues/4026)
