### PR TITLE
[ko] fix: code block typo in deployment.md

### DIFF
--- a/content/ko/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ko/docs/concepts/workloads/controllers/deployment.md
@@ -214,7 +214,7 @@ kubectl apply -f https://k8s.io/examples/controllers/nginx-deployment.yaml
 * 롤아웃이 성공하면 `kubectl get deployments` 를 실행해서 디플로이먼트를 볼 수 있다.
     이와 유사하게 출력된다.
 
-  ```ini
+  ```
   NAME               READY   UP-TO-DATE   AVAILABLE   AGE
   nginx-deployment   3/3     3            3           36s
   ```


### PR DESCRIPTION
the same as in english documentation #49600 .

fix a small inconsistency.

one of the code blocks for a command output has a different color (red).
this is because it is a code block of type 'ini',
but it should not be.