### PR TITLE
Improve PV Storage Task

### DIFF
--- a/content/en/examples/pods/storage/nginx.conf
+++ b/content/en/examples/pods/storage/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  60;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/content/en/examples/pods/storage/pv-duplicate.yaml
+++ b/content/en/examples/pods/storage/pv-duplicate.yaml
@@ -19,4 +19,4 @@ spec:
   volumes:
     - name: config
       persistentVolumeClaim:
-        claimName: test-nfs-claim
+        claimName: task-pv-storage


### PR DESCRIPTION
### Description

This PR improves the explanation of this section titled "Mounting the same persistentVolume in two places" in the [Configure a Pod to Use a PersistentVolume for Storage](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#mounting-the-same-persistentvolume-in-two-places) page.

1. I used the existing PV and PVC in this example.
2. I created a new `nginx.conf` file to show the file referenced in the pods manifest.
3. I explained why a `subPath` is used.

### Issue

Closes: #43293 and #49119