### PR TITLE
fix: typo in sidecar-containers.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -91,7 +91,7 @@ execute the primary application logic; instead, they provide supporting function
 the main application.
 
 Sidecar containers have their own independent lifecycles. They can be started, stopped,
-and restarted independently of app containers. This means you can update, scale, or
+and restarted independently of app containers. This means you can update or
 maintain sidecar containers without affecting the primary application.
 
 Sidecar containers share the same network and storage namespaces with the primary


### PR DESCRIPTION
i deleted the word 'scale' as it seems to be the wrong word .

the section 'Differences from application containers' describes how sidecar containers 
work in Pods . 

as far as i know there is no 'scaling' mechanism for containers inside a Pod .
so probably:
- it was supposed to be a different word 
- it might have been added by accident
