### PR TITLE
Delay Kubernetes v1.33 mid cycle blog release

### DIFF
--- a/content/en/blog/_posts/2025-03-24-kubernetes-1.33-sneak-peek.md
+++ b/content/en/blog/_posts/2025-03-24-kubernetes-1.33-sneak-peek.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: 'Kubernetes v1.33 sneak peek'
-date: 2025-03-24T10:30:00-08:00
+date: 2025-03-26T10:30:00-08:00
 slug: kubernetes-v1-33-upcoming-changes
 author: >
   Agustina Barbetta,


### PR DESCRIPTION
The new schedule is 26th March rather than 24th March.