### PR TITLE
Removes sftim from leads; adds katcosgrove

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -158,10 +158,10 @@ aliases:
     - ysyukr
   sig-docs-leads: # Website chairs and tech leads
     - divya-mohan0209
+    - katcosgrove
     - natalisucks
     - reylejano
     - salaxander
-    - sftim
     - tengqm
   sig-docs-zh-owners: # Admins for Chinese content
     - chenrui333


### PR DESCRIPTION
### Description

Removes sftim from leads, as he is now emeritus. Adds katcosgrove, as I am a tech lead.

cc: @divya-mohan0209 @natalisucks @reylejano @salaxander 