### PR TITLE
[zh-cn] Renamed search placeholder

### DIFF
--- a/content/zh-cn/docs/contribute/localization.md
+++ b/content/zh-cn/docs/contribute/localization.md
@@ -818,7 +818,7 @@ placeholder text for the search form:
 例如，这是搜索表单的德语占位符文本：
 
 ```toml
-[ui_search_placeholder]
+[ui_search]
 other = "Suchen"
 ```
 

--- a/i18n/zh-cn/zh-cn.toml
+++ b/i18n/zh-cn/zh-cn.toml
@@ -577,7 +577,7 @@ other = """本页面中的条目引用了 Kubernetes 外部的供应商。Kubern
 [translated_by]
 other = "译者"
 
-[ui_search_placeholder]
+[ui_search]
 other = "搜索"
 
 [version_check_mustbe]


### PR DESCRIPTION
This is a housekeeping PR following the merge of #50049 which renames `ui_search_placeholder` localisation key by the Docsy provided `ui_search`. It also updates the documentation to reflect this change.