### PR TITLE
fix: duplicate element ID in training page

### DIFF
--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -148,7 +148,7 @@ menu:
 
 <section class="call-to-action">
   <div class="main-section">
-    <div class="call-to-action" id="cta-certification">
+    <div class="call-to-action" id="cta-kubestronaut">
       <div class="cta-text">
         <h2>Kubestronaut Program: Elevate Your Kubernetes Expertise</h2>
         <p> The CNCF's Kubestronaut Program celebrates and recognizes exceptional community leaders who have demonstrated a profound commitment to mastering Kubernetes. This prestigious initiative highlights individuals who have consistently invested in their ongoing education and achieved the highest levels of proficiency. To earn the esteemed title of Kubestronaut, individuals must successfully obtain and maintain all five CNCF Kubernetes certifications: Certified Kubernetes Administrator (CKA), Certified Kubernetes Application Developer (CKAD), Certified Kubernetes Security Specialist (CKS), Kubernetes and Cloud Native Associate (KCNA), and Kubernetes and Cloud Security Associate (KCSA). </p>


### PR DESCRIPTION
### Description

Removes duplicate element IDs in the training page.

### Issue

Closes: #50010
