### PR TITLE
Remove link to Release Engineering teams page on GitHub in Release Managers docs

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -85,7 +85,7 @@ set forth in the [Security Release Process][security-release-process].
 
 GitHub Access Controls: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
 
-GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kubernetes/teams/release-engineering)
+GitHub Mentions: @kubernetes/release-engineering
 
 - Adolfo García Veytia ([@puerco](https://github.com/puerco))
 - Cici Huang ([@cici37](https://github.com/cici37))


### PR DESCRIPTION
### Description

Remove the link to GitHub @kubernetes/release-engineering page in Release Managers docs. This means to team mention (as text), should not provide link to prevent misleading.

### Issue

NONE