### PR TITLE
Propose new playground for kubernetes practice labs

### DIFF
--- a/content/de/includes/task-tutorial-prereqs.md
+++ b/content/de/includes/task-tutorial-prereqs.md
@@ -1,5 +1,5 @@
 Sie benötigen einen Kubernetes-Cluster, und das Kommandozeilen-Tool kubectl muss für die Kommunikation mit Ihrem Cluster konfiguriert sein. Wenn Sie noch keinen Cluster haben, können Sie ihn mit [Minikube](/docs/setup/minikube) erstellen.
 
 Oder Sie können einen dieser Kubernetes-Spielplätze benutzen:
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [KodeKloud](https://kodekloud.com/public-playgrounds)
 * [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Katacoda is closed. I would like to propose a new playground to be added: **KodeKloud Kubernetes Playgrounds**. It's an open playground, supporting multiple versions of kubernetes to try out, and no Sign Ups needed too. Making learning quick.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #49890