### PR TITLE
[pt-br] Removed site-searchbar 

### DIFF
--- a/content/pt-br/_index.html
+++ b/content/pt-br/_index.html
@@ -4,8 +4,6 @@ abstract: "Implantação, dimensionamento e gerenciamento automatizado de contê
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### Kubernetes (K8s) é um produto Open Source utilizado para automatizar a implantação, o dimensionamento e o gerenciamento de aplicativos em contêiner.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode