### PR TITLE
fixed:modify an incoherent statement

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/nodelocaldns.md
@@ -239,7 +239,7 @@ This feature can be enabled using the following steps:
 -->
 * 运行 `kubectl create -f nodelocaldns.yaml`
 
-* 如果 kube-proxy 运行在 IPVS 模式，需要修改 kubelet 的 `--cluster-dns` 参数
+* 如果 kube-proxy 运行在 IPVS 模式，需要修改 kubelet 的 `--cluster-dns` 参数为
   NodeLocal DNSCache 正在侦听的 `<node-local-address>` 地址。
   否则，不需要修改 `--cluster-dns` 参数，因为 NodeLocal DNSCache 会同时侦听
   kube-dns 服务的 IP 地址和 `<node-local-address>` 的地址。


### PR DESCRIPTION
### Description
Modify an incoherent statement
### Issue
The "为" is missing from the statement, making the context unintelligible.
语句中缺少了“为”，使上下文无法理解。