### PR TITLE
[zh-cn] fix: typo in leases.md

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/leases.md
+++ b/content/zh-cn/docs/concepts/architecture/leases.md
@@ -89,13 +89,13 @@ Existence of kube-apiserver leases enables future capabilities that may require 
 each kube-apiserver.
 
 You can inspect Leases owned by each kube-apiserver by checking for lease objects in the `kube-system` namespace
-with the name `kube-apiserver-<sha256-hash>`. Alternatively you can use the label selector `apiserver.kubernetes.io/identity=kube-apiserver`:
+with the name `apiserver-<sha256-hash>`. Alternatively you can use the label selector `apiserver.kubernetes.io/identity=kube-apiserver`:
 -->
 从 Kubernetes v1.26 开始，每个 `kube-apiserver` 都使用 Lease API 将其身份发布到系统中的其他位置。
 虽然它本身并不是特别有用，但为客户端提供了一种机制来发现有多少个 `kube-apiserver` 实例正在操作
 Kubernetes 控制平面。kube-apiserver 租约的存在使得未来可以在各个 kube-apiserver 之间协调新的能力。
 
-你可以检查 `kube-system` 名字空间中名为 `kube-apiserver-<sha256-hash>` 的 Lease 对象来查看每个
+你可以检查 `kube-system` 名字空间中名为 `apiserver-<sha256-hash>` 的 Lease 对象来查看每个
 kube-apiserver 拥有的租约。你还可以使用标签选择算符 `apiserver.kubernetes.io/identity=kube-apiserver`：
 
 ```shell


### PR DESCRIPTION
there is no 'kube-' in 'kube-apiserver-sha256-hash' .
i reported this typo in pull request #49475 for english language 
and it was accepted .
however, the next day, i realized that this it is a technical typo so 
it should be corrected in all other translations .

today, I corrected that typo in the translations: es, fr, ja, ko, zh-cn .

but interestingly, in the 'JA' translation (at lines 39-44) and
the 'KO' translation (at lines 46-50), there is a result with 'kube-apiserver-' .
maybe someone who translated it into JA/KO languages noticed this typo, but
it was corrected in the wrong place, or perhaps it worked differently 
in an older version.

i double-checked on my computer, and I have 'apiserver-sha256-hash' with no 'kube-'.
```
myuser@workstation0:~$ kind --version
kind version 0.26.0

myuser@workstation0:~$ kubectl version
Client Version: v1.32.1
Kustomize Version: v5.5.0
Server Version: v1.32.0

myuser@workstation0:~$ kubectl -n kube-system get lease -l apiserver.kubernetes.io/identity=kube-apiserver
NAME                                   HOLDER                                                                      AGE
apiserver-c7uylvfxlbqccnk6myfkwetzze   apiserver-c7uylvfxlbqccnk6myfkwetzze_079d15a9-a58d-4ca4-a411-8d69f3a00b58   5h57m
```