### PR TITLE
Remove unnecessary flag --target-port=8080 from expose deployment of type ClusterIP command

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -105,7 +105,7 @@ iptables
 You can test source IP preservation by creating a Service over the source IP app:
 
 ```shell
-kubectl expose deployment source-ip-app --name=clusterip --port=80 --target-port=8080
+kubectl expose deployment source-ip-app --name=clusterip --port=80
 ```
 The output is:
 ```


### PR DESCRIPTION
Remove unnecessary flag `--target-port=8080` from expose deployment of type ClusterIP command

### Description
`--target-port=8080` is required for NodePort and not required for ClusterIP. Although it works, it is confusing.

### Issue
None

Closes: None