### PR TITLE
[ja] Removed site-searchbar

### DIFF
--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -4,8 +4,6 @@ abstract: "自動化されたコンテナのデプロイ・スケール・管理
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/" >}})は、デプロイやスケーリングを自動化したり、コンテナ化されたアプリケーションを管理したりするための、オープンソースのシステムです。


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode