### PR TITLE
[uk] Sync KubeCon section UI & 2025 links to Ukrainian

### DIFF
--- a/content/uk/_index.html
+++ b/content/uk/_index.html
@@ -62,19 +62,13 @@ Kubernetes - проект з відкритим вихідним кодом. В�
         -->
         <p>Сара Уеллз, технічний директор з експлуатації і безпеки роботи, Financial Times</p>
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Переглянути відео</button>
-        <br>
-        <br>
-         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024" button id="desktopKCButton">Відвідайте KubeCon + CloudNativeCon у Північній Америці, 12-15 листопада 2024 року</a>
-        <br>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" button id="desktopKCButton">Відвідайте KubeCon + CloudNativeCon в Індії 11-12 грудня</a>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" button id="desktopKCButton">Відвідайте KubeCon + CloudNativeCon в Європі 1-4 квітня</a>
 
+<h3>Відвідайте наступні події KubeCon + CloudNativeCon</h3>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" class="desktopKCButton"><strong>Europe</strong> (Лондон, Квiт. 1-4)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Гонконг, Черв. 10-11)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Токіо, Черв. 16-17)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Гайдарабад, Серп. 6-7)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2025/" class="desktopKCButton"><strong>North America</strong> (Атланта, Лист. 10-13)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Following the recent KubeCon links section UI update & content actualisation for 2025 (#49167), I'm applying the same changes to the Ukrainian localisation.