### PR TITLE
Fix typo in mismatchLabelKeys example

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -453,7 +453,7 @@ spec:
                  # tenant is running.
         labelSelector:
           # We have to have the labelSelector which selects only Pods with the tenant label,
-          # otherwise this Pod would hate Pods from daemonsets as well, for example,
+          # otherwise this Pod would have Pods from daemonsets as well, for example,
           # which aren't supposed to have the tenant label.
           matchExpressions:
           - key: tenant


### PR DESCRIPTION
### Description

There is a typo in the example for `mismatchLabelKeys` where the word `have` was accidentally written as `hate`.

Furthermore, the part `otherwise this Pod would have Pods from daemonsets as well` does not seem clear enough to me. I guess we could replace `have` with something more descriptive? 