### PR TITLE
Add t-inu to sig-docs-ja-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -127,6 +127,7 @@ aliases:
     - inductor
     - nasa9084
     - Okabe-Junya
+    - t-inu
   sig-docs-ja-reviews: # PR reviews for Japanese content
     - atoato88
     - b1gb4by


### PR DESCRIPTION
Added myself to sig-docs-ja-owners.

[[Requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-2)]
- Reviewer of the codebase for at least 3 months
  - I have been a ja-reviewer since [Aug 17, 2022](https://github.com/kubernetes/website/pull/35970).
- Primary reviewer for at least 10 substantial PRs to the codebase
  - [is:pr label:language/ja assignee:t-inu](https://github.com/kubernetes/website/pulls?q=is%3Apr+label%3Alanguage%2Fja+assignee%3At-inu) (165+)
- Reviewed or merged at least 30 PRs to the codebase
  - Reviewed: [is:pr label:language/ja reviewed-by:t-inu](https://github.com/kubernetes/website/pulls?q=is%3Apr+label%3Alanguage%2Fja+reviewed-by%3At-inu) (190+)
  - Merged: [is:pr is:merged label:language/ja author:t-inu](https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Amerged+label%3Alanguage%2Fja+author%3At-inu) (15+)

cc @kubernetes/sig-docs-ja-owners