### PR TITLE
[es] Removed site-searchbar

### DIFF
--- a/content/es/_index.html
+++ b/content/es/_index.html
@@ -4,8 +4,6 @@ abstract: "Automatización del despliegue, escalado y administración de contene
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### Kubernetes (K8s) es una plataforma de código abierto para automatizar la implementación, el escalado y la administración de aplicaciones en contenedores.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode