### PR TITLE
Add information about topologySpeadConstraint duplicate values

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -70,6 +70,10 @@ spec:
   ### other Pod fields go here
 ```
 
+{{< note >}}
+There can only be one topologySpreadConstraint for a given topologyKey and whenUnsatisfiable value. For example, if you have defined a topologySpreadConstraint that uses the topologyKey "kubernetes.io/hostname" and whenUnsatisfiable value "DoNotSchedule", you can only add another topologySpreadConstraint for the topologyKey "kubernetes.io/hostname" if you use a different whenUnsatisfiable value.
+{{< /note >}}
+
 You can read more about this field by running `kubectl explain Pod.spec.topologySpreadConstraints` or
 refer to the [scheduling](/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) section of the API reference for Pod.
 


### PR DESCRIPTION
### Description

TopologySpreadConstraints cannot conflict on a given (toplogyKey, whenUnsatisfiable) pair, but this is currently not documented, this adds a note describing this behaviour.

You can see the limitation yourself by trying to create this deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      topologySpreadConstraints:
      - maxSkew: 1
        topologyKey: "kubernetes.io/hostname"
        whenUnsatisfiable: "DoNotSchedule"
        labelSelector:
          matchLabels:
            app: nginx
      - maxSkew: 3
        topologyKey: "kubernetes.io/hostname"
        whenUnsatisfiable: "DoNotSchedule"
        labelSelector:
          matchLabels:
            foo: bar
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```
