### PR TITLE
Release blog post: Swap fresh improvements

### DIFF
--- a/content/en/blog/_posts/2025-03-24-swap-fresh-improvements.md
+++ b/content/en/blog/_posts/2025-03-24-swap-fresh-improvements.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Kubernetes 1.32: Fresh Swap Features for Linux Users"
+title: "Fresh Swap Features for Linux Users in Kubernetes 1.32"
 date: 2025-03-24T10:00:00-08:00
 slug: swap-linux-improvements
 author: >

--- a/content/en/blog/_posts/2025-03-24-swap-fresh-improvements.md
+++ b/content/en/blog/_posts/2025-03-24-swap-fresh-improvements.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes 1.32: Fresh Swap Features for Linux Users"
-date: 2025-01-15T10:00:00-08:00
-draft: true
+date: 2025-03-24T10:00:00-08:00
 slug: swap-linux-improvements
 author: >
   Itamar Holder (Red Hat)


### PR DESCRIPTION
## Description

Releases the blog post "Kubernetes 1.32: Fresh Swap Features for Linux Users" that was introduced here https://github.com/kubernetes/website/pull/48099

cc @sftim @iholder101 