### PR TITLE
KEP-5040: Disable git_repo volume driver.

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -352,7 +352,7 @@ third party storage driver instead.
 ### gitRepo (deprecated) {#gitrepo}
 
 {{< warning >}}
-The `gitRepo` volume type is deprecated.
+The `gitRepo` volume plugin is deprecated and is disabled by default.
 
 To provision a Pod that has a Git repository mounted, you can mount an
 [`emptyDir`](#emptydir) volume into an [init container](/docs/concepts/workloads/pods/init-containers/)
@@ -371,6 +371,10 @@ part of a policy to reject use of `gitRepo` volumes:
 ```
 
 {{< /warning >}}
+
+You can use this deprecated storage plugin in your cluster if you explicitly
+enable the `GitRepoVolumeDriver`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 
 A `gitRepo` volume is an example of a volume plugin. This plugin
 mounts an empty directory and clones a git repository into this directory

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletFineGrainedAuthz.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletFineGrainedAuthz.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.32"
+    toVersion: "1.32"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.33"
 ---
 Enable [fine-grained authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/#fine-grained-authorization) 
 for the kubelet's HTTP(s) API.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletFineGrainedAuthz.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletFineGrainedAuthz.md
@@ -9,10 +9,6 @@ stages:
   - stage: alpha 
     defaultValue: false
     fromVersion: "1.32"
-    toVersion: "1.32"
-  - stage: beta
-    defaultValue: true
-    fromVersion: "1.33"
 ---
 Enable [fine-grained authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/#fine-grained-authorization) 
 for the kubelet's HTTP(s) API.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Update the documentation for gitRepo volumes to highlight that the gitRepo volume plugin has been disabled by default.


### Issue

xref: https://github.com/kubernetes/enhancements/issues/5040