### PR TITLE
Update discovery document link

### DIFF
--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -86,7 +86,7 @@ Without indicating the resource type using the `Accept` header, the default
 response for the `/api` and `/apis` endpoint is an unaggregated discovery
 document.
 
-The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)
+The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2.json)
 for the built-in resources can be found in the Kubernetes GitHub repository.
 This Github document can be used as a reference of the base set of the available resources
 if a Kubernetes cluster is not available to query.

--- a/content/fr/docs/concepts/overview/kubernetes-api.md
+++ b/content/fr/docs/concepts/overview/kubernetes-api.md
@@ -78,7 +78,7 @@ la ressource de découverte agrégée :
 Sans indiquer le type de ressource à l'aide de l'en-tête `Accept`, la réponse par défaut
 pour les endpoints `/api` et `/apis` est un document de découverte non agrégé.
 
-Le [document de découverte](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)
+Le [document de découverte](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2.json)
 pour les ressources intégrées peut être trouvé dans le référentiel GitHub de Kubernetes.
 Ce document GitHub peut être utilisé comme référence pour l'ensemble de base des ressources disponibles
 si un cluster Kubernetes n'est pas disponible pour la requête.

--- a/content/zh-cn/docs/concepts/overview/kubernetes-api.md
+++ b/content/zh-cn/docs/concepts/overview/kubernetes-api.md
@@ -157,14 +157,14 @@ document.
 如果没有使用 `Accept` 头指示资源类型，对于 `/api` 和 `/apis` 端点的默认响应将是一个非聚合的发现文档。
 
 <!--
-The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)
+The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2.json)
 for the built-in resources can be found in the Kubernetes GitHub repository.
 This Github document can be used as a reference of the base set of the available resources
 if a Kubernetes cluster is not available to query.
 
 The endpoint also supports ETag and protobuf encoding.
 -->
-内置资源的[发现文档](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)可以在
+内置资源的[发现文档](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2.json)可以在
 Kubernetes GitHub 代码仓库中找到。如果手头没有 Kubernetes 集群可供查询，
 此 Github 文档可用作可用资源的基础集合的参考。端点还支持 ETag 和 protobuf 编码。
 


### PR DESCRIPTION
### Description
Update the discovery document link in the [Kubernetes APIs documentation](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#aggregated-discovery). The current link is returning a 404 error on GitHub.