### PR TITLE
[pt-br] Renamed search placeholder

### DIFF
--- a/i18n/pt-br/pt-br.toml
+++ b/i18n/pt-br/pt-br.toml
@@ -600,7 +600,7 @@ other = """Itens nesta página referem-se a fornecedores externos ao Kubernetes.
 [translated_by]
 other = "Traduzido Por"
 
-[ui_search_placeholder]
+[ui_search]
 other = "Procurar"
 
 [version_check_mustbe]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.