### PR TITLE
[KEP-3973]: update the DeploymentPodReplacementPolicy FG references to DeploymentReplicaSetTerminatingReplicas

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -1329,9 +1329,9 @@ a Pod is considered ready, see [Container Probes](/docs/concepts/workloads/pods/
 
 ### Terminating Pods
 
-{{< feature-state feature_gate_name="DeploymentPodReplacementPolicy" >}}
+{{< feature-state feature_gate_name="DeploymentReplicaSetTerminatingReplicas" >}}
 
-You can enable this feature it by setting the `DeploymentPodReplacementPolicy`
+You can enable this feature it by setting the `DeploymentReplicaSetTerminatingReplicas`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 on the [API server](/docs/reference/command-line-tools-reference/kube-apiserver/)
 and on the [kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/)

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -322,9 +322,9 @@ ReplicaSets do not support a rolling update directly.
 
 ### Terminating Pods
 
-{{< feature-state feature_gate_name="DeploymentPodReplacementPolicy" >}}
+{{< feature-state feature_gate_name="DeploymentReplicaSetTerminatingReplicas" >}}
 
-You can enable this feature it by setting the `DeploymentPodReplacementPolicy`
+You can enable this feature it by setting the `DeploymentReplicaSetTerminatingReplicas`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 on the [API server](/docs/reference/command-line-tools-reference/kube-apiserver/)
 and on the [kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/)

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/deployment-pod-replacement-policy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/deployment-pod-replacement-policy.md
@@ -1,5 +1,5 @@
 ---
-title: DeploymentPodReplacementPolicy
+title: DeploymentReplicaSetTerminatingReplicas
 content_type: feature_gate
 _build:
   list: never


### PR DESCRIPTION
React to last minute changes in the feature gate name once https://github.com/kubernetes/kubernetes/pull/131088 merges.

### Issue

- https://github.com/kubernetes/kubernetes/pull/128546
- https://github.com/kubernetes/enhancements/issues/3973
- https://github.com/kubernetes/kubernetes/pull/131088
