### PR TITLE
[fr] Removed site-searchbar

### DIFF
--- a/content/fr/_index.html
+++ b/content/fr/_index.html
@@ -6,8 +6,6 @@ sitemap:
   priority: 1.0
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/" >}}) est un système open-source permettant d'automatiser le déploiement, la mise à l'échelle et la gestion des applications conteneurisées.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode