### PR TITLE
Replace `ui_search_placeholder` with docsy provided `ui_search`

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -450,7 +450,7 @@ translate the value of each string. For example, this is the German-language
 placeholder text for the search form:
 
 ```toml
-[ui_search_placeholder]
+[ui_search]
 other = "Suchen"
 ```
 

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -648,7 +648,7 @@ other = "Copied to clipboard: "
 [translated_by]
 other = "Translated By"
 
-[ui_search_placeholder]
+[ui_search]
 other = "Search this site"
 
 [version_check_mustbe]

--- a/layouts/partials/search-input-custom.html
+++ b/layouts/partials/search-input-custom.html
@@ -2,6 +2,14 @@
 {{ $lang := .Site.Language.Lang }}
 {{ $searchFile := printf "content/%s/search.md" $lang }}
 
+{{ $check := "" }}
+{{ if T "ui_search_placeholder" }}
+{{ warnf "The search bar placeholder for the language %s is using a custom \"ui_search_placeholder\" key. Please change the key in the translations to the Docsy provided \"ui_search\"." $lang }}
+{{ $check = T "ui_search_placeholder" }}
+{{ else }}
+{{ $check = T "ui_search" }}
+{{ end }}
+
 <div class="search-bar">
   <i class="search-icon fa-solid fa-search"></i>
   <input
@@ -13,8 +21,8 @@
     data-search-page="{{ "search/" | relURL }}"
     {{ end }}
     class="search-input td-search-input"
-    placeholder="{{ T "ui_search_placeholder" }}"
-    aria-label="{{ T "ui_search_placeholder" }}"
+    placeholder="{{ $check }}"
+    aria-label="{{ $check }}"
     autocomplete="off"
   >
 </div>


### PR DESCRIPTION
### Description
This PR replaces the old translation placeholder key `ui_search_placeholder` with the newer placeholder [`ui_search`](https://github.com/google/docsy/blob/de445c7305ec72c29c262f5d032864b5cba34af5/i18n/en.toml#L12). This was only possible after #49643 was closed as without the changes in that PR, using the same placeholder key as Docsy would not override Docsy's value.

But now, this change works.

This is a technical change and *should* not impact localisation but if needed, I can update this PR only for english and let other languages do their own updates.