### PR TITLE
Added "LinkedIn" to en.toml

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -63,7 +63,7 @@ other = "GitHub"
 # Also cover [community_learn] if localizing this site
 
 [community_linkedin_name]
-other = "LinkedIn
+other = "LinkedIn"
 
 [community_server_fault_name]
 other = "Server Fault"

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -62,6 +62,9 @@ other = "GitHub"
 
 # Also cover [community_learn] if localizing this site
 
+[community_linkedin_name]
+other = "LinkedIn
+
 [community_server_fault_name]
 other = "Server Fault"
 


### PR DESCRIPTION

### Description

This PR adds "LinkedIn" to the Community page that is currently missing.
Before | After
--- | --
<img width="1134" alt="Monosnap Image 2025-02-24 10-04-43" src="https://github.com/user-attachments/assets/1c1ead48-9bd6-40c8-b8bd-46da8895e06e" /> | <img width="1134" alt="Monosnap Image 2025-02-24 10-10-19" src="https://github.com/user-attachments/assets/fa14643e-ab87-4357-91bb-5ae0f7521043" />



### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #