### PR TITLE
[pt-br] Remove tutorial link to java microservice example

### DIFF
--- a/content/pt-br/docs/tutorials/_index.md
+++ b/content/pt-br/docs/tutorials/_index.md
@@ -30,8 +30,6 @@ Antes de iniciar um tutorial, é interessante que você salve a página do
 
 ## Configuração
 
-* [Exemplo: Configurando um Microsserviço Java](/docs/tutorials/configuration/configure-java-microservice/)
-
 * [Configurando o Redis usando um ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Aplicações sem estado (_stateless_)


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324