### PR TITLE
Mention official kubectl pronunciation

### DIFF
--- a/content/en/docs/reference/glossary/kubectl.md
+++ b/content/en/docs/reference/glossary/kubectl.md
@@ -20,3 +20,5 @@ using the Kubernetes API.
 
 You can use `kubectl` to create, inspect, update, and delete Kubernetes objects.
 
+<!-- localization note: OK to omit the rest of this entry -->
+In English, `kubectl` is (officially) pronounced /kjuːb/ /kənˈtɹəʊl/ (like "cube control").


### PR DESCRIPTION
In the glossary entry for [kubectl](https://kubernetes.io/docs/reference/glossary/?all=true#term-kubectl), mention how to pronounce it ([preview](https://deploy-preview-49089--kubernetes-io-main-staging.netlify.app/docs/reference/glossary/?all=true#term-kubectl)).


/language en
/priority backlog