### PR TITLE
Return css.html partial to the layout

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -43,6 +43,8 @@
 <link rel="stylesheet" href="{{ "css/prism.css" | relURL }}"/>
 {{ end -}}
 
+{{ partial "css.html" . -}}
+
 {{ partial "hooks/head-end.html" . -}}
 
 {{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}


### PR DESCRIPTION
### Description

Removing the `layouts/partials/css.html` from the website layout (#48350) led to missing CSS styles for some pages (such as [Training](https://kubernetes.io/training/) and [Case Studies](https://kubernetes.io/case-studies/)). This PR brings this partial back to fix affected CSS styles.

Since @sftim worked with tidying up the &lt;head>, I'm mentioning him to be sure we actually want to have this partial back (perhaps there was some other plan).

### Issue

Closes: #49590