### PR TITLE
Update the Network Policies Page

### DIFF
--- a/content/en/examples/service/networking/network-policy-allow-all-egress-deny-all-ingress.yaml
+++ b/content/en/examples/service/networking/network-policy-allow-all-egress-deny-all-ingress.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-deny-ingress
+spec:
+  podSelector: {} 
+  policyTypes:
+    - Egress
+    - Ingress
+  egress:
+    - {}
+  ingress: [] # Removing this line also works


### PR DESCRIPTION
### Description

This PR improves the understanding of the `to` and `from` selectors in a network policy. It adds an egress example when describing a namespaceSelector and podSelector. The previous explanation only included an ingress example.

### Issue

Closes: #45615