### PR TITLE
[pl] docs/contribute/generate-ref-docs/kubectl.md

### DIFF
--- a/content/pl/docs/contribute/generate-ref-docs/kubectl.md
+++ b/content/pl/docs/contribute/generate-ref-docs/kubectl.md
@@ -1,0 +1,256 @@
+---
+title: Generowanie materiałów źródłowych dla polecenia kubectl
+content_type: task
+weight: 90
+---
+
+<!-- overview -->
+
+Ta strona pokazuje, jak wygenerować materiały źródłowe polecenia `kubectl`.
+
+{{< note >}}
+Ten temat pokazuje, jak wygenerować materiały źródłowe dla
+[poleceń kubectl](/docs/reference/generated/kubectl/kubectl-commands) takich jak
+[kubectl apply](/docs/reference/generated/kubectl/kubectl-commands#apply) i
+[kubectl taint](/docs/reference/generated/kubectl/kubectl-commands#taint).
+Ten temat nie pokazuje, jak wygenerować stronę materiałów źródłowych opcji [kubectl](/docs/reference/generated/kubectl/kubectl-commands/).
+Aby
+uzyskać instrukcje dotyczące generowania strony materiałów źródłowych opcji
+kubectl, zobacz [Generowanie stron materiałów źródłowych dla komponentów i narzędzi Kubernetesa](/docs/contribute/generate-ref-docs/kubernetes-components/).
+
+{{< /note >}}
+
+## {{% heading "prerequisites" %}}
+
+{{< include "prerequisites-ref-docs.md" >}}
+
+<!-- steps -->
+
+## Skonfiguruj lokalne repozytoria {#set-up-the-local-repositories}
+
+Utwórz lokalną przestrzeń roboczą i ustaw swoje `GOPATH`:
+
+```shell
+mkdir -p $HOME/<workspace>
+
+export GOPATH=$HOME/<workspace>
+```
+
+Utwórz lokalną kopię następujących repozytoriów:
+
+```shell
+go get -u github.com/spf13/pflag
+go get -u github.com/spf13/cobra
+go get -u gopkg.in/yaml.v2
+go get -u github.com/kubernetes-sigs/reference-docs
+```
+
+Jeśli nie masz jeszcze repozytorium kubernetes/website, pobierz je teraz:
+
+```shell
+git clone https://github.com/<your-username>/website $GOPATH/src/github.com/<your-username>/website
+```
+
+Zrób klon repozytorium kubernetes/kubernetes jako k8s.io/kubernetes:
+
+```shell
+git clone https://github.com/kubernetes/kubernetes $GOPATH/src/k8s.io/kubernetes
+```
+
+Usuń pakiet spf13 z `$GOPATH/src/k8s.io/kubernetes/vendor/github.com`:
+
+```shell
+rm -rf $GOPATH/src/k8s.io/kubernetes/vendor/github.com/spf13
+```
+
+Repozytorium kubernetes/kubernetes dostarcza kod źródłowy `kubectl` oraz `kustomize`.
+
+* Określ katalog bazowy twojej kopii repozytorium
+  [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes). Na przykład,
+  jeśli postępowałeś zgodnie z poprzednim krokiem, aby pobrać
+  repozytorium, twój katalog bazowy to `$GOPATH/src/k8s.io/kubernetes`.
+  Kolejne kroki odwołują się do twojego katalogu bazowego jako `<k8s-base>`.
+
+* Określ katalog bazowy klonu Twojego repozytorium
+  [kubernetes/website](https://github.com/kubernetes/website). Na przykład, jeśli
+  wykonałeś poprzedni krok, aby pobrać repozytorium, Twoim katalogiem bazowym
+  jest `$GOPATH/src/github.com/<your-username>/website`.
+  Kolejne kroki odnoszą się do Twojego katalogu bazowego jako `<web-base>`.
+
+* Określ katalog główny dla Twojej kopii repozytorium
+  [kubernetes-sigs/reference-docs](https://github.com/kubernetes-sigs/reference-docs). Na przykład,
+  jeśli postępowałeś zgodnie z poprzednim krokiem, aby uzyskać repozytorium,
+  Twoim katalogiem głównym będzie `$GOPATH/src/github.com/kubernetes-sigs/reference-docs`.
+  Dalsze kroki odnoszą się do Twojego katalogu głównego jako `<rdocs-base>`.
+
+W swoim lokalnym repozytorium k8s.io/kubernetes przejdź do interesującej Cię
+gałęzi i upewnij się, że jest ona aktualna. Na przykład, jeśli chcesz wygenerować
+dokumentację dla Kubernetesa {{< skew prevMinorVersion >}}.0, możesz użyć tych poleceń:
+
+```shell
+cd <k8s-base>
+git checkout v{{< skew prevMinorVersion >}}.0
+git pull https://github.com/kubernetes/kubernetes {{< skew prevMinorVersion >}}.0
+```
+
+Jeśli nie musisz edytować kodu źródłowego `kubectl`, postępuj zgodnie z
+instrukcjami dotyczącymi [Ustawiania zmiennych kompilacji](#setting-build-variables).
+
+## Edytowanie kodu źródłowego kubectl {#edit-the-kubectl-source-code}
+
+Materiały źródłowe polecenia kubectl są automatycznie generowana z kodu źródłowego kubectl.
+Jeśli chcesz zmienić materiały źródłowe, pierwszym krokiem jest zmiana
+jednego lub więcej komentarzy w kodzie źródłowym kubectl. Wprowadź zmianę w swoim
+lokalnym repozytorium kubernetes/kubernetes, a następnie zgłoś pull requesta do
+gałęzi master na [github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).
+
+[PR 56673](https://github.com/kubernetes/kubernetes/pull/56673/files) jest
+przykładem pull requesta, który poprawia literówkę w kodzie źródłowym kubectl.
+
+Monitoruj swój pull request (PR) i odpowiadaj na komentarze recenzentów. Kontynuuj
+monitorowanie swojego PR, aż zostanie scalony z docelową gałęzią w repozytorium kubernetes/kubernetes.
+
+## Zrób cherry pick do gałęzi wydania {#cherry-pick-your-change-into-a-release-branch}
+
+Twoja zmiana znajduje się teraz w głównej gałęzi, która jest używana do
+rozwoju następnego wydania Kubernetesa. Jeśli chcesz, aby twoja
+zmiana pojawiła się w wersji dokumentacji Kubernetesa, która została już
+wydana, musisz zaproponować włączenie twojej zmiany do gałęzi wydania.
+
+Na przykład, załóżmy, że gałąź master jest używana do rozwijania Kubernetes
+{{< skew currentVersion >}} i chcesz przenieść swoją zmianę do gałęzi
+release-{{< skew prevMinorVersion >}}. Aby uzyskać instrukcje, jak to zrobić, zobacz
+[Proponowanie Cherry Pick](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md).
+
+Monitoruj swój cherry pick pull request, aż zostanie scalone z gałęzią wydania.
+
+{{< note >}}
+Proponowanie cherry pick wymaga posiadania uprawnień do ustawiania etykiety oraz
+kamienia milowego w swoim pull requeście. Jeśli nie posiadasz tych uprawnień,
+będziesz musiał współpracować z kimś, kto może ustawić etykietę i kamień milowy za Ciebie.
+{{< /note >}}
+
+## Ustaw zmienne budowania {#set-build-variables}
+
+Przejdź do `<rdocs-base>`. W swoim wierszu poleceń ustaw następujące zmienne środowiskowe.
+
+* Ustaw `K8S_ROOT` na `<k8s-base>`.
+* Ustaw `K8S_WEBROOT` na `<web-base>`.
+* Ustaw `K8S_RELEASE` na wersję dokumentacji, którą chcesz zbudować. Na przykład,
+  jeśli chcesz zbudować dokumentację dla Kubernetesa
+  {{< skew prevMinorVersion >}}, ustaw `K8S_RELEASE` na {{< skew prevMinorVersion >}}.
+
+Na przykład:
+
+```shell
+export K8S_WEBROOT=$GOPATH/src/github.com/<your-username>/website
+export K8S_ROOT=$GOPATH/src/k8s.io/kubernetes
+export K8S_RELEASE={{< skew prevMinorVersion >}}
+```
+
+## Tworzenie katalogu wersjonowanego {#creating-a-versioned-directory}
+
+Uruchomienie budowania (ang. build target) `createversiondirs` tworzy katalog z
+wersjonowaniem i kopiuje pliki konfiguracyjne kubectl dotyczące materiałów źródłowych do tego
+katalogu. Nazwa katalogu z wersjonowaniem jest zgodna z wzorcem `v<major>_<minor>`.
+
+W katalogu `<rdocs-base>`, uruchom następujący cel budowania:
+
+```shell
+cd <rdocs-base>
+make createversiondirs
+```
+
+## Sprawdź tag wydania w k8s.io/kubernetes {#check-out-a-release-tag-in-k8siokubernetes}
+
+W swoim lokalnym repozytorium `<k8s-base>`, przejdź do gałęzi, która zawiera
+wersję Kubernetesa, którą chcesz udokumentować. Na przykład, jeśli chcesz
+wygenerować dokumentację dla Kubernetesa {{< skew prevMinorVersion >}}.0, przejdź do tagu `v{{< skew prevMinorVersion >}}`.
+Upewnij się, że Twoja lokalna gałąź jest aktualna.
+
+```shell
+cd <k8s-base>
+git checkout v{{< skew prevMinorVersion >}}.0
+git pull https://github.com/kubernetes/kubernetes v{{< skew prevMinorVersion >}}.0
+```
+
+## Uruchom kod generowania dokumentacji {#run-the-doc-generation-code}
+
+W lokalnym katalogu `<rdocs-base>`, uruchom cel budowania (ang. build target) `copycli`. Komenda działa z uprawnieniami `root`:
+
+```shell
+cd <rdocs-base>
+make copycli
+```
+
+Polecenie `copycli` czyści tymczasowy katalog kompilacji, generuje pliki poleceń kubectl i
+kopiuje zbiorczą stronę HTML materiałów źródłowych poleceń kubectl oraz zasoby do `<web-base>`.
+
+## Zlokalizuj wygenerowane pliki {#locate-the-generated-files}
+
+Zweryfikuj, czy te dwa pliki zostały wygenerowane:
+
+```shell
+[ -e "<rdocs-base>/gen-kubectldocs/generators/build/index.html" ] && echo "index.html built" || echo "no index.html"
+[ -e "<rdocs-base>/gen-kubectldocs/generators/build/navData.js" ] && echo "navData.js built" || echo "no navData.js"
+```
+
+## Zlokalizuj skopiowane pliki {#locate-the-copied-files}
+
+Zweryfikuj, czy wszystkie wygenerowane pliki zostały skopiowane do Twojego `<web-base>`:
+
+```shell
+cd <web-base>
+git status
+```
+
+Wynik powinien zawierać zmodyfikowane pliki:
+
+```
+static/docs/reference/generated/kubectl/kubectl-commands.html
+static/docs/reference/generated/kubectl/navData.js
+```
+
+Wynik może również zawierać:
+
+```
+static/docs/reference/generated/kubectl/scroll.js
+static/docs/reference/generated/kubectl/stylesheet.css
+static/docs/reference/generated/kubectl/tabvisibility.js
+static/docs/reference/generated/kubectl/node_modules/bootstrap/dist/css/bootstrap.min.css
+static/docs/reference/generated/kubectl/node_modules/highlight.js/styles/default.css
+static/docs/reference/generated/kubectl/node_modules/jquery.scrollto/jquery.scrollTo.min.js
+static/docs/reference/generated/kubectl/node_modules/jquery/dist/jquery.min.js
+static/docs/reference/generated/kubectl/node_modules/font-awesome/css/font-awesome.min.css
+```
+
+## Lokalne testowanie dokumentacji {#locally-test-the-documentation}
+
+Zbuduj dokumentację Kubernetes w lokalnym `<web-base>`.
+
+```shell
+cd <web-base>
+git submodule update --init --recursive --depth 1 # if not already done
+make container-serve
+```
+
+Zobacz [podgląd lokalny](https://localhost:1313/docs/reference/generated/kubectl/kubectl-commands/).
+
+## Dodaj i zatwierdź zmiany w kubernetes/website {#add-and-commit-changes-in-kuberneteswebsite}
+
+Uruchom `git add` i `git commit`, aby zatwierdzić pliki.
+
+## Utwórz pull requesta {#create-a-pull-request}
+
+Utwórz pull requesta do repozytorium `kubernetes/website`.
+Monitoruj swój pull request i odpowiadaj na komentarze z przeglądu.
+Kontynuuj monitorowanie swojego pull requesta aż do momentu jego włączenia do głównej gałęzi kodu.
+
+Kilka minut po włączeniu twojego pull requesta, zaktualizowane tematy
+materiałów źródłowych będą widoczne w [opublikowanej dokumentacji](/docs/home).
+
+## {{% heading "whatsnext" %}}
+
+* [Szybki start generowania materiałów źródłowych](/docs/contribute/generate-ref-docs/quickstart/)
+* [Generowanie materiałów źródłowych dla komponentów i narzędzi Kubernetesa](/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [Generowanie materiałów źródłowych dla Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/)

--- a/content/pl/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/pl/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,0 +1,21 @@
+
+### Wymagania: {#requirements}
+
+- Potrzebujesz maszyny z systemem operacyjnym Linux lub macOS.
+
+- Musisz mieć zainstalowane następujące narzędzia:
+
+  - [Python](https://www.python.org/downloads/) w wersji 3.7.x+
+  - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - Dokumentacja opisuje, jak zainstalować i rozpocząć pracę z systemem kontroli wersji `Git`.
+  - [Golang](https://go.dev/dl/) wersja 1.13+
+  - [Pip](https://pypi.org/project/pip/) używany do instalacji PyYAML
+  - [PyYAML](https://pyyaml.org/) w wersji 5.1.2
+  - [make](https://www.gnu.org/software/make/)
+  - [gcc compiler/linker](https://gcc.gnu.org/)
+  - [Docker](https://docs.docker.com/engine/installation/) (Wymagany tylko do odniesień do poleceń `kubectl`)
+
+- Twoja zmienna środowiskowa `PATH` musi zawierać wymagane narzędzia do budowania, takie jak binaria `Go` i `python`.
+
+- Musisz wiedzieć, jak utworzyć pull requesta do repozytorium na GitHubie.
+  Wymaga to utworzenia własnego forka repozytorium. Aby uzyskać więcej informacji,
+  zobacz [Praca z lokalnej kopii](/docs/contribute/new-content/open-a-pr/#fork-the-repo).

--- a/content/pl/includes/index.md
+++ b/content/pl/includes/index.md
@@ -1,0 +1,3 @@
+---
+headless: true
+---


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
