### PR TITLE
[bn] Removed site-searchbar

### DIFF
--- a/content/bn/_index.html
+++ b/content/bn/_index.html
@@ -6,8 +6,6 @@ sitemap:
   priority: 1.0
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section class="k8s-overview" >}}
 {{% blocks/feature image="flower" id="feature-primary" %}}
 [কুবারনেটিস]({{< relref "/docs/concepts/overview/" >}}), K8s নামেও পরিচিত, কনটেইনারাইজড অ্যাপ্লিকেশনের স্বয়ংক্রিয় ডিপ্লয়মেন্ট, স্কেলিং এবং পরিচালনার জন্য একটি ওপেন-সোর্স সিস্টেম।


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode