### PR TITLE
[vi] Removed site-searchbar 

### DIFF
--- a/content/vi/_index.html
+++ b/content/vi/_index.html
@@ -4,8 +4,6 @@ abstract: "Triển khai tự động, nhân rộng và quản lý container"
 cid: home
 ---
 
-{{< site-searchbar >}}
-
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) là một hệ thống mã nguồn mở giúp tự động hóa việc triển khai, nhân rộng và quản lý các ứng dụng container.


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50040 which removes the `site-searchbar` shortcode