### PR TITLE
Update documentation for SLIs and z-pages with descriptions

### DIFF
--- a/content/en/docs/reference/instrumentation/slis.md
+++ b/content/en/docs/reference/instrumentation/slis.md
@@ -1,19 +1,21 @@
 ---
 reviewers:
-- logicalhan
+  - logicalhan
 title: Kubernetes Component SLI Metrics
 linkTitle: Service Level Indicator Metrics
 content_type: reference
 weight: 20
+description: >-
+  High-level indicators for measuring the reliability and performance of Kubernetes components.
 ---
 
 <!-- overview -->
 
 {{< feature-state for_k8s_version="v1.29" state="stable" >}}
 
-By default, Kubernetes {{< skew currentVersion >}} publishes Service Level Indicator (SLI) metrics 
-for each Kubernetes component binary. This metric endpoint is exposed on the serving 
-HTTPS port of each component, at the path `/metrics/slis`. The 
+By default, Kubernetes {{< skew currentVersion >}} publishes Service Level Indicator (SLI) metrics
+for each Kubernetes component binary. This metric endpoint is exposed on the serving
+HTTPS port of each component, at the path `/metrics/slis`. The
 `ComponentSLIs` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 defaults to enabled for each Kubernetes component as of v1.27.
 
@@ -30,7 +32,6 @@ labeled per healthcheck:
 You can use the metric information to calculate per-component availability statistics.
 For example, the API server checks the health of etcd. You can work out and report how
 available or unavailable etcd has been - as reported by its client, the API server.
-
 
 The prometheus gauge data looks like this:
 
@@ -73,4 +74,4 @@ kubernetes_healthchecks_total{name="ping",status="success",type="readyz"} 15
 The component SLIs metrics endpoint is intended to be scraped at a high frequency. Scraping
 at a high frequency means that you end up with greater granularity of the gauge's signal, which
 can be then used to calculate SLOs. The `/metrics/slis` endpoint provides the raw data necessary
-to calculate an availability SLO for the respective Kubernetes component. 
+to calculate an availability SLO for the respective Kubernetes component.

--- a/content/en/docs/reference/instrumentation/zpages.md
+++ b/content/en/docs/reference/instrumentation/zpages.md
@@ -3,9 +3,10 @@ title: Kubernetes z-pages
 content_type: reference
 weight: 60
 reviewers:
-- dashpole
+  - dashpole
+description: >-
+  Provides runtime diagnostics for Kubernetes components, offering insights into traces, stats, and debugging information.
 ---
-
 
 <!-- overview -->
 


### PR DESCRIPTION
**Description:**  
This pull request updates the Kubernetes documentation to include concise descriptions for SLIs (Service Level Indicators) and z-pages. These updates aim to improve clarity and provide readers with a better understanding of these components' functionality:  

1. **Kubernetes Component SLIs:** Added a brief overview explaining SLIs and their role in monitoring the health and performance of Kubernetes components.  
2. **Kubernetes z-pages:** Included a description of z-pages, highlighting their purpose in runtime diagnostics and real-time performance monitoring.  

**Fixes:**  
This pull request addresses [[issue #48959](https://github.com/kubernetes/website/issues/48959)](https://github.com/kubernetes/website/issues/48959) by adding the required descriptions to the documentation.  

Feedback and suggestions are welcome!