### PR TITLE
[pl] docs/contribute/generate-ref-docs/metrics-reference.md

### DIFF
--- a/content/pl/docs/contribute/generate-ref-docs/metrics-reference.md
+++ b/content/pl/docs/contribute/generate-ref-docs/metrics-reference.md
@@ -1,0 +1,90 @@
+---
+title: Generowanie materiałów źródłowych dla metryk
+content_type: task
+weight: 100
+---
+
+<!-- overview -->
+
+Ta strona demonstruje generowanie materiałów źródłowych dotyczących metryk.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "prerequisites-ref-docs.md" >}}
+
+<!-- steps -->
+
+## Sklonuj repozytorium Kubernetesa {#clone-the-kubernetes-repository}
+
+Generowanie metryk odbywa się w repozytorium Kubernetesa. Aby
+sklonować repozytorium, przejdź do katalogu, w którym chcesz, aby klon istniał.
+
+Następnie wykonaj następujące polecenie:
+
+```shell
+git clone https://www.github.com/kubernetes/kubernetes 
+```
+
+To tworzy folder `kubernetes` w bieżącym katalogu roboczym.
+
+## Generowanie metryk {#generate-the-metrics}
+
+W sklonowanym repozytorium Kubernetesa
+zlokalizuj katalog `test/instrumentation/documentation`.
+Dokumentacja metryk jest generowana w tym katalogu.
+
+Przy każdej wersji dodawane są nowe metryki. Po
+uruchomieniu skryptu generatora dokumentacji metryk,
+skopiuj dokumentację metryk na stronę internetową
+Kubernetesa i opublikuj zaktualizowaną dokumentację metryk.
+
+Aby wygenerować najnowsze metryki, upewnij się, że znajdujesz się w katalogu
+głównym sklonowanego katalogu Kubernetesa. Następnie wykonaj następujące polecenie:
+
+```shell
+./test/instrumentation/update-documentation.sh
+```
+
+Aby sprawdzić zmiany, wykonaj:
+
+```shell
+git status
+```
+
+Wynik jest podobny do:
+
+```
+./test/instrumentation/documentation/documentation.md
+./test/instrumentation/documentation/documentation-list.yaml
+```
+
+## Skopiuj wygenerowany plik dokumentacji metryk do repozytorium strony internetowej Kubernetesa {#copy-the-generated-metrics-documentation-file-to-the-kubernetes-website-repository}
+
+1. Ustaw zmienną środowiskową głównego katalogu strony Kubernetesa.
+
+   Wykonaj następujące polecenie, aby ustawić główny katalog witryny:
+
+   ```shell
+   export WEBSITE_ROOT=<path to website root>
+   ```
+
+2. Skopiuj wygenerowany plik metryk do repozytorium witryny Kubernetesa.
+
+   ```shell
+   cp ./test/instrumentation/documentation/documentation.md "${WEBSITE_ROOT}/content/en/docs/reference/instrumentation/metrics.md"
+   ```
+
+   {{< note >}}
+   Jeśli pojawi się błąd, sprawdź, czy masz uprawnienia do skopiowania
+   pliku. Możesz użyć `chown`, aby zmienić własność pliku na swojego użytkownika.
+   {{< /note >}}
+
+## Utwórz pull requesta {#create-a-pull-request}
+
+Aby utworzyć pull request, postępuj zgodnie z instrukcjami w [Otwarcie pull requesta](/docs/contribute/new-content/open-a-pr/).
+
+## {{% heading "whatsnext" %}}
+
+* [Współpraca z głównym projektem](/docs/contribute/generate-ref-docs/contribute-upstream/)
+* [Generowanie materiałów źródłowych dla komponentów i narzędzi Kubernetesa](/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [Generowanie materiałów źródłowych dla poleceń kubectl](/docs/contribute/generate-ref-docs/kubectl/)


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
