### PR TITLE
Add drain to glossary

### DIFF
--- a/content/en/docs/reference/glossary/drain.md
+++ b/content/en/docs/reference/glossary/drain.md
@@ -1,0 +1,18 @@
+---
+title: Drain
+id: drain
+date: 2024-12-27
+full_link:
+short_description: >
+  Safely evicts Pods from a Node to prepare for maintenance or removal.
+tags:
+- fundamental
+- operation
+---
+The process of safely evicting {{< glossary_tooltip text="Pods" term_id="pod" >}} from a {{< glossary_tooltip text="Node" term_id="node" >}} to prepare it for maintenance or removal from a {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
+
+<!--more-->
+
+The `kubectl drain` command is used to mark a {{< glossary_tooltip text="Node" term_id="node" >}} as going out of service. 
+When executed, it evicts all {{< glossary_tooltip text="Pods" term_id="pod" >}} from the {{< glossary_tooltip text="Node" term_id="node" >}}. 
+If an eviction request is temporarily rejected, `kubectl drain` retries until all {{< glossary_tooltip text="Pods" term_id="pod" >}} are terminated or a configurable timeout is reached.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR adds a new glossary entry for the term "drain" to explain its meaning in Kubernetes. 
The entry includes a brief explanation of the concept, along with a reference to the kubectl drain command. 

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #49185