### PR TITLE
[zh] Update on-duty maintainers list in readme

### DIFF
--- a/content/zh-cn/README.md
+++ b/content/zh-cn/README.md
@@ -452,6 +452,7 @@ SIG Docs 的当前新贡献者大使：
 可以通过以下方式联系中文本地化的维护人员：
 
 * Qiming Teng ([GitHub - @tengqm](https://github.com/tengqm))
+* Rui Chen ([GitHub - @chenrui333](https://github.com/chenrui333))
 * Michael Yao ([GitHub - @windsonsea](https://github.com/windsonsea))
 * [Slack 频道](https://kubernetes.slack.com/messages/kubernetes-docs-zh)
 


### PR DESCRIPTION
This is a revert action. Apologies for my mistake in removing a zh-maintainer, @chenrui333, in #49712.

He has been actively reviewing PRs and making significant contributions to k/website in recent years:
https://github.com/kubernetes/website/pulls?q=is%3Apr+reviewed-by%3Achenrui333