### PR TITLE
[uk] Renamed search placeholder

### DIFF
--- a/i18n/uk/uk.toml
+++ b/i18n/uk/uk.toml
@@ -236,7 +236,7 @@ other = "Перш ніж ви розпочнете"
 # other = "Subscribe"
 other = "Підписатися"
 
-[ui_search_placeholder]
+[ui_search]
 # other = "Search"
 other = "Пошук"
 


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`.