### PR TITLE
Add descriptions of ClusterRole and ClusterRoleBinding to docs/reference/glossary/rbac.md

### DIFF
--- a/content/en/docs/reference/glossary/rbac.md
+++ b/content/en/docs/reference/glossary/rbac.md
@@ -16,9 +16,17 @@ tags:
 <!--more--> 
 
 RBAC utilizes four kinds of Kubernetes objects:
-* **Role**: Defines permission rules in a specific namespace.
-* **ClusterRole**: Defines permission rules cluster-wide.
-* **RoleBinding**: Grants the permissions defined in a role to a set of users in a specific namespace.
-* **ClusterRoleBinding**: Grants the permissions defined in a role to a set of users cluster-wide.
+
+Role
+: Defines permission rules in a specific namespace.
+
+ClusterRole
+: Defines permission rules cluster-wide.
+
+RoleBinding
+: Grants the permissions defined in a role to a set of users in a specific namespace.
+
+ClusterRoleBinding
+: Grants the permissions defined in a role to a set of users cluster-wide.
 
 For more information, see [RBAC](/docs/reference/access-authn-authz/rbac/).

--- a/content/en/docs/reference/glossary/rbac.md
+++ b/content/en/docs/reference/glossary/rbac.md
@@ -15,5 +15,10 @@ tags:
 
 <!--more--> 
 
-RBAC utilizes *roles*, which contain permission rules, and *role bindings*, which grant the permissions defined in a role to a set of users.
+RBAC utilizes four kinds of Kubernetes objects:
+* **Role**: Defines permission rules in a specific namespace.
+* **ClusterRole**: Defines permission rules cluster-wide.
+* **RoleBinding**: Grants the permissions defined in a role to a set of users in a specific namespace.
+* **ClusterRoleBinding**: Grants the permissions defined in a role to a set of users cluster-wide.
 
+For more information, see [RBAC](/docs/reference/access-authn-authz/rbac/).


### PR DESCRIPTION
### Description

The RBAC section of the glossary page explains only two types of Kubernetes objects: `Role` and `RoleBinding`.
However, RBAC utilizes four types of Kubernetes objects: `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding`.
This PR adds descriptions of `ClusterRole` and `ClusterRoleBinding` along with a link to the RBAC documentation to help readers better understand RBAC.

### Issue

Closes: #48967