### PR TITLE
fix: past newsletter not being shown

### DIFF
--- a/data/i18n/bn/bn.toml
+++ b/data/i18n/bn/bn.toml
@@ -384,7 +384,7 @@ other = "কুবারনেটিস ফিচার"
 [main_kubeweekly_baseline]
 other = "সর্বশেষ কুবারনেটিস খবর পেতে আগ্রহী? KubeWeekly এর জন্য সাইন আপ করুন"
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "অতীতের নিউজলেটার দেখুন"
 
 [main_kubeweekly_signup]

--- a/data/i18n/de/de.toml
+++ b/data/i18n/de/de.toml
@@ -90,7 +90,7 @@ other = """Wir sind ein <a href="https://cncf.io/">CNCF</a> Abschlussprojekt</p>
 [main_kubeweekly_baseline]
 other = "Möchtest du die neuesten Nachrichten von Kubernetes erhalten? Melde dich für KubeWeekly an."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Frühere Newsletter anzeigen"
 
 [main_kubeweekly_signup]

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -407,7 +407,7 @@ other = "Kubernetes Features"
 [main_kubeweekly_baseline]
 other = "Interested in receiving the latest Kubernetes news? Sign up for KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "View past newsletters"
 
 [main_kubeweekly_signup]

--- a/data/i18n/es/es.toml
+++ b/data/i18n/es/es.toml
@@ -90,7 +90,7 @@ other = """Somos un proyecto graduado de la <a href="https://cncf.io/">CNCF</a><
 [main_kubeweekly_baseline]
 other = "¿Interesado en recibir las últimas noticias de Kubernetes? Suscríbase a KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Ver boletines anteriores"
 
 [main_kubeweekly_signup]

--- a/data/i18n/fr/fr.toml
+++ b/data/i18n/fr/fr.toml
@@ -87,7 +87,7 @@ other = """Nous sommes un projet <a href="https://cncf.io/">CNCF</a> diplômé</
 [main_kubeweekly_baseline]
 other = "Intéressez pour recevoir les dernières informations sur Kubernetes ? Abonnez-vous à KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Voir les newsletters précédentes"
 
 [main_kubeweekly_signup]

--- a/data/i18n/hi/hi.toml
+++ b/data/i18n/hi/hi.toml
@@ -194,7 +194,7 @@ other = "कुबेरनेट्स की विशेषताएं"
 [main_kubeweekly_baseline]
 other = "नवीनतम कुबेरनेट्स समाचार प्राप्त करने के इच्छुक हैं? KubeWeekly के लिए साइन अप करें।"
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "पिछले न्यूज़लेटर देखें"
 
 [main_kubeweekly_signup]

--- a/data/i18n/id/id.toml
+++ b/data/i18n/id/id.toml
@@ -160,7 +160,7 @@ other = "Fitur Kubernetes"
 [main_kubeweekly_baseline]
 other = "Tertarik untuk mendapatkan info terbaru tentang Kubernetes? Daftarkan dirimu ke KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Lihat buletin edisi sebelumnya"
 
 [main_kubeweekly_signup]

--- a/data/i18n/it/it.toml
+++ b/data/i18n/it/it.toml
@@ -157,7 +157,7 @@ other = "Caratteristiche di Kubernetes"
 [main_kubeweekly_baseline]
 other = "Sei interessato a ricevere le ultime notizie su Kubernetes? Registrati alla newsletter KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Vedi le precedenti mail della newsletter"
 
 [main_kubeweekly_signup]

--- a/data/i18n/ja/ja.toml
+++ b/data/i18n/ja/ja.toml
@@ -278,7 +278,7 @@ other = "Kubernetesの機能"
 [main_kubeweekly_baseline]
 other = "最新のKubernetesのニュースを受け取りたいですか？ KubeWeeklyにサインアップしてください。"
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "過去のニュースレターを見る"
 
 [main_kubeweekly_signup]

--- a/data/i18n/ko/ko.toml
+++ b/data/i18n/ko/ko.toml
@@ -217,7 +217,7 @@ other = "쿠버네티스 기능"
 [main_kubeweekly_baseline]
 other = "최신 쿠버네티스 뉴스 수신에 관심이 있으십니까? KubeWeekly를 신청하세요."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "과거 뉴스레터 보기"
 
 [main_kubeweekly_signup]

--- a/data/i18n/nl/nl.toml
+++ b/data/i18n/nl/nl.toml
@@ -78,7 +78,7 @@ other = """We zijn een <a href="https://cncf.io/">CNCF</a> project</p>"""
 [main_kubeweekly_baseline]
 other = "Wil je het laatste Kubernetes nieuws ontvangen? Abonneer je op KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Eerdere nieuwsbrieven bekijken"
 
 [main_kubeweekly_signup]

--- a/data/i18n/pl/pl.toml
+++ b/data/i18n/pl/pl.toml
@@ -304,7 +304,7 @@ other = "Funkcjonalności Kubernetesa"
 [main_kubeweekly_baseline]
 other = "Chcesz być na bieżąco z wiadomościami o Kubernetesie? Zapisz się do KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Zobacz poprzednie newslettery"
 
 [main_kubeweekly_signup]

--- a/data/i18n/pt-br/pt-br.toml
+++ b/data/i18n/pt-br/pt-br.toml
@@ -388,7 +388,7 @@ other = "Recursos do Kubernetes"
 [main_kubeweekly_baseline]
 other = "Interessado em receber as últimas novidades sobre o Kubernetes? Inscreva-se no KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Veja boletins passados"
 
 [main_kubeweekly_signup]

--- a/data/i18n/ru/ru.toml
+++ b/data/i18n/ru/ru.toml
@@ -384,7 +384,7 @@ other = "Возможности Kubernetes"
 [main_kubeweekly_baseline]
 other = "Интересуетесь последними новостями Kubernetes? Подпишитесь на KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Посмотреть последние новостные выпуски"
 
 [main_kubeweekly_signup]

--- a/data/i18n/uk/uk.toml
+++ b/data/i18n/uk/uk.toml
@@ -193,7 +193,7 @@ other = "Функціональні можливості Kubernetes"
 # other = "Interested in receiving the latest Kubernetes news? Sign up for KubeWeekly."
 other = "Хочете отримувати останні новини Kubernetes? Підпишіться на KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 # other = "View past newsletters"
 other = "Переглянути попередні інформаційні розсилки"
 

--- a/data/i18n/vi/vi.toml
+++ b/data/i18n/vi/vi.toml
@@ -352,7 +352,7 @@ other = "Tính năng Kubernetes"
 [main_kubeweekly_baseline]
 other = "Muốn nhận tin tức Kubernetes mới nhất không? Đăng ký KubeWeekly."
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "Xem những bản tin trước đó"
 
 [main_kubeweekly_signup]

--- a/data/i18n/zh-cn/zh-cn.toml
+++ b/data/i18n/zh-cn/zh-cn.toml
@@ -372,7 +372,7 @@ other = "Kubernetes 特性"
 [main_kubeweekly_baseline]
 other = "想要获取最新的 Kubernetes 新闻么？请订阅 KubeWeekly。"
 
-[main_kubernetes_past_link]
+[main_kubeweekly_past_link]
 other = "浏览往期的周报"
 
 [main_kubeweekly_signup]


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Updated the translation key for the text to be shown for past newsletters.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #49164 