### PR TITLE
[es] Remove tutorials link to java microservice example

### DIFF
--- a/content/es/docs/tutorials/_index.md
+++ b/content/es/docs/tutorials/_index.md
@@ -29,7 +29,6 @@ Antes de recorrer cada tutorial, recomendamos añadir un marcador a
 
 ## Configuración
 
-* [Ejemplo: Configurando un Microservicio en Java](/docs/tutorials/configuration/configure-java-microservice/)
 * [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Creación de Pods


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324