### PR TITLE
Update the description of TopologySpreadConstraints's matchLabelKeys to align with the design change

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -139,8 +139,11 @@ your cluster. Those fields are:
   `matchLabelKeys` cannot be set when `labelSelector` isn't set. 
   Keys that don't exist in the pod labels will be ignored. 
   A null or empty list means only match against the `labelSelector`.
+
+  {{< warning >}}
   It's not recommended to use `matchLabelKeys` with labels that might be updated 
-  because the update of the label isn't reflected onto the merged `LabelSelector`.
+  because the update of the label isn't reflected onto the merged `labelSelector`.
+  {{< /warning >}}
 
   With `matchLabelKeys`, you don't need to update the `pod.spec` between different revisions.
   The controller/operator just needs to set different values to the same label key for different

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -133,17 +133,17 @@ your cluster. Those fields are:
 
 - **matchLabelKeys** is a list of pod label keys to select the group of pods over which 
   the spreading skew will be calculated. At a pod creation, 
-  apiserver will use those keys to lookup values from the incoming pod labels,
-  and those key-value labels will be merged with existing `labelSelector`. 
+  the kube-apiserver uses those keys to lookup values from the incoming pod labels,
+  and those key-value labels will be merged with any existing `labelSelector`.
   The same key is forbidden to exist in both `matchLabelKeys` and `labelSelector`. 
   `matchLabelKeys` cannot be set when `labelSelector` isn't set. 
   Keys that don't exist in the pod labels will be ignored. 
   A null or empty list means only match against the `labelSelector`.
 
-  {{< warning >}}
+  {{< caution >}}
   It's not recommended to use `matchLabelKeys` with labels that might be updated 
   because the update of the label isn't reflected onto the merged `labelSelector`.
-  {{< /warning >}}
+  {{< /caution >}}
 
   With `matchLabelKeys`, you don't need to update the `pod.spec` between different revisions.
   The controller/operator just needs to set different values to the same label key for different

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -131,18 +131,20 @@ your cluster. Those fields are:
   See [Label Selectors](/docs/concepts/overview/working-with-objects/labels/#label-selectors)
   for more details.
 
-- **matchLabelKeys** is a list of pod label keys to select the pods over which
-  spreading will be calculated. The keys are used to lookup values from the pod labels,
-  those key-value labels are ANDed with `labelSelector` to select the group of existing
-  pods over which spreading will be calculated for the incoming pod. The same key is
-  forbidden to exist in both `matchLabelKeys` and `labelSelector`. `matchLabelKeys` cannot
-  be set when `labelSelector` isn't set. Keys that don't exist in the pod labels will be
-  ignored. A null or empty list means only match against the `labelSelector`.
+- **matchLabelKeys** is a list of pod label keys to select the group of pods over which 
+  the spreading skew will be calculated. At a pod creation, 
+  apiserver will use those keys to lookup values from the incoming pod labels,
+  and those key-value labels will be merged with existing `labelSelector`. 
+  The same key is forbidden to exist in both `matchLabelKeys` and `labelSelector`. 
+  `matchLabelKeys` cannot be set when `labelSelector` isn't set. 
+  Keys that don't exist in the pod labels will be ignored. 
+  A null or empty list means only match against the `labelSelector`.
+  It's not recommended to use `matchLabelKeys` with labels that might be updated 
+  because the update of the label isn't reflected onto the merged `LabelSelector`.
 
   With `matchLabelKeys`, you don't need to update the `pod.spec` between different revisions.
   The controller/operator just needs to set different values to the same label key for different
-  revisions. The scheduler will assume the values automatically based on `matchLabelKeys`. For
-  example, if you are configuring a Deployment, you can use the label keyed with
+  revisions. For example, if you are configuring a Deployment, you can use the label keyed with
   [pod-template-hash](/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label), which
   is added automatically by the Deployment controller, to distinguish between different revisions
   in a single Deployment.

--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -141,8 +141,9 @@ your cluster. Those fields are:
   A null or empty list means only match against the `labelSelector`.
 
   {{< caution >}}
-  It's not recommended to use `matchLabelKeys` with labels that might be updated 
-  because the update of the label isn't reflected onto the merged `labelSelector`.
+  It's not recommended to use `matchLabelKeys` with labels that might be updated directly on pods.
+  Even if you edit the pod's label that is specified at `matchLabelKeys` **directly**, (that is, not via a deployment),
+  kube-apiserver doesn't reflect the label update onto the merged `labelSelector`.
   {{< /caution >}}
 
   With `matchLabelKeys`, you don't need to update the `pod.spec` between different revisions.


### PR DESCRIPTION
#### Description

This PR updates the description of TopologySpreadConstraints's `matchLabelKeys` to align with the design change by https://github.com/kubernetes/kubernetes/pull/129874.
This also includes the [deprecation notice](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades#the-update-to-labels-specified-at-matchlabelkeys-isnt-supported) related to `matchLabelKeys`.

related: 
- [KEP-3243 he update to labels specified at matchLabelKeys isn't supported](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades#the-update-to-labels-specified-at-matchlabelkeys-isnt-supported)
- https://github.com/kubernetes/kubernetes/pull/129874
- https://github.com/kubernetes/enhancements/pull/5033