### PR TITLE
Upgrade Docsy to 0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ nohup.out
 .hugo_build.lock
 
 # Netlify Functions build output
-package-lock.json
 /functions/
 /node_modules/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ FROM docker.io/library/golang:1.23.0-alpine3.20
 RUN apk add --no-cache \
     runuser \
     git \
+    gcompat \
     openssh-client \
     rsync \
     npm

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NETLIFY_FUNC      = $(NODE_BIN)/netlify-lambda
 # CONTAINER_ENGINE=podman make container-image
 CONTAINER_ENGINE ?= docker
 IMAGE_REGISTRY ?= gcr.io/k8s-staging-sig-docs
-IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile | cut -c 1-12)
+IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile package.json package-lock.json | cut -c 1-12)
 CONTAINER_IMAGE   = $(IMAGE_REGISTRY)/k8s-website-hugo:v$(HUGO_VERSION)-$(IMAGE_VERSION)
 # Mount read-only to allow use with tools like Podman in SELinux mode
 # Container targets don't need to write into /src

--- a/content/en/docs/contribute/style/diagram-guide.md
+++ b/content/en/docs/contribute/style/diagram-guide.md
@@ -473,7 +473,7 @@ Figure 6. Pod Topology Spread Constraints.
 
 Code block:
 
-``` 
+```text
 graph TB
    subgraph "zoneB"
        n3(Node3)
@@ -528,7 +528,7 @@ Figure 7. Ingress
 
 Code block:
 
-```mermaid
+```text
 graph LR;
  client([client])-. Ingress-managed <br> load balancer .->ingress[Ingress];
  ingress-->|routing rule|service[Service];
@@ -556,7 +556,7 @@ K8s components to start a container.
 
 Code block:
 
-```
+```text
 %%{init:{"theme":"neutral"}}%%
 sequenceDiagram
     actor me
