### PR TITLE
Fix incorrect width for search page

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1932,9 +1932,13 @@ div.alert > em.javascript-required {
   font-size: 1.15rem;
 }
 
-body.td-search #search {
-  margin-top: 1rem;
-  margin-bottom: 3rem;
+body.td-search {
+  width: 100%; // avoid confusion with other .td-search elements that have a width set
+
+  #search {
+    margin-top: 1rem;
+    margin-bottom: 3rem;
+  }
 }
 
 /* CSS for 'figure' full-screen display */


### PR DESCRIPTION
I think this may have been a recent regression.

It makes https://k8s.io/search/?q=Kubernetes look right. [[Preview](https://deploy-preview-49630--kubernetes-io-main-staging.netlify.app/search/?q=Kubernetes)]