### PR TITLE
Add docs for KEP-4876: Mutable CSINode Allocatable Property

### DIFF
--- a/content/en/docs/concepts/storage/storage-limits.md
+++ b/content/en/docs/concepts/storage/storage-limits.md
@@ -79,4 +79,33 @@ Refer to the [CSI specifications](https://github.com/container-storage-interface
 
 * For volumes managed by in-tree plugins that have been migrated to a CSI driver, the maximum number of volumes will be the one reported by the CSI driver.
 
+### Mutable CSI Node Allocatable Count
+
+{{< feature-state state="alpha" for_k8s_version="v1.33" >}}
+
+CSI drivers can dynamically adjust the maximum number of volumes that can be attached to a Node at runtime. This enhances scheduling accuracy and reduces pod scheduling failures due to changes in resource availability.
+
+This is an alpha feature and is disabled by default.
+
+To use this feature, you must enable the `MutableCSINodeAllocatableCount` feature gate on the following components:
+
+- `kube-apiserver`
+- `kubelet`
+
+#### Periodic Updates
+
+When enabled, CSI drivers can request periodic updates to their volume limits by setting the `nodeAllocatableUpdatePeriodSeconds` field in the `CSIDriver` specification. For example:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: hostpath.csi.k8s.io
+spec:
+  nodeAllocatableUpdatePeriodSeconds: 60
+```
+
+Kubelet will periodically call the corresponding CSI driver’s `NodeGetInfo` endpoint to refresh the maximum number of attachable volumes, using the interval specified in `nodeAllocatableUpdatePeriodSeconds`. The minimum allowed value for this field is 10 seconds.
+
+Additionally, if a volume attachment operation fails with a `ResourceExhausted` error (gRPC code 8), Kubernetes triggers an immediate update to the allocatable volume count for that Node.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MutableCSINodeAllocatableCount.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MutableCSINodeAllocatableCount.md
@@ -1,0 +1,13 @@
+---
+title: MutableCSINodeAllocatableCount
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.33"
+---
+When this feature gate is enabled, the `CSINode.Spec.Drivers[*].Allocatable.Count` field becomes mutable, and a new field, `NodeAllocatableUpdatePeriodSeconds`, is available in the `CSIDriver` object. This allows periodic updates to a node's reported allocatable volume capacity, preventing stateful pods from becoming stuck due to outdated information that `kube-scheduler` relies on.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Add docs for KEP-4876: Mutable CSINode Allocatable Property.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
https://github.com/kubernetes/enhancements/issues/4876
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->