### PR TITLE
fix: use docsy dependency without hugo-extended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "kubernetes.io",
       "devDependencies": {
         "autoprefixer": "^10.4.20",
-        "docsy": "github:google/docsy#semver:0.6.0",
+        "docsy": "github:google/docsy#v0.6.x",
         "postcss-cli": "^11.0.0"
       }
     },
@@ -322,8 +323,8 @@
       }
     },
     "node_modules/docsy": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/google/docsy.git#5597d435dc74ce68240e0c3871addf24567493b0",
+      "version": "0.6.0+1",
+      "resolved": "git+ssh://git@github.com/google/docsy.git#de445c7305ec72c29c262f5d032864b5cba34af5",
       "dev": true,
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
-    "docsy": "github:google/docsy#semver:0.6.0",
+    "docsy": "github:google/docsy#v0.6.x",
     "postcss-cli": "^11.0.0"
   },
   "spelling": "cSpell:ignore docsy pkgs -"


### PR DESCRIPTION
### Description
This PR changes the docsy dependency to the 0.6.x branch of Docsy which removed `hugo-extended` from its dependencies. This ensures that `hugo-extended` is not installed.

### Issue
Closes: #49460