### PR TITLE
[pl] Removed site-searchbar for

### DIFF
--- a/content/pl/_index.html
+++ b/content/pl/_index.html
@@ -6,8 +6,6 @@ sitemap:
   priority: 1.0
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 [Kubernetes]({{< relref "/docs/concepts/overview/" >}}), znany też jako K8s, to otwarte oprogramowanie służące do automatyzacji procesów uruchamiania, skalowania i zarządzania aplikacjami w kontenerach.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode