### PR TITLE
Rework the stylesheet of sidebar

### DIFF
--- a/assets/js/sidebar-tree.js
+++ b/assets/js/sidebar-tree.js
@@ -1,0 +1,25 @@
+let splitInstance = null;
+
+function enableSplitter(mediaQuery) {
+  if (mediaQuery.matches) {
+    if (!splitInstance) {
+      splitInstance = Split(["#sidebarnav", "#maindoc"], {
+        sizes: [20, 80],
+        minSize: 100,
+      });
+    }
+  } else {
+    if (splitInstance) {
+      splitInstance.destroy();
+      splitInstance = null;
+    }
+  }
+}
+
+const screenWidthMediaQuery = window.matchMedia("(min-width: 768px)");
+
+const eleNav = document.getElementById("sidebarnav");
+if (eleNav !== null) {
+  enableSplitter(screenWidthMediaQuery);
+  screenWidthMediaQuery.addListener(enableSplitter);
+}

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -50,35 +50,6 @@ body {
   }
 }
 
-/* Gutter for sidebar splitter */
-.gutter {
-    background-color: #eee;
-    background-repeat: no-repeat;
-    background-position: 50%;
-}
-
-.gutter.gutter-horizontal {
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
-    cursor: col-resize;
-}
-
-#sidebarnav,
-#maindoc {
-  max-width: 100%;
-}
-
-#maindoc {
-  overflow-wrap: break-word;
-}
-
-@media (max-width: 768px) {
-  #sidebarnav {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
-}
-
 /* Complex table layout support */
 
 .td-content, body.td-content {
@@ -1381,58 +1352,12 @@ body.cid-code-of-conduct main {
     }
 }
 
-// search & sidebar
-.td-sidebar {
-  @media only screen and (min-width: 768px) {
-    padding-top: 1.5rem !important;
-
-    .td-sidebar__inner {
-      top: 8.5rem;
-
-      @media only screen and (min-width: 1075px) {
-        top: 6.5rem;
-      }
-    }
-  }
-}
-
-.td-sidebar-nav {
-  & > .td-sidebar-nav__section {
-    padding-top: .5rem;
-    padding-left: 1.5rem;
-  }
-}
-
-.td-sidebar__inner {
-  form.td-sidebar__search {
-
-    .td-sidebar__toggle {
-      &:hover {
-        color: #000000;
-      }
-
-      color: $primary;
-      margin: 1rem;
-    }
-  }
-}
-
 .no-underline {
   text-decoration: none !important;
 }
 
 .hide {
   display: none !important;
-}
-
-.td-sidebar-link__page {
-  &#m-docs-search {
-    display: none;
-  }
-
-  &#m-docs-test {
-    display: none;
-  }
 }
 
 //Tutorials

--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -1,0 +1,75 @@
+.td-sidebar-nav {
+  .td-sidebar-link.tree-root {
+    display: none;
+  }
+
+  #navbarDropdownMenuLink {
+    display: none;
+  }
+}
+
+/* Gutter for sidebar splitter */
+.gutter {
+  background-color: #eee;
+  background-repeat: no-repeat;
+  background-position: 50%;
+
+  &.gutter-horizontal {
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+    cursor: col-resize;
+  }
+}
+
+#sidebarnav,
+#maindoc {
+  max-width: 100%;
+}
+
+#maindoc {
+  overflow-wrap: break-word;
+}
+
+@include media-breakpoint-down(sm)  {
+  #sidebarnav {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+}
+
+// search & sidebar
+.td-sidebar {
+  @include media-breakpoint-up(sm){
+    padding-top: 1.5rem !important;
+
+    .td-sidebar__inner {
+      top: 8.5rem;
+
+      @media only screen and (min-width: 1075px) {
+        top: 6.5rem;
+      }
+    }
+  }
+}
+
+.td-sidebar-nav {
+  & > .td-sidebar-nav__section {
+    padding-top: .5rem;
+    padding-left: 1.5rem;
+  }
+}
+
+.td-sidebar__inner form.td-sidebar__search {
+  .td-sidebar__toggle {
+    &:hover {
+      color: #000000;
+    }
+
+    color: $primary;
+  }
+}
+
+.td-sidebar-link__page {
+  &#m-docs-test {
+    display: none;
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -9,6 +9,7 @@ Add styles or import other files. */
 // Base styles
 @import "k8s_community";
 @import "k8s_nav";
+@import "k8s_sidebar-tree";
 
 //Media queries
 @import "base";

--- a/layouts/partials/blog-sidebar-tree.html
+++ b/layouts/partials/blog-sidebar-tree.html
@@ -22,13 +22,11 @@ sidebar-tree in use elsewhere on the site. */}}
   <div id="content-desktop"></div>
   {{ end -}}
   <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
