### PR TITLE
Add description for Kubernetes Component SLI Metrics and z-pages

### DIFF
--- a/content/en/docs/reference/instrumentation/slis.md
+++ b/content/en/docs/reference/instrumentation/slis.md
@@ -5,6 +5,8 @@ title: Kubernetes Component SLI Metrics
 linkTitle: Service Level Indicator Metrics
 content_type: reference
 weight: 20
+description: >-
+  High-level indicators for measuring the reliability and performance of Kubernetes components.
 ---
 
 <!-- overview -->

--- a/content/en/docs/reference/instrumentation/zpages.md
+++ b/content/en/docs/reference/instrumentation/zpages.md
@@ -5,7 +5,7 @@ weight: 60
 reviewers:
 - dashpole
 description: >-
-  Provides runtime diagnostics for Kubernetes components, offering insights into traces, stats, and debugging information.
+  Provides runtime diagnostics for Kubernetes components, offering insights into component runtime status and configuration flags.
 ---
 
 

--- a/content/en/docs/reference/instrumentation/zpages.md
+++ b/content/en/docs/reference/instrumentation/zpages.md
@@ -4,6 +4,8 @@ content_type: reference
 weight: 60
 reviewers:
 - dashpole
+description: >-
+  Provides runtime diagnostics for Kubernetes components, offering insights into traces, stats, and debugging information.
 ---
 
 


### PR DESCRIPTION
**Description**
Add descriptions for Kubernetes Component SLI Metrics and z-pages as they are only missing ones.

**Issue**
Closes: [#48959](https://github.com/kubernetes/website/issues/48959)

**Additional**
This PR is addition to [#49295](https://github.com/kubernetes/website/pull/49295). Because, this one also includes description for z-pages.