### PR TITLE
Fix horizontal scrolling for the deprecation warning

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1135,7 +1135,7 @@ body.cid-community #cncf-code-of-conduct h2:after {
     color: #fff;
     padding: 0;
     margin: 0;
-    width: 100vw;
+    width: 100%;
 }
 #caseStudies body > #deprecation-warning, body.cid-casestudies > #deprecation-warning {
     padding-top: 32px;


### PR DESCRIPTION
Currently, if the deprecation warning is displayed, it brings unnecessary horizontal scrolling when old versions of some pages (e.g. [/community in v1.31](https://v1-31.docs.kubernetes.io/community/)) rendered in Google Chrome. It happens due to this block's width being a bit larger than the actual screen width:

![image](https://github.com/user-attachments/assets/486921b8-c1fb-4f26-a462-e1df35a20dc0)

This PR fixes that by changing the width value from `100vw` to `100%`. I tested this change in Google Chrome 131.0.6778.139 (Official Build) (64-bit) under Linux + reassured it didn't affect the page rendering in Firefox/Linux.