### PR TITLE
Remove announcement about gitRepo

### DIFF
--- a/content/en/blog/_posts/2024-12-11-Kubernetes-v1-32-Release/index.md
+++ b/content/en/blog/_posts/2024-12-11-Kubernetes-v1-32-Release/index.md
@@ -333,13 +333,6 @@ the complexities of back and forth API calls to the kube-apiserver.
 
 See the enhancement issue [#3063](https://github.com/kubernetes/enhancements/issues/3063) to find out more.
 
-#### Deprecation of gitRepo volume types
-
-The [gitRepo](https://kubernetes.io/docs/concepts/storage/volumes/#gitrepo) volume type is deprecated and will be
-removed in a future release, the deprecation has been executed in light of the security advisory encompassing the
-[CVE-2024-10220](https://nvd.nist.gov/vuln/detail/CVE-2024-10220): Arbitrary command execution through gitRepo volume,
-which was reported publicly in [this issue](https://github.com/kubernetes/kubernetes/issues/128885).
-    
 #### API removals
 
 There is one API removal in [Kubernetes v1.32](/docs/reference/using-api/deprecation-guide/#v1-32):


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

There are open discussions regarding whether gitRepo volume plugin should be removed or not.  It will be discussed in the next SIG Architecture meeting (which will happen after the 1.32 release). We should remove this announcement from the 1.32 release blog until a decision is made.
https://github.com/kubernetes/kubernetes/issues/125983#issuecomment-2528923329
https://github.com/kubernetes/website/pull/48666#discussion_r1876466815


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #