### PR TITLE
Fix grammar in "Autoscaling Workloads" page

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -111,7 +111,7 @@ in the cluster.
 It is also possible to scale workloads based on events, for example using the
 [_Kubernetes Event Driven Autoscaler_ (**KEDA**)](https://keda.sh/).
 
-KEDA is a CNCF graduated enabling you to scale your workloads based on the number
+KEDA is a CNCF-graduated project enabling you to scale your workloads based on the number
 of events to be processed, for example the amount of messages in a queue. There exists
 a wide range of adapters for different event sources to choose from.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

I was going through the docs, and found this mistake here:

![Image](https://github.com/user-attachments/assets/a172250b-cb31-4134-b3d9-6d0735e42d7c)

This PR changes it to "KEDA is a CNCF-graduated project enabling..."

### Issue

Closes #49934

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
