### PR TITLE
Updates v1.31 hugo.toml for release v1.32

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -146,7 +146,7 @@ showedit = true
 latest = "v1.32"
 
 version = "v1.31"
-githubbranch = "1.31.4"
+githubbranch = "1.31.3"
 docsbranch = "release-1.32"
 deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"

--- a/hugo.toml
+++ b/hugo.toml
@@ -147,7 +147,7 @@ latest = "v1.32"
 
 version = "v1.31"
 githubbranch = "1.31.3"
-docsbranch = "release-1.32"
+docsbranch = "release-1.31"
 deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"

--- a/hugo.toml
+++ b/hugo.toml
@@ -143,12 +143,12 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.31"
+latest = "v1.32"
 
 version = "v1.31"
-githubbranch = "main"
-docsbranch = "main"
-deprecated = false
+githubbranch = "1.31.4"
+docsbranch = "release-1.32"
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 
@@ -185,34 +185,34 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.31"
-githubbranch = "v1.31.0"
+version = "v1.32"
+githubbranch = "v1.32.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
+version = "v1.31"
+githubbranch = "v1.31.4"
+docsbranch = "release-1.31"
+url = "https://v1-31.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.30"
-githubbranch = "v1.30.3"
+githubbranch = "v1.30.8"
 docsbranch = "release-1.30"
 url = "https://v1-30.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.29"
-githubbranch = "v1.29.7"
+githubbranch = "v1.29.12"
 docsbranch = "release-1.29"
 url = "https://v1-29.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.28"
-githubbranch = "v1.28.12"
+githubbranch = "v1.28.15"
 docsbranch = "release-1.28"
 url = "https://v1-28.docs.kubernetes.io"
-
-[[params.versions]]
-version = "v1.27"
-githubbranch = "v1.27.16"
-docsbranch = "release-1.27"
-url = "https://v1-27.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]

--- a/hugo.toml
+++ b/hugo.toml
@@ -192,19 +192,19 @@ url = "https://kubernetes.io"
 
 [[params.versions]]
 version = "v1.31"
-githubbranch = "v1.31.4"
+githubbranch = "v1.31.3"
 docsbranch = "release-1.31"
 url = "https://v1-31.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.30"
-githubbranch = "v1.30.8"
+githubbranch = "v1.30.7"
 docsbranch = "release-1.30"
 url = "https://v1-30.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.29"
-githubbranch = "v1.29.12"
+githubbranch = "v1.29.11"
 docsbranch = "release-1.29"
 url = "https://v1-29.docs.kubernetes.io"
 


### PR DESCRIPTION
This PR updates the hugo.toml for v1.31 ahead of the v1.32 release.

Base branch will be updated from main to release-1.31 once that branch exists.

/hold for v1.32 release day