### PR TITLE
[Do not merge:] Rewrite 'Configuring Redis using a ConfigMap' & its prereqs snippet

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,7 +9,7 @@ weight: 30
 
 <!-- overview -->
 
-This page provides a real-world example of how to configure Redis and its memory requirements, using a ConfigMap. It builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+This page provides a real-world example of how to configure Redis and its memory management, using a ConfigMap. It builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 
 
@@ -269,7 +269,7 @@ It should now reflect the desired value of `allkeys-lru`:
 
 ### Wrap up {#wrap-up}
 
-In this tutorial, you created a basic ConfigMap, applied it to a Redis Pod, and verified the Pod's initial configuration. Next, you updated the ConfigMap with realistic `maxmemory` and `maxmemory-policy` values to support the Redis cache, reapplied the ConfigMap, and restarted the Pod to verify that your configuration took effect.
+In this tutorial, you created a basic ConfigMap, applied it to a Redis Pod, and verified the Pod's initial configuration. Next, you updated the ConfigMap with realistic `maxmemory` and `maxmemory-policy` values to support the Redis cache. You then reapplied the ConfigMap, and restarted the Pod to verify that your configuration took effect.
 
 Now, you can clean up your work by deleting the created resources:
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -2,23 +2,24 @@
 reviewers:
 - eparis
 - pmorie
-title: Configuring Redis using a ConfigMap
+title: Configuring Redis Memory using a ConfigMap
 content_type: tutorial
 weight: 30
 ---
 
 <!-- overview -->
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+This page provides a real-world example of how to configure Redis and its memory requirements, using a ConfigMap. It builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 
 
 ## {{% heading "objectives" %}}
 
 
-* Create a ConfigMap with Redis configuration values
-* Create a Redis Pod that mounts and uses the created ConfigMap
-* Verify that the configuration was correctly applied.
+* Set Redis configuration values by creating a ConfigMap.
+* Create a Redis Pod that mounts and uses the created ConfigMap.
+* Adjust `maxmemory` and `maxmemory-policy` values to support the Redis cache.
+* Verify that the Pod correctly applies the configuration.
 
 
 
@@ -28,18 +29,20 @@ This page provides a real world example of how to configure Redis using a Config
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * The example shown on this page works with `kubectl` 1.14 and above.
-* Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-
-
+* Understand the configuration injection model in [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 <!-- lessoncontent -->
 
 
-## Real World Example: Configuring Redis using a ConfigMap
+## Real-world example: Configuring Redis memory requirements using a ConfigMap {#overview}
 
-Follow the steps below to configure a Redis cache using data stored in a ConfigMap.
+<!-- Query: ^ Could we eliminate this redundant h2? This would allow us to promote all the h3's to h2's, making them visible in the right nav. -->
 
-First create a ConfigMap with an empty configuration block:
+Follow the steps below to configure memory for a Redis cache, using data stored in a ConfigMap.
+
+### Create a ConfigMap shell {#create}
+
+First, create a ConfigMap with an empty configuration block:
 
 ```shell
 cat <<EOF >./example-redis-config.yaml
@@ -52,26 +55,32 @@ data:
 EOF
 ```
 
-Apply the ConfigMap created above, along with a Redis pod manifest:
+### Apply the empty ConfigMap and examine the manifest {#manifest}
+
+Apply the ConfigMap created above, along with a Redis Pod manifest:
 
 ```shell
 kubectl apply -f example-redis-config.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
 ```
 
-Examine the contents of the Redis pod manifest and note the following:
+Examine the Redis Pod manifest below, and note the following:
 
-* A volume named `config` is created by `spec.volumes[1]`
-* The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the 
-  `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
+* A volume named `config` is created by `spec.volumes[1]`.
+* The `key` and `path` under `spec.volumes[1].configMap.items[0]` expose the `redis-config` key from the 
+  `example-redis-config` ConfigMap, with the path value set to a file named `redis.conf` on the `config` volume.
 * The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
 
-This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
-ConfigMap above as `/redis-master/redis.conf` inside the Pod.
+<!-- Query: ^ I'd like to avoid the passive voice above, and the indexes aren't visible in the displayed manifest. Can we omit them, and instead just say "at <element-name>"?? -->
+
+Inside the Pod, this exposes the `data.redis-config` data (from the `example-redis-config`
+ConfigMap above) as `/redis-master/redis.conf`.
 
 {{% code_sample file="pods/config/redis-pod.yaml" %}}
 
-Examine the created objects:
+### Verify the created objects {#objects}
+
+Examine the created objects with this command:
 
 ```shell
 kubectl get pod/redis configmap/example-redis-config 
@@ -87,13 +96,13 @@ NAME                             DATA   AGE
 configmap/example-redis-config   1      14s
 ```
 
-Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
+Recall that in the `example-redis-config` ConfigMap, the `redis-config` key was blank. You can verify this with this command:
 
 ```shell
 kubectl describe configmap/example-redis-config
 ```
 
-You should see an empty `redis-config` key:
+You should see an empty `redis-config` key, which you will populate later:
 
 ```shell
 Name:         example-redis-config
@@ -106,55 +115,65 @@ Data
 redis-config:
 ```
 
-Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
+### Verify the Pod's configuration {#pod-baseline}
+
+Before adding config keys, verify the Pod's baseline configuration. Use `kubectl exec` to enter the Pod, and run the `redis-cli` tool in the same command:
 
 ```shell
 kubectl exec -it redis -- redis-cli
 ```
 
-Check `maxmemory`:
+Check `maxmemory` with this command:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory
 ```
 
-It should show the default value of 0:
+It should show the default value of `0`:
 
 ```shell
 1) "maxmemory"
 2) "0"
 ```
 
-Similarly, check `maxmemory-policy`:
+Also check `maxmemory-policy`:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory-policy
 ```
 
-Which should also yield its default value of `noeviction`:
+This should similarly its default value of `noeviction`:
 
 ```shell
 1) "maxmemory-policy"
 2) "noeviction"
 ```
 
-Now let's add some configuration values to the `example-redis-config` ConfigMap:
+The next step is to change both values to support the Redis cache.
+
+### Reconfigure memory {#config-memory}
+
+Next, add these configuration values to the `example-redis-config` ConfigMap:
 
 {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
-Apply the updated ConfigMap:
+Setting `maxmemory` to `2mb` gives the cache a reasonable upper memory limit. Setting `maxmemory-policy` to `allkeys-lru` enables loading new keys when the memory limit is reached, by removing least-recently-used (lru) keys.
+
+### Reapply and verify the ConfigMap {#reapply}
+
+Apply the updated ConfigMap with this command:
 
 ```shell
 kubectl apply -f example-redis-config.yaml
 ```
 
-Confirm that the ConfigMap was updated:
+Next, confirm that the ConfigMap was updated:
 
 ```shell
 kubectl describe configmap/example-redis-config
 ```
 
-You should see the configuration values we just added:
+You should see the configuration values you  just added:
 
 ```shell
 Name:         example-redis-config
