### PR TITLE
[es] Fixed link for core dns helm charts

### DIFF
--- a/content/es/docs/concepts/cluster-administration/addons.md
+++ b/content/es/docs/concepts/cluster-administration/addons.md
@@ -81,7 +81,7 @@ En esta página se listan algunos de los complementos disponibles con sus respec
 ## Detección de Servicios 
 
 * [CoreDNS](https://coredns.io) es un servidor de DNS flexible y extensible que  
-  puede [instalarse](https://github.com/coredns/deployment/tree/master/kubernetes)
+  puede [instalarse](https://github.com/coredns/helm)
   como DNS dentro del clúster para los Pods.
 
 ## Visualización y Control


### PR DESCRIPTION
https://github.com/kubernetes/website/pull/49391/files