### PR TITLE
Announce improved SELinux volume relabelling beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/SELinuxChangePolicy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/SELinuxChangePolicy.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.32"
+    toVersion: "1.32"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.33"
 ---
 Enables `spec.securityContext.seLinuxChangePolicy` field.
 This field can be used to opt-out from applying the SELinux label to the pod

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/SELinuxMount.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/SELinuxMount.md
@@ -9,6 +9,11 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.30"
+    toVersion: "1.32"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.33"
+
 ---
 Speeds up container startup by allowing kubelet to mount volumes
 for a Pod directly with the correct SELinux label instead of changing each file on the volumes

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -701,7 +701,7 @@ to volumes (and PersistentVolumeClaims) using the `ReadWriteOncePod` access mode
 Kubernetes v1.33 promotes `SELinuxChangePolicy` and `SELinuxMount`
 [feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
 as beta to widen that performance improvement to other kinds of PersistentVolumeClaims,
-as explained in detail below. While beta, `SELinuxMount` is still disabled by default.
+as explained in detail below. While in beta, `SELinuxMount` is still disabled by default.
 {{< /note >}}
 
 With `SELinuxMount` feature gate disabled (the default in Kubernetes 1.33 and any previous release),

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -698,7 +698,7 @@ below have no effect.
 Kubernetes v1.27 introduced an early limited form of this behavior that was only applicable
 to volumes (and PersistentVolumeClaims) using the `ReadWriteOncePod` access mode.
 
-Kubernetes v1.33 introduced `SELinuxChangePolicy` and `SELinuxMount`
+Kubernetes v1.33 promotes `SELinuxChangePolicy` and `SELinuxMount`
 [feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
 as beta to widen that performance improvement to other kinds of PersistentVolumeClaims,
 as explained in detail below. While beta, `SELinuxMount` is still disabled by default.

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -686,7 +686,7 @@ securityContext:
 
 {{< note >}}
 To assign SELinux labels, the SELinux security module must be loaded on the host operating system.
-On Windows and Linux workers without SELinux support, this field and any SELinux feature gates described
+On Windows and Linux worker nodes without SELinux support, this field and any SELinux feature gates described
 below have no effect.
 {{< /note >}}
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -686,6 +686,8 @@ securityContext:
 
 {{< note >}}
 To assign SELinux labels, the SELinux security module must be loaded on the host operating system.
+On Windows and Linux workers without SELinux support, this field and any SELinux feature gates described
+below have no effect.
 {{< /note >}}
 
 ### Efficient SELinux volume relabeling
@@ -696,24 +698,25 @@ To assign SELinux labels, the SELinux security module must be loaded on the host
 Kubernetes v1.27 introduced an early limited form of this behavior that was only applicable
 to volumes (and PersistentVolumeClaims) using the `ReadWriteOncePod` access mode.
 
-As an alpha feature, you can enable the `SELinuxMount` and `SELinuxChangePolicy`
-[feature gates](/docs/reference/command-line-tools-reference/feature-gates/) to widen that
-performance improvement to other kinds of PersistentVolumeClaims, as explained in detail
-below.
+Kubernetes v1.33 introduced `SELinuxChangePolicy` and `SELinuxMount`
+[feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
+as beta to widen that performance improvement to other kinds of PersistentVolumeClaims,
+as explained in detail below. While beta, `SELinuxMount` is still disabled by default.
 {{< /note >}}
 
-By default, the container runtime recursively assigns SELinux label to all
-files on all Pod volumes. To speed up this process, Kubernetes can change the
+With `SELinuxMount` feature gate disabled (the default in Kubernetes 1.33 and any previous release),
+the container runtime recursively assigns SELinux label to all
+files on all Pod volumes by default. To speed up this process, Kubernetes can change the
 SELinux label of a volume instantly by using a mount option
 `-o context=<label>`.
 
 To benefit from this speedup, all these conditions must be met:
 
-* The [feature gates](/docs/reference/command-line-tools-reference/feature-gates/) `ReadWriteOncePod`
-  and `SELinuxMountReadWriteOncePod` must be enabled.
+* The [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+  `SELinuxMountReadWriteOncePod` must be enabled.
 * Pod must use PersistentVolumeClaim with applicable `accessModes` and [feature gates](/docs/reference/command-line-tools-reference/feature-gates/):
   * Either the volume has `accessModes: ["ReadWriteOncePod"]`, and feature gate `SELinuxMountReadWriteOncePod` is enabled.
-  * Or the volume can use any other access modes and both feature gates
+  * Or the volume can use any other access modes and all feature gates
     `SELinuxMountReadWriteOncePod`, `SELinuxChangePolicy` and `SELinuxMount` must be enabled
     and the Pod has `spec.securityContext.seLinuxChangePolicy` either nil (default) or `MountOption`. 
 * Pod (or all its Containers that use the PersistentVolumeClaim) must
@@ -724,9 +727,15 @@ To benefit from this speedup, all these conditions must be met:
     The CSI driver must announce that it supports mounting with `-o context` by setting
     `spec.seLinuxMount: true` in its CSIDriver instance.
 
-For any other volume types, SELinux relabelling happens another way: the container
+When any of these conditions is not met, SELinux relabelling happens another way: the container
 runtime  recursively changes the SELinux label for all inodes (files and directories)
-in the volume.
+in the volume. Calling out explicitly, this applies to Kubernetes ephemeral volumes like
+`secrets`, `configMaps` and `projected`, and all volumes whose CSIDriver instance does not
+explicitly announce mounting with `-o context`.
+
+When this speedup is used, all Pods that use the same applicable volume concurrently on the same node
+**must have the same SELinux label**. A Pod with a different SELinux label will fail to start and will be
+`ContainerCreating` until all Pods with other SELinux labels that use the volume are deleted.
 
 {{< feature-state feature_gate_name="SELinuxChangePolicy" >}}
 For Pods that want to opt-out from relabeling using mount options, they can set
@@ -758,6 +767,12 @@ with different SELinux labels:
 A cluster admin can use this information to identify pods affected by the planning change and
 proactively opt-out Pods from the optimization (i.e. set `spec.securityContext.seLinuxChangePolicy: Recursive`).
 
+{{< warning >}}
+We strongly recommend clusters that use SELinux to enable this controller and make sure that
+`selinux_warning_controller_selinux_volume_conflict` metric does not report any conflicts before enabling `SELinuxMount`
+feature gate or upgrading to a version where `SELinuxMount` is enabled by default.
+{{< /warning >}}
+
 #### Feature gates
 
 The following feature gates control the behavior of SELinux volume relabeling:
@@ -768,11 +783,11 @@ The following feature gates control the behavior of SELinux volume relabeling:
 * `SELinuxChangePolicy`: enables `spec.securityContext.seLinuxChangePolicy` field in Pod and related SELinuxWarningController
   in kube-controller-manager. This feature can be used before enabling `SELinuxMount` to check Pods running on a cluster,
   and to pro-actively opt-out Pods from the optimization.
-  This feature gate requires `SELinuxMountReadWriteOncePod` enabled. It is alpha and disabled by default in 1.32.
+  This feature gate requires `SELinuxMountReadWriteOncePod` enabled. It is beta and enabled by default in 1.33.
 * `SELinuxMount` enables the optimization for all eligible volumes. Since it can break existing workloads, we recommend
   enabling `SELinuxChangePolicy` feature gate + SELinuxWarningController first to check the impact of the change.
-  This feature gate requires `SELinuxMountReadWriteOncePod` and `SELinuxChangePolicy` enabled. It is alpha and disabled
-  by default in 1.32.
+  This feature gate requires `SELinuxMountReadWriteOncePod` and `SELinuxChangePolicy` enabled. It is beta, but disabled
+  by default in 1.33.
 
 ## Managing access to the `/proc` filesystem {#proc-access}
 

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -730,7 +730,7 @@ To benefit from this speedup, all these conditions must be met:
 When any of these conditions is not met, SELinux relabelling happens another way: the container
 runtime  recursively changes the SELinux label for all inodes (files and directories)
 in the volume. Calling out explicitly, this applies to Kubernetes ephemeral volumes like
-`secrets`, `configMaps` and `projected`, and all volumes whose CSIDriver instance does not
+`secret`, `configMap` and `projected`, and all volumes whose CSIDriver instance does not
 explicitly announce mounting with `-o context`.
 
 When this speedup is used, all Pods that use the same applicable volume concurrently on the same node


### PR DESCRIPTION
### Description

Document how SELinux feature gates (now beta) work together and potential actions needed before they graduate to GA.

Goals:

* Ensure non-SELinux users that nothing changes for them (= vast majority of users / cluster admins can just ignore all SELinux feature gates).
* Warn users / cluster admins / Kubernetes vendors that use SELinux about potentially breaking changes in a future release. Provide a clear way how to check if they're safe or they need to change anything. This is important to ensure smooth update.
    * OpenShift stats show that ~ 1.3% of all clusters would have at least one affected Pod, most of them with just handful of them. Some clusters (~0.3%) have more than 100 affected Pods and may need some work before the breaking upgrade when `SELinuxMount` goes GA + locked. Data taken on 2025-03-24.
* Emphasize that ephemeral volumes like `secrets` and `configMaps` can be still shared among pods with different SELinux labels.

Random notes:

* Removed note about ReadWriteOncePod feature gate, it's GA and locked.

### Issue

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
Enhancement issue: https://github.com/kubernetes/enhancements/issues/1710