### PR TITLE
Update readiness probe docs to match observed behaviour

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -534,10 +534,11 @@ processing its startup data, you might prefer a readiness probe.
 
 {{< note >}}
 If you want to be able to drain requests when the Pod is deleted, you do not
-necessarily need a readiness probe; when the POD is deleted, the corresponding endpoint
-will have its `ready` status as `false`, so load balancers will not use it for regular
-traffic. The endpoint remains in the unready state while it waits for the containers
-in the Pod to stop.
+necessarily need a readiness probe; when the Pod is deleted, the corresponding endpoint
+will update its [conditions](../../services-networking/endpoint-slices.md#conditions).
+Namely, the `ready` condition will be set to `false`, so load balancers
+will not use the Pod for regular traffic. The `serving` condition will reflect
+the Pod's ready status.
 {{< /note >}}
 
 #### When should you use a startup probe?

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -537,8 +537,8 @@ If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; on deletion, the Pod automatically puts itself
 into an unready state regardless of whether the readiness probe exists.
 The Pod remains in the unready state while it waits for the containers in the Pod
-to stop. Note that`Ready` condition in the Pod status is still `"True"`
-and `.status.phase` is `"Running"` while the Pod is terminating.
+to stop. The`Ready` condition in the Pod status remains true, and `.status.phase`
+remains Running, until the Pod is fully terminated.
 {{< /note >}}
 
 #### When should you use a startup probe?

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -536,9 +536,9 @@ processing its startup data, you might prefer a readiness probe.
 If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; when the Pod is deleted, the corresponding endpoint
 will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions).
-Namely, the `ready` condition will be set to `false`, so load balancers
-will not use the Pod for regular traffic. The `serving` condition will reflect
-the Pod's ready status.
+Namely, the endpoint `ready` condition will be set to `false`, so load balancers
+will not use the Pod for regular traffic. The endpoint `serving` condition will
+reflect the Pod's `Ready` condition.
 {{< /note >}}
 
 #### When should you use a startup probe?

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -535,10 +535,10 @@ processing its startup data, you might prefer a readiness probe.
 {{< note >}}
 If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; when the Pod is deleted, the corresponding endpoint
-will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions).
-Namely, the endpoint `ready` condition will be set to `false`, so load balancers
-will not use the Pod for regular traffic. The endpoint `serving` condition will
-reflect the Pod's `Ready` condition.
+in the `EndppointSlice` will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions):
+the endpoint `ready` condition will be set to `false`, so load balancers
+will not use the Pod for regular traffic. See [Pod termination](#pod-termination)
+for more information about how the kubelet handles Pod deletion.
 {{< /note >}}
 
 #### When should you use a startup probe?

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -537,7 +537,8 @@ If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; on deletion, the Pod automatically puts itself
 into an unready state regardless of whether the readiness probe exists.
 The Pod remains in the unready state while it waits for the containers in the Pod
-to stop.
+to stop. Note that`Ready` condition in the Pod status is still `"True"`
+and `.status.phase` is `"Running"` while the Pod is terminating.
 {{< /note >}}
 
 #### When should you use a startup probe?

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -537,8 +537,9 @@ If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; on deletion, the Pod automatically puts itself
 into an unready state regardless of whether the readiness probe exists.
 The Pod remains in the unready state while it waits for the containers in the Pod
-to stop. The`Ready` condition in the Pod status remains true, and `.status.phase`
-remains Running, until the Pod is fully terminated.
+to stop. If liveness probe is successful or not defined, the `Ready` condition
+in the Pod status remains true, and `.status.phase`remains Running until the Pod
+is fully terminated.
 {{< /note >}}
 
 #### When should you use a startup probe?

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -535,7 +535,7 @@ processing its startup data, you might prefer a readiness probe.
 {{< note >}}
 If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; when the Pod is deleted, the corresponding endpoint
-will update its [conditions](../../services-networking/endpoint-slices.md#conditions).
+will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions).
 Namely, the `ready` condition will be set to `false`, so load balancers
 will not use the Pod for regular traffic. The `serving` condition will reflect
 the Pod's ready status.

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -534,12 +534,10 @@ processing its startup data, you might prefer a readiness probe.
 
 {{< note >}}
 If you want to be able to drain requests when the Pod is deleted, you do not
-necessarily need a readiness probe; on deletion, the Pod automatically puts itself
-into an unready state regardless of whether the readiness probe exists.
-The Pod remains in the unready state while it waits for the containers in the Pod
-to stop. If liveness probe is successful or not defined, the `Ready` condition
-in the Pod status remains true, and `.status.phase`remains Running until the Pod
-is fully terminated.
+necessarily need a readiness probe; when the POD is deleted, the corresponding endpoint
+will have its `ready` status as `false`, so load balancers will not use it for regular
+traffic. The endpoint remains in the unready state while it waits for the containers
+in the Pod to stop.
 {{< /note >}}
 
 #### When should you use a startup probe?


### PR DESCRIPTION
### Description

This PR updates documentation about readiness probes to explicitly state that pods that are being terminating (i.e. `.metadata.deletionTimestamp` is set) still have `Ready` condition `"True"` and `.status.Phase == "Running"`. I kept the exiting text, but looking at

1.  https://github.com/kubernetes/kubernetes/blob/f64b651ebae643d422f4625161dc415970e2c166/pkg/kubelet/prober/prober_manager.go#L298 and https://github.com/kubernetes/kubernetes/blob/f64b651ebae643d422f4625161dc415970e2c166/pkg/kubelet/prober/prober_manager.go#L339 

2. https://github.com/kubernetes/kubernetes/blob/f64b651ebae643d422f4625161dc415970e2c166/pkg/kubelet/prober/worker.go#L259

I'd say that ~~liveness~~ READINESS probes are processed the same way no matter is the pod is terminating or not. Please advice if we should rephrase the note more, or remove it entirely. Thank you!

EDIT: Confused readiness and liveness probes