### PR TITLE
Add 1.32 to release schedule for 1.32 release

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,6 +4,14 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 schedules:
+- endOfLifeDate: "2026-02-28"
+  maintenanceModeStartDate: "2025-12-28"
+  next:
+    release: 1.32.1
+    cherryPickDeadline: "2025-01-03"
+    targetDate: "2025-01-08"
+  release: "1.32"
+  releaseDate: "2024-12-11"
 - endOfLifeDate: "2025-10-28"
   maintenanceModeStartDate: "2025-08-28"
   next:

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -8,8 +8,9 @@ schedules:
   maintenanceModeStartDate: "2025-12-28"
   next:
     release: 1.32.1
-    cherryPickDeadline: "2025-01-03"
-    targetDate: "2025-01-08"
+    cherryPickDeadline: "2025-01-10"
+    targetDate: "2025-01-15"
+  previousPatches:
   release: "1.32"
   releaseDate: "2024-12-11"
 - endOfLifeDate: "2025-10-28"


### PR DESCRIPTION
This PR adds 1.32 to the releases schedule for the 1.32.0 release.

/milestone 1.32
@fsmunoz @sreeram-venkitesh @katcosgrove @kubernetes/release-managers