### PR TITLE
Add new page for self-healing

### DIFF
--- a/content/en/docs/concepts/architecture/self-healing.md
+++ b/content/en/docs/concepts/architecture/self-healing.md
@@ -12,7 +12,7 @@ It automatically replaces failed containers, reschedules workloads when nodes be
 
 ## Self-Healing capabilities {#self-healing-capabilities} 
 
-- **Container-level restarts:** If a container inside a Pod fails, Kubernetes restarts it based on the [`restartPolicy`](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)`.
+- **Container-level restarts:** If a container inside a Pod fails, Kubernetes restarts it based on the [`restartPolicy`](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy).
 
 - **Replica replacement:** If a Pod in a [Deployment](/docs/concepts/workloads/controllers/deployment/) or [StatefulSet](/docs/concepts/workloads/controllers/statefulset/) fails, Kubernetes creates a replacement Pod to maintain the specified number of replicas.
   If a Pod fails that is part of a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) fails, the control plane

--- a/content/en/docs/concepts/architecture/self-healing.md
+++ b/content/en/docs/concepts/architecture/self-healing.md
@@ -1,0 +1,45 @@
+---
+title: Kubernetes Self-Healing  
+content_type: concept  
+Weight: 50  
+---
+<!-- overview -->
+
+Kubernetes is designed with self-healing capabilities that help maintain the health and availability of workloads. 
+It automatically replaces failed containers, reschedules workloads when nodes become unavailable, and ensures that the desired state of the system is maintained.
+
+<!-- body -->
+
+## Self-Healing capabilities {#self-healing-capabilities} 
+
+- **Container-level restarts:** If a container inside a Pod fails, Kubernetes restarts it based on the [`restartPolicy`](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)`.
+
+- **Replica replacement:** If a Pod in a [Deployment](/docs/concepts/workloads/controllers/deployment/) or [StatefulSet](/docs/concepts/workloads/controllers/statefulset/) fails, Kubernetes creates a replacement Pod to maintain the specified number of replicas.
+  If a Pod fails that is part of a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) fails, the control plane
+  creates a replacement Pod to run on the same node.
+  
+- **Persistent storage recovery:** If a node is running a Pod with a PersistentVolume (PV) attached, and the node fails, Kubernetes can reattach the volume to a new Pod on a different node.
+
+- **Load balancing for Services:** If a Pod behind a [Service](/docs/concepts/services-networking/service/) fails, Kubernetes automatically removes it from the Service's endpoints to route traffic only to healthy Pods.
+
+Here are some of the key components that provide Kubernetes self-healing:
+
+- **[kubelet](/docs/concepts/architecture/#kubelet):** Ensures that containers are running, and restarts those that fail.
+
+- **ReplicaSet, StatefulSet and DaemonSet controller:** Maintains the desired number of Pod replicas.
+
+- **PersistentVolume controller:** Manages volume attachment and detachment for stateful workloads.
+
+## Considerations {#considerations} 
+
+- **Storage Failures:** If a persistent volume becomes unavailable, recovery steps may be required.
+
+- **Application Errors:** Kubernetes can restart containers, but underlying application issues must be addressed separately.
+
+## {{% heading "whatsnext" %}} 
+
+- Read more about [Pods](/docs/concepts/workloads/pods/)
+- Learn about [Kubernetes Controllers](/docs/concepts/architecture/controller/)
+- Explore [PersistentVolumes](/docs/concepts/storage/persistent-volumes/)
+- Read about [node autoscaling](/docs/concepts/cluster-administration/node-autoscaling/). Node autoscaling
+  also provides automatic healing if or when nodes fail in your cluster.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR introduces a new page under [Kubernetes Architecture](https://kubernetes.io/docs/concepts/architecture/) to explain Kubernetes' self-healing capabilities. 
The page provides an overview of how Kubernetes automatically recovers from failures.
- Explains key self-healing mechanisms, including Pod restarts, replica replacement, node failover, and storage recovery 
- Lists Kubernetes components involved in self-healing 
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->


Closes: https://github.com/kubernetes/website/issues/48963