### PR TITLE
[zh] Add a diagram to admission-controllers.md

### DIFF
--- a/content/zh-cn/docs/reference/access-authn-authz/admission-control-phases.svg
+++ b/content/zh-cn/docs/reference/access-authn-authz/admission-control-phases.svg
@@ -1,0 +1,921 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml-stylesheet href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" type="text/css"?><svg
+   aria-describedby="chart-desc-graph-div"
+   aria-roledescription="sequence"
+   role="graphics-document document"
+   viewBox="-50 -10 2035.5 1098"
+   style="max-width: 100%;"
+   width="100%"
+   id="graph-div"
+   height="100%"
+   version="1.1"
+   sodipodi:docname="admission-control-phases.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview44"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.4298725"
+     inkscape:cx="1025.8856"
+     inkscape:cy="865.37288"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="graph-div" />
+  <desc
+     id="chart-desc-graph-div">Sequence diagram for kube-apiserver handling requests during the admission phase showing mutation webhooks, followed by validatingadmissionpolicies and finally validating webhooks. &#10;It shows that the continue until the first rejection, or being accepted by all of them. &#10;It also shows that mutations by mutating webhooks cause all previously called webhooks to be called again.</desc>
+  <g
+     id="g2">
+    <rect
+       class="rect"
+       height="1077"
+       width="872"
+       stroke="rgb(0,0,0, 0.5)"
+       fill="Gainsboro"
+       y="0"
+       x="1063.5"
+       id="rect1" />
+    <text
+       class="text"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="27"
+       x="1499.5"
+       id="text1"><tspan
+         x="1499.5"
+         id="tspan1">准入控制被调用</tspan></text>
+    <text
+       class="text"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="49.099575"
+       x="1498.3369"
+       id="text2"><tspan
+         x="1498.3369"
+         id="tspan2">直到第一次被拒绝</tspan></text>
+  </g>
+  <g
+     id="g3">
+    <rect
+       class="actor actor-bottom"
+       ry="3"
+       rx="3"
+       name="ValidatingWebhook"
+       height="65"
+       width="237"
+       stroke="#666"
+       fill="#eaeaea"
+       y="1002"
+       x="1693.5"
+       id="rect2" />
+    <text
+       class="actor actor-box"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="1034.5"
+       x="1812"
+       id="text3"><tspan
+         x="1812"
+         id="tspan3">验证性 Webhook</tspan></text>
+  </g>
+  <g
+     id="g4">
+    <rect
+       class="actor actor-bottom"
+       ry="3"
+       rx="3"
+       name="ValidatingPol"
+       height="65"
+       width="297"
+       stroke="#666"
+       fill="#eaeaea"
+       y="1002"
+       x="1346.5"
+       id="rect3" />
+    <text
+       class="actor actor-box"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="1034.5"
+       x="1495"
+       id="text4"><tspan
+         x="1495"
+         id="tspan4">验证准入策略</tspan></text>
+  </g>
+  <g
+     id="g5">
+    <rect
+       class="actor actor-bottom"
+       ry="3"
+       rx="3"
+       name="MutatingWebhook"
+       height="65"
+       width="228"
+       stroke="#666"
+       fill="#eaeaea"
+       y="1002"
+       x="1068.5"
+       id="rect4" />
+    <text
+       class="actor actor-box"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="1034.5"
+       x="1182.5"
+       id="text5"><tspan
+         x="1182.5"
+         id="tspan5">变更性 Webhook</tspan></text>
+  </g>
+  <g
+     id="g6">
+    <rect
+       class="actor actor-bottom"
+       ry="3"
+       rx="3"
+       name="Auth"
+       height="65"
+       width="311"
+       stroke="#666"
+       fill="#eaeaea"
+       y="1002"
+       x="627"
+       id="rect5" />
+    <text
+       class="actor actor-box"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="1034.5"
+       x="782.5"
+       id="text6"><tspan
+         x="782.5"
+         id="tspan6">身份认证+鉴权</tspan></text>
+  </g>
+  <g
+     id="g7">
+    <rect
+       class="actor actor-bottom"
+       ry="3"
+       rx="3"
+       name="API"
+       height="65"
+       width="236"
+       stroke="#666"
+       fill="#eaeaea"
+       y="1002"
+       x="341"
+       id="rect6" />
+    <text
+       class="actor actor-box"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="1034.5"
+       x="459"
+       id="text7"><tspan
+         dy="0"
+         x="459"
+         id="tspan7">Kubernetes API服务器</tspan></text>
+  </g>
+  <g
+     id="g8">
+    <rect
+       class="actor actor-bottom"
+       ry="3"
+       rx="3"
+       name="User"
+       height="65"
+       width="150"
+       stroke="#666"
+       fill="#eaeaea"
+       y="1002"
+       x="0"
+       id="rect7" />
+    <text
+       class="actor actor-box"
+       alignment-baseline="central"
+       dominant-baseline="central"
+       style="font-weight:400;font-size:22px;text-anchor:middle"
+       y="1034.5"
+       x="75"
+       id="text8"><tspan
+         x="75"
+         id="tspan8">用户</tspan></text>
+  </g>
+  <g
+     id="g9">
+    <line
+       name="ValidatingWebhook"
+       stroke="#999"
+       stroke-width="0.5px"
+       class="actor-line 200"
+       y2="1002"
+       x2="1812"
+       y1="129"
+       x1="1812"
+       id="actor107" />
+    <g
+       id="root-107">
+      <rect
+         class="actor actor-top"
+         ry="3"
+         rx="3"
+         name="ValidatingWebhook"
+         height="65"
+         width="237"
+         stroke="#666"
+         fill="#eaeaea"
+         y="64"
+         x="1693.5"
+         id="rect8" />
+      <text
+         class="actor actor-box"
+         alignment-baseline="central"
+         dominant-baseline="central"
+         style="font-weight:400;font-size:22px;text-anchor:middle"
+         y="96.5"
+         x="1812"
+         id="text9"><tspan
+           x="1812"
+           id="tspan9">验证性 Webhook</tspan></text>
+    </g>
+  </g>
+  <g
+     id="g10">
+    <line
+       name="ValidatingPol"
+       stroke="#999"
+       stroke-width="0.5px"
+       class="actor-line 200"
+       y2="1002"
+       x2="1495"
+       y1="129"
+       x1="1495"
+       id="actor106" />
+    <g
+       id="root-106">
+      <rect
+         class="actor actor-top"
+         ry="3"
+         rx="3"
+         name="ValidatingPol"
+         height="65"
+         width="297"
+         stroke="#666"
+         fill="#eaeaea"
+         y="64"
+         x="1346.5"
+         id="rect9" />
+      <text
+         class="actor actor-box"
+         alignment-baseline="central"
+         dominant-baseline="central"
+         style="font-weight:400;font-size:22px;text-anchor:middle"
+         y="96.5"
+         x="1495"
+         id="text10"><tspan
+           x="1495"
+           id="tspan10">验证准入策略</tspan></text>
+    </g>
+  </g>
+  <g
+     id="g11">
+    <line
+       name="MutatingWebhook"
+       stroke="#999"
+       stroke-width="0.5px"
+       class="actor-line 200"
+       y2="1002"
+       x2="1182.5"
+       y1="129"
+       x1="1182.5"
+       id="actor105" />
+    <g
+       id="root-105">
+      <rect
+         class="actor actor-top"
+         ry="3"
+         rx="3"
+         name="MutatingWebhook"
+         height="65"
+         width="228"
+         stroke="#666"
+         fill="#eaeaea"
+         y="64"
+         x="1068.5"
+         id="rect10" />
+      <text
+         class="actor actor-box"
+         alignment-baseline="central"
+         dominant-baseline="central"
+         style="font-weight:400;font-size:22px;text-anchor:middle"
+         y="96.5"
+         x="1182.5"
+         id="text11"><tspan
+           x="1182.5"
+           id="tspan11">变更性 Webhook</tspan></text>
+    </g>
+  </g>
+  <g
+     id="g12">
+    <line
+       name="Auth"
+       stroke="#999"
+       stroke-width="0.5px"
+       class="actor-line 200"
+       y2="1002"
+       x2="782.5"
+       y1="129"
+       x1="782.5"
+       id="actor104" />
+    <g
+       id="root-104">
+      <rect
+         class="actor actor-top"
+         ry="3"
+         rx="3"
+         name="Auth"
+         height="65"
+         width="311"
+         stroke="#666"
+         fill="#eaeaea"
+         y="64"
+         x="627"
+         id="rect11" />
+      <text
+         class="actor actor-box"
+         alignment-baseline="central"
+         dominant-baseline="central"
+         style="font-weight:400;font-size:22px;text-anchor:middle"
+         y="96.5"
+         x="782.5"
+         id="text12"><tspan
+           x="782.5"
+           id="tspan12">身份认证+鉴权</tspan></text>
+    </g>
+  </g>
+  <g
+     id="g13">
+    <line
+       name="API"
+       stroke="#999"
+       stroke-width="0.5px"
+       class="actor-line 200"
+       y2="1002"
+       x2="459"
+       y1="129"
+       x1="459"
+       id="actor103" />
+    <g
+       id="root-103">
+      <rect
+         class="actor actor-top"
+         ry="3"
+         rx="3"
+         name="API"
+         height="65"
+         width="236"
+         stroke="#666"
+         fill="#eaeaea"
+         y="64"
+         x="341"
+         id="rect12" />
+      <text
+         class="actor actor-box"
+         alignment-baseline="central"
+         dominant-baseline="central"
+         style="font-weight:400;font-size:22px;text-anchor:middle"
+         y="96.5"
+         x="459"
+         id="text13"><tspan
+           dy="0"
+           x="459"
+           id="tspan13">Kubernetes API服务器</tspan></text>
+    </g>
+  </g>
+  <g
+     id="g14">
+    <line
+       name="User"
+       stroke="#999"
+       stroke-width="0.5px"
+       class="actor-line 200"
+       y2="1002"
+       x2="75"
+       y1="129"
+       x1="75"
+       id="actor102" />
+    <g
+       id="root-102">
+      <rect
+         class="actor actor-top"
+         ry="3"
+         rx="3"
+         name="User"
+         height="65"
+         width="150"
+         stroke="#666"
+         fill="#eaeaea"
+         y="64"
+         x="0"
+         id="rect13" />
+      <text
+         class="actor actor-box"
+         alignment-baseline="central"
+         dominant-baseline="central"
+         style="font-weight:400;font-size:22px;text-anchor:middle"
+         y="96.5"
+         x="75"
+         id="text14"><tspan
+           x="75"
+           id="tspan14">用户</tspan></text>
+    </g>
+  </g>
+  <style
+     id="style14">#graph-div{font-family:&quot;trebuchet ms&quot;,verdana,arial,sans-serif;font-size:22px;fill:#000000;}#graph-div .error-icon{fill:#552222;}#graph-div .error-text{fill:#552222;stroke:#552222;}#graph-div .edge-thickness-normal{stroke-width:1px;}#graph-div .edge-thickness-thick{stroke-width:3.5px;}#graph-div .edge-pattern-solid{stroke-dasharray:0;}#graph-div .edge-thickness-invisible{stroke-width:0;fill:none;}#graph-div .edge-pattern-dashed{stroke-dasharray:3;}#graph-div .edge-pattern-dotted{stroke-dasharray:2;}#graph-div .marker{fill:#666;stroke:#666;}#graph-div .marker.cross{stroke:#666;}#graph-div svg{font-family:&quot;trebuchet ms&quot;,verdana,arial,sans-serif;font-size:22px;}#graph-div p{margin:0;}#graph-div .actor{stroke:hsl(0, 0%, 83%);fill:#326ce5;}#graph-div text.actor&gt;tspan{fill:white;stroke:none;}#graph-div .actor-line{stroke:hsl(0, 0%, 83%);}#graph-div .messageLine0{stroke-width:1.5;stroke-dasharray:none;stroke:#333;}#graph-div .messageLine1{stroke-width:1.5;stroke-dasharray:2,2;stroke:#333;}#graph-div #arrowhead path{fill:#333;stroke:#333;}#graph-div .sequenceNumber{fill:white;}#graph-div #sequencenumber{fill:#333;}#graph-div #crosshead path{fill:#333;stroke:#333;}#graph-div .messageText{fill:#333;stroke:none;}#graph-div .labelBox{stroke:hsl(0, 0%, 83%);fill:#eee;}#graph-div .labelText,#graph-div .labelText&gt;tspan{fill:#333;stroke:none;}#graph-div .loopText,#graph-div .loopText&gt;tspan{fill:#326ce5;stroke:none;}#graph-div .loopLine{stroke-width:2px;stroke-dasharray:2,2;stroke:hsl(0, 0%, 83%);fill:hsl(0, 0%, 83%);}#graph-div .note{stroke:#999;fill:grey;}#graph-div .noteText,#graph-div .noteText&gt;tspan{fill:#fff;stroke:none;}#graph-div .activation0{fill:#f4f4f4;stroke:#666;}#graph-div .activation1{fill:#f4f4f4;stroke:#666;}#graph-div .activation2{fill:#f4f4f4;stroke:#666;}#graph-div .actorPopupMenu{position:absolute;}#graph-div .actorPopupMenuPanel{position:absolute;fill:#326ce5;box-shadow:0px 8px 16px 0px rgba(0,0,0,0.2);filter:drop-shadow(3px 5px 2px rgb(0 0 0 / 0.4));}#graph-div .actor-man line{stroke:hsl(0, 0%, 83%);fill:#326ce5;}#graph-div .actor-man circle,#graph-div line{stroke:hsl(0, 0%, 83%);fill:#326ce5;stroke-width:2px;}#graph-div :root{--mermaid-font-family:&quot;trebuchet ms&quot;,verdana,arial,sans-serif;}</style>
+  <g
+     id="g15" />
+  <defs
+     id="defs15">
+    <symbol
+       height="24"
+       width="24"
+       id="computer">
+      <path
+         d="M2 2v13h20v-13h-20zm18 11h-16v-9h16v9zm-10.228 6l.466-1h3.524l.467 1h-4.457zm14.228 3h-24l2-6h2.104l-1.33 4h18.45l-1.297-4h2.073l2 6zm-5-10h-14v-7h14v7z"
+         transform="scale(.5)"
+         id="path15" />
+    </symbol>
+  </defs>
+  <defs
+     id="defs16">
+    <symbol
+       clip-rule="evenodd"
+       fill-rule="evenodd"
+       id="database">
+      <path
+         d="M12.258.001l.256.004.255.005.253.008.251.01.249.012.247.015.246.016.242.019.241.02.239.023.236.024.233.027.231.028.229.031.225.032.223.034.22.036.217.038.214.04.211.041.208.043.205.045.201.046.198.048.194.05.191.051.187.053.183.054.18.056.175.057.172.059.168.06.163.061.16.063.155.064.15.066.074.033.073.033.071.034.07.034.069.035.068.035.067.035.066.035.064.036.064.036.062.036.06.036.06.037.058.037.058.037.055.038.055.038.053.038.052.038.051.039.05.039.048.039.047.039.045.04.044.04.043.04.041.04.04.041.039.041.037.041.036.041.034.041.033.042.032.042.03.042.029.042.027.042.026.043.024.043.023.043.021.043.02.043.018.044.017.043.015.044.013.044.012.044.011.045.009.044.007.045.006.045.004.045.002.045.001.045v17l-.001.045-.002.045-.004.045-.006.045-.007.045-.009.044-.011.045-.012.044-.013.044-.015.044-.017.043-.018.044-.02.043-.021.043-.023.043-.024.043-.026.043-.027.042-.029.042-.03.042-.032.042-.033.042-.034.041-.036.041-.037.041-.039.041-.04.041-.041.04-.043.04-.044.04-.045.04-.047.039-.048.039-.05.039-.051.039-.052.038-.053.038-.055.038-.055.038-.058.037-.058.037-.06.037-.06.036-.062.036-.064.036-.064.036-.066.035-.067.035-.068.035-.069.035-.07.034-.071.034-.073.033-.074.033-.15.066-.155.064-.16.063-.163.061-.168.06-.172.059-.175.057-.18.056-.183.054-.187.053-.191.051-.194.05-.198.048-.201.046-.205.045-.208.043-.211.041-.214.04-.217.038-.22.036-.223.034-.225.032-.229.031-.231.028-.233.027-.236.024-.239.023-.241.02-.242.019-.246.016-.247.015-.249.012-.251.01-.253.008-.255.005-.256.004-.258.001-.258-.001-.256-.004-.255-.005-.253-.008-.251-.01-.249-.012-.247-.015-.245-.016-.243-.019-.241-.02-.238-.023-.236-.024-.234-.027-.231-.028-.228-.031-.226-.032-.223-.034-.22-.036-.217-.038-.214-.04-.211-.041-.208-.043-.204-.045-.201-.046-.198-.048-.195-.05-.19-.051-.187-.053-.184-.054-.179-.056-.176-.057-.172-.059-.167-.06-.164-.061-.159-.063-.155-.064-.151-.066-.074-.033-.072-.033-.072-.034-.07-.034-.069-.035-.068-.035-.067-.035-.066-.035-.064-.036-.063-.036-.062-.036-.061-.036-.06-.037-.058-.037-.057-.037-.056-.038-.055-.038-.053-.038-.052-.038-.051-.039-.049-.039-.049-.039-.046-.039-.046-.04-.044-.04-.043-.04-.041-.04-.04-.041-.039-.041-.037-.041-.036-.041-.034-.041-.033-.042-.032-.042-.03-.042-.029-.042-.027-.042-.026-.043-.024-.043-.023-.043-.021-.043-.02-.043-.018-.044-.017-.043-.015-.044-.013-.044-.012-.044-.011-.045-.009-.044-.007-.045-.006-.045-.004-.045-.002-.045-.001-.045v-17l.001-.045.002-.045.004-.045.006-.045.007-.045.009-.044.011-.045.012-.044.013-.044.015-.044.017-.043.018-.044.02-.043.021-.043.023-.043.024-.043.026-.043.027-.042.029-.042.03-.042.032-.042.033-.042.034-.041.036-.041.037-.041.039-.041.04-.041.041-.04.043-.04.044-.04.046-.04.046-.039.049-.039.049-.039.051-.039.052-.038.053-.038.055-.038.056-.038.057-.037.058-.037.06-.037.061-.036.062-.036.063-.036.064-.036.066-.035.067-.035.068-.035.069-.035.07-.034.072-.034.072-.033.074-.033.151-.066.155-.064.159-.063.164-.061.167-.06.172-.059.176-.057.179-.056.184-.054.187-.053.19-.051.195-.05.198-.048.201-.046.204-.045.208-.043.211-.041.214-.04.217-.038.22-.036.223-.034.226-.032.228-.031.231-.028.234-.027.236-.024.238-.023.241-.02.243-.019.245-.016.247-.015.249-.012.251-.01.253-.008.255-.005.256-.004.258-.001.258.001zm-9.258 20.499v.01l.001.021.003.021.004.022.005.021.006.022.007.022.009.023.01.022.011.023.012.023.013.023.015.023.016.024.017.023.018.024.019.024.021.024.022.025.023.024.024.025.052.049.056.05.061.051.066.051.07.051.075.051.079.052.084.052.088.052.092.052.097.052.102.051.105.052.11.052.114.051.119.051.123.051.127.05.131.05.135.05.139.048.144.049.147.047.152.047.155.047.16.045.163.045.167.043.171.043.176.041.178.041.183.039.187.039.19.037.194.035.197.035.202.033.204.031.209.03.212.029.216.027.219.025.222.024.226.021.23.02.233.018.236.016.24.015.243.012.246.01.249.008.253.005.256.004.259.001.26-.001.257-.004.254-.005.25-.008.247-.011.244-.012.241-.014.237-.016.233-.018.231-.021.226-.021.224-.024.22-.026.216-.027.212-.028.21-.031.205-.031.202-.034.198-.034.194-.036.191-.037.187-.039.183-.04.179-.04.175-.042.172-.043.168-.044.163-.045.16-.046.155-.046.152-.047.148-.048.143-.049.139-.049.136-.05.131-.05.126-.05.123-.051.118-.052.114-.051.11-.052.106-.052.101-.052.096-.052.092-.052.088-.053.083-.051.079-.052.074-.052.07-.051.065-.051.06-.051.056-.05.051-.05.023-.024.023-.025.021-.024.02-.024.019-.024.018-.024.017-.024.015-.023.014-.024.013-.023.012-.023.01-.023.01-.022.008-.022.006-.022.006-.022.004-.022.004-.021.001-.021.001-.021v-4.127l-.077.055-.08.053-.083.054-.085.053-.087.052-.09.052-.093.051-.095.05-.097.05-.1.049-.102.049-.105.048-.106.047-.109.047-.111.046-.114.045-.115.045-.118.044-.12.043-.122.042-.124.042-.126.041-.128.04-.13.04-.132.038-.134.038-.135.037-.138.037-.139.035-.142.035-.143.034-.144.033-.147.032-.148.031-.15.03-.151.03-.153.029-.154.027-.156.027-.158.026-.159.025-.161.024-.162.023-.163.022-.165.021-.166.02-.167.019-.169.018-.169.017-.171.016-.173.015-.173.014-.175.013-.175.012-.177.011-.178.01-.179.008-.179.008-.181.006-.182.005-.182.004-.184.003-.184.002h-.37l-.184-.002-.184-.003-.182-.004-.182-.005-.181-.006-.179-.008-.179-.008-.178-.01-.176-.011-.176-.012-.175-.013-.173-.014-.172-.015-.171-.016-.17-.017-.169-.018-.167-.019-.166-.02-.165-.021-.163-.022-.162-.023-.161-.024-.159-.025-.157-.026-.156-.027-.155-.027-.153-.029-.151-.03-.15-.03-.148-.031-.146-.032-.145-.033-.143-.034-.141-.035-.14-.035-.137-.037-.136-.037-.134-.038-.132-.038-.13-.04-.128-.04-.126-.041-.124-.042-.122-.042-.12-.044-.117-.043-.116-.045-.113-.045-.112-.046-.109-.047-.106-.047-.105-.048-.102-.049-.1-.049-.097-.05-.095-.05-.093-.052-.09-.051-.087-.052-.085-.053-.083-.054-.08-.054-.077-.054v4.127zm0-5.654v.011l.001.021.003.021.004.021.005.022.006.022.007.022.009.022.01.022.011.023.012.023.013.023.015.024.016.023.017.024.018.024.019.024.021.024.022.024.023.025.024.024.052.05.056.05.061.05.066.051.07.051.075.052.079.051.084.052.088.052.092.052.097.052.102.052.105.052.11.051.114.051.119.052.123.05.127.051.131.05.135.049.139.049.144.048.147.048.152.047.155.046.16.045.163.045.167.044.171.042.176.042.178.04.183.04.187.038.19.037.194.036.197.034.202.033.204.032.209.03.212.028.216.027.219.025.222.024.226.022.23.02.233.018.236.016.24.014.243.012.246.01.249.008.253.006.256.003.259.001.26-.001.257-.003.254-.006.25-.008.247-.01.244-.012.241-.015.237-.016.233-.018.231-.02.226-.022.224-.024.22-.025.216-.027.212-.029.21-.03.205-.032.202-.033.198-.035.194-.036.191-.037.187-.039.183-.039.179-.041.175-.042.172-.043.168-.044.163-.045.16-.045.155-.047.152-.047.148-.048.143-.048.139-.05.136-.049.131-.05.126-.051.123-.051.118-.051.114-.052.11-.052.106-.052.101-.052.096-.052.092-.052.088-.052.083-.052.079-.052.074-.051.07-.052.065-.051.06-.05.056-.051.051-.049.023-.025.023-.024.021-.025.02-.024.019-.024.018-.024.017-.024.015-.023.014-.023.013-.024.012-.022.01-.023.01-.023.008-.022.006-.022.006-.022.004-.021.004-.022.001-.021.001-.021v-4.139l-.077.054-.08.054-.083.054-.085.052-.087.053-.09.051-.093.051-.095.051-.097.05-.1.049-.102.049-.105.048-.106.047-.109.047-.111.046-.114.045-.115.044-.118.044-.12.044-.122.042-.124.042-.126.041-.128.04-.13.039-.132.039-.134.038-.135.037-.138.036-.139.036-.142.035-.143.033-.144.033-.147.033-.148.031-.15.03-.151.03-.153.028-.154.028-.156.027-.158.026-.159.025-.161.024-.162.023-.163.022-.165.021-.166.02-.167.019-.169.018-.169.017-.171.016-.173.015-.173.014-.175.013-.175.012-.177.011-.178.009-.179.009-.179.007-.181.007-.182.005-.182.004-.184.003-.184.002h-.37l-.184-.002-.184-.003-.182-.004-.182-.005-.181-.007-.179-.007-.179-.009-.178-.009-.176-.011-.176-.012-.175-.013-.173-.014-.172-.015-.171-.016-.17-.017-.169-.018-.167-.019-.166-.02-.165-.021-.163-.022-.162-.023-.161-.024-.159-.025-.157-.026-.156-.027-.155-.028-.153-.028-.151-.03-.15-.03-.148-.031-.146-.033-.145-.033-.143-.033-.141-.035-.14-.036-.137-.036-.136-.037-.134-.038-.132-.039-.13-.039-.128-.04-.126-.041-.124-.042-.122-.043-.12-.043-.117-.044-.116-.044-.113-.046-.112-.046-.109-.046-.106-.047-.105-.048-.102-.049-.1-.049-.097-.05-.095-.051-.093-.051-.09-.051-.087-.053-.085-.052-.083-.054-.08-.054-.077-.054v4.139zm0-5.666v.011l.001.02.003.022.004.021.005.022.006.021.007.022.009.023.01.022.011.023.012.023.013.023.015.023.016.024.017.024.018.023.019.024.021.025.022.024.023.024.024.025.052.05.056.05.061.05.066.051.07.051.075.052.079.051.084.052.088.052.092.052.097.052.102.052.105.051.11.052.114.051.119.051.123.051.127.05.131.05.135.05.139.049.144.048.147.048.152.047.155.046.16.045.163.045.167.043.171.043.176.042.178.04.183.04.187.038.19.037.194.036.197.034.202.033.204.032.209.03.212.028.216.027.219.025.222.024.226.021.23.02.233.018.236.017.24.014.243.012.246.01.249.008.253.006.256.003.259.001.26-.001.257-.003.254-.006.25-.008.247-.01.244-.013.241-.014.237-.016.233-.018.231-.02.226-.022.224-.024.22-.025.216-.027.212-.029.21-.03.205-.032.202-.033.198-.035.194-.036.191-.037.187-.039.183-.039.179-.041.175-.042.172-.043.168-.044.163-.045.16-.045.155-.047.152-.047.148-.048.143-.049.139-.049.136-.049.131-.051.126-.05.123-.051.118-.052.114-.051.11-.052.106-.052.101-.052.096-.052.092-.052.088-.052.083-.052.079-.052.074-.052.07-.051.065-.051.06-.051.056-.05.051-.049.023-.025.023-.025.021-.024.02-.024.019-.024.018-.024.017-.024.015-.023.014-.024.013-.023.012-.023.01-.022.01-.023.008-.022.006-.022.006-.022.004-.022.004-.021.001-.021.001-.021v-4.153l-.077.054-.08.054-.083.053-.085.053-.087.053-.09.051-.093.051-.095.051-.097.05-.1.049-.102.048-.105.048-.106.048-.109.046-.111.046-.114.046-.115.044-.118.044-.12.043-.122.043-.124.042-.126.041-.128.04-.13.039-.132.039-.134.038-.135.037-.138.036-.139.036-.142.034-.143.034-.144.033-.147.032-.148.032-.15.03-.151.03-.153.028-.154.028-.156.027-.158.026-.159.024-.161.024-.162.023-.163.023-.165.021-.166.02-.167.019-.169.018-.169.017-.171.016-.173.015-.173.014-.175.013-.175.012-.177.01-.178.01-.179.009-.179.007-.181.006-.182.006-.182.004-.184.003-.184.001-.185.001-.185-.001-.184-.001-.184-.003-.182-.004-.182-.006-.181-.006-.179-.007-.179-.009-.178-.01-.176-.01-.176-.012-.175-.013-.173-.014-.172-.015-.171-.016-.17-.017-.169-.018-.167-.019-.166-.02-.165-.021-.163-.023-.162-.023-.161-.024-.159-.024-.157-.026-.156-.027-.155-.028-.153-.028-.151-.03-.15-.03-.148-.032-.146-.032-.145-.033-.143-.034-.141-.034-.14-.036-.137-.036-.136-.037-.134-.038-.132-.039-.13-.039-.128-.041-.126-.041-.124-.041-.122-.043-.12-.043-.117-.044-.116-.044-.113-.046-.112-.046-.109-.046-.106-.048-.105-.048-.102-.048-.1-.05-.097-.049-.095-.051-.093-.051-.09-.052-.087-.052-.085-.053-.083-.053-.08-.054-.077-.054v4.153zm8.74-8.179l-.257.004-.254.005-.25.008-.247.011-.244.012-.241.014-.237.016-.233.018-.231.021-.226.022-.224.023-.22.026-.216.027-.212.028-.21.031-.205.032-.202.033-.198.034-.194.036-.191.038-.187.038-.183.04-.179.041-.175.042-.172.043-.168.043-.163.045-.16.046-.155.046-.152.048-.148.048-.143.048-.139.049-.136.05-.131.05-.126.051-.123.051-.118.051-.114.052-.11.052-.106.052-.101.052-.096.052-.092.052-.088.052-.083.052-.079.052-.074.051-.07.052-.065.051-.06.05-.056.05-.051.05-.023.025-.023.024-.021.024-.02.025-.019.024-.018.024-.017.023-.015.024-.014.023-.013.023-.012.023-.01.023-.01.022-.008.022-.006.023-.006.021-.004.022-.004.021-.001.021-.001.021.001.021.001.021.004.021.004.022.006.021.006.023.008.022.01.022.01.023.012.023.013.023.014.023.015.024.017.023.018.024.019.024.02.025.021.024.023.024.023.025.051.05.056.05.06.05.065.051.07.052.074.051.079.052.083.052.088.052.092.052.096.052.101.052.106.052.11.052.114.052.118.051.123.051.126.051.131.05.136.05.139.049.143.048.148.048.152.048.155.046.16.046.163.045.168.043.172.043.175.042.179.041.183.04.187.038.191.038.194.036.198.034.202.033.205.032.21.031.212.028.216.027.22.026.224.023.226.022.231.021.233.018.237.016.241.014.244.012.247.011.25.008.254.005.257.004.26.001.26-.001.257-.004.254-.005.25-.008.247-.011.244-.012.241-.014.237-.016.233-.018.231-.021.226-.022.224-.023.22-.026.216-.027.212-.028.21-.031.205-.032.202-.033.198-.034.194-.036.191-.038.187-.038.183-.04.179-.041.175-.042.172-.043.168-.043.163-.045.16-.046.155-.046.152-.048.148-.048.143-.048.139-.049.136-.05.131-.05.126-.051.123-.051.118-.051.114-.052.11-.052.106-.052.101-.052.096-.052.092-.052.088-.052.083-.052.079-.052.074-.051.07-.052.065-.051.06-.05.056-.05.051-.05.023-.025.023-.024.021-.024.02-.025.019-.024.018-.024.017-.023.015-.024.014-.023.013-.023.012-.023.01-.023.01-.022.008-.022.006-.023.006-.021.004-.022.004-.021.001-.021.001-.021-.001-.021-.001-.021-.004-.021-.004-.022-.006-.021-.006-.023-.008-.022-.01-.022-.01-.023-.012-.023-.013-.023-.014-.023-.015-.024-.017-.023-.018-.024-.019-.024-.02-.025-.021-.024-.023-.024-.023-.025-.051-.05-.056-.05-.06-.05-.065-.051-.07-.052-.074-.051-.079-.052-.083-.052-.088-.052-.092-.052-.096-.052-.101-.052-.106-.052-.11-.052-.114-.052-.118-.051-.123-.051-.126-.051-.131-.05-.136-.05-.139-.049-.143-.048-.148-.048-.152-.048-.155-.046-.16-.046-.163-.045-.168-.043-.172-.043-.175-.042-.179-.041-.183-.04-.187-.038-.191-.038-.194-.036-.198-.034-.202-.033-.205-.032-.21-.031-.212-.028-.216-.027-.22-.026-.224-.023-.226-.022-.231-.021-.233-.018-.237-.016-.241-.014-.244-.012-.247-.011-.25-.008-.254-.005-.257-.004-.26-.001-.26.001z"
+         transform="scale(.5)"
+         id="path16" />
+    </symbol>
+  </defs>
+  <defs
+     id="defs17">
+    <symbol
+       height="24"
+       width="24"
+       id="clock">
+      <path
+         d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10-10-4.486-10-10 4.486-10 10-10zm0-2c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm5.848 12.459c.202.038.202.333.001.372-1.907.361-6.045 1.111-6.547 1.111-.719 0-1.301-.582-1.301-1.301 0-.512.77-5.447 1.125-7.445.034-.192.312-.181.343.014l.985 6.238 5.394 1.011z"
+         transform="scale(.5)"
+         id="path17" />
+    </symbol>
+  </defs>
+  <defs
+     id="defs18">
+    <marker
+       orient="auto-start-reverse"
+       markerHeight="12"
+       markerWidth="12"
+       markerUnits="userSpaceOnUse"
+       refY="5"
+       refX="7.9"
+       id="arrowhead">
+      <path
+         d="M -1 0 L 10 5 L 0 10 z"
+         id="path18" />
+    </marker>
+  </defs>
+  <defs
+     id="defs19">
+    <marker
+       refY="4.5"
+       refX="4"
+       orient="auto"
+       markerHeight="8"
+       markerWidth="15"
+       id="crosshead">
+      <path
+         d="M 1,2 L 6,7 M 6,2 L 1,7"
+         stroke-width="1pt"
+         style="stroke-dasharray: 0px, 0px;"
+         stroke="#000000"
+         fill="none"
+         id="path19" />
+    </marker>
+  </defs>
+  <defs
+     id="defs20">
+    <marker
+       orient="auto"
+       markerHeight="28"
+       markerWidth="20"
+       refY="7"
+       refX="15.5"
+       id="filled-head">
+      <path
+         d="M 18,7 L9,13 L14,7 L9,1 Z"
+         id="path20" />
+    </marker>
+  </defs>
+  <defs
+     id="defs21">
+    <marker
+       orient="auto"
+       markerHeight="40"
+       markerWidth="60"
+       refY="15"
+       refX="15"
+       id="sequencenumber">
+      <circle
+         r="6"
+         cy="15"
+         cx="15"
+         id="circle20" />
+    </marker>
+  </defs>
+  <g
+     id="g25">
+    <line
+       class="loopLine"
+       y2="294"
+       x2="1193.5"
+       y1="294"
+       x1="771.5"
+       id="line21" />
+    <line
+       class="loopLine"
+       y2="474"
+       x2="1193.5"
+       y1="294"
+       x1="1193.5"
+       id="line22" />
+    <line
+       class="loopLine"
+       y2="474"
+       x2="1193.5"
+       y1="474"
+       x1="771.5"
+       id="line23" />
+    <line
+       class="loopLine"
+       y2="474"
+       x2="771.5"
+       y1="294"
+       x1="771.5"
+       id="line24" />
+    <polygon
+       class="labelBox"
+       points="771.5,294 821.5,294 821.5,307 813.1,314 771.5,314"
+       id="polygon24" />
+    <text
+       class="labelText"
+       style="font-size: 22px; font-weight: 400;"
+       alignment-baseline="middle"
+       dominant-baseline="middle"
+       text-anchor="middle"
+       y="307"
+       x="797"
+       id="text24">loop</text>
+    <text
+       class="loopText"
+       style="font-weight:400;font-size:22px"
+       text-anchor="middle"
+       y="312"
+       x="1007.5"
+       id="text25"><tspan
+         x="1007.5"
+         id="tspan24">[对于所有变更性 Webhook]</tspan></text>
+  </g>
+  <g
+     id="g29">
+    <line
+       class="loopLine"
+       y2="484"
+       x2="1506"
+       y1="484"
+       x1="771.5"
+       id="line25" />
+    <line
+       class="loopLine"
+       y2="664"
+       x2="1506"
+       y1="484"
+       x1="1506"
+       id="line26" />
+    <line
+       class="loopLine"
+       y2="664"
+       x2="1506"
+       y1="664"
+       x1="771.5"
+       id="line27" />
+    <line
+       class="loopLine"
+       y2="664"
+       x2="771.5"
+       y1="484"
+       x1="771.5"
+       id="line28" />
+    <polygon
+       class="labelBox"
+       points="771.5,484 821.5,484 821.5,497 813.1,504 771.5,504"
+       id="polygon28" />
+    <text
+       class="labelText"
+       style="font-size: 22px; font-weight: 400;"
+       alignment-baseline="middle"
+       dominant-baseline="middle"
+       text-anchor="middle"
+       y="497"
+       x="797"
+       id="text28">loop</text>
+    <text
+       class="loopText"
+       style="font-weight:400;font-size:22px"
+       text-anchor="middle"
+       y="502"
+       x="1163.75"
+       id="text29"><tspan
+         x="1163.75"
+         id="tspan28">[对于所有验证策略]</tspan></text>
+  </g>
+  <g
+     id="g33">
+    <line
+       class="loopLine"
+       y2="674"
+       x2="1823"
+       y1="674"
+       x1="771.5"
+       id="line29" />
+    <line
+       class="loopLine"
+       y2="854"
+       x2="1823"
+       y1="674"
+       x1="1823"
+       id="line30" />
+    <line
+       class="loopLine"
+       y2="854"
+       x2="1823"
+       y1="854"
+       x1="771.5"
+       id="line31" />
+    <line
+       class="loopLine"
+       y2="854"
+       x2="771.5"
+       y1="674"
+       x1="771.5"
+       id="line32" />
+    <polygon
+       class="labelBox"
+       points="771.5,674 821.5,674 821.5,687 813.1,694 771.5,694"
+       id="polygon32" />
+    <text
+       class="labelText"
+       style="font-size: 22px; font-weight: 400;"
+       alignment-baseline="middle"
+       dominant-baseline="middle"
+       text-anchor="middle"
+       y="687"
+       x="797"
+       id="text32">par</text>
+    <text
+       class="loopText"
+       style="font-weight:400;font-size:22px"
+       text-anchor="middle"
+       y="692"
+       x="1322.25"
+       id="text33"><tspan
+         x="1322.25"
+         id="tspan32">[对于并行的所有验证性 Webhook]</tspan></text>
+  </g>
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="163.19174"
+     x="254.95021"
+     id="text34">请求（例如创建Pod）</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="193"
+     x2="455"
+     y1="193"
+     x1="76"
+     id="line34" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="208"
+     x="619"
+     id="text35">用户身份认证</text>
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="234"
+     x="619"
+     id="text36">检查用户权限</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="284"
+     x2="778.5"
+     y1="284"
+     x1="460"
+     id="line36" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="351"
+     x="981"
+     id="text37">调用变更性 Webhook</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="400"
+     x2="1178.5"
+     y1="400"
+     x1="783.5"
+     id="line37" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="415"
+     x="984"
+     id="text38">修改或拒绝对象（如果需要）</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="464"
+     x2="786.5"
+     y1="464"
+     x1="1181.5"
+     id="line38" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="541"
+     x="1137"
+     id="text39">调用验证策略</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="590"
+     x2="1491"
+     y1="590"
+     x1="783.5"
+     id="line39" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="605"
+     x="1140"
+     id="text40">拒绝对象（如果需要）</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="654"
+     x2="786.5"
+     y1="654"
+     x1="1494"
+     id="line40" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="731"
+     x="1296"
+     id="text41">调用验证性 Webhook</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="780"
+     x2="1808"
+     y1="780"
+     x1="783.5"
+     id="line41" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="795"
+     x="1140"
+     id="text42">拒绝对象（如果需要）</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="844"
+     x2="786.5"
+     y1="844"
+     x1="1494"
+     id="line42" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="869"
+     x="622"
+     id="text43">允许或拒绝请求</text>
+  <line
+     marker-end="url(#arrowhead)"
+     style="fill: none;"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine0"
+     y2="918"
+     x2="463"
+     y1="918"
+     x1="781.5"
+     id="line43" />
+  <text
+     class="messageText"
+     style="font-weight:400;font-size:22px"
+     alignment-baseline="middle"
+     dominant-baseline="middle"
+     text-anchor="middle"
+     y="933"
+     x="269"
+     id="text44">响应（例如成功或报错）</text>
+  <line
+     marker-end="url(#arrowhead)"
+     stroke="none"
+     stroke-width="2"
+     class="messageLine1"
+     style="stroke-dasharray: 3px, 3px; fill: none;"
+     y2="982"
+     x2="79"
+     y1="982"
+     x1="458"
+     id="line44" />
+</svg>


### PR DESCRIPTION
Sync with en #43836 

```
content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
```
See [preview](https://deploy-preview-49876--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/access-authn-authz/admission-controllers/#admission-control-phases)