### PR TITLE
Remove post-hero block and some more-hero block

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,10 +23,8 @@
 				{{ block "hero-more" . }}{{ end }}
 			</div>
 		</section>
-		{{ block "post-hero" . }}
-    </header>
     {{ end }}
-		{{ end }}
+    </header>
     <div class="td-outer">
       <main role="main" class="td-main" {{ if (or (ne .FirstSection "case-studies") (not .IsSection) ) }}data-pagefind-body{{ end }}>
         {{ block "deprecation_warning" . }}

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -20,7 +20,6 @@
           {{ end }}
         {{ if .IsSection }}</h1>{{ else }}</h2>{{ end }}
       </section>
-         {{ block "hero-more" . }}{{ end }}
       {{ end }}
     </header>
     <div class="container-fluid td-outer">

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -11,7 +11,6 @@
       {{ block "hero" . }}
         <section class="header-hero filler">
         </section>
-         {{ block "hero-more" . }}{{ end }}
       {{ end }}
     </header>
     <div class="container-fluid td-outer">

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -10,10 +10,3 @@
     {{ partial "docs/api-reference-links" . }}
     </div>
 {{ end }}
-{{ define "hero-more" }}
-{{ if .IsHome }}
-{{ with site.GetPage "section" "docs/tutorials/kubernetes-basics" }}
-<a href="{{ .RelPermalink }}" id="quickstartButton" class="button">{{ .LinkTitle }}</a>
-{{ end }}
-{{ end }}
-{{ end }}


### PR DESCRIPTION
### Description
This PR removes some template blocks that are not required anymore.

- `post-hero` block is removed from `_default/baseof.html` as its an empty `block` and is not defined anywhere else.
- `hero-more` is removed from `blog/baseof.html` and `docs/baseof.html` as they are empty blocks and not defined anywhere else.
- `hero-more` definition is removed from `docs/single.html` as that block is only applicable when `.IsHome` is true but it's never true for any content applicable for the docs/single layout.

### Issue
Closes: #50317 

Helps with #41171

/area web-development
/kind cleanup
/hold