### PR TITLE
Add feature gate for APIServingWithRoute

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/APIServingWithRoute.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/APIServingWithRoute.md
@@ -1,0 +1,16 @@
+---
+title: APIServingWithRoute
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.30"
+---
+This feature gate enables an API server performance improvement:
+the API server can use separate goroutines (lightweight threads managed by the Go runtime)
+to serve [**watch**](/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
+requests.


### PR DESCRIPTION
Docs for this gate has been missing since v1.30.
