### PR TITLE
[it] Renamed search placeholder

### DIFF
--- a/i18n/it/it.toml
+++ b/i18n/it/it.toml
@@ -187,7 +187,7 @@ other = "Prima di cominciare"
 [subscribe_button]
 other = "Iscriviti"
 
-[ui_search_placeholder]
+[ui_search]
 other = "Cerca"
 
 [version_check_mustbe]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.