### PR TITLE
[ko] Update outdated files in dev-1.27-ko.1 (M138-M149)

### DIFF
--- a/content/ko/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/content/ko/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -5,6 +5,7 @@
 # - piosz
 title: 중요한 애드온 파드 스케줄링 보장하기
 content_type: concept
+weight: 220
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -53,13 +53,13 @@ CA 키없이 진행한다.
 
 `check-expiration` 하위 명령을 사용하여 인증서가 만료되는 시기를 확인할 수 있다.
 
-```
+```shell
 kubeadm certs check-expiration
 ```
 
 출력 결과는 다음과 비슷하다.
 
-```
+```console
 CERTIFICATE                EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
 admin.conf                 Dec 30, 2020 23:36 UTC   364d                                    no
 apiserver                  Dec 30, 2020 23:36 UTC   364d            ca                      no
@@ -78,9 +78,12 @@ etcd-ca                 Dec 28, 2029 23:36 UTC   9y              no
 front-proxy-ca          Dec 28, 2029 23:36 UTC   9y              no
 ```
 
-이 명령은 `/etc/kubernetes/pki` 폴더의 클라이언트 인증서와 kubeadm이 사용하는 KUBECONFIG 파일(`admin.conf`, `controller-manager.conf` 및 `scheduler.conf`)에 포함된 클라이언트 인증서의 만료/잔여 기간을 표시한다.
+이 명령은 `/etc/kubernetes/pki` 폴더의 클라이언트 인증서와 kubeadm이 사용하는
+kubeconfig 파일(`admin.conf`, `controller-manager.conf` 및 `scheduler.conf`)에 포함된 클라이언트 인증서의
+만료/잔여 기간을 표시한다.
 
-또한, kubeadm은 인증서가 외부에서 관리되는지를 사용자에게 알린다. 이 경우 사용자는 수동으로 또는 다른 도구를 사용해서 인증서 갱신 관리를 해야 한다.
+또한, kubeadm은 인증서가 외부에서 관리되는지를 사용자에게 알린다. 이 경우 사용자는
+수동으로 또는 다른 도구를 사용해서 인증서 갱신 관리를 해야 한다.
 
 {{< warning >}}
 `kubeadm` 은 외부 CA가 서명한 인증서를 관리할 수 없다.
@@ -96,8 +99,10 @@ kubeadm이 [자동 인증서 갱신](/ko/docs/tasks/tls/certificate-rotation/)�
 
 {{< warning >}}
 kubeadm 1.17 이전의 버전에서 `kubeadm init` 으로 작성된 노드에는
