### PR TITLE
fix: code block typo in deployment.md

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -227,7 +227,7 @@ Get more details on your updated Deployment:
 * After the rollout succeeds, you can view the Deployment by running `kubectl get deployments`.
   The output is similar to this:
 
-  ```ini
+  ```
   NAME               READY   UP-TO-DATE   AVAILABLE   AGE
   nginx-deployment   3/3     3            3           36s
   ```


### PR DESCRIPTION
fix a small inconsistency.

one of the code blocks for a command output has a different color (red).
this is because it is a code block of type 'ini', 
but it should not be.