### PR TITLE
fix: reinstate splitter

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -38,6 +38,8 @@
 {{ end -}}
 
 <!--for the splitter-->
+<!--script src="https://unpkg.com/split.js/dist/split.min.js"></script-->
+<script src="/js/split-1.6.0.js" intregrity="sha384-0blL3GqHy6+9fw0cyY2Aoiwg4onHAtslAs4OkqZY7UQBrR65/K4gI+hxLdWDrjpz"></script>
 <script>
   let splitInstance = null;
 


### PR DESCRIPTION
Add the missing code to load the splitter library.
Fixup for PR #48350

/area web-development
/priority critical-urgent