### PR TITLE
Update pause with Docker Schema 2 image

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -69,7 +69,7 @@ metadata:
 spec:
   containers:
     - name: demo-container-1
-      image: registry.k8s.io/pause:2.0
+      image: registry.k8s.io/pause:3.8
       resources:
         limits:
           hardware-vendor.example/foo: 2

--- a/content/en/examples/admin/sched/pod1.yaml
+++ b/content/en/examples/admin/sched/pod1.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: pod-with-no-annotation-container
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8

--- a/content/en/examples/admin/sched/pod2.yaml
+++ b/content/en/examples/admin/sched/pod2.yaml
@@ -8,4 +8,4 @@ spec:
   schedulerName: default-scheduler
   containers:
   - name: pod-with-default-annotation-container
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8

--- a/content/en/examples/admin/sched/pod3.yaml
+++ b/content/en/examples/admin/sched/pod3.yaml
@@ -8,4 +8,4 @@ spec:
   schedulerName: my-scheduler
   containers:
   - name: pod-with-second-annotation-container
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8

--- a/content/en/examples/concepts/policy/limit-range/example-conflict-with-limitrange-cpu.yaml
+++ b/content/en/examples/concepts/policy/limit-range/example-conflict-with-limitrange-cpu.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: demo
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8
     resources:
       requests:
         cpu: 700m

--- a/content/en/examples/concepts/policy/limit-range/example-no-conflict-with-limitrange-cpu.yaml
+++ b/content/en/examples/concepts/policy/limit-range/example-no-conflict-with-limitrange-cpu.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: demo
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8
     resources:
       requests:
         cpu: 700m

--- a/content/en/examples/pods/pod-with-affinity-preferred-weight.yaml
+++ b/content/en/examples/pods/pod-with-affinity-preferred-weight.yaml
@@ -29,4 +29,4 @@ spec:
             - key-2
   containers:
   - name: with-node-affinity
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8

--- a/content/en/examples/pods/pod-with-node-affinity.yaml
+++ b/content/en/examples/pods/pod-with-node-affinity.yaml
@@ -23,4 +23,4 @@ spec:
             - another-node-label-value
   containers:
   - name: with-node-affinity
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8

--- a/content/en/examples/pods/pod-with-pod-affinity.yaml
+++ b/content/en/examples/pods/pod-with-pod-affinity.yaml
@@ -26,4 +26,4 @@ spec:
           topologyKey: topology.kubernetes.io/zone
   containers:
   - name: with-pod-affinity
-    image: registry.k8s.io/pause:2.0
+    image: registry.k8s.io/pause:3.8


### PR DESCRIPTION
Docker Schema 1 images are deprecated and support is [removed in containerd 2.0](https://containerd.io/releases/#deprecated-features). These workloads need updating in order to continue working.