### PR TITLE
Fix gate status for StorageVersionMigrator in v1.32

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StorageVersionMigrator.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StorageVersionMigrator.md
@@ -9,6 +9,5 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.30"
-    toVersion: "1.32"
 ---
 Enables storage version migration. See [Migrate Kubernetes Objects Using Storage Version Migration](/docs/tasks/manage-kubernetes-objects/storage-version-migration) for more details.


### PR DESCRIPTION
The alpha stage for `StorageVersionMigrator` has not ended yet.
