### PR TITLE
Update information about CronJob's unsupported time zone field

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -60,7 +60,7 @@ The `.spec.schedule` field is required. The value of that field follows the [Cro
 # │ │ │ ┌───────────── month (1 - 12)
 # │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
 # │ │ │ │ │                                   OR sun, mon, tue, wed, thu, fri, sat
-# │ │ │ │ │ 
+# │ │ │ │ │
 # │ │ │ │ │
 # * * * * *
 ```
@@ -192,13 +192,10 @@ A time zone database from the Go standard library is included in the binaries an
 ### Unsupported TimeZone specification
 
 Specifying a timezone using `CRON_TZ` or `TZ` variables inside `.spec.schedule`
-is **not officially supported** (and never has been).
-
-Starting with Kubernetes 1.29 if you try to set a schedule that includes `TZ` or `CRON_TZ`
-timezone specification, Kubernetes will fail to create the resource with a validation
-error.
-Updates to CronJobs already using `TZ` or `CRON_TZ` will continue to report a
-[warning](/blog/2020/09/03/warnings/) to the client.
+is **not officially supported** (and never has been). If you try to set a schedule
+that includes `TZ` or `CRON_TZ` timezone specification, Kubernetes will fail to
+create or update the resource with a validation error. You should specify time zones
+using the [time zone field](#time-zones), instead.
 
 ### Modifying a CronJob
 


### PR DESCRIPTION
### Description
This is accompanying the change from https://github.com/kubernetes/kubernetes/pull/129510 which entirely forbids `CRON_TZ` and `TZ` variables in `.spec.schedule` of a cronjob. 

/hold 
for the k8s PR to merge first

