### PR TITLE
Fix: Ensure resource names in ClusterRole are plural and lowercase

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -342,6 +342,10 @@ rules:
 The following examples are excerpts from Role or ClusterRole objects, showing only
 the `rules` section.
 
+Note: When specifying resources in a ClusterRole or Role, always use the plural and lowercase form of the resource name.
+For example, use pods instead of pod, services instead of service.
+Incorrect resource names will cause RBAC policies to fail.
+
 Allow reading `"pods"` resources in the core
 {{< glossary_tooltip text="API Group" term_id="api-group" >}}:
 


### PR DESCRIPTION

### Description
Resource names in RBAC must be specified in their plural and lowercase form.  
Previously, using a singular resource name caused issues with ClusterRole bindings.  
This update clarifies the requirement in rbac.md to prevent similar errors in the future.

### Issue
https://github.com/kubernetes/website/issues/50352

Closes: #50352 