### PR TITLE
docs: improve compatibility version docs with benefits and clarity

### DIFF
--- a/content/en/docs/concepts/cluster-administration/compatibility-version.md
+++ b/content/en/docs/concepts/cluster-administration/compatibility-version.md
@@ -6,7 +6,7 @@ reviewers:
 content_type: concept
 weight: 70
 ---
-
+ 
 <!-- overview -->
 
 Since Kubernetes v1.32, configurable version compatibility and emulation options have been introduced for control plane components. These enhancements provide cluster administrators with greater control over upgrades, enabling safer transitions and minimizing compatibility risks.

--- a/content/en/docs/concepts/cluster-administration/compatibility-version.md
+++ b/content/en/docs/concepts/cluster-administration/compatibility-version.md
@@ -18,7 +18,7 @@ Since Kubernetes v1.32, configurable version compatibility and emulation options
 The `--emulated-version` flag allows a control plane component to emulate the behavior of an earlier Kubernetes version. When set, the component's available capabilities align with the specified emulated version:
 
 * Features introduced after the emulated version are disabled.
-* Features removed after the emulated version are re-enabled.
+* Features that were removed after the emulated version can be configured again based on their default settings.
 
 This enables a binary from a specific Kubernetes release to emulate the behavior of an earlier version with high fidelity, ensuring interoperability with other system components based on the emulated version.
 
@@ -28,8 +28,8 @@ The `--emulated-version` must be <= `binaryVersion`. Refer to the help message o
 
 Using version emulation provides several advantages for cluster administrators:
 
-* **Controlled Upgrades**: Allows administrators to test newer Kubernetes versions incrementally by emulating them in a controlled environment before full deployment.
-* **Extended Component Compatibility**: Ensures that control plane components remain interoperable with older versions, reducing the likelihood of unexpected failures during upgrades.
+* **Controlled Upgrades**: Allows administrators to upgrade the control plane with more granular steps, so that failures are more easily diagnosed and more easily auto-reverted on a failure condition.
+* **Skip Binary Version Upgrade**: It is possible to skip binary versions while still performing a stepwise upgrade of Kubernetes control-plane.
 * **Rollback Flexibility**: Provides an additional safeguard by allowing reversion to a previous emulated version without immediate downgrades, minimizing downtime and operational disruptions.
 
 By leveraging version emulation, administrators can enhance the stability and reliability of Kubernetes clusters while managing upgrades with greater confidence.

--- a/content/en/docs/concepts/cluster-administration/compatibility-version.md
+++ b/content/en/docs/concepts/cluster-administration/compatibility-version.md
@@ -1,5 +1,5 @@
 ---
-title: Compatibility Version For Kubernetes Control Plane Components
+title: Compatibility Version for Kubernetes Control Plane Components
 reviewers:
 - jpbetz
 - siyuanfoundation
@@ -9,18 +9,27 @@ weight: 70
 
 <!-- overview -->
 
-Since release v1.32, we introduced configurable version compatibility and emulation options to Kubernetes control plane components to make upgrades safer by providing more control and increasing the granularity of steps available to cluster administrators.
+Since Kubernetes v1.32, configurable version compatibility and emulation options have been introduced for control plane components. These enhancements provide cluster administrators with greater control over upgrades, enabling safer transitions and minimizing compatibility risks.
 
 <!-- body -->
 
 ## Emulated Version
 
-The emulation option is set by the `--emulated-version` flag of control plane components. It allows the component to emulate the behavior (APIs, features, ...) of an earlier version of Kubernetes.
+The `--emulated-version` flag allows a control plane component to emulate the behavior of an earlier Kubernetes version. When set, the component's available capabilities align with the specified emulated version:
 
-When used, the capabilities available will match the emulated version: 
-* Any capabilities present in the binary version that were introduced after the emulation version will be unavailable. 
-* Any capabilities removed after the emulation version will be available. 
+* Features introduced after the emulated version are disabled.
+* Features removed after the emulated version are re-enabled.
 
-This enables a binary from a particular Kubernetes release to emulate the behavior of a previous version with sufficient fidelity that interoperability with other system components can be defined in terms of the emulated version.
+This enables a binary from a specific Kubernetes release to emulate the behavior of an earlier version with high fidelity, ensuring interoperability with other system components based on the emulated version.
 
-The `--emulated-version` must be <= `binaryVersion`. See the help message of the `--emulated-version` flag for supported range of emulated versions.
+The `--emulated-version` must be <= `binaryVersion`. Refer to the help message of the `--emulated-version` flag for the supported range of emulated versions.
+
+## Benefits for Cluster Administrators
+
+Using version emulation provides several advantages for cluster administrators:
+
+* **Controlled Upgrades**: Allows administrators to test newer Kubernetes versions incrementally by emulating them in a controlled environment before full deployment.
+* **Extended Component Compatibility**: Ensures that control plane components remain interoperable with older versions, reducing the likelihood of unexpected failures during upgrades.
+* **Rollback Flexibility**: Provides an additional safeguard by allowing reversion to a previous emulated version without immediate downgrades, minimizing downtime and operational disruptions.
+
+By leveraging version emulation, administrators can enhance the stability and reliability of Kubernetes clusters while managing upgrades with greater confidence.


### PR DESCRIPTION
### Description

- Aligned content with Kubernetes style guide for consistency  
- Expanded explanation of version emulation for better understanding  
- Highlighted benefits to help cluster administrators gain confidence in using this feature  


### Issue
This solves the issue earlier given by @sftim stating, "We want people who encounter this feature to have confidence in using it. Right now the docs are basic and may put people off trying it out."

Closes: #50244 