### PR TITLE
Move 2 pages about new content to appropriate section

### DIFF
--- a/content/en/docs/contribute/docs.md
+++ b/content/en/docs/contribute/docs.md
@@ -148,7 +148,7 @@ Figure 2. Preparation for your first contribution.
   Kubernetes community members for accuracy and language.
 - Read the Kubernetes [content](/docs/contribute/style/content-guide/) and
   [style guides](/docs/contribute/style/style-guide/) so you can leave informed comments.
-- Learn about [page content types](/docs/contribute/style/page-content-types/)
+- Learn about [page content types](/docs/contribute/new-content/page-content-types/)
   and [Hugo shortcodes](/docs/contribute/style/hugo-shortcodes/).
 
 ## Getting help when contributing

--- a/content/en/docs/contribute/new-content/_index.md
+++ b/content/en/docs/contribute/new-content/_index.md
@@ -61,7 +61,7 @@ prior to submitting new content. The information details follow.
   Kubernetes documentation at `/content/en/docs/`. Some of the reference
   documentation is automatically generated from scripts in
   the `update-imported-docs/` directory.
-- [Page content types](/docs/contribute/style/page-content-types/) describe the
+- [Page content types](/docs/contribute/new-content/page-content-types/) help to declare the
   presentation of documentation content in Hugo.
 - You can use [Docsy shortcodes](https://www.docsy.dev/docs/adding-content/shortcodes/) or [custom Hugo shortcodes](/docs/contribute/style/hugo-shortcodes/) to contribute to Kubernetes documentation.
 - In addition to the standard Hugo shortcodes, we use a number of

--- a/content/en/docs/contribute/new-content/page-content-types.md
+++ b/content/en/docs/contribute/new-content/page-content-types.md
@@ -1,7 +1,7 @@
 ---
 title: Page content types
 content_type: concept
-weight: 80
+weight: 70
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/new-content/write-new-topic.md
+++ b/content/en/docs/contribute/new-content/write-new-topic.md
@@ -1,7 +1,7 @@
 ---
 title: Writing a new topic
 content_type: task
-weight: 70
+weight: 60
 ---
 
 <!-- overview -->
@@ -30,7 +30,7 @@ Tutorial | A tutorial page shows how to accomplish a goal that ties together sev
 
 ### Creating a new page
 
-Use a [content type](/docs/contribute/style/page-content-types/) for each new page
+Use a [content type](/docs/contribute/new-content/page-content-types/) for each new page
 that you write. The docs site provides templates or
 [Hugo archetypes](https://gohugo.io/content-management/archetypes/) to create
 new content pages. To create a new type of page, run `hugo new` with the path to the file
@@ -165,6 +165,6 @@ image format is SVG.
 
 ## {{% heading "whatsnext" %}}
 
-* Learn about [using page content types](/docs/contribute/style/page-content-types/).
+* Learn about [using page content types](/docs/contribute/new-content/page-content-types/).
 * Learn about [creating a pull request](/docs/contribute/new-content/open-a-pr/).
 

--- a/content/en/docs/contribute/review/reviewing-prs.md
+++ b/content/en/docs/contribute/review/reviewing-prs.md
@@ -155,13 +155,15 @@ When reviewing, use the following as a starting point.
 
 - Does the PR introduce a new page? If so:
 
-  - Is the page using the right [page content type](/docs/contribute/style/page-content-types/)
-    and associated Hugo shortcodes?
+  - Is the page using the right [page content type](/docs/contribute/new-content/page-content-types/)?
   - Does the page appear correctly in the section's side navigation (or at all)?
   - Should the page appear on the [Docs Home](/docs/home/) listing?
 
+- Do any new headings use the right shortcodes? See [content sections](/docs/contribute/new-content/page-content-types/#content-sections).
+
 - Do the changes show up in the Netlify preview? Be particularly vigilant about lists, code
   blocks, tables, notes and images.
+
 
 ### Blog
 

--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -466,7 +466,7 @@ Renders to:
 ## {{% heading "whatsnext" %}}
 
 * Learn about [Hugo](https://gohugo.io/).
-* Learn about [writing a new topic](/docs/contribute/style/write-new-topic/).
-* Learn about [page content types](/docs/contribute/style/page-content-types/).
+* Learn about [writing a new topic](/docs/contribute/new-content/write-new-topic/).
+* Learn about [page content types](/docs/contribute/new-content/page-content-types/).
 * Learn about [opening a pull request](/docs/contribute/new-content/open-a-pr/).
 * Learn about [advanced contributing](/docs/contribute/advanced/).

--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -288,8 +288,8 @@ Code examples and configuration examples that include version information should
 be consistent with the accompanying text.
 
 If the information is version specific, the Kubernetes version needs to be defined
-in the `prerequisites` section of the [Task template](/docs/contribute/style/page-content-types/#task)
-or the [Tutorial template](/docs/contribute/style/page-content-types/#tutorial).
+in the `prerequisites` section of the [Task template](/docs/contribute/new-content/page-content-types/#task)
+or the [Tutorial template](/docs/contribute/new-content/page-content-types/#tutorial).
 Once the page is saved, the `prerequisites` section is shown as **Before you begin**.
 
 To specify the Kubernetes version for a task or tutorial page, include
@@ -711,7 +711,7 @@ the rest of the project. To view the file, refer to
 
 ## {{% heading "whatsnext" %}}
 
-* Learn about [writing a new topic](/docs/contribute/style/write-new-topic/).
-* Learn about [using page templates](/docs/contribute/style/page-content-types/).
-* Learn about [custom hugo shortcodes](/docs/contribute/style/hugo-shortcodes/).
+* Learn about [writing a new topic](/docs/contribute/new-content/write-new-topic/).
+* Learn about [using page templates](/docs/contribute/new-content/page-content-types/).
 * Learn about [creating a pull request](/docs/contribute/new-content/open-a-pr/).
+* Learn about [custom hugo shortcodes](/docs/contribute/style/hugo-shortcodes/).

--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -62,5 +62,5 @@ Before walking through each tutorial, you may want to bookmark the
 ## {{% heading "whatsnext" %}}
 
 If you would like to write a tutorial, see
-[Content Page Types](/docs/contribute/style/page-content-types/)
+[Content Page Types](/docs/contribute/new-content/page-content-types/)
 for information about the tutorial page type.

--- a/static/_redirects
+++ b/static/_redirects
@@ -169,12 +169,14 @@
 /docs/home/contribute/generated-reference/kubernetes-api/ /docs/contribute/generate-ref-docs/kubernetes-api/ 301
 /docs/home/contribute/generated-reference/kubernetes-components/ /docs/contribute/generate-ref-docs/kubernetes-components/ 301
 /docs/home/contribute/localization/ /docs/contribute/localization/ 301
-/docs/home/contribute/page-templates/ /docs/contribute/style/page-content-types/ 301
+/docs/home/contribute/page-templates/ /docs/contribute/new-content/page-content-types/ 301
 /docs/home/contribute/participating/ /docs/contribute/participate/ 301
 /docs/home/contribute/review-issues/ /docs/contribute/intermediate/ 301
 /docs/home/contribute/blog-post/ /docs/contribute/start/ 301
-/docs/home/contribute/write-new-topic/ /docs/contribute/style/write-new-topic/ 301
-/docs/contribute/style/page-templates/ /docs/contribute/style/page-content-types/ 301
+/docs/home/contribute/write-new-topic/ /docs/contribute/new-content/write-new-topic/ 301
+/docs/contribute/style/page-templates/ /docs/contribute/new-content/page-content-types/ 301
+/docs/home/contribute/style/write-new-topic/ /docs/contribute/new-content/write-new-topic/ 301
+/docs/contribute/style/page-content-types/ /docs/contribute/new-content/page-content-types/ 301
 
 /docs/reference/command-line-tools-reference/labels-annotations-taints/     /docs/reference/labels-annotations-taints/ 301
 


### PR DESCRIPTION
The moved pages were in the docs style section of our docs about contributin, but they are more more relevant as guides to new content.

* If you have an existing page, it already has a content type set.
* If you are writing a new topic, it is new content.

/language en
/label refactor

I made [proposed] this change to support improvements around our guide to blog contribution.