### PR TITLE
Fix missing command for local container preview

### DIFF
--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -313,6 +313,13 @@ variable to override this behaviour.
    make container-image
    ```
 
+1. Fetch submodule dependencies in your local repository:
+
+   ```shell
+   # Run this in a terminal
+   make module-init
+   ```
+
 1. Start Hugo in a container:
 
    ```shell


### PR DESCRIPTION
## where is a problem

Section "Preview your changes locally" at https://kubernetes.io/docs/contribute/new-content/open-a-pr/#preview-locally .

There is a lack of a step about the required initiation before `make container-serve` . 

## how to reproduce this problem

When you perform the steps according to the document:
https://kubernetes.io/docs/contribute/new-content/open-a-pr/#preview-locally ,
you get the following error:

```
~/w/tool/kdoc-ws$ git clone https://github.com/kubernetes/website website-tmp

~/w/tool/kdoc-ws$ cd website-tmp

~/w/tool/kdoc-ws/website-tmp$ make container-image

~/w/tool/kdoc-ws/website-tmp$ make container-serve
WARNING Submodule not initialized: api-ref-generator
You need to run make module-init to initialize missing modules first
make: *** [Makefile:41: module-check] Error 1
```

## the solution

This step is required:
```
~/w/tool/kdoc-ws/website-tmp$ make module-init
```
prior to `make container-serve`.

---

## my full console output

