### PR TITLE
Improve ResourceQuota concept

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -14,36 +14,57 @@ weight: 20
 When several users or teams share a cluster with a fixed number of nodes,
 there is a concern that one team could use more than its fair share of resources.
 
-Resource quotas are a tool for administrators to address this concern.
+_Resource quotas_ are a tool for administrators to address this concern.
+
+A resource quota, defined by a ResourceQuota object, provides constraints that limit
+aggregate resource consumption per {{< glossary_tooltip text="namespace" term_id="namespace" >}}. A ResourceQuota can also
+limit the [quantity of objects that can be created in a namespace](#quota-on-object-count) by API kind, as well as the total
+amount of {{< glossary_tooltip text="infrastructure resources" term_id="infrastructure-resource" >}} that may be consumed by
+API objects found in that namespace.
+
+{{< caution >}}
+Neither contention nor changes to quota will affect already created resources.
+{{< /caution >}}
 
 <!-- body -->
 
-A resource quota, defined by a `ResourceQuota` object, provides constraints that limit
-aggregate resource consumption per namespace. It can limit the quantity of objects that can
-be created in a namespace by type, as well as the total amount of compute resources that may
-be consumed by resources in that namespace.
+## How Kubernetes ResourceQuotas work
 
-Resource quotas work like this:
+ResourceQuotas work like this:
 
-- Different teams work in different namespaces. This can be enforced with
-  [RBAC](/docs/reference/access-authn-authz/rbac/).
+- Different teams work in different namespaces. This separation can be enforced with
+  [RBAC](/docs/reference/access-authn-authz/rbac/) or any other [authorization](/docs/reference/access-authn-authz/authorization/)
+  mechanism.
 
-- The administrator creates one ResourceQuota for each namespace.
+- A cluster administrator creates at least one ResourceQuota for each namespace.
+  - To make sure the enforcement stays enforced, the cluster administrator should also restrict access to delete or update
+    that ResourceQuota; for example, by defining a [ValidatingAdmissionPolicy](/docs/reference/access-authn-authz/validating-admission-policy/).
 
 - Users create resources (pods, services, etc.) in the namespace, and the quota system
   tracks usage to ensure it does not exceed hard resource limits defined in a ResourceQuota.
 
-- If creating or updating a resource violates a quota constraint, the request will fail with HTTP
-  status code `403 FORBIDDEN` with a message explaining the constraint that would have been violated.
+  You can apply a [scope](#quota-scopes) to a ResourceQuota to limit where it applies,
 
-- If quotas are enabled in a namespace for compute resources like `cpu` and `memory`, users must specify
-  requests or limits for those values; otherwise, the quota system may reject pod creation. Hint: Use
-  the `LimitRanger` admission controller to force defaults for pods that make no compute resource requirements.
+- If creating or updating a resource violates a quota constraint, the control plane rejects that request with HTTP
+  status code `403 Forbidden`. The error includes a message explaining the constraint that would have been violated.
 
-  See the [walkthrough](/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
-  for an example of how to avoid this problem.
+- If quotas are enabled in a namespace for {{< glossary_tooltip text="resource" term_id="infrastructure-resource" >}}
+  such as `cpu` and `memory`, users must specify requests or limits for those values when they define a Pod; otherwise,
+  the quota system may reject pod creation.
+
+  The resource quota [walkthrough](/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
+  shows an example of how to avoid this problem.
 
 {{< note >}}
+* You can define a [LimitRange](/docs/concepts/policy/limit-range/)
+  to force defaults on pods that make no compute resource requirements (so that users don't have to remember to do that).
+{{< /note >}}
+
+You often do not create Pods directly; for example, you more usually create a [workload management](/docs/concepts/workloads/controllers/)
+object such as a {{< glossary_tooltip term_id="deployment" >}}. If you create a Deployment that tries to use more
+resources than are available, the creation of the Deployment (or other workload management object) **succeeds**, but
+the Deployment may not be able to get all of the Pods it manages to exist. In that case you can check the status of
+the Deployment, for example with `kubectl describe`, to see what has happened.
 
 - For `cpu` and `memory` resources, ResourceQuotas enforce that **every**
   (new) pod in that namespace sets a limit for that resource.
@@ -59,8 +80,6 @@ Resource quotas work like this:
 You can use a [LimitRange](/docs/concepts/policy/limit-range/) to automatically set
 a default request for these resources.
 
-{{< /note >}}
-
 The name of a ResourceQuota object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
@@ -74,7 +93,6 @@ Examples of policies that could be created using namespaces and quotas are:
 In the case where the total capacity of the cluster is less than the sum of the quotas of the namespaces,
 there may be contention for resources. This is handled on a first-come-first-served basis.
 
-Neither contention nor changes to quota will affect already created resources.
 
 ## Enabling Resource Quota
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -104,7 +104,11 @@ one of its arguments.
 A resource quota is enforced in a particular namespace when there is a
 ResourceQuota in that namespace.
 
-## Compute Resource Quota
+## Types of resource quota
+
+The ResourceQuota mechanism lets you enforce several different kinds of limit.
+
+### Quota for infrastructure resources {#compute-resource-quota}
 
 You can limit the total sum of
 [compute resources](/docs/concepts/configuration/manage-resources-containers/)
@@ -122,7 +126,7 @@ The following resource types are supported:
 | `cpu` | Same as `requests.cpu` |
 | `memory` | Same as `requests.memory` |
 
-### Resource Quota For Extended Resources
+### Quota for extended resources
 
 In addition to the resources mentioned above, in release 1.10, quota support for
 [extended resources](/docs/concepts/configuration/manage-resources-containers/#extended-resources) is added.
@@ -138,12 +142,13 @@ limit the total number of GPUs requested in a namespace to 4, you can define a q
 
 See [Viewing and Setting Quotas](#viewing-and-setting-quotas) for more details.
 
-## Storage Resource Quota
+### Quota for storage
 
-You can limit the total sum of [storage resources](/docs/concepts/storage/persistent-volumes/)
+You can limit the total sum of [storage](/docs/concepts/storage/persistent-volumes/) for volumes
 that can be requested in a given namespace.
 
-In addition, you can limit consumption of storage resources based on associated storage-class.
+In addition, you can limit consumption of storage resources based on associated
+[StorageClass](/docs/concepts/storage/storage-classes/).
 
 | Resource Name | Description |
 | ------------- | ----------- |
@@ -158,7 +163,10 @@ a `bronze` StorageClass, you can define a quota as follows:
 * `gold.storageclass.storage.k8s.io/requests.storage: 500Gi`
 * `bronze.storageclass.storage.k8s.io/requests.storage: 100Gi`
 
-In release 1.8, quota support for local ephemeral storage is added as an alpha feature:
+#### Quota for local ephemeral storage
+
+{{< feature-state for_k8s_version="v1.8" state="alpha" >}}
+
 
 | Resource Name | Description |
 | ------------- | ----------- |
@@ -169,46 +177,56 @@ In release 1.8, quota support for local ephemeral storage is added as an alpha f
 {{< note >}}
 When using a CRI container runtime, container logs will count against the ephemeral storage quota.
 This can result in the unexpected eviction of pods that have exhausted their storage quotas.
+
 Refer to [Logging Architecture](/docs/concepts/cluster-administration/logging/) for details.
 {{< /note >}}
 
-## Object Count Quota
+### Quota on object count
 
-You can set quota for *the total number of one particular resource kind* in the Kubernetes API,
+You can set quota for *the total number of one particular {{< glossary_tooltip text="resource" term_id="api-resource" >}} kind* in the Kubernetes API,
 using the following syntax:
 
-* `count/<resource>.<group>` for resources from non-core groups
-* `count/<resource>` for resources from the core group
+* `count/<resource>.<group>` for resources from non-core API groups
+* `count/<resource>` for resources from the core API group
 
-Here is an example set of resources users may want to put under object count quota:
+For example, the PodTemplate API is in the core API group and so if you want to limit the number of
+PodTemplate objects in a namespace, you use `count/podtemplates`.
 
+These types of quotas are useful to protect against exhaustion of control plane storage. For example, you may
+want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can
+actually prevent servers and controllers from starting. You can set a quota for Jobs to protect against
+a poorly configured CronJob. CronJobs that create too many Jobs in a namespace can lead to a denial of service.
+
+
+
+If you define a quota this way, it applies to Kubernetes' APIs that are part of the API server, and
+to any custom resources backed by a CustomResourceDefinition.
+For example, to create a quota on a `widgets` custom resource in the `example.com` API group,
+use `count/widgets.example.com`.
+If you use [API aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) to
+add additional, custom APIs that are not defined as CustomResourceDefinitions, the core Kubernetes
+control plane does not enforce quota for the aggregated API. The extension API server is expected to
+provide quota enforcement if that's appropriate for the custom API.
+
+##### Generic syntax {#resource-quota-object-count-generic}
+
+This is a list of common examples of object kinds that you may want to put under object count quota,
+listed by the configuration string that you would use.
+
+* `count/pods`
 * `count/persistentvolumeclaims`
 * `count/services`
 * `count/secrets`
 * `count/configmaps`
-* `count/replicationcontrollers`
 * `count/deployments.apps`
 * `count/replicasets.apps`
 * `count/statefulsets.apps`
 * `count/jobs.batch`
 * `count/cronjobs.batch`
 
-If you define a quota this way, it applies to Kubernetes' APIs that are part of the API server, and
-to any custom resources backed by a CustomResourceDefinition. If you use
-[API aggregation](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) to
-add additional, custom APIs that are not defined as CustomResourceDefinitions, the core Kubernetes
-control plane does not enforce quota for the aggregated API. The extension API server is expected to
-provide quota enforcement if that's appropriate for the custom API.
-For example, to create a quota on a `widgets` custom resource in the `example.com` API group, use `count/widgets.example.com`.
+##### Specialized syntax {#resource-quota-object-count-specialized}
 
-When using such a resource quota (nearly for all object kinds), an object is charged
-against the quota if the object kind exists (is defined) in the control plane.
-These types of quotas are useful to protect against exhaustion of storage resources. For example, you may
-want to limit the number of Secrets in a server given their large size. Too many Secrets in a cluster can
-actually prevent servers and controllers from starting. You can set a quota for Jobs to protect against
-a poorly configured CronJob. CronJobs that create too many Jobs in a namespace can lead to a denial of service.
-
-There is another syntax only to set the same type of quota for certain resources.
+There is another syntax only to set the same type of quota, that only works for certain API kinds.
 The following types are supported:
 
 | Resource Name | Description |

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -248,262 +248,6 @@ exhausts the cluster's supply of Pod IPs.
 
 You can find more examples on [Viewing and Setting Quotas](#viewing-and-setting-quotas).
 
-## Quota Scopes
-
-Each quota can have an associated set of `scopes`. A quota will only measure usage for a resource if it matches
-the intersection of enumerated scopes.
-
-When a scope is added to the quota, it limits the number of resources it supports to those that pertain to the scope.
-Resources specified on the quota outside of the allowed set results in a validation error.
-
-| Scope | Description |
-| ----- | ----------- |
-| `Terminating` | Match pods where `.spec.activeDeadlineSeconds` >= `0` |
-| `NotTerminating` | Match pods where `.spec.activeDeadlineSeconds` is `nil` |
-| `BestEffort` | Match pods that have best effort quality of service. |
-| `NotBestEffort` | Match pods that do not have best effort quality of service. |
-| `PriorityClass` | Match pods that references the specified [priority class](/docs/concepts/scheduling-eviction/pod-priority-preemption). |
-| `CrossNamespacePodAffinity` | Match pods that have cross-namespace pod [(anti)affinity terms](/docs/concepts/scheduling-eviction/assign-pod-node). |
-
-The `BestEffort` scope restricts a quota to tracking the following resource:
-
-* `pods`
-
-The `Terminating`, `NotTerminating`, `NotBestEffort` and `PriorityClass`
-scopes restrict a quota to tracking the following resources:
-
-* `pods`
-* `cpu`
-* `memory`
-* `requests.cpu`
-* `requests.memory`
-* `limits.cpu`
-* `limits.memory`
-
-Note that you cannot specify both the `Terminating` and the `NotTerminating`
-scopes in the same quota, and you cannot specify both the `BestEffort` and
-`NotBestEffort` scopes in the same quota either.
-
-The `scopeSelector` supports the following values in the `operator` field:
-
-* `In`
-* `NotIn`
-* `Exists`
-* `DoesNotExist`
-
-When using one of the following values as the `scopeName` when defining the
-`scopeSelector`, the `operator` must be `Exists`.
-
-* `Terminating`
-* `NotTerminating`
-* `BestEffort`
-* `NotBestEffort`
-
-If the `operator` is `In` or `NotIn`, the `values` field must have at least
-one value. For example:
-
-```yaml
-  scopeSelector:
-    matchExpressions:
-      - scopeName: PriorityClass
-        operator: In
-        values:
-          - middle
-```
-
-If the `operator` is `Exists` or `DoesNotExist`, the `values` field must *NOT* be
-specified.
-
-### Resource Quota Per PriorityClass
-
-{{< feature-state for_k8s_version="v1.17" state="stable" >}}
-
-Pods can be created at a specific [priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority).
-You can control a pod's consumption of system resources based on a pod's priority, by using the `scopeSelector`
-field in the quota spec.
-
-A quota is matched and consumed only if `scopeSelector` in the quota spec selects the pod.
-
-When quota is scoped for priority class using `scopeSelector` field, quota object
-is restricted to track only following resources:
-
-* `pods`
-* `cpu`
-* `memory`
-* `ephemeral-storage`
-* `limits.cpu`
-* `limits.memory`
-* `limits.ephemeral-storage`
-* `requests.cpu`
-* `requests.memory`
-* `requests.ephemeral-storage`
-
-This example creates a quota object and matches it with pods at specific priorities. The example
-works as follows:
-
-- Pods in the cluster have one of the three priority classes, "low", "medium", "high".
-- One quota object is created for each priority.
-
-Save the following YAML to a file `quota.yaml`.
-
-{{% code_sample file="policy/quota.yaml" %}}
-
-Apply the YAML using `kubectl create`.
-
-```shell
-kubectl create -f ./quota.yaml
-```
-
-```
-resourcequota/pods-high created
-resourcequota/pods-medium created
-resourcequota/pods-low created
-```
-
-Verify that `Used` quota is `0` using `kubectl describe quota`.
-
-```shell
-kubectl describe quota
-```
-
-```
-Name:       pods-high
-Namespace:  default
-Resource    Used  Hard
---------    ----  ----
-cpu         0     1k
-memory      0     200Gi
-pods        0     10
-
-
-Name:       pods-low
-Namespace:  default
-Resource    Used  Hard
---------    ----  ----
-cpu         0     5
-memory      0     10Gi
-pods        0     10
-
-
-Name:       pods-medium
-Namespace:  default
-Resource    Used  Hard
---------    ----  ----
-cpu         0     10
-memory      0     20Gi
-pods        0     10
-```
-
-Create a pod with priority "high". Save the following YAML to a
-file `high-priority-pod.yaml`.
-
-{{% code_sample file="policy/high-priority-pod.yaml" %}}
-
-Apply it with `kubectl create`.
-
-```shell
-kubectl create -f ./high-priority-pod.yaml
-```
-
-Verify that "Used" stats for "high" priority quota, `pods-high`, has changed and that
-the other two quotas are unchanged.
-
-```shell
-kubectl describe quota
-```
-
-```
-Name:       pods-high
-Namespace:  default
-Resource    Used  Hard
---------    ----  ----
-cpu         500m  1k
-memory      10Gi  200Gi
-pods        1     10
-
-
-Name:       pods-low
-Namespace:  default
-Resource    Used  Hard
---------    ----  ----
-cpu         0     5
-memory      0     10Gi
-pods        0     10
-
-
-Name:       pods-medium
-Namespace:  default
-Resource    Used  Hard
---------    ----  ----
-cpu         0     10
-memory      0     20Gi
-pods        0     10
-```
-
-### Cross-namespace Pod Affinity Quota
-
-{{< feature-state for_k8s_version="v1.24" state="stable" >}}
-
-Operators can use `CrossNamespacePodAffinity` quota scope to limit which namespaces are allowed to
-have pods with affinity terms that cross namespaces. Specifically, it controls which pods are allowed
-to set `namespaces` or `namespaceSelector` fields in pod affinity terms.
-
-Preventing users from using cross-namespace affinity terms might be desired since a pod
-with anti-affinity constraints can block pods from all other namespaces
-from getting scheduled in a failure domain.
-
-Using this scope operators can prevent certain namespaces (`foo-ns` in the example below)
-from having pods that use cross-namespace pod affinity by creating a resource quota object in
-that namespace with `CrossNamespacePodAffinity` scope and hard limit of 0:
-
-```yaml
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: disable-cross-namespace-affinity
-  namespace: foo-ns
-spec:
-  hard:
-    pods: "0"
-  scopeSelector:
-    matchExpressions:
-    - scopeName: CrossNamespacePodAffinity
-      operator: Exists
-```
-
-If operators want to disallow using `namespaces` and `namespaceSelector` by default, and
-only allow it for specific namespaces, they could configure `CrossNamespacePodAffinity`
-as a limited resource by setting the kube-apiserver flag `--admission-control-config-file`
-to the path of the following configuration file:
-
-```yaml
-apiVersion: apiserver.config.k8s.io/v1
-kind: AdmissionConfiguration
-plugins:
-- name: "ResourceQuota"
-  configuration:
-    apiVersion: apiserver.config.k8s.io/v1
-    kind: ResourceQuotaConfiguration
-    limitedResources:
-    - resource: pods
-      matchScopes:
-      - scopeName: CrossNamespacePodAffinity
-        operator: Exists
-```
-
-With the above configuration, pods can use `namespaces` and `namespaceSelector` in pod affinity only
-if the namespace where they are created have a resource quota object with
-`CrossNamespacePodAffinity` scope and a hard limit greater than or equal to the number of pods using those fields.
-
-## Requests compared to Limits {#requests-vs-limits}
-
-When allocating compute resources, each container may specify a request and a limit value for either CPU or memory.
-The quota can be configured to quota either value.
-
-If the quota has a value specified for `requests.cpu` or `requests.memory`, then it requires that every incoming
-container makes an explicit request for those resources. If the quota has a value specified for `limits.cpu` or `limits.memory`,
-then it requires that every incoming container specifies an explicit limit for those resources.
-
 ## Viewing and Setting Quotas
 
 kubectl supports creating, updating, and viewing quotas:
@@ -648,7 +392,298 @@ hard limits of each namespace according to other signals.
 Note that resource quota divides up aggregate cluster resources, but it creates no
 restrictions around nodes: pods from several namespaces may run on the same node.
 
-## Limit Priority Class consumption by default
+## Quota scopes
+
+Each quota can have an associated set of `scopes`. A quota will only measure usage for a resource if it matches
+the intersection of enumerated scopes.
+
+When a scope is added to the quota, it limits the number of resources it supports to those that pertain to the scope.
+Resources specified on the quota outside of the allowed set results in a validation error.
+
+Kubernetes {{< skew currentVersion >}} supports the following scopes:
+
+| Scope | Description |
+| ----- | ----------- |
+| [`BestEffort`](#quota-scope-best-effort) | Match pods that have best effort quality of service. |
+| [`CrossNamespacePodAffinity`](#cross-namespace-pod-affinity-scope) | Match pods that have cross-namespace pod [(anti)affinity terms](/docs/concepts/scheduling-eviction/assign-pod-node). |
+| [`NotBestEffort`](#quota-scope-non-best-effort) | Match pods that do not have best effort quality of service. |
+| [`NotTerminating`](#quota-scope-non-terminating) | Match pods where `.spec.activeDeadlineSeconds`]() is `nil`]() |
+| [`PriorityClass`](#resource-quota-per-priorityclass) | Match pods that references the specified [priority class](/docs/concepts/scheduling-eviction/pod-priority-preemption). |
+| [`Terminating`](##quota-scope-terminating) | Match pods where `.spec.activeDeadlineSeconds`]() >= `0`]() |
+
+ResourceQuotas with a scope set can also have a optional `scopeSelector` field. You define one or more _match expressions_
+that specify an `operators` and, if relevant, a set of `values` to match. For example:
+
+```yaml
+  scopeSelector:
+    matchExpressions:
+      - scopeName: BestEffort # Match pods that have best effort quality of service
+        operator: Exists # optional; "Exists" is implied for BestEffort scope
+```
+
+The `scopeSelector` supports the following values in the `operator` field:
+
+* `In`
+* `NotIn`
+* `Exists`
+* `DoesNotExist`
+
+If the `operator` is `In` or `NotIn`, the `values` field must have at least
+one value. For example:
+
+```yaml
+  scopeSelector:
+    matchExpressions:
+      - scopeName: PriorityClass
+        operator: In
+        values:
+          - middle
+```
+
+If the `operator` is `Exists` or `DoesNotExist`, the `values` field must *NOT* be
+specified.
+
+### Best effort Pods scope {#quota-scope-best-effort}
+
+This scope only tracks quota consumed by Pods.
+It only matches pods that have the [best effort](/docs/concepts/workloads/pods/pod-qos/#besteffort)
+[QoS class](/docs/concepts/workloads/pods/pod-qos/).
+
+The `operator` for a `scopeSelector` must be `Exists`.
+
+### Not-best effort Pods scope {#quota-scope-non-best-effort}
+
+This scope only tracks quota consumed by Pods.
+It only matches pods that have the [Guaranteed](/docs/concepts/workloads/pods/pod-qos/#guaranteed)
+or [Burstable](/docs/concepts/workloads/pods/pod-qos/#burstable)
+[QoS class](/docs/concepts/workloads/pods/pod-qos/).
+
+The `operator` for a `scopeSelector` must be `Exists`.
+
+### Non-terminating Pods scope {#quota-scope-non-terminating}
+
+This scope only tracks quota consumed by Pods that are not terminating. The `operator` for a `scopeSelector`
+must be `Exists`.
+
+A Pod is not terminating if the `.spec.activeDeadlineSeconds` field is unset.
+
+You can use a ResourceQuota with this scope to manage the following resources:
+
+* `count.pods`
+* `pods`
+* `cpu`
+* `memory`
+* `requests.cpu`
+* `requests.memory`
+* `limits.cpu`
+* `limits.memory`
+
+### Terminating Pods scope {#quota-scope-terminating}
+
+This scope only tracks quota consumed by Pods that are not terminating. The `operator` for a `scopeSelector`
+must be `Exists`.
+
+A Pod is considered as _terminating_ if the `.spec.activeDeadlineSeconds` field is set to any number.
+
+You can use a ResourceQuota with this scope to manage the following resources:
+
+* `count.pods`
+* `pods`
+* `cpu`
+* `memory`
+* `requests.cpu`
+* `requests.memory`
+* `limits.cpu`
+* `limits.memory`
+
+### Cross-namespace pod affinity scope
+ 
+{{< feature-state for_k8s_version="v1.24" state="stable" >}}
+
+You can use `CrossNamespacePodAffinity` [quota scope](#quota-scopes) to limit which namespaces are allowed to
+have pods with affinity terms that cross namespaces. Specifically, it controls which pods are allowed
+to set `namespaces` or `namespaceSelector` fields in pod [(anti)affinity terms](/docs/concepts/scheduling-eviction/assign-pod-node).
+
+Preventing users from using cross-namespace affinity terms might be desired since a pod
+with anti-affinity constraints can block pods from all other namespaces
+from getting scheduled in a failure domain.
+
+Using this scope, you (as a cluster administrator) can prevent certain namespaces - such as `foo-ns` in the example below -
+from having pods that use cross-namespace pod affinity. You configure this creating a ResourceQuota object in
+that namespace with `CrossNamespacePodAffinity` scope and hard limit of 0:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: disable-cross-namespace-affinity
+  namespace: foo-ns
+spec:
+  hard:
+    pods: "0"
+  scopeSelector:
+    matchExpressions:
+    - scopeName: CrossNamespacePodAffinity
+      operator: Exists
+```
+
+If you want to disallow using `namespaces` and `namespaceSelector` by default, and
+only allow it for specific namespaces, you could configure `CrossNamespacePodAffinity`
+as a limited resource by setting the kube-apiserver flag `--admission-control-config-file`
+to the path of the following configuration file:
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: "ResourceQuota"
+  configuration:
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: ResourceQuotaConfiguration
+    limitedResources:
+    - resource: pods
+      matchScopes:
+      - scopeName: CrossNamespacePodAffinity
+        operator: Exists
+```
+
+With the above configuration, pods can use `namespaces` and `namespaceSelector` in pod affinity only
+if the namespace where they are created have a resource quota object with
+`CrossNamespacePodAffinity` scope and a hard limit greater than or equal to the number of pods using those fields.
+
+### PriorityClass scope {#resource-quota-per-priorityclass}
+
+{{< feature-state for_k8s_version="v1.17" state="stable" >}}
+
+A ResourceQuota with a PriorityClass scope only matches Pods that have a particular
+[priority class](/docs/concepts/scheduling-eviction/pod-priority-preemption), and only
+if any `scopeSelector` in the quota spec selects a particular Pod.
+
+Pods can be created at a specific [priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority).
+You can control a pod's consumption of system resources based on a pod's priority, by using the `scopeSelector`
+field in the quota spec.
+
+
+When quota is scoped for PriorityClass using the `scopeSelector` field, the ResourceQuota
+can only track (and limit) the following resources:
+
+* `pods`
+* `cpu`
+* `memory`
+* `ephemeral-storage`
+* `limits.cpu`
+* `limits.memory`
+* `limits.ephemeral-storage`
+* `requests.cpu`
+* `requests.memory`
+* `requests.ephemeral-storage`
+
+#### Example {#quota-scope-priorityclass-example}
+
+This example creates a ResourceQuota matches it with pods at specific priorities. The example
+works as follows:
+
+- Pods in the cluster have one of the three [PriorityClasses](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass), "low", "medium", "high".
+  - If you want to try this out, use a testing cluster and set up those three PriorityClasses before you continue.
+- One quota object is created for each priority.
+
+Inspect this set of ResourceQuotas:
+
+{{% code_sample file="policy/quota.yaml" %}}
+
+Apply the YAML using `kubectl create`.
+
+```shell
+kubectl create -f https://k8s.io/examples/policy/quota.yaml
+```
+
+```
+resourcequota/pods-high created
+resourcequota/pods-medium created
+resourcequota/pods-low created
+```
+
+Verify that `Used` quota is `0` using `kubectl describe quota`.
+
+```shell
+kubectl describe quota
+```
+
+```
+Name:       pods-high
+Namespace:  default
+Resource    Used  Hard
+--------    ----  ----
+cpu         0     1k
+memory      0     200Gi
+pods        0     10
+
+
+Name:       pods-low
+Namespace:  default
+Resource    Used  Hard
+--------    ----  ----
+cpu         0     5
+memory      0     10Gi
+pods        0     10
+
+
+Name:       pods-medium
+Namespace:  default
+Resource    Used  Hard
+--------    ----  ----
+cpu         0     10
+memory      0     20Gi
+pods        0     10
+```
+
+Create a pod with priority "high".
+
+{{% code_sample file="policy/high-priority-pod.yaml" %}}
+
+To create the Pod:
+
+```shell
+kubectl create -f https://k8s.io/examples/policy/high-priority-pod.yaml
+
+```
+
+Verify that "Used" stats for "high" priority quota, `pods-high`, has changed and that
+the other two quotas are unchanged.
+
+```shell
+kubectl describe quota
+```
+
+```
+Name:       pods-high
+Namespace:  default
+Resource    Used  Hard
+--------    ----  ----
+cpu         500m  1k
+memory      10Gi  200Gi
+pods        1     10
+
+
+Name:       pods-low
+Namespace:  default
+Resource    Used  Hard
+--------    ----  ----
+cpu         0     5
+memory      0     10Gi
+pods        0     10
+
+
+Name:       pods-medium
+Namespace:  default
+Resource    Used  Hard
+--------    ----  ----
+cpu         0     10
+memory      0     20Gi
+pods        0     10
+```
+
+#### Limiting PriorityClass consumption by default
 
 It may be desired that pods at a particular priority, such as "cluster-services",
 should be allowed in a namespace, if and only if, a matching quota object exists.

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -103,20 +103,13 @@ a default request for these resources.
 
 ## Examples
 
-Here's an example ResourceQuota:
+Here's an example ResourceQuota. The example prevents (new) Pods in a namespace from setting
+an aggregate memory limit higher than 1024 GiB. This can be one Pod that tries to use all 1TiB
+of available RAM, or many smaller Pods that use up to the configured limit.
+
 
 ```yaml
 ---
-# Prevent Pods setting an aggregate memory limit higher than 1024 GiB.
-# This can be one Pod that tries to use all 1TiB of available RAM, or many smaller
-# Pods that use up to the configured limit.
-#
-# You can use a LimitRange or ValidatingAdmissionPolicy to ensure that Pods
-# (in the relevant namespace) always have a memory limit either at the overall
-# Pod level, or across each of their containers. However, Kubernetes automatically
-# enforces a limit and rejects Pods that don't set a memory limit, because of
-# the special treatment for resource types "cpu" and "memory".
-
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -125,6 +118,12 @@ spec:
   hard:
     limits.memory: "1024G"
 ```
+
+If you apply this ResourceQuota, Kubernetes automatically enforces a limit and rejects Pods that
+don't set a memory limit, because of the special treatment for resource types `cpu` and `memory`.
+To improve ergonomics for people who are using this namespace, You can add a LimitRange to
+ensure that Pods always have a relevant memory limit (either at the overall Pod level, or
+across each of their containers).
 
 ### ResourceQuota as part of an overall enforcement design {#example-overall-enforcement}
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -372,25 +372,6 @@ count/replicasets.apps        1     4
 count/secrets                 1     4
 ```
 
-## Quota and Cluster Capacity
-
-ResourceQuotas are independent of the cluster capacity. They are
-expressed in absolute units. So, if you add nodes to your cluster, this does *not*
-automatically give each namespace the ability to consume more resources.
-
-Sometimes more complex policies may be desired, such as:
-
-- Proportionally divide total cluster resources among several teams.
-- Allow each tenant to grow resource usage as needed, but have a generous
-  limit to prevent accidental resource exhaustion.
-- Detect demand from one namespace, add nodes, and increase quota.
-
-Such policies could be implemented using `ResourceQuotas` as building blocks, by
-writing a "controller" that watches the quota usage and adjusts the quota
-hard limits of each namespace according to other signals.
-
-Note that resource quota divides up aggregate cluster resources, but it creates no
-restrictions around nodes: pods from several namespaces may run on the same node.
 
 ## Quota scopes
 
@@ -732,6 +713,27 @@ In this case, a pod creation will be allowed if:
 
 A Pod creation request is rejected if its `priorityClassName` is set to `cluster-services`
 and it is to be created in a namespace other than `kube-system`.
+
+## Quota and cluster capacity
+
+ResourceQuotas are independent of the cluster capacity. They are
+expressed in absolute units. So, if you add nodes to your cluster, this does *not*
+automatically give each namespace the ability to consume more resources.
+
+Sometimes more complex policies may be desired, such as:
+
+- Proportionally divide total cluster resources among several teams.
+- Allow each tenant to grow resource usage as needed, but have a generous
+  limit to prevent accidental resource exhaustion.
+- Detect demand from one namespace, add nodes, and increase quota.
+
+Such policies could be implemented using ResourceQuotas as building blocks, by
+writing a  that watches the quota usage and adjusts the quota
+hard limits of each namespace according to other signals.
+
+Note that resource quota divides up aggregate cluster resources, but it creates no
+restrictions around nodes: pods from several namespaces may run on the same node.
+
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -682,8 +682,9 @@ and it is to be created in a namespace other than `kube-system`.
 
 ## {{% heading "whatsnext" %}}
 
-- See [ResourceQuota design document](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_resource_quota.md)
-  for more information.
 - See a [detailed example for how to use resource quota](/docs/tasks/administer-cluster/quota-api-object/).
-- Read [Quota support for priority class design document](https://git.k8s.io/design-proposals-archive/scheduling/pod-priority-resourcequota.md).
-- See [LimitedResources](https://github.com/kubernetes/kubernetes/pull/36765).
+- Read the ResourceQuota [API reference](/docs/reference/kubernetes-api/policy-resources/resource-quota-v1/)
+- Learn about [LimitRanges](/docs/concepts/policy/limit-range/)
+- You can read the historical [ResourceQuota design document](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_resource_quota.md)
+  for more information.
+- You can also read the [Quota support for priority class design document](https://git.k8s.io/design-proposals-archive/scheduling/pod-priority-resourcequota.md).

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -178,10 +178,10 @@ As overcommit is not allowed for extended resources, it makes no sense to specif
 and `limits` for the same extended resource in a quota. So for extended resources, only quota items
 with prefix `requests.` are allowed.
 
-Take the GPU resource as an example, if the resource name is `nvidia.com/gpu`, and you want to
+Take the GPU resource as an example, if the resource name is `vndr.example/gpu`, and you want to
 limit the total number of GPUs requested in a namespace to 4, you can define a quota as follows:
 
-* `requests.nvidia.com/gpu: 4`
+* `requests.vndr.example/gpu: 4`
 
 See [Viewing and Setting Quotas](#viewing-and-setting-quotas) for more details.
 
@@ -311,7 +311,7 @@ spec:
     requests.memory: "1Gi"
     limits.cpu: "2"
     limits.memory: "2Gi"
-    requests.nvidia.com/gpu: 4
+    requests.vndr.example/gpu: 4 # GPU from example vendor
 EOF
 ```
 
@@ -356,15 +356,15 @@ kubectl describe quota compute-resources --namespace=myspace
 ```
 
 ```none
-Name:                    compute-resources
-Namespace:               myspace
-Resource                 Used  Hard
---------                 ----  ----
-limits.cpu               0     2
-limits.memory            0     2Gi
-requests.cpu             0     1
-requests.memory          0     1Gi
-requests.nvidia.com/gpu  0     4
+Name:                      compute-resources
+Namespace:                 myspace
+Resource                   Used  Hard
+--------                   ----  ----
+limits.cpu                 0     2
+limits.memory              0     2Gi
+requests.cpu               0     1
+requests.memory            0     1Gi
+requests.vndr.example/gpu  0     4
 ```
 
 ```shell


### PR DESCRIPTION
Changes that, I hope, make https://kubernetes.io/docs/concepts/policy/resource-quotas/ better [[preview](https://deploy-preview-50179--kubernetes-io-main-staging.netlify.app/docs/concepts/policy/resource-quotas/)].

Tip: You might want to review this commit-by-commit and then look at the final page preview to check it all makes sense.

- Improve the page introduction
  - Add a cautionary note that lowering ResourceQuota doesn't affect existing resource use
- Describe the different kinds of ResourceQuota, each in their own section
- Refactor how we describe the different kinds of ResourceQuota scope, each now in their own section
- Reorder page sections to make better sense
- General other tweaks
  - Use more glossary tooltips
  - mention that RBAC is not the only authz game in town
  - allow creating examples using manifests fetched via HTTP (well, HTTPS)
  - mention that ValidatingAdmissionPolicies are a thing
  - mention why it's good not to let namespace admins remove their ResourceQuotas
  - and more&hellip;
- Add some extra links to the What's Next footer

/language en