### PR TITLE
[pl] docs/contribute/generate-ref-docs/quickstart.md

### DIFF
--- a/content/pl/docs/contribute/generate-ref-docs/quickstart.md
+++ b/content/pl/docs/contribute/generate-ref-docs/quickstart.md
@@ -1,0 +1,258 @@
+---
+title: Szybki start generowania materiałów źródłowych
+linkTitle: Szybki start
+content_type: task
+weight: 10
+hide_summary: true
+---
+
+<!-- overview -->
+
+Ta strona pokazuje, jak używać skryptu `update-imported-docs.py`
+do generowania materiałów źródłowych Kubernetes. Skrypt
+automatyzuje konfigurację budowania i generuje materiały źródłowe dla wydania.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "prerequisites-ref-docs.md" >}}
+
+<!-- steps -->
+
+## Pobieranie repozytorium dokumentacji {#getting-the-docs-repository}
+
+Upewnij się, że Twój fork `website` jest zaktualizowany do najnowszej wersji zdalnego
+repozytorium `kubernetes/website` na GitHubie (gałąź `main`), a następnie sklonuj swój fork `website`.
+
+```shell
+mkdir github.com
+cd github.com
+git clone git@github.com:<your_github_username>/website.git
+```
+
+Określ katalog bazowy swojego klonu. Na przykład, jeśli
+wykonałeś poprzedni krok, aby uzyskać repozytorium, Twoim
+katalogiem bazowym jest `github.com/website.` Kolejne
+kroki odnoszą się do Twojego katalogu bazowego jako `<web-base>`.
+
+{{< note>}}
+Jeśli chcesz wieść zmiane do narzędzi komponentu i materiałów źródłowych, zobacz
+[Wkład w kod źródłowy Kubernetesa](/docs/contribute/generate-ref-docs/contribute-upstream).
+{{< /note >}}
+
+## Wprowadzenie do update-imported-docs {#overview-of-update-imported-docs}
+
+Skrypt `update-imported-docs.py` znajduje się w
+katalogu `<web-base>/update-imported-docs/`.
+
+Skrypt tworzy następujące odniesienia:
+
+* Materiały źródłowe komponentów i narzędzi
+* Materiały źródłowe do polecenia `kubectl`
+* Materiały źródłowe API Kubernetesa
+
+Skrypt `update-imported-docs.py` generuje materiały źródłowe z
+kodu źródłowego Kubernetesa. Skrypt tworzy tymczasowy
+katalog w `/tmp` na Twoim komputerze i klonuje do tego katalogu wymagane
+repozytoria: `kubernetes/kubernetes` oraz
+`kubernetes-sigs/reference-docs`. Skrypt ustawia Twój `GOPATH` na
+ten tymczasowy katalog. Ustawiane są trzy dodatkowe zmienne środowiskowe:
+
+* `K8S_RELEASE`
+* `K8S_ROOT`
+* `K8S_WEBROOT`
+
+Skrypt wymaga dwóch argumentów do prawidłowego działania:
+
+* Plik konfiguracyjny YAML (`reference.yml`)
+* Wersja wydania, na przykład: `1.17`
+
+Plik konfiguracyjny zawiera pole
+`generate-command`. Pole `generate-command` definiuje serię
+instrukcji budowania z `kubernetes-sigs/reference-docs/Makefile`.
+Zmienna `K8S_RELEASE` określa wersję wydania.
+
+Skrypt `update-imported-docs.py` wykonuje następujące kroki:
+
+1. Klonuje powiązane repozytoria określone w pliku
+   konfiguracyjnym. W celu generowania materiałów źródłowych, repozytorium,
+   które jest domyślnie klonowane, to `kubernetes-sigs/reference-docs`.
+1. Uruchamia polecenia w klonowanych repozytoriach, aby
+   przygotować generator dokumentacji, a następnie generuje pliki HTML i Markdown.
+1. Kopiuje wygenerowane pliki HTML i Markdown do lokalnej kopii
+   repozytorium `<web-base>` w lokalizacjach określonych w pliku konfiguracyjnym.
+1. Aktualizacje odnośników do poleceń `kubectl` w `kubectl`.md, aby odnosiły
+   się do sekcji w materiałach źródłowych polecenia `kubectl`.
+
+Gdy wygenerowane pliki znajdują się w Twojej lokalnej kopii repozytorium
+`<web-base>`, możesz je przesłać w
+[pull requeście](/docs/contribute/new-content/open-a-pr/) do `<web-base>`.
+
+## Format pliku konfiguracyjnego {#configuration-file-format}
+
+Każdy plik konfiguracyjny może zawierać wiele repozytoriów, które będą
+importowane razem. W razie potrzeby możesz dostosować plik konfiguracyjny, edytując
+go ręcznie. Możesz tworzyć nowe pliki konfiguracyjne do importowania innych
+grup dokumentów. Poniżej znajduje się przykład pliku konfiguracyjnego w formacie YAML:
+
+```yaml
+repos:
+- name: community
+  remote: https://github.com/kubernetes/community.git
+  branch: master
+  files:
+  - src: contributors/devel/README.md
+    dst: docs/imported/community/devel.md
+  - src: contributors/guide/README.md
+    dst: docs/imported/community/guide.md
+```
+
+Jednostronicowe dokumenty w formacie Markdown, importowane przez narzędzie, muszą
+być zgodne z [Przewodnikiem Stylu Dokumentacji](/docs/contribute/style/style-guide/).
+
+## Dostosowywanie pliku reference.yml {#customizing-referenceyml}
+
+Otwórz `<web-base>/update-imported-docs/reference.yml` do edycji. Nie
+zmieniaj zawartości pola `generate-command`, chyba że rozumiesz, jak
+ta komenda jest używana do budowy materiałów źródłowych. Nie powinno
+być konieczności aktualizowania `reference.yml`. Czasami zmiany w kodzie źródłowym
+nadrzędnym mogą wymagać zmian w pliku konfiguracyjnym (na
+przykład: zależności od wersji golang i zmiany w bibliotekach
+zewnętrznych). Jeśli napotkasz problemy z budowaniem, skontaktuj się z zespołem SIG-Docs
+na [kanale Slack #sig-docs Kubernetes](https://kubernetes.slack.com).
+
+{{< note >}}
+Pole `generate-command` jest opcjonalnym wpisem, który może być użyty do uruchomienia
+określonego polecenia lub krótkiego skryptu w celu wygenerowania dokumentacji z poziomu repozytorium.
+{{< /note >}}
+
+W `reference.yml`, `files` zawiera listę pól `src` i `dst`.
+Pole `src` zawiera lokalizację wygenerowanego pliku
+Markdown w sklonowanym katalogu kompilacji
+`kubernetes-sigs/reference-docs`, a pole `dst` określa, gdzie skopiować ten
+plik w sklonowanym repozytorium `kubernetes/website`. Na przykład:
+
+```yaml
+repos:
+- name: reference-docs
+  remote: https://github.com/kubernetes-sigs/reference-docs.git
+  files:
+  - src: gen-compdocs/build/kube-apiserver.md
+    dst: content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+  ...
+```
+
+Zauważ, że gdy istnieje wiele plików do skopiowania z tego
+samego katalogu źródłowego do tego samego katalogu docelowego,
+możesz użyć symboli wieloznacznych w wartości przekazywanej do
+`src`. Musisz podać nazwę katalogu jako wartość dla `dst`. Na przykład:
+
+```yaml
+  files:
+  - src: gen-compdocs/build/kubeadm*.md
+    dst: content/en/docs/reference/setup-tools/kubeadm/generated/
+```
+
+## Uruchamianie narzędzia update-imported-docs {#running-the-update-imported-docs-tool}
+
+Możesz uruchomić narzędzie `update-imported-docs.py` w następujący sposób:
+
+```shell
+cd <web-base>/update-imported-docs
+./update-imported-docs.py <configuration-file.yml> <release-version>
+```
+
+Na przykład:
+
+```shell
+./update-imported-docs.py reference.yml 1.17
+```
+
+<!-- Revisit: is the release configuration used -->
+## Naprawianie linków {#fixing-links}
+
+Plik konfiguracyjny `release.yml` zawiera instrukcje do naprawienia względnych
+odnośników. Aby naprawić względne odnośniki w zaimportowanych plikach, ustaw
+właściwość `gen-absolute-links` na `true`. Przykład tego możesz znaleźć w
+[`release.yml`](https://github.com/kubernetes/website/blob/main/update-imported-docs/release.yml).
+
+## Dodawanie i zatwierdzanie zmian w kubernetes/website {#adding-and-committing-changes-in-kuberneteswebsite}
+
+Wymień pliki, które zostały wygenerowane i skopiowane do `<web-base>`:
+
+```shell
+cd <web-base>
+git status
+```
+
+Wynik pokazuje nowe i zmodyfikowane pliki. Generowane dane
+wyjściowe różnią się w zależności od wprowadzonych zmian w kodzie źródłowym.
+
+### Wygenerowane pliki materiałów źródłowych narzędzi {#generated-component-tool-files}
+
+```
+content/en/docs/reference/command-line-tools-reference/cloud-controller-manager.md
+content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
+content/en/docs/reference/command-line-tools-reference/kube-proxy.md
+content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
+content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm.md
+content/en/docs/reference/kubectl/kubectl.md
+```
+
+### Wygenerowane pliki materiałów źródłowych poleceń kubectl {#generated-kubectl-command-reference-files}
+
+```
+static/docs/reference/generated/kubectl/kubectl-commands.html
+static/docs/reference/generated/kubectl/navData.js
+static/docs/reference/generated/kubectl/scroll.js
+static/docs/reference/generated/kubectl/stylesheet.css
+static/docs/reference/generated/kubectl/tabvisibility.js
+static/docs/reference/generated/kubectl/node_modules/bootstrap/dist/css/bootstrap.min.css
+static/docs/reference/generated/kubectl/node_modules/highlight.js/styles/default.css
+static/docs/reference/generated/kubectl/node_modules/jquery.scrollto/jquery.scrollTo.min.js
+static/docs/reference/generated/kubectl/node_modules/jquery/dist/jquery.min.js
+static/docs/reference/generated/kubectl/css/font-awesome.min.css
+```
+
+### Wygenerowane katalogi i pliki materiałów źródłowych API Kubernetess {#generated-kubernetes-api-reference-directories-and-files}
+
+```
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/index.html
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/js/navData.js
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/js/scroll.js
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/js/query.scrollTo.min.js
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/css/font-awesome.min.css
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/css/bootstrap.min.css
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/css/stylesheet.css
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/fonts/FontAwesome.otf
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/fonts/fontawesome-webfont.eot
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/fonts/fontawesome-webfont.svg
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/fonts/fontawesome-webfont.ttf
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/fonts/fontawesome-webfont.woff
+static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/fonts/fontawesome-webfont.woff2
+```
+
+Uruchom `git add` i `git commit`, aby zatwierdzić pliki.
+
+## Tworzenie pull requesta {#creating-a-pull-request}
+
+Utwórz pull requesta do repozytorium `kubernetes/website`. Monitoruj swój pull
+request i odpowiadaj na komentarze związane z przeglądem zgodnie z
+potrzebą. Kontynuuj monitorowanie swojego pull requesta, aż zostanie scalony.
+
+Kilka minut po scaleniu twojego pull requesta,
+zaktualizowane tematy materiałów źródłowych będą
+widoczne w [opublikowanej dokumentacji](/docs/home/).
+
+
+
+## {{% heading "whatsnext" %}}
+
+
+Materiały źródłowe można wygenerować ręcznie, konfigurując niezbędne repozytoria i uruchamiając
+odpowiednie cele (ang. build targets). Szczegółowe instrukcje znajdują się w poniższych przewodnikach:
+
+* [Generowanie materiałów źródłowych dla komponentów i narzędzi Kubernetes](/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [Generowanie materiałów źródłowych dla poleceń kubectl](/docs/contribute/generate-ref-docs/kubectl/)
+* [Generowanie materiałów źródłowych dla API Kubernetesa](/docs/contribute/generate-ref-docs/kubernetes-api/)
+


### PR DESCRIPTION
This is the Polish translation.

My remarks:

1. The English version is the canonical source. It is the source of truth.
1. I translate everything exactly as it is - every sentence.
   I don't add anything, and I don't leave anything out.
   This translation is a mirror of the English version in Polish.
1. This is not a poem :) so it is more important to provide
   a good source of translated knowledge than to write in beautiful Polish.
   So I translate each English sentence into a Polish sentence:
   - I don’t merge sentences.
   - I don’t split sentences.
   - I don’t change the order of sentences. 
1. I keep the original formatting, comments, and everything else to ensure synchronization 
   by line numbers between the English and Polish files.
1. It is important to me to create documents that are easy to maintain!
   So, Polish documents have all lines in the same places (with the same line numbers)
   as in the English version. This makes it very easy to compare, translate, fix,
   and maintain the content.
1. The Polish translation follows the English header ID, so for every header, I explicitly 
   add the English header ID when it is not explicitly defined. For example, for the English header:
   ```
   ## Contributing basics
   ```
   I convert it into Polish:
   ```
   ## Podstawy kontrybucji {#contributing-basics}
   ```
   with header-id `contributing-basics` created base on English `Contributing basics`.

   When the English source contains a header with an explicitly set header ID, I simply copy it. 
   For example, for the English header:
   ```
   ## Work from a local fork {#fork-the-repo}
   ```
   I convert it into Polish:
   ```
   ## Praca z lokalną kopią {#fork-the-repo}
   ```
   . So here we have header-id `fork-the-repo`, not `work-from-a-local-fork`.
1. Some English words are so commonly used in the Polish language that it is better 
   NOT to translate them; otherwise, no Polish IT specialist would understand them :) For example:
   - pull request
   - commit
   - deploy
   - fork
     I translate it as if it were a Polish word.
1. When some words might be misunderstood in the Polish translation, I add the original English word 
   in brackets. For example:
   - "you must also create a symbolic link" to "musisz również utworzyć dowiązanie symboliczne
     (ang. symbolic link)"
   - "you need to switch the upstream branch" to "musisz przełączyć gałąź (ang. upstream branch)"
1. When content refers to something material that contains English words, I keep it as it is. 
   For example, in a sentence like this:
   ```
   1. Click the **Create an issue** link on the right sidebar. This redirects you
   ```
   I keep `**Create an issue**` in its original form, so we have:
   ```
   1. Kliknij link **Create an issue** na prawym pasku bocznym. Przekieruje Cię  
   ```
1. Some English words are difficult to translate into Polish in the sense that the corresponding 
   Polish word is very uncommon, is translated into more than one word, or sounds strange. In these cases, 
   I sometimes translate the same word in different ways. For example:
   - "contribution / to contribute" into: 
     - "wkład / wnosić wkład / robić wkład"
     - "robić kontrybucje"
     - "kontrybucja"
     - "przyczyniać się"
   - "to localize / localizing" into:
     - "lokalizować"
     - "regionalizować"
     - "tłumaczenie i adaptacja językowa"
   - "content" into:
     - "treść"
     - "zawartość"

   In these cases, when I am not sure, I add these tricky words or sentences to 
   the PR description or comments to make the review process easier for reviewers.
1. As a starting point, I use chat-gpt, and then I read and adjust every sentence to check 
   and modify/correct it if necessary.
1. If something is wrong in the English version, for example some diagrams, I copy it as it is.
   Once it is corrected in the English version, I correct it in the Polish version.
