### PR TITLE
[id] Removed site-searchbar

### DIFF
--- a/content/id/_index.html
+++ b/content/id/_index.html
@@ -4,8 +4,6 @@ abstract: "Otomatisasi Kontainer deployment, scaling, dan management"
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### Kubernetes (K8s)


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode