### PR TITLE
[ja] Remove tutorials link to java microservice example

### DIFF
--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -24,8 +24,6 @@ content_type: concept
 
 ## 設定
 
-* [例: Javaのマイクロサービスの設定](/docs/tutorials/configuration/configure-java-microservice/)
-
 * [ConfigMapを用いたRedisの設定](/ja/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## ステートレスアプリケーション


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324