### PR TITLE
Fixed link navigation bug

### DIFF
--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -434,7 +434,6 @@ The above scenario can be replicated by using a [Sidecar Container](/docs/concep
 as a helper container to write the HTML file.  
 As a Sidecar Container is conceptually an Init Container, it is guaranteed to start before the main web server container.  
 This ensures that the HTML file is always available when the web server is ready to serve it.  
-Please see [Enabling sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/#sidecar-example) to utilize this feature.
 
 If you are continuing from the previous scenario, you can reuse the ConfigMap named `color` for this scenario.  
 If you are executing this scenario independently, use the `kubectl create configmap` command to create a ConfigMap

--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -434,7 +434,7 @@ The above scenario can be replicated by using a [Sidecar Container](/docs/concep
 as a helper container to write the HTML file.  
 As a Sidecar Container is conceptually an Init Container, it is guaranteed to start before the main web server container.  
 This ensures that the HTML file is always available when the web server is ready to serve it.  
-Please see [Enabling sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/#enabling-sidecar-containers) to utilize this feature.
+Please see [Enabling sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/#sidecar-example) to utilize this feature.
 
 If you are continuing from the previous scenario, you can reuse the ConfigMap named `color` for this scenario.  
 If you are executing this scenario independently, use the `kubectl create configmap` command to create a ConfigMap


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The subsection "Update configuration via a ConfigMap in a Pod possessing a sidecar container" contains the sentence:

> Please see [Enabling sidecar containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#enabling-sidecar-containers) to utilize this feature.

The sidecar-containers page doesn't have a subsection on enabling sidecar containers, so I navigated the link to example showing deployment having sidecar config.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #49326 