### PR TITLE
update docker image (busybox)

### DIFF
--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -241,7 +241,7 @@ or [Installing CoreDNS](/docs/tasks/administer-cluster/coredns/#installing-cored
 Let's run another curl application to test this:
 
 ```shell
-kubectl run curl --image=radial/busyboxplus:curl -i --tty --rm
+kubectl run -i --tty --image busybox:1.37 dns-test --restart=Never --rm
 ```
 ```
 Waiting for pod default/curl-131556218-9fnch to be running, status is Pending, pod ready: false


### PR DESCRIPTION
### Description

Updated the docker image radial/busyboxplus:curl to busybox:1.37

Don't know if it's suitable to run the nslookup command. Therefore please check it during the review and maybe adjust it to solve the issue described below.

### Issue

The docker image radial/busyboxplus:curl was not updated for long time. Therefore when running the command mentioned in the tutorial, I get this error (with RKE2, server version v1.31.6+rke2r1):

```
ErrImagePull (failed to pull and unpack image "docker.io/radial/busyboxplus:curl": failed to get converter for "docker.io/radial/busyboxplus:curl": Pulling Schema 1 images have been deprecated and disabled by default since containerd v2.0. As a workaround you may set an environment variable `CONTAINERD_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1`, but this will be completely removed in containerd v2.1.)
```