### PR TITLE
Update Hugo to v0.145.0 and fix Resource.Err deprecation

### DIFF
--- a/layouts/_default/cve-feed.json
+++ b/layouts/_default/cve-feed.json
@@ -1,6 +1,6 @@
 {{- $url := .Site.Params.cveFeedBucket -}}
-{{- with resources.GetRemote $url -}}
-  {{- if .Err -}}
+{{- with try (resources.GetRemote $url) -}}
+  {{- with .Err -}}
     {{- $message := printf "Failed to retrieve CVE data: %s" .Err -}}
     {{- if eq hugo.Environment "production" -}}
       {{- errorf $message -}}
@@ -8,7 +8,7 @@
       {{- warnf $message -}}
     {{- end -}}
   {{- else -}}
-    {{- .Content | transform.Unmarshal | jsonify -}}
+    {{- .Value | transform.Unmarshal | jsonify -}}
   {{- end -}}
 {{- else -}}
   {{- $message := printf "Unable to fetch CVE data from the specified URL: %q" $url -}}

--- a/layouts/_default/cve-feed.rss.xml
+++ b/layouts/_default/cve-feed.rss.xml
@@ -1,8 +1,8 @@
 {{- $url := .Site.Params.cveFeedBucket -}}
 {{- $feed := "" -}}
 
-{{- with resources.GetRemote $url -}}
-  {{- if .Err -}}
+{{- with try (resources.GetRemote $url) -}}
+  {{- with .Err -}}
     {{- $message := printf "Failed to retrieve CVE data: %s" .Err -}}
     {{- if eq hugo.Environment "production" -}}
       {{- errorf $message -}}
@@ -10,7 +10,7 @@
       {{- warnf $message -}}
     {{- end -}}
   {{- else -}}
-    {{- $feed = .Content | transform.Unmarshal -}}
+    {{- $feed = .Value | transform.Unmarshal -}}
   {{- end -}}
 {{- else -}}
   {{- $message := printf "Unable to fetch CVE data from the specified URL: %q" $url -}}

--- a/layouts/shortcodes/cve-feed.html
+++ b/layouts/shortcodes/cve-feed.html
@@ -1,8 +1,8 @@
 {{- $url := .Site.Params.cveFeedBucket }}
 {{- $feed := "" -}}
 <!-- Try to fetch remote resource from the specified URL -->
-{{- with resources.GetRemote $url -}}
-  {{- if .Err -}}
+{{- with try (resources.GetRemote $url) -}}
+  {{- with .Err -}}
     <!-- Error message if retrieval fails -->
     {{- $message := printf "Failed to retrieve CVE data: %s" .Err -}}
     {{- if eq hugo.Environment "production" -}}
@@ -12,7 +12,7 @@
     {{- end -}}
   {{- else -}}
     <!-- Process the content if retrieval is successful -->
-    {{- $feed = .Content | transform.Unmarshal -}}
+    {{- $feed = .Value | transform.Unmarshal -}}
     {{- if ne $feed.version "https://jsonfeed.org/version/1.1" -}}
       {{- $warningMessage := "CVE feed shortcode. KEP-3203: CVE feed does not comply with JSON feed v1.1." -}}
       {{- if eq hugo.Environment "production" -}}

--- a/layouts/shortcodes/release-binaries.html
+++ b/layouts/shortcodes/release-binaries.html
@@ -2,8 +2,8 @@
 {{- $url := "https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/dist/release_binaries.json" }}
 {{- $response := "" }}
 
-{{- with resources.GetRemote $url -}}
-  {{- if .Err -}}
+{{- with try (resources.GetRemote $url) -}}
+  {{- with .Err -}}
     {{- $message := printf "Failed to retrieve release binaries data: %s" .Err -}}
     {{- if eq hugo.Environment "production" -}}
       {{- errorf $message -}}
@@ -11,7 +11,7 @@
       {{- warnf $message -}}
     {{- end -}}
   {{- else -}}
-    {{- $response = .Content | transform.Unmarshal }}
+    {{- $response = .Value | transform.Unmarshal }}
   {{- end -}}
 {{- else -}}
   {{ $message := printf "Unable to fetch release binaries data from the specified URL: %q" $url -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = "git submodule update --init --recursive --depth 1 && make non-product
 
 [build.environment]
 NODE_VERSION = "20.17.0"
-HUGO_VERSION = "0.133.0"
+HUGO_VERSION = "0.145.0"
 
 [context.deploy-preview]
 command = "git submodule update --init --recursive --depth 1 && make deploy-preview && npx -y pagefind --site public"


### PR DESCRIPTION
### Description
This PR updates the website to use Hugo v0.145.0 (from v0.133.0) and fixes compatibility issues with the deprecated Resource.Err field.
See: https://gohugo.io/functions/go-template/try
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

When running with Hugo v0.141.0+, the build fails with the error:
"can't evaluate field Err in type resource.Resource: Resource.Err was removed in Hugo v0.141.0 and replaced with a new try keyword"

Closes: #49836