### PR TITLE
Clarify how to config maximum loopback off delay

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletCrashLoopBackOffMax.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletCrashLoopBackOffMax.md
@@ -11,4 +11,7 @@ stages:
     fromVersion: "1.32"
 ---
 Enables support for configurable per-node backoff maximums for restarting
-containers in the CrashLoopBackOff state.
+containers in the `CrashLoopBackOff` state.
+For more details, check the `crashLoopBackOff.maxContainerRestartPeriod` field in the
+[kubelet config file](/docs/reference/config-api/kubelet-config.v1beta1/).
+


### PR DESCRIPTION
This PR amends the feature gate description for configuring the maximum loop backoff delay in kubelet.
