### PR TITLE
Update Link of Inventory in Install k8s doc

### DIFF
--- a/content/en/docs/setup/production-environment/tools/_index.md
+++ b/content/en/docs/setup/production-environment/tools/_index.md
@@ -20,7 +20,7 @@ For example:
 
 - [kubespray](https://kubespray.io/):
   A composition of [Ansible](https://docs.ansible.com/) playbooks,
-  [inventory](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible.md#inventory),
+  [inventory](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible/inventory.md),
   provisioning tools, and domain knowledge for generic OS/Kubernetes clusters configuration
   management tasks. You can reach out to the community on Slack channel
   [#kubespray](https://kubernetes.slack.com/messages/kubespray/).


### PR DESCRIPTION
In [Installing Kubernetes with deployment tools](https://kubernetes.io/docs/setup/production-environment/tools/) the link for `inventory` was updated from: https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible.md#inventory to: https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible/inventory.md

It was necessary as it shows "404-Page not found".