@@ -170,40 +189,46 @@ maxmemory 2mb
 maxmemory-policy allkeys-lru
 ```
 
-Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+### Re-check the Pod's configuration (this won't work) {#pod-re-check}
+
+Check the Redis Pod again, using `kubectl exec` with `redis-cli`, to see if the configuration was applied:
 
 ```shell
 kubectl exec -it redis -- redis-cli
 ```
 
-Check `maxmemory`:
+Check `maxmemory` with this command:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory
 ```
 
-It remains at the default value of 0:
+It remains at the default value of `0`:
 
 ```shell
 1) "maxmemory"
 2) "0"
 ```
 
-Similarly, `maxmemory-policy` remains at the `noeviction` default setting:
+Similarly, verify that `maxmemory-policy` remains at its `noeviction` default setting:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory-policy
 ```
 
-Returns:
+This should return:
 
 ```shell
 1) "maxmemory-policy"
 2) "noeviction"
 ```
 
-The configuration values have not changed because the Pod needs to be restarted to grab updated
-values from associated ConfigMaps. Let's delete and recreate the Pod:
+Why didn't these configuration values change? The Pod needs to be restarted to grab updated
+values from associated ConfigMaps. 
+
+### Restart the Pod {#pod-restart}
+
+Delete and re-create the Pod, using these commands:
 
 ```shell
 kubectl delete pod redis
@@ -216,33 +241,37 @@ Now re-check the configuration values one last time:
 kubectl exec -it redis -- redis-cli
 ```
 
-Check `maxmemory`:
+Check `maxmemory` with this command:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory
 ```
 
-It should now return the updated value of 2097152:
+It should now return the updated value of `2097152` bytes:
 
 ```shell
 1) "maxmemory"
 2) "2097152"
 ```
 
-Similarly, `maxmemory-policy` has also been updated:
+Similarly, use this command to verify that `maxmemory-policy` has also been updated:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory-policy
 ```
 
-It now reflects the desired value of `allkeys-lru`:
+It should now reflect the desired value of `allkeys-lru`:
 
 ```shell
 1) "maxmemory-policy"
 2) "allkeys-lru"
 ```
 
-Clean up your work by deleting the created resources:
+### Wrap up {#wrap-up}
+
+In this tutorial, you created a basic ConfigMap, applied it to a Redis Pod, and verified the Pod's initial configuration. Next, you updated the ConfigMap with realistic `maxmemory` and `maxmemory-policy` values to support the Redis cache, reapplied the ConfigMap, and restarted the Pod to verify that your configuration took effect.
+
+Now, you can clean up your work by deleting the created resources:
 
 ```shell
 kubectl delete pod/redis configmap/example-redis-config
@@ -252,4 +281,4 @@ kubectl delete pod/redis configmap/example-redis-config
 
 
 * Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-* Follow an example of [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).
+* Follow an example of [Updating Configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -1,8 +1,4 @@
-You need to have a Kubernetes cluster, and the kubectl command-line tool must
-be configured to communicate with your cluster. It is recommended to run this tutorial on a cluster with at least two nodes that are not acting as control plane hosts. If you do not already have a
-cluster, you can create one by using
-[minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
-or you can use one of these Kubernetes playgrounds:
+You must have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. This tutorial runs best on a cluster with at least two nodes that are not acting as control-plane hosts. If you do not already have a cluster, you can create one by using [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/), or you can use one of these Kubernetes playgrounds:
 
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
### Description

- Retitled & reframed topic & its Objectives around updating _memory_ K-V pairs to support a Redis cache.
- Streamlined prerequisites snippet.
- Added headings for each separate procedure, with anchors to preserve stable inks.
- Added more "why" to intermediate steps.
- Recast "Examine x" and "Check x" instructions as "Verify x," to clarify their "why."
- Conformed case, tagging, and voice to K8s style guide.
- Rewrote and repunctuated for clarity, consistency, grammar, and concision.
- Put context first.
- Added some preview and wrap-up/summary text.
- Hyphenated compounds.

Closes: #