### PR TITLE
[pl] docs/contribute/new-content/_index.md

### DIFF
--- a/content/pl/docs/contribute/new-content/_index.md
+++ b/content/pl/docs/contribute/new-content/_index.md
@@ -1,0 +1,120 @@
+---
+title: Współtworzenie nowych treści
+content_type: concept
+main_menu: true
+weight: 20
+---
+
+
+
+<!-- overview -->
+
+Ta sekcja zawiera informacje, które
+powinieneś znać przed dodaniem nowej treści. 
+<!-- See https://github.com/kubernetes/website/issues/28808 for live-editor URL to this figure -->
+<!-- You can also cut/paste the mermaid code into the live editor at https://mermaid-js.github.io/mermaid-live-editor to play around with it -->
+
+{{< mermaid >}}
+flowchart LR
+    subgraph second[Zanim zaczniesz]
+    direction TB
+    S[ ] -.-
+    A[Podpisz CNCF CLA] --> B[Wybierz gałąź Git]
+    B --> C[Jeden język na PR]
+    C --> F[Sprawdź<br>narzędzia dla współtwórców]
+    end
+    subgraph first[Podstawy współtworzenia]
+    direction TB
+       T[ ] -.-
+       D[Pisz dokumentację w Markdown<br>i buduj stronę za pomocą Hugo] --- E[Kod źródłowy w GitHub]
+       E --- G[Folder '/content/../docs' zawiera dokumentację<br>w wielu językach]
+       G --- H[Zapoznaj się z typami stron<br>i shortcode'ami w Hugo]
+    end
+    
+
+    first ----> second
+     
+
+classDef grey fill:#dddddd,stroke:#ffffff,stroke-width:px,color:#000000, font-size:15px;
+classDef white fill:#ffffff,stroke:#000,stroke-width:px,color:#000,font-weight:bold
+classDef spacewhite fill:#ffffff,stroke:#fff,stroke-width:0px,color:#000
+class A,B,C,D,E,F,G,H grey
+class S,T spacewhite
+class first,second white
+{{</ mermaid >}}
+
+***Rysunek - Przygotowanie nowej treści***
+
+Powyższy rysunek przedstawia informacje, które powinieneś znać przed
+przesłaniem nowej treści. Szczegóły znajdują się poniżej.
+
+
+
+<!-- body -->
+
+## Podstawy kontrybucji {#contributing-basics}
+
+- Napisz dokumentację Kubernetesa w formacie Markdown i
+  zbuduj stronę Kubernetesa za pomocą [Hugo](https://gohugo.io/).
+- Dokumentacja Kubernetesa używa [CommonMark](https://commonmark.org/) jako swojej wersji Markdown.
+- Źródło znajduje się na [GitHub](https://github.com/kubernetes/website).
+  Dokumentację Kubernetesa można znaleźć w
+  `/content/en/docs/`. Część dokumentacji referencyjnej jest
+  automatycznie generowana ze skryptów w katalogu `update-imported-docs/`.
+- [Typy zawartości strony](/docs/contribute/style/page-content-types/)
+  opisują sposób prezentacji treści dokumentacji w Hugo.
+- Możesz użyć [kodów Docsy](https://www.docsy.dev/docs/adding-content/shortcodes/) lub [niestandardowych skrótów Hugo](/docs/contribute/style/hugo-shortcodes/), aby wspierać dokumentację Kubernetes.
+- Oprócz standardowych kodów Hugo, w naszej dokumentacji
+  używamy wielu [niestandardowych kodów Hugo](/docs/contribute/style/hugo-shortcodes/),
+  aby kontrolować prezentację treści.
+- Dokumentacja jest dostępna w wielu językach w katalogu `/content/`. Każdy język
+  ma własny folder z dwuliterowym kodem określonym przez
+  [standard ISO 639-1](https://www.loc.gov/standards/iso639-2/php/code_list.php) . Na
+  przykład, źródło dokumentacji angielskiej jest przechowywane w `/content/en/docs/`.
+- Aby uzyskać więcej informacji na temat wnoszenia wkładu
+  do dokumentacji w wielu językach lub rozpoczęcia nowego
+  tłumaczenia, zobacz [Lokalizowanie](/docs/contribute/localization).
+
+## Zanim zaczniesz {#before-you-begin}
+
+### Podpisz CNCF CLA {#sign-the-cla}
+
+Wszyscy współtwórcy Kubernetesa **muszą** przeczytać
+[Przewodnik dla Współtwórców](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md) i
+[podpisać Umowę Licencyjną Współtwórcy (CLA)](https://github.com/kubernetes/community/blob/master/CLA.md) .
+
+
+Pull requesty od autorów, którzy nie podpisali umowy CLA, nie
+przechodzą testów automatycznych. Imię i adres e-mail, które podasz,
+muszą zgadzać się z tymi ustawionymi w twoim `git config`, a twoje
+imię i adres e-mail w git muszą być takie same jak te używane dla CNCF CLA.
+
+### Wybierz gałąź w Git {#choose-which-git-branch-to-use}
+
+Podczas otwierania pull requesta musisz
+wiedzieć z góry, na której gałęzi oprzeć swoją pracę.
+
+Scenariusz | Gałąź
+:---------|:------------
+Istniejąca lub nowa treść w języku angielskim dla bieżącego wydania | `main`
+Treść dla wydania zmiany funkcji | Gałąź, która odpowiada głównej i mniejszej wersji, w której znajduje się zmiana funkcji, używając wzorca `dev-<version>`. Na przykład, jeśli funkcja zmienia się w wydaniu `v{{< skew nextMinorVersion >}}`, należy dodać zmiany w dokumentacji do gałęzi ``dev-{{< skew nextMinorVersion >}}``.
+Treść w innych językach (lokalizacje) | Użyj konwencji danej lokalizacji. Zobacz [Strategia rozgałęzień lokalizacji](/docs/contribute/localization/#branch-strategy) po więcej informacji.
+
+Jeśli nadal nie masz pewności, którą gałąź wybrać, zapytaj na `#sig-docs` na Slacku.
+
+{{< note >}} Jeśli już zgłosiłeś swoj pull request i wiesz, że była to
+ niepoprawna gałąź bazowa, możesz ją zmienić (ty i tylko ty, zgłaszający). {{<
+/note >}}
+
+### Języki na PR {#languages-per-pr}
+
+Ogranicz żądania pull request do jednego języka na PR.
+Jeśli musisz wprowadzić identyczną zmianę w tym samym
+fragmencie kodu w wielu językach, otwórz osobne PR dla każdego języka.
+
+## Narzędzia dla współtwórców {#tools-for-contributors}
+
+Katalog [narzędzi dla współtwórców dokumentacji](https://github.com/kubernetes/website/tree/main/content/en/docs/doc-contributor-tools)
+w repozytorium
+`kubernetes/website` zawiera narzędzia, wspierające proces współtworzenia dokumentacji.
+


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
