### PR TITLE
Update extend-service-ip-ranges.md

### DIFF
--- a/content/en/docs/tasks/network/extend-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/extend-service-ip-ranges.md
@@ -24,7 +24,8 @@ This document shares how to extend the existing Service IP range assigned to a c
 ## API
 
 Kubernetes clusters with kube-apiservers that have enabled the `MultiCIDRServiceAllocator`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and the `networking.k8s.io/v1beta1` API,
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and have the `networking.k8s.io/v1beta1`
+API group active,
 will create a ServiceCIDR object that takes the well-known name `kubernetes`, and that specifies an IP address range
 based on the value of the `--service-cluster-ip-range` command line argument to kube-apiserver.
 

--- a/content/en/docs/tasks/network/extend-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/extend-service-ip-ranges.md
@@ -25,7 +25,7 @@ This document shares how to extend the existing Service IP range assigned to a c
 
 Kubernetes clusters with kube-apiservers that have enabled the `MultiCIDRServiceAllocator`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and the `networking.k8s.io/v1beta1` API,
-will create a new ServiceCIDR object that takes the well-known name `kubernetes`, and that uses an IP address range
+will create a ServiceCIDR object that takes the well-known name `kubernetes`, and that specifies an IP address range
 based on the value of the `--service-cluster-ip-range` command line argument to kube-apiserver.
 
 ```sh

--- a/content/en/docs/tasks/network/extend-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/extend-service-ip-ranges.md
@@ -136,7 +136,7 @@ Kubernetes uses a finalizer on the ServiceCIDR to track this dependent relations
 kubectl get servicecidr newcidr1 -o yaml
 ```
 ```
-apiVersion: networking.k8s.io/v1alpha1
+apiVersion: networking.k8s.io/v1beta1
 kind: ServiceCIDR
 metadata:
   creationTimestamp: "2023-10-12T15:11:07Z"

--- a/content/en/docs/tasks/network/extend-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/extend-service-ip-ranges.md
@@ -24,7 +24,7 @@ This document shares how to extend the existing Service IP range assigned to a c
 ## API
 
 Kubernetes clusters with kube-apiservers that have enabled the `MultiCIDRServiceAllocator`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and the `networking.k8s.io/v1alpha1` API,
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) and the `networking.k8s.io/v1beta1` API,
 will create a new ServiceCIDR object that takes the well-known name `kubernetes`, and that uses an IP address range
 based on the value of the `--service-cluster-ip-range` command line argument to kube-apiserver.
 
@@ -94,7 +94,7 @@ that extends or adds new IP address ranges.
 
 ```sh
 cat <EOF | kubectl apply -f -
-apiVersion: networking.k8s.io/v1alpha1
+apiVersion: networking.k8s.io/v1beta1
 kind: ServiceCIDR
 metadata:
   name: newcidr1


### PR DESCRIPTION



@aojea 

### Description

we are enabling below beta API's 

```
networking.k8s.io/v1beta1/ipaddresses
networking.k8s.io/v1beta1/servicecidrs
```

Edited the manifest to use v1beta1

### Issue

Feature uses beta API instead of alpha API.
