### PR TITLE
Fix gate status for StrictCostEnforcementForWebhooks in v1.32

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForWebhooks.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictCostEnforcementForWebhooks.md
@@ -10,6 +10,10 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.31"
+    toVersion: "1.31"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.32"
 ---
 Apply strict CEL cost validation for `matchConditions` within
 admission webhooks.


### PR DESCRIPTION
The feature gate `StrictCostEnforcementForWebhooks` is now stable in v1.32.
