### PR TITLE
[pl] fix: typo in docs/reference/glossary

### DIFF
--- a/content/pl/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/pl/docs/reference/glossary/cloud-controller-manager.md
@@ -20,4 +20,4 @@ chmurowej od tych, które dotyczą wyłącznie samego klastra.
 
 Dzięki rozdzieleniu logiki zarządzającej pomiędzy klaster Kubernetesa i leżącą poniżej infrastrukturę chmurową,
 cloud-controller-manager umożliwia operatorom usług chmurowych na dostarczanie nowych funkcjonalności
-niezależnie od cyklu wydawniczego głównego projektu Kubernetes.
+niezależnie od cyklu wydawniczego głównego projektu Kubernetesa.

--- a/content/pl/docs/reference/glossary/etcd.md
+++ b/content/pl/docs/reference/glossary/etcd.md
@@ -4,18 +4,18 @@ id: etcd
 date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
-  Magazyn typu klucz-wartość *(key/value store)*, zapewniający spójność i wysoką dostępność, używany do przechowywania wszystkich danych o klastrze Kubernetes.
+  Magazyn typu klucz-wartość *(key/value store)*, zapewniający spójność i wysoką dostępność, używany do przechowywania wszystkich danych o klastrze Kubernetesa.
 
 aka: 
 tags:
 - architecture
 - storage
 ---
-Magazyn typu klucz-wartość *(key/value store)*, zapewniający spójność i wysoką dostępność, używany do przechowywania wszystkich danych o klastrze Kubernetes.
+Magazyn typu klucz-wartość *(key/value store)*, zapewniający spójność i wysoką dostępność, używany do przechowywania wszystkich danych o klastrze Kubernetesa.
 
 <!--more-->
 
-Jeśli Twój klaster Kubernetes używa etcd do przechowywania swoich danych, upewnij się, że masz opracowany plan tworzenia
+Jeśli Twój klaster Kubernetesa używa etcd do przechowywania swoich danych, upewnij się, że masz opracowany plan tworzenia
 [kopii zapasowych](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster) tych danych.
 
 Szczegółowe informacje na temat etcd można znaleźć w oficjalnej [dokumentacji](https://etcd.io/docs/).

--- a/content/pl/docs/reference/glossary/kube-apiserver.md
+++ b/content/pl/docs/reference/glossary/kube-apiserver.md
@@ -14,7 +14,7 @@ tags:
 ---
 Serwer API jest składnikiem
 {{< glossary_tooltip text="warstwy sterowania" term_id="control-plane" >}} Kubernetesa, który udostępnia API.
-Server API służy jako front-end warstwy sterowania Kubernetes.
+Server API służy jako front-end warstwy sterowania Kubernetesa.
 
 <!--more-->
 


### PR DESCRIPTION
fix a minor typo in the directory: docs/reference/glossary