-    {{/* Re enable below once the disabling is done from CSS
     {{ if  (gt (len .Site.Home.Translations) 0) -}}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end -}}
-    */}}
     {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
     {{ $ulNr := 0 -}}
     {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -108,3 +108,7 @@
 {{- end -}}
 {{ with .Params.js }}{{ range (split . ",") }}<script src="{{ (trim . " ") | relURL }}"></script><!-- custom js added -->
 {{ end }}{{ else }}<!-- no custom js detected -->{{ end }}
+
+<!--for the splitter-->
+<!--script src="https://unpkg.com/split.js/dist/split.min.js"></script-->
+<script src="/js/split-1.6.0.js" integrity="sha384-0blL3GqHy6+9fw0cyY2Aoiwg4onHAtslAs4OkqZY7UQBrR65/K4gI+hxLdWDrjpz"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -31,6 +31,7 @@
 {{ $jsBase := resources.Get "js/base.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $jsNav := resources.Get "js/nav.js" | resources.ExecuteAsTemplate "js/nav.js" .Site.Params }}
+{{ $jsSidebarTree := resources.Get "js/sidebar-tree.js" | resources.ExecuteAsTemplate "js/sidebar-tree.js" .Site.Params }}
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}
 {{ if .Site.Params.offlineSearch }}
 {{ $jsSearch = resources.Get "js/offline-search.js" }}
@@ -38,7 +39,7 @@
 {{ else if .Site.Params.customSearch }}
 {{ $jsSearch = resources.Get "js/custom-search.js" }}
 {{ end }}
-{{ $js := (slice $jsBs $jsBase $jsAnchor $jsNav $jsSearch) | resources.Concat "js/main.js" -}}
+{{ $js := (slice $jsBs $jsBase $jsAnchor $jsNav $jsSidebarTree $jsSearch) | resources.Concat "js/main.js" -}}
 {{ if hugo.IsProduction -}}
   {{ $js := $js | minify | fingerprint -}}
   <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
@@ -57,36 +58,5 @@
     integrity="{{ . }}" {{ end -}}
     crossorigin="anonymous"></script>
 {{ end -}}
-
-<!--for the splitter-->
-<!--script src="https://unpkg.com/split.js/dist/split.min.js"></script-->
-<script src="/js/split-1.6.0.js" integrity="sha384-0blL3GqHy6+9fw0cyY2Aoiwg4onHAtslAs4OkqZY7UQBrR65/K4gI+hxLdWDrjpz"></script>
-<script>
-  let splitInstance = null;
-
-  function enableSplitter(mediaQuery) {
-    if (mediaQuery.matches) {
-      if (!splitInstance) {
-        splitInstance = Split(["#sidebarnav", "#maindoc"], {
-          sizes: [20, 80],
-          minSize: 100,
-        });
-      }
-    } else {
-      if (splitInstance) {
-        splitInstance.destroy();
-        splitInstance = null;
-      }
-    }
-  }
-
-  const screenWidthMediaQuery = window.matchMedia("(min-width: 768px)");
-
-  const eleNav = document.getElementById("sidebarnav");
-  if (eleNav !== null) {
-    enableSplitter(screenWidthMediaQuery);
-    screenWidthMediaQuery.addListener(enableSplitter);
-  }
-</script>
 
 {{ partial "hooks/body-end.html" . }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,24 +1,25 @@
-{{/* Always cache this partial; set the active class client side. */}}
-{{ $shouldDelayActive := true }}
+{{/* We cache this partial for bigger sites and set the active class client side. */}}
+{{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
+{{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fa-solid fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="{{ T "sidebar_toggle_nav" }}">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="{{ T "sidebar_toggle_nav" }}">
     </button>
   </form>
   {{ else -}}
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fa-solid fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="{{ T "sidebar_toggle_nav" }}">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="{{ T "sidebar_toggle_nav" }}">
     </button>
   </form>
   </div>
   <div id="content-desktop"></div>
   {{ end -}}
   <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
-    {{- if (and false (gt (len .Site.Home.Translations) 0) ) -}}
+    {{ if  (gt (len .Site.Home.Translations) 0) -}}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}
     </div>
@@ -34,52 +35,49 @@
   </nav>
 </div>
 {{ define "section-tree-nav-section" -}}
-  {{ $s := .section -}}
-  {{ $p := .page -}}
-  {{ $shouldDelayActive := .shouldDelayActive -}}
-  {{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
-  {{ $treeRoot := cond (eq .ulNr 0) true false -}}
-  {{ $ulNr := .ulNr -}}
-  {{ $ulShow := .ulShow -}}
-  {{ $currentLang := .currentLang -}}
-  {{ $active := and (not $shouldDelayActive) (eq $s $p) -}}
-  {{ $activePath := and (not $shouldDelayActive) ($p.IsDescendant $s) -}}
-  {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false -}}
-  {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
-  {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
-  {{/* We get untranslated subpages below to make sure we build all levels of the sidenav in localizationed docs sets */}}
-  {{ with site.Params.language_alternatives -}}
-    {{ range . }}
-      {{ with (where $.section.Translations ".Lang" . ) -}}
-        {{ $p := index . 0 -}}
-        {{ $pages_tmp = where ( $pages_tmp | lang.Merge (union $p.Pages $p.Sections)) ".Params.toc_hide" "!=" true -}}
-      {{ end -}}
+{{ $s := .section -}}
+{{ $p := .page -}}
+{{ $shouldDelayActive := .shouldDelayActive -}}
+{{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
+{{ $treeRoot := cond (eq .ulNr 0) true false -}}
+{{ $ulNr := .ulNr -}}
+{{ $ulShow := .ulShow -}}
+{{ $currentLang := .currentLang -}}
+{{ $active := and (not $shouldDelayActive) (eq $s $p) -}}
+{{ $activePath := and (not $shouldDelayActive) (or (eq $p $s) ($p.IsDescendant $s)) -}}
+{{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false -}}
+{{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
+{{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+{{/* We get untranslated subpages below to make sure we build all levels of the sidenav in localized docs sets */}}
+{{ with site.Params.language_alternatives -}}
+  {{ range . }}
+    {{ with (where $.section.Translations ".Lang" . ) -}}
+      {{ $p := index . 0 -}}
+      {{ $pages_tmp = where ( $pages_tmp | lang.Merge (union $p.Pages $p.Sections)) ".Params.toc_hide" "!=" true -}}
     {{ end -}}
   {{ end -}}
-  {{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
-  {{ $withChild := gt (len $pages) 0 -}}
-  {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
-  {{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}
-  {{ $isForeignLanguage := (ne (string $s.Lang) ($.currentLang)) -}}
-  <li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
-    {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
-    <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
-    <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span>{{ if $isForeignLanguage }} <small title="{{ T (printf "i18n_language_name_long_%s" $s.Lang ) }}">({{ $s.Lang | upper }})</small>{{ end -}}</a></label>
-    {{ else -}}
-    {{ if not $treeRoot }}
-    <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span>{{ if $isForeignLanguage }} <small title="{{ T (printf "i18n_language_name_long_%s" $s.Lang ) }}">({{ $s.Lang | upper }})</small>{{ end -}}</a>
+{{ end -}}
+{{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
+{{ $withChild := gt (len $pages) 0 -}}
+{{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
+{{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}
+{{ $isForeignLanguage := (ne (string $s.Lang) ($.currentLang)) -}}
+<li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}" id="{{ $mid }}-li">
+  {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
+  <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
+  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span>{{ if $isForeignLanguage }} <small title="{{ T (printf "i18n_language_name_long_%s" $s.Lang ) }}">({{ $s.Lang | upper }})</small>{{ end -}}</a></label>
+  {{ else -}}
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span>{{ if $isForeignLanguage }} <small title="{{ T (printf "i18n_language_name_long_%s" $s.Lang ) }}">({{ $s.Lang | upper }})</small>{{ end -}}</a>
+  {{- end }}
+  {{- if $withChild }}
+  {{- $ulNr := add $ulNr 1 }}
+  <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
+    {{ range $pages -}}
+    {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+    {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow "currentLang" $currentLang) }}
     {{- end }}
     {{- end }}
-    {{- if $withChild }}
-    {{- $ulNr := add $ulNr 1 }}
-    <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
-      {{ range $pages -}}
-      {{ $mid := printf "m-%s" (.RelPermalink | anchorize) -}}
-      {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
-      {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow "currentLang" $currentLang) }}
-      {{- end }}
-      {{- end }}
-    </ul>
-    {{- end }}
-  </li>
+  </ul>
+  {{- end }}
+</li>
 {{- end }}


### PR DESCRIPTION
This PR reworks the styling of the sidebar components

- Moves all sidebar related styles out of `_custom.scss` into a new `_k8s_sidebar-tree.scss`.
- `_k8s_sidebar-tree.scss` is imported as a partial into `_styles_project.scss`.
- The sidebar heading and the language dropdowns are disabled via CSS instead of removing the block in the layout.
- Instead of using a media query, `media-breakpoint-*` bootstrap functions are used wherever possible.
- The 1 rem margin from the search within the sidebar is removed.
- The CSS associated with `#m-docs-search` is removed as that element id no longer exists
- The script for using split.js for the sidebar is moved away from `scripts.html` to its own `assets/js/sidebar-tree.js` and then imported back in `scripts.html`.
- Proper cache handling using the `sidebar_cache_limit` configured in `hugo.toml` for `sidebar-tree.html`.
- Removed a `$treeRoot` check and an `$mid` assignment as they are no longer necessary in `sidebar-tree.html`.
- Remove the workaround check for the language selector in `sidebar-tree.html` and the commenting in `blog-sidebar-tree.html` as the language selector is now disabled via CSS.

~**Note that this PR is not directly based on `main` and has a couple of commits from 2 other PRs (#50097 and #50211). Only the final commit of this PR is the important one. I will try to rebase this PR once at least #50211 is merged. But feel free to review the final commit.**~