### PR TITLE
[pl] docs/contribute/participate/issue-wrangler.md

### DIFF
--- a/content/pl/docs/contribute/participate/issue-wrangler.md
+++ b/content/pl/docs/contribute/participate/issue-wrangler.md
@@ -1,0 +1,91 @@
+---
+title: Wranglerzy zgłoszeń
+content_type: concept
+weight: 20
+---
+
+<!-- overview -->
+
+Wraz z [koordynatorem PR](/docs/contribute/participate/pr-wranglers), formalni
+akceptujący, recenzenci oraz członkowie SIG Docs odbywają
+tygodniowe dyżury [przeglądając i kategoryzując problemy](/docs/contribute/review/for-approvers/#triage-and-categorize-issues)
+dla repozytorium.
+
+<!-- body -->
+
+## Obowiązki {#duties}
+
+Każdego dnia w tygodniowej zmianie osoba odpowiedzialna za problemy (ang. Issue Wrangler) będzie odpowiedzialna za:
+
+- Codzienne ocenianie i tagowanie zgłoszeń. Zobacz
+  [Ocenianie i kategoryzowanie zgłoszeń](/docs/contribute/review/for-approvers/#triage-and-categorize-issues) aby
+  uzyskać wskazówki dotyczące tego, jak SIG Docs korzysta z metadanych.
+- Monitorowanie nieaktywnych i przeterminowanych zgłoszeń w repozytorium kubernetes/website.
+- Utrzymanie [tablicy problemów](https://github.com/orgs/kubernetes/projects/72/views/1).
+
+## Wymagania {#requirements}
+
+- Musi być aktywnym członkiem organizacji Kubernetes.
+- Minimum 15 [nietrywialnych](https://www.kubernetes.dev/docs/guide/pull-requests/#trivial-edits)
+  wkładów do Kubernetes (z czego pewna ilość powinna być skierowana na kubernetes/website).
+- Pełni już rolę w nieformalnym charakterze.
+
+## Przydatne polecenia Prow dla wranglerów {#helpful-prow-commands-for-wranglers}
+
+Poniżej znajdują się niektóre powszechnie używane polecenia przez wranglerów zgłoszeń:
+
+```bash
+# ponowne otwarcie zgłoszenia
+/reopen
+
+# przeniesienie zgłoszeń, które nie pasują do k/website, do innego repozytorium
+/transfer[-issue]
+
+# zmiana statusu zgłoszeń oznaczonych jako rotten
+/remove-lifecycle rotten
+
+# zmiana statusu zgłoszeń oznaczonych jako stale
+/remove-lifecycle stale
+
+# przypisanie SIG (Special Interest Group) do zgłoszenia
+/sig <sig_name>
+
+# dodanie konkretnego obszaru
+/area <area_name>
+
+# dla zgłoszeń przyjaznych dla początkujących
+/good-first-issue
+
+# zgłoszenia wymagające pomocy
+/help wanted
+
+# oznaczenie zgłoszenia jako związane z pomocą techniczną
+/kind support
+
+# zaakceptowanie triage dla zgłoszenia
+/triage accepted
+
+# zamknięcie zgłoszenia, nad którym nie będziemy pracować i które nie zostało naprawione
+/close not-planned
+```
+
+Aby znaleźć więcej poleceń Prow, zapoznaj się z dokumentacją [pomocy kommend](https://prow.k8s.io/command-help).
+
+## Kiedy zamykać zgłoszenia {#when-to-close-issues}
+
+Aby projekt open source odniósł sukces, kluczowe jest dobre zarządzanie
+zgłoszeniami. Jednak równie ważne jest rozwiązywanie problemów, aby
+utrzymać repozytorium i jasno komunikować się z współtwórcami oraz użytkownikami.
+
+Zamknij zgłoszenia, gdy:
+
+- Podobny problem jest zgłaszany więcej niż raz. Najpierw musisz oznaczyć go jako `/triage duplicate`; połącz
+  go z głównym problemem, a następnie zamknij. Zaleca się również skierowanie użytkowników do oryginalnego problemu.
+- Dostępne informacje nie pozwalają na pełne zrozumienie ani rozwiązanie zgłoszonego problemu. Warto jednak zachęcić
+  użytkownika do podania większej ilości szczegółów lub ponownego otwarcia zgłoszenia, jeśli uda mu się ponownie odtworzyć problem.
+- Ta sama funkcjonalność jest zaimplementowana gdzieś indziej. Można zamknąć to zgłoszenie i skierować użytkownika do odpowiedniego miejsca.
+- Zgłoszony problem nie jest obecnie planowany ani zgodny z celami projektu.
+- Jeśli problem wydaje się być spamem i jest wyraźnie niepowiązany.
+- Jeśli problem jest związany z zewnętrznym ograniczeniem lub zależnością i znajduje się poza kontrolą projektu.
+
+Aby zamknąć zgłoszenie, zostaw komentarz `/close` w zgłoszeniu.


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
