### PR TITLE
[uk] Remove tutorials link to java microservice example

### DIFF
--- a/content/uk/docs/tutorials/_index.md
+++ b/content/uk/docs/tutorials/_index.md
@@ -36,7 +36,6 @@ Before walking through each tutorial, you may want to bookmark the
 -->
 ## Конфігурація
 
-* [Приклад: Конфігурування Java мікросервісу](/docs/tutorials/configuration/configure-java-microservice/)
 * [Конфігурування Redis використовуючи ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Застосунки без стану (Stateless Applications) {#застосунки-без-стану}


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324