```
~/w/tool/kdoc-ws$ git clone https://github.com/kubernetes/website website-tmp
Cloning into 'website-tmp'...
remote: Enumerating objects: 442023, done.
remote: Counting objects: 100% (404/404), done.
remote: Compressing objects: 100% (236/236), done.
remote: Total 442023 (delta 319), reused 168 (delta 168), pack-reused 441619 (from 4)
Receiving objects: 100% (442023/442023), 458.47 MiB | 21.20 MiB/s, done.
Resolving deltas: 100% (326716/326716), done.
Updating files: 100% (10789/10789), done.

~/w/tool/kdoc-ws$ cd website-tmp

~/w/tool/kdoc-ws/website-tmp$ make container-image
docker build . \
--network=host \
--tag gcr.io/k8s-staging-sig-docs/k8s-website-hugo:v0.133.0-b2fd7a71e676 \
--build-arg HUGO_VERSION=0.133.0
[+] Building 0.7s (14/14) FINISHED                                                                                                                                                              docker:default
=> [internal] load build definition from Dockerfile                                                                                                                                                      0.0s
=> => transferring dockerfile: 1.26kB                                                                                                                                                                    0.0s
=> [internal] load metadata for docker.io/library/golang:1.23.1-alpine3.20                                                                                                                               0.6s
=> [internal] load .dockerignore                                                                                                                                                                         0.0s
=> => transferring context: 76B                                                                                                                                                                          0.0s
=> [stage-0 1/3] FROM docker.io/library/golang:1.23.1-alpine3.20@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06                                                                 0.0s
=> [internal] load build context                                                                                                                                                                         0.0s
=> => transferring context: 39.13kB                                                                                                                                                                      0.0s
=> CACHED [stage-1 2/7] RUN apk add --no-cache     runuser     git     gcompat     openssh-client     rsync     npm                                                                                      0.0s
=> CACHED [stage-1 3/7] RUN mkdir -p /var/hugo &&     addgroup -Sg 1000 hugo &&     adduser -Sg hugo -u 1000 -h /var/hugo hugo &&     chown -R hugo: /var/hugo &&     runuser -u hugo -- git config --g  0.0s
=> CACHED [stage-0 2/3] RUN apk add --no-cache     curl     gcc     g++     musl-dev     build-base     libc6-compat                                                                                     0.0s
=> CACHED [stage-0 3/3] RUN mkdir $HOME/src &&     cd $HOME/src &&     curl -L https://github.com/gohugoio/hugo/archive/refs/tags/v0.133.0.tar.gz | tar -xz &&     cd "hugo-0.133.0" &&     go install   0.0s
=> CACHED [stage-1 4/7] COPY --from=0 /go/bin/hugo /usr/local/bin/hugo                                                                                                                                   0.0s
=> CACHED [stage-1 5/7] WORKDIR /src                                                                                                                                                                     0.0s
=> CACHED [stage-1 6/7] COPY package.json package-lock.json ./                                                                                                                                           0.0s
=> CACHED [stage-1 7/7] RUN npm ci                                                                                                                                                                       0.0s
=> exporting to image                                                                                                                                                                                    0.0s
=> => exporting layers                                                                                                                                                                                   0.0s
=> => writing image sha256:74420f9bc6d254a52d7a3c96cd70a0d3e704a9ece41db3fd92a2d454ca5d45f1                                                                                                              0.0s
=> => naming to gcr.io/k8s-staging-sig-docs/k8s-website-hugo:v0.133.0-b2fd7a71e676                                                                                                                       0.0s

~/w/tool/kdoc-ws/website-tmp$ make container-serve
WARNING Submodule not initialized: api-ref-generator
You need to run make module-init to initialize missing modules first
make: *** [Makefile:41: module-check] Error 1

~/w/tool/kdoc-ws/website-tmp$ make module-init
Initializing submodules...
Submodule 'api-ref-generator' (https://github.com/kubernetes-sigs/reference-docs) registered for path 'api-ref-generator'
Cloning into '/home/myuser/w/tool/kdoc-ws/website-tmp/api-ref-generator'...
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Enumerating objects: 43, done.
remote: Counting objects: 100% (43/43), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 22 (delta 14), reused 7 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (22/22), 3.53 KiB | 113.00 KiB/s, done.
From https://github.com/kubernetes-sigs/reference-docs
* branch            096a94d6e7d0d04e41356f21233498c3c4e31699 -> FETCH_HEAD
  Submodule path 'api-ref-generator': checked out '096a94d6e7d0d04e41356f21233498c3c4e31699'

~/w/tool/kdoc-ws/website-tmp$ make container-serve
  "docker" run --rm --interactive --tty --cap-drop=ALL --cap-add=AUDIT_WRITE --read-only --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/.git,target=/src/.git,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/archetypes,target=/src/archetypes,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/assets,target=/src/assets,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/content,target=/src/content,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/data,target=/src/data,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/i18n,target=/src/i18n,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/layouts,target=/src/layouts,readonly --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/static,target=/src/static,readonly --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 --mount type=bind,source=/home/myuser/w/tool/kdoc-ws/website-tmp/hugo.toml,target=/src/hugo.toml,readonly \
  -p 1313:1313 gcr.io/k8s-staging-sig-docs/k8s-website-hugo:v0.133.0-b2fd7a71e676 \
  hugo server --buildDrafts --buildFuture --environment development --bind 0.0.0.0 --destination /tmp/public --cleanDestinationDir --noBuildLock
  Watching for changes in /src/{archetypes,assets,content,data,layouts,node_modules,package.json,static}
  Watching for config changes in /src/hugo.toml, /src/node_modules/docsy/config.yaml
  Start building sites …
  hugo v0.133.0+extended linux/amd64 BuildDate=unknown


                   |  EN  | BN  | ZH-CN | FR  | DE  | HI  | ID  | IT  | JA  | KO  | PL  | PT-BR | RU  | ES  | UK  | VI   
-------------------+------+-----+-------+-----+-----+-----+-----+-----+-----+-----+-----+-------+-----+-----+-----+------
Pages            | 2297 | 236 |  1891 | 381 | 210 | 137 | 337 |  92 | 585 | 617 |  71 |   369 | 195 | 319 |  95 |  83  
Paginator pages  |   61 |   0 |    24 |   0 |   0 |   0 |   0 |   0 |   2 |   0 |   0 |     0 |   0 |   0 |   0 |   0  
Non-page files   |  747 | 612 |   628 |  84 |  83 |  75 |  80 |  40 | 537 |  86 |  74 |    86 |  80 |  83 |  82 |  75  
Static files     |  830 | 830 |   830 | 830 | 830 | 830 | 830 | 830 | 830 | 830 | 830 |   830 | 830 | 830 | 830 | 830  
Processed images |   14 |  13 |     1 |   0 |   0 |   0 |   0 |   0 |   0 |   0 |   0 |     0 |   0 |   0 |   0 |   0  
Aliases          |    8 |   1 |     6 |   2 |   1 |   0 |   1 |   1 |   3 |   3 |   0 |     3 |   4 |   2 |   1 |   0  
Cleaned          |    0 |   0 |     0 |   0 |   0 |   0 |   0 |   0 |   0 |   0 |   0 |     0 |   0 |   0 |   0 |   0

Built in 29871 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 0.0.0.0)
Press Ctrl+C to stop
```
