### PR TITLE
[zh-cn] Remove tutorial link to java microservice example

### DIFF
--- a/content/zh-cn/docs/tutorials/_index.md
+++ b/content/zh-cn/docs/tutorials/_index.md
@@ -46,12 +46,10 @@ Kubernetes 文档的这一部分包含教程。
 <!--
 ## Configuration
 
-* [Example: Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
 * [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 -->
 ## 配置  {#configuration}
 
-* [示例：配置 Java 微服务](/zh-cn/docs/tutorials/configuration/configure-java-microservice/)
 * [使用 ConfigMap 配置 Redis](/zh-cn/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 <!--


### PR DESCRIPTION
### Description

This content was removed by an earlier PR (#48776), but not cleaned up from the tutorials index.

### Issue

Closes: #49324