### PR TITLE
Bump Golang version for local preview container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # change is that the Hugo version is now an overridable argument rather than a fixed
 # environment variable.
 
-FROM docker.io/library/golang:1.23.0-alpine3.20
+FROM docker.io/library/golang:1.23.1-alpine3.20
 
 RUN apk add --no-cache \
     curl \
@@ -22,7 +22,7 @@ RUN mkdir $HOME/src && \
     cd "hugo-${HUGO_VERSION}" && \
     go install --tags extended
 
-FROM docker.io/library/golang:1.23.0-alpine3.20
+FROM docker.io/library/golang:1.23.1-alpine3.20
 
 RUN apk add --no-cache \
     runuser \


### PR DESCRIPTION
### Description
Creating this draft PR to check if the issue #49460 is due to flakiness. This PR updates the Dockerfile by changing the version of the base image from `golang:1.23.0-alpine3.20` to `golang:1.23.1-alpine3.20` which is a trigger condition for the prow job to run.

### Issue

Re: #49460 

/cc @ameukam 