### PR TITLE
modify pod-lifecycle.md to clarify 'Container restart policy'

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -239,17 +239,21 @@ To investigate the root cause of a `CrashLoopBackOff` issue, a user can:
 The `spec` of a Pod has a `restartPolicy` field with possible values Always, OnFailure,
 and Never. The default value is Always.
 
+* `Always`: Automatically restarts the container after any termination.
+* `OnFailure`: Only restarts the container if it exits with an error (non-zero exit status).
+* `Never`: Does not automatically restart the terminated container.
+
 The `restartPolicy` for a Pod applies to {{< glossary_tooltip text="app containers" term_id="app-container" >}}
 in the Pod and to regular [init containers](/docs/concepts/workloads/pods/init-containers/).
 [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/)
 ignore the Pod-level `restartPolicy` field: in Kubernetes, a sidecar is defined as an
 entry inside `initContainers` that has its container-level `restartPolicy` set to `Always`.
-For init containers that exit with an error, the kubelet restarts the init container if
-the Pod level `restartPolicy` is either `OnFailure` or `Always`:
 
-* `Always`: Automatically restarts the container after any termination.
-* `OnFailure`: Only restarts the container if it exits with an error (non-zero exit status).
-* `Never`: Does not automatically restart the terminated container.
+The main container waits until all _regular init containers_ succeed.
+For init containers that exit with an error, the kubelet restarts the init container if
+the Pod level `restartPolicy` is either `OnFailure` or `Always`.
+However, if any _regular init container_ fails and the Pod level `restartPolicy` is set to `Never`, 
+the Pod fails with the status `Init:Error`. 
 
 When the kubelet is handling container restarts according to the configured restart
 policy, that only applies to restarts that make replacement containers inside the


### PR DESCRIPTION
the section 'Container restart policy' describes the impact of the restartPolicy 
with values 'Always' and 'OnFailure' on initContainers, but it is not clear 
what happens to the entire Pod when initContainers fail and 
the restartPolicy is set to 'Never'.

i added two sentences to emphasize that:

- regular init containers must succeed before main container can start
- and restartPolicy affects the entire Pod startup process even if the main container would start with no issues


my case with 'Init:Error' :

```
$ kind --version
kind version 0.26.0

$ kubectl version
Client Version: v1.32.1
Kustomize Version: v5.5.0
Server Version: v1.32.0

$ cat << EOF > pod-x.yaml
apiVersion: v1
kind: Pod
metadata:
  name: pod-x
spec:
  restartPolicy: Never
  containers:
    - name: main-container
      image: nginx
  initContainers:
    - name: init-container
      image: busybox
      command: ["sh", "-c", "exit 1"]
EOF

$ kubectl apply -f ./pod-x.yaml

$ kubectl get pod pod-x
NAME    READY   STATUS       RESTARTS   AGE
pod-x   0/1     Init:Error   0          26s
```