### PR TITLE
[pl] Remove tutorials link to java microservice example

### DIFF
--- a/content/pl/docs/tutorials/_index.md
+++ b/content/pl/docs/tutorials/_index.md
@@ -26,8 +26,6 @@ Przed zapoznaniem się z samouczkami warto stworzyć zakładkę do
 
 ## Konfiguracja
 
-* [Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
-
 * [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Aplikacje bezstanowe *(Stateless Applications)*


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324