### PR TITLE
[zh-cn]sync kubeadm_init/*

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/_index.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/_index.md
@@ -53,14 +53,13 @@ upload-certs                 Upload certificates to kubeadm-certs
 mark-control-plane           Mark a node as a control-plane
 bootstrap-token              Generates bootstrap tokens used to join a node to a cluster
 kubelet-finalize             Updates settings relevant to the kubelet after TLS bootstrap
-  /experimental-cert-rotation  Enable kubelet client certificate rotation
 addon                        Install required addons for passing conformance tests
   /coredns                     Install the CoreDNS addon to a Kubernetes cluster
   /kube-proxy                  Install the kube-proxy addon to a Kubernetes cluster
 show-join-command            Show the join command for control-plane and worker node
 ```
 -->
-```
+```shell
 preflight                    预检
 certs                        生成证书
   /ca                          生成自签名根 CA 用于配置其他 kubernetes 组件
@@ -94,14 +93,13 @@ upload-certs                 将证书上传到 kubeadm-certs
 mark-control-plane           将节点标记为控制面
 bootstrap-token              生成用于将节点加入集群的引导令牌
 kubelet-finalize             在 TLS 引导后更新与 kubelet 相关的设置
-  /experimental-cert-rotation  启用 kubelet 客户端证书轮换
 addon                        安装用于通过一致性测试所需的插件
   /coredns                     将 CoreDNS 插件安装到 Kubernetes 集群
   /kube-proxy                  将 kube-proxy 插件安装到 Kubernetes 集群
 show-join-command            显示控制平面和工作节点的加入命令
 ```
 
-```
+```shell
 kubeadm init [flags]
 ```
 
@@ -262,17 +260,19 @@ Don't apply any changes; just output what would be done.
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-EtcdLearnerMode=true|false (BETA - default=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - default=false)<br/>
+EtcdLearnerMode=true|false (default=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - default=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - default=false)
 -->
 一组用来描述各种功能特性的键值（key=value）对。选项是：<br/>
-EtcdLearnerMode=true|false (BETA - 默认值=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - 默认值=false)<br/>
+EtcdLearnerMode=true|false (默认值=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - 默认值=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - 默认值=false)
 </td>
 </tr>
@@ -367,12 +367,12 @@ Path to a directory that contains files named &quot;target[suffix][+patchtype].e
 -->
 <p>
 它包含名为 &quot;target[suffix][+patchtype].extension&quot; 的文件的目录的路径。
-例如，&quot;kube-apiserver0+merge.yaml&quot;或仅仅是 &quot;etcd.json&quot;。
+例如，&quot;kube-apiserver0+merge.yaml&quot; 或仅仅是 &quot;etcd.json&quot;。
 &quot;target&quot; 可以是 &quot;kube-apiserver&quot;、&quot;kube-controller-manager&quot;、&quot;kube-scheduler&quot;、&quot;etcd&quot;、&quot;kubeletconfiguration&quot; 之一。
 &quot;patchtype&quot; 可以是 &quot;strategic&quot;、&quot;merge&quot; 或者 &quot;json&quot; 之一，
 并且它们与 kubectl 支持的补丁格式相同。
 默认的 &quot;patchtype&quot; 是 &quot;strategic&quot;。
-&quot;extension&quot; 必须是&quot;json&quot; 或&quot;yaml&quot;。
+&quot;extension&quot; 必须是 &quot;json&quot; 或 &quot;yaml&quot;。
 &quot;suffix&quot; 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </p>
 </td>
@@ -526,7 +526,7 @@ Upload control-plane certificates to the kubeadm-certs Secret.
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -542,7 +542,7 @@ Upload control-plane certificates to the kubeadm-certs Secret.
 [EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
 <p>
-[实验] 到 '真实' 主机根文件系统的路径。
+[实验] 到'真实'主机根文件系统的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_all.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_all.md
@@ -13,7 +13,7 @@ Install all the addons
 -->
 安装所有插件（addon）。
 
-```
+```shell
 kubeadm init phase addon all [flags]
 ```
 
@@ -22,7 +22,7 @@ kubeadm init phase addon all [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -111,17 +111,19 @@ Don't apply any changes; just output what would be done.
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-EtcdLearnerMode=true|false (BETA - default=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - default=false)<br/>
+EtcdLearnerMode=true|false (default=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - default=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - default=false)
 -->
 一组键值对（key=value），描述了各种特征。选项包括：<br/>
-EtcdLearnerMode=true|false (BETA - 默认值=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - 默认值=false)<br/>
+EtcdLearnerMode=true|false (默认值=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - 默认值=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - 默认值=false)
 </td>
 </tr>
@@ -255,7 +257,7 @@ Use alternative domain for services, e.g. &quot;myorg.internal&quot;.
 -->
 ### 继承于父命令的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -271,7 +273,7 @@ Use alternative domain for services, e.g. &quot;myorg.internal&quot;.
 [EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
 <p>
-[实验] 到 '真实' 主机根文件系统的路径。
+[实验] 到'真实'主机根文件系统的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs.md
@@ -9,11 +9,11 @@ Certificate generation
 ### 概要
 
 <!--
-This command is not meant to be run on its own. See list of available subcommands.
+Certificate generation
 -->
-此命令不应单独运行。请参阅可用子命令列表。
+证书生成：
 
-```
+```shell
 kubeadm init phase certs [flags]
 ```
 
@@ -22,7 +22,7 @@ kubeadm init phase certs [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -51,7 +51,7 @@ certs 操作的帮助命令。
 -->
 ### 从父指令中继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -67,7 +67,7 @@ certs 操作的帮助命令。
 [EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
 <p>
-[实验] 到 '真实' 主机根文件系统的路径。
+[实验] 到'真实'主机根文件系统的路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_all.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_all.md
@@ -31,7 +31,7 @@ kubeadm init phase control-plane all --config config.yaml
 -->
 ### 示例
 
-```
+```shell
 # 为控制平面组件生成静态 Pod 清单文件，其功能等效于 kubeadm init 生成的文件。
 kubeadm init phase control-plane all
 
@@ -44,7 +44,7 @@ kubeadm init phase control-plane all --config config.yaml
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -176,18 +176,20 @@ Don't apply any changes; just output what would be done.
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-EtcdLearnerMode=true|false (BETA - default=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - default=false)<br/>
+EtcdLearnerMode=true|false (default=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - default=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - default=false)
 -->
 <p>
 一组用来描述各种特性门控的键值（key=value）对。选项是：<br/>
-EtcdLearnerMode=true|false (BETA - 默认值=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - 默认值=false)<br/>
+EtcdLearnerMode=true|false (默认值=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - 默认值=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)
 WaitForAllControlPlaneComponents=true|false (ALPHA - 默认值=false)
 </p>
 </td>
@@ -255,7 +257,7 @@ Path to a directory that contains files named &quot;target[suffix][+patchtype].e
 -->
 <p>
 包含名为 &quot;target[suffix][+patchtype].extension&quot; 的文件的目录的路径。
-例如，&quot;kube-apiserver0+merge.yaml&quot;或是简单的 &quot;etcd.json&quot;。
+例如，&quot;kube-apiserver0+merge.yaml&quot; 或是简单的 &quot;etcd.json&quot;。
 &quot;target&quot; 可以是 &quot;kube-apiserver&quot;、&quot;kube-controller-manager&quot;、&quot;kube-scheduler&quot;、&quot;etcd&quot;、&quot;kubeletconfiguration&quot; 之一。
 &quot;patchtype&quot; 可以是 &quot;strategic&quot;、&quot;merge&quot; 或者 &quot;json&quot; 之一，
 并且它们与 kubectl 支持的补丁格式相匹配。
@@ -322,7 +324,7 @@ Use alternative range of IP address for service VIPs.
 -->
 ### 从父指令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_apiserver.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_apiserver.md
@@ -13,7 +13,7 @@ Generates the kube-apiserver static Pod manifest
 -->
 生成 kube-apiserver 静态 Pod 清单。
 
-```
+```shell
 kubeadm init phase control-plane apiserver [flags]
 ```
 
@@ -22,7 +22,7 @@ kubeadm init phase control-plane apiserver [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -87,10 +87,10 @@ A set of extra flags to pass to the API Server or override default ones in form 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 The path where to save and store the certificates.
 -->
-<p>
 保存和存储证书的路径。
 </p>
 </td>
@@ -101,10 +101,10 @@ The path where to save and store the certificates.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Path to a kubeadm configuration file.
 -->
-<p>
 kubeadm 配置文件的路径。
 </p>
 </td>
@@ -115,10 +115,10 @@ kubeadm 配置文件的路径。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Specify a stable IP address or DNS name for the control plane.
 -->
-<p>
 为控制平面指定一个稳定的 IP 地址或 DNS 名称。
 </p>
 </td>
@@ -135,7 +135,7 @@ Don't apply any changes; just output what would be done.
 不做任何更改；只输出将要执行的操作。
 </p>
 </td>
- </tr>
+</tr>
 
 <tr>
 <td colspan="2">--feature-gates string</td>
@@ -144,18 +144,20 @@ Don't apply any changes; just output what would be done.
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-EtcdLearnerMode=true|false (BETA - default=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - default=false)<br/>
+EtcdLearnerMode=true|false (default=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - default=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - default=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - default=false)
 -->
 <p>
 一组键值对，用于描述各种功能特性的特性门控。选项是：<br/>
-EtcdLearnerMode=true|false (BETA - 默认值=true)<br/>
+ControlPlaneKubeletLocalMode=true|false (ALPHA - 默认值=false)<br/>
+EtcdLearnerMode=true|false (默认值=true)<br/>
+NodeLocalCRISocket=true|false (ALPHA - 默认值=false)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)<br/>
-UpgradeAddonsBeforeControlPlane=true|false (DEPRECATED - 默认值=false)<br/>
 WaitForAllControlPlaneComponents=true|false (ALPHA - 默认值=false)
 </p>
 </td>
@@ -261,7 +263,7 @@ Use alternative range of IP address for service VIPs.
 -->
 ### 继承于父命令的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -277,7 +279,7 @@ Use alternative range of IP address for service VIPs.
 [EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
 <p>
-[实验] 到 '真实' 主机根文件系统路径。
+[实验] 到'真实'主机根文件系统路径。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_upload-config_kubeadm.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_upload-config_kubeadm.md
@@ -19,7 +19,7 @@ Alternatively, you can use kubeadm config.
 -->
 另外，可以使用 kubeadm 配置。
 
-```
+```shell
 kubeadm init phase upload-config kubeadm [flags]
 ```
 
@@ -31,9 +31,9 @@ kubeadm init phase upload-config kubeadm [flags]
 <!--
 # upload the configuration of your cluster
 -->
-```
+```shell
 # 上传集群配置
-kubeadm init phase upload-config --config=myConfig.yaml
+kubeadm init phase upload-config kubeadm --config=myConfig.yaml
 ```
 
 <!--
@@ -41,7 +41,7 @@ kubeadm init phase upload-config --config=myConfig.yaml
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -132,7 +132,7 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 -->
 ### 从父命令继承的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -148,7 +148,7 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 [EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
 <p>
-[实验] 到 '真实' 主机根文件系统的路径。
+[实验] 到'真实'主机根文件系统的路径。
 </p>
 </td>
 </tr>


### PR DESCRIPTION
```bash
#       modified:   content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/_index.md
#       modified:   content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_all.md
#       modified:   content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs.md
#       modified:   content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_all.md
#       modified:   content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_apiserver.md
#       modified:   content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_upload-config_kubeadm.md
```