### PR TITLE
Remove the site-searchbar shortcode

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -9,7 +9,6 @@ Do not use the `search-results-search` id elsewhere as it is used
 delete this element for pagefind/China users
 */}}
 
-{{/* From shortcodes/site-searchbar.html which is used in the home page */}}
 <div id="search-results-search" class="col-sm-6 col-md-6 col-lg-6 mx-auto py-3">
   {{partial "search-input" .}}
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,11 +1,7 @@
 {{ define "main" }}
-{{ if .HasShortcode "site-searchbar" }}
-  {{ warnf "The homepage of the language %s is using a deprecated shortcode site-searchbar. Please remove the shortcode. No other step is needed." .Lang }}
-{{ else }}
 <div class="col-sm-6 col-md-6 col-lg-6 mx-auto py-3">
   {{partial "search-input" .}}
 </div>
-{{ end }}
 {{ .Content }}
 <section id="cncf">
     {{ partial "cncf.html" . }}

--- a/layouts/shortcodes/site-searchbar.html
+++ b/layouts/shortcodes/site-searchbar.html
@@ -1,3 +1,0 @@
-<div class="col-sm-6 col-md-6 col-lg-6 mx-auto py-3">
-{{partial "search-input" .}}
-</div>


### PR DESCRIPTION
This PR removes the `site-searchbar` shortcode following the merge of #50040.
But this PR can't be merged unless the following are merged.

- #50185
- #50186
- #50187
- #50188
- #50189
- #50190
- #50191
- #50192
- #50193
- #50194
- #50195
- #50196
- ~~#50197~~#50207

Closes #50147 