### PR TITLE
feat: move js detection script to its own module and import into body-end

### DIFF
--- a/assets/js/detect-js.js
+++ b/assets/js/detect-js.js
@@ -1,0 +1,3 @@
+$(document).ready(function () {
+    document.documentElement.classList.remove('no-js');
+});

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -55,5 +55,13 @@ function copyCode(elem) {
   }
 }
 </script>
+{{- end -}}
 
+{{/* JavaScript detector */}}
+{{- if hugo.IsProduction -}}
+  {{- $jsDetect :=  resources.Get "js/detect-js.js" | minify | fingerprint -}}
+<script defer src="{{ $jsDetect.RelPermalink }}" integrity="{{ $jsDetect.Data.Integrity }}" crossorigin="anonymous"></script>
+{{- else -}}
+  {{- $jsDetect := resources.Get "js/detect-js.js" -}}
+<script defer src="{{ $jsDetect.RelPermalink }}"></script>
 {{- end -}}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -72,8 +72,6 @@ var kub = (function () {
         headlineWrapper = $('#headlineWrapper');
         HEADER_HEIGHT = header.outerHeight();
 
-        document.documentElement.classList.remove('no-js');
-
         resetTheView();
 
         window.addEventListener('resize', resetTheView);


### PR DESCRIPTION
Moves the script which detects if js is enabled in the browser to its own module. Its also imported separately into the `body-end` hook.

Intended to help with #41171 

/area web-development