### PR TITLE
[uk] Removed site-searchbar 

### DIFF
--- a/content/uk/_index.html
+++ b/content/uk/_index.html
@@ -4,8 +4,6 @@ abstract: "Автоматичне розгортання, масштабуван
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 <!--


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode