### PR TITLE
[ko] Removed site-searchbar 

### DIFF
--- a/content/ko/_index.html
+++ b/content/ko/_index.html
@@ -6,8 +6,6 @@ sitemap:
   priority: 1.0
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 K8s라고도 알려진 [쿠버네티스]({{< relref "/docs/concepts/overview/" >}})는 컨테이너화된 애플리케이션을 자동으로 배포, 스케일링 및 관리해주는 오픈소스 시스템입니다.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode