### PR TITLE
Clarify ReadWriteOnce allows multiple pods to read and write

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -632,7 +632,7 @@ The access modes are:
 
 `ReadWriteOnce`
 : the volume can be mounted as read-write by a single node. ReadWriteOnce access
-  mode still can allow multiple pods to access, read or write, the volume when the pods are
+  mode still can allow multiple pods to access (read from or write to) that volume when the pods are
   running on the same node. For single pod access, please see ReadWriteOncePod.
 
 `ReadOnlyMany`

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -632,7 +632,7 @@ The access modes are:
 
 `ReadWriteOnce`
 : the volume can be mounted as read-write by a single node. ReadWriteOnce access
-  mode still can allow multiple pods to access the volume when the pods are
+  mode still can allow multiple pods to access, read or write, the volume when the pods are
   running on the same node. For single pod access, please see ReadWriteOncePod.
 
 `ReadOnlyMany`


### PR DESCRIPTION
Courrently, description of `ReadWriteOnce` leaves room for misinterpretation
of the `access` in "multiple pods to access the volume" bit. This leads
to spread of confusing information like multiple pods can access but only
one pod can write at a time.

See also  https://github.com/kubernetes/kubernetes/issues/60903#issuecomment-2592863002
