### PR TITLE
Move the search bar in the homepage from the content to the layout

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -6,8 +6,6 @@ sitemap:
   priority: 1.0
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section class="k8s-overview" >}}
 {{% blocks/feature image="flower" id="feature-primary" %}}
 [Kubernetes]({{< relref "/docs/concepts/overview/" >}}), also known as K8s, is an open source system for automating deployment, scaling, and management of containerized applications.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,11 @@
 {{ define "main" }}
+{{ if .HasShortcode "site-searchbar" }}
+  {{ warnf "The homepage of the language %s is using a deprecated shortcode site-searchbar. Please remove the shortcode. No other step is needed." .Lang }}
+{{ else }}
 <div class="col-sm-6 col-md-6 col-lg-6 mx-auto py-3">
   {{partial "search-input" .}}
 </div>
+{{ end }}
 {{ .Content }}
 <section id="cncf">
     <div class="main-section">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+<div class="col-sm-6 col-md-6 col-lg-6 mx-auto py-3">
+  {{partial "search-input" .}}
+</div>
 {{ .Content }}
 <section id="cncf">
     <div class="main-section">


### PR DESCRIPTION
### Description
This PR creates a way to move the search bar in the homepage from the content html file to the layout. This reduces code duplication as a shortcode is used in the homepage file for every language.

It checks if a page calls the search bar shortcode and if it does, it emits a warning during build time. This gives localisation teams enough information and the resolution to convert all homepages to remove the shortcode. Once the shortcode is removed, the search bar in the layout is automatically removed.

This check must be removed once all localized home pages have removed the shortcode.

### Issue
Closes: #50031 