### PR TITLE
update non-existing old version of fluentd image

### DIFF
--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+        image: quay.io/fluentd_elasticsearch/fluentd:v5.0.1
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
### Description

I've updated the fluentd container image version to the most recent version.

### Issue

The currently used version of fluentd does not exist any more in the public registry.

I've run into this issue when reading the tutorial here: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/

This command fails to deploy the pods:
```
kubectl apply -f https://k8s.io/examples/controllers/daemonset.yaml
```