### PR TITLE
Redesign KubeCon links on the main page

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -545,16 +545,27 @@ section#cncf {
     margin-bottom: 20px;
   }
 
-  #desktopKCButton {
-    position: absolute;
+  // All #desktopKCButton blocks are left for back compatibility and
+  // should be removed later, leaving .desktopKCButton only
+  // See https://github.com/kubernetes/website/pull/49167 for details
+  #desktopKCButton, .desktopKCButton {
+    display: inline-block;
     font-size: 18px;
     background-color: $dark-grey;
     border-radius: 8px;
     color: $white;
+    padding: 2px 8px;
+    margin: 5px;
+  }
+  
+  #desktopKCButton {
+    display: inline;
+    position: absolute;
     padding: 20px 10px 20px 10px;
+    margin: 0;
   }
 
-  #desktopKCButton:hover{
+  #desktopKCButton:hover, .desktopKCButton:hover{
     background-color: #ffffff;
     color: #326ce5;
     transition: 150ms;
@@ -567,7 +578,7 @@ section#cncf {
     border-radius: 8px;
     color: $primary;
     padding: 15px 30px 15px 80px;
-    margin-bottom: 15px;
+    margin-bottom: 35px;
 
     &:before {
       content: "";

--- a/assets/scss/_desktop.scss
+++ b/assets/scss/_desktop.scss
@@ -1,6 +1,6 @@
 $main-max-width: 1200px;
 $vendor-strip-height: 44px;
-$video-section-height: 550px;
+$video-section-height: 580px;
 
 @media screen and (min-width: 1024px) {
 

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -136,7 +136,7 @@ $video-section-height: 400px;
   #video {
     height: $video-section-height;
     display: block;
-    height: 500px;
+    height: 550px;
 
     & > .light-text {
       display: block;

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -42,20 +42,16 @@ To download Kubernetes, visit the [download](/releases/download/) section.
 
 {{< blocks/section id="video" background-image="kub_video_banner_homepage" >}}
 <div class="light-text">
-<h2>The Challenges of Migrating 150+ Microservices to Kubernetes</h2>
+    <h2>The Challenges of Migrating 150+ Microservices to Kubernetes</h2>
         <p>By Sarah Wells, Technical Director for Operations and Reliability, Financial Times</p>
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon North America on November 12-15</a>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon India on December 11-12</a>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe on April 1-4, 2025</a>
+
+    <h3>Attend upcoming KubeCon + CloudNativeCon events</h3>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" class="desktopKCButton"><strong>Europe</strong> (London, Apr 1-4)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Hong Kong, Jun 10-11)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Tokyo, Jun 16-17)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Hyderabad, Aug 6-7)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2025/" class="desktopKCButton"><strong>North America</strong> (Atlanta, Nov 10-13)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
### Description
I'm suggesting this redesign of the "Attend KubeCon…" block on the main page (see _After_):

![image](https://github.com/user-attachments/assets/9d8b44c1-ba44-4adb-a28b-3fe67197319b)

In my understanding, it's needed since we have five KubeCons now, and adding more huge buttons (as we did before — see _Before_) won't really work anymore.

While working on this design improvement, I've also noticed a long-standing HTML bug since we had such entities for the KubeCon links for many years: `<a href="..." button id="desktopKCButton">`. They are not valid for two reasons: a) the `<a>`  tag does not have the `button` attribute, and b) we can't use the same `id` for numerous HTML objects on the same page. Thus, I removed the `button` attribute and converted `desktopKCButton` from `id` to `class`.

UPDATE: To maintain back compatibility with the localised pages having old content at the moment, I left the `#desktopKCButton` blocks in the CSS file, which we'll be able to remove later (i.e. when all localisations switch to the new HTML code for KubeCon links).

Obviously, I've also synced the actual KubeCon events (links & dates) with the upcoming 2025 events. 

I've checked how the suggested changes are rendered in two browsers (Firefox and Chrome in Linux). However, more testing, as well as general feedback, will be very much appreciated.