### PR TITLE
[zh] update discovery document link

### DIFF
--- a/content/zh-cn/docs/concepts/overview/kubernetes-api.md
+++ b/content/zh-cn/docs/concepts/overview/kubernetes-api.md
@@ -157,14 +157,14 @@ document.
 如果没有使用 `Accept` 头指示资源类型，对于 `/api` 和 `/apis` 端点的默认响应将是一个非聚合的发现文档。
 
 <!--
-The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)
+The [discovery document](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2.json)
 for the built-in resources can be found in the Kubernetes GitHub repository.
 This Github document can be used as a reference of the base set of the available resources
 if a Kubernetes cluster is not available to query.
 
 The endpoint also supports ETag and protobuf encoding.
 -->
-内置资源的[发现文档](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2beta1.json)可以在
+内置资源的[发现文档](https://github.com/kubernetes/kubernetes/blob/release-{{< skew currentVersion >}}/api/discovery/aggregated_v2.json)可以在
 Kubernetes GitHub 代码仓库中找到。如果手头没有 Kubernetes 集群可供查询，
 此 Github 文档可用作可用资源的基础集合的参考。端点还支持 ETag 和 protobuf 编码。
 


### PR DESCRIPTION
### Description

Update the discovery document link in the [Kubernetes APIs documentation](https://kubernetes.io/zh-cn/docs/concepts/overview/kubernetes-api/#aggregated-discovery). The current link is returning a 404 error on GitHub.