### PR TITLE
Use a path different from the key in the ConfigMap

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -179,11 +179,11 @@ spec:
         name: log-config
         items:
           - key: log_level
-            path: log_level
+            path: log_level.conf
 ```
 
 The `log-config` ConfigMap is mounted as a volume, and all contents stored in
-its `log_level` entry are mounted into the Pod at path `/etc/config/log_level`.
+its `log_level` entry are mounted into the Pod at path `/etc/config/log_level.conf`.
 Note that this path is derived from the volume's `mountPath` and the `path`
 keyed with `log_level`.
 


### PR DESCRIPTION

### Description

Currently, the name of the `key` in the `ConfigMap` coincides with the name of the `path` inside the `volumes` declaration. This may confuse people since it is not clear which of the values will be used later on when constructing the path to the file in the `volumeMounts` specification of the Container. To make the example more clear I renamed the filename so that it is different from the `key` and therefore it is more clear what object is used.

Currently, the value of the `ConfigMap.items[].key` field is the same as the `ConfigMap.items[].path` name in the declaration of `volumes`:

```yaml
  volumes:
    - name: config-vol
      configMap:
        name: log-config
        items:
          - key: log_level
            path: log_level

```

This can confuse people, as it is not clear which of these values will be used when constructing the file path in the `volumeMounts` specification of the container. To make the example clearer, I have renamed the `path` so that it is different from the `key` value and therefore it is clear which object is being used in the `volumeMounts` section.
