### PR TITLE
Fix for `(EN)` not appearing in docs sidebar for i18nised site

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -163,16 +163,6 @@ div.feature-state-notice {
   background-color: rgba(255, 255, 255, 0.25);
 }
 
-/* Sidebar menu */
-#td-sidebar-menu {
-  #m-docs span, small {
-    visibility: hidden;
-  }
-  #m-docs small {
-    visibility: collapse; // if supported
-  }
-}
-
 /* Styles for CVE table */
 table tr.cve-status-open, table tr.cve-status-unknown {
   > td.cve-item-summary {


### PR DESCRIPTION
### Description

The fix involves removing the SCSS which "hid" the element. Moreover, the sidebars no longer have the `#m-docs` HTML ID anywhere as the HTML element bearing that ID in Docsy is removed from the overriden `sidebar-tree.html` template.

### Issue

Closes: #50132 

Before -> After
![image](https://github.com/user-attachments/assets/809cce03-d825-4e10-b7b8-8953ec78d573)
