### PR TITLE
fix: wrong v1beta1 score configuration example

### DIFF
--- a/content/en/docs/reference/scheduling/config.md
+++ b/content/en/docs/reference/scheduling/config.md
@@ -415,7 +415,6 @@ profiles:
         enabled:
         - name: 'CustomPlugin1'
         - name: 'CustomPlugin2'
-        - name: 'DefaultPlugin2'
         disabled:
         - name: 'DefaultPlugin1'
 
@@ -425,60 +424,15 @@ profiles:
         - name: 'DefaultPlugin2'
           weight: 1
         - name: 'DefaultPlugin1'
+          weight: 1
+        - name: 'CustomPlugin1'
           weight: 3
+        - name: 'CustomPlugin2'
+          weight: 1
 ```
 
 While this is a complicated example, it demonstrates the flexibility of `MultiPoint` config
 as well as its seamless integration with the existing methods for configuring extension points.
-
-## Scheduler configuration migrations
-
-{{< tabs name="tab_with_md" >}}
-{{% tab name="v1beta1 → v1beta2" %}}
-* With the v1beta2 configuration version, you can use a new score extension for the
-  `NodeResourcesFit` plugin.
-  The new extension combines the functionalities of the `NodeResourcesLeastAllocated`,
-  `NodeResourcesMostAllocated` and `RequestedToCapacityRatio` plugins.
-  For example, if you previously used the `NodeResourcesMostAllocated` plugin, you
-  would instead use `NodeResourcesFit` (enabled by default) and add a `pluginConfig`
-  with a `scoreStrategy` that is similar to:
-  ```yaml
-  apiVersion: kubescheduler.config.k8s.io/v1beta2
-  kind: KubeSchedulerConfiguration
-  profiles:
-  - pluginConfig:
-    - args:
-        scoringStrategy:
-          resources:
-          - name: cpu
-            weight: 1
-          type: MostAllocated
-      name: NodeResourcesFit
-  ```
-
-* The scheduler plugin `NodeLabel` is deprecated; instead, use the [`NodeAffinity`](/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) plugin (enabled by default) to achieve similar behavior.
-
-* The scheduler plugin `ServiceAffinity` is deprecated; instead, use the [`InterPodAffinity`](/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) plugin (enabled by default) to achieve similar behavior.
-
-* The scheduler plugin `NodePreferAvoidPods` is deprecated; instead, use [node taints](/docs/concepts/scheduling-eviction/taint-and-toleration/) to achieve similar behavior.
-
-* A plugin enabled in a v1beta2 configuration file takes precedence over the default configuration for that plugin.
-
-* Invalid `host` or `port` configured for scheduler healthz and metrics bind address will cause validation failure.
-{{% /tab %}}
-
-{{% tab name="v1beta2 → v1beta3" %}}
-* Three plugins' weight are increased by default:
-  * `InterPodAffinity` from 1 to 2
-  * `NodeAffinity` from 1 to 2
-  * `TaintToleration` from 1 to 3
-{{% /tab %}}
-
-{{% tab name="v1beta3 → v1" %}}
-* The scheduler plugin `SelectorSpread` is removed, instead, use the `PodTopologySpread` plugin (enabled by default)
-to achieve similar behavior.
-{{% /tab %}}
-{{< /tabs >}}
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
The v1beta2 example shows DefaultPlugin1 with a weight of 3 while it's the CustomPlugin1 that is configured with this weight.

Also, based on the code documentation, custom plugins configured through MultiPoint should take precedence over default plugins, so also disable DefaultPlugin1 and re-enabled it to match the order that should happen following the MultiPoint documentation.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes: #41316 