### PR TITLE
Fix typo in volumes.md

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -14,7 +14,7 @@ weight: 10
 
 <!-- overview -->
 
-Kubernetes _volumes_ provide a way for containers in a {{< glossary_tooltip text="pods" term_id="pod" >}}
+Kubernetes _volumes_ provide a way for containers in a {{< glossary_tooltip text="pod" term_id="pod" >}}
 to access and share data via the filesystem. There are different kinds of volume that you can use for different purposes,
 such as:
 


### PR DESCRIPTION
Simple fix to small typo in first sentence of the page.

Before: 
"Kubernetes volumes provide a way for containers in a `pods` to access[...]"

After: 
"Kubernetes volumes provide a way for containers in a `pod` to access[...]"