### PR TITLE
Add docs for ServiceAccountNodeAudienceRestriction feature gate in KAS

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -602,6 +602,8 @@ and may be disallowed or allowed by the `NodeRestriction` admission plugin in th
 Future versions may add additional restrictions to ensure kubelets have the minimal set of
 permissions required to operate correctly.
 
+`ServiceAccountNodeAudienceRestriction`: *Add details about the feature gate, effect and rbac roles to dynamically configure service account/audience*
+
 ### OwnerReferencesPermissionEnforcement {#ownerreferencespermissionenforcement}
 
 **Type**: Validating.


### PR DESCRIPTION
Doc update for KEP 4412: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/README.md
KEP issue: https://github.com/kubernetes/enhancements/issues/4412

Implementation PR:
- https://github.com/kubernetes/kubernetes/pull/128077
- https://github.com/kubernetes/kubernetes/pull/130485