### PR TITLE
Update sig-docs-es OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -84,11 +84,13 @@ aliases:
   sig-docs-es-owners: # Admins for Spanish content
     - electrocucaracha
     - krol3
+    - raelga
     - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
     - electrocucaracha
     - jossemarGT
     - krol3
+    - raelga
     - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - perriea


### PR DESCRIPTION
### Description

This PR adds @raelga to the sig-docs-es-owners and  sig-docs-es-reviewers aliases as discussed in the weekly meeting.

/label language/es
/cc @electrocucaracha 
/cc @krol3