### PR TITLE
Fix some blog post typos

### DIFF
--- a/content/en/blog/_posts/2018-05-04-Announcing-Kubeflow-0-1.md
+++ b/content/en/blog/_posts/2018-05-04-Announcing-Kubeflow-0-1.md
@@ -42,7 +42,7 @@ NAMESPACE=kubeflow
 kubectl create namespace ${NAMESPACE}
 VERSION=v0.1.3
 
-# Initialize a ksonnet app. Set the namespace for it's default environment.
+# Initialize a ksonnet app. Set the namespace for its default environment.
 APP_NAME=my-kubeflow
 ks init ${APP_NAME}
 cd ${APP_NAME}

--- a/content/en/blog/_posts/2021-10-18-kpng-specialized-proxiers.md
+++ b/content/en/blog/_posts/2021-10-18-kpng-specialized-proxiers.md
@@ -41,7 +41,7 @@ spec:
 
 If the `service.kubernetes.io/service-proxy-name` label is defined the
 `kube-proxy` will ignore the service. A custom controller can watch
-services with the label set to it's own name, "kpng-example" in
+services with the label set to its own name, "kpng-example" in
 this example, and setup specialized load-balancing.
 
 The `service.kubernetes.io/service-proxy-name` label is [not

--- a/content/en/blog/_posts/2024-12-11-Kubernetes-v1-32-Release/index.md
+++ b/content/en/blog/_posts/2024-12-11-Kubernetes-v1-32-Release/index.md
@@ -30,7 +30,7 @@ each release cycle is a journey, and just like Penelope, in "The Odyssey",
 weaved for 10 years -- each night removing parts of what she had done during the day -- 
 so does each release add new features and removes others, albeit here with a much 
 clearer purpose of constantly improving Kubernetes. 
-With v1.32 being the last release in the year Kubernetes marks it's first decade anniversary, 
+With v1.32 being the last release in the year Kubernetes marks its first decade anniversary, 
 we wanted to honour all of those that have been part of the global Kubernetes crew 
 that roams the cloud-native seas through perils and challanges: 
 may we continue to weave the future of Kubernetes together.


### PR DESCRIPTION
I just noticed the Kubernetes Penelope blog post typo but while
fixing it I looked around to see if it was anywhere else and found
a couple.
