### PR TITLE
[ja] Fix link typo for mrbobbytables

### DIFF
--- a/content/ja/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
+++ b/content/ja/blog/_posts/2024-06-06-10-Years-of-Kubernetes/index.md
@@ -4,7 +4,7 @@ title: "Kubernetesの10年間の歴史"
 date: 2024-06-06
 slug: 10-years-of-kubernetes
 author: >
-  [Bob Killen](https://github.com/mybobbytables) (CNCF),
+  [Bob Killen](https://github.com/mrbobbytables) (CNCF),
   [Chris Short](https://github.com/chris-short) (AWS),
   [Frederico Muñoz](https://github.com/fsmunoz) (SAS),
   [Kaslin Fields](https://github.com/kaslin) (Google),


### PR DESCRIPTION
### Description

Both `ja` and `zh-cn` have the wrong link for Bob Killen on the 2024-06-06 blog post "10 Years of Kubernetes". This PR fixes `ja`.

See also #49611