### PR TITLE
Remove broken hyperlink

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/crictl.md
+++ b/content/en/docs/tasks/debug/debug-cluster/crictl.md
@@ -238,5 +238,4 @@ The output is similar to this:
 ## {{% heading "whatsnext" %}}
 
 * [Learn more about `crictl`](https://github.com/kubernetes-sigs/cri-tools).
-* [Map `docker` CLI commands to `crictl`](/docs/reference/tools/map-crictl-dockercli/).
 


### PR DESCRIPTION
### Description

This PR removed `Map docker CLI commands to crictl` hyperlink from the [What's next](https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/#what-s-next) section of [Debugging Kubernetes nodes with crictl](https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/) task.

### Issue

Closes: #49979