### PR TITLE
[ja] Redirect legacy AppArmor tutorial to new page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -339,6 +339,7 @@
 /docs/tutorials/kubernetes-basics/scale-interactive/     /docs/tutorials/kubernetes-basics/scale/scale-interactive/ 301
 /docs/tutorials/kubernetes-basics/scale-intro/     /docs/tutorials/kubernetes-basics/scale/scale-intro/ 301
 /docs/tutorials/clusters/apparmor/     /docs/tutorials/security/apparmor/   301
+/ja/docs/tutorials/clusters/apparmor/     /ja/docs/tutorials/security/apparmor/ 301
 /docs/tutorials/clusters/seccomp/      /docs/tutorials/security/seccomp/    301
 /ja/docs/tutorials/kubernetes-basics/scale-intro/     /ja/docs/tutorials/kubernetes-basics/scale/scale-intro/ 301
 /ko/docs/tutorials/kubernetes-basics/scale-intro/     /ko/docs/tutorials/kubernetes-basics/scale/scale-intro/ 301


### PR DESCRIPTION
### Description

As per [comments](https://github.com/kubernetes/website/pull/49304#discussion_r1905522620) in #49304, add a redirect link from the legacy AppArmor tutorial to the new page.

If there are legacy links, send people to the new page.
Done for Japanese only.

/cc @Okabe-Junya 