### PR TITLE
Fix missing backticks in Pod Lifecycle concept page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -136,7 +136,7 @@ without a finalizer, to a terminal phase (`Failed` or `Succeeded` depending on
 the exit statuses of the pod containers) before their deletion from the API server.
 
 If a node dies or is disconnected from the rest of the cluster, Kubernetes
-applies a policy for setting the `phase` of all Pods on the lost node to Failed.
+applies a policy for setting the `phase` of all Pods on the lost node to `Failed`.
 
 ## Container states
 


### PR DESCRIPTION
### Description
Missing backquotes to the word Failed in the pod lifecycle documentation. 
Also, I wanted to make a first commit to the project.

### Issue

Closes: #