### PR TITLE
KEP-4049: Add StorageCapacityScoring feature gate documents

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -130,6 +130,18 @@ defined range of integers representing the minimum and maximum scores. After the
 [NormalizeScore](#normalize-scoring) phase, the scheduler will combine node
 scores from all plugins according to the configured plugin weights.
 
+#### Capacity scoring {#scoring-capacity}
+
+{{< feature-state feature_gate_name="StorageCapacityScoring" >}}
+
+The feature gate `VolumeCapacityPriority` was used in v1.32 to support storage that are
+statically provisioned. Starting from v1.33, the new feature gate `StorageCapacityScoring`
+replaces the old `VolumeCapacityPriority` gate with added support to dynamically provisioned storage.
+When `StorageCapacityScoring` is enabled, the VolumeBinding plugin in the kube-scheduler is extended
+to score Nodes based on the storage capacity on each of them.
+This feature is applicable to CSI volumes that supported [Storage Capacity](/docs/concepts/storage/storage-capacity/),
+including local storage backed by a CSI driver.
+
 ### NormalizeScore {#normalize-scoring}
 
 These plugins are used to modify scores before the scheduler computes a final

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StorageCapacityScoring.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StorageCapacityScoring.md
@@ -1,0 +1,19 @@
+---
+title: StorageCapacityScoring
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.33"
+---
+The feature gate `VolumeCapacityPriority` was used in v1.32 to support storage that are
+statically provisioned. Starting from v1.33, the new feature gate `StorageCapacityScoring`
+replaces the old `VolumeCapacityPriority` gate with added support to dynamically provisioned storage.
+When `StorageCapacityScoring` is enabled, the VolumeBinding plugin in the kube-scheduler is extended
+to score Nodes based on the storage capacity on each of them.
+This feature is applicable to CSI volumes that supported [Storage Capacity](/docs/concepts/storage/storage-capacity/),
+including local storage backed by a CSI driver.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/VolumeCapacityPriority.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/VolumeCapacityPriority.md
@@ -9,6 +9,9 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.21"
+    toVersion: "1.32"
+
+removed: true
 ---
 Enable support for prioritizing nodes in different
 topologies based on available PV capacity.

--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -143,7 +143,7 @@ extension points:
   {{< glossary_tooltip text="volumes" term_id="volume" >}}.
   Extension points: `preFilter`, `filter`, `reserve`, `preBind`, `score`.
   {{< note >}}
-  `score` extension point is enabled when `VolumeCapacityPriority` feature is
+  `score` extension point is enabled when `StorageCapacityScoring` feature is
   enabled. It prioritizes the smallest PVs that can fit the requested volume
   size.
   {{< /note >}}
@@ -332,14 +332,14 @@ The general hierarchy for precedence when configuring `MultiPoint` plugins is as
 3. Default plugins and their default settings
 
 To demonstrate the above hierarchy, the following example is based on these plugins:
-|Plugin|Extension Points|
-|---|---|
-|`DefaultQueueSort`|`QueueSort`|
-|`CustomQueueSort`|`QueueSort`|
-|`DefaultPlugin1`|`Score`, `Filter`|
-|`DefaultPlugin2`|`Score`|
-|`CustomPlugin1`|`Score`, `Filter`|
-|`CustomPlugin2`|`Score`, `Filter`|
+| Plugin             | Extension Points  |
+| ------------------ | ----------------- |
+| `DefaultQueueSort` | `QueueSort`       |
+| `CustomQueueSort`  | `QueueSort`       |
+| `DefaultPlugin1`   | `Score`, `Filter` |
+| `DefaultPlugin2`   | `Score`           |
+| `CustomPlugin1`    | `Score`, `Filter` |
+| `CustomPlugin2`    | `Score`, `Filter` |
 
 A valid sample configuration for these plugins would be:
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This PR updates existing documentation to include the addition of the StorageCapacityScoring feature gate of KEP-4049  as an alpha version.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

- https://github.com/kubernetes/enhancements/issues/4049