### PR TITLE
SSA request bodies can include either JSON or YAML

### DIFF
--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -579,6 +579,7 @@ to the URI of a resource.  When applying a configuration, you should always incl
 fields that are important to the outcome (such as a desired state) that you want to define.
 
 All JSON messages are valid YAML. Therefore, in addition to using YAML request bodies for Server-Side Apply requests, you can also use JSON request bodies, as they are also valid YAML.
+In either case, use the media type `application/apply-patch+yaml` for the HTTP request.
 
 ### Access control and permissions {#rbac-and-permissions}
 

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -578,8 +578,7 @@ Apply can send partially specified objects as YAML as the body of a `PATCH` requ
 to the URI of a resource.  When applying a configuration, you should always include all the
 fields that are important to the outcome (such as a desired state) that you want to define.
 
-All JSON messages are valid YAML. Some clients specify Server-Side Apply requests using JSON
-request bodies that are also valid YAML.
+All JSON messages are valid YAML. Therefore, in addition to using YAML request bodies for Server-Side Apply requests, you can also use JSON request bodies, as they are also valid YAML.
 
 ### Access control and permissions {#rbac-and-permissions}
 

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -578,8 +578,8 @@ Apply can send partially specified objects as YAML as the body of a `PATCH` requ
 to the URI of a resource.  When applying a configuration, you should always include all the
 fields that are important to the outcome (such as a desired state) that you want to define.
 
-All JSON messages are valid YAML. Some clients specify Server-Side Apply requests using YAML
-request bodies that are also valid JSON.
+All JSON messages are valid YAML. Some clients specify Server-Side Apply requests using JSON
+request bodies that are also valid YAML.
 
 ### Access control and permissions {#rbac-and-permissions}
 


### PR DESCRIPTION

### SSA request bodies can include either JSON or YAML

Since JSON messages are valid YAML, the request body for a server-side apply request (`application/apply-patch+yaml` content type) can be in either JSON or YAML.

Example:

```
kubectl create deploy nginx --image nginx --replicas 1

# request body is in JSON
cat <<EOF | curl  -XPATCH -H 'content-type: application/apply-patch+yaml' \
 'http://localhost:8001/apis/apps/v1/namespaces/default/deployments/nginx?fieldManager=test&force=true' \
 --data-binary @-
{
  "apiVersion": "apps/v1",
  "kind": "Deployment",
  "spec": {
    "replicas": 2
  }
}
EOF


# request body is in YAML
cat <<EOF | curl  -XPATCH -H 'content-type: application/apply-patch+yaml' \
 'http://localhost:8001/apis/apps/v1/namespaces/default/deployments/nginx?fieldManager=test&force=true' \
 --data-binary @-
apiVersion: apps/v1
kind: Deployment
spec:
  replicas: 1
EOF
```