### PR TITLE
Delete unnecessary blank line from volumes sample yaml in the Auditing Page.

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/audit.md
+++ b/content/en/docs/tasks/debug/debug-cluster/audit.md
@@ -171,7 +171,6 @@ volumes:
   hostPath:
     path: /etc/kubernetes/audit-policy.yaml
     type: File
-
 - name: audit-log
   hostPath:
     path: /var/log/kubernetes/audit/


### PR DESCRIPTION
This PR proposes to remove an unnecessary blank line from the volumes sample YAML in the Auditing page. The change aims to improve consistency within the document and enhance readability.

Current volumes example:
```yaml
volumes:
- name: audit
  hostPath:
    path: /etc/kubernetes/audit-policy.yaml
    type: File

- name: audit-log
  hostPath:
    path: /var/log/kubernetes/audit/
    type: DirectoryOrCreate
```
Proposed change:
```yaml
volumes:
- name: audit
  hostPath:
    path: /etc/kubernetes/audit-policy.yaml
    type: File
- name: audit-log
  hostPath:
    path: /var/log/kubernetes/audit/
    type: DirectoryOrCreate
```
Rationale:

Consistency: The volumeMounts example in the same document doesn't use blank lines between elements. Removing the blank line from the volumes example aligns the formatting across related examples.
```yaml
volumeMounts:
  - mountPath: /etc/kubernetes/audit-policy.yaml
    name: audit
    readOnly: true
  - mountPath: /var/log/kubernetes/audit/
    name: audit-log
    readOnly: false
```
Reduced confusion: Consistent formatting helps readers focus on content rather than wondering about formatting differences between similar examples.

Improved readability: While blank lines can aid readability in some cases, maintaining consistent style across related examples can make the document easier to parse and understand as a whole.

YAML validity: Both versions (with or without the blank line) are valid YAML. This change doesn't affect the functionality of the example.

This small change contributes to the overall quality and consistency of the documentation, making it more user-friendly for readers.

I'm open to feedback and discussion on this approach. If there's a preference for adding blank lines to the volumeMounts example instead, I'd be happy to modify the PR accordingly.