### PR TITLE
Show correct proxied Pod API URL in deploy-intro

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -153,7 +153,7 @@ description: |-
                 <p><b><code>export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')</code></b><br />
                    <b><code>echo Name of the Pod: $POD_NAME</code></b></p>
                 <p>You can access the Pod through the proxied API, by running:</p>
-                <p><b><code>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME:8080/proxy/</code></b></p>
+                <p><b><code>curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME/</code></b></p>
                 <p>In order for the new Deployment to be accessible without using the proxy, a Service is required which will be explained in <a href="/docs/tutorials/kubernetes-basics/expose/">Module 4</a>.</p>
             </div>
 


### PR DESCRIPTION
### Description

Old URL -- `.../$POD_NAME:8080/proxy` -- returns nothing when we send a (curl) request as suggested by the docs around.
I believe the goal at that point of the documentation is to show the user they can retrieve information about pod `$POD_NAME` using the proxy mechanism -- _i.e._ `localhost:8001`.

When we request from `.../$POD_NAME/`, though, we get information about that pod. Which I believe is correct: for the user to understand the point on proxying+API.