### PR TITLE
kubeadm: remove the EtcdLearnerMode FG

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -156,7 +156,6 @@ List of feature gates:
 Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
 `ControlPlaneKubeletLocalMode` | `false` | 1.31 | - | -
-`EtcdLearnerMode` | `true` | 1.27 | 1.29 | 1.32
 `NodeLocalCRISocket` | `false` | 1.32 | - | -
 `WaitForAllControlPlaneComponents` | `false` | 1.30 | - | -
 {{< /table >}}
@@ -171,10 +170,6 @@ Feature gate descriptions:
 : With this feature gate enabled, when joining a new control plane node, kubeadm will configure the kubelet
 to connect to the local kube-apiserver. This ensures that there will not be a violation of the version skew
 policy during rolling upgrades.
-
-`EtcdLearnerMode`
-: With this feature gate enabled, when joining a new control plane node, a new etcd member will be created
-as a learner and promoted to a voting member only after the etcd data are fully aligned.
 
 `NodeLocalCRISocket`
 : With this feature gate enabled, kubeadm will read/write the CRI socket for each node from/to the file
@@ -230,12 +225,17 @@ List of removed feature gates:
 {{< table caption="kubeadm removed feature gates" >}}
 Feature | Alpha | Beta | GA | Removed
 :-------|:------|:-----|:---|:-------
+`EtcdLearnerMode` | 1.27 | 1.29 | 1.32 | 1.33
 `IPv6DualStack` | 1.16 | 1.21 | 1.23 | 1.24
 `UnversionedKubeletConfigMap` | 1.22 | 1.23 | 1.25 | 1.26
 `UpgradeAddonsBeforeControlPlane` | 1.28 | - | - | 1.31
 {{< /table >}}
 
 Feature gate descriptions:
+
+`EtcdLearnerMode`
+: With this feature gate enabled, when joining a new control plane node, a new etcd member will be created
+as a learner and promoted to a voting member only after the etcd data are fully aligned.
 
 `IPv6DualStack`
 : This flag helps to configure components dual stack when the feature is in progress. For more details on Kubernetes


### PR DESCRIPTION
The FG graduated to GA in 1.32 and can be removed in 1.33.
 - https://github.com/kubernetes/kubernetes/pull/129589
 - https://github.com/kubernetes/kubeadm/issues/1793