-`kubelet.conf` 의 내용을 수동으로 수정해야 하는 [버그](https://github.com/kubernetes/kubeadm/issues/1753)가 있다. `kubeadm init` 수행 완료 후, `client-certificate-data` 및 `client-key-data` 를 다음과 같이 교체하여,
-로테이트된 kubelet 클라이언트 인증서를 가리키도록 `kubelet.conf` 를 업데이트해야 한다.
+`kubelet.conf` 의 내용을 수동으로 수정해야 하는 [버그](https://github.com/kubernetes/kubeadm/issues/1753)가
+있다. `kubeadm init` 수행 완료 후, `client-certificate-data` 및 `client-key-data` 를 다음과 같이 교체하여,
+로테이트된 kubelet 클라이언트 인증서를 가리키도록 `kubelet.conf` 를
+업데이트해야 한다.
 
 ```yaml
 client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
@@ -107,16 +112,21 @@ client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
 
 ## 자동 인증서 갱신
 
-kubeadm은 컨트롤 플레인 [업그레이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) 동안 모든 인증서를 갱신한다.
+kubeadm은 컨트롤 플레인 [업그레이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) 동안
+모든 인증서를 갱신한다.
 
 이 기능은 가장 간단한 유스케이스를 해결하기 위해 설계되었다.
-인증서 갱신에 대해 특별한 요구 사항이 없고 쿠버네티스 버전 업그레이드를 정기적으로(매 1년 이내 업그레이드 수행) 수행하는 경우, kubeadm은 클러스터를 최신 상태로 유지하고 합리적으로 보안을 유지한다.
+인증서 갱신에 대해 특별한 요구 사항이 없고 쿠버네티스 버전 업그레이드를
+정기적으로(매 1년 이내 업그레이드 수행) 수행하는 경우,kubeadm은 클러스터를 최신 상태로
+유지하고 합리적으로 보안을 유지한다.
 
 {{< note >}}
 보안을 유지하려면 클러스터를 자주 업그레이드하는 것이 가장 좋다.
 {{< /note >}}
 
-인증서 갱신에 대해 보다 복잡한 요구 사항이 있는 경우, `--certificate-renewal=false` 를 `kubeadm upgrade apply` 또는 `kubeadm upgrade node` 와 함께 사용하여 기본 동작이 수행되지 않도록 할 수 있다.
+인증서 갱신에 대해 보다 복잡한 요구 사항이 있는 경우, `--certificate-renewal=false` 를
+`kubeadm upgrade apply` 또는 `kubeadm upgrade node` 와 함께 사용하여
+기본 동작이 수행되지 않도록 할 수 있다.
 
 {{< warning >}}
 kubeadm 1.17 이전 버전에는 `kubeadm upgrade node` 명령에서
@@ -145,14 +155,18 @@ HA 클러스터를 실행 중인 경우, 모든 컨트롤 플레인 노드에서
 {{< /warning >}}
 
 {{< note >}}
-`certs renew` 는 기존 인증서를 kubeadm-config 컨피그맵(ConfigMap) 대신 속성(공통 이름, 조직, SAN 등)의 신뢰할 수 있는 소스로 사용한다. 둘 다 동기화 상태를 유지하는 것을 강력히 권장한다.
+`certs renew` 는 기존 인증서를 kubeadm-config 컨피그맵(ConfigMap) 대신
+속성(공통 이름, 조직, SAN 등)의 신뢰할 수 있는 소스로 사용한다. 둘 다 동기화 상태를
+유지하는 것을 강력히 권장한다.
 {{< /note >}}
 
 `kubeadm certs renew` 는 다음의 옵션을 제공한다.
 
-쿠버네티스 인증서는 일반적으로 1년 후 만료일에 도달한다.
+- 쿠버네티스 인증서는 일반적으로 1년 후 만료일에 도달한다.
 
-- `--csr-only` 는 실제로 인증서를 갱신하지 않고 인증서 서명 요청을 생성하여 외부 CA로 인증서를 갱신하는 데 사용할 수 있다. 자세한 내용은 다음 단락을 참고한다.
+- `--csr-only` 는 실제로 인증서를 갱신하지 않고 인증서 서명 요청을
+  생성하여 외부 CA로 인증서를 갱신하는 데 사용할 수 있다. 자세한 내용은 다음 단락을
+  참고한다.
 
 - 모든 인증서 대신 단일 인증서를 갱신할 수도 있다.
 
@@ -161,19 +175,24 @@ HA 클러스터를 실행 중인 경우, 모든 컨트롤 플레인 노드에서
 이 섹션에서는 쿠버네티스 인증서 API를 사용하여 수동 인증서 갱신을 실행하는 방법에 대한 자세한 정보를 제공한다.
 
 {{< caution >}}
-조직의 인증서 인프라를 kubeadm으로 생성된 클러스터에 통합해야 하는 사용자를 위한 고급 주제이다. 기본 kubeadm 구성이 요구 사항을 충족하면 kubeadm이 인증서를 대신 관리하도록 해야 한다.
+조직의 인증서 인프라를 kubeadm으로 생성된 클러스터에 통합해야 하는 사용자를 위한
+고급 주제이다. 기본 kubeadm 구성이 요구 사항을 충족하면 kubeadm이 인증서를 대신
+관리하도록 해야 한다.
 {{< /caution >}}
 
 ### 서명자 설정
 
 쿠버네티스 인증 기관(Certificate Authority)은 기본적으로 작동하지 않는다.
-[cert-manager](https://cert-manager.io/docs/configuration/ca/)와 같은 외부 서명자를 설정하거나, 빌트인 서명자를 사용할 수 있다.
+[cert-manager](https://cert-manager.io/docs/configuration/ca/)와 같은 외부 서명자를 설정하거나,
+빌트인 서명자를 사용할 수 있다.
 
 빌트인 서명자는 [`kube-controller-manager`](/docs/reference/command-line-tools-reference/kube-controller-manager/)의 일부이다.
 
-빌트인 서명자를 활성화하려면, `--cluster-signing-cert-file` 와 `--cluster-signing-key-file` 플래그를 전달해야 한다.
+빌트인 서명자를 활성화하려면, `--cluster-signing-cert-file` 와
+`--cluster-signing-key-file` 플래그를 전달해야 한다.
 
-새 클러스터를 생성하는 경우, kubeadm [구성 파일](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3)을 사용할 수 있다.
+새 클러스터를 생성하는 경우, kubeadm
+[구성 파일](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3)을 사용할 수 있다.
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta3
@@ -186,7 +205,8 @@ controllerManager:
 
 ### 인증서 서명 요청(CSR) 생성
 
-쿠버네티스 API로 CSR을 작성하려면 [CertificateSigningRequest 생성](/docs/reference/access-authn-authz/certificate-signing-requests/#create-certificatesigningrequest)을 본다.
+쿠버네티스 API로 CSR을 작성하려면
+[CertificateSigningRequest 생성](/docs/reference/access-authn-authz/certificate-signing-requests/#create-certificatesigningrequest)을 본다.
 
 ## 외부 CA로 인증서 갱신
 
@@ -194,7 +214,8 @@ controllerManager:
 
 외부 CA와 보다 효과적으로 통합하기 위해 kubeadm은 인증서 서명 요청(CSR)을 생성할 수도 있다.
 CSR은 클라이언트의 서명된 인증서에 대한 CA 요청을 나타낸다.
-kubeadm 관점에서, 일반적으로 온-디스크(on-disk) CA에 의해 서명되는 모든 인증서는 CSR로 생성될 수 있다. 그러나 CA는 CSR로 생성될 수 없다.
+kubeadm 관점에서, 일반적으로 온-디스크(on-disk) CA에 의해 서명되는 모든 인증서는
+CSR로 생성될 수 있다. 그러나 CA는 CSR로 생성될 수 없다.
 
 ### 인증서 서명 요청(CSR) 생성
 
@@ -216,7 +237,8 @@ CSR에는 인증서 이름, 도메인 및 IP가 포함되지만, 용도를 지�
 * `cfssl` 의 경우
   [설정 파일에 용도](https://github.com/cloudflare/cfssl/blob/master/doc/cmd/cfssl.txt#L170)를 지정한다.
 
-선호하는 방법으로 인증서에 서명한 후, 인증서와 개인 키를 PKI 디렉터리(기본적으로 `/etc/kubernetes/pki`)에 복사해야 한다.
+선호하는 방법으로 인증서에 서명한 후, 인증서와 개인 키를
+PKI 디렉터리(기본적으로 `/etc/kubernetes/pki`)에 복사해야 한다.
 
 ## 인증 기관(CA) 순환(rotation) {#certificate-authority-rotation}
 
@@ -246,7 +268,7 @@ serverTLSBootstrap: true
 만약 이미 클러스터를 생성했다면 다음을 따라 이를 조정해야 한다.
  - `kube-system` 네임스페이스에서 `kubelet-config-{{< skew currentVersion >}}` 컨피그맵을 찾아서 수정한다.
 해당 컨피그맵에는 `kubelet` 키가
-[KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+[KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/)
 문서를 값으로 가진다. `serverTLSBootstrap: true` 가 되도록 KubeletConfiguration 문서를 수정한다.
 - 각 노드에서, `serverTLSBootstrap: true` 필드를 `/var/lib/kubelet/config.yaml` 에 추가한다.
 그리고 `systemctl restart kubelet` 로 kubelet을 재시작한다.
@@ -262,6 +284,8 @@ serverTLSBootstrap: true
 
 ```shell
 kubectl get csr
+```
+```console
 NAME        AGE     SIGNERNAME                        REQUESTOR                      CONDITION
 csr-9wvgt   112s    kubernetes.io/kubelet-serving     system:node:worker-1           Pending
 csr-lz97v   1m58s   kubernetes.io/kubelet-serving     system:node:control-plane-1    Pending
@@ -301,10 +325,10 @@ kubelet 인증서(클라이언트 인증)를 사용하여 아무 IP나 도메인
 `admin.conf`를 추가 사용자와 공유하는 것은 **권장하지 않는다**!
 
 대신, [`kubeadm kubeconfig user`](/docs/reference/setup-tools/kubeadm/kubeadm-kubeconfig) 
-명령어를 사용하여 추가 사용자를 위한 kubeconfig 파일을 생성할 수 있다. 
-이 명령어는 명령줄 플래그와 
-[kubeadm 환경 설정](/docs/reference/config-api/kubeadm-config.v1beta3/) 옵션을 모두 인식한다. 
-생성된 kubeconfig는 stdout으로 출력되며, 
+명령어를 사용하여 추가 사용자를 위한 kubeconfig 파일을 생성할 수 있다.
+이 명령어는 명령줄 플래그와
+[kubeadm 환경 설정](/docs/reference/config-api/kubeadm-config.v1beta3/) 옵션을 모두 인식한다.
+생성된 kubeconfig는 stdout으로 출력되며,
 `kubeadm kubeconfig user ... > somefile.conf` 명령어를 사용하여 파일에 기록될 수 있다.
 
 다음은 `--config` 플래그와 함께 사용될 수 있는 환경 설정 파일 예시이다.

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -3,7 +3,7 @@
 # - sig-cluster-lifecycle
 title: kubeadm 클러스터 업그레이드
 content_type: task
-weight: 20
+weight: 40
 ---
 
 <!-- overview -->
@@ -58,15 +58,19 @@ OS 패키지 관리자를 사용하여 쿠버네티스의 최신 패치 릴리�
 
 {{< tabs name="k8s_install_versions" >}}
 {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-    apt update
-    apt-cache madison kubeadm
-    # 목록에서 최신 버전({{< skew currentVersion >}})을 찾는다
-    # {{< skew currentVersion >}}.x-00과 같아야 한다. 여기서 x는 최신 패치이다.
+```shell
+# 목록에서 최신 버전({{< skew currentVersion >}})을 찾는다
+# {{< skew currentVersion >}}.x-00과 같아야 한다. 여기서 x는 최신 패치이다.
+apt update
+apt-cache madison kubeadm
+```
 {{% /tab %}}
 {{% tab name="CentOS, RHEL 또는 Fedora" %}}
-    yum list --showduplicates kubeadm --disableexcludes=kubernetes
-    # 목록에서 최신 버전({{< skew currentVersion >}})을 찾는다
-    # {{< skew currentVersion >}}.x-0과 같아야 한다. 여기서 x는 최신 패치이다.
+```shell
+# 목록에서 최신 버전({{< skew currentVersion >}})을 찾는다
+# {{< skew currentVersion >}}.x-0과 같아야 한다. 여기서 x는 최신 패치이다.
+yum list --showduplicates kubeadm --disableexcludes=kubernetes
+```
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -79,75 +83,74 @@ OS 패키지 관리자를 사용하여 쿠버네티스의 최신 패치 릴리�
 
 **첫 번째 컨트롤 플레인 노드의 경우**
 
-- kubeadm 업그레이드
+1. kubeadm 업그레이드
 
-  {{< tabs name="k8s_install_kubeadm_first_cp" >}}
-  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-  ```shell
+   {{< tabs name="k8s_install_kubeadm_first_cp" >}}
+   {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
+   ```shell
    # {{< skew currentVersion >}}.x-00에서 x를 최신 패치 버전으로 바꾼다.
    apt-mark unhold kubeadm && \
    apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
    apt-mark hold kubeadm
-  ```
-  {{% /tab %}}
-  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
-  ```shell
-  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다.
-  yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-  ```
-  {{% /tab %}}
-  {{< /tabs >}}
-<br />
+   ```
+   {{% /tab %}}
+   {{% tab name="CentOS, RHEL 또는 Fedora" %}}
+   ```shell
+   # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다.
+   yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
-- 다운로드하려는 버전이 잘 받아졌는지 확인한다.
+1. 다운로드하려는 버전이 잘 받아졌는지 확인한다.
 
   ```shell
   kubeadm version
   ```
 
-- 업그레이드 계획을 확인한다.
+1. 업그레이드 계획을 확인한다.
 
-  ```shell
-  kubeadm upgrade plan
-  ```
+   ```shell
+   kubeadm upgrade plan
+   ```
 
-  이 명령은 클러스터를 업그레이드할 수 있는지를 확인하고, 업그레이드할 수 있는 버전을 가져온다.
-  또한 컴포넌트 구성 버전 상태가 있는 표를 보여준다.
+   이 명령은 클러스터를 업그레이드할 수 있는지를 확인하고, 업그레이드할 수 있는 버전을 가져온다.
+   또한 컴포넌트 구성 버전 상태가 있는 표를 보여준다.
 
-  {{< note >}}
-  또한 `kubeadm upgrade` 는 이 노드에서 관리하는 인증서를 자동으로 갱신한다.
-  인증서 갱신을 하지 않으려면 `--certificate-renewal=false` 플래그를 사용할 수 있다.
-  자세한 내용은 [인증서 관리 가이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs)를 참고한다.
-  {{</ note >}}
+   {{< note >}}
+   또한 `kubeadm upgrade` 는 이 노드에서 관리하는 인증서를 자동으로 갱신한다.
+   인증서 갱신을 하지 않으려면 `--certificate-renewal=false` 플래그를 사용할 수 있다.
+   자세한 내용은 [인증서 관리 가이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs)를 참고한다.
+   {{</ note >}}
 
-  {{< note >}}
-  `kubeadm upgrade plan` 이 수동 업그레이드가 필요한 컴포넌트 구성을 표시하는 경우, 사용자는
-  `--config` 커맨드 라인 플래그를 통해 대체 구성이 포함된 구성 파일을 `kubeadm upgrade apply` 에 제공해야 한다.
-  그렇게 하지 않으면 `kubeadm upgrade apply` 가 오류와 함께 종료되고 업그레이드를 수행하지 않는다.
-  {{</ note >}}
+   {{< note >}}
+   `kubeadm upgrade plan` 이 수동 업그레이드가 필요한 컴포넌트 구성을 표시하는 경우, 사용자는
+   `--config` 커맨드 라인 플래그를 통해 대체 구성이 포함된 구성 파일을 `kubeadm upgrade apply` 에 제공해야 한다.
+   그렇게 하지 않으면 `kubeadm upgrade apply` 가 오류와 함께 종료되고 업그레이드를 수행하지 않는다.
+   {{</ note >}}
 
-- 업그레이드할 버전을 선택하고, 적절한 명령을 실행한다. 예를 들면 다음과 같다.
+1. 업그레이드할 버전을 선택하고, 적절한 명령을 실행한다. 예를 들면 다음과 같다.
 
-  ```shell
-  # 이 업그레이드를 위해 선택한 패치 버전으로 x를 바꾼다.
-  sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
-  ```
+   ```shell
+   # 이 업그레이드를 위해 선택한 패치 버전으로 x를 바꾼다.
+   sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
+   ```
 
-  명령이 완료되면 다음을 확인해야 한다.
+   명령이 완료되면 다음을 확인해야 한다.
 
-  ```
-  [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew currentVersion >}}.x". Enjoy!
+   ```
+   [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew currentVersion >}}.x". Enjoy!
 
-  [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
-  ```
+   [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
+   ```
 
-- CNI 제공자 플러그인을 수동으로 업그레이드한다.
+1. CNI 제공자 플러그인을 수동으로 업그레이드한다.
 
-  CNI(컨테이너 네트워크 인터페이스) 제공자는 자체 업그레이드 지침을 따를 수 있다.
-  [애드온](/ko/docs/concepts/cluster-administration/addons/) 페이지에서
-  사용하는 CNI 제공자를 찾고 추가 업그레이드 단계가 필요한지 여부를 확인한다.
+   CNI(컨테이너 네트워크 인터페이스) 제공자는 자체 업그레이드 지침을 따를 수 있다.
+   [애드온](/ko/docs/concepts/cluster-administration/addons/) 페이지에서
+   사용하는 CNI 제공자를 찾고 추가 업그레이드 단계가 필요한지 여부를 확인한다.
 
-  CNI 제공자가 데몬셋(DaemonSet)으로 실행되는 경우 추가 컨트롤 플레인 노드에는 이 단계가 필요하지 않다.
+   CNI 제공자가 데몬셋(DaemonSet)으로 실행되는 경우 추가 컨트롤 플레인 노드에는 이 단계가 필요하지 않다.
 
 **다른 컨트롤 플레인 노드의 경우**
 
@@ -167,45 +170,44 @@ sudo kubeadm upgrade apply
 
 ### 노드 드레인
 
-- 스케줄 불가능(unschedulable)으로 표시하고 워크로드를 축출하여 유지 보수할 노드를 준비한다.
+스케줄 불가능(unschedulable)으로 표시하고 워크로드를 축출하여 유지 보수할 노드를 준비한다.
 
-  ```shell
-  # <node-to-drain>을 드레인하는 노드의 이름으로 바꾼다.
-  kubectl drain <node-to-drain> --ignore-daemonsets
-  ```
+```shell
+# <node-to-drain>을 드레인하는 노드의 이름으로 바꾼다.
+kubectl drain <node-to-drain> --ignore-daemonsets
+```
 
 ### kubelet과 kubectl 업그레이드
 
-- 모든 컨트롤 플레인 노드에서 kubelet 및 kubectl을 업그레이드한다.
+1. kubelet 및 kubectl을 업그레이드한다.
 
-  {{< tabs name="k8s_install_kubelet" >}}
-  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-  ```shell
-  # replace x in {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
-  apt-mark unhold kubelet kubectl && \
-  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
-  apt-mark hold kubelet kubectl
-  ```
-  {{% /tab %}}
-  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
-  ```shell
-  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
-  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-  ```
-  {{% /tab %}}
-  {{< /tabs >}}
-<br />
+   {{< tabs name="k8s_install_kubelet" >}}
+   {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
+   ```shell
+   # replace x in {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
+   apt-mark unhold kubelet kubectl && \
+   apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+   apt-mark hold kubelet kubectl
+   ```
+   {{% /tab %}}
+   {{% tab name="CentOS, RHEL 또는 Fedora" %}}
+   ```shell
+   # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
+   yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
-- kubelet을 다시 시작한다.
+1. kubelet을 다시 시작한다.
 
-  ```shell
-  sudo systemctl daemon-reload
-  sudo systemctl restart kubelet
-  ```
+   ```shell
+   sudo systemctl daemon-reload
+   sudo systemctl restart kubelet
+   ```
 
 ### 노드 uncordon
 
-- 노드를 스케줄 가능(schedulable)으로 표시하여 노드를 다시 온라인 상태로 전환한다.
+노드를 스케줄 가능(schedulable)으로 표시하여 노드를 다시 온라인 상태로 전환한다.
 
   ```shell
   # <node-to-uncordon>을 드레인하려는 노드의 이름으로 바꾼다.
@@ -217,81 +219,10 @@ sudo kubeadm upgrade apply
 워커 노드의 업그레이드 절차는 워크로드를 실행하는 데 필요한 최소 용량을 보장하면서,
 한 번에 하나의 노드 또는 한 번에 몇 개의 노드로 실행해야 한다.
 
-### kubeadm 업그레이드
+다음 페이지에서는 리눅스 및 윈도우 워커 노드를 업그레이드하는 방법을 보여준다.
 
-- 모든 워커 노드에서 kubeadm을 업그레이드한다.
-
-  {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
-  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-  ```shell
-  # {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
-  apt-mark unhold kubeadm && \
-  apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
-  apt-mark hold kubeadm
-  ```
-  {{% /tab %}}
-  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
-  ```shell
-  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
-  yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-  ```
-  {{% /tab %}}
-  {{< /tabs >}}
-
-### "kubeadm upgrade" 호출
-
-- 워커 노드의 경우 로컬 kubelet 구성을 업그레이드한다.
-
-  ```shell
-  sudo kubeadm upgrade node
-  ```
-
-### 노드 드레인
-
-- 스케줄 불가능(unschedulable)으로 표시하고 워크로드를 축출하여 유지 보수할 노드를 준비한다.
-
-  ```shell
-  # <node-to-drain>을 드레인하려는 노드 이름으로 바꾼다.
-  kubectl drain <node-to-drain> --ignore-daemonsets
-  ```
-
-### kubelet과 kubectl 업그레이드
-
-- kubelet 및 kubectl을 업그레이드한다.
-
-  {{< tabs name="k8s_kubelet_and_kubectl" >}}
-  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-  ```shell
-  # {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
-  apt-mark unhold kubelet kubectl && \
-  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
-  apt-mark hold kubelet kubectl
-  ```
-  {{% /tab %}}
-  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
-  ```shell
-  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
-  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-  ```
-  {{% /tab %}}
-  {{< /tabs >}}
-<br />
-
-- kubelet을 다시 시작한다.
-
-  ```shell
-  sudo systemctl daemon-reload
-  sudo systemctl restart kubelet
-  ```
-
-### 노드에 적용된 cordon 해제
-
--  스케줄 가능(schedulable)으로 표시하여 노드를 다시 온라인 상태로 만든다.
-
-  ```shell
-  # <node-to-uncordon>을 노드의 이름으로 바꾼다.
-  kubectl uncordon <node-to-uncordon>
-  ```
+* [리눅스 노드 업그레이드](/ko/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes/)
+* [윈도우 노드 업그레이드](/ko//docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes/)
 
 ## 클러스터 상태 확인
 

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -2,17 +2,14 @@
 title: 윈도우 노드 업그레이드
 min-kubernetes-server-version: 1.17
 content_type: task
-weight: 40
+weight: 110
 ---
 
 <!-- overview -->
 
 {{< feature-state for_k8s_version="v1.18" state="beta" >}}
 
-이 페이지는 [kubeadm으로 생성된](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) 윈도우 노드를 업그레이드하는 방법을 설명한다.
-
-
-
+이 페이지는 kubeadm으로 생성된 윈도우 노드를 업그레이드하는 방법을 설명한다.
 
 ## {{% heading "prerequisites" %}}
 
@@ -20,9 +17,6 @@ weight: 40
 * [남은 kubeadm 클러스터를 업그레이드하는 프로세스](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade)에
 익숙해져야 한다. 윈도우 노드를
 업그레이드하기 전에 컨트롤 플레인 노드를 업그레이드해야 한다.
-
-
-
 
 <!-- steps -->
 
@@ -81,7 +75,8 @@ weight: 40
     ```
 
 {{< note >}}
-만약 kube-proxy를 윈도우 서비스로 실행중이지 않고 파드 내의 HostProcess 컨테이너에서 실행중이라면, 새로운 버전의 kube-proxy 매니페스트를 적용함으로써 업그레이드할 수 있다.
+만약 kube-proxy를 윈도우 서비스로 실행중이지 않고 파드 내의 HostProcess 컨테이너에서 실행 중이라면,
+새로운 버전의 kube-proxy 매니페스트를 적용함으로써 업그레이드할 수 있다.
 {{< /note >}}
 
 ### 노드에 적용된 cordon 해제
@@ -93,3 +88,7 @@ weight: 40
     # <node-to-drain>을 노드의 이름으로 바꾼다
     kubectl uncordon <node-to-drain>
     ```
+
+## {{% heading "whatsnext" %}}
+
+* [리눅스 노드 업그레이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade)에 대해 알아본다.

--- a/content/ko/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/ko/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -4,6 +4,7 @@
 # - dawnchen
 title: 구성 파일을 통해 Kubelet 파라미터 설정하기
 content_type: task
+weight: 330
 ---
 
 <!-- overview -->
@@ -45,7 +46,7 @@ evictionHard:
 ## 구성 파일을 통해 구성된 Kubelet 프로세스 시작하기
 
 {{< note >}}
-kubeadm을 사용하여 클러스터를 초기화하는 경우 `kubeadmin init`으로 클러스터를 생성하는 동안 kubelet-config를 사용해야 한다.
+kubeadm을 사용하여 클러스터를 초기화하는 경우 `kubeadm init`으로 클러스터를 생성하는 동안 kubelet-config를 사용해야 한다.
 자세한 내용은 [kubeadm을 사용하여 kubelet 구성하기](/docs/setup/production-environment/tools/kubeadm/kubelet-integration/)를 참고한다.
 {{< /note >}}
 

--- a/content/ko/docs/tasks/administer-cluster/kubelet-credential-provider.md
+++ b/content/ko/docs/tasks/administer-cluster/kubelet-credential-provider.md
@@ -6,6 +6,7 @@ title: kubelet 이미지 자격 증명 공급자 구성하기
 description: kubelet의 이미지 자격 증명 공급자 플러그인을 구성한다.
 content_type: task
 min-kubernetes-server-version: v1.26
+weight: 120
 ---
 
 {{< feature-state for_k8s_version="v1.26" state="stable" >}}
@@ -53,7 +54,7 @@ kubelet은 플러그인을 통해 정적 자격 증명을 디스크에 저장하
 
 kubelet은 `--image-credential-provider-config`로 전달된 구성 파일을 읽고,
 컨테이너 이미지에 대해 어떤 exec 플러그인을 호출할지 결정한다.
-[ECR](https://aws.amazon.com/ecr/)-based 플러그인을 사용하는 경우 사용하게 될 수 있는 구성 파일의 예:
+[ECR-based 플러그인](https://github.com/kubernetes/cloud-provider-aws/tree/master/cmd/ecr-credential-provider)을 사용하는 경우 사용하게 될 수 있는 구성 파일의 예시는 다음과 같다.
 
 ```yaml
 apiVersion: kubelet.config.k8s.io/v1
@@ -67,7 +68,7 @@ providers:
   # name 필드는 자격 증명 공급자를 구분하기 위한 필수 필드이다. 
   # 이 이름은 kubelet이 인식하는 공급자 실행 파일의 이름과 일치해야 한다. 
   # 해당 실행 파일은 kubelet의 bin 디렉토리에 존재해야 한다(--image-credential-provider-bin-dir 플래그로 설정).
-  - name: ecr
+  - name: ecr-credential-provider
     # matchImages 필드는 각 이미지에 대해 이 공급자가 활성화되어야 하는지를 
     # 판단하기 위한 문자열의 목록을 나타내는 필수 필드이다. 
     # kubelet이 요청한 이미지가 다음 문자열 중 하나와 매치되면, 
@@ -82,8 +83,8 @@ providers:
     #
     # 다음 사항이 모두 만족될 때에만 image와 matchImage가 매치되었다고 판단한다.
     # - 양쪽의 도메인 파트 수가 동일하고, 각 파트가 매치됨
-    # - imageMatch의 URL 경로가 타겟 이미지 URL 경로의 접두사임
-    # - imageMatch가 포트를 포함하면, 이미지 쪽에 기재된 포트와 매치됨
+    # - matchImages의 URL 경로가 타겟 이미지 URL 경로의 접두사임
+    # - matchImages가 포트를 포함하면, 이미지 쪽에 기재된 포트와 매치됨
     #
     # matchImages 예시는 다음과 같다.
     # - 123456789.dkr.ecr.us-east-1.amazonaws.com
@@ -93,7 +94,7 @@ providers:
     # - registry.io:8080/path
     matchImages:
       - "*.dkr.ecr.*.amazonaws.com"
-      - "*.dkr.ecr.*.amazonaws.cn"
+      - "*.dkr.ecr.*.amazonaws.com.cn"
       - "*.dkr.ecr-fips.*.amazonaws.com"
       - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
       - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
@@ -106,8 +107,8 @@ providers:
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     # args 필드는 커맨드를 실행할 때 전달할 인자를 지정하는 필드이다.
     # 이 필드는 선택사항이다.
-    args:
-      - get-credentials
+    # args:
+      # - --example-argument
     # env 필드는 프로세스에 노출할 추가적인 환경 변수를 기재하는 필드이다. 
     # 이들은 호스트의 환경 변수 및 
     # client-go가 플러그인에 인자를 전달하기 위해 사용하는 변수와 합산된다.
@@ -142,7 +143,7 @@ Glob은 `*.k8s.io`이나 `k8s.*.io` 같은 서브도메인과 `k8s.*`와 같은 
 
 * 둘 다 동일한 수의 도메인 파트를 포함하고 있으며 각 파트가 매치한다.
 * 매치 이미지의 URL 경로는 대상 이미지 URL 경로의 접두사여야 한다.
-* imageMatch에 포트가 포함되어 있으면 해당 포트는 이미지에서도 매치해야 한다.
+* matchImages에 포트가 포함되어 있으면 해당 포트는 이미지에서도 매치해야 한다.
 
 `matchImages` 패턴의 예시 값은 아래와 같다.
 

--- a/content/ko/docs/tasks/administer-cluster/limit-storage-consumption.md
+++ b/content/ko/docs/tasks/administer-cluster/limit-storage-consumption.md
@@ -1,6 +1,7 @@
 ---
 title: 스토리지 사용량 제한
 content_type: task
+weight: 240
 ---
 
 <!-- overview -->

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/_index.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/_index.md
@@ -1,4 +1,4 @@
 ---
 title: 메모리, CPU 와 API 리소스 관리
-weight: 20
+weight: 40
 ---

--- a/content/ko/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/ko/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -140,8 +140,7 @@ resources:
 kubectl apply -f https://k8s.io/examples/admin/resource/cpu-defaults-pod-3.yaml --namespace=default-cpu-example
 ```
 
-생성한 파드의 
-[명세](/ko/docs/concepts/overview/working-with-objects/kubernetes-objects/#오브젝트-명세-spec-와-상태-status)를 확인한다.
+생성한 파드의 명세를 확인한다.
 
 ```
 kubectl get pod default-cpu-demo-3 --output=yaml --namespace=default-cpu-example

--- a/content/ko/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
+++ b/content/ko/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "도커심으로부터 마이그레이션"
-weight: 10
+weight: 20
 content_type: task
 no_list: true
 ---
@@ -19,10 +19,14 @@ no_list: true
 컨테이너 런타임으로 도커 엔진을 통한 도커심을 사용하는 상황에서 v1.24로
 업그레이드하려는 경우, 다른 런타임으로 마이그레이션하거나 다른 방법을 찾아 도커 엔진 지원을 받는 것이 좋다.
 선택 가능한 옵션은 [컨테이너 런타임](/ko/docs/setup/production-environment/container-runtimes/) 섹션에서 확인한다.
+
+도커심이 포함된 쿠버네티스 버전(1.23)은 지원이 종료되었으며, v1.24는 [곧](/releases/#release-v1-24) 지원이 종료될 예정이다.
 마이그레이션 중 문제를 마주한다면
 [문제를 보고](https://github.com/kubernetes/kubernetes/issues)하면 좋다. 이를 통해 문제를 시기적절하게
 해결할 수 있으며, 클러스터도 도커심 제거에
-대비할 수 있다.
+대비할 수 있다. 1.24의 지원이 종료된 후에는 쿠버네티스 프로바이더에
+지원을 요청하거나 클러스터에 영향을 미치는 중요한 문제가 있는 경우
+여러 버전을 한 번에 업그레이드해야 한다.
 
 클러스터는 두 종류 이상의 노드들을 포함할 수 있지만
 이는 일반적인 구성은 아니다.
@@ -35,11 +39,8 @@ no_list: true
 
 ## {{% heading "whatsnext" %}}
 
-- 컨테이너 런타임에 대한 옵션을 이해하기 위해
-  [컨테이너 런타임](/ko/docs/setup/production-environment/container-runtimes/)을 확인한다.
-* 도커심의
-  사용 중단 및 제거에 대한 논의를 추적하는
-  [깃허브 이슈](https://github.com/kubernetes/kubernetes/issues/106917)가 있다.
+* [컨테이너 런타임](/ko/docs/setup/production-environment/container-runtimes/)을
+  확인하여 대안 옵션을 이해한다.
 * 도커심에서 마이그레이션하는 것에 관한
   결함이나 다른 기술적 문제를 발견한다면,
   쿠버네티스 프로젝트에 [이슈를 남길 수 있다.](https://github.com/kubernetes/kubernetes/issues/new/choose)

--- a/content/ko/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/ko/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -1,6 +1,6 @@
 ---
 title: "도커 엔진 노드를 도커심에서 cri-dockerd로 마이그레이션하기"
-weight: 9
+weight: 20
 content_type: task 
 ---
 

--- a/content/ko/docs/tasks/administer-cluster/namespaces.md
+++ b/content/ko/docs/tasks/administer-cluster/namespaces.md
@@ -4,28 +4,32 @@
 # - janetkuo
 title: 네임스페이스를 사용해 클러스터 공유하기
 content_type: task
+weight: 340
 ---
 
 <!-- overview -->
-이 페이지는 {{< glossary_tooltip text="네임스페이스" term_id="namespace" >}}를 살펴보고, 작업하고, 삭제하는 방법에 대해 다룬다. 또한 쿠버네티스 네임스페이스를 사용해 클러스터를 세분화하는 방법에 대해서도 다룬다.
+이 페이지는 {{< glossary_tooltip text="네임스페이스" term_id="namespace" >}}를 살펴보고, 작업하고, 삭제하는 방법에 대해 다룬다.
+또한 쿠버네티스 네임스페이스를 사용해 클러스터를 세분화하는 방법에 대해서도 다룬다.
 
 
 ## {{% heading "prerequisites" %}}
 
 * [기존 쿠버네티스 클러스터](/ko/docs/setup/)가 있다.
-* 쿠버네티스 {{< glossary_tooltip text="파드" term_id="pod" >}}, {{< glossary_tooltip term_id="service" text="서비스" >}}, 그리고 {{< glossary_tooltip text="디플로이먼트" term_id="deployment" >}}에 대해 이해하고 있다.
+* 쿠버네티스 {{< glossary_tooltip text="파드" term_id="pod" >}},
+  {{< glossary_tooltip term_id="service" text="서비스" >}},
+  그리고 {{< glossary_tooltip text="디플로이먼트" term_id="deployment" >}}에 대해 이해하고 있다.
 
 
 <!-- steps -->
 
 ## 네임스페이스 보기
 
-1. 아래 명령어를 사용해 클러스터의 현재 네임스페이스를 나열한다.
+아래 명령어를 사용해 클러스터의 현재 네임스페이스를 나열한다.
 
 ```shell
 kubectl get namespaces
 ```
-```
+```console
 NAME          STATUS    AGE
 default       Active    11d
 kube-system   Active    11d
@@ -34,9 +38,12 @@ kube-public   Active    11d
 
 쿠버네티스를 시작하면 세 개의 초기 네임스페이스가 있다.
 
-   * `default` 다른 네임스페이스가 없는 오브젝트를 위한 기본 네임스페이스
-   * `kube-system` 쿠버네티스 시스템에서 생성된 오브젝트의 네임스페이스
-   * `kube-public` 이 네임스페이스는 자동으로 생성되며 모든 사용자(미인증 사용자를 포함)가 읽을 수 있다. 이 네임스페이스는 일부 리소스를 공개적으로 보고 읽을 수 있어야 하는 경우에 대비하여 대부분이 클러스터 사용을 위해 예약돼 있다. 그러나 이 네임스페이스의 공개적인 성격은 관례일 뿐 요구 사항은 아니다.
+* `default` 다른 네임스페이스가 없는 오브젝트를 위한 기본 네임스페이스
+* `kube-system` 쿠버네티스 시스템에서 생성된 오브젝트의 네임스페이스
+* `kube-public` 이 네임스페이스는 자동으로 생성되며 모든 사용자(미인증 사용자를 포함)가
+  읽을 수 있다. 이 네임스페이스는 일부 리소스를 공개적으로 보고 읽을 수 있어야 하는 경우에
+  대비하여 대부분이 클러스터 사용을 위해 예약돼 있다. 그러나 이 네임스페이스의 공개적인
+  성격은 관례일 뿐 요구 사항은 아니다.
    
 아래 명령을 실행해 특정 네임스페이스에 대한 요약 정보를 볼 수 있다.
 
@@ -49,7 +56,7 @@ kubectl get namespaces <name>
 ```shell
 kubectl describe namespaces <name>
 ```
-```
+```console
 Name:           default
 Labels:         <none>
 Annotations:    <none>
@@ -65,18 +72,18 @@ Resource Limits
 
 이러한 세부 정보에는 리소스 한도(limit) 범위 뿐만 아니라 리소스 쿼터(만약 있다면)까지 모두 표시된다.
 
-리소스 쿼터는 *네임스페이스* 내 리소스의 집계 사용량을 추적하며, 
-*네임스페이스*에서 사용할 수 있는 *하드(Hard)* 리소스 사용 제한을 클러스터 운영자가 정의할 수 있도록 해준다.
+리소스 쿼터는 네임스페이스 내 리소스의 집계 사용량을 추적하며, 
+네임스페이스에서 사용할 수 있는 *하드(Hard)* 리소스 사용 제한을 클러스터 운영자가 정의할 수 있도록 해준다.
 
-제한 범위는 하나의 엔티티(entity)가 하나의 *네임스페이스*에서 사용할 수 있는 
+제한 범위는 하나의 엔티티(entity)가 하나의 네임스페이스에서 사용할 수 있는 
 리소스 양에 대한 최대/최소 제약 조건을 정의한다.
 
 [어드미션 컨트롤: 리밋 레인지(Limit Range)](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_limit_range.md)를 참조하자.
 
 네임스페이스는 다음 두 상태 중 하나에 있을 수 있다.
 
-   * `Active` 네임스페이스가 사용 중이다.
-   * `Terminating` 네임스페이스가 삭제 중이므로 새 오브젝트에 사용할 수 없다.
+`Active` 네임스페이스가 사용 중이다.
+`Terminating` 네임스페이스가 삭제 중이므로 새 오브젝트에 사용할 수 없다.
 
 자세한 내용은 API 레퍼런스의 [네임스페이스](/docs/reference/kubernetes-api/cluster-resources/namespace-v1/)를
 참조한다.
@@ -84,35 +91,37 @@ Resource Limits
 ## 새 네임스페이스 생성하기
 
 {{< note >}}
-    `kube-` 접두사는 쿠버네티스 시스템 네임스페이스로 예약돼 있으므로 이를 사용해 네임스페이스를 생성하지 않도록 한다.
+`kube-` 접두사는 쿠버네티스 시스템 네임스페이스로 예약돼 있으므로 이를 사용해 네임스페이스를 생성하지 않도록 한다.
 {{< /note >}}
 
-1. `my-namespace.yaml`이라는 YAML 파일을 생성하고 아래 내용을 작성한다.
+`my-namespace.yaml`이라는 YAML 파일을 생성하고 아래 내용을 작성한다.
 
-    ```yaml
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: <insert-namespace-name-here>
-    ```
-    다음 명령을 실행한다.
-   
-    ```
-    kubectl create -f ./my-namespace.yaml
-    ```
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <insert-namespace-name-here>
+```
+다음 명령을 실행한다.
+```
+kubectl create -f ./my-namespace.yaml
+```
 
-2. 아래 명령으로 네임스페이스를 생성할 수도 있다.
+아래 명령으로 네임스페이스를 생성할 수도 있다.
 
-    ```
-    kubectl create namespace <insert-namespace-name-here>
-    ``` 
+```
+kubectl create namespace <insert-namespace-name-here>
+``` 
 
 네임스페이스의 이름은 
 유효한 [DNS 레이블](/ko/docs/concepts/overview/working-with-objects/names/#dns-label-names)이어야 한다.
 
-옵션 필드인 `finalizer`는 네임스페이스가 삭제 될 때 관찰자가 리소스를 제거할 수 있도록 한다. 존재하지 않는 파이널라이저(finalizer)를 명시한 경우 네임스페이스는 생성되지만 사용자가 삭제하려 하면 `Terminating` 상태가 된다.
+옵션 필드인 `finalizer`는 네임스페이스가 삭제 될 때 관찰자가 리소스를 제거할 수
+있도록 한다. 존재하지 않는 파이널라이저(finalizer)를 명시한 경우 네임스페이스는
+생성되지만 사용자가 삭제하려 하면 `Terminating` 상태가 된다.
 
-파이널라이저에 대한 자세한 내용은 네임스페이스 [디자인 문서](https://git.k8s.io/design-proposals-archive/architecture/namespaces.md#finalizers)에서 확인할 수 있다.
+파이널라이저에 대한 자세한 내용은 네임스페이스
+[디자인 문서](https://git.k8s.io/design-proposals-archive/architecture/namespaces.md#finalizers)에서 확인할 수 있다.
 
 ## 네임스페이스 삭제하기
 
@@ -130,190 +139,184 @@ kubectl delete namespaces <insert-some-namespace-name>
 
 ## 쿠버네티스 네임스페이스를 사용해 클러스터 세분화하기
 
-1. 기본 네임스페이스 이해하기
+기본적으로 쿠버네티스 클러스터는 클러스터에서 사용할 기본 파드, 서비스, 그리고 디플로이먼트(Deployment) 집합을 가지도록 
+클러스터를 프로비저닝 할 때 기본 네임스페이스를 인스턴스화한다.
 
-    기본적으로 쿠버네티스 클러스터는 클러스터에서 사용할 기본 파드, 서비스, 그리고 디플로이먼트(Deployment) 집합을 가지도록 
-    클러스터를 프로비저닝 할 때 기본 네임스페이스를 인스턴스화한다.
-    
-    새 클러스터가 있다고 가정하고 아래 명령을 수행하면 사용 가능한 네임스페이스를 볼 수 있다.
+새 클러스터가 있다고 가정하고 아래 명령을 수행하면 사용 가능한 네임스페이스를 볼 수 있다.
 
-    ```shell
-    kubectl get namespaces
-    ```
-    ```
-    NAME      STATUS    AGE
-    default   Active    13m
-    ```
+```shell
+kubectl get namespaces
+```
+```console
+NAME      STATUS    AGE
+default   Active    13m
+```
 
-2. 새 네임스페이스 생성하기
+### 새 네임스페이스 생성하기
 
-    이 예제에서는 내용을 저장할 쿠버네티스 네임스페이스를 추가로 두 개 생성할 것이다.
+이 예제에서는 내용을 저장할 쿠버네티스 네임스페이스를 추가로 두 개 생성할 것이다.
 
-    개발과 프로덕션 유스케이스에서 공유 쿠버네티스 클러스터를 사용하는 조직이 있다고 가정하자.
+개발과 프로덕션 유스케이스에서 공유 쿠버네티스 클러스터를 사용하는 조직이 있다고 가정하자.
 
-    개발 팀은 애플리케이션을 구축하고 실행하는데 사용하는 파드, 서비스, 디플로이먼트의 목록을 볼 수 있는 공간을 클러스터에 유지하려 한다.
-    이 공간에서는 쿠버네티스 리소스가 자유롭게 추가 및 제거되고, 
-    누가 리소스를 수정할 수 있는지 없는지에 대한 제약이 완화돼 빠른 개발이 가능해진다.
+- 개발 팀은 애플리케이션을 구축하고 실행하는데 사용하는 파드, 서비스, 디플로이먼트의 목록을
+  볼 수 있는 공간을 클러스터에 유지하려 한다.
+  이 공간에서는 쿠버네티스 리소스가 자유롭게 추가 및 제거되고, 
+  누가 리소스를 수정할 수 있는지 없는지에 대한 제약이 완화돼 빠른 개발이 가능해진다.
 
-    운영 팀은 운영 사이트를 실행하는 파드, 서비스, 디플로이먼트 집합을 조작할 수 있는 사람과 
-    그렇지 않은 사람들에 대해 엄격한 절차를 적용할 수 있는 공간을 클러스터에 유지하려 한다.
+- 운영 팀은 운영 사이트를 실행하는 파드, 서비스, 디플로이먼트 집합을 조작할 수
+  있는 사람과 그렇지 않은 사람들에 대해 엄격한 절차를 적용할 수 있는
+  공간을 클러스터에 유지하려 한다.
 
-    이 조직이 따를 수 있는 한 가지 패턴은 쿠버네티스 클러스터를 `development(개발)`와 `production(운영)`이라는 두 개의 네임스페이스로 분할하는 것이다.
+이 조직이 따를 수 있는 한 가지 패턴은 쿠버네티스 클러스터를
+`development(개발)`와 `production(운영)`이라는 두 개의 네임스페이스로 분할하는 것이다.
 
-    우리의 작업을 보존하기 위해 새로운 네임스페이스 두 개를 만들자.
+우리의 작업을 보존하기 위해 새로운 네임스페이스 두 개를 만들자.
 
-    kubectl을 사용해 `development` 네임스페이스를 생성한다.
+kubectl을 사용해 `development` 네임스페이스를 생성한다.
 
-    ```shell
-    kubectl create -f https://k8s.io/examples/admin/namespace-dev.json
-    ```
+```shell
+kubectl create -f https://k8s.io/examples/admin/namespace-dev.json
+```
 
-    그런 다음 kubectl을 사용해 `production` 네임스페이스를 생성한다.
+그런 다음 kubectl을 사용해 `production` 네임스페이스를 생성한다.
 
-    ```shell
-    kubectl create -f https://k8s.io/examples/admin/namespace-prod.json
-    ```
+```shell
+kubectl create -f https://k8s.io/examples/admin/namespace-prod.json
+```
 
-    제대로 생성이 되었는지 확인하기 위해 클러스터 내의 모든 네임스페이스를 나열한다.
+제대로 생성이 되었는지 확인하기 위해 클러스터 내의 모든 네임스페이스를 나열한다.
 
-    ```shell
-    kubectl get namespaces --show-labels
-    ```
-    ```
-    NAME          STATUS    AGE       LABELS
-    default       Active    32m       <none>
-    development   Active    29s       name=development
-    production    Active    23s       name=production
-    ```
+```shell
+kubectl get namespaces --show-labels
+```
+```console
+NAME          STATUS    AGE       LABELS
+default       Active    32m       <none>
+development   Active    29s       name=development
+production    Active    23s       name=production
+```
 
-3. 네임스페이스마다 파드 생성
+### 네임스페이스마다 파드 생성
 
-    쿠버네티스 네임스페이스는 클러스터의 파드, 서비스 그리고 디플로이먼트의 범위를 제공한다.
+쿠버네티스 네임스페이스는 클러스터의 파드, 서비스 그리고 디플로이먼트의 범위를 제공한다.
+하나의 네임스페이스와 상호 작용하는 사용자는 다른 네임스페이스의 내용을 볼 수 없다.
+이를 보여주기 위해 `development` 네임스페이스에 간단한 디플로이먼트와 파드를 생성하자.
 
-    하나의 네임스페이스와 상호 작용하는 사용자는 다른 네임스페이스의 내용을 볼 수 없다.
+```shell
+kubectl create deployment snowflake --image=registry.k8s.io/serve_hostname  -n=development --replicas=2
+```
+단순히 호스트명을 제공해주는 `snowflake`라는 파드의 개수를 2개로 유지하는 디플로이먼트를 생성하였다.
 
-    이를 보여주기 위해 `development` 네임스페이스에 간단한 디플로이먼트와 파드를 생성하자.
+```shell
+kubectl get deployment -n=development
+```
+```console
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+snowflake    2/2     2            2           2m
+```
+```shell
+kubectl get pods -l app=snowflake -n=development
+```
+```console
+NAME                         READY     STATUS    RESTARTS   AGE
+snowflake-3968820950-9dgr8   1/1       Running   0          2m
+snowflake-3968820950-vgc4n   1/1       Running   0          2m
+```
 
-    ```shell
-    kubectl create deployment snowflake --image=registry.k8s.io/serve_hostname  -n=development --replicas=2
-    ```
-    단순히 호스트명을 제공해주는 `snowflake`라는 파드의 개수를 2개로 유지하는 디플로이먼트를 생성하였다.
+개발자들은 `production` 네임스페이스의 내용에 영향을 끼칠 걱정 없이 하고 싶은 것을 할 수 있으니 대단하지 않은가.
 
-    ```shell
-    kubectl get deployment -n=development
-    ```
-    ```
-    NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-    snowflake    2/2     2            2           2m
-    ```
-    ```shell
-    kubectl get pods -l app=snowflake -n=development
-    ```
-    ```
-    NAME                         READY     STATUS    RESTARTS   AGE
-    snowflake-3968820950-9dgr8   1/1       Running   0          2m
-    snowflake-3968820950-vgc4n   1/1       Running   0          2m
-    ```
+이제 `production` 네임스페이스로 전환해 한 네임스페이스의 리소스가 다른 네임스페이스에서는 어떻게 숨겨지는지 보자.
 
-    개발자들은 `production` 네임스페이스의 내용에 영향을 끼칠 걱정 없이 하고 싶은 것을 할 수 있으니 대단하지 않은가.
+`production` 네임스페이스는 비어있어야 하며 아래 명령은 아무 것도 반환하지 않아야 한다.
 
-    이제 `production` 네임스페이스로 전환해 한 네임스페이스의 리소스가 다른 네임스페이스에서는 어떻게 숨겨지는지 보자.
+```shell
+kubectl get deployment -n=production
+kubectl get pods -n=production
+```
 
-    `production` 네임스페이스는 비어있어야 하며 아래 명령은 아무 것도 반환하지 않아야 한다.
+프로덕션이 가축 키우는 것을 좋아하듯이, 우리도 `production` 네임스페이스에 cattle(가축)이라는 이름의 파드를 생성한다.
 
-    ```shell
-    kubectl get deployment -n=production
-    kubectl get pods -n=production
-    ```
+```shell
+kubectl create deployment cattle --image=registry.k8s.io/serve_hostname -n=production
+kubectl scale deployment cattle --replicas=5 -n=production
 
-    프로덕션이 가축 키우는 것을 좋아하듯이, 우리도 `production` 네임스페이스에 cattle(가축)이라는 이름의 파드를 생성한다.
+kubectl get deployment -n=production
+```
+```console
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+cattle       5/5     5            5           10s
+```
 
-    ```shell
-    kubectl create deployment cattle --image=registry.k8s.io/serve_hostname -n=production
-    kubectl scale deployment cattle --replicas=5 -n=production
-
-    kubectl get deployment -n=production
-    ```
-    ```
-    NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-    cattle       5/5     5            5           10s
-    ```
-
-    ```shell
-    kubectl get pods -l app=cattle -n=production
-    ```
-    ```
-    NAME                      READY     STATUS    RESTARTS   AGE
-    cattle-2263376956-41xy6   1/1       Running   0          34s
-    cattle-2263376956-kw466   1/1       Running   0          34s
-    cattle-2263376956-n4v97   1/1       Running   0          34s
-    cattle-2263376956-p5p3i   1/1       Running   0          34s
-    cattle-2263376956-sxpth   1/1       Running   0          34s
-    ```
+```shell
+kubectl get pods -l app=cattle -n=production
+```
+```console
+NAME                      READY     STATUS    RESTARTS   AGE
+cattle-2263376956-41xy6   1/1       Running   0          34s
+cattle-2263376956-kw466   1/1       Running   0          34s
+cattle-2263376956-n4v97   1/1       Running   0          34s
+cattle-2263376956-p5p3i   1/1       Running   0          34s
+cattle-2263376956-sxpth   1/1       Running   0          34s
+```
 
 지금 쯤이면 사용자가 한 네임스페이스에 생성한 리소스는 다른 네임스페이스에서 숨겨져 있어야 한다는 것을 잘 알고 있을 것이다.
 
 쿠버네티스 정책 지원이 발전함에 따라, 이 시나리오를 확장해 각 네임스페이스에 
 서로 다른 인증 규칙을 제공하는 방법을 보이도록 하겠다.
 
-
-
 <!-- discussion -->
 
 ## 네임스페이스의 사용 동기 이해하기
 
-단일 클러스터는 여러 사용자 및 사용자 그룹(이하 '사용자 커뮤니티')의 요구를 충족시킬 수 있어야 한다.
+단일 클러스터는 여러 사용자 및 사용자 그룹(이 문서에서 이후로는 _사용자 커뮤니티_ 라고 함)의
+요구를 충족시킬 수 있어야 한다.
 
 쿠버네티스 _네임스페이스_ 는 여러 프로젝트, 팀 또는 고객이 쿠버네티스 클러스터를 공유할 수 있도록 지원한다.
 
 이를 위해 다음을 제공한다.
 
 1. [이름](/ko/docs/concepts/overview/working-with-objects/names/)에 대한 범위
-2. 인증과 정책을 클러스터의 하위 섹션에 연결하는 메커니즘
+1. 인증과 정책을 클러스터의 하위 섹션에 연결하는 메커니즘
 
 여러 개의 네임스페이스를 사용하는 것은 선택 사항이다.
 
 각 사용자 커뮤니티는 다른 커뮤니티와 격리된 상태로 작업할 수 있기를 원한다.
-
 각 사용자 커뮤니티는 다음을 가진다.
 
 1. 리소스 (파드, 서비스, 레플리케이션 컨트롤러(replication controller) 등
-2. 정책 (커뮤니티에서 조치를 수행할 수 있거나 없는 사람)
-3. 제약 조건 (해당 커뮤니티에서는 어느 정도의 쿼터가 허용되는지 등)
+1. 정책 (커뮤니티에서 조치를 수행할 수 있거나 없는 사람)
+1. 제약 조건 (해당 커뮤니티에서는 어느 정도의 쿼터가 허용되는지 등)
 
 클러스터 운영자는 각 사용자 커뮤니티 마다 네임스페이스를 생성할 수 있다.
 
 네임스페이스는 다음을 위한 고유한 범위를 제공한다.
 
 1. (기본 명명 충돌을 방지하기 위해) 명명된 리소스
-2. 신뢰할 수 있는 사용자에게 관리 권한 위임
-3. 커뮤니티 리소스 소비를 제한하는 기능
+1. 신뢰할 수 있는 사용자에게 관리 권한 위임
+1. 커뮤니티 리소스 소비를 제한하는 기능
 
 유스케이스는 다음을 포함한다.
 
 1.  클러스터 운영자로서 단일 클러스터에서 여러 사용자 커뮤니티를 지원하려 한다.
-2.  클러스터 운영자로서 클러스터 분할에 대한 권한을 
+1. 클러스터 운영자로서 클러스터 분할에 대한 권한을 
     해당 커뮤니티의 신뢰할 수 있는 사용자에게 위임하려 한다.
-3.  클러스터 운영자로서 클러스터를 사용하는 다른 커뮤니티에 미치는 영향을 제한하기 위해 
+1. 클러스터 운영자로서 클러스터를 사용하는 다른 커뮤니티에 미치는 영향을 제한하기 위해 
     각 커뮤니티가 사용할 수 있는 리소스의 양을 제한하고자 한다.
-4.  클러스터 사용자로서 다른 사용자 커뮤니티가 클러스터에서 수행하는 작업과는 별도로 
+1. 클러스터 사용자로서 다른 사용자 커뮤니티가 클러스터에서 수행하는 작업과는 별도로 
     사용자 커뮤니티와 관련된 리소스와 상호 작용하고 싶다.
 
 ## 네임스페이스와 DNS 이해하기
 
-[서비스](/ko/docs/concepts/services-networking/service/)를 생성하면 상응하는 [DNS 엔트리(entry)](/ko/docs/concepts/services-networking/dns-pod-service/)가 생성된다.
+[서비스](/ko/docs/concepts/services-networking/service/)를 생성하면 상응하는
+[DNS 엔트리(entry)](/ko/docs/concepts/services-networking/dns-pod-service/)가 생성된다.
 이 엔트리는 `<서비스-이름><네임스페이스=이름>.svc.cluster.local` 형식을 갖는데, 
 컨테이너가 `<서비스-이름>`만 갖는 경우에는 네임스페이스에 국한된 서비스로 연결된다.
 이 기능은 개발, 스테이징 및 프로덕션과 같이 
 여러 네임스페이스 내에서 동일한 설정을 사용할 때 유용하다. 
 네임스페이스를 넘어서 접근하려면 전체 주소 도메인 이름(FQDN)을 사용해야 한다.
 
-
-
 ## {{% heading "whatsnext" %}}
 
 * [네임스페이스 선호(preference)](/ko/docs/concepts/overview/working-with-objects/namespaces/#선호하는-네임스페이스-설정하기)에 대해 자세히 알아보기.
 * [요청(request)에 대한 네임스페이스 설정](/ko/docs/concepts/overview/working-with-objects/namespaces/#요청에-네임스페이스-설정하기)에 대해 자세히 알아보기.
 * [네임스페이스 설계](https://git.k8s.io/design-proposals-archive/architecture/namespaces.md) 참조하기.
-
-


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Related Issue: #41631

Updated outdated files in `content/en/docs/tasks/administer-cluster/`.

**12 files to be modified**

- [x] M138. `content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md` | 1(+XS) 0(-)
- [x] M139. `content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md` | 46(+M) 22(-)
- [x] M140. `content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md` | 115(+L) 173(-)
- [x] M141. `content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md` | 10(+S) 16(-)
- [x] M142. `content/en/docs/tasks/administer-cluster/kubelet-config-file.md` | 2(+XS) 1(-)
- [x] M143. `content/en/docs/tasks/administer-cluster/kubelet-credential-provider.md` | 9(+XS) 8(-)
- [x] M144. `content/en/docs/tasks/administer-cluster/limit-storage-consumption.md` | 1(+XS) 0(-)
- [x] M145. `content/en/docs/tasks/administer-cluster/manage-resources/_index.md` | 1(+XS) 1(-)
- [x] M146. `content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md` | 2(+XS) 3(-)
- [x] M147. `content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md` | 13(+S) 11(-)
- [x] M148. `content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md` | 1(+XS) 1(-)
- [x] M149. `content/en/docs/tasks/administer-cluster/namespaces.md` | 157(+L) 148(-)