### PR TITLE
Updating OWNERS files with filters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,6 @@ insert_final_newline = true
 
 [Makefile]
 indent_style = tab
+
+[OWNERS]
+indent_size = 2

--- a/assets/images/OWNERS
+++ b/assets/images/OWNERS
@@ -4,13 +4,12 @@
 # reviewers to review and approve.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-en-reviews
-
-approvers:
-- sig-docs-en-owners
-
 filters:
+  ".*":
+    reviewers:
+    - sig-docs-en-reviews
+    approvers:
+    - sig-docs-en-owners
   "\\.svg":
     labels:
     - area/web-development

--- a/i18n/bn/OWNERS
+++ b/i18n/bn/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Bengali.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-bn-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-bn-owners
+    reviewers:
+    - sig-docs-bn-reviews
 
-labels:
-- area/localization
-- language/bn
+    approvers:
+    - sig-docs-bn-owners
+
+    labels:
+    - area/localization
+    - language/bn

--- a/i18n/de/OWNERS
+++ b/i18n/de/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for German.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-de-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-de-owners
+    reviewers:
+    - sig-docs-de-reviews
 
-labels:
-- area/localization
-- language/de
+    approvers:
+    - sig-docs-de-owners
+
+    labels:
+    - area/localization
+    - language/de

--- a/i18n/en/OWNERS
+++ b/i18n/en/OWNERS
@@ -3,11 +3,14 @@
 # Upstream (English) localized strings.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-en-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-en-owners
+    reviewers:
+    - sig-docs-en-reviews
 
-labels:
-- language/en
+    approvers:
+    - sig-docs-en-owners
+
+    labels:
+    - language/en

--- a/i18n/es/OWNERS
+++ b/i18n/es/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Spanish.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-es-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-es-owners
+    reviewers:
+    - sig-docs-es-reviews
 
-labels:
-- area/localization
-- language/es
+    approvers:
+    - sig-docs-es-owners
+
+    labels:
+    - area/localization
+    - language/es

--- a/i18n/fr/OWNERS
+++ b/i18n/fr/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for French.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-fr-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-fr-owners
+    reviewers:
+    - sig-docs-fr-reviews
 
-labels:
-- area/localization
-- language/fr
+    approvers:
+    - sig-docs-fr-owners
+
+    labels:
+    - area/localization
+    - language/fr

--- a/i18n/hi/OWNERS
+++ b/i18n/hi/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Hindi.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-hi-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-hi-owners
+    reviewers:
+    - sig-docs-hi-reviews
 
-labels:
-- area/localization
-- language/hi
+    approvers:
+    - sig-docs-hi-owners
+
+    labels:
+    - area/localization
+    - language/hi

--- a/i18n/id/OWNERS
+++ b/i18n/id/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Bahasa.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-id-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-id-owners
+    reviewers:
+    - sig-docs-id-reviews
 
-labels:
-- area/localization
-- language/id
+    approvers:
+    - sig-docs-id-owners
+
+    labels:
+    - area/localization
+    - language/id

--- a/i18n/it/OWNERS
+++ b/i18n/it/OWNERS
@@ -1,12 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 # Localized strings for Italian.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-it-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-it-owners
+    reviewers:
+    - sig-docs-it-reviews
 
-labels:
-- area/localization
-- language/it
+    approvers:
+    - sig-docs-it-owners
+
+    labels:
+    - area/localization
+    - language/it

--- a/i18n/ja/OWNERS
+++ b/i18n/ja/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Japanese.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-ja-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-ja-owners
+    reviewers:
+    - sig-docs-ja-reviews
 
-labels:
-- area/localization
-- language/ja
+    approvers:
+    - sig-docs-ja-owners
+
+    labels:
+    - area/localization
+    - language/ja

--- a/i18n/ko/OWNERS
+++ b/i18n/ko/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Korean.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-ko-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-ko-owners
+    reviewers:
+    - sig-docs-ko-reviews
 
-labels:
-- area/localization
-- language/ko
+    approvers:
+    - sig-docs-ko-owners
+
+    labels:
+    - area/localization
+    - language/ko

--- a/i18n/pl/OWNERS
+++ b/i18n/pl/OWNERS
@@ -3,11 +3,15 @@
 # Localized strings for Polish.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-pl-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-pl-owners
+    reviewers:
+    - sig-docs-pl-reviews
 
-labels:
-- language/pl
+    approvers:
+    - sig-docs-pl-owners
+
+    labels:
+    - area/localization
+    - language/pl

--- a/i18n/pt-br/OWNERS
+++ b/i18n/pt-br/OWNERS
@@ -1,12 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 # Localized strings for Portuguese.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-pt-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-pt-owners
+    reviewers:
+    - sig-docs-pt-reviews
 
-labels:
-- area/localization
-- language/pt
+    approvers:
+    - sig-docs-pt-owners
+
+    labels:
+    - area/localization
+    - language/pt

--- a/i18n/ru/OWNERS
+++ b/i18n/ru/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Russian.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-ru-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-ru-owners
+    reviewers:
+    - sig-docs-ru-reviews
 
-labels:
-- area/localization
-- language/ru
+    approvers:
+    - sig-docs-ru-owners
+
+    labels:
+    - area/localization
+    - language/ru

--- a/i18n/uk/OWNERS
+++ b/i18n/uk/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Ukrainian.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-uk-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-uk-owners
+    reviewers:
+    - sig-docs-uk-reviews
 
-labels:
-- area/localization
-- language/uk
+    approvers:
+    - sig-docs-uk-owners
+
+    labels:
+    - area/localization
+    - language/uk

--- a/i18n/vi/OWNERS
+++ b/i18n/vi/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Vietnamese.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-vi-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-vi-owners
+    reviewers:
+    - sig-docs-vi-reviews
 
-labels:
-- area/localization
-- language/vi
+    approvers:
+    - sig-docs-vi-owners
+
+    labels:
+    - area/localization
+    - language/vi

--- a/i18n/zh-cn/OWNERS
+++ b/i18n/zh-cn/OWNERS
@@ -3,12 +3,15 @@
 # Localized strings for Chinese.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
-reviewers:
-- sig-docs-zh-reviews
+filters:
+  "\\.toml$":
 
-approvers:
-- sig-docs-zh-owners
+    reviewers:
+    - sig-docs-zh-reviews
 
-labels:
-- area/localization
-- language/zh
+    approvers:
+    - sig-docs-zh-owners
+
+    labels:
+    - area/localization
+    - language/zh

--- a/static/js/OWNERS
+++ b/static/js/OWNERS
@@ -1,9 +1,9 @@
 # Label certain changes as web development
 
-approvers:
-- sig-docs-website-owners # Defined in OWNERS_ALIASES
-
 filters:
+  ".*":
+    approvers:
+    - sig-docs-website-owners # Defined in OWNERS_ALIASES
   "\\.js":
     labels:
     - area/web-development


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR updates the OWNERS files to add filters, comments and other changes.

- Added a line of comment to `it/OWNERS` and `pt-br/OWNERS` to align them to all the other `OWNERS` files.
- Added missing `area/localization` label to `pl/OWNERS`.
- Updated `assets/images/OWNERS` and `static/js/OWNERS` such that `approvers` and `reviwers` keys are within the `filters` key. Without this fix, it *seems* like the declared `approvers` and `reviewers` will be silently ignored. See the [docs](https://www.kubernetes.dev/docs/guide/owners/#filters) mentioning that at the very least `labels` must be a child of `filters` and on closer inspection of the [Prow codebase](https://github.com/kubernetes-sigs/prow/blob/0e909e33e02e45dcb2f2fc5b605f8057e44f1c5a/pkg/repoowners/repoowners.go#L74), it seems to be true for other properties too. [A search of the `kubernetes` GitHub org](https://github.com/search?q=filters+user%3Akubernetes+path%3A**%2FOWNERS&type=code&ref=advsearch) shows that other projects also use `approvers` and `reviewers` and child properties of `filters`. Also see the [discussion](https://kubernetes.slack.com/archives/C09QZ4DQB/p1741095131314059) in [Slack](https://kubernetes.slack.com/archives/CDECRSC5U/p1741172238111619?thread_ts=1741104811.635469&cid=CDECRSC5U)
- Updated all `OWNERS` files in the `i18n/<lang>` dirs to have a filter which will only apply the `OWNERS` configuration for `toml` files.
- Added `OWNERS` in the `.editorconfig` to ensure that it is indented with 2 spaces

Related: https://github.com/kubernetes/website/pull/49643#pullrequestreview-2632428416

cc @sftim 