### PR TITLE
Drop div used for Katacoda button

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,6 +1,3 @@
-{{ if .HasShortcode "kat-button" }}
-<div id="katacoda-environment" data-katacoda-ondemand="true" data-katacoda-port="30000" data-katacoda-env="minikube:1.20" data-katacoda-command="start.sh" data-katacoda-ui="panel"></div>
-{{ end }}
 {{ with .Site.Params.algolia_docsearch }}
 <!-- scripts for algolia docsearch -->
 {{ end }}


### PR DESCRIPTION
It no longer works, so drop it. Only stale localized pages still use this shortcode.

See https://kubernetes.io/blog/2023/02/14/kubernetes-katacoda-tutorials-stop-from-2023-03-31/ and discussion https://github.com/kubernetes/website/discussions/38878

/area web-development
/kind cleanup