### PR TITLE
[pl] docs/contribute/generate-ref-docs/prerequisites-ref-docs.md

### DIFF
--- a/content/pl/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/pl/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,0 +1,21 @@
+
+### Wymagania: {#requirements}
+
+- Potrzebujesz maszyny z systemem operacyjnym Linux lub macOS.
+
+- Musisz mieć zainstalowane następujące narzędzia:
+
+  - [Python](https://www.python.org/downloads/) w wersji 3.7.x+
+  - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - Dokumentacja opisuje, jak zainstalować i rozpocząć pracę z systemem kontroli wersji `Git`.
+  - [Golang](https://go.dev/dl/) wersja 1.13+
+  - [Pip](https://pypi.org/project/pip/) używany do instalacji PyYAML
+  - [PyYAML](https://pyyaml.org/) w wersji 5.1.2
+  - [make](https://www.gnu.org/software/make/)
+  - [gcc compiler/linker](https://gcc.gnu.org/)
+  - [Docker](https://docs.docker.com/engine/installation/) (Wymagany tylko do odniesień do poleceń `kubectl`)
+
+- Twoja zmienna środowiskowa `PATH` musi zawierać wymagane narzędzia do budowania, takie jak binaria `Go` i `python`.
+
+- Musisz wiedzieć, jak utworzyć pull requesta do repozytorium na GitHubie.
+  Wymaga to utworzenia własnego forka repozytorium. Aby uzyskać więcej informacji,
+  zobacz [Praca z lokalnej kopii](/docs/contribute/new-content/open-a-pr/#fork-the-repo).


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
