### PR TITLE
added working navigation link to netlify.toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this repository, you need the following installed locally:
 - A container runtime, like [Docker](https://www.docker.com/).
 
 > [!NOTE]
-Make sure to install the Hugo extended version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L11) file.
+Make sure to install the Hugo extended version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](./netlify.toml) file.
 
 Before you start, install the dependencies. Clone the repository and navigate to the directory:
 


### PR DESCRIPTION
### Description
The README.md file has a link ( netlify.toml ) that is supposed to take the reader to the netlify.toml file, but the link is not working, so I added proper navigation to the file and the link is now working.

### Issue

Closes: #