### PR TITLE
Fix wrong field name in dual-stack networking page

### DIFF
--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -148,7 +148,7 @@ These examples demonstrate the behavior of various dual-stack Service configurat
 1. This Service specification explicitly defines `IPv6` and `IPv4` in `.spec.ipFamilies` as well
    as defining `PreferDualStack` in `.spec.ipFamilyPolicy`. When Kubernetes assigns an IPv6 and
    IPv4 address in `.spec.clusterIPs`, `.spec.clusterIP` is set to the IPv6 address because that is
-   the first element in the `.spec.clusterIPs` array, overriding the default.
+   the first element in the `.spec.ipFamilies` array, overriding the default.
 
    {{% code_sample file="service/networking/dual-stack-preferred-ipfamilies-svc.yaml" %}}
 


### PR DESCRIPTION
### Description

This PR updates the documentation under [Dual-stack options on new Services](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#dual-stack-options-on-new-services). In point 3, the last mention of .spec.clusterIPs is incorrectly referenced and should be replaced with spec.ipFamilies .


### Issue
This PR resolves #49773

Closes: #49773