### PR TITLE
[pt-br] Sync KubeCon section UI & 2025 links to Portuguese

### DIFF
--- a/content/pt-br/_index.html
+++ b/content/pt-br/_index.html
@@ -39,14 +39,13 @@ O Kubernetes é Open Source, o que te oferece a liberdade de utilizá-lo em seu 
 <h2>Os desafios da migração de mais de 150 micro serviços para o Kubernetes</h2>
         <p>Sarah Wells, Diretora Técnica de Operações e Confiabilidade do Financial Times</p>
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Assista Video</button>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" id="desktopKCButton">KubeCon + CloudNativeCon na Europa de 19 a 22 de março de 2024</a>
-        <br>
-        <br>
-        <br>
-        <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2024/" button id="desktopKCButton">KubeCon + CloudNativeCon na América do Norte de 12 a 15 de novembro de 2024</a>
+
+<h3>Participe dos próximos eventos KubeCon + CloudNativeCon</h3>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Hong Kong, 10-11 de junho)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Tóquio, 16-17 de junho)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Haiderabade, 6-7 de agosto)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" class="desktopKCButton"><strong>North America</strong> (Atlanta, 10-13 de novembro)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Amsterdam, 23-26 de março, 2026)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Following the recent KubeCon links section UI update & content actualisation for 2025 (#49167), I'm applying the same changes to the Portuguese localisation.