### PR TITLE
[fr] Sync KubeCon section UI & 2025 links to French

### DIFF
--- a/content/fr/_index.html
+++ b/content/fr/_index.html
@@ -43,17 +43,13 @@ Kubernetes est une solution open-source qui vous permet de tirer parti de vos in
 <h2>Les défis de la migration de plus de 150 microservices vers Kubernetes</h2>
         <p>Par Sarah Wells, directrice technique des opérations et de la fiabilité, Financial Times</p>
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Voir la video (en)</button>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">Venez au KubeCon + CloudNativeCon North America du 12 au 15 Novembre</a>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" button id="desktopKCButton">Venez au KubeCon + CloudNativeCon India du 11 au 12 Decembre</a>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2025/" button id="desktopKCButton">Attend KubeCon + CloudNativeCon Europe du 1 au 4 Avril</a>
+
+<h3>Assistez à la prochaine KubeCon + CloudNativeCon</h3>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" class="desktopKCButton"><strong>Europe</strong> (Londres, avr. 1-4)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Hong Kong, juin 10-11)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Tokyo, juin 16-17)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Hyderabad, août 6-7)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2025/" class="desktopKCButton"><strong>North America</strong> (Atlanta, nov. 10-13)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Following the recent KubeCon links section UI update & content actualisation for 2025 (https://github.com/kubernetes/website/pull/49167), I'm applying the same changes to the French localisation.