### PR TITLE
[zh] Sync command-line-tools-reference/kube-apiserver.md

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -571,13 +571,13 @@ API group and version used for serializing audit events written to webhook.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>
 <!--
-File with Authentication Configuration to configure the JWT Token authenticator or the anonymous authenticator. Note: This feature is in Alpha since v1.29.--feature-gate=StructuredAuthenticationConfiguration=true needs to be set for enabling this feature.This feature is mutually exclusive with the oidc-* flags.To configure anonymous authenticator you need to enable --feature-gate=AnonymousAuthConfigurableEndpoints.When you configure anonymous authenticator in the authentication config you cannot use the --anonymous-auth flag.
+File with Authentication Configuration to configure the JWT Token authenticator or the anonymous authenticator. Requires the StructuredAuthenticationConfiguration feature gate. Also requires the feature gate AnonymousAuthConfigurableEndpoints to configure the anonymous authenticator in the config file. This flag is mutually exclusive with the --oidc-* flags if the file configures the JWT Token authenticator. This flag is mutually exclusive with --anonymous-auth if the file configures the Anonymous authenticator.
 -->
-用于配置 JWT 令牌身份认证模块或匿名身份认证模块的身份认证配置文件。注意：此特性自 v1.29 起处于 Alpha 阶段。
-需要设置 <code>--feature-gate=StructuredAuthenticationConfiguration=true</code> 才能启用此特性。
-此特性与 <code>oidc-*</code> 标志互斥。要配置匿名身份认证模块，
-你需要启用 <code>--feature-gate=AnonymousAuthConfigurableEndpoints</code>。
-如果在身份认证配置文件中配置了匿名身份认证模块，就不能使用 <code>--anonymous-auth</code> 标志。
+用于配置 JWT 令牌身份认证模块或匿名身份认证模块的身份认证配置文件。
+你需要启用 <code>StructuredAuthenticationConfiguration</code> 特性门控。
+还需要启用 <code>AnonymousAuthConfigurableEndpoints</code> 特性门控以在配置文件中配置匿名身份认证模块。
+如果在配置文件中配置了 JWT 令牌认证模块，此标志与 <code>oidc-*</code> 标志互斥。
+如果在配置文件中配置了匿名身份认证模块，此标志与 <code>--anonymous-auth</code> 标志互斥。
 </p></td>
 </tr>
 
@@ -626,11 +626,11 @@ The API version of the authentication.k8s.io TokenReview to send to and expect f
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>
 <!--
-File with Authorization Configuration to configure the authorizer chain.Note: This feature is in Alpha since v1.29.--feature-gate=StructuredAuthorizationConfiguration=true feature flag needs to be set to true for enabling the functionality.This feature is mutually exclusive with the other --authorization-mode and --authorization-webhook-* flags.
+File with Authorization Configuration to configure the authorizer chain. Requires feature gate StructuredAuthorizationConfiguration. This flag is mutually exclusive with the other --authorization-mode and --authorization-webhook-* flags.
 -->
-用于配置鉴权链的鉴权配置文件。注意：此特性自 v1.29 起处于 Alpha 阶段。
-需要将 <code>--feature-gate=StructuredAuthorizationConfiguration=true</code> 特性标志设置为 true 才能启用此特性。
-此特性与其他 <code>--authorization-mode和--authorization-webhook-*</code> 标志互斥。
+用于配置鉴权链的鉴权配置文件。
+需要启用 <code>StructuredAuthorizationConfiguration</code> 特性门控。
+此标志与其他 <code>--authorization-mode</code> 和 <code>--authorization-webhook-*</code> 标志互斥。
 </p></td>
 </tr>
 
@@ -854,12 +854,12 @@ plugins list (NamespaceLifecycle, LimitRanger, ServiceAccount, TaintNodesByCondi
 PodSecurity, Priority, DefaultTolerationSeconds, DefaultStorageClass, StorageObjectInUseProtection,
 PersistentVolumeClaimResize, RuntimeClass, CertificateApproval, CertificateSigning,
 ClusterTrustBundleAttest, CertificateSubjectRestriction, DefaultIngressClass,
-MutatingAdmissionWebhook, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook, ResourceQuota).
+MutatingAdmissionPolicy, MutatingAdmissionWebhook, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook, ResourceQuota).
 Comma-delimited list of admission plugins: AlwaysAdmit, AlwaysDeny, AlwaysPullImages,
 CertificateApproval, CertificateSigning, CertificateSubjectRestriction, ClusterTrustBundleAttest,
 DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, DenyServiceExternalIPs, EventRateLimit,
 ExtendedResourceToleration, ImagePolicyWebhook, LimitPodHardAntiAffinityTopology, LimitRanger,
-MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle,
+MutatingAdmissionPolicy, MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle,
 NodeRestriction, OwnerReferencesPermissionEnforcement, PersistentVolumeClaimResize,
 PodNodeSelector, PodSecurity, PodTolerationRestriction, Priority, ResourceQuota,
 RuntimeClass, ServiceAccount, StorageObjectInUseProtection, TaintNodesByCondition,
@@ -871,13 +871,13 @@ The order of plugins in this flag does not matter.
 ServiceAccount、TaintNodesByCondition、PodSecurity、Priority、DefaultTolerationSeconds、
 DefaultStorageClass、StorageObjectInUseProtection、PersistentVolumeClaimResize、
 RuntimeClass、CertificateApproval、CertificateSigning、ClusterTrustBundleAttest、
