### PR TITLE
[bn] Remove tutorials link to java microservice example

### DIFF
--- a/content/bn/docs/tutorials/_index.md
+++ b/content/bn/docs/tutorials/_index.md
@@ -25,7 +25,6 @@ content_type: ধারণা
 
 ## কনফিগারেশন
 
-* [উদাহরণ: একটি জাভা মাইক্রোসার্ভিস কনফিগার কর](/docs/tutorials/configuration/configure-java-microservice/)
 * [কনফিগার ম্যাপ ব্যবহার করে রেডিস কনফিগার কর](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## স্টেটলেস অ্যাপ্লিকেশন


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324