### PR TITLE
Remove Fedora and CentOS packages for kompose

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -53,27 +53,6 @@ go get -u github.com/kubernetes/kompose
 ```
 
 {{% /tab %}}
-{{% tab name="CentOS package" %}}
-
-Kompose is in [EPEL](https://fedoraproject.org/wiki/EPEL) CentOS repository.
-If you don't have [EPEL](https://fedoraproject.org/wiki/EPEL) repository already installed and enabled you can do it by running `sudo yum install epel-release`.
-
-If you have [EPEL](https://fedoraproject.org/wiki/EPEL) enabled in your system, you can install Kompose like any other package.
-
-```bash
-sudo yum -y install kompose
-```
-
-{{% /tab %}}
-{{% tab name="Fedora package" %}}
-
-Kompose is in Fedora 24, 25 and 26 repositories. You can install it like any other package.
-
-```bash
-sudo dnf -y install kompose
-```
-
-{{% /tab %}}
 {{% tab name="Homebrew (macOS)" %}}
 
 On macOS you can install the latest release via [Homebrew](https://brew.sh):


### PR DESCRIPTION
### Description

Remove the Fedora and CentOS (i.e. epel) install section from kompose as the package have been orphaned for over 2 years.
See [this commit](https://src.fedoraproject.org/rpms/kompose/c/8afab6b0014862b81ffa30f9ee87d4b8192fdf3f?branch=rawhide) for more details.


### Issue
The docs pointed users to install non-existing packages.