### PR TITLE
Make the video section height on the main page flexible

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -32,9 +32,6 @@ $quickstart-button-padding: 0 50px;
 $vendor-strip-height: 88px;
 $vendor-strip-font-size: 16px;
 
-// video
-$video-section-height: 200px;
-
 @import "size";
 @import "documentation";
 
@@ -434,9 +431,6 @@ $ocean-nodes-padding-Y: 60px;
 $ocean-nodes-main-margin-bottom: 60px;
 $ocean-nodes-h3-margin-bottom: 30px;
 
-// video
-$video-section-height: 200px;
-
 // Home-specific
 
 .td-home {
@@ -515,12 +509,9 @@ section#cncf {
 
 // Video thingy
 #video {
-  height: $video-section-height;
-}
-
-#video {
   width: 100%;
   position: relative;
+  overflow: hidden;
   background-position: center center;
   background-size: cover;
 
@@ -557,7 +548,7 @@ section#cncf {
     padding: 2px 8px;
     margin: 5px;
   }
-  
+
   #desktopKCButton {
     display: inline;
     position: absolute;
@@ -621,6 +612,10 @@ section#cncf {
       border-color: transparent transparent transparent #ffffff;
     }
   }
+}
+
+#video:has(#desktopKCButton) {
+  height: 580px;
 }
 
 #videoPlayer {

--- a/assets/scss/_desktop.scss
+++ b/assets/scss/_desktop.scss
@@ -1,6 +1,5 @@
 $main-max-width: 1200px;
 $vendor-strip-height: 44px;
-$video-section-height: 580px;
 
 @media screen and (min-width: 1024px) {
 
@@ -50,13 +49,12 @@ $video-section-height: 580px;
   }
 
   #video {
-    height: $video-section-height;
     position: relative;
-    background-position: center center;
+    background-position: top center;
     background-size: cover;
 
     &>.light-text {
-      margin-right: 10%;
+      margin: 0 10% 15px 0;
     }
   }
 

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -28,9 +28,6 @@ $headline-wrapper-margin-bottom: 40px;
 $quickstart-button-padding: 0 50px;
 $vendor-strip-font-size: 16px;
 
-//video
-$video-section-height: 400px;
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -134,15 +131,13 @@ $video-section-height: 400px;
   }
 
   #video {
-    height: $video-section-height;
     display: block;
-    height: 550px;
 
     & > .light-text {
       display: block;
       float: right;
       text-align: left;
-      margin-right: 5%;
+      margin: 0 5% 15px 0;
     }
   }
 


### PR DESCRIPTION
This PR improves the KubeCon links section redesign introduced in #49167. While propagating these recent changes to various localisations, I stumbled upon an issue in #49442. When we have a lot of content in the video block (which includes the KubeCon links section), some links might not fit due to a limited height. Here, you can see a missing (hidden) link to the 5th event in the Portuguese localisation:

![image](https://github.com/user-attachments/assets/de18fc6b-835e-4592-bda1-ba3c029e47c3)

To prevent this from happening, this PR gets rid of fixed heights for the video block. With `overflow:hidden` added, it makes its height flexible. E.g., we'll be able to add even more events with no issue:

![image](https://github.com/user-attachments/assets/71214d7f-28c9-4704-b6db-dd977dc3f150)

To keep backward compatibility with the pages using old KubeCon links, the `#video:has(#desktopKCButton)` workaround is added to `_base.scss`.

My changes also remove an unnecessary `200px`-height video block with no content for the mobile layout — it will just disappear. Let me know if we really need it back for mobiles:

![image](https://github.com/user-attachments/assets/c09ff76c-d567-4e84-8c22-ca0b21006411)

P.S. I tested the changes in two browsers (Chrome & Firefox) and various localisations (e.g., those that have already adopted new KubeCon links and those that have not).