### PR TITLE
[id] Renamed search placeholder

### DIFF
--- a/i18n/id/id.toml
+++ b/i18n/id/id.toml
@@ -205,7 +205,7 @@ other = "Sinopsis"
 [thirdparty_message]
 other = """Bagian ini tertaut ke proyek-proyek pihak ketiga yang menyediakan fungsionalitas yang dibutuhkan oleh Kubernetes. Pencipta proyek Kubernetes tidak bertanggung jawab atas proyek-proyek tersebut. Laman ini mengikuti <a href="https://github.com/cncf/foundation/blob/master/website-guidelines.md" target="_blank">pedoman website CNCF</a> dengan membuat daftar proyek menurut abjad. Untuk menambakan proyek ke dalam daftar ini, bacalah <a href="/docs/contribute/style/content-guide/#third-party-content">panduan</a> sebelum mengirimkan perubahan."""
 
-[ui_search_placeholder]
+[ui_search]
 other = "Cari"
 
 [version_check_mustbe]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.