### PR TITLE
Fix gate status for DisableNodeKubeProxyVersion

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableNodeKubeProxyVersion.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableNodeKubeProxyVersion.md
@@ -12,6 +12,14 @@ stages:
     toVersion: "1.30"
   - stage: beta
     defaultValue: true
-    fromVersion: "1.31"
+    fromVersion: '1.31.0'
+    toVersion: '1.31.0'
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.31.1"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.32"
+
 ---
 Disable setting the `kubeProxyVersion` field of the Node.


### PR DESCRIPTION
The gate was "deprecated" in v1.31 after several rounds of battles.
