### PR TITLE
[fr] fix: typo in leases.md

### DIFF
--- a/content/fr/docs/concepts/architecture/leases.md
+++ b/content/fr/docs/concepts/architecture/leases.md
@@ -49,7 +49,7 @@ L'existence des Lease kube-apiserver permet des fonctionnalités futures qui peu
 chaque kube-apiserver.
 
 Vous pouvez inspecter les Lease détenus par chaque kube-apiserver en vérifiant les objets de bail dans le namespace `kube-system`
-avec le nom `kube-apiserver-<sha256-hash>`. Alternativement, vous pouvez utiliser le sélecteur d'étiquettes `apiserver.kubernetes.io/identity=kube-apiserver`:
+avec le nom `apiserver-<sha256-hash>`. Alternativement, vous pouvez utiliser le sélecteur d'étiquettes `apiserver.kubernetes.io/identity=kube-apiserver`:
 
 ```shell
 kubectl -n kube-system get lease -l apiserver.kubernetes.io/identity=kube-apiserver


### PR DESCRIPTION
there is no 'kube-' in 'kube-apiserver-sha256-hash' .
i reported this typo in pull request #49475 for english language 
and it was accepted .
however, the next day, i realized that this it is a technical typo so 
it should be corrected in all other translations .

today, I corrected that typo in the translations: es, fr, ja, ko, zh-cn .

but interestingly, in the 'JA' translation (at lines 39-44) and
the 'KO' translation (at lines 46-50), there is a result with 'kube-apiserver-' .
maybe someone who translated it into JA/KO languages noticed this typo, but
it was corrected in the wrong place, or perhaps it worked differently 
in an older version.

i double-checked on my computer, and I have 'apiserver-sha256-hash' with no 'kube-'.
```
myuser@workstation0:~$ kind --version
kind version 0.26.0

myuser@workstation0:~$ kubectl version
Client Version: v1.32.1
Kustomize Version: v5.5.0
Server Version: v1.32.0

myuser@workstation0:~$ kubectl -n kube-system get lease -l apiserver.kubernetes.io/identity=kube-apiserver
NAME                                   HOLDER                                                                      AGE
apiserver-c7uylvfxlbqccnk6myfkwetzze   apiserver-c7uylvfxlbqccnk6myfkwetzze_079d15a9-a58d-4ca4-a411-8d69f3a00b58   5h57m
```