### PR TITLE
Fix header nesting in cpu-management-policies.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -59,7 +59,7 @@ CPU Manager support can be enabled on Windows by using the `WindowsCPUAndMemoryA
 and it requires support in the container runtime.
 Once the feature gate is enabled, follow the steps below to configure the [CPU manager policy](#configuration).
 
-### Configuration
+## Configuration
 
 The CPU Manager policy is set with the `--cpu-manager-policy` kubelet
 flag or the `cpuManagerPolicy` field in [KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/).
@@ -89,7 +89,7 @@ and `CPUManagerPolicyBetaOptions` feature gates. Diverging from the Kubernetes s
 feature gates guard groups of options, because it would have been too cumbersome to add a feature
 gate for each individual option.
 
-### Changing the CPU Manager Policy
+## Changing the CPU Manager Policy
 
 Since the CPU manager policy can only be applied when kubelet spawns new pods, simply changing from
 "none" to "static" won't apply to existing pods. So in order to properly change the CPU manager
@@ -115,11 +115,11 @@ if the set of online CPUs changes on the node, the node must be drained and CPU 
 state file `cpu_manager_state` in the kubelet root directory.
 {{< /note >}}
 
-#### `none` policy configuration
+### `none` policy configuration
 
 This policy has no extra configuration items.
 
-#### `static` policy configuration
+### `static` policy configuration
 
 This policy manages a shared pool of CPUs that initially contains all CPUs in the
 node. The amount of exclusively allocatable CPUs is equal to the total
@@ -142,7 +142,7 @@ the static policy is enabled. This is because zero CPU reservation would allow t
 pool to become empty.
 {{< /note >}}
 
-#### Static policy options {#cpu-policy-static--options}
+### Static policy options {#cpu-policy-static--options}
 
 You can toggle groups of options on and off based upon their maturity level
 using the following feature gates:


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Fix header levels in CPU Management article: https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/

### Issue
After the brief intro, pretty much the whole article appears to be about Windows Support. There is nothing in it about CPU management policies on Linux. Presumably it is just an error with the headers.