### PR TITLE
kubeadm: Document ControlPlaneKubeletLocalMode promotion to beta

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -155,7 +155,7 @@ List of feature gates:
 {{< table caption="kubeadm feature gates" >}}
 Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
-`ControlPlaneKubeletLocalMode` | `false` | 1.31 | - | -
+`ControlPlaneKubeletLocalMode` | `true` | 1.31 | 1.33 | -
 `NodeLocalCRISocket` | `false` | 1.32 | - | -
 `WaitForAllControlPlaneComponents` | `false` | 1.30 | - | -
 {{< /table >}}


### PR DESCRIPTION
### Description

This change documents the promotion of kubeadm's ControlPlaneKubeletLocalMode feature gate to beta. 

/hold not sure if I should change the chinese version or if it is generated in some way or needs a separate PR to separate branch.

### Issue

Part of:
- https://github.com/kubernetes/enhancements/issues/4471

Note: the following PR should merge first:
- https://github.com/kubernetes/kubernetes/pull/129716