### PR TITLE
docs: add necessary feature gate information for KEP-5073 - Declarative Validation of K8s Native Types With validation-gen

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
@@ -1,0 +1,13 @@
+---
+title: DeclarativeValidation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.33"
+---
+Enables declarative validation of in-tree Kubernetes APIs. When enabled, APIs with declarative validation rules (defined using IDL tags in the Go code) will have both the generated declarative validation code and the original hand-written validation code executed.  The results are compared, and any discrepancies are reported via the `declarative_validation_mismatch_total` metric.  Only the hand-written validation result is returned to the user (eg: actually validates in the request path).  The original hand-written validation are still the authoritative validations when this is enabled but this can be changed if the [DeclarativeValidationTakeover feature gate](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md) is enabled in addition to this gate.  This feature gate only operates on the kube-apiserver.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
@@ -1,0 +1,13 @@
+---
+title: DeclarativeValidationTakeover
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.33"
+---
+When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md) feature gate, declarative validation errors are returned directly to the caller, replacing hand-written validation errors for rules that have declarative implementations. When disabled (and `DeclarativeValidation` is enabled), hand-written validation errors are always returned, effectively putting declarative validation in a __mismatch validation mode__ that monitors but does not affect API responses.  This __mismatch validation mode__  allows for the monitoring of the `declarative_validation_mismatch_total` and `declarative_validation_panic_total` metrics which are implementation details for a safer rollout, average user shouldn't need to interact with it directly. This feature gate only operates on the kube-apiserver.  Note: Although declarative validation aims for functional equivalence with hand-written validation, the exact description of error messages may differ between the two approaches.


### PR DESCRIPTION
PR related to docs changes necessary for KEP 5073

KEP Issue: https://github.com/kubernetes/enhancements/issues/5073
KEP PR: https://github.com/kubernetes/enhancements/pull/5074


KEP Implementation PRs:
- Migrate to declarative validation - ReplicationController spec.replicas and spec.minReadySeconds fields: https://github.com/kubernetes/kubernetes/pull/130725
- Enable Declarative Validation for ReplicationController: https://github.com/kubernetes/kubernetes/pull/130724
- add declarative validation metrics and associated runtime verification tests: https://github.com/kubernetes/kubernetes/pull/130705
- Add default + optional handling: https://github.com/kubernetes/kubernetes/pull/130706
- add Add CoveredByDeclarative to field error struct: https://github.com/kubernetes/kubernetes/pull/130695
- add feature gates: https://github.com/kubernetes/kubernetes/pull/130478, [Declarative Validation] update Declarative Validation featuregate  kubernetes#130703
- add validation-gen framework: https://github.com/kubernetes/kubernetes/pull/130349


 (related: https://github.com/kubernetes/enhancements/issues/5073#issuecomment-2654441272)