### PR TITLE
Fix KubeWeekly archive link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,7 +30,7 @@
             <div class="clear"><input type="submit" value="{{ T "subscribe_button" }}" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
             </div>
         </form>
-        <h5 style="text-align: center"><a href="https://us10.campaign-archive.com/home/?u=3885586f8f1175194017967d6&id=11c1b8bcb2" aria-label="Kube Weekly" style="color: #3371E3; font-weight: 400; font-size: 20px">{{ T "main_kubeweekly_past_link" }}</a></h5>
+        <h5 style="text-align: center"><a href="https://www.cncf.io/kubeweekly/" aria-label="Kube Weekly" style="color: #3371E3; font-weight: 400; font-size: 20px">{{ T "main_kubeweekly_past_link" }}</a></h5>
         </div>
 
         <!--End mc_embed_signup-->

--- a/layouts/shortcodes/kubeweekly.html
+++ b/layouts/shortcodes/kubeweekly.html
@@ -12,7 +12,7 @@
             <div class="clear"><input type="submit" value="{{ T "subscribe_button" }}" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
             </div>
         </form>
-        <h5><a class="kubeweekly-signup" href="https://us10.campaign-archive.com/home/?u=3885586f8f1175194017967d6&id=11c1b8bcb2" aria-label="Kube Weekly">{{ T "main_kubeweekly_past_link" }}</a></h5>
+        <h5><a class="kubeweekly-signup" href="https://www.cncf.io/kubeweekly/" aria-label="Kube Weekly">{{ T "main_kubeweekly_past_link" }}</a></h5>
     </div>
     </div>
 </section>


### PR DESCRIPTION
Currently, the "[View past newsletters](https://us10.campaign-archive.com/home/?u=3885586f8f1175194017967d6&id=11c1b8bcb2)" link on the main page leads to an old Mailchimp page listing really outdated KubeWeekly issues. The latest issue available there is KubeWeekly 257 (dated 04/02/2021).

I found the full and up-to-date KubeWeekly archive on the [CNCF website](https://www.cncf.io/kubeweekly/) and suggest using this link instead.
