### PR TITLE
fix: indentation for list items in reviewing-prs.md

### DIFF
--- a/content/en/docs/contribute/review/reviewing-prs.md
+++ b/content/en/docs/contribute/review/reviewing-prs.md
@@ -168,13 +168,13 @@ When reviewing, use the following as a starting point.
 - Early feedback on blog posts is welcome via a Google Doc or HackMD. Please request input early from the [#sig-docs-blog Slack channel](https://kubernetes.slack.com/archives/CJDHVD54J).
 - Before reviewing blog PRs, be familiar with [Submitting blog posts and case studies](/docs/contribute/new-content/blogs-case-studies/).
 - We are willing to mirror any blog article that was published to https://kubernetes.dev/blog/ (the contributor blog) provided that:
-- the mirrored article has the same publication date as the original (it should have the same publication time too, but you can also set a time stamp up to 12 hours later for special cases)
+  - the mirrored article has the same publication date as the original (it should have the same publication time too, but you can also set a time stamp up to 12 hours later for special cases)
   - for PRs that arrive the original article was merged to https://kubernetes.dev/, there haven't been 
   (and won't be) any articles published to the main blog between time that the original and mirrored article 
   [will] publish. 
   This is because we don't want to add articles to people's feeds, such as RSS, except at the very end of their feed.
   - the original article doesn't contravene any strongly recommended review guidelines or community norms.
-  - You should set the canonical URL for the mirrored article, to the URL of the original article 
+- You should set the canonical URL for the mirrored article, to the URL of the original article 
   (you can use a preview to predict the URL and fill this in ahead of actual publication). Use the `canonicalUrl` 
   field in [front matter](https://gohugo.io/content-management/front-matter/) for this.
 - Consider the target audience and whether the blog post is appropriate for kubernetes.io 


### PR DESCRIPTION
it seems that there is an error with the indentation of two list items.

after the sentence :

```
- We are willing to mirror any blog article that was published to https://kubernetes.dev/blog/ (the contributor blog) provided that:
```

the three next points refer to that sentence,
so they should have the same indentation,
but the first one is not indented and it is the same level as the main sentence.

the second error is about the sentence starting with :

```
  - You should set the canonical URL for the mirrored article, to the URL of the original article
```

it looks like it refers to the main sentence, but it seems it should not.

---

EDIT: 2025-02-14

it seems that it is:
```
- AAA
- BBB
- CCC
- DDD1
    - DDD2
    - DDD3
    - EEE
- FFF
```
but should be:
```
- AAA
- BBB
- CCC
    - DDD1
    - DDD2
    - DDD3
- EEE
- FFF
```

