### PR TITLE
Define 'resource' in glossary

### DIFF
--- a/content/en/docs/reference/glossary/api-resource.md
+++ b/content/en/docs/reference/glossary/api-resource.md
@@ -1,0 +1,18 @@
+---
+title: API resource
+id: api-resource
+date: 2025-02-09
+full_link: /docs/reference/using-api/api-concepts/#standard-api-terminology
+short_description: >
+  A Kubernetes entity, representing an endpoint on the Kubernetes API server.
+
+aka:
+ - Resource
+tags:
+- architecture
+---
+An entity in the Kubernetes type system, corresponding to an endpoint on the {{< glossary_tooltip text="Kubernetes API" term_id="kubernetes-api" >}}.
+A resource typically represents an {{< glossary_tooltip text="object" term_id="object" >}}.
+Some resources represent an operation on other objects, such as a permission check.
+<!--more-->
+Each resource represents an HTTP endpoint (URI) on the Kubernetes API server, defining the schema for the objects or operations on that resource.

--- a/content/en/docs/reference/glossary/infrastructure-resource.md
+++ b/content/en/docs/reference/glossary/infrastructure-resource.md
@@ -1,0 +1,24 @@
+---
+title: Resource (infrastructure)
+id: infrastructure-resource
+date: 2025-02-09
+short_description: >
+  A defined amount of infrastructure available for consumption (CPU, memory, etc).
+
+aka:
+tags:
+- architecture
+---
+Capabilities provided to one or more {{< glossary_tooltip text="nodes" term_id="node" >}} (CPU, memory, GPUs, etc), and made available for consumption by
+{{< glossary_tooltip text="Pods" term_id="pod" >}} running on those nodes.
+
+Kubernetes also uses the term _resource_ to describe an {{< glossary_tooltip text="API resource" term_id="api-resource" >}}.
+
+<!--more-->
+Computers provide fundamental hardware facilities: processing power, storage memory, network, etc.
+These resources have finite capacity, measured in a unit applicable to that resource (number of CPUs, bytes of memory, etc).
+Kubernetes abstracts common [resources](/docs/concepts/configuration/manage-resources-containers/)
+for allocation to workloads and utilizes operating system primitives (for example, Linux {{< glossary_tooltip text="cgroups" term_id="cgroup" >}}) to manage consumption by {{< glossary_tooltip text="workloads" term_id="workload" >}}).
+
+You can also use [dynamic resource allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) to
+manage complex resource allocations automatically.

--- a/content/en/docs/reference/glossary/object.md
+++ b/content/en/docs/reference/glossary/object.md
@@ -5,12 +5,14 @@ date: 2020-10-12
 full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
 short_description: >
    An entity in the Kubernetes system, representing part of the state of your cluster.
-aka: 
+aka:
 tags:
+- architecture
 - fundamental
 ---
-An entity in the Kubernetes system. The Kubernetes API uses these entities to represent the state
-of your cluster.
+An entity in the Kubernetes system. An object is an
+{{< glossary_tooltip text="API resource" term_id="api-resource" >}} that the Kubernetes API
+uses to represent the state of your cluster.
 <!--more-->
 A Kubernetes object is typically a “record of intent”—once you create the object, the Kubernetes
 {{< glossary_tooltip text="control plane" term_id="control-plane" >}} works constantly to ensure


### PR DESCRIPTION
### Description

Add a definitions of 'API resource' and 'resource (infrastructure)' to the glossary. As the term "resource" is frequently used in the docs, the Kubernetes API itself, and in the community (but not actually defined).

Inspiration / definitions taken from:
https://kubernetes.io/docs/reference/using-api/api-concepts/#standard-api-terminology
https://stackoverflow.com/questions/52309496/difference-between-kubernetes-objects-and-resources
https://datatracker.ietf.org/doc/html/rfc7231#section-2

https://en.wikipedia.org/wiki/System_resource

### Issue

Closes: https://github.com/kubernetes/website/issues/25903