### PR TITLE
Fix JavaScript null object error in banner-dismiss.js

### DIFF
--- a/assets/js/banner-dismiss.js
+++ b/assets/js/banner-dismiss.js
@@ -21,21 +21,25 @@ $(document).ready(function() {
 
   /* Check the presence of a cookie */
   let announcement = document.querySelector("#announcement");
-  let token = `announcement_ack_${announcement.getAttribute('data-announcement-name').replace(/\s/g, '_')}`; // Generate the unique token for announcement
-  let acknowledged = getCookie(token);
-  if (acknowledged === "true") {
-    announcement.remove(); // Remove the announcement if the cookie is set
-  }
-  else {
-    announcement.classList.add('display-announcement') // Display the announcement if the cookie is not set
+  if (announcement) {
+    let token = `announcement_ack_${announcement.getAttribute('data-announcement-name').replace(/\s/g, '_')}`; // Generate the unique token for announcement
+    let acknowledged = getCookie(token);
+    if (acknowledged === "true") {
+      announcement.remove(); // Remove the announcement if the cookie is set
+    }
+    else {
+      announcement.classList.add('display-announcement') // Display the announcement if the cookie is not set
+    }
   }
 
   /* Driver code to set the cookie */
   let button = document.querySelector('#banner-dismiss');
-  button.removeAttribute('style');
-  button.addEventListener('click', function() {
-    setCookie(token, "true", 
-    button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
-    announcement.remove();
-  });
+  if (button) {
+    button.removeAttribute('style');
+    button.addEventListener('click', function() {
+      setCookie(token, "true",
+      button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
+      announcement.remove();
+    });
+  }
 });


### PR DESCRIPTION
At the moment, opening any documentation page results in a JavaScript error caused by referring to a null object. Here's how Firefox displays it in the Console:

```
Uncaught TypeError: e is null
	<anonymous> https://kubernetes.io/js/banner-dismiss.min.095ea25f4d8d1299fa348e27bfc7822ce87d0fba4f01d3660670afc7b3184df0.js:1
	jQuery 2
    	e
    	t
banner-dismiss.min.095ea25f4d8d1299fa348e27bfc7822ce87d0fba4f01d3660670afc7b3184df0.js:1:394
	<anonymous> https://kubernetes.io/js/banner-dismiss.min.095ea25f4d8d1299fa348e27bfc7822ce87d0fba4f01d3660670afc7b3184df0.js:1
	jQuery 2
```

This PR fixes the error by adding extra `if`'s to check whether the desired HTML objects (`#announcement` and `#banner-dismiss`) exist before using them. It's very similar to what was offered in #45991, but I'm not sure why that PR wasn't merged. This problem seems to persist on the website for a long time already.

I tried this fix locally in Firefox and Chrome, and it helps to get rid of the JS errors, as confirmed by both browsers.

Closes: #45830

/area web-development