### PR TITLE
KEP-2625: cpumanager full-pcpus-only becomes GA

### DIFF
--- a/content/en/docs/concepts/policy/node-resource-managers.md
+++ b/content/en/docs/concepts/policy/node-resource-managers.md
@@ -200,8 +200,8 @@ listed in alphabetical order:
 : Spread CPUs across different NUMA domains, aiming for an even balance between the selected domains
   (available since Kubernetes v1.23)
 
-`full-pcpus-only` (beta, visible by default)
-: Always allocate full physical cores (available since Kubernetes v1.22)
+`full-pcpus-only` (GA, visible by default)
+: Always allocate full physical cores (available since Kubernetes v1.22, GA since Kubernetes v1.33)
 
 `strict-cpu-reservation` (beta, visible by default)
 : Prevent all the pods regardless of their Quality of Service class to run on reserved CPUs

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -151,7 +151,7 @@ using the following feature gates:
 You will still have to enable each option using the `CPUManagerPolicyOptions` kubelet option.
 
 The following policy options exist for the static `CPUManager` policy:
-* `full-pcpus-only` (beta, visible by default) (1.22 or higher)
+* `full-pcpus-only` (GA, visible by default) (1.33 or higher)
 * `distribute-cpus-across-numa` (beta, visible by default) (1.33 or higher)
 * `align-by-socket` (alpha, hidden by default) (1.25 or higher)
 * `distribute-cpus-across-cores` (alpha, hidden by default) (1.31 or higher)


### PR DESCRIPTION
### Description
Documentation update for the KEP-2625 GA graduation

### Issue

Closes: https://github.com/kubernetes/enhancements/issues/2625

k/k code changes:

- https://github.com/kubernetes/kubernetes/pull/129950
- https://github.com/kubernetes/kubernetes/pull/130535

### KEP

https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2625-cpumanager-policies-thread-placement/README.md