### PR TITLE
feat: the RecoverVolumeExpansionFailure feature flag is in Beta stage since 1.32

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/recover-volume-expansion-failure.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/recover-volume-expansion-failure.md
@@ -9,6 +9,9 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.23"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.32"
 ---
 Enables users to edit their PVCs to smaller
 sizes so as they can recover from previously issued volume expansion failures.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/recover-volume-expansion-failure.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/recover-volume-expansion-failure.md
@@ -9,6 +9,7 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.23"
+    toVersion: "1.31"
   - stage: beta
     defaultValue: true
     fromVersion: "1.32"


### PR DESCRIPTION

### Description

Since Kubernetes 1.32 release, the RecoverVolumeExpansionFailure feature flag is in Beta stage.
C.f: https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/
