### PR TITLE
[ja] Fix broken image in SIG Node Spotlight 2024 blog post due to incorrect path

### DIFF
--- a/content/ja/blog/_posts/2024-05-21-sig-node-spotlight/index.md
+++ b/content/ja/blog/_posts/2024-05-21-sig-node-spotlight/index.md
@@ -24,7 +24,7 @@ _複数の回答者による共同回答の場合は、回答者全員のイニ�
 
 **Matthias:** Matthias Bertschyと申します。フランス人で、フランスアルプスの近く、ジュネーブ湖のそばに住んでいます。2017年からKubernetesのコントリビューターとして活動し、SIG Nodeのレビュアー、そして[Prow](https://docs.prow.k8s.io/docs/overview/)のメンテナーを務めています。現在は、[ARMO](https://www.armosec.io/)というセキュリティスタートアップでシニアKubernetes開発者として働いています。ARMOは、[Kubescape](https://www.cncf.io/projects/kubescape/)というプロジェクトをCNCFに寄贈しました。
 
-![ジュネーブ湖とアルプス](/Lake_Geneva_and_the_Alps.jpg)
+![ジュネーブ湖とアルプス](Lake_Geneva_and_the_Alps.jpg)
 
 **Gunju:** Gunju Kimと申します。[NAVER](https://www.navercorp.com/naver/naverMain)でソフトウェアエンジニアとして働いており、検索サービス用のクラウドプラットフォームの開発に注力しています。2021年から空き時間を使ってKubernetesプロジェクトにコントリビュートしています。
 

--- a/content/ja/blog/_posts/2024-05-21-sig-node-spotlight/index.md
+++ b/content/ja/blog/_posts/2024-05-21-sig-node-spotlight/index.md
@@ -24,7 +24,7 @@ _複数の回答者による共同回答の場合は、回答者全員のイニ�
 
 **Matthias:** Matthias Bertschyと申します。フランス人で、フランスアルプスの近く、ジュネーブ湖のそばに住んでいます。2017年からKubernetesのコントリビューターとして活動し、SIG Nodeのレビュアー、そして[Prow](https://docs.prow.k8s.io/docs/overview/)のメンテナーを務めています。現在は、[ARMO](https://www.armosec.io/)というセキュリティスタートアップでシニアKubernetes開発者として働いています。ARMOは、[Kubescape](https://www.cncf.io/projects/kubescape/)というプロジェクトをCNCFに寄贈しました。
 
-![ジュネーブ湖とアルプス](/ja/Lake_Geneva_and_the_Alps.jpg)
+![ジュネーブ湖とアルプス](/Lake_Geneva_and_the_Alps.jpg)
 
 **Gunju:** Gunju Kimと申します。[NAVER](https://www.navercorp.com/naver/naverMain)でソフトウェアエンジニアとして働いており、検索サービス用のクラウドプラットフォームの開発に注力しています。2021年から空き時間を使ってKubernetesプロジェクトにコントリビュートしています。
 


### PR DESCRIPTION
### Description

Fixes the image rendering issue in the Japanese version of the blog post
[`SIG Node Spotlight 2024`](https://kubernetes.io/ja/blog/2024/06/20/sig-node-spotlight-2024/).

The current image path is:
```markdown
![ジュネーブ湖とアルプス](/ja/Lake_Geneva_and_the_Alps.jpg)
```

However, the image file is located in the same directory as index.md, so the correct relative path should be:

```
![ジュネーブ湖とアルプス](Lake_Geneva_and_the_Alps.jpg)
```

This PR updates the Markdown file to use the correct relative path so that the image renders properly. The English version already uses the correct format and displays correctly.

### issue

Closes: #50326 

<img width="1440" alt="fixed_webpage" src="https://github.com/user-attachments/assets/ae4bb028-6e60-4efe-95b9-04494bb3b815" />


