### PR TITLE
added a info about the auto heal of k8

### DIFF
--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -106,6 +106,29 @@ kube-proxy on the nodes in your cluster.
 
 {{< glossary_definition term_id="container-runtime" length="all" >}}
 
+## Ability to self-heal
+
+The idea behind self-healing Kubernetes is simple: If a container fails, Kubernetes automatically redeploys the afflicted 
+container to its desired state to restore operations
+
+Self-healing Kubernetes has four capabilities :
+
+ - restart failed containers.
+ - replace containers that require updates, such as a new software version.
+ - disable containers that don't respond to predefined health checks.
+ - prevent containers from appearing to users or other containers until they are ready.
+
+Ideally, container detection and restoration should be seamless and immediate, minimize application disruption and mitigate negative UX.
+Organizations can specify how Kubernetes performs health checks and what actions it should take after it detects a problem.
+
+How does self-healing work with Kubernetes? :
+ 
+- Pending. The pod has been created but is not running.
+- Running. The pod and its containers are running without issue
+- Succeeded. The pod completes its container lifecycle properly -- it runs and stops normally.
+- Failed. At least one container within the pod has failed, and the pod is terminated.
+- Unknown. The pod's state and disposition cannot be determined.
+
 ## Addons
 
 Addons use Kubernetes resources ({{< glossary_tooltip term_id="daemonset" >}},


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The Kubernetes documentation currently mentions self-healing as a feature, but it does not provide a detailed explanation of what self-healing entails. This feature request aims to address that gap by adding a concise, dedicated page within the [Kubernetes architecture section](https://kubernetes.io/docs/concepts/architecture/). The new page will briefly outline Kubernetes' self-healing capabilities, such as automatic Pod replacement, workload rescheduling, node health monitoring, and storage recovery. It will also link to relevant documentation to guide users in implementing and understanding these features.

### Issue
#48963