### PR TITLE
fix: "node autoscaling" link in disruptions

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -49,7 +49,7 @@ Cluster administrator actions include:
 
 - [Draining a node](/docs/tasks/administer-cluster/safely-drain-node/) for repair or upgrade.
 - Draining a node from a cluster to scale the cluster down (learn about
-[Node Autoscaling]((/docs/concepts/cluster-administration/node-autoscaling/)).
+[Node Autoscaling](/docs/concepts/cluster-administration/node-autoscaling/)).
 - Removing a pod from a node to permit something else to fit on that node.
 
 These actions might be taken directly by the cluster administrator, or by automation


### PR DESCRIPTION
### Description

As a user, I noticed that in PodDisruptionBudget a bracket replacement is incorrect and therefore the closing bracket is visually missing in the text, as well as incorrect referencing.

### Issue

Closes: -