### PR TITLE
[fr] Renamed search placeholder

### DIFF
--- a/i18n/fr/fr.toml
+++ b/i18n/fr/fr.toml
@@ -145,7 +145,7 @@ other = "Forum"
 other = "Calendrier"
 
 # UI elements
-[ui_search_placeholder]
+[ui_search]
 other = "Recherche"
 
 [input_placeholder_email_address]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.