### PR TITLE
[zh] Add zh text to pods/pod-lifecycle.md and related feature gate

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-crash-loop-back-off-max.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-crash-loop-back-off-max.md
@@ -1,0 +1,18 @@
+---
+title: KubeletCrashLoopBackOffMax
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.32"
+---
+
+<!--
+Enables support for configurable per-node backoff maximums for restarting
+containers in the CrashLoopBackOff state.
+-->
+启用对可逐节点配置的、在重启 CrashLoopBackOff 状态的容器时回退最大值的支持。


### PR DESCRIPTION
Update zh text in:

```
content/zh-cn/docs/concepts/workloads/pods/pod-lifecycle.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/kubelet-crash-loop-back-off-max.md
```