### PR TITLE
Fix gate status for JobManagedBy in v1.32

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/JobManagedBy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/JobManagedBy.md
@@ -12,7 +12,7 @@ stages:
     fromVersion: "1.30"
     toVersion: "1.31"
   - stage: beta
-    defaultValue: false
+    defaultValue: true
     fromVersion: "1.32"
 ---
 Allows to delegate reconciliation of a Job object to an external controller.


### PR DESCRIPTION
The default value for `JobManagedBy` is `true`, not `false`.
