### PR TITLE
Update the Website Setup Instructions in Contributor Docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ git clone https://github.com/kubernetes/website.git
 cd website
 ```
 
-The Kubernetes website uses git submodules. Even if you plan to run the website in a container, we strongly recommend pulling in the submodule and other development dependencies by running the following:
+The Kubernetes website uses the [Docsy Hugo theme](https://github.com/google/docsy#readme),
+which can be installed via npm. You can also download a pre-configured
+development container image that includes Hugo and Docsy. Additionally, a Git
+submodule is used for tools that generate the reference documentation.
 
 ### Windows
 

--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -169,7 +169,6 @@ Figure 2. Working from a local fork to make your changes.
    ```shell
    git clone git@github.com:<github_username>/website
    cd website
-   git submodule update --init --recursive --depth 1
    ```
 
 1. Navigate to the new `website` directory. Set the `kubernetes/website` repository as the `upstream` remote:
@@ -338,20 +337,24 @@ variable to override this behaviour.
 
 Alternately, install and use the `hugo` command on your computer:
 
-1. Install the [Hugo](https://gohugo.io/getting-started/installing/) version specified in
+1. Install the [Hugo (Extended edition)](https://gohugo.io/getting-started/installing/) and [Node](https://nodejs.org/en) version specified in
    [`website/netlify.toml`](https://raw.githubusercontent.com/kubernetes/website/main/netlify.toml).
 
-1. If you have not updated your website repository, the `website/themes/docsy` directory is empty.
-   The site cannot build without a local copy of the theme. To update the website theme, run:
+1. Install any dependencies:
 
    ```shell
-   git submodule update --init --recursive --depth 1
+   npm ci
    ```
 
 1. In a terminal, go to your Kubernetes website repository and start the Hugo server:
 
    ```shell
    cd <path_to_your_repo>/website
+   make serve
+   ```
+   If you're on a Windows machine or unable to run the `make` command, use the following command:
+
+   ```
    hugo server --buildFuture
    ```
 


### PR DESCRIPTION
This PR updates the Kubernetes contributor documentation regarding the local setup for building and previewing the website. The current instructions are outdated due to recent changes in the Docsy theme and the build process. The steps for installing dependencies and building the site locally have been updated to reflect the new, correct process.

Changes:
Revise instructions for installing the Docsy theme.
Update the README to include the correct steps for setting up the project.
Clarify the build process using npm ci and make serve to preview changes locally.

This update ensures that contributors can successfully follow the steps for local development and avoid issues caused by the previous setup instructions.

Closes: #49627