### PR TITLE
fix: clarify that certain Pod A records are only available with CoreDNS

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -107,10 +107,9 @@ and the domain name for your cluster is `cluster.local`, then the Pod has a DNS 
 
 `172-17-0-3.default.pod.cluster.local`.
 
-If you're using [CoreDNS], Pods exposed by a Service will also have the following
-DNS resolution available:
+Some cluster DNS mechanisms, like [CoreDNS], also provide `A` records for:
 
-`pod-ipv4-address.service-name.my-namespace.svc.cluster-domain.example`.
+<tt><em>pod-ipv4-address</em>.<em>service-name</em>.<em>my-namespace</em>.svc.<em>cluster-domain.example</em>.</tt>
 
 ### Pod's hostname and subdomain fields
 
@@ -365,4 +364,4 @@ this problem.
 For guidance on administering DNS configurations, check
 [Configure DNS Service](/docs/tasks/administer-cluster/dns-custom-nameservers/)
 
-[CoreDNS]: /docs/tasks/administer-cluster/coredns/
+[CoreDNS]: https://coredns.io/

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -107,7 +107,8 @@ and the domain name for your cluster is `cluster.local`, then the Pod has a DNS 
 
 `172-17-0-3.default.pod.cluster.local`.
 
-Any Pods exposed by a Service have the following DNS resolution available:
+If you're using [CoreDNS], Pods exposed by a Service will also have the following
+DNS resolution available:
 
 `pod-ipv4-address.service-name.my-namespace.svc.cluster-domain.example`.
 
@@ -363,3 +364,5 @@ this problem.
 
 For guidance on administering DNS configurations, check
 [Configure DNS Service](/docs/tasks/administer-cluster/dns-custom-nameservers/)
+
+[CoreDNS]: /docs/tasks/administer-cluster/coredns/


### PR DESCRIPTION
related to https://github.com/kubernetes/dns/issues/633