### PR TITLE
fix: move KubeletSeparateDiskGC feature notice inside note

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -6,9 +6,9 @@ weight: 100
 
 {{<glossary_definition term_id="node-pressure-eviction" length="short">}}</br>
 
-{{< feature-state feature_gate_name="KubeletSeparateDiskGC" >}}
 
 {{<note>}}
+{{< feature-state feature_gate_name="KubeletSeparateDiskGC" >}}
 The _split image filesystem_ feature, which enables support for the `containerfs`
 filesystem, adds several new eviction signals, thresholds and metrics. To use
 `containerfs`, the Kubernetes release v{{< skew currentVersion >}} requires the


### PR DESCRIPTION

### Description

Moving the feature-state notice to where it belongs.

### Issue

Currently the feature-state block appears to be for the entire "Node-pressure eviction" page, however, it's just for the note block listed on top of the page. So moving this notice inside the node block.

Closes: N/A (no bug open).