### PR TITLE
Update the Volume Snapshot Classes Page

### DIFF
--- a/content/en/docs/concepts/storage/volume-snapshot-classes.md
+++ b/content/en/docs/concepts/storage/volume-snapshot-classes.md
@@ -67,6 +67,22 @@ deletionPolicy: Delete
 parameters:
 ```
 
+If multiple CSI drivers exist, a default VolumeSnapshotClass can be specified
+for each of them.
+
+### VolumeSnapshotClass dependencies
+
+When you create a VolumeSnapshot without specifying a VolumeSnapshotClass, Kubernetes
+automatically selects a default VolumeSnapshotClass that has a CSI driver matching
+the CSI driver of the PVC’s StorageClass.
+
+This behavior allows multiple default VolumeSnapshotClass objects to coexist in a cluster, as long as
+each one is associated with a unique CSI driver.
+
+Always ensure that there is only one default VolumeSnapshotClass for each CSI driver. If
+multiple default VolumeSnapshotClass objects are created using the same CSI driver,
+a VolumeSnapshot creation will fail because Kubernetes cannot determine which one to use.
+
 ### Driver
 
 Volume snapshot classes have a driver that determines what CSI volume plugin is


### PR DESCRIPTION
### Description

This improves the understanding of what happens when you run multiple CSI drivers and create a default VolumeSnapshotClass. For example:
- The effect of creating a volume snapshot for multiple CSI drivers without specifying a VolumeSnapshotClass.
- The effect of creating multiple default VolumeSnapshotClass for the same CSI driver.

### Issue

Closes: #49069