### PR TITLE
cfg: update sig docs es owners aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -84,11 +84,13 @@ aliases:
   sig-docs-es-owners: # Admins for Spanish content
     - electrocucaracha
     - krol3
+    - raelga
     - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
     - electrocucaracha
     - jossemarGT
     - krol3
+    - raelga
     - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - perriea


### PR DESCRIPTION
Description
Adds @raelga to to sig-docs-es reviewer and owner aliases as discussed in the weekly meeting.

/cc @electrocucaracha
/cc @krol3