### PR TITLE
KEP-3866 nftables kube-proxy to GA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/NFTablesProxyMode.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/NFTablesProxyMode.md
@@ -13,5 +13,9 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.31"
+    toVersion: "1.32"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.33"
 ---
 Allow running kube-proxy in [nftables mode](/docs/reference/networking/virtual-ips/#proxy-mode-nftables).


### PR DESCRIPTION
### Description
update `NFTablesProxyMode` feature gate info for 1.33

I wasn't sure if I was supposed to remove the line:

```
{{< feature-state feature_gate_name="NFTablesProxyMode" >}}
```

from `content/en/docs/reference/networking/virtual-ips.md` or not?

Also, the existing note

```
As of Kubernetes {{< skew currentVersion >}}, the `nftables` mode is
still relatively new, and may not be compatible with all network
plugins; consult the documentation for your network plugin.
```

still seems true for now, so I didn't remove it.

### Issue

https://github.com/kubernetes/enhancements/issues/3866