### PR TITLE
[zh] fix contribute/_index.md

### DIFF
--- a/content/zh-cn/docs/contribute/_index.md
+++ b/content/zh-cn/docs/contribute/_index.md
@@ -32,7 +32,7 @@ you can implement those new features or fix bugs. You can help people join our c
 community, or support existing contributors.
 -->
 为 Kubernetes 做出贡献的方法有很多。你可以致力于新特性的设计、记录我们已有的代码、为我们的[博客](/blog)写文章。
-还有更多：你可以实现这些新特性或修复 Bug、可以帮助人们加入我们的贡献者社区，或支持现有的贡献者。
+不仅如此：你还可以实现这些新特性或修复 Bug、可以帮助新人加入我们的贡献者社区，或支持现有的贡献者。
 
 <!--
 With all these different ways to make a difference to the project, we - Kubernetes - have made
@@ -42,7 +42,18 @@ contributing to Kubernetes.
 If you specifically want to learn about contributing to _this_ documentation, read
 [Contribute to Kubernetes documentation](/docs/contribute/docs/).
 -->
-通过所有这些不同的方式来改变项目，我们（Kubernetes）制作了一个专门的网站：https://k8s.dev/。
+通过所有这些不同的方式来改变项目，我们（Kubernetes）制作了一个专门的网站：[https://k8s.dev/](https://k8s.dev/)。
 你可以去那里了解有关为 Kubernetes 做出贡献的更多信息。
 
-如果你特别想了解如何为**本**文档做出贡献，请阅读[为 Kubernetes 文档做出贡献](/zh-cn/docs/contribute/docs/)。
+如果你特别想了解如何为**本项目的文档**做出贡献，请阅读[为 Kubernetes 文档出一份力](/zh-cn/docs/contribute/docs/)。
+
+<!--
+You can also read the
+{{< glossary_tooltip text="CNCF" term_id="cncf" >}}
+[page](https://contribute.cncf.io/contributors/projects/#kubernetes)
+about contributing to Kubernetes.
+-->
+你也可以阅读
+{{< glossary_tooltip text="CNCF" term_id="cncf" >}}
+[页面](https://contribute.cncf.io/contributors/projects/#kubernetes)
+，了解如何为 Kubernetes 做贡献。


### PR DESCRIPTION
- Add one missing paragraph
- Fix the link syntax (was invalid due to full-width period `。`)
- Improve some wording

(The file is already synced as `lsync.sh` said)

Current Page: https://kubernetes.io/zh-cn/docs/contribute/
Netlify Preview: https://deploy-preview-50152--kubernetes-io-main-staging.netlify.app/zh-cn/docs/contribute/