### PR TITLE
Add note for TLS settings on default rule

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -520,6 +520,24 @@ section.
 {{% code_sample file="service/networking/tls-example-ingress.yaml" %}}
 
 {{< note >}}
+As an alternative to make TLS work on the default rule or when faced with specific 
+Subject Alternative Name requirements (e.g mandatory IPs instead of FQDN), user can update the 
+Ingress Controller to set as default certificate a custom Secret that satifies those requirements.
+
+If using Nginx Ingress:
+
+kubectl -n ingress-nginx edit deployment ingress-controller
+
+Edit the args section as follows:
+
+args:
+ - /nginx-ingress-controller
+ - '--publish-service=$(POD_NAMESPACE)/ingress-nginx-controller'
+ - '--default-ssl-certificate=default/testsecret-tls'
+ - ...
+{{< /note >}}
+
+{{< note >}}
 There is a gap between TLS features supported by various Ingress
 controllers. Please refer to documentation on
 [nginx](https://kubernetes.github.io/ingress-nginx/user-guide/tls/),


### PR DESCRIPTION
Alternative to make TLS work on the default rule or when faced with specific Subject Alternative Name requirements (e.g mandatory IPs instead of FQDN)

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #