### PR TITLE
[ru] Sync KubeCon section UI & 2025 links to Russian

### DIFF
--- a/content/ru/_index.html
+++ b/content/ru/_index.html
@@ -43,19 +43,13 @@ Kubernetes — это проект с открытым исходным кодо
 <h2>О сложности миграции 150+ микросервисов в Kubernetes</h2>
         <p>Сара Уэллс, технический директор по эксплуатации и надёжности в Financial Times</p>
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Смотреть видео</button>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в США 12-15 ноября</a>
-        <br>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Индии 11-12 декабря</a>
-        <br>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Посетите KubeCon + CloudNativeCon в Лондоне 1-4 апреля, 2025</a>
+
+    <h3>Посетите следующие KubeCon + CloudNativeCon</h3>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" class="desktopKCButton"><strong>Europe</strong> (Лондон, Апр 1-4)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Гонконг, Июн 10-11)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Токио, Июн 16-17)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Хайдарабад, Авг 6-7)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2025/" class="desktopKCButton"><strong>North America</strong> (Атланта, Ноя 10-13)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Following the recent KubeCon links section UI update & content actualisation for 2025 (#49167), I'm applying the same changes to the Russian localisation.

