### PR TITLE
Update release schedule based on main

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -9,17 +9,20 @@ schedules:
   next:
     release: 1.32.1
     cherryPickDeadline: "2025-01-10"
-    targetDate: "2025-01-15"
+    targetDate: "2025-01-14"
   previousPatches:
   release: "1.32"
   releaseDate: "2024-12-11"
 - endOfLifeDate: "2025-10-28"
   maintenanceModeStartDate: "2025-08-28"
   next:
-    cherryPickDeadline: "2024-12-06"
+    cherryPickDeadline: "2025-01-10"
+    release: 1.31.5
+    targetDate: "2025-01-14"
+  previousPatches:
+  - cherryPickDeadline: "2024-12-06"
     release: 1.31.4
     targetDate: "2024-12-10"
-  previousPatches:
   - cherryPickDeadline: "2024-11-15"
     release: 1.31.3
     targetDate: "2024-11-19"
@@ -36,10 +39,13 @@ schedules:
 - endOfLifeDate: "2025-06-28"
   maintenanceModeStartDate: "2025-04-28"
   next:
-    cherryPickDeadline: "2024-12-06"
+    cherryPickDeadline: "2025-01-10"
+    release: 1.30.9
+    targetDate: "2025-01-14"
+  previousPatches:
+  - cherryPickDeadline: "2024-12-06"
     release: 1.30.8
     targetDate: "2024-12-10"
-  previousPatches:
   - cherryPickDeadline: "2024-11-15"
     release: 1.30.7
     targetDate: "2024-11-19"
@@ -68,10 +74,13 @@ schedules:
 - endOfLifeDate: "2025-02-28"
   maintenanceModeStartDate: "2024-12-28"
   next:
-    cherryPickDeadline: "2024-12-06"
+    cherryPickDeadline: "2025-01-10"
+    release: 1.29.13
+    targetDate: "2025-01-14"
+  previousPatches:
+  - cherryPickDeadline: "2024-12-06"
     release: 1.29.12
     targetDate: "2024-12-10"
-  previousPatches:
   - cherryPickDeadline: "2024-11-15"
     release: 1.29.11
     targetDate: "2024-11-19"
@@ -110,9 +119,9 @@ schedules:
   release: "1.29"
   releaseDate: "2023-12-13"
 upcoming_releases:
-- cherryPickDeadline: "2024-12-06"
-  targetDate: "2024-12-10"
 - cherryPickDeadline: "2025-01-10"
   targetDate: "2025-01-14"
 - cherryPickDeadline: "2025-02-07"
   targetDate: "2025-02-11"
+- cherryPickDeadline: "2025-03-07"
+  targetDate: "2025-03-11"


### PR DESCRIPTION
This PR updates the patches if we merge https://github.com/kubernetes/website/pull/49006 into `main`. 

It also fixes the target date of v1.32.1 to become Jan 14. 

Follow-up on https://github.com/kubernetes/website/pull/48933

cc @kubernetes/release-engineering 