### PR TITLE
[es] Renamed search placeholder

### DIFF
--- a/i18n/es/es.toml
+++ b/i18n/es/es.toml
@@ -205,7 +205,7 @@ other = "Calendario de eventos"
 other = "YouTube"
 
 # UI elements
-[ui_search_placeholder]
+[ui_search]
 other = "Buscar"
 
 [input_placeholder_email_address]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.