### PR TITLE
[ja] Renamed search placeholder

### DIFF
--- a/i18n/ja/ja.toml
+++ b/i18n/ja/ja.toml
@@ -317,7 +317,7 @@ other = "(リリース日: "
 [subscribe_button]
 other = "購読する"
 
-[ui_search_placeholder]
+[ui_search]
 other = "検索"
 
 [thirdparty_message]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.