### PR TITLE
Publish nftables GA blog post

### DIFF
--- a/content/en/blog/_posts/2025-02-28-nftables-kube-proxy/index.md
+++ b/content/en/blog/_posts/2025-02-28-nftables-kube-proxy/index.md
@@ -2,7 +2,6 @@
 layout: blog
 title: "NFTables mode for kube-proxy"
 date: 2025-02-28
-draft: true
 slug: nftables-kube-proxy
 author: >
   Dan Winship (Red Hat)


### PR DESCRIPTION
Updates the nftables GA blog post (#49393) to remove `draft: true`.

/hold

1. I picked the current date at random. Needs a real date.
2. I need to make sure everything actually renders correctly... it didn't show up in the netlify preview before, I guess because it was still draft?