### PR TITLE
Update node-shutdown docs: typo in word 'administrators'

### DIFF
--- a/content/en/docs/concepts/cluster-administration/node-shutdown.md
+++ b/content/en/docs/concepts/cluster-administration/node-shutdown.md
@@ -108,7 +108,7 @@ Message:        Pod was terminated in response to imminent node shutdown.
 To provide more flexibility during graceful node shutdown around the ordering
 of pods during shutdown, graceful node shutdown honors the PriorityClass for
 Pods, provided that you enabled this feature in your cluster. The feature
-allows cluster administers to explicitly define the ordering of pods
+allows cluster administrators to explicitly define the ordering of pods
 during graceful node shutdown based on
 [priority classes](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).
 


### PR DESCRIPTION
Hello!

I was just reading the documentation and noticed that there's probably a misuse of the word 'administers', where we should be using the word 'administrators' instead, to be more coherent with the rest of the documentation.