### PR TITLE
[pl] docs/contribute/participate/roles-and-responsibilities.md

### DIFF
--- a/content/pl/docs/contribute/participate/roles-and-responsibilities.md
+++ b/content/pl/docs/contribute/participate/roles-and-responsibilities.md
@@ -1,0 +1,237 @@
+---
+title: Role i obowiązki
+content_type: concept
+weight: 10
+---
+
+<!-- overview -->
+
+Każdy może przyczynić się do rozwoju Kubernetesa. W miarę jak Twoje wkłady w
+SIG Docs będą się zwiększać, możesz ubiegać się o różne poziomy członkostwa w społeczności.
+Te role pozwalają Ci na przyjęcie większej odpowiedzialności w ramach
+społeczności. Każda rola wymaga więcej czasu i zaangażowania. Role te to:
+
+- Każdy (ang. Anyone): regularni współpracownicy dokumentacji Kubernetesa
+- Członkowie (ang. Members): mogą przypisywać i oceniać problemy oraz zapewniać niewiążącą recenzję w pull requestach.
+- Recenzenci (ang. Reviewers): mogą prowadzić przeglądy pull requestów zgłoszonych dla dokumentacji i mogą ręczyć za jakość zmiany
+- Zatwierdzający (ang. Approvers): mogą prowadzić przeglądy dokumentacji i scalać zmiany
+
+<!-- body -->
+
+## Każdy {#anyone}
+
+Każda osoba posiadająca konto na GitHub może przyczynić się do rozwoju Kubernetesa. SIG Docs serdecznie zaprasza wszystkich nowych współtwórców!
+
+Każdy może:
+
+- Otwórz zgłoszenie w dowolnym repozytorium
+  [Kubernetes](https://github.com/kubernetes/), w tym
+  [`kubernetes/website`](https://github.com/kubernetes/website)
+- Udziel nieobowiązującej opinii na temat pull requesta
+- Wnieś wkład do tłumaczenia
+- Zasugeruj ulepszenia na [Slacku](https://slack.k8s.io/) lub na
+  [liście mailingowej SIG docs](https://groups.google.com/forum/#!forum/kubernetes-sig-docs).
+
+Po [podpisaniu CLA](https://github.com/kubernetes/community/blob/master/CLA.md), każdy może również:
+
+- Otworzyć pull requesta, aby ulepszyć istniejącą treść, dodać nową treść lub zrobić wpis na blogu lub studium przypadku
+- Tworzyć diagramy, zasoby graficzne oraz osadzane screencasty i filmy
+
+Więcej informacji można znaleźć w [wprowadzaniu nowej treści](/docs/contribute/new-content/).
+
+## Członkowie {#members}
+
+Członek to osoba, która złożyła wiele pull requestów do `kubernetes/website`.
+Członkowie są częścią
+[organizacji Kubernetes na GitHubie](https://github.com/kubernetes).
+
+Członkowie mogą:
+
+- Wykonać wszystko wymienione w sekcji [Każdy](#anyone)
+- Użyć komentarza `/lgtm`, aby dodać etykietę LGTM (wygląda dobrze dla mnie) do pull requesta
+
+  {{< note >}}
+  Użycie `/lgtm` uruchamia automatyzację. Jeśli chcesz
+  udzielić niewiążącej aprobaty, komentarz "LGTM" również działa!
+  {{< /note >}}
+
+- Użyć komentarza `/hold`, aby zablokować scalanie dla pull requesta
+- Użyć komentarza `/assign`, aby przypisać recenzenta do pull requesta
+- Zapewnić niewiążącą ocenę pull requestów
+- Użyć automatyzacji do triage'u i kategoryzacji problemów
+- Dokumentować nowe funkcje
+
+### Zostanie członkiem {#becoming-a-member}
+
+Po przesłaniu co najmniej 5 znaczących pull requestów i spełnieniu pozostałych
+[wymagań](https://github.com/kubernetes/community/blob/master/community-membership.md#member):
+
+1. Znajdź dwóch [recenzentów](#reviewers) lub
+   [zatwierdzających](#approvers), aby
+   [sponsorować](/docs/contribute/advanced#sponsor-a-new-contributor) twoje członkostwo.
+
+   Poproś o sponsorowanie na kanale [#sig-docs na Slacku](https://kubernetes.slack.com) lub
+   na [liście mailingowej SIG Docs](https://groups.google.com/forum/#!forum/kubernetes-sig-docs).
+
+   {{< note >}}
+   Nie wysyłaj bezpośredniego e-maila ani bezpośredniej wiadomości Slack do
+   poszczególnego członka SIG Docs. Musisz poprosić o sponsorowanie przed złożeniem swojej aplikacji.
+   {{< /note >}}
+
+1. Otwórz zgłoszenie GitHub w
+   [repozytorium `kubernetes/org`](https://github.com/kubernetes/org/). Użyj
+   szablonu zgłoszenia **Organization Membership Request**.
+
+1. Poinformuj swoich sponsorów o zgłoszeniu na GitHubie. Możesz:
+   - Wspomnieć ich nazwę użytkownika GitHub w zgłoszeniu (`@<GitHub-username>`)
+   - Wysłać im link do zgłoszenia za pomocą Slacka lub e-maila.
+
+     Sponsorzy zatwierdzą Twoją prośbę poprzez głosowanie `+1`.
+     Gdy sponsorzy zatwierdzą prośbę,
+     administrator GitHub Kubernetes dodaje Cię jako członka. Gratulacje!
+
+     Jeśli Twoja prośba o członkostwo nie zostanie zaakceptowana, otrzymasz
+     informację zwrotną. Po uwzględnieniu informacji zwrotnej, złóż wniosek ponownie.
+
+1. Zaakceptuj zaproszenie do organizacji Kubernetes na GitHubie w swojej skrzynce e-mail.
+
+   {{< note >}}
+   GitHub wysyła zaproszenie na domyślny adres e-mail w Twoim koncie.
+   {{< /note >}}
+
+## Recenzenci {#reviewers}
+
+Recenzenci są odpowiedzialni za przeglądanie otwartych pull requestów.
+W przeciwieństwie do opinii członków, autor PR musi uwzględnić uwagi
+recenzenta. Recenzenci są członkami zespołu GitHub
+[@kubernetes/sig-docs-{language}-reviews](https://github.com/orgs/kubernetes/teams?query=sig-docs).
+
+Recenzenci mogą:
+
+- Wykonać wszystko, co znajduje się w sekcjach [Każdy](#anyone) i [Członkowie](#members)
+- Przeglądać pull requesty i dostarczać wiążące opinie
+
+  {{< note >}}
+  Aby udzielić niewiążącej opinii, poprzedź swoje komentarze frazą "Optionally: ".
+  {{< /note >}}
+
+- Edytować teksty widoczne dla użytkowników w kodzie
+- Poprawiać uwagi do kodu
+
+Możesz być recenzentem SIG Docs lub recenzentem dokumentacji w konkretnej dziedzinie tematycznej.
+
+### Przypisywanie recenzentów do pull requestów {#assigning-reviewers-to-pull-requests}
+
+Automatyzacja przypisuje recenzentów do wszystkich pull
+requestów. Możesz poprosić o recenzję od
+konkretnej osoby, komentując: `/assign [@_github_handle]`.
+
+Jeśli przydzielony recenzent nie skomentował PR, inny recenzent może przejąć zadanie.
+Możesz również przydzielić technicznych recenzentów w razie potrzeby.
+
+### Używanie `/lgtm` {#using-lgtm}
+
+LGTM oznacza "Wygląda dobrze dla mnie" i wskazuje, że pull request jest
+technicznie poprawny i gotowy do połączenia. Wszystkie PR-y wymagają komentarza `/lgtm` od
+recenzenta i komentarza `/approve` od osoby zatwierdzającej, aby można je było połączyć.
+
+Komentarz `/lgtm` od recenzenta jest wiążący i uruchamia automatyzację, która dodaje etykietę `lgtm`.
+
+### Zostanie recenzentem {#becoming-a-reviewer}
+
+Kiedy spełnisz [wymagania](https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer),
+możesz
+zostać recenzentem SIG Docs. Recenzenci w
+innych SIG muszą ubiegać się osobno o status recenzenta w SIG Docs.
+
+Aby złozyć wniosek:
+
+1. Otwórz pull request, który dodaje Twoją nazwę użytkownika
+   GitHub do sekcji pliku [OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES)
+   w repozytorium `kubernetes/website`.
+
+   {{< note >}}
+   Jeśli nie jesteś pewien, gdzie się dodać, dodaj się do `sig-docs-en-reviews`.
+   {{< /note >}}
+
+1. Przypisz PR do jednego lub więcej zatwierdzających SIG-Docs
+   (nazwy użytkowników wymienione pod `sig-docs-{language}-owners`).
+
+Jeśli zgłoszenie zostanie zatwierdzone, lider SIG Docs dodaje Cię do odpowiedniego
+zespołu na GitHubie. Po dodaniu, [K8s-ci-robot](https://github.com/kubernetes/test-infra/tree/master/prow#bots-home)
+przypisuje i sugeruje Cię jako recenzenta nowych pull requestów.
+
+## Zatwierdzający {#approvers}
+
+Osoby zatwierdzające przeglądają i zatwierdzają wnioski o scalenie.
+Zatwierdzający są członkami zespołów GitHub
+[@kubernetes/sig-docs-{language}-owners](https://github.com/orgs/kubernetes/teams/?query=sig-docs).
+
+Zatwierdzający mogą wykonać następujące czynności:
+
+- Wszystko wymienione w sekcjach [Każdy](#anyone), [Członkowie](#members) i [Recenzenci](#reviewers)
+- Publikować treści autorów, zatwierdzając i scalając pull requesty za pomocą komentarza `/approve`
+- Zaproponować ulepszenia do przewodnika stylu
+- Zaproponować usprawnienia testów dokumentacji
+- Zaproponować usprawnienia dla strony internetowej Kubernetesa lub innych narzędzi
+
+Jeśli PR już ma `/lgtm`, lub jeśli zatwierdzający również skomentuje `/lgtm`,
+PR zostaje automatycznie scalony. Zatwierdzający SIG Docs powinien zostawić
+`/lgtm` tylko w przypadku zmiany, która nie wymaga dodatkowej recenzji technicznej.
+
+
+### Zatwierdzanie pull requestów {#approving-pull-requests}
+
+Akceptujący i liderzy SIG Docs są jedynymi, którzy mogą scalać pull requesty
+do repozytorium witryny. Wiąże się to z pewnymi obowiązkami.
+
+- Osoby zatwierdzające mogą używać polecenia `/approve`, które scala PR-y do repozytorium.
+
+  {{< warning >}}
+  Nieuważne scalenie może zepsuć witrynę, więc upewnij się, że kiedy coś scalasz, naprawdę chcesz to zrobić.
+  {{< /warning >}}
+
+- Upewnij się, że proponowane zmiany spełniają
+  [przewodnik dotyczący treści dokumentacji](/docs/contribute/style/content-guide/).
+
+  Jeśli masz jakieś pytanie lub nie jesteś pewien
+  czegoś, nie krępuj się poprosić o dodatkową recenzję.
+
+- Zweryfikuj, czy testy Netlify przechodzą pomyślnie przed zatwierdzeniem PR za pomocą `/approve`.
+
+    <img src="/images/docs/contribute/netlify-pass.png" width="75%" alt="Testy Netlify muszą przejść pomyślnie przed zatwierdzeniem" />
+
+- Odwiedź stronę podglądu Netlify dla PR, aby upewnić się, że wszystko wygląda dobrze przed zatwierdzeniem.
+
+- Weź udział w [harmonogramie rotacji PR Wrangler](https://github.com/kubernetes/website/wiki/PR-Wranglers)
+  dla
+  cotygodniowych rotacji. SIG Docs oczekuje, że wszyscy
+  zatwierdzający będą uczestniczyć w tej rotacji. Zobacz
+  [PR wranglers](/docs/contribute/participate/pr-wranglers/) po więcej szczegółów.
+
+### Zostanie zatwierdzającym {#becoming-an-approver}
+
+Kiedy spełnisz [wymagania](https://github.com/kubernetes/community/blob/master/community-membership.md#approver),
+możesz zostać
+zatwierdzającym SIG Docs. Zatwierdzający w innych
+SIGs muszą osobno ubiegać się o status zatwierdzającego w SIG Docs.
+
+Aby złozyć wniosek:
+
+1. Otwórz pull requesta, dodając siebie do sekcji pliku
+   [OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES) w
+   repozytorium `kubernetes/website`.
+
+    {{< note >}}
+    Jeśli nie jesteś pewien, gdzie się dodać, dodaj się do `sig-docs-en-owners`.
+    {{< /note >}}
+
+2. Przypisz PR do jednego lub więcej obecnych zatwierdzających SIG Docs.
+
+Jeśli wniosek zostanie zatwierdzony, lider SIG Docs dodaje Cię do odpowiedniego
+zespołu w GitHub. Po dodaniu, [@k8s-ci-robot](https://github.com/kubernetes/test-infra/tree/master/prow#bots-home)
+przypisuje Cię i sugeruje jako recenzenta nowych pull requestów.
+
+## {{% heading "whatsnext" %}}
+
+- Przeczytaj o [zarządzaniu PR](/docs/contribute/participate/pr-wranglers/), roli, którą wszyscy zatwierdzający przyjmują rotacyjnie.


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
