### PR TITLE
[ko] fix: typo in leases.md

### DIFF
--- a/content/ko/docs/concepts/architecture/leases.md
+++ b/content/ko/docs/concepts/architecture/leases.md
@@ -39,15 +39,15 @@ weight: 30
 kube-apiserver 리스의 존재는 향후 각 kube-apiserver 간의 조정이 필요할 때
 기능을 제공해 줄 수 있다.
 
-각 kube-apiserver가 소유한 리스는 `kube-system` 네임스페이스에서`kube-apiserver-<sha256-hash>`라는 이름의
+각 kube-apiserver가 소유한 리스는 `kube-system` 네임스페이스에서`apiserver-<sha256-hash>`라는 이름의
 리스 오브젝트를 확인하여 볼 수 있다. 또는 `k8s.io/component=kube-apiserver` 레이블 설렉터를 사용하여 볼 수도 있다.
 
 ```shell
 $ kubectl -n kube-system get lease -l k8s.io/component=kube-apiserver
 NAME                                        HOLDER                                                                           AGE
-kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a   kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a_9cbf54e5-1136-44bd-8f9a-1dcd15c346b4   5m33s
-kube-apiserver-dz2dqprdpsgnm756t5rnov7yka   kube-apiserver-dz2dqprdpsgnm756t5rnov7yka_84f2a85d-37c1-4b14-b6b9-603e62e4896f   4m23s
-kube-apiserver-fyloo45sdenffw2ugwaz3likua   kube-apiserver-fyloo45sdenffw2ugwaz3likua_c5ffa286-8a9a-45d4-91e7-61118ed58d2e   4m43s
+apiserver-c4vwjftbvpc5os2vvzle4qg27a   kube-apiserver-c4vwjftbvpc5os2vvzle4qg27a_9cbf54e5-1136-44bd-8f9a-1dcd15c346b4   5m33s
+apiserver-dz2dqprdpsgnm756t5rnov7yka   kube-apiserver-dz2dqprdpsgnm756t5rnov7yka_84f2a85d-37c1-4b14-b6b9-603e62e4896f   4m23s
+apiserver-fyloo45sdenffw2ugwaz3likua   kube-apiserver-fyloo45sdenffw2ugwaz3likua_c5ffa286-8a9a-45d4-91e7-61118ed58d2e   4m43s
 ```
 
 리스 이름에 사용된 SHA256 해시는 kube-apiserver가 보는 OS 호스트 이름을 기반으로 한다.


### PR DESCRIPTION
there is no 'kube-' in 'kube-apiserver-sha256-hash' .
i reported this typo in pull request #49475 for english language 
and it was accepted .
however, the next day, i realized that this it is a technical typo so 
it should be corrected in all other translations .

today, I corrected that typo in the translations: es, fr, ja, ko, zh-cn .

but interestingly, in the 'JA' translation (at lines 39-44) and
the 'KO' translation (at lines 46-50), there is a result with 'kube-apiserver-' .
maybe someone who translated it into JA/KO languages noticed this typo, but
it was corrected in the wrong place, or perhaps it worked differently 
in an older version.

i double-checked on my computer, and I have 'apiserver-sha256-hash' with no 'kube-'.
```
myuser@workstation0:~$ kind --version
kind version 0.26.0

myuser@workstation0:~$ kubectl version
Client Version: v1.32.1
Kustomize Version: v5.5.0
Server Version: v1.32.0

myuser@workstation0:~$ kubectl -n kube-system get lease -l apiserver.kubernetes.io/identity=kube-apiserver
NAME                                   HOLDER                                                                      AGE
apiserver-c7uylvfxlbqccnk6myfkwetzze   apiserver-c7uylvfxlbqccnk6myfkwetzze_079d15a9-a58d-4ca4-a411-8d69f3a00b58   5h57m
```