### PR TITLE
Simplify kube-proxy refresh once the kube-proxy ConfigMap is updated

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure.md
@@ -173,16 +173,10 @@ The configuration is located under the `data.config.conf` key.
 
 Once the `kube-proxy` ConfigMap is updated, you can restart all kube-proxy Pods:
 
-Obtain the Pod names:
+Delete the Pods with:
 
 ```shell
-kubectl get po -n kube-system | grep kube-proxy
-```
-
-Delete a Pod with:
-
-```shell
-kubectl delete po -n kube-system <pod-name>
+kubectl delete po -n kube-system -l k8s-app=kube-proxy
 ```
 
 New Pods that use the updated ConfigMap will be created.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Once the `kube-proxy` ConfigMap has been updated, we need to restart the `kube-proxy` pods. 
Instead of using two `kubectl` commands, we can do this in one go. 
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #