### PR TITLE
[zh-cn]sync slis kubeadm_init_phase_etcd

### DIFF
--- a/content/zh-cn/docs/reference/instrumentation/slis.md
+++ b/content/zh-cn/docs/reference/instrumentation/slis.md
@@ -15,7 +15,7 @@ weight: 20
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.29" state="stable" >}}
+{{< feature-state feature_gate_name="ComponentSLIs" >}}
 
 <!--
 By default, Kubernetes {{< skew currentVersion >}} publishes Service Level Indicator (SLI) metrics 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_etcd.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_etcd.md
@@ -9,9 +9,9 @@ Generate static Pod manifest file for local etcd
 ### 概要
 
 <!--
-This command is not meant to be run on its own. See list of available subcommands.
+Generate static Pod manifest file for local etcd
 -->
-此命令并非设计用来单独运行。请参阅可用子命令列表。
+为本地 etcd 创建静态 Pod 清单。
 
 ```
 kubeadm init phase etcd [flags]


### PR DESCRIPTION
content/zh-cn/docs/reference/instrumentation/slis.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_etcd.md