### PR TITLE
[dev-1.33] KEP-3619: Promote Fine-grained SupplementalGroups control to Beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/SupplementalGroupsPolicy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/SupplementalGroupsPolicy.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.31"
+    toVersion: "1.32"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.33"
 ---
 Enables support for fine-grained SupplementalGroups control.
 For more details, see [Configure fine-grained SupplementalGroups control for a Pod](/content/en/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy).

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -336,6 +336,25 @@ status:
   features:
     supplementalGroupsPolicy: true
 ```
+{{<note>}}
+At this alpha release(from v1.31 to v1.32), when a pod with `SupplementalGroupsPolicy=Strict` are scheduled to a node that does NOT support this feature(i.e. `.status.features.supplementalGroupsPolicy=false`), the pod's supplemental groups policy gets fallback-ed to the `Merge` policy _silently_.
+
+However, since the beta release (v1.33), to enforce the policy more strictly, __such pod creation will be rejected by kubelet because the node can not ensure the specified policy__. When your pod is rejected, you will see warning events with `reason=SupplementalGroupsPolicyNotSupported` like below:
+
+```yaml
+apiVersion: v1
+kind: Event
+...
+type: Warning
+reason: SupplementalGroupsPolicyNotSupported
+message: "SupplementalGroupsPolicy=Strict is not supported in this node"
+involvedObject:
+  apiVersion: v1
+  kind: Pod
+  ...
+```
+{{</note>}}
+
 
 ## Configure volume permission and ownership change policy for Pods
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -337,7 +337,7 @@ status:
     supplementalGroupsPolicy: true
 ```
 {{<note>}}
-At this alpha release(from v1.31 to v1.32), when a pod with `SupplementalGroupsPolicy=Strict` are scheduled to a node that does NOT support this feature(i.e. `.status.features.supplementalGroupsPolicy=false`), the pod's supplemental groups policy gets fallback-ed to the `Merge` policy _silently_.
+At this alpha release(from v1.31 to v1.32), when a pod with `SupplementalGroupsPolicy=Strict` are scheduled to a node that does NOT support this feature(i.e. `.status.features.supplementalGroupsPolicy=false`), the pod's supplemental groups policy falls back to the `Merge` policy _silently_.
 
 However, since the beta release (v1.33), to enforce the policy more strictly, __such pod creation will be rejected by kubelet because the node can not ensure the specified policy__. When your pod is rejected, you will see warning events with `reason=SupplementalGroupsPolicyNotSupported` like below:
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -339,7 +339,7 @@ status:
 {{<note>}}
 At this alpha release(from v1.31 to v1.32), when a pod with `SupplementalGroupsPolicy=Strict` are scheduled to a node that does NOT support this feature(i.e. `.status.features.supplementalGroupsPolicy=false`), the pod's supplemental groups policy falls back to the `Merge` policy _silently_.
 
-However, since the beta release (v1.33), to enforce the policy more strictly, __such pod creation will be rejected by kubelet because the node can not ensure the specified policy__. When your pod is rejected, you will see warning events with `reason=SupplementalGroupsPolicyNotSupported` like below:
+However, since the beta release (v1.33), to enforce the policy more strictly, __such pod creation will be rejected by kubelet because the node cannot ensure the specified policy__. When your pod is rejected, you will see warning events with `reason=SupplementalGroupsPolicyNotSupported` like below:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->

### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This PR updates a user-facing document for https://github.com/kubernetes/enhancements/issues/3619 in [Configure a Security Context for a Pod or Container](https://deploy-preview-46920--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/security-context/)

- bump the feature gate information to beta
- adds the behavioral change(pod rejection when the pod uses `Strict` policy and get scheduled to a node that does NOT support this feature) introduced in beta release in notes. 

### Preview

https://deploy-preview-49880--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/security-context/

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

For
- https://github.com/kubernetes/enhancements/issues/3619

Depends on:
- k/k
  - https://github.com/kubernetes/kubernetes/pull/130210
