### PR TITLE
Fixed link for core dns helm charts

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -89,7 +89,7 @@ installation instructions. The list does not try to be exhaustive.
 ## Service Discovery
 
 * [CoreDNS](https://coredns.io) is a flexible, extensible DNS server which can
-  be [installed](https://github.com/coredns/deployment/tree/master/kubernetes)
+  be [installed](https://github.com/coredns/helm)
   as the in-cluster DNS for pods.
 
 ## Visualization &amp; Control


### PR DESCRIPTION

### Description
Fixed hyperlink for core dns helm charts on the page https://kubernetes.io/docs/concepts/cluster-administration/addons/

### Issue

https://github.com/kubernetes/website/issues/49208

Closes: #
https://github.com/kubernetes/website/issues/49208