### PR TITLE
update image tag in manifest

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -60,7 +60,7 @@ broken states, and cannot recover except by being restarted. Kubernetes provides
 liveness probes to detect and remedy such situations.
 
 In this exercise, you create a Pod that runs a container based on the
-`registry.k8s.io/busybox` image. Here is the configuration file for the Pod:
+`registry.k8s.io/busybox:1.27.2` image. Here is the configuration file for the Pod:
 
 {{% code_sample file="pods/probe/exec-liveness.yaml" %}}
 
@@ -101,8 +101,8 @@ The output indicates that no liveness probes have failed yet:
 Type    Reason     Age   From               Message
 ----    ------     ----  ----               -------
 Normal  Scheduled  11s   default-scheduler  Successfully assigned default/liveness-exec to node01
-Normal  Pulling    9s    kubelet, node01    Pulling image "registry.k8s.io/busybox"
-Normal  Pulled     7s    kubelet, node01    Successfully pulled image "registry.k8s.io/busybox"
+Normal  Pulling    9s    kubelet, node01    Pulling image "registry.k8s.io/busybox:1.27.2"
+Normal  Pulled     7s    kubelet, node01    Successfully pulled image "registry.k8s.io/busybox:1.27.2"
 Normal  Created    7s    kubelet, node01    Created container liveness
 Normal  Started    7s    kubelet, node01    Started container liveness
 ```
@@ -120,8 +120,8 @@ probes have failed, and the failed containers have been killed and recreated.
 Type     Reason     Age                From               Message
 ----     ------     ----               ----               -------
 Normal   Scheduled  57s                default-scheduler  Successfully assigned default/liveness-exec to node01
-Normal   Pulling    55s                kubelet, node01    Pulling image "registry.k8s.io/busybox"
-Normal   Pulled     53s                kubelet, node01    Successfully pulled image "registry.k8s.io/busybox"
+Normal   Pulling    55s                kubelet, node01    Pulling image "registry.k8s.io/busybox:1.27.2"
+Normal   Pulled     53s                kubelet, node01    Successfully pulled image "registry.k8s.io/busybox:1.27.2"
 Normal   Created    53s                kubelet, node01    Created container liveness
 Normal   Started    53s                kubelet, node01    Started container liveness
 Warning  Unhealthy  10s (x3 over 20s)  kubelet, node01    Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory

--- a/content/en/examples/pods/inject/dapi-envars-container.yaml
+++ b/content/en/examples/pods/inject/dapi-envars-container.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox:1.24
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/inject/dapi-envars-pod.yaml
+++ b/content/en/examples/pods/inject/dapi-envars-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/inject/dapi-volume-resources.yaml
+++ b/content/en/examples/pods/inject/dapi-volume-resources.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: registry.k8s.io/busybox:1.24
+      image: registry.k8s.io/busybox:1.27.2
       command: ["sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/inject/dapi-volume.yaml
+++ b/content/en/examples/pods/inject/dapi-volume.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: ["sh", "-c"]
       args:
       - while true; do

--- a/content/en/examples/pods/pod-configmap-env-var-valueFrom.yaml
+++ b/content/en/examples/pods/pod-configmap-env-var-valueFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/echo", "$(SPECIAL_LEVEL_KEY) $(SPECIAL_TYPE_KEY)" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/en/examples/pods/pod-configmap-envFrom.yaml
+++ b/content/en/examples/pods/pod-configmap-envFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "env" ]
       envFrom:
       - configMapRef:

--- a/content/en/examples/pods/pod-configmap-volume-specific-key.yaml
+++ b/content/en/examples/pods/pod-configmap-volume-specific-key.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh","-c","cat /etc/config/keys" ]
       volumeMounts:
       - name: config-volume

--- a/content/en/examples/pods/pod-configmap-volume.yaml
+++ b/content/en/examples/pods/pod-configmap-volume.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "ls /etc/config/" ]
       volumeMounts:
       - name: config-volume

--- a/content/en/examples/pods/pod-multiple-configmap-env-variable.yaml
+++ b/content/en/examples/pods/pod-multiple-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/en/examples/pods/pod-single-configmap-env-variable.yaml
+++ b/content/en/examples/pods/pod-single-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "env" ]
       env:
         # Define the environment variable

--- a/content/en/examples/pods/probe/exec-liveness.yaml
+++ b/content/en/examples/pods/probe/exec-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: registry.k8s.io/busybox
+    image: registry.k8s.io/busybox:1.27.2
     args:
     - /bin/sh
     - -c


### PR DESCRIPTION
fixes this https://github.com/kubernetes/website/issues/49406

Updating the tag for `registry.k8s.io/busybox` from `latest` to `1.27.2`.
When using the `registry.k8s.io/busybox` image with the `latest` tag to create a workload, the workload is stuck in `ImagePullBackOff` with the error.
```
Failed to pull image "registry.k8s.io/busybox": Error response from daemon: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of registry.k8s.io/busybox:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2.
```


Issue
Closes: https://github.com/kubernetes/website/issues/49406