### PR TITLE
Add deprecation notices related to PodAffinity's matchLabelKeys/mismatchLabelKeys

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -378,10 +378,10 @@ The keys are used to look up values from the pod labels; those key-value labels 
 (using `AND`) with the match restrictions defined using the `labelSelector` field. The combined
 filtering selects the set of existing pods that will be taken into Pod (anti)affinity calculation.
 
-{{< warning >}}
+{{< caution >}}
 It's not recommended to use `matchLabelKeys` with labels that might be updated 
 because the update of the label isn't reflected onto the merged `labelSelector`.
-{{< /warning >}}
+{{< /caution >}}
 
 A common use case is to use `matchLabelKeys` with `pod-template-hash` (set on Pods
 managed as part of a Deployment, where the value is unique for each revision).
@@ -430,10 +430,10 @@ Kubernetes includes an optional `mismatchLabelKeys` field for Pod affinity
 or anti-affinity. The field specifies keys for the labels that should **not** match with the incoming Pod's labels,
 when satisfying the Pod (anti)affinity.
 
-{{< warning >}}
+{{< caution >}}
 It's not recommended to use `matchLabelKeys` with labels that might be updated 
 because the update of the label isn't reflected onto the merged `labelSelector`.
-{{< /warning >}}
+{{< /caution >}}
 
 One example use case is to ensure Pods go to the topology domain (node, zone, etc) where only Pods from the same tenant or team are scheduled in.
 In other words, you want to avoid running Pods from two different tenants on the same topology domain at the same time.

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -379,8 +379,9 @@ The keys are used to look up values from the pod labels; those key-value labels 
 filtering selects the set of existing pods that will be taken into Pod (anti)affinity calculation.
 
 {{< caution >}}
-It's not recommended to use `matchLabelKeys` with labels that might be updated 
-because the update of the label isn't reflected onto the merged `labelSelector`.
+It's not recommended to use `matchLabelKeys` with labels that might be updated directly on pods.
+Even if you edit the pod's label that is specified at `matchLabelKeys` **directly**, (that is, not via a deployment),
+kube-apiserver doesn't reflect the label update onto the merged `labelSelector`.
 {{< /caution >}}
 
 A common use case is to use `matchLabelKeys` with `pod-template-hash` (set on Pods
@@ -431,8 +432,9 @@ or anti-affinity. The field specifies keys for the labels that should **not** ma
 when satisfying the Pod (anti)affinity.
 
 {{< caution >}}
-It's not recommended to use `matchLabelKeys` with labels that might be updated 
-because the update of the label isn't reflected onto the merged `labelSelector`.
+It's not recommended to use `mismatchLabelKeys` with labels that might be updated directly on pods.
+Even if you edit the pod's label that is specified at `mismatchLabelKeys` **directly**, (that is, not via a deployment),
+kube-apiserver doesn't reflect the label update onto the merged `labelSelector`.
 {{< /caution >}}
 
 One example use case is to ensure Pods go to the topology domain (node, zone, etc) where only Pods from the same tenant or team are scheduled in.

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -377,8 +377,11 @@ when satisfying the Pod (anti)affinity.
 The keys are used to look up values from the pod labels; those key-value labels are combined
 (using `AND`) with the match restrictions defined using the `labelSelector` field. The combined
 filtering selects the set of existing pods that will be taken into Pod (anti)affinity calculation.
+
+{{< warning >}}
 It's not recommended to use `matchLabelKeys` with labels that might be updated 
-because the update of the label isn't reflected onto the merged `LabelSelector`.
+because the update of the label isn't reflected onto the merged `labelSelector`.
+{{< /warning >}}
 
 A common use case is to use `matchLabelKeys` with `pod-template-hash` (set on Pods
 managed as part of a Deployment, where the value is unique for each revision).
@@ -426,8 +429,11 @@ When you want to disable it, you have to disable it explicitly via the
 Kubernetes includes an optional `mismatchLabelKeys` field for Pod affinity
 or anti-affinity. The field specifies keys for the labels that should **not** match with the incoming Pod's labels,
 when satisfying the Pod (anti)affinity.
-It's not recommended to use `mismatchLabelKeys` with labels that might be updated 
-because the update of the label isn't reflected onto the merged `LabelSelector`.
+
+{{< warning >}}
+It's not recommended to use `matchLabelKeys` with labels that might be updated 
+because the update of the label isn't reflected onto the merged `labelSelector`.
+{{< /warning >}}
 
 One example use case is to ensure Pods go to the topology domain (node, zone, etc) where only Pods from the same tenant or team are scheduled in.
 In other words, you want to avoid running Pods from two different tenants on the same topology domain at the same time.

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -377,6 +377,8 @@ when satisfying the Pod (anti)affinity.
 The keys are used to look up values from the pod labels; those key-value labels are combined
 (using `AND`) with the match restrictions defined using the `labelSelector` field. The combined
 filtering selects the set of existing pods that will be taken into Pod (anti)affinity calculation.
+It's not recommended to use `matchLabelKeys` with labels that might be updated 
+because the update of the label isn't reflected onto the merged `LabelSelector`.
 
 A common use case is to use `matchLabelKeys` with `pod-template-hash` (set on Pods
 managed as part of a Deployment, where the value is unique for each revision).
@@ -424,6 +426,8 @@ When you want to disable it, you have to disable it explicitly via the
 Kubernetes includes an optional `mismatchLabelKeys` field for Pod affinity
 or anti-affinity. The field specifies keys for the labels that should **not** match with the incoming Pod's labels,
 when satisfying the Pod (anti)affinity.
+It's not recommended to use `mismatchLabelKeys` with labels that might be updated 
+because the update of the label isn't reflected onto the merged `LabelSelector`.
 
 One example use case is to ensure Pods go to the topology domain (node, zone, etc) where only Pods from the same tenant or team are scheduled in.
 In other words, you want to avoid running Pods from two different tenants on the same topology domain at the same time.


### PR DESCRIPTION
#### Description
Add deprecation notices related to PodAffinity's `matchLabelKeys`/`mismatchLabelKeys`.

related:
- [KEP-3633 Introduce MatchLabelKeys and MismatchLabelKeys to PodAffinity and PodAntiAffinity](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity) 
- [KEP-3243 he update to labels specified at matchLabelKeys isn't supported](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades#the-update-to-labels-specified-at-matchlabelkeys-isnt-supported)
- https://github.com/kubernetes/kubernetes/issues/129480#issuecomment-2599513823

#### Special notes for your reviewer
This notification was found when we discussed about PodTopologySpread's `matchLabelKeys`.([#129480](https://github.com/kubernetes/kubernetes/issues/129480#issuecomment-2599513823))
But the same can be applied to PodAffinity's `matchLabelKeys`/`mismatchLabelKeys`.