@@ -592,7 +592,7 @@ In the code for
 [figure 7](https://mermaid-js.github.io/mermaid-live-editor/edit/#eyJjb2RlIjoiZ3JhcGggIExSXG4gIGNsaWVudChbY2xpZW50XSktLiBJbmdyZXNzLW1hbmFnZWQgPGJyPiBsb2FkIGJhbGFuY2VyIC4tPmluZ3Jlc3NbSW5ncmVzc107XG4gIGluZ3Jlc3MtLT58cm91dGluZyBydWxlfHNlcnZpY2VbU2VydmljZV07XG4gIHN1YmdyYXBoIGNsdXN0ZXJcbiAgaW5ncmVzcztcbiAgc2VydmljZS0tPnBvZDFbUG9kXTtcbiAgc2VydmljZS0tPnBvZDJbUG9kXTtcbiAgZW5kXG4gIGNsYXNzRGVmIHBsYWluIGZpbGw6I2RkZCxzdHJva2U6I2ZmZixzdHJva2Utd2lkdGg6NHB4LGNvbG9yOiMwMDA7XG4gIGNsYXNzRGVmIGs4cyBmaWxsOiMzMjZjZTUsc3Ryb2tlOiNmZmYsc3Ryb2tlLXdpZHRoOjRweCxjb2xvcjojZmZmO1xuICBjbGFzc0RlZiBjbHVzdGVyIGZpbGw6I2ZmZixzdHJva2U6I2JiYixzdHJva2Utd2lkdGg6MnB4LGNvbG9yOiMzMjZjZTU7XG4gIGNsYXNzIGluZ3Jlc3Msc2VydmljZSxwb2QxLHBvZDIgazhzO1xuICBjbGFzcyBjbGllbnQgcGxhaW47XG4gIGNsYXNzIGNsdXN0ZXIgY2x1c3RlcjtcbiIsIm1lcm1haWQiOiJ7XG4gIFwidGhlbWVcIjogXCJkZWZhdWx0XCJcbn0iLCJ1cGRhdGVFZGl0b3IiOmZhbHNlLCJhdXRvU3luYyI6dHJ1ZSwidXBkYXRlRGlhZ3JhbSI6dHJ1ZX0),
 you can see examples of both.
 
-```
+```text
 classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff; // defines style for the k8s class
 class ingress,service,pod1,pod2 k8s; // k8s class is applied to elements ingress, service, pod1 and pod2.
 ```

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -28,7 +28,7 @@
 {{ if .HasShortcode "mermaid" }}
   <!-- Copied from https://unpkg.com/mermaid@10.6.1/dist/mermaid.min.js -->
   {{- with resources.Get "js/mermaid-10.6.1.min.js" -}}
-  <script src="{{ .RelPermalink }}" integrity="sha384-+NGfjU8KzpDLXRHduEqW+ZiJr2rIg+cidUVk7B51R5xK7cHwMKQfrdFwGdrq1Bcz"></script>
+  <script src="{{ .RelPermalink }}" integrity="sha384-toDgDinNQVuBBJdT9Q9AnvM4szGg0g7BSEy/yLPRkkQylpeePcz8Mx/JLOFf33o+"></script>
   {{- else -}}
     <!-- without Mermaid, the site won't appear right -->
     {{- errorf "No Mermaid helper script found" -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -25,16 +25,6 @@
   {{- end -}}
 {{- end -}}
 
-{{ if .HasShortcode "mermaid" }}
-  <!-- Copied from https://unpkg.com/mermaid@10.6.1/dist/mermaid.min.js -->
-  {{- with resources.Get "js/mermaid-10.6.1.min.js" -}}
-  <script src="{{ .RelPermalink }}" integrity="sha384-toDgDinNQVuBBJdT9Q9AnvM4szGg0g7BSEy/yLPRkkQylpeePcz8Mx/JLOFf33o+"></script>
-  {{- else -}}
-    <!-- without Mermaid, the site won't appear right -->
-    {{- errorf "No Mermaid helper script found" -}}
-  {{- end -}}
-{{- end -}}
-
 {{- if eq .Layout "glossary" -}}
   {{- with resources.Get "js/glossary.js" -}}
   <script defer src="{{ .RelPermalink }}"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,14 +1,23 @@
 <script src="{{ "js/script.js" | relURL }}"></script>
 
+{{/* Handle legacy Kubernetes shortcode for Mermaid diagrams */}}
+{{- if (.HasShortcode "mermaid") -}}
+{{ .Page.Store.Set "hasmermaid" true -}}
+{{- end -}}
+
+{{/* future Docsy versions move this to partials/mermaid.html */}}
+{{- if .Page.Store.Get "hasmermaid" -}}
+<script src="https://cdn.jsdelivr.net/npm/mermaid@9.2.2/dist/mermaid.min.js" integrity="sha512-IX+bU+wShHqfqaMHLMrtwi4nK6W/Z+QdZoL4kPNtRxI2wCLyHPMAdl3a43Fv1Foqv4AP+aiW6hg1dcrTt3xc+Q==" crossorigin="anonymous"></script>
+{{- end }}
+
 {{ $jsBs := resources.Get "vendor/bootstrap/dist/js/bootstrap.bundle.js" -}}
 {{ $jsBase := resources.Get "js/base.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}
-{{ $jsMermaid := resources.Get "js/mermaid.js" | resources.ExecuteAsTemplate "js/mermaid.js" . }}
 {{ if .Site.Params.offlineSearch }}
 {{ $jsSearch = resources.Get "js/offline-search.js" }}
 {{ end }}
-{{ $js := (slice $jsBs $jsBase $jsAnchor $jsSearch $jsMermaid) | resources.Concat "js/main.js" -}}
+{{ $js := (slice $jsBs $jsBase $jsAnchor $jsSearch) | resources.Concat "js/main.js" -}}
 {{ if hugo.IsProduction -}}
   {{ $js := $js | minify | fingerprint -}}
   <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "autoprefixer": "^10.4.20",
-        "docsy": "github:google/docsy#v0.5.x",
+        "docsy": "github:google/docsy#semver:0.6.0",
         "postcss-cli": "^11.0.0"
       }
     },
@@ -322,8 +322,8 @@
       }
     },
     "node_modules/docsy": {
-      "version": "0.5.1+2",
-      "resolved": "git+ssh://git@github.com/google/docsy.git#cc857439cbba9e9aebeac726bf45bba95d1e6406",
+      "version": "0.6.0",
+      "resolved": "git+ssh://git@github.com/google/docsy.git#5597d435dc74ce68240e0c3871addf24567493b0",
       "dev": true,
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
+  "name": "kubernetes.io",
   "private": true,
   "scripts": {
     "update:pkgs": "npx npm-check-updates -u"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
-    "docsy": "github:google/docsy#v0.5.x",
+    "docsy": "github:google/docsy#semver:0.6.0",
     "postcss-cli": "^11.0.0"
   },
   "spelling": "cSpell:ignore docsy pkgs -"


### PR DESCRIPTION
This PR upgrades to a newer version of Docsy: 0.6.0
Relevant to issue #44002

Local and container testing looks good, including mermaid graphs

/area web-development

Related PR #48724 