### PR TITLE
Fix collection of node host names for AppArmor profile distribution

### DIFF
--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -132,7 +132,7 @@ discussed in [Setting up nodes with profiles](#setting-up-nodes-with-profiles).
 
 ```shell
 # This example assumes that node names match host names, and are reachable via SSH.
-NODES=($(kubectl get nodes -o name))
+NODES=($(kubectl get nodes -o name | cut -d/ -f2))
 
 for NODE in ${NODES[*]}; do ssh $NODE 'sudo apparmor_parser -q <<EOF
 #include <tunables/global>

--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -132,7 +132,7 @@ discussed in [Setting up nodes with profiles](#setting-up-nodes-with-profiles).
 
 ```shell
 # This example assumes that node names match host names, and are reachable via SSH.
-NODES=($(kubectl get nodes -o name | cut -d/ -f2))
+NODES=($( kubectl get node -o jsonpath='{.items[].status.addresses[?(.type == "Hostname")].address}' ))
 
 for NODE in ${NODES[*]}; do ssh $NODE 'sudo apparmor_parser -q <<EOF
 #include <tunables/global>

--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -132,7 +132,7 @@ discussed in [Setting up nodes with profiles](#setting-up-nodes-with-profiles).
 
 ```shell
 # This example assumes that node names match host names, and are reachable via SSH.
-NODES=($( kubectl get node -o jsonpath='{.items[].status.addresses[?(.type == "Hostname")].address}' ))
+NODES=($( kubectl get node -o jsonpath='{.items[*].status.addresses[?(.type == "Hostname")].address}' ))
 
 for NODE in ${NODES[*]}; do ssh $NODE 'sudo apparmor_parser -q <<EOF
 #include <tunables/global>


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Fix collection of node host names for AppArmor profile distribution.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
An example in [Setting up nodes with profiles](https://kubernetes.io/docs/tutorials/security/apparmor/#setting-up-nodes-with-profiles) assumes that cluster node names match host names. However, when cluster nodes are listed using the name output format, each node is prefixed with the resource type prefix `node/`, which may not match the node hostname.  