### PR TITLE
[zh-cn] fix: code block typo in deployment.md

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/controllers/deployment.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/deployment.md
@@ -439,7 +439,7 @@ Get more details on your updated Deployment:
 * 在上线成功后，可以通过运行 `kubectl get deployments` 来查看 Deployment：
   输出类似于：
 
-  ```ini
+  ```
   NAME               READY   UP-TO-DATE   AVAILABLE   AGE
   nginx-deployment   3/3     3            3           36s
   ```


### PR DESCRIPTION
the same as in english documentation #49600 .

fix a small inconsistency.

one of the code blocks for a command output has a different color (red).
this is because it is a code block of type 'ini',
but it should not be.
