### PR TITLE
Drop stale reviewers for Pod priority pages

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -1,7 +1,4 @@
 ---
-reviewers:
-- davidopp
-- wojtek-t
 title: Pod Priority and Preemption
 content_type: concept
 weight: 90

--- a/content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -1,8 +1,4 @@
 ---
-reviewers:
-- davidopp
-- filipg
-- piosz
 title: Guaranteed Scheduling For Critical Add-On Pods
 content_type: concept
 weight: 220


### PR DESCRIPTION
AIUI, this list of per-item reviewers is stale; drop it and let SIG Docs handle reviews here.

/kind cleanup

@davidopp, @wojtek-t, @piosz, @filipg FYI