### PR TITLE
Add note on feature flag for PodLevelResources

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -216,7 +216,8 @@ spec:
 
 {{< feature-state feature_gate_name="PodLevelResources" >}}
 
-The following Pod has an explicit request of 1 CPU and 100 MiB of memory, and an
+This feature can be enabled by setting the `PodLevelResources` [feature
+gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/). The following Pod has an explicit request of 1 CPU and 100 MiB of memory, and an
 explicit limit of 1 CPU and 200 MiB of memory. The `pod-resources-demo-ctr-1`
 container has explicit requests and limits set. However, the
 `pod-resources-demo-ctr-2` container will simply share the resources available


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR adds a note on enabling the `PodLevelResources` feature gate to the section detailing this feature.

### Issue

Closes: #49550 

![pod-level-resource](https://github.com/user-attachments/assets/c5b7e9b6-de30-477e-9d5e-e6a21a0d059d)

