### PR TITLE
docs: extend VAP docs with exempt resources

### DIFF
--- a/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
@@ -214,3 +214,18 @@ as well as:
 - `jsonpatch.escapeKey` - Performs JSONPatch key escaping. `~` and  `/` are escaped as `~0` and `~1` respectively.
 
 Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
+
+## API kinds exempt from mutating admission
+
+There are certain API kinds that are exempt from admission-time mutation. For example, you can't create a MutatingAdmissionPolicy that changes a MutatingAdmissionPolicy.
+
+The list of exempt API kinds is:
+
+* [ValidatingAdmissionPolicies]({{< relref "/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-v1/" >}})
+* [ValidatingAdmissionPolicyBindings]({{< relref "/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-binding-v1/" >}})
+* MutatingAdmissionPolicies
+* MutatingAdmissionPolicyBindings
+* [TokenReviews]({{< relref "/docs/reference/kubernetes-api/authentication-resources/token-review-v1/" >}})
+* [LocalSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1/" >}})
+* [SelfSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/" >}})
+* [SelfSubjectReviews]({{< relref "/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1/" >}})

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -501,7 +501,7 @@ The error message is similar to this.
 error: failed to create deployment: deployments.apps "invalid" is forbidden: ValidatingAdmissionPolicy 'image-matches-namespace-environment.policy.example.com' with binding 'demo-binding-test.example.com' denied request: only prod images are allowed in namespace default
 ```
 
-## Resources exempt from admission validation/mutation
+## API kinds exempt from admission validation
 
 There are certain resources which are exempt from admission validation/mutation which means they can't be targeted by an admission/mutation policy. For example you cant create a Validating Admission Policy to validate
 the creation of other Validating Admission Policies/Policy Bindings.

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -505,7 +505,8 @@ error: failed to create deployment: deployments.apps "invalid" is forbidden: Val
 
 There are certain API kinds that are exempt from admission-time validation checks. For example, you can't create a ValidatingAdmissionPolicy that prevents changes to ValidatingAdmissionPolicyBindings.
 
-The list of exempt resources includes:
+The list of exempt API kinds is:
+
 * `validatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)
 * `validatingadmissionpolicybindings` (API group: `admissionregistration.k8s.io`)
 * `mutatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -507,12 +507,11 @@ There are certain API kinds that are exempt from admission-time validation check
 
 The list of exempt API kinds is:
 
-* `validatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)
-* `validatingadmissionpolicybindings` (API group: `admissionregistration.k8s.io`)
-* `mutatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)
-* `mutatingadmissionpolicybindings` (API group: `admissionregistration.k8s.io`)
-* `selfsubjectreviews` (API group: `authentication.k8s.io`)
-* `tokenreviews` (API group: `authentication.k8s.io`)
-* `localsubjectaccessreviews` (API group: `authentication.k8s.io`)
-* `selfsubjectaccessreviews` (API group: `authentication.k8s.io`)
-* `subjectaccessreviews` (API group: `authentication.k8s.io`)
+* [ValidatingAdmissionPolicies]({{< relref "/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-v1/" >}})
+* [ValidatingAdmissionPolicyBindings]({{< relref "/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-binding-v1/" >}})
+* MutatingAdmissionPolicies
+* MutatingAdmissionPolicyBindings
+* [TokenReviews]({{< relref "/docs/reference/kubernetes-api/authentication-resources/token-review-v1/" >}})
+* [LocalSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1/" >}})
+* [SelfSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/">}})
+* [SelfSubjectReviews]({{< relref "/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1/" >}})

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -503,8 +503,7 @@ error: failed to create deployment: deployments.apps "invalid" is forbidden: Val
 
 ## API kinds exempt from admission validation
 
-There are certain resources which are exempt from admission validation/mutation which means they can't be targeted by an admission/mutation policy. For example you cant create a Validating Admission Policy to validate
-the creation of other Validating Admission Policies/Policy Bindings.
+There are certain API kinds that are exempt from admission-time validation checks. For example, you can't create a ValidatingAdmissionPolicy that prevents changes to ValidatingAdmissionPolicyBindings.
 
 The list of exempt resources includes:
 * `validatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -513,5 +513,5 @@ The list of exempt API kinds is:
 * MutatingAdmissionPolicyBindings
 * [TokenReviews]({{< relref "/docs/reference/kubernetes-api/authentication-resources/token-review-v1/" >}})
 * [LocalSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1/" >}})
-* [SelfSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/">}})
+* [SelfSubjectAccessReviews]({{< relref "/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/" >}})
 * [SelfSubjectReviews]({{< relref "/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1/" >}})

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -500,3 +500,19 @@ The error message is similar to this.
 ```console
 error: failed to create deployment: deployments.apps "invalid" is forbidden: ValidatingAdmissionPolicy 'image-matches-namespace-environment.policy.example.com' with binding 'demo-binding-test.example.com' denied request: only prod images are allowed in namespace default
 ```
+
+## Resources exempt from admission validation/mutation
+
+There are certain resources which are exempt from admission validation/mutation which means they can't be targeted by an admission/mutation policy. For example you cant create a Validating Admission Policy to validate
+the creation of other Validating Admission Policies/Policy Bindings.
+
+The list of exempt resources includes:
+* `validatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)
+* `validatingadmissionpolicybindings` (API group: `admissionregistration.k8s.io`)
+* `mutatingadmissionpolicies` (API group: `admissionregistration.k8s.io`)
+* `mutatingadmissionpolicybindings` (API group: `admissionregistration.k8s.io`)
+* `selfsubjectreviews` (API group: `authentication.k8s.io`)
+* `tokenreviews` (API group: `authentication.k8s.io`)
+* `localsubjectaccessreviews` (API group: `authentication.k8s.io`)
+* `selfsubjectaccessreviews` (API group: `authentication.k8s.io`)
+* `subjectaccessreviews` (API group: `authentication.k8s.io`)


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Certain resources are (by design) exempt from being targeted by `ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy`. Unfortunately there is no clear documentation in the [KEP-3488](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3488-cel-admission-control) nor in the official Kubernetes docs which resources are affected by this exemption.

This MR extends the documentation to mention these resources in the official docs. I think this helps other users in the future to not waste a lot of time (like I did) to figure out which resources are exempt.

Im not sure if this is the right approach but I think it is better than no documentation at all. See also these issues/PRs for reference:
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3488-cel-admission-control
- https://github.com/kubernetes/kubernetes/issues/122205
- https://github.com/kubernetes/kubernetes/pull/123543/

I appreciate your feedback on this. Thank you ❤️ 

### Issue
\-
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
