### PR TITLE
Fix status for EventedPLEG

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/EventedPLEG.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/EventedPLEG.md
@@ -8,7 +8,7 @@ _build:
 stages:
   - stage: alpha
     defaultValue: false
-    fromVersion: "1.25"
+    fromVersion: "1.26"
 ---
 Enable support for the kubelet to receive container life cycle events from the
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}} via


### PR DESCRIPTION
This gate was introduced in v1.26 rather than v1.25.
