### PR TITLE
Fix locale string configuration for parentoptions

### DIFF
--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -456,6 +456,9 @@ other = "This article is more than one year old. Older articles may contain outd
 [page_deprecated]
 other = "(stale page)"
 
+[parentoptions_heading]
+other = "Parent Options Inherited"
+
 [patch_release]
 other = "Patch Release"
 


### PR DESCRIPTION
The `parentoptions` heading is missing from the locale string file. The result is that in the command reference pages, the second table has no heading. It is weird to see two tables on the same page without this heading text.
