### PR TITLE
Add blog post about CVE-2025-1974 and friends

### DIFF
--- a/content/en/blog/_posts/2025-03-24-ingress-nginx-CVE-2025-1974.md
+++ b/content/en/blog/_posts/2025-03-24-ingress-nginx-CVE-2025-1974.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Ingress-nginx CVE-2025-1974: What You Need to Know"
-date: 2025-03-24
+date: 2025-03-24T12:00:00-08:00
 slug: ingress-nginx-CVE-2025-1974
 author: >
   Tabitha Sable (Kubernetes Security Response Committee)
@@ -11,7 +11,7 @@ Today, the ingress-nginx maintainers have [released patches for a batch of criti
 
 ## Background
 
-[Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) is the traditional Kubernetes feature for exposing your workload Pods to the world so that they can be useful. In an implementation-agnostic way, Kubernetes users can define how their applications should be made available on the network. Then, an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) uses that definition to set up local or cloud resources as required for the user’s particular situation and needs.
+[Ingress](/docs/concepts/services-networking/ingress/) is the traditional Kubernetes feature for exposing your workload Pods to the world so that they can be useful. In an implementation-agnostic way, Kubernetes users can define how their applications should be made available on the network. Then, an [ingress controller](/docs/concepts/services-networking/ingress-controllers/) uses that definition to set up local or cloud resources as required for the user’s particular situation and needs.
 
 Many different ingress controllers are available, to suit users of different cloud providers or brands of load balancers. Ingress-nginx is a software-only ingress controller provided by the Kubernetes project. Because of its versatility and ease of use, ingress-nginx is quite popular: it is deployed in over 40% of Kubernetes clusters\!
 
@@ -19,13 +19,13 @@ Ingress-nginx translates the requirements from Ingress objects into configuratio
 
 ## Vulnerabilities Patched Today
 
-Four of today’s ingress-nginx vulnerabilities are improvements to how ingress-nginx handles particular bits of nginx config. Without these fixes, a specially-crafted Ingress object can cause nginx to misbehave in various ways, including revealing the values of [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) that are accessible to ingress-nginx. By default, ingress-nginx has access to all Secrets cluster-wide, so this can often lead to complete cluster takeover by any user or entity that has permission to create an Ingress.
+Four of today’s ingress-nginx vulnerabilities are improvements to how ingress-nginx handles particular bits of nginx config. Without these fixes, a specially-crafted Ingress object can cause nginx to misbehave in various ways, including revealing the values of [Secrets](/docs/concepts/configuration/secret/) that are accessible to ingress-nginx. By default, ingress-nginx has access to all Secrets cluster-wide, so this can often lead to complete cluster takeover by any user or entity that has permission to create an Ingress.
 
 The most serious of today’s vulnerabilities, [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009), rated [9.8 CVSS](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H), allows anything on the Pod network to exploit configuration injection vulnerabilities via the Validating Admission Controller feature of ingress-nginx. This makes such vulnerabilities far more dangerous: ordinarily one would need to be able to create an Ingress object in the cluster, which is a fairly privileged action. When combined with today’s other vulnerabilities, **CVE-2025-1974 means that anything on the Pod network has a good chance of taking over your Kubernetes cluster, with no credentials or administrative access required**. In many common scenarios, the Pod network is accessible to all workloads in your cloud VPC, or even anyone connected to your corporate network\! This is a very serious situation.
 
 Today, we have [released ingress-nginx v1.12.1 and v1.11.5](https://github.com/kubernetes/ingress-nginx/releases), which have fixes for all five of these vulnerabilities.
 
-## Your Next Steps
+## Your next steps
 
 First, determine if your clusters are using ingress-nginx. In most cases, you can check this by running `kubectl get pods --all-namespaces --selector app.kubernetes.io/name=ingress-nginx` with cluster administrator permissions.
 
@@ -43,12 +43,12 @@ If you can’t upgrade right away, you can significantly reduce your risk by tur
 
 If you turn off the Validating Admission Controller feature as a mitigation for CVE-2025-1974, remember to turn it back on after you upgrade. This feature provides important quality of life improvements for your users, warning them about incorrect Ingress configurations before they can take effect. 
 
-## Conclusion, Thanks, and Further Reading
+## Conclusion, thanks, and further reading
 
 The ingress-nginx vulnerabilities announced today, including CVE-2025-1974, present a serious risk to many Kubernetes users and their data. If you use ingress-nginx, you should take action immediately to keep yourself safe.
 
 Thanks go out to Nir Ohfeld, Sagi Tzadik, Ronen Shustin, and Hillai Ben-Sasson from Wiz for responsibly disclosing these vulnerabilities, and for working with the Kubernetes SRC members and ingress-nginx maintainers (Marco Ebert and James Strong) to ensure we fixed them effectively.
 
-For further information about the maintenance and future of ingress-nginx, please see [this GitHub issue](https://github.com/kubernetes/ingress-nginx/issues/13002) and/or attend [James and Marco’s KubeCon/CloudNativeCon EU 2025 presentation](https://kccnceu2025.sched.com/event/1tcyc/).
+For further information about the maintenance and future of ingress-nginx, please see this [GitHub issue](https://github.com/kubernetes/ingress-nginx/issues/13002) and/or attend [James and Marco’s KubeCon/CloudNativeCon EU 2025 presentation](https://kccnceu2025.sched.com/event/1tcyc/).
 
 For further information about the specific vulnerabilities discussed in this article, please see the appropriate GitHub issue: [CVE-2025-24513](https://github.com/kubernetes/kubernetes/issues/131005), [CVE-2025-24514](https://github.com/kubernetes/kubernetes/issues/131006), [CVE-2025-1097](https://github.com/kubernetes/kubernetes/issues/131007), [CVE-2025-1098](https://github.com/kubernetes/kubernetes/issues/131008), or [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009)


### PR DESCRIPTION
### Description

Add a blog post encouraging users to patch CVE-2025-1974, a recently-announced critical vulnerability in ingress-nginx.

See also https://github.com/kubernetes/kubernetes/issues/131005 https://github.com/kubernetes/kubernetes/issues/131006 https://github.com/kubernetes/kubernetes/issues/131007 https://github.com/kubernetes/kubernetes/issues/131008 https://github.com/kubernetes/kubernetes/issues/131009