### PR TITLE
Remove tutorials link to java microservice example

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -25,7 +25,6 @@ Before walking through each tutorial, you may want to bookmark the
 
 ## Configuration
 
-* [Example: Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
 * [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Authoring Pods


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

Follow up needed for other languages, and Java tutorial source files still need to be removed for KO and HI translations.

### Issue

Closes: #49324