### PR TITLE
[de] Renamed search placeholder

### DIFF
--- a/i18n/de/de.toml
+++ b/i18n/de/de.toml
@@ -205,7 +205,7 @@ other = "Forum"
 other = "Veranstaltungskalender"
 
 # UI elements
-[ui_search_placeholder]
+[ui_search]
 other = "Suchen"
 
 [input_placeholder_email_address]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.