### PR TITLE
Localize content/pt-br/docs/tasks/debug/debug-application/_index.md

### DIFF
--- a/content/pt-br/docs/tasks/debug/debug-application/_index.md
+++ b/content/pt-br/docs/tasks/debug/debug-application/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Solução de Problemas em Aplicações"
+description: Depuração de problemas comuns em aplicações conteinerizadas.
+weight: 20
+---
+
+Este documento contém um conjunto de recursos para solucionar problemas em aplicações conteinerizadas. Ele aborda questões comuns relacionadas a recursos do Kubernetes (como Pods, Services e StatefulSets), orientações para interpretar mensagens de término de contêineres e métodos para depurar contêineres em execução.


### PR DESCRIPTION
### Description

Esse PR traz a localização da página https://kubernetes.io/docs/tasks/debug/debug-application/ para **PT-BR**. 
Adicionado a raiz de `content/en/docs/tasks/debug/debug-application/` o arquivo `_index.md`, ficando localizado como `content/en/docs/tasks/debug/debug-application/_index.md` no repositório.

---

This PR brings the localization of the page https://kubernetes.io/docs/tasks/debug/debug-application/ to **PT-BR**.  
The `_index.md` file was added to the root of `content/en/docs/tasks/debug/debug-application/`, making it located as `content/pt-br/docs/tasks/debug/debug-application/_index.md` in the repository. 

### Issue

Closes: #49557 