### PR TITLE
Add note about deployment cleanup policy

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -1079,6 +1079,14 @@ Explicitly setting this field to 0, will result in cleaning up all the history o
 thus that Deployment will not be able to roll back.
 {{< /note >}}
 
+{{< note >}}
+The cleanup will ONLY start after a deployment reaches a 
+[complete state](/docs/concepts/workloads/controllers/deployment/#complete-deployment)
+For example, if pods are crash looping, and there are multiple rolling updates
+events triggered over time, you might end up with more ReplicaSets than the 
+`.spec.revisionHistoryLimit` because the deployment never reaches a complete state.
+{{< /note >}}
+
 ## Canary Deployment
 
 If you want to roll out releases to a subset of users or servers using the Deployment, you

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -1079,13 +1079,15 @@ Explicitly setting this field to 0, will result in cleaning up all the history o
 thus that Deployment will not be able to roll back.
 {{< /note >}}
 
-{{< note >}}
-The cleanup will ONLY start after a deployment reaches a 
-[complete state](/docs/concepts/workloads/controllers/deployment/#complete-deployment)
-For example, if pods are crash looping, and there are multiple rolling updates
+The cleanup only starts **after** a Deployment reaches a 
+[complete state](/docs/concepts/workloads/controllers/deployment/#complete-deployment).
+If you set `.spec.revisionHistoryLimit` to 0, any rollout nonetheless triggers creation of a new
+ReplicaSet before Kubernetes removes the old one.
+
+Even with a non-zero revision history limit, you can have more ReplicaSets than the limit
+you configure. For example, if pods are crash looping, and there are multiple rolling updates
 events triggered over time, you might end up with more ReplicaSets than the 
-`.spec.revisionHistoryLimit` because the deployment never reaches a complete state.
-{{< /note >}}
+`.spec.revisionHistoryLimit` because the Deployment never reaches a complete state.
 
 ## Canary Deployment
 


### PR DESCRIPTION
### Description

This PR adds a new note about deployment cleanup policy.

See https://kubernetes.slack.com/archives/C18NZM5K9/p1740135413167499 for more context.

### Issue

There are some cases when number of ReplicaSets associated with a deployment might get higher than `.spec.revisionHistoryLimit`. These cases are not documented very well.

