### PR TITLE
[pt-br] Translate card front-matter for configuring clusters

### DIFF
--- a/content/pt-br/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/pt-br/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -5,7 +5,7 @@ weight: 30
 card:
   name: tasks
   weight: 25
-  title: Configure access to clusters
+  title: Configure o acesso a clusters
 ---
 
 <!-- overview -->


### PR DESCRIPTION
### Description

Translate the card front-matter in the
`tasks/access-application-cluster/configure-access-multiple-clusters` page so the correct version shows up in the documentation initial page.

/cc @edsoncelio @MrErlison 