### PR TITLE
[de] Removed site-searchbar for

### DIFF
--- a/content/de/_index.html
+++ b/content/de/_index.html
@@ -4,8 +4,6 @@ abstract: "Automatisierte Bereitstellung, Skalierung und Verwaltung von Containe
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) ist ein Open-Source-System zur Automatisierung der Bereitstellung, Skalierung und Verwaltung von containerisierten Anwendungen.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode