### PR TITLE
[pl] docs/contribute/style/content-organization.md

### DIFF
--- a/content/pl/docs/contribute/style/content-organization.md
+++ b/content/pl/docs/contribute/style/content-organization.md
@@ -1,0 +1,147 @@
+---
+title: Organizacja treści
+content_type: concept
+weight: 90
+---
+
+<!-- overview -->
+
+Ta strona używa Hugo. W Hugo, [organizacja treści (ang. content organization)](https://gohugo.io/content-management/organization/) jest podstawowym pojęciem.
+
+<!-- body -->
+
+{{% note %}}
+**Wskazówka Hugo:** Uruchom Hugo z `hugo server --navigateToChanged`, aby pracować nad edycją treści.
+{{% /note %}}
+
+## Listy stron {#page-lists}
+
+### Kolejność stron {#page-order}
+
+Menu boczne dokumentacji, przeglądarka stron dokumentacji itd. są
+wyświetlane według domyślnego porządku sortowania Hugo, który sortuje
+według wagi (od 1), daty (od najnowszej) i ostatecznie według tytułu linku.
+
+Biorąc pod uwagę, że jeśli chcesz przenieść stronę lub sekcję do góry, ustaw wagę w części _front matter_ strony:
+
+```yaml
+title: My Page
+weight: 10
+```
+
+{{% note %}}
+W przypadku wag stron, dobrym pomysłem jest nie używać 1, 2, 3 ..., ale
+jakiegoś innego interwału, na przykład 10, 20, 30... Pozwala to na
+późniejsze wstawienie stron tam, gdzie chcesz. Dodatkowo, każda waga w tym samym
+katalogu (sekcji) nie powinna się nakładać z innymi wagami. Zapewnia to, że
+treści zawsze są prawidłowo zorganizowane, zwłaszcza w treściach lokalizowanych.
+{{% /note %}}
+
+### Główne Menu Dokumentacji {#documentation-main-menu}
+
+Główne menu `Documentation` generowane jest na podstawie sekcji znajdujących się w
+katalogu `docs/`, które mają ustawioną flagę `main_menu` w sekcji front matter pliku _index.md.
+
+```yaml
+main_menu: true
+```
+
+Zauważ, że tytuł linku jest pobierany z `linkTitle` strony, więc jeśli
+chcesz, aby był inny niż tytuł, zmień go w pliku zawartości:
+
+```yaml
+main_menu: true
+title: Tytuł strony
+linkTitle: Tytuł używany w linkach
+```
+
+{{% note %}}
+Powyższe kroki należy wykonać dla każdego języka osobno. Jeśli
+nie widzisz swojej sekcji w menu, prawdopodobnie Hugo nie
+rozpoznaje jej jako sekcji. Utwórz plik `_index.md` w katalogu danej sekcji.
+{{% /note %}}
+
+### Menu boczne dokumentacji {#documentation-side-menu}
+
+Dokumentacja w menu bocznym jest zbudowana z _bieżącego drzewa sekcji_ zaczynającego się poniżej `docs/`.
+
+Wyświetli wszystkie sekcje i ich strony.
+
+Jeśli nie chcesz uwzględniać sekcji lub strony, ustaw flagę `toc_hide` na `true` w sekcji front matter:
+
+```yaml
+toc_hide: true
+```
+
+Po wejściu do sekcji z treścią wyświetlana jest przypisana strona (np.
+`_index.md`). Jeśli taka strona nie istnieje, Hugo wyświetli pierwszą stronę w sekcji.
+
+### Przeglądarka Dokumentacji {#documentation-browser}
+
+Przeglądarka stron na stronie głównej dokumentacji jest zbudowana z
+wykorzystaniem wszystkich sekcji i stron, które znajdują się bezpośrednio poniżej `sekcji docs`.
+
+Jeśli nie chcesz uwzględniać sekcji lub strony, ustaw flagę `toc_hide` na `true` w sekcji front matter:
+
+```yaml
+toc_hide: true
+```
+
+### Główne Menu {#the-main-menu}
+
+Linki w menu w prawym górnym rogu oraz w stopce są dynamicznie generowane poprzez
+wyszukiwanie stron. Pozwala to zweryfikować, czy dana strona rzeczywiście istnieje. Jeśli sekcja
+`case-studies` nie jest dostępna w danej wersji językowej serwisu, link do niej nie zostanie utworzony.
+
+## Pakiety Stron {#page-bundles}
+
+Oprócz samodzielnych stron (pliki Markdown), Hugo obsługuje
+[Pakiety Stron](https://gohugo.io/content-management/page-bundles/).
+
+Jednym z przykładów są [niestandardowe kody Hugo](/docs/contribute/style/hugo-shortcodes/).
+Jest to uważane za `leaf bundle`. Wszystko poniżej katalogu, włącznie z `index.md`, będzie częścią pakietu.
+Dotyczy to także linków względnych do strony, obrazów, które mogą być przetwarzane, itp.:
+
+```bash
+en/docs/home/contribute/includes
+├── example1.md
+├── example2.md
+├── index.md
+└── podtemplate.json
+```
+
+Innym powszechnie używanym przykładem jest pakiet `includes`. Ustawia on `headless: true` w
+metadanych front matter, co oznacza, że nie otrzymuje własnego URL-a. Jest używany tylko na innych stronach.
+
+```bash
+en/includes
+├── default-storage-class-prereqs.md
+├── index.md
+├── partner-script.js
+├── partner-style.css
+├── task-tutorial-prereqs.md
+├── user-guide-content-moved.md
+└── user-guide-migration-notice.md
+```
+
+Niektóre ważne uwagi dotyczące plików w pakietach:
+
+* W pakietach tłumaczeń wszelkie brakujące pliki inne niż treść zostaną
+  odziedziczone z wyższych wersji językowych. Zapobiega to zbędnemu powielaniu plików.
+* Każdy plik w pakiecie jest uznawany przez Hugo za `Resource`. Można do niego
+  przypisać metadane dla różnych języków, takie jak parametry i tytuł, nawet
+  jeśli format pliku nie obsługuje front matter (np. YAML). Zobacz
+  [Metadane Zasobów Strony](https://gohugo.io/content-management/page-resources/#page-resources-metadata).
+* Wartość, którą uzyskujesz z `.RelPermalink` zasobu (`Resource`), jest względna
+  względem strony. Zobacz [Permalinki](https://gohugo.io/content-management/urls/#permalinks).
+
+## Style {#styles}
+
+Źródło arkuszy stylów [SASS](https://sass-lang.com/) dla tej strony
+jest przechowywane w `assets/sass` i jest automatycznie budowane przez Hugo.
+
+## {{% heading "whatsnext" %}}
+
+* Dowiedz się więcej o [niestandardowych kodach Hugo](/docs/contribute/style/hugo-shortcodes/)
+* Dowiedz się więcej o [Przewodniku stylu](/docs/contribute/style/style-guide)
+* Dowiedz się więcej o [Przewodniku treści](/docs/contribute/style/content-guide)


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
