### PR TITLE
Update branch based context to production for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,8 +21,10 @@ command = "git submodule update --init --recursive --depth 1 && make deploy-prev
 [context.branch-deploy]
 command = "git submodule update --init --recursive --depth 1 && make non-production-build && npx -y pagefind --site public"
 
-[context.main]
-# This context is triggered by the `main` branch and allows search indexing
-# DO NOT REMOVE THIS (contact @kubernetes/sig-docs-leads)
+[context.production]
+# Rather than specifying context.main, which will supersede any of the above
+# context, make a production specific build separately based on the context
+# with the same priority.
+# Ref: https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
 publish = "public"
 command = "git submodule update --init --recursive --depth 1 && make production-build && npx -y pagefind --site public"


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This removes the branch based context of "context.main" which would be triggered and override any other contexts even during the PR cycle. The assumption here is that "production" context is marked appropriately on Netlify admin UI, and once it's in place, this should have the same effect to ensure we do not publish any draft or future date posts.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Other

I'm not fully familiar with Netlify, and this is an attempt to solve the draft blog posts to be reviewed in the future (this was originally highlighted in #48962 and tested with #48998). While I believe we need Netlify build to handle PRs better, this would need to be checked carefully as it could impact the website as a whole.