### PR TITLE
Fix formula in HPA page

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -134,7 +134,7 @@ value:
 
 ```math
 \begin{equation*}
-desiredReplicas = \left( currentReplicas \times  { currentMetricValue \over desiredMetricValue }  \right)
+desiredReplicas = ceil\left\lceil currentReplicas \times \frac{currentMetricValue}{desiredMetricValue} \right\rceil
 \end{equation*}
 ```
 


### PR DESCRIPTION
Added ceil function in the desired replicas Algorithm

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The kubernetes documentation had a ceil function added in the desired replicas Algorithm and recently a PR "https://github.com/kubernetes/website/pull/49719" was created to update the math style formulae. In doing so, the ceil function was also removed. Hence, I have created this PR to update the same.

### Issue


Closes: #