### PR TITLE
[pl] docs/contribute/style/write-new-topic.md

### DIFF
--- a/content/pl/docs/contribute/style/write-new-topic.md
+++ b/content/pl/docs/contribute/style/write-new-topic.md
@@ -1,0 +1,170 @@
+---
+title: Pisanie nowego tematu
+content_type: task
+weight: 70
+---
+
+<!-- overview -->
+Ta strona pokazuje, jak utworzyć nowy temat dla dokumentacji Kubernetesa.
+
+
+## {{% heading "prerequisites" %}}
+
+Utwórz fork repozytorium dokumentacji Kubernetesa, jak opisano w
+[Otwieranie pull requesta](/docs/contribute/new-content/open-a-pr/).
+
+
+<!-- steps -->
+
+## Wybieranie typu strony {#choosing-a-page-type}
+
+Przygotowując się do napisania nowego tematu, zastanów się nad typem strony, który najlepiej pasowałby do Twojej treści:
+
+{{< table caption = "Wytyczne dotyczące wyboru typu strony" >}}
+Typ | Opis
+:--- | :----------
+Pojecia (ang. Concept) | Strona o koncepcyjach (pojęciach) przedstawia różne aspekty Kubernetesa. Przykładowo, może opisywać obiekt Deployment w Kubernetes, wyjaśniając jego funkcję w aplikacji podczas jej wdrażania, skalowania i aktualizacji. Zazwyczaj strony koncepcyjne nie zawierają sekwencji kroków, lecz zamiast tego zapewniają linki do zadań lub samouczków. Dla przykładu tematu koncepcyjnego zobacz <a href="/docs/concepts/architecture/nodes/">Węzły</a>.
+Zadanie (ang. Task) | Strona zadania to instrukcja, która pokazuje, jak wykonać konkretną czynność. Jej celem jest przedstawienie czytelnikowi kroków, które może realizować na bieżąco podczas lektury. Strona zadania może mieć różną długość, o ile pozostaje skupiona na jednym zagadnieniu. Można na niej łączyć krótkie wyjaśnienia z instrukcjami krok po kroku, ale jeśli konieczne jest szersze omówienie tematu, lepiej umieścić je na stronie koncepcyjnej. Powiązane strony zadań i koncepcji powinny odsyłać do siebie nawzajem. Przykład krótkiej strony zadania można znaleźć w <a href="/docs/tasks/configure-pod-container/configure-volume-storage/">Konfiguracja Pod do korzystania z Volumenu jako pamięci</a>. Przykład dłuższej strony zadania można znaleźć w <a href="/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/">Konfiguracja Liveness i Readiness Probes</a>.
+Samouczek (ang. Tutorial) | Strona z samouczkiem pokazuje, jak osiągnąć cel, który łączy ze sobą kilka funkcji Kubernetesa. Samouczek może zawierać kilka sekwencji kroków, które czytelnicy mogą faktycznie wykonać podczas czytania strony. Może również zawierać wyjaśnienia dotyczące powiązanych fragmentów kodu. Na przykład, samouczek może zapewniać przeprowadzenie przez przykładowy kod. Samouczek może zawierać krótkie wyjaśnienia funkcji Kubernetes, które są ze sobą łączone, ale powinien odsyłać do powiązanych tematów koncepcyjnych w celu dogłębnych wyjaśnień poszczególnych funkcji.
+{{< /table >}}
+
+### Tworzenie nowej strony {#creating-a-new-page}
+
+Dla każdej nowej strony, którą tworzysz, zastosuj odpowiedni
+[typ treści](/docs/contribute/style/page-content-types/). Strona dokumentacji
+zapewnia szablony lub [archetypy Hugo](https://gohugo.io/content-management/archetypes/)
+do tworzenia nowych stron z treścią. Aby utworzyć nowy typ
+strony, uruchom `hugo new` z ścieżką do pliku, który chcesz utworzyć. Na przykład:
+
+```
+hugo new docs/concepts/my-first-concept.md
+```
+
+## Wybór tytułu i nazwy pliku {#choosing-a-title-and-filename}
+
+Wybierz tytuł zawierający słowa kluczowe, które mają być łatwo
+odnajdywane przez wyszukiwarki. Utwórz nazwę pliku, która
+wykorzystuje słowa z tytułu oddzielone myślnikami. Na przykład, temat o
+tytule [Korzystanie z HTTP Proxy do uzyskania dostępu do Kubernetes API](/docs/tasks/extend-kubernetes/http-proxy-access-api/)
+ma
+nazwę pliku `http-proxy-access-api.md`. Nie musisz dodawać "słowa"
+w nazwie pliku, ponieważ "kubernetes" jest już w URL dla tematu, na przykład:
+
+       /docs/tasks/extend-kubernetes/http-proxy-access-api/
+
+## Dodawanie tytułu tematu do sekcji wprowadzającej {#adding-the-topic-title-to-the-front-matter}
+
+W swoim temacie umieść pole `title` we
+[front matter](https://gohugo.io/content-management/front-matter/). _Front matter_
+to blok YAML, który znajduje się
+między linami z trzema myślnikami na górze strony. Oto przykład:
+
+    ---
+    title: Using an HTTP Proxy to Access the Kubernetes API
+    ---
+
+## Wybieranie katalogu {#choosing-a-directory}
+
+W zależności od rodzaju strony umieść nowy plik w podfolderze jednego z tych katalogów:
+
+* /content/en/docs/tasks/
+* /content/en/docs/tutorials/
+* /content/en/docs/concepts/
+
+Możesz umieścić swój plik w istniejącym
+podkatalogu albo utworzyć nowy podkatalog.
+
+## Umieszczenie swojego tematu w spisie treści {#placing-your-topic-in-the-table-of-contents}
+
+Spis treści tworzony jest dynamicznie przy użyciu
+struktury katalogów dokumentacji. Katalogi najwyższego
+poziomu pod `/content/en/docs/` tworzą nawigację
+najwyższego poziomu, a podkatalogi mają swoje wpisy w spisie treści.
+
+Każdy podkatalog zawiera plik `_index.md`, który reprezentuje stronę
+główną dla zawartości danego podkatalogu. Plik `_index.md` nie wymaga szablonu.
+Może zawierać poglądową treść dotyczącą tematów w podkatalogu.
+
+Inne pliki w katalogu są domyślnie sortowane alfabetycznie. To prawie nigdy
+nie jest najlepszy porządek. Aby kontrolować sortowanie
+tematów w podkatalogu, ustaw klucz `weight:` we front-matter na liczbę
+całkowitą. Zazwyczaj używamy wielokrotności 10, aby móc później dodać
+inne tematy. Na przykład temat z wagą `10` znajdzie się przed tym z wagą `20`.
+
+## Osadzanie kodu w swoim temacie {#embedding-code-in-your-topic}
+
+Jeśli chcesz umieścić jakiś kod w swoim temacie, możesz umieścić kod
+bezpośrednio w swoim pliku, używając składni bloku kodu markdown. Jest
+to zalecane w następujących przypadkach (nie jest to lista wyczerpująca):
+
+- Kod pokazuje wynik polecenia takiego jak
+  `kubectl get deploy mydeployment -o json | jq '.status'`.
+- Kod nie jest wystarczająco ogólny, aby użytkownicy
+  mogli go wypróbować. Jako przykład, możesz osadzić plik
+  YAML do tworzenia Poda, który zależy od konkretnej
+  implementacji [FlexVolume](/docs/concepts/storage/volumes/#flexvolume).
+- Kod jest niekompletnym przykładem, ponieważ jego celem jest
+  wyróżnienie fragmentu większego pliku. Na przykład, opisując sposoby
+  dostosowywania [RoleBinding](/docs/reference/access-authn-authz/rbac/#role-binding-examples),
+  możesz zamieścić krótki fragment bezpośrednio w pliku tematu.
+- Kod nie jest przeznaczony dla użytkowników do
+  wypróbowania z innych powodów. Na przykład, opisując, jak dodać nowy atrybut
+  do zasobu za pomocą polecenia `kubectl edit`,
+  można podać krótki przykład, który zawiera tylko atrybut do dodania.
+
+## Włączanie kodu z innego pliku {#including-code-from-another-file}
+
+Innym sposobem na umieszczenie kodu w swoim temacie jest utworzenie nowego,
+kompletnego przykładowego pliku (lub grupy plików), a następnie odwołanie się do
+niego w swoim pliku tematu. Użyj tej metody, aby dołączyć przykładowe pliki YAML,
+gdy są one ogólne i wielokrotnego użytku, a Ty chcesz, aby czytelnik sam ją wypróbował.
+
+Gdy dodajesz nowy samodzielny przykładowy plik, taki jak plik YAML,
+umieść kod w jednym z podkatalogów `<LANG>/examples/`, gdzie `<LANG>`
+oznacza język dla danego tematu. W pliku tematu użyj skrótu `code_sample`:
+
+```none
+{{%/* code_sample file="<RELPATH>/my-example-yaml>" */%}}
+```
+gdzie `<RELPATH>` jest ścieżką do pliku do dołączenia, względną do
+katalogu `examples`. Następujący kod Hugo odnosi się do pliku YAML
+znajdującego się w `/content/en/examples/pods/storage/gce-volume.yaml`.
+
+```none
+{{%/* code_sample file="pods/storage/gce-volume.yaml" */%}}
+```
+
+## Pokazuje, jak utworzyć obiekt API z pliku konfiguracyjnego {#showing-how-to-create-an-api-object-from-a-configuration-file}
+
+Jeśli musisz zademonstrować, jak utworzyć obiekt API
+na podstawie pliku konfiguracyjnego, umieść plik
+konfiguracyjny w jednym z podkatalogów pod `<LANG>/examples`.
+
+W twoim temacie, pokaż to polecenie:
+
+```
+kubectl create -f https://k8s.io/examples/pods/storage/gce-volume.yaml
+```
+
+{{< note >}}
+Podczas dodawania nowych plików YAML do katalogu `<LANG>/examples`,
+upewnij się, że plik jest również dołączony do pliku
+`<LANG>/examples_test.go`. Travis CI dla witryny automatycznie uruchamia ten przypadek testowy, gdy
+zgłaszane są PR, aby upewnić się, że wszystkie przykłady przechodzą testy.
+{{< /note >}}
+
+Aby zapoznać się z przykładem tematu, który używa tej techniki, zobacz
+[Uruchomienie aplikacji stateful z jednym instancją](/docs/tasks/run-application/run-single-instance-stateful-application/).
+
+## Dodawanie obrazów do tematu {#adding-images-to-a-topic}
+
+Umieść pliki obrazów w katalogu
+`/images`. Preferowanym formatem obrazu jest SVG.
+
+
+
+## {{% heading "whatsnext" %}}
+
+* Dowiedz się więcej o [używaniu typów zawartości strony](/docs/contribute/style/page-content-types/).
+* Dowiedz się więcej o [tworzeniu pull requestu](/docs/contribute/new-content/open-a-pr/).
+


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
