### PR TITLE
service-accounts-admin.md: Explain invalidating short-lived tokens

### DIFF
--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -506,6 +506,8 @@ time. Please refer to [auto-generated legacy ServiceAccount token clean up](#aut
 
 ## Delete/invalidate a ServiceAccount token {#delete-token}
 
+### Delete/invalidate a long-lived/legacy ServiceAccount token {#delete-legacy-token}
+
 If you know the name of the Secret that contains the token you want to remove:
 
 ```shell
@@ -543,6 +545,17 @@ Then, delete the Secret you now know the name of:
 ```shell
 kubectl -n examplens delete secret/example-automated-thing-token-zyxwv
 ```
+
+### Delete/invalidate a short-lived ServiceAccount token {#delete-short-lived}
+
+Short lived ServiceAccount tokens automatically expire after the amount
+specified during their creation. There is no central record of tokens issued,
+so there is no way to revoke individual tokens.
+
+If you absolutely have to revoke a short-lived token before its expiration, you
+can delete and re-create the ServiceAccount it is associated to. This will
+change its UID and hence invalidate **all** ServiceAccount tokens that were
+created for it.
 
 ## Clean up
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The page "Managing Service Accounts" explains two types of tokens: short-lived tokens created via API and legacy/long-lived tokens created via Secrets.

The section about token deletion/invalidation however completely ignores the existence of short-lived tokens.

This PR fixes that and explains how to invalidate short-lived tokens.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #