### PR TITLE
Fix gate status for StrictCostEnforcementForVAP in v1.32

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForVAP.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForVAP.md
@@ -9,7 +9,11 @@ _build:
 stages:
   - stage: beta
     defaultValue: false
-    fromVersion: "1.31"
+    fromVersion: "1.30"
+    toVersion: "1.31"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.32"
 ---
 Apply strict CEL cost validation for ValidatingAdmissionPolicies.
 


### PR DESCRIPTION
The gate `StrictCostEnforcementForVAP` has been GA'ed and locked to default in v1.32.
