### PR TITLE
extra space in pod tag

### DIFF
--- a/content/en/docs/reference/glossary/device-plugin.md
+++ b/content/en/docs/reference/glossary/device-plugin.md
@@ -12,7 +12,7 @@ tags:
 ---
  Device plugins run on worker
 {{< glossary_tooltip term_id="node" text="Nodes">}} and provide
-{{< glossary_tooltip term_id="pod" text="Pods ">}} with access to resources,
+{{< glossary_tooltip term_id="pod" text="Pods">}} with access to resources,
 such as local hardware, that require vendor-specific initialization or setup
 steps.
 


### PR DESCRIPTION
### Description
There was an extra space within the Pod tag of `content/en/docs/reference/glossary/device-plugin.md`

### Issue

On the website it seems to be missing an extra space in the device-plugin.md

![image](https://github.com/user-attachments/assets/bd77b548-f2c2-457f-8ae8-c0dc26ba3c22)

Looking at the file, I'm assuming this is due to the extra space in the pod tag. Please correct me if I'm wrong

Link: https://kubernetes.io/docs/reference/glossary/?fundamental=true

go to device plugin

Closes: #