### PR TITLE
Annual updation of OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -203,9 +203,11 @@ aliases:
     - shurup
   sig-docs-pl-owners: # Admins for Polish content
     - mfilocha
+    - nvtkaszpir
   sig-docs-pl-reviews: # PR reviews for Polish content
     - kpucynski
     - mfilocha
+    - nvtkaszpir
   sig-docs-uk-owners: # Admins for Ukrainian content
     - Arhell
     - MaxymVlasov

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -43,10 +43,12 @@ aliases:
     - asem-hamid
     - Imtiaz1234
     - mitul3737
+    - rajibmitra
   sig-docs-bn-reviews: # PR reviews for Bengali content
     - asem-hamid
     - Imtiaz1234
     - mitul3737
+    - rajibmitra
     - sajibAdhi
   sig-docs-de-owners: # Admins for German content
     - bene2k1
@@ -85,25 +87,41 @@ aliases:
     - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
     - electrocucaracha
+    - jossemarGT
     - krol3
     - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - perriea
+    - rekcah78
+    - remyleone
   sig-docs-fr-reviews: # PR reviews for French content
     - perriea
+    - rekcah78
+    - remyleone
   sig-docs-hi-owners: # Admins for Hindi content
     - dipesh-rawat
     - divya-mohan0209
   sig-docs-hi-reviews: # PR reviews for Hindi content
+    - bishal7679
     - dipesh-rawat
     - divya-mohan0209
     - niranjandarshann
   sig-docs-id-owners: # Admins for Indonesian content
+    - ariscahyadi
+    - girikuncoro
     - habibrosyad
   sig-docs-id-reviews: # PR reviews for Indonesian content
+    - ariscahyadi
+    - girikuncoro
     - habibrosyad
   sig-docs-it-owners: # Admins for Italian content
+    - fabriziopandini
+    - Fale
+    - mattiaperi
   sig-docs-it-reviews: # PR reviews for Italian content
+    - fabriziopandini
+    - Fale
+    - mattiaperi
   sig-docs-ja-owners: # Admins for Japanese content
     - bells17
     - inductor
@@ -114,6 +132,7 @@ aliases:
     - b1gb4by
     - bells17
     - inductor
+    - kakts
     - nasa9084
     - Okabe-Junya
     - t-inu
@@ -121,10 +140,16 @@ aliases:
     - gochist
     - jihoon-seo
     - seokho-son
+    - yoonian
+    - ysyukr
   sig-docs-ko-reviews: # PR reviews for Korean content
+    - gochist
     - jihoon-seo
+    - jmyung
     - jongwooo
     - seokho-son
+    - yoonian
+    - ysyukr
   sig-docs-leads: # Website chairs and tech leads
     - divya-mohan0209
     - natalisucks
@@ -137,6 +162,7 @@ aliases:
     - howieyuen
     - mengjiao-liu
     - my-git9
+    - SataQiu
     - tengqm
     - windsonsea
     - xichengliudui
@@ -149,15 +175,18 @@ aliases:
     - mengjiao-liu
     - my-git9
     # pigletfly
+    - SataQiu
     - tengqm
     - windsonsea
     - xichengliudui
     - ydFu
   sig-docs-pt-owners: # Admins for Portuguese content
     - edsoncelio
+    - jcjesus
     - stormqueen1990
   sig-docs-pt-reviews: # PR reviews for Portugese content
     - edsoncelio
+    - jcjesus
     - mrerlison
     - stormqueen1990
   sig-docs-vi-owners: # Admins for Vietnamese content
@@ -173,7 +202,10 @@ aliases:
     - kirkonru
     - shurup
   sig-docs-pl-owners: # Admins for Polish content
+    - mfilocha
   sig-docs-pl-reviews: # PR reviews for Polish content
+    - kpucynski
+    - mfilocha
   sig-docs-uk-owners: # Admins for Ukrainian content
     - Arhell
     - MaxymVlasov

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -43,19 +43,15 @@ aliases:
     - asem-hamid
     - Imtiaz1234
     - mitul3737
-    - rajibmitra
   sig-docs-bn-reviews: # PR reviews for Bengali content
     - asem-hamid
     - Imtiaz1234
     - mitul3737
-    - rajibmitra
     - sajibAdhi
   sig-docs-de-owners: # Admins for German content
     - bene2k1
-    - rlenferink
   sig-docs-de-reviews: # PR reviews for German content
     - bene2k1
-    - rlenferink
   sig-docs-en-owners: # Admins for English content
     - dipesh-rawat
     - divya-mohan0209
@@ -73,7 +69,6 @@ aliases:
     - katcosgrove
     - kbhawkey
     - mengjiao-liu
-    - mickeyboxell
     - natalisucks
     - nate-double-u
     - reylejano
@@ -90,44 +85,25 @@ aliases:
     - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
     - electrocucaracha
-    - jossemarGT
     - krol3
     - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - perriea
-    - rekcah78
-    - remyleone
   sig-docs-fr-reviews: # PR reviews for French content
     - perriea
-    - rekcah78
-    - remyleone
   sig-docs-hi-owners: # Admins for Hindi content
     - dipesh-rawat
     - divya-mohan0209
   sig-docs-hi-reviews: # PR reviews for Hindi content
-    - Babapool
-    - bishal7679
     - dipesh-rawat
     - divya-mohan0209
     - niranjandarshann
   sig-docs-id-owners: # Admins for Indonesian content
-    - ariscahyadi
-    - danninov
-    - girikuncoro
     - habibrosyad
   sig-docs-id-reviews: # PR reviews for Indonesian content
-    - ariscahyadi
-    - danninov
-    - girikuncoro
     - habibrosyad
   sig-docs-it-owners: # Admins for Italian content
-    - fabriziopandini
-    - Fale
-    - mattiaperi
   sig-docs-it-reviews: # PR reviews for Italian content
-    - fabriziopandini
-    - Fale
-    - mattiaperi
   sig-docs-ja-owners: # Admins for Japanese content
     - bells17
     - inductor
@@ -138,7 +114,6 @@ aliases:
     - b1gb4by
     - bells17
     - inductor
-    - kakts
     - nasa9084
     - Okabe-Junya
     - t-inu
@@ -146,16 +121,10 @@ aliases:
     - gochist
     - jihoon-seo
     - seokho-son
-    - yoonian
-    - ysyukr
   sig-docs-ko-reviews: # PR reviews for Korean content
-    - gochist
     - jihoon-seo
-    - jmyung
     - jongwooo
     - seokho-son
-    - yoonian
-    - ysyukr
   sig-docs-leads: # Website chairs and tech leads
     - divya-mohan0209
     - natalisucks
@@ -168,9 +137,6 @@ aliases:
     - howieyuen
     - mengjiao-liu
     - my-git9
-    - SataQiu
-    - Sea-n
-    - tanjunchen
     - tengqm
     - windsonsea
     - xichengliudui
@@ -180,33 +146,23 @@ aliases:
     - chenrui333
     - howieyuen
     # idealhack
-    - kinzhi
     - mengjiao-liu
     - my-git9
     # pigletfly
-    - SataQiu
-    - Sea-n
-    - tanjunchen
     - tengqm
     - windsonsea
     - xichengliudui
     - ydFu
   sig-docs-pt-owners: # Admins for Portuguese content
-    - devlware
     - edsoncelio
-    - jcjesus
     - stormqueen1990
   sig-docs-pt-reviews: # PR reviews for Portugese content
-    - devlware
     - edsoncelio
-    - jcjesus
     - mrerlison
     - stormqueen1990
   sig-docs-vi-owners: # Admins for Vietnamese content
-    - huynguyennovem
     - truongnh1992
   sig-docs-vi-reviews: # PR reviews for Vietnamese content
-    - huynguyennovem
     - truongnh1992
   sig-docs-ru-owners: # Admins for Russian content
     - Arhell
@@ -217,12 +173,7 @@ aliases:
     - kirkonru
     - shurup
   sig-docs-pl-owners: # Admins for Polish content
-    - mfilocha
-    - nvtkaszpir
   sig-docs-pl-reviews: # PR reviews for Polish content
-    - kpucynski
-    - mfilocha
-    - nvtkaszpir
   sig-docs-uk-owners: # Admins for Ukrainian content
     - Arhell
     - MaxymVlasov


### PR DESCRIPTION
### Context

We've been using the [maintainer's tool](https://github.com/kubernetes-sigs/maintainers) to clean up the OWNERS_ALIASES file for k/website annually. With this exercise, we aim to keep the file updated and hope to foster healthy community leadership within SIG Docs. The results of running the tool this year have been provided below.

### What do I need to do if I have been tagged on this PR?

If you wish to continue as an approver, reviewer, or localization owner, please confirm your intent on this PR by **2nd February 2025**

### Points to note:

- We recognize that GitHub isn't the only way to contribute and are seeking confirmation of your intent to continue as an approver/reviewer for the next year based on your bandwidth. 
- While we understand that localisations have a different volume of contributors and contributions, the respective approvers & reviewers are expected to grow a community around every translation. If you face challenges in this aspect, please make sure you bring it up in the appropriate forum for awareness and seek assistance (e.g. slack channel, routine meetings etc) cc: @seokho-son @a-mccarthy 
- Failure to confirm your intent within the lazy consensus timeframe will cause removal from the OWNERS_ALIASES file.

### Changes proposed by this PR

Pruning following folks from OWNERS_ALIASES due to zero contributions OR contributions < 25.

@Babapool
@ariscahyadi
@bishal7679
@cji
@danninov
@devlware
@gochist
@jmyung
@mattiaperi
@yoonian
@ysyukr
@Fale
@SataQiu
@Sea-n
@fabriziopandini
@girikuncoro
@huynguyennovem
@jcjesus
@jossemarGT
@kakts
@kinzhi
@kpucynski
@mfilocha
@micahhausler
@mickeyboxell
@nvtkaszpir
@rajibmitra
@rekcah78
@remyleone
@rlenferink
@tanjunchen

### Output of the maintainers tool

```
 maintainers prune --repository-devstats "kubernetes/website" --repository-github "kubernetes/website" --dryrun=true
Running script : 01-02-2025 10:21:44
Processed /Users/divyamohan/website/OWNERS
Processed /Users/divyamohan/website/OWNERS_ALIASES
Found 44 unique aliases
Found 110 unique users
..............................................................................................................................................................

>>>>> Missing Contributions in kubernetes/website (devstats == 0): 15
Babapool
IanColdwater
ariscahyadi
bishal7679
cji
danninov
devlware
gochist
idvoretskyi
jmyung
joelsmith
jrsapi
mattiaperi
yoonian
ysyukr


>>>>> Low reviews/approvals in kubernetes/website (GH pr comments <= 10 && devstats <=20): 29
Fale
SaranBalaji90
SataQiu
Sea-n
Verolop
ameukam
cjcullen
fabriziopandini
girikuncoro
huynguyennovem
jcjesus
jeremyrickard
jimangel
jossemarGT
justaugustus
kakts
kinzhi
kpucynski
mfilocha
micahhausler
mickeyboxell
mrbobbytables
nvtkaszpir
palnabarun
rajibmitra
rekcah78
remyleone
rlenferink
tanjunchen
--dryrun is set to true, will skip updating OWNERS and OWNER_ALIASES%   
```

cc: @natalisucks @reylejano @katcosgrove @tengqm @salaxander 