-CertificateSubjectRestriction、DefaultIngressClass、MutatingAdmissionWebhook、
+CertificateSubjectRestriction、DefaultIngressClass、MutatingAdmissionPolicy、MutatingAdmissionWebhook、
 ValidatingAdmissionPolicy、ValidatingAdmissionWebhook、ResourceQuota）。
 取值为逗号分隔的准入插件列表：AlwaysAdmit、AlwaysDeny、AlwaysPullImages、CertificateApproval、
 CertificateSigning、CertificateSubjectRestriction、ClusterTrustBundleAttest、
 DefaultIngressClass、DefaultStorageClass、DefaultTolerationSeconds、DenyServiceExternalIPs、
 EventRateLimit、ExtendedResourceToleration、ImagePolicyWebhook、LimitPodHardAntiAffinityTopology、
-LimitRanger、MutatingAdmissionWebhook、NamespaceAutoProvision、NamespaceExists、NamespaceLifecycle、
+LimitRanger、MutatingAdmissionPolicy、MutatingAdmissionWebhook、NamespaceAutoProvision、NamespaceExists、NamespaceLifecycle、
 NodeRestriction、OwnerReferencesPermissionEnforcement、PersistentVolumeClaimResize、
 PodNodeSelector、PodSecurity、PodTolerationRestriction、Priority、ResourceQuota、RuntimeClass、ServiceAccount、
 StorageObjectInUseProtection、TaintNodesByCondition、ValidatingAdmissionPolicy、ValidatingAdmissionWebhook。
@@ -930,12 +930,12 @@ File with apiserver egress selector configuration.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>
 <!--
-The versions different components emulate their capabilities (APIs, features, ...) of.<br/>If set, the component will emulate the behavior of this version instead of the underlying binary version.<br/>Version format could only be major.minor, for example: '--emulated-version=wardle=1.2,kube=1.31'. Options are:<br/>kube=1.31..1.31 (default=1.31)If the component is not specified, defaults to &quot;kube&quot;
+The versions different components emulate their capabilities (APIs, features, ...) of.<br/>If set, the component will emulate the behavior of this version instead of the underlying binary version.<br/>Version format could only be major.minor, for example: '--emulated-version=wardle=1.2,kube=1.31'. Options are:<br/>kube=1.32..1.32 (default=1.32)If the component is not specified, defaults to &quot;kube&quot;
 -->
 不同组件所模拟的能力（API、特性等）的版本。<br/>
 如果设置了该选项，组件将模拟此版本的行为，而不是下层可执行文件版本的行为。<br/>
 版本格式只能是 major.minor，例如 “--emulated-version=wardle=1.2,kube=1.31”。
-选项包括：<br/>kube=1.31..1.31（默认值=1.31）。如果组件未被指定，默认为 “kube”。
+选项包括：<br/>kube=1.32..1.32（默认值=1.32）。如果组件未被指定，默认为 “kube”。
 </p></td>
 </tr>
 
@@ -947,17 +947,18 @@ The versions different components emulate their capabilities (APIs, features, ..
 </td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <!--
+The order of plugins in this flag does not matter.
 admission plugins that should be enabled in addition to default enabled ones
 (NamespaceLifecycle, LimitRanger, ServiceAccount, TaintNodesByCondition, PodSecurity,
 Priority, DefaultTolerationSeconds, DefaultStorageClass, StorageObjectInUseProtection,
 PersistentVolumeClaimResize, RuntimeClass, CertificateApproval, CertificateSigning,
 ClusterTrustBundleAttest, CertificateSubjectRestriction, DefaultIngressClass,
-MutatingAdmissionWebhook, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook, ResourceQuota).
+MutatingAdmissionPolicy, MutatingAdmissionWebhook, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook, ResourceQuota).
 Comma-delimited list of admission plugins: AlwaysAdmit, AlwaysDeny, AlwaysPullImages,
 CertificateApproval, CertificateSigning, CertificateSubjectRestriction, ClusterTrustBundleAttest,
 DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, DenyServiceExternalIPs,
 EventRateLimit, ExtendedResourceToleration, ImagePolicyWebhook, LimitPodHardAntiAffinityTopology,
-LimitRanger, MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle,
+LimitRanger, MutatingAdmissionPolicy, MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle,
 NodeRestriction, OwnerReferencesPermissionEnforcement, PersistentVolumeClaimResize,
 PodNodeSelector, PodSecurity, PodTolerationRestriction, Priority,
 ResourceQuota, RuntimeClass, ServiceAccount, StorageObjectInUseProtection,
@@ -968,13 +969,13 @@ The order of plugins in this flag does not matter.
 除了默认启用的插件（NamespaceLifecycle、LimitRanger、ServiceAccount、TaintNodesByCondition、
 PodSecurity、Priority、DefaultTolerationSeconds、DefaultStorageClass、StorageObjectInUseProtection、
 PersistentVolumeClaimResize、RuntimeClass、CertificateApproval、CertificateSigning、ClusterTrustBundleAttest、
-CertificateSubjectRestriction、DefaultIngressClass、MutatingAdmissionWebhook、ValidatingAdmissionPolicy、
-ValidatingAdmissionWebhook、ResourceQuota）之外要启用的准入插件。
+CertificateSubjectRestriction、DefaultIngressClass、MutatingAdmissionPolicy、MutatingAdmissionWebhook、
+ValidatingAdmissionPolicy、ValidatingAdmissionWebhook、ResourceQuota）之外要启用的准入插件。
 取值为逗号分隔的准入插件列表：AlwaysAdmit、AlwaysDeny、AlwaysPullImages、CertificateApproval、
 CertificateSigning、CertificateSubjectRestriction、ClusterTrustBundleAttest、DefaultIngressClass、
 DefaultStorageClass、DefaultTolerationSeconds、DenyServiceExternalIPs、EventRateLimit、
 ExtendedResourceToleration、ImagePolicyWebhook、LimitPodHardAntiAffinityTopology、LimitRanger、
-MutatingAdmissionWebhook、NamespaceAutoProvision、NamespaceExists、NamespaceLifecycle、
+MutatingAdmissionPolicy、MutatingAdmissionWebhook、NamespaceAutoProvision、NamespaceExists、NamespaceLifecycle、
 NodeRestriction、OwnerReferencesPermissionEnforcement、PersistentVolumeClaimResize、
 PodNodeSelector、PodSecurity、PodTolerationRestriction、Priority、
 ResourceQuota、RuntimeClass、ServiceAccount、StorageObjectInUseProtection、TaintNodesByCondition、
@@ -1267,34 +1268,39 @@ kube:APIServerTracing=true|false (BETA - default=true)<br/>
 kube:APIServingWithRoutine=true|false (ALPHA - default=false)<br/>
 kube:AllAlpha=true|false (ALPHA - default=false)<br/>
 kube:AllBeta=true|false (BETA - default=false)<br/>
-kube:AnonymousAuthConfigurableEndpoints=true|false (ALPHA - default=false)<br/>
+kube:AllowUnsafeMalformedObjectDeletion=true|false (ALPHA - default=false)<br/>
+kube:AnonymousAuthConfigurableEndpoints=true|false (BETA - default=true)<br/>
 kube:AnyVolumeDataSource=true|false (BETA - default=true)<br/>
-kube:AuthorizeNodeWithSelectors=true|false (ALPHA - default=false)<br/>
-kube:AuthorizeWithSelectors=true|false (ALPHA - default=false)<br/>
+kube:AuthorizeNodeWithSelectors=true|false (BETA - default=true)<br/>
+kube:AuthorizeWithSelectors=true|false (BETA - default=true)<br/>
+kube:BtreeWatchCache=true|false (BETA - default=true)<br/>
+kube:CBORServingAndStorage=true|false (ALPHA - default=false)<br/>
 kube:CPUManagerPolicyAlphaOptions=true|false (ALPHA - default=false)<br/>
 kube:CPUManagerPolicyBetaOptions=true|false (BETA - default=true)<br/>
 kube:CPUManagerPolicyOptions=true|false (BETA - default=true)<br/>
 kube:CRDValidationRatcheting=true|false (BETA - default=true)<br/>
 kube:CSIMigrationPortworx=true|false (BETA - default=true)<br/>
 kube:CSIVolumeHealth=true|false (ALPHA - default=false)<br/>
+kube:ClientsAllowCBOR=true|false (ALPHA - default=false)<br/>
+kube:ClientsPreferCBOR=true|false (ALPHA - default=false)<br/>
 kube:CloudControllerManagerWebhook=true|false (ALPHA - default=false)<br/>
 kube:ClusterTrustBundle=true|false (ALPHA - default=false)<br/>
 kube:ClusterTrustBundleProjection=true|false (ALPHA - default=false)<br/>
-kube:ComponentSLIs=true|false (BETA - default=true)<br/>
+kube:ComponentFlagz=true|false (ALPHA - default=false)<br/>
+kube:ComponentStatusz=true|false (ALPHA - default=false)<br/>
 kube:ConcurrentWatchObjectDecode=true|false (BETA - default=false)<br/>
 kube:ConsistentListFromCache=true|false (BETA - default=true)<br/>
 kube:ContainerCheckpoint=true|false (BETA - default=true)<br/>
 kube:ContextualLogging=true|false (BETA - default=true)<br/>
 kube:CoordinatedLeaderElection=true|false (ALPHA - default=false)<br/>
-kube:CronJobsScheduledAnnotation=true|false (BETA - default=true)<br/>
 kube:CrossNamespaceVolumeDataSource=true|false (ALPHA - default=false)<br/>
 kube:CustomCPUCFSQuotaPeriod=true|false (ALPHA - default=false)<br/>
-kube:CustomResourceFieldSelectors=true|false (BETA - default=true)<br/>
-kube:DRAControlPlaneController=true|false (ALPHA - default=false)<br/>
+kube:DRAAdminAccess=true|false (ALPHA - default=false)<br/>
+kube:DRAResourceClaimDeviceStatus=true|false (ALPHA - default=false)<br/>
 kube:DisableAllocatorDualWrite=true|false (ALPHA - default=false)<br/>
-kube:DisableNodeKubeProxyVersion=true|false (BETA - default=true)<br/>
-kube:DynamicResourceAllocation=true|false (ALPHA - default=false)<br/>
+kube:DynamicResourceAllocation=true|false (BETA - default=false)<br/>
 kube:EventedPLEG=true|false (ALPHA - default=false)<br/>
+kube:ExternalServiceAccountTokenSigner=true|false (ALPHA - default=false)<br/>
 kube:GracefulNodeShutdown=true|false (BETA - default=true)<br/>
 kube:GracefulNodeShutdownBasedOnPodPriority=true|false (BETA - default=true)<br/>
 kube:HPAScaleToZero=true|false (ALPHA - default=false)<br/>
@@ -1302,26 +1308,28 @@ kube:HonorPVReclaimPolicy=true|false (BETA - default=true)<br/>
 kube:ImageMaximumGCAge=true|false (BETA - default=true)<br/>
 kube:ImageVolume=true|false (ALPHA - default=false)<br/>
 kube:InPlacePodVerticalScaling=true|false (ALPHA - default=false)<br/>
+kube:InPlacePodVerticalScalingAllocatedStatus=true|false (ALPHA - default=false)<br/>
+kube:InPlacePodVerticalScalingExclusiveCPUs=true|false (ALPHA - default=false)<br/>
 kube:InTreePluginPortworxUnregister=true|false (ALPHA - default=false)<br/>
 kube:InformerResourceVersion=true|false (ALPHA - default=false)<br/>
 kube:JobBackoffLimitPerIndex=true|false (BETA - default=true)<br/>
-kube:JobManagedBy=true|false (ALPHA - default=false)<br/>
+kube:JobManagedBy=true|false (BETA - default=true)<br/>
 kube:JobPodReplacementPolicy=true|false (BETA - default=true)<br/>
 kube:JobSuccessPolicy=true|false (BETA - default=true)<br/>
 kube:KubeletCgroupDriverFromCRI=true|false (BETA - default=true)<br/>
+kube:KubeletCrashLoopBackOffMax=true|false (ALPHA - default=false)<br/>
+kube:KubeletFineGrainedAuthz=true|false (ALPHA - default=false)<br/>
 kube:KubeletInUserNamespace=true|false (ALPHA - default=false)<br/>
 kube:KubeletPodResourcesDynamicResources=true|false (ALPHA - default=false)<br/>
 kube:KubeletPodResourcesGet=true|false (ALPHA - default=false)<br/>
 kube:KubeletSeparateDiskGC=true|false (BETA - default=true)<br/>
 kube:KubeletTracing=true|false (BETA - default=true)<br/>
-kube:LoadBalancerIPMode=true|false (BETA - default=true)<br/>
 kube:LocalStorageCapacityIsolationFSQuotaMonitoring=true|false (BETA - default=false)<br/>
 kube:LoggingAlphaOptions=true|false (ALPHA - default=false)<br/>
 kube:LoggingBetaOptions=true|false (BETA - default=true)<br/>
 kube:MatchLabelKeysInPodAffinity=true|false (BETA - default=true)<br/>
 kube:MatchLabelKeysInPodTopologySpread=true|false (BETA - default=true)<br/>
 kube:MaxUnavailableStatefulSet=true|false (ALPHA - default=false)<br/>
-kube:MemoryManager=true|false (BETA - default=true)<br/>
 kube:MemoryQoS=true|false (ALPHA - default=false)<br/>
 kube:MultiCIDRServiceAllocator=true|false (BETA - default=false)<br/>
 kube:MutatingAdmissionPolicy=true|false (ALPHA - default=false)<br/>
@@ -1332,47 +1340,45 @@ kube:NodeSwap=true|false (BETA - default=true)<br/>
 kube:OpenAPIEnums=true|false (BETA - default=true)<br/>
 kube:PodAndContainerStatsFromCRI=true|false (ALPHA - default=false)<br/>
 kube:PodDeletionCost=true|false (BETA - default=true)<br/>
-kube:PodIndexLabel=true|false (BETA - default=true)<br/>
+kube:PodLevelResources=true|false (ALPHA - default=false)<br/>
 kube:PodLifecycleSleepAction=true|false (BETA - default=true)<br/>
+kube:PodLifecycleSleepActionAllowZero=true|false (ALPHA - default=false)<br/>
+kube:PodLogsQuerySplitStreams=true|false (ALPHA - default=false)<br/>
 kube:PodReadyToStartContainersCondition=true|false (BETA - default=true)<br/>
 kube:PortForwardWebsockets=true|false (BETA - default=true)<br/>
 kube:ProcMountType=true|false (BETA - default=false)<br/>
 kube:QOSReserved=true|false (ALPHA - default=false)<br/>
-kube:RecoverVolumeExpansionFailure=true|false (ALPHA - default=false)<br/>
+kube:RecoverVolumeExpansionFailure=true|false (BETA - default=true)<br/>
 kube:RecursiveReadOnlyMounts=true|false (BETA - default=true)<br/>
-kube:RelaxedEnvironmentVariableValidation=true|false (ALPHA - default=false)<br/>
+kube:RelaxedDNSSearchValidation=true|false (ALPHA - default=false)<br/>
+kube:RelaxedEnvironmentVariableValidation=true|false (BETA - default=true)<br/>
 kube:ReloadKubeletServerCertificateFile=true|false (BETA - default=true)<br/>
+kube:RemoteRequestHeaderUID=true|false (ALPHA - default=false)<br/>
 kube:ResilientWatchCacheInitialization=true|false (BETA - default=true)<br/>
 kube:ResourceHealthStatus=true|false (ALPHA - default=false)<br/>
-kube:RetryGenerateName=true|false (BETA - default=true)<br/>
 kube:RotateKubeletServerCertificate=true|false (BETA - default=true)<br/>
 kube:RuntimeClassInImageCriApi=true|false (ALPHA - default=false)<br/>
+kube:SELinuxChangePolicy=true|false (ALPHA - default=false)<br/>
 kube:SELinuxMount=true|false (ALPHA - default=false)<br/>
 kube:SELinuxMountReadWriteOncePod=true|false (BETA - default=true)<br/>
-kube:SchedulerQueueingHints=true|false (BETA - default=false)<br/>
+kube:SchedulerAsyncPreemption=true|false (ALPHA - default=false)<br/>
+kube:SchedulerQueueingHints=true|false (BETA - default=true)<br/>
 kube:SeparateCacheWatchRPC=true|false (BETA - default=true)<br/>
 kube:SeparateTaintEvictionController=true|false (BETA - default=true)<br/>
-kube:ServiceAccountTokenJTI=true|false (BETA - default=true)<br/>
+kube:ServiceAccountNodeAudienceRestriction=true|false (BETA - default=true)<br/>
 kube:ServiceAccountTokenNodeBinding=true|false (BETA - default=true)<br/>
-kube:ServiceAccountTokenNodeBindingValidation=true|false (BETA - default=true)<br/>
-kube:ServiceAccountTokenPodNodeInfo=true|false (BETA - default=true)<br/>
 kube:ServiceTrafficDistribution=true|false (BETA - default=true)<br/>
 kube:SidecarContainers=true|false (BETA - default=true)<br/>
-kube:SizeMemoryBackedVolumes=true|false (BETA - default=true)<br/>
-kube:StatefulSetAutoDeletePVC=true|false (BETA - default=true)<br/>
 kube:StorageNamespaceIndex=true|false (BETA - default=true)<br/>
 kube:StorageVersionAPI=true|false (ALPHA - default=false)<br/>
 kube:StorageVersionHash=true|false (BETA - default=true)<br/>
 kube:StorageVersionMigrator=true|false (ALPHA - default=false)<br/>
-kube:StrictCostEnforcementForVAP=true|false (BETA - default=false)<br/>
-kube:StrictCostEnforcementForWebhooks=true|false (BETA - default=false)<br/>
 kube:StructuredAuthenticationConfiguration=true|false (BETA - default=true)<br/>
-kube:StructuredAuthorizationConfiguration=true|false (BETA - default=true)<br/>
 kube:SupplementalGroupsPolicy=true|false (ALPHA - default=false)<br/>
+kube:SystemdWatchdog=true|false (BETA - default=true)<br/>
 kube:TopologyAwareHints=true|false (BETA - default=true)<br/>
 kube:TopologyManagerPolicyAlphaOptions=true|false (ALPHA - default=false)<br/>
 kube:TopologyManagerPolicyBetaOptions=true|false (BETA - default=true)<br/>
-kube:TopologyManagerPolicyOptions=true|false (BETA - default=true)<br/>
 kube:TranslateStreamCloseWebsocketRequests=true|false (BETA - default=true)<br/>
 kube:UnauthenticatedHTTP2DOSMitigation=true|false (BETA - default=true)<br/>
 kube:UnknownVersionInteroperabilityProxy=true|false (ALPHA - default=false)<br/>
@@ -1382,10 +1388,12 @@ kube:VolumeAttributesClass=true|false (BETA - default=false)<br/>
 kube:VolumeCapacityPriority=true|false (ALPHA - default=false)<br/>
 kube:WatchCacheInitializationPostStartHook=true|false (BETA - default=false)<br/>
 kube:WatchFromStorageWithoutResourceVersion=true|false (BETA - default=false)<br/>
-kube:WatchList=true|false (ALPHA - default=false)<br/>
+kube:WatchList=true|false (BETA - default=true)<br/>
 kube:WatchListClient=true|false (BETA - default=false)<br/>
 kube:WinDSR=true|false (ALPHA - default=false)<br/>
 kube:WinOverlay=true|false (BETA - default=true)<br/>
+kube:WindowsCPUAndMemoryAffinity=true|false (ALPHA - default=false)<br/>
+kube:WindowsGracefulNodeShutdown=true|false (ALPHA - default=false)<br/>
 kube:WindowsHostNetwork=true|false (ALPHA - default=true)
 -->
 逗号分隔的组件列表，这些 key=value 对用来描述不同组件测试性/试验性特性的特性门控。<br/>
@@ -1398,34 +1406,39 @@ kube:APIServerTracing=true|false (BETA - 默认值=true)<br/>
 kube:APIServingWithRoutine=true|false (ALPHA - 默认值=false)<br/>
 kube:AllAlpha=true|false (ALPHA - 默认值=false)<br/>
 kube:AllBeta=true|false (BETA - 默认值=false)<br/>
-kube:AnonymousAuthConfigurableEndpoints=true|false (ALPHA - 默认值=false)<br/>
+kube:AllowUnsafeMalformedObjectDeletion=true|false (ALPHA - 默认值=false)<br/>
+kube:AnonymousAuthConfigurableEndpoints=true|false (BETA - 默认值=true)<br/>
 kube:AnyVolumeDataSource=true|false (BETA - 默认值=true)<br/>
-kube:AuthorizeNodeWithSelectors=true|false (ALPHA - 默认值=false)<br/>
-kube:AuthorizeWithSelectors=true|false (ALPHA - 默认值=false)<br/>
+kube:AuthorizeNodeWithSelectors=true|false (BETA - 默认值=true)<br/>
+kube:AuthorizeWithSelectors=true|false (BETA - 默认值=true)<br/>
+kube:BtreeWatchCache=true|false (BETA - 默认值=true)<br/>
+kube:CBORServingAndStorage=true|false (ALPHA - 默认值=false)<br/>
 kube:CPUManagerPolicyAlphaOptions=true|false (ALPHA - 默认值=false)<br/>
 kube:CPUManagerPolicyBetaOptions=true|false (BETA - 默认值=true)<br/>
 kube:CPUManagerPolicyOptions=true|false (BETA - 默认值=true)<br/>
 kube:CRDValidationRatcheting=true|false (BETA - 默认值=true)<br/>
 kube:CSIMigrationPortworx=true|false (BETA - 默认值=true)<br/>
 kube:CSIVolumeHealth=true|false (ALPHA - 默认值=false)<br/>
+kube:ClientsAllowCBOR=true|false (ALPHA - 默认值=false)<br/>
+kube:ClientsPreferCBOR=true|false (ALPHA - 默认值=false)<br/>
 kube:CloudControllerManagerWebhook=true|false (ALPHA - 默认值=false)<br/>
 kube:ClusterTrustBundle=true|false (ALPHA - 默认值=false)<br/>
 kube:ClusterTrustBundleProjection=true|false (ALPHA - 默认值=false)<br/>
-kube:ComponentSLIs=true|false (BETA - 默认值=true)<br/>
+kube:ComponentFlagz=true|false (ALPHA - 默认值=false)<br/>
+kube:ComponentStatusz=true|false (ALPHA - 默认值=false)<br/>
 kube:ConcurrentWatchObjectDecode=true|false (BETA - 默认值=false)<br/>
 kube:ConsistentListFromCache=true|false (BETA - 默认值=true)<br/>
 kube:ContainerCheckpoint=true|false (BETA - 默认值=true)<br/>
 kube:ContextualLogging=true|false (BETA - 默认值=true)<br/>
 kube:CoordinatedLeaderElection=true|false (ALPHA - 默认值=false)<br/>
-kube:CronJobsScheduledAnnotation=true|false (BETA - 默认值=true)<br/>
 kube:CrossNamespaceVolumeDataSource=true|false (ALPHA - 默认值=false)<br/>
 kube:CustomCPUCFSQuotaPeriod=true|false (ALPHA - 默认值=false)<br/>
-kube:CustomResourceFieldSelectors=true|false (BETA - 默认值=true)<br/>
-kube:DRAControlPlaneController=true|false (ALPHA - 默认值=false)<br/>
+kube:DRAAdminAccess=true|false (ALPHA - 默认值=false)<br/>
+kube:DRAResourceClaimDeviceStatus=true|false (ALPHA - 默认值=false)<br/>
 kube:DisableAllocatorDualWrite=true|false (ALPHA - 默认值=false)<br/>
-kube:DisableNodeKubeProxyVersion=true|false (BETA - 默认值=true)<br/>
-kube:DynamicResourceAllocation=true|false (ALPHA - 默认值=false)<br/>
+kube:DynamicResourceAllocation=true|false (BETA - 默认值=false)<br/>
 kube:EventedPLEG=true|false (ALPHA - 默认值=false)<br/>
+kube:ExternalServiceAccountTokenSigner=true|false (ALPHA - 默认值=false)<br/>
 kube:GracefulNodeShutdown=true|false (BETA - 默认值=true)<br/>
 kube:GracefulNodeShutdownBasedOnPodPriority=true|false (BETA - 默认值=true)<br/>
 kube:HPAScaleToZero=true|false (ALPHA - 默认值=false)<br/>
@@ -1433,26 +1446,28 @@ kube:HonorPVReclaimPolicy=true|false (BETA - 默认值=true)<br/>
 kube:ImageMaximumGCAge=true|false (BETA - 默认值=true)<br/>
 kube:ImageVolume=true|false (ALPHA - 默认值=false)<br/>
 kube:InPlacePodVerticalScaling=true|false (ALPHA - 默认值=false)<br/>
+kube:InPlacePodVerticalScalingAllocatedStatus=true|false (ALPHA - 默认值=false)<br/>
+kube:InPlacePodVerticalScalingExclusiveCPUs=true|false (ALPHA - 默认值=false)<br/>
 kube:InTreePluginPortworxUnregister=true|false (ALPHA - 默认值=false)<br/>
 kube:InformerResourceVersion=true|false (ALPHA - 默认值=false)<br/>
 kube:JobBackoffLimitPerIndex=true|false (BETA - 默认值=true)<br/>
-kube:JobManagedBy=true|false (ALPHA - 默认值=false)<br/>
+kube:JobManagedBy=true|false (BETA - 默认值=true)<br/>
 kube:JobPodReplacementPolicy=true|false (BETA - 默认值=true)<br/>
 kube:JobSuccessPolicy=true|false (BETA - 默认值=true)<br/>
 kube:KubeletCgroupDriverFromCRI=true|false (BETA - 默认值=true)<br/>
+kube:KubeletCrashLoopBackOffMax=true|false (ALPHA - 默认值=false)<br/>
+kube:KubeletFineGrainedAuthz=true|false (ALPHA - 默认值=false)<br/>
 kube:KubeletInUserNamespace=true|false (ALPHA - 默认值=false)<br/>
 kube:KubeletPodResourcesDynamicResources=true|false (ALPHA - 默认值=false)<br/>
 kube:KubeletPodResourcesGet=true|false (ALPHA - 默认值=false)<br/>
 kube:KubeletSeparateDiskGC=true|false (BETA - 默认值=true)<br/>
 kube:KubeletTracing=true|false (BETA - 默认值=true)<br/>
-kube:LoadBalancerIPMode=true|false (BETA - 默认值=true)<br/>
 kube:LocalStorageCapacityIsolationFSQuotaMonitoring=true|false (BETA - 默认值=false)<br/>
 kube:LoggingAlphaOptions=true|false (ALPHA - 默认值=false)<br/>
 kube:LoggingBetaOptions=true|false (BETA - 默认值=true)<br/>
 kube:MatchLabelKeysInPodAffinity=true|false (BETA - 默认值=true)<br/>
 kube:MatchLabelKeysInPodTopologySpread=true|false (BETA - 默认值=true)<br/>
 kube:MaxUnavailableStatefulSet=true|false (ALPHA - 默认值=false)<br/>
-kube:MemoryManager=true|false (BETA - 默认值=true)<br/>
 kube:MemoryQoS=true|false (ALPHA - 默认值=false)<br/>
 kube:MultiCIDRServiceAllocator=true|false (BETA - 默认值=false)<br/>
 kube:MutatingAdmissionPolicy=true|false (ALPHA - 默认值=false)<br/>
@@ -1463,47 +1478,45 @@ kube:NodeSwap=true|false (BETA - 默认值=true)<br/>
 kube:OpenAPIEnums=true|false (BETA - 默认值=true)<br/>
 kube:PodAndContainerStatsFromCRI=true|false (ALPHA - 默认值=false)<br/>
 kube:PodDeletionCost=true|false (BETA - 默认值=true)<br/>
-kube:PodIndexLabel=true|false (BETA - 默认值=true)<br/>
+kube:PodLevelResources=true|false (ALPHA - 默认值=false)<br/>
 kube:PodLifecycleSleepAction=true|false (BETA - 默认值=true)<br/>
+kube:PodLifecycleSleepActionAllowZero=true|false (ALPHA - 默认值=false)<br/>
+kube:PodLogsQuerySplitStreams=true|false (ALPHA - 默认值=false)<br/>
 kube:PodReadyToStartContainersCondition=true|false (BETA - 默认值=true)<br/>
 kube:PortForwardWebsockets=true|false (BETA - 默认值=true)<br/>
 kube:ProcMountType=true|false (BETA - 默认值=false)<br/>
 kube:QOSReserved=true|false (ALPHA - 默认值=false)<br/>
-kube:RecoverVolumeExpansionFailure=true|false (ALPHA - 默认值=false)<br/>
+kube:RecoverVolumeExpansionFailure=true|false (BETA - 默认值=true)<br/>
 kube:RecursiveReadOnlyMounts=true|false (BETA - 默认值=true)<br/>
-kube:RelaxedEnvironmentVariableValidation=true|false (ALPHA - 默认值=false)<br/>
+kube:RelaxedDNSSearchValidation=true|false (ALPHA - 默认值=false)<br/>
+kube:RelaxedEnvironmentVariableValidation=true|false (BETA - 默认值=true)<br/>
 kube:ReloadKubeletServerCertificateFile=true|false (BETA - 默认值=true)<br/>
+kube:RemoteRequestHeaderUID=true|false (ALPHA - 默认值=false)<br/>
 kube:ResilientWatchCacheInitialization=true|false (BETA - 默认值=true)<br/>
 kube:ResourceHealthStatus=true|false (ALPHA - 默认值=false)<br/>
-kube:RetryGenerateName=true|false (BETA - 默认值=true)<br/>
 kube:RotateKubeletServerCertificate=true|false (BETA - 默认值=true)<br/>
 kube:RuntimeClassInImageCriApi=true|false (ALPHA - 默认值=false)<br/>
+kube:SELinuxChangePolicy=true|false (ALPHA - 默认值=false)<br/>
 kube:SELinuxMount=true|false (ALPHA - 默认值=false)<br/>
 kube:SELinuxMountReadWriteOncePod=true|false (BETA - 默认值=true)<br/>
-kube:SchedulerQueueingHints=true|false (BETA - 默认值=false)<br/>
+kube:SchedulerAsyncPreemption=true|false (ALPHA - 默认值=false)<br/>
+kube:SchedulerQueueingHints=true|false (BETA - 默认值=true)<br/>
 kube:SeparateCacheWatchRPC=true|false (BETA - 默认值=true)<br/>
 kube:SeparateTaintEvictionController=true|false (BETA - 默认值=true)<br/>
-kube:ServiceAccountTokenJTI=true|false (BETA - 默认值=true)<br/>
+kube:ServiceAccountNodeAudienceRestriction=true|false (BETA - 默认值=true)<br/>
 kube:ServiceAccountTokenNodeBinding=true|false (BETA - 默认值=true)<br/>
-kube:ServiceAccountTokenNodeBindingValidation=true|false (BETA - 默认值=true)<br/>
-kube:ServiceAccountTokenPodNodeInfo=true|false (BETA - 默认值=true)<br/>
 kube:ServiceTrafficDistribution=true|false (BETA - 默认值=true)<br/>
 kube:SidecarContainers=true|false (BETA - 默认值=true)<br/>
-kube:SizeMemoryBackedVolumes=true|false (BETA - 默认值=true)<br/>
-kube:StatefulSetAutoDeletePVC=true|false (BETA - 默认值=true)<br/>
 kube:StorageNamespaceIndex=true|false (BETA - 默认值=true)<br/>
 kube:StorageVersionAPI=true|false (ALPHA - 默认值=false)<br/>
 kube:StorageVersionHash=true|false (BETA - 默认值=true)<br/>
 kube:StorageVersionMigrator=true|false (ALPHA - 默认值=false)<br/>
-kube:StrictCostEnforcementForVAP=true|false (BETA - 默认值=false)<br/>
-kube:StrictCostEnforcementForWebhooks=true|false (BETA - 默认值=false)<br/>
 kube:StructuredAuthenticationConfiguration=true|false (BETA - 默认值=true)<br/>
-kube:StructuredAuthorizationConfiguration=true|false (BETA - 默认值=true)<br/>
 kube:SupplementalGroupsPolicy=true|false (ALPHA - 默认值=false)<br/>
+kube:SystemdWatchdog=true|false (BETA - 默认值=true)<br/>
 kube:TopologyAwareHints=true|false (BETA - 默认值=true)<br/>
 kube:TopologyManagerPolicyAlphaOptions=true|false (ALPHA - 默认值=false)<br/>
 kube:TopologyManagerPolicyBetaOptions=true|false (BETA - 默认值=true)<br/>
-kube:TopologyManagerPolicyOptions=true|false (BETA - 默认值=true)<br/>
 kube:TranslateStreamCloseWebsocketRequests=true|false (BETA - 默认值=true)<br/>
 kube:UnauthenticatedHTTP2DOSMitigation=true|false (BETA - 默认值=true)<br/>
 kube:UnknownVersionInteroperabilityProxy=true|false (ALPHA - 默认值=false)<br/>
@@ -1513,10 +1526,12 @@ kube:VolumeAttributesClass=true|false (BETA - 默认值=false)<br/>
 kube:VolumeCapacityPriority=true|false (ALPHA - 默认值=false)<br/>
 kube:WatchCacheInitializationPostStartHook=true|false (BETA - 默认值=false)<br/>
 kube:WatchFromStorageWithoutResourceVersion=true|false (BETA - 默认值=false)<br/>
-kube:WatchList=true|false (ALPHA - 默认值=false)<br/>
+kube:WatchList=true|false (BETA - 默认值=true)<br/>
 kube:WatchListClient=true|false (BETA - 默认值=false)<br/>
 kube:WinDSR=true|false (ALPHA - 默认值=false)<br/>
 kube:WinOverlay=true|false (BETA - 默认值=true)<br/>
+kube:WindowsCPUAndMemoryAffinity=true|false (ALPHA - 默认值=false)<br/>
+kube:WindowsGracefulNodeShutdown=true|false (ALPHA - 默认值=false)<br/>
 kube:WindowsHostNetwork=true|false (ALPHA - 默认值=true)
 </p></td>
 </tr>
@@ -2149,6 +2164,19 @@ List of request headers to inspect for groups. X-Remote-Group is suggested.
 </tr>
 
 <tr>
+<td colspan="2">--requestheader-uid-headers strings</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>
+<!--
+List of request headers to inspect for UIDs. X-Remote-Uid is suggested. Requires the RemoteRequestHeaderUID feature to be enabled.
+-->
+用于查验 UID 的请求头字段列表。建议使用 <code>X-Remote-Uid</code>。
+要求 <code>RemoteRequestHeaderUID</code> 特性被启用。
+</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--requestheader-username-headers strings</td>
 </tr>
 <tr>
@@ -2313,10 +2341,23 @@ a token will be issued with a validity duration of this value.
 </tr>
 
 <tr>
+<td colspan="2">--service-account-signing-endpoint string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>
+<!--
+Path to socket where a external JWT signer is listening. This flag is mutually exclusive with --service-account-signing-key-file and --service-account-key-file. Requires enabling feature gate (ExternalServiceAccountTokenSigner)
+-->
+外部 JWT 签名程序正在侦听的套接字的路径。
+此标志与 <code>--service-account-signing-key-file</code> 和 <code>--service-account-key-file</code> 互斥。
+需要启用 <code>ExternalServiceAccountTokenSigner</code> 特性门控。
+</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--service-account-signing-key-file string</td>
 </tr>
 <tr>
-
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
 Path to the file that contains the current private key of the service account token issuer. 


### PR DESCRIPTION
Sync with en text:

```
content/zh-cn/docs/reference/command-line-tools-reference/kube-apiserver.md
```
See [preview](https://deploy-preview-49060--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/command-line-tools-reference/kube-apiserver/)