### PR TITLE
Fix typo in autoscaling docs

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -63,7 +63,7 @@ Once installed, it allows you to create {{< glossary_tooltip text="CustomResourc
 
 {{< note >}}
 You will need to have the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
-installed to your cluster for the HPA to work.
+installed to your cluster for the VPA to work.
 {{< /note >}}
 
 At the moment, the VPA can operate in four different modes:


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Fix a typo in the autoscaling docs: this part is about VPA, the Vertical Pod Autoscaler, not HPA, like in the previous section.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
