### PR TITLE
[vi] update Code of Conduct link to use localized Vietnamese path

### DIFF
--- a/content/vi/community/_index.html
+++ b/content/vi/community/_index.html
@@ -54,7 +54,7 @@ cid: community
 <div class="conducttextnobutton" style="margin-bottom:2%"><h1>Quy tắc ứng xử</h1>
 Cộng đồng Kubernetes coi trọng sự tôn trọng và thực thi Quy tắc ứng xử trong tất cả các tương tác. Nếu bạn nhận thấy vi phạm Quy tắc ứng xử tại một sự kiện hoặc cuộc họp, trong Slack hoặc trong một cơ chế giao tiếp khác, hãy liên hệ với Ủy ban Quy tắc ứng xử Kubernetes tại <a href="mailto:conduct@kubernetes.io" style="color:#0662EE;font-weight:300">conduct@kubernetes.io</a>. Tất cả các báo cáo được giữ bí mật. Bạn có thể đọc về ủy ban&nbsp;<a href="https://github.com/kubernetes/community/tree/master/committee-code-of-conduct" style="color:#0662EE;font-weight:300">ở đây</a>.
 <br>
-<a href="https://kubernetes.io/community/code-of-conduct/">
+<a href="https://kubernetes.io/vi/community/code-of-conduct/">
 <br class="mobile"><br class="mobile">
 
 <span class="fullbutton">


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR updates the Code of Conduct link in the Vietnamese community page to point to the localized Vietnamese version of the Code of Conduct document.
Link: https://kubernetes.io/community/
### Issue

NONE