### PR TITLE
Fix gate status for DefaultHostNetworkHostPortsInPodTemplates

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DefaultHostNetworkHostPortsInPodTemplates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DefaultHostNetworkHostPortsInPodTemplates.md
@@ -8,7 +8,10 @@ _build:
 stages:
   - stage: deprecated
     defaultValue: false
-    fromVersion: "1.28"  
+    fromVersion: "1.28"
+    toVersion: "1.30"
+
+removed: true
 ---
 This feature gate controls the point at which a default value for
 `.spec.containers[*].ports[*].hostPort`


### PR DESCRIPTION
The gate was removed in v1.31.
