### PR TITLE
Fix gate status for WindowsGMSA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/WindowsGMSA.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/WindowsGMSA.md
@@ -19,7 +19,7 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.18"
-    toVersion: "1.20"
+    toVersion: "1.18"
 
 removed: true
 ---


### PR DESCRIPTION
The feature gate `WindowsGMSA` was removed in v1.19.
