### PR TITLE
Fix typo in kubeadm documentation: Corrected `kubectl init` to `kubeadm init`

### DIFF
--- a/content/ja/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -170,7 +170,7 @@ as root:
   kubeadm join <control-plane-host>:<control-plane-port> --token <token> --discovery-token-ca-cert-hash sha256:<hash>
 ```
 
-kubectlをroot以外のユーザーでも実行できるようにするには、次のコマンドを実行します。これらのコマンドは、`kubectl init`の出力の中にも書かれています。
+kubectlをroot以外のユーザーでも実行できるようにするには、次のコマンドを実行します。これらのコマンドは、`kubeadm init`の出力の中にも書かれています。
 
 ```bash
 mkdir -p $HOME/.kube


### PR DESCRIPTION
Description

This pull request fixes a typo in the Kubernetes Japanese documentation on creating a cluster with Kubeadm. The command kubectl init was incorrectly referenced and has been corrected to kubeadm init in the section on allowing non-root users to run kubectl.

```
$ kubectl init
error: unknown command "init" for "kubectl"

Did you mean this?
	edit
	wait
```

You can view the relevant page here: [kubeadmを使用したクラスターの作成 | Kubernetes](https://kubernetes.io/ja/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#%E8%A9%B3%E7%B4%B0%E3%81%AA%E6%83%85%E5%A0%B1)

Issue

This PR addresses a minor typo in the documentation that could lead to confusion for users following the setup instructions.

Closes: #