### PR TITLE
Fix feature gate DaemonSetUpdateSurge status

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DaemonSetUpdateSurge.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DaemonSetUpdateSurge.md
@@ -18,7 +18,7 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.25"
-    toVersion: "1.28"
+    toVersion: "1.26"
 
 removed: true  
 ---


### PR DESCRIPTION
This gate was removed in 1.27, not 1.29.
