### PR TITLE
fixing the typo the Object Names and IDs page

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -34,7 +34,7 @@ In cases when objects represent a physical entity, like a Node representing a ph
 
 The server may generate a name when `generateName` is provided instead of `name` in a resource create request.
 When `generateName` is used, the provided value is used as a name prefix, which server appends a generated suffix
-to. Even though the name is generated, it may conflict with existing names resulting in a HTTP 409 resopnse. This
+to. Even though the name is generated, it may conflict with existing names resulting in a HTTP 409 response. This
 became far less likely to happen in Kubernetes v1.31 and later, since the server will make up to 8 attempt to generate a
 unique name before returning a HTTP 409 response.
 


### PR DESCRIPTION
Hello ,

This PR resolve the issue bellow related to a typographical error in "Object Names and IDs" page #49199 
### Description

Current Text:
resulting in a HTTP 409 resopnse.

Change made:
resulting in a HTTP 409 response.

The related Page :
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
### Issue

https://github.com/kubernetes/website/issues/49199