### PR TITLE
image version hash should depend on all files that trigger cloud build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NETLIFY_FUNC      = $(NODE_BIN)/netlify-lambda
 # CONTAINER_ENGINE=podman make container-image
 CONTAINER_ENGINE ?= docker
 IMAGE_REGISTRY ?= gcr.io/k8s-staging-sig-docs
-IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile package.json package-lock.json | cut -c 1-12)
+IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile netlify.toml .dockerignore cloudbuild.yaml package.json package-lock.json | cut -c 1-12)
 CONTAINER_IMAGE   = $(IMAGE_REGISTRY)/k8s-website-hugo:v$(HUGO_VERSION)-$(IMAGE_VERSION)
 # Mount read-only to allow use with tools like Podman in SELinux mode
 # Container targets don't need to write into /src


### PR DESCRIPTION
### Description
This PR adds all the files that trigger the cloud container build to the image tag hash.

It also plays a secondary role in trying to fix #49460 once and for all since the couldbuild didn't trigger on merging #49610. This issue depends on https://github.com/kubernetes/test-infra/pull/34253 so it will be on hold until that PR gets merged. Feel free to unhold it once that happens.