### PR TITLE
Rework CEL page to use HTML table rather than Markdown table

### DIFF
--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -44,43 +44,200 @@ variables are available for that field.
 
 Example CEL expressions:
 
-{{< table caption="Examples of CEL expressions and the purpose of each" >}}
-| Rule                                                                               | Purpose                                                                           |
-|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `self.minReplicas <= self.replicas && self.replicas <= self.maxReplicas`           | Validate that the three fields defining replicas are ordered appropriately        |
-| `'Available' in self.stateCounts`                                                  | Validate that an entry with the 'Available' key exists in a map                   |
-| `(self.list1.size() == 0) != (self.list2.size() == 0)`                             | Validate that one of two lists is non-empty, but not both                         |
-| `self.envars.filter(e, e.name = 'MY_ENV').all(e, e.value.matches('^[a-zA-Z]*$'))`  | Validate the 'value' field of a listMap entry where key field 'name' is 'MY_ENV'  |
-| `has(self.expired) && self.created + self.ttl < self.expired`                      | Validate that 'expired' date is after a 'create' date plus a 'ttl' duration       |
-| `self.health.startsWith('ok')`                                                     | Validate a 'health' string field has the prefix 'ok'                              |
-| `self.widgets.exists(w, w.key == 'x' && w.foo < 10)`                               | Validate that the 'foo' property of a listMap item with a key 'x' is less than 10 |
-| `type(self) == string ? self == '99%' : self == 42`                                | Validate an int-or-string field for both the int and string cases                 |
-| `self.metadata.name == 'singleton'`                                                | Validate that an object's name matches a specific value (making it a singleton)   |
-| `self.set1.all(e, !(e in self.set2))`                                              | Validate that two listSets are disjoint                                           |
-| `self.names.size() == self.details.size() && self.names.all(n, n in self.details)` | Validate the 'details' map is keyed by the items in the 'names' listSet           |
-| `self.details.all(key, key.matches('^[a-zA-Z]*$'))`                                | Validate the keys of the 'details' map                                            |
-| `self.details.all(key, self.details[key].matches('^[a-zA-Z]*$'))`                  | Validate the values of the 'details' map                                          |
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions and the purpose of each</caption>
+<thead>
+<tr>
+  <th>Rule</th>
+  <th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>self.minReplicas &lt;= self.replicas && self.replicas &lt;= self.maxReplicas</tt></td>
+  <td>Validate that the three fields defining replicas are ordered appropriately</td>
+</tr>
+<tr>
+  <td><tt>'Available' in self.stateCounts</tt></td>
+  <td>Validate that an entry with the 'Available' key exists in a map</td>
+</tr>
+<tr>
+  <td><tt>(self.list1.size() == 0) != (self.list2.size() == 0)</tt></td>
+  <td>Validate that one of two lists is non-empty, but not both</td>
+</tr>
+<tr>
+  <td><tt>self.envars.filter(e, e.name = 'MY_ENV').all(e, e.value.matches('^[a-zA-Z]*$'))</tt></td>
+  <td>Validate the 'value' field of a listMap entry where key field 'name' is 'MY_ENV'</td>
+</tr>
+<tr>
+  <td><tt>has(self.expired) && self.created + self.ttl &lt; self.expired</tt></td>
+  <td>Validate that 'expired' date is after a 'create' date plus a 'ttl' duration</td>
+</tr>
+<tr>
+  <td><tt>self.health.startsWith('ok')</tt></td>
+  <td>Validate a 'health' string field has the prefix 'ok'</td>
+</tr>
+<tr>
+  <td><tt>self.widgets.exists(w, w.key == 'x' && w.foo &lt; 10)</tt></td>
+  <td>Validate that the 'foo' property of a listMap item with a key 'x' is less than 10</td>
+</tr>
+<tr>
+  <td><tt>type(self) == string ? self == '99%' : self == 42</tt></td>
+  <td>Validate an int-or-string field for both the int and string cases</td>
+</tr>
+<tr>
+  <td><tt>self.metadata.name == 'singleton'</tt></td>
+  <td>Validate that an object's name matches a specific value (making it a singleton)</td>
+</tr>
+<tr>
+  <td><tt>self.set1.all(e, !(e in self.set2))</tt></td>
+  <td>Validate that two listSets are disjoint</td>
+</tr>
+<tr>
+  <td><tt>self.names.size() == self.details.size() && self.names.all(n, n in self.details)</tt></td>
+  <td>Validate the 'details' map is keyed by the items in the 'names' listSet</td>
+</tr>
+<tr>
+  <td><tt>self.details.all(key, key.matches('^[a-zA-Z]*$'))</tt></td>
+  <td>Validate the keys of the 'details' map</td>
+</tr>
+<tr>
+  <td><tt>self.details.all(key, self.details[key].matches('^[a-zA-Z]*$'))</tt></td>
+  <td>Validate the values of the 'details' map</td>
+</tr>
+</tbody>
+</table>
 
 ## CEL options, language features, and libraries
 
-CEL is configured with the following options, libraries and language features, introduced at the specified Kubernetes versions:
+CEL is configured with the following options, libraries and language features,
+introduced at the specified Kubernetes versions:
 
-| CEL option, library or language feature | Included | Availablity |
-|-----------------------------------------|----------|-------------|
-| [Standard macros](https://github.com/google/cel-spec/blob/v0.7.0/doc/langdef.md#macros) | `has`, `all`, `exists`, `exists_one`, `map`, `filter` | All Kubernetes versions |
-| [Standard functions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions) | See [official list of standard definitions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions) | All Kubernetes versions |
-| [Homogeneous Aggregate Literals](https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#HomogeneousAggregateLiterals) | | All Kubernetes versions |
-| [Default UTC Time Zone](https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#DefaultUTCTimeZone) | | All Kubernetes versions |
-| [Eagerly Validate Declarations](https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#EagerlyValidateDeclarations) | | All Kubernetes versions |
-| [Extended strings library](https://pkg.go.dev/github.com/google/cel-go/ext#Strings), Version 1 | `charAt`, `indexOf`, `lastIndexOf`, `lowerAscii`, `upperAscii`, `replace`, `split`, `join`, `substring`, `trim` | All Kubernetes versions |
-| Kubernetes list library | See [Kubernetes list library](#kubernetes-list-library) | All Kubernetes versions |
-| Kubernetes regex library | See [Kubernetes regex library](#kubernetes-regex-library) | All Kubernetes versions |
-| Kubernetes URL library | See [Kubernetes URL library](#kubernetes-url-library) | All Kubernetes versions |
-| Kubernetes authorizer library | See [Kubernetes authorizer library](#kubernetes-authorizer-library) | All Kubernetes versions |
-| Kubernetes quantity library | See [Kubernetes quantity library](#kubernetes-quantity-library) | Kubernetes versions 1.29+ |
-| CEL optional types | See [CEL optional types](https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#OptionalTypes) | Kubernetes versions 1.29+ |
-| CEL CrossTypeNumericComparisons | See [CEL CrossTypeNumericComparisons](https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#CrossTypeNumericComparisons) | Kubernetes versions 1.29+ |
+<table>
+<thead>
+<tr>
+  <th>CEL option, library or language feature</th>
+  <th>Included</th>
+  <th>Availability</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>CEL option, library or language feature</td>
+  <td>Included</td>
+  <td>Availablity</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/google/cel-spec/blob/v0.7.0/doc/langdef.md#macros">Standard macros</a></td>
+  <td><code>has</code>, <code>all</code>, <code>exists</code>, <code>exists_one</code>, <code>map</code>, <code>filter</code></td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions">Standard functions</a></td>
+  <td>See
+    <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions">
+      official list of standard definitions
+    </a>
+  </td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>
+    <a href="https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#HomogeneousAggregateLiterals">
+      Homogeneous Aggregate Literals
+    </a>
+  </td>
+  <td>-</td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td><a href="https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#DefaultUTCTimeZone">Default UTC Time Zone</a></td>
+  <td>-</td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>
+    <a href="https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#EagerlyValidateDeclarations">
+      Eagerly Validate Declarations
+    </a>
+  </td>
+  <td>-</td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td><a href="https://pkg.go.dev/github.com/google/cel-go/ext#Strings">Extended strings library</a>, Version 1</td>
+  <td>
+    <code>charAt</code>, <code>indexOf</code>, <code>lastIndexOf</code>, <code>lowerAscii</code>,
+    <code>upperAscii</code>, <code>replace</code>, <code>split</code>, <code>join</code>, <code>substring</code>,
+    <code>trim</code>
+  </td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>Kubernetes list library</td>
+  <td>See
+    <a href="#kubernetes-list-library">
+      Kubernetes list library
+    </a>
+  </td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>Kubernetes regex library</td>
+  <td>See
+    <a href="#kubernetes-regex-library">
+      Kubernetes regex library
+    </a>
+  </td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>Kubernetes URL library</td>
+  <td>See
+    <a href="#kubernetes-url-library">
+      Kubernetes URL library
+    </a>
+  </td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>Kubernetes authorizer library</td>
+  <td>See
+    <a href="#kubernetes-authorizer-library">
+      Kubernetes authorizer library
+    </a>
+  </td>
+  <td>All Kubernetes versions</td>
+</tr>
+<tr>
+  <td>Kubernetes quantity library</td>
+  <td>See
+    <a href="#kubernetes-quantity-library">
+      Kubernetes quantity library
+    </a>
+  </td>
+  <td>Kubernetes versions 1.29+</td>
+</tr>
+<tr>
+  <td>CEL optional types</td>
+  <td>See
+    <a href="https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#OptionalTypes">
+      CEL optional types
+    </a>
+  </td>
+  <td>Kubernetes versions 1.29+</td>
+</tr>
+<tr>
+  <td>CEL CrossTypeNumericComparisons</td>
+  <td>See
+    <a href="https://pkg.go.dev/github.com/google/cel-go@v0.17.4/cel#CrossTypeNumericComparisons">
+      CEL CrossTypeNumericComparisons
+   </a>
+  </td>
+  <td>Kubernetes versions 1.29+</td>
+</tr>
+</tbody>
+</table>
 
 CEL functions, features and language settings support Kubernetes control plane
 rollbacks. For example, _CEL Optional Values_ was introduced at Kubernetes 1.29
@@ -109,14 +266,33 @@ comparable types.
 
 Examples:
 
-{{< table caption="Examples of CEL expressions using list library functions" >}}
-| CEL Expression                                                                     | Purpose                                                   |
-|------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| `names.isSorted()`                                                                 | Verify that a list of names is kept in alphabetical order |
-| `items.map(x, x.weight).sum() == 1.0`                                              | Verify that the "weights" of a list of objects sum to 1.0 |
-| `lowPriorities.map(x, x.priority).max() < highPriorities.map(x, x.priority).min()` | Verify that two sets of priorities do not overlap         |
-| `names.indexOf('should-be-first') == 1`                                            | Require that the first name in a list if a specific value | 
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions using list library functions</caption>
+<thead>
+<tr>
+  <td>CEL Expression</td>
+  <td>Purpose</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>names.isSorted()</tt></td>
+  <td>Verify that a list of names is kept in alphabetical order</td>
+</tr>
+<tr>
+  <td><tt>items.map(x, x.weight).sum() == 1.0</tt></td>
+  <td>Verify that the "weights" of a list of objects sum to 1.0</td>
+</tr>
+<tr>
+  <td><tt>lowPriorities.map(x, x.priority).max() &lt; highPriorities.map(x, x.priority).min()</tt></td>
+  <td>Verify that two sets of priorities do not overlap</td>
+</tr>
+<tr>
+  <td><tt>names.indexOf('should-be-first') == 1</tt></td>
+  <td>Require that the first name in a list if a specific value</td>
+</tr>
+</tbody>
+</table>
 
 See the [Kubernetes List Library](https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/library#Lists)
 godoc for more information.
@@ -129,12 +305,25 @@ regex operations.
 
 Examples:
 
-{{< table caption="Examples of CEL expressions using regex library functions" >}}
-| CEL Expression                                              | Purpose                                                  |
-|-------------------------------------------------------------|----------------------------------------------------------|
-| `"abc 123".find('[0-9]+')`                                  | Find the first number in a string                        |
-| `"1, 2, 3, 4".findAll('[0-9]+').map(x, int(x)).sum() < 100` | Verify that the numbers in a string sum to less than 100 |
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions using regex library functions</caption>
+<thead>
+<tr>
+  <td>CEL Expression</td>
+  <td>Purpose</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>"abc 123".find('[0-9]+')</tt></td>
+  <td>Find the first number in a string</td>
+</tr>
+<tr>
+  <td><tt>"1, 2, 3, 4".findAll('[0-9]+').map(x, int(x)).sum() &lt; 100</tt></td>
+  <td>Verify that the numbers in a string sum to less than 100</td>
+</tr>
+</tbody>
+</table>
 
 See the [Kubernetes regex library](https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/library#Regex)
 godoc for more information.
@@ -154,12 +343,26 @@ Once parsed via the `url` function, the resulting URL object has `getScheme`,
 
 Examples:
 
-{{< table caption="Examples of CEL expressions using URL library functions" >}}
-| CEL Expression                                                  | Purpose                                        |
-|-----------------------------------------------------------------|------------------------------------------------|
-| `url('https://example.com:80/').getHost()`                      | Gets the 'example.com:80' host part of the URL |
-| `url('https://example.com/path with spaces/').getEscapedPath()` | Returns '/path%20with%20spaces/'               |
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions using URL library functions</caption>
+<thead>
+<tr>
+  <td>CEL Expression</td>
+  <td>Purpose</td>
+</tr>
+</thead>
+<tbody>
+</tr>
+<tr>
+  <td><tt>url('https://example.com:80/').getHost()</tt></td>
+  <td>Gets the 'example.com:80' host part of the URL</td>
+</tr>
+<tr>
+  <td><tt>url('https://example.com/path with spaces/').getEscapedPath()</tt></td>
+  <td>Returns '/path%20with%20spaces/'</td>
+</tr>
+</tbody>
+</table>
 
 See the [Kubernetes URL library](https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/library#URLs)
 godoc for more information.
@@ -191,24 +394,59 @@ To perform an authorization check for a service account:
 
 - `Authorizer.serviceAccount(namespace string, name string) Authorizer`
 
-{{< table caption="Examples of CEL expressions using URL library functions" >}}
-| CEL Expression | Purpose |
-|----------------|---------|
-| `authorizer.group('').resource('pods').namespace('default').check('create').allowed()` | Returns true if the principal (user or service account) is allowed create pods in the 'default' namespace. |
-| `authorizer.path('/healthz').check('get').allowed()` | Checks if the principal (user or service account) is authorized to make HTTP GET requests to the /healthz API path. |
-| `authorizer.serviceAccount('default', 'myserviceaccount').resource('deployments').check('delete').allowed()` | Checks if the service account is authorized to delete deployments. |
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions using URL library functions</caption>
+<thead>
+<tr>
+  <th>CEL Expression</th>
+  <th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>authorizer.group('').resource('pods').namespace('default').check('create').allowed()</tt></td>
+  <td>Returns true if the principal (user or service account) is allowed create pods in the 'default' namespace.</td>
+</tr>
+<tr>
+  <td><tt>authorizer.path('/healthz').check('get').allowed()</tt></td>
+  <td>Checks if the principal (user or service account) is authorized to make HTTP GET requests to the /healthz API path.</td>
+</tr>
+<tr>
+  <td><tt>authorizer.serviceAccount('default', 'myserviceaccount').resource('deployments').check('delete').allowed()<tt></td>
+  <td>Checks if the service account is authorized to delete deployments.</td>
+</tr>
+</tbody>
+</table>
 
 {{< feature-state state="alpha" for_k8s_version="v1.31" >}}
 
 With the alpha `AuthorizeWithSelectors` feature enabled, field and label selectors can be added to authorization checks.
 
-{{< table caption="Examples of CEL expressions using selector authorization functions" >}}
-| CEL Expression | Purpose |
-|----------------|---------|
-| `authorizer.group('').resource('pods').fieldSelector('spec.nodeName=mynode').check('list').allowed()` | Returns true if the principal (user or service account) is allowed to list pods with the field selector `spec.nodeName=mynode`. |
-| `authorizer.group('').resource('pods').labelSelector('example.com/mylabel=myvalue').check('list').allowed()` | Returns true if the principal (user or service account) is allowed to list pods with the label selector `example.com/mylabel=myvalue`. |
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions using selector authorization functions</caption>
+<thead>
+<tr>
+  <th>CEL Expression</th>
+  <th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>authorizer.group('').resource('pods').fieldSelector('spec.nodeName=mynode').check('list').allowed()</tt></td>
+  <td>
+    Returns true if the principal (user or service account) is allowed
+    to list pods with the field selector <tt>spec.nodeName=mynode</tt>.
+  </td>
+</tr>
+<tr>
+  <td><tt>authorizer.group('').resource('pods').labelSelector('example.com/mylabel=myvalue').check('list').allowed()</tt></td>
+  <td>
+    Returns true if the principal (user or service account) is allowed
+    to list pods with the label selector <tt>example.com/mylabel=myvalue</tt>.
+  </td>
+</tr>
+</tbody>
+</table>
 
 See the [Kubernetes Authz library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz)
 and [Kubernetes AuthzSelectors library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#AuthzSelectors)
@@ -226,37 +464,135 @@ Kubernetes 1.28 adds support for manipulating quantity strings (ex 1.5G, 512k, 2
 Once parsed via the `quantity` function, the resulting Quantity object has the
 following library of member functions:
 
-{{< table caption="Available member functions of a Quantity" >}}
-| Member Function             | CEL Return Value | Description |
-|-----------------------------|------------------|-------------|
-| `isInteger()`               | bool             | Returns true if and only if asInteger is safe to call without an error |
-| `asInteger()`               | int              | Returns a representation of the current value as an int64 if possible or results in an error if conversion would result in overflow or loss of precision. |
-| `asApproximateFloat()`      | float            | Returns a float64 representation of the quantity which may lose precision. If the value of the quantity is outside the range of a float64 +Inf/-Inf will be returned. |
-| `sign()`                    | int              | Returns `1` if the quantity is positive, `-1` if it is negative. `0` if it is zero |
-| `add(<Quantity>)`           | Quantity         | Returns sum of two quantities |
-| `add(<int>)`                | Quantity         | Returns sum of quantity and an integer | 
-| `sub(<Quantity>)`           | Quantity         | Returns difference between two quantities |
-| `sub(<int>)`                | Quantity         | Returns difference between a quantity and an integer |
-| `isLessThan(<Quantity>)`    | bool             | Returns true if and only if the receiver is less than the operand |
-| `isGreaterThan(<Quantity>)` | bool             | Returns true if and only if the receiver is greater than the operand |
-| `compareTo(<Quantity>)`     | int              | Compares receiver to operand and returns 0 if they are equal, 1 if the receiver is greater, or -1 if the receiver is less than the operand |
-{{< /table >}}
+<table>
+<caption>Available member functions of a Quantity</caption>
+<thead>
+<tr>
+  <th>Member Function</th>
+  <th>CEL Return Value</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>isInteger()</tt></td>
+  <td>bool</td>
+  <td>Returns true if and only if asInteger is safe to call without an error</td>
+</tr>
+<tr>
+  <td><tt>asInteger()</tt></td>
+  <td>int</td>
+  <td>
+    Returns a representation of the current value as an <tt>int64</tt> if possible
+    or results in an error if conversion would result in overflowor loss of precision.
+  </td>
+</tr>
+<tr>
+  <td><tt>asApproximateFloat()</tt></td>
+  <td>float</td>
+  <td>
+    Returns a <tt>float64</tt> representation of the quantity which may lose precision.
+    If the value of the quantity is outside the range of a <tt>float64</tt>,
+    <tt>+Inf/-Inf</tt> will be returned.</td>
+</tr>
+<tr>
+  <td><tt>sign()</tt></td>
+  <td>int</td>
+  <td>
+    Returns <tt>1</tt> if the quantity is positive, <tt>-1</tt> if it is negative.
+    <tt>0</tt> if it is zero.
+  </td>
+</tr>
+<tr>
+  <td><tt>add(&lt;Quantity&gt;)</tt></td>
+  <td>Quantity</td>
+  <td>Returns sum of two quantities</td>
+</tr>
+<tr>
+  <td><tt>add(&lt;int&gt;)</tt></td>
+  <td>Quantity</td>
+  <td>Returns sum of quantity and an integer</td>
+  <td>
+<tr>
+  <td><tt>sub(&lt;Quantity&gt;)</tt></td>
+  <td>Quantity</td>
+  <td>Returns difference between two quantities</td>
+</tr>
+<tr>
+  <td><tt>sub(&lt;int&gt;)</tt></td>
+  <td>Quantity</td>
+  <td>Returns difference between a quantity and an integer</td>
+</tr>
+<tr>
+  <td><tt>isLessThan(&lt;Quantity&gt;)</tt></td>
+  <td>bool</td>
+  <td>Returns true if and only if the receiver is less than the operand</td>
+</tr>
+<tr>
+  <td><tt>isGreaterThan(&lt;Quantity&gt;)</tt></td>
+  <td>bool</td>
+  <td>Returns true if and only if the receiver is greater than the operand</td>
+</tr>
+<tr>
+  <td><tt>compareTo(&lt;Quantity&gt;)</tt></td>
+  <td>int</td>
+  <td>
+    Compares receiver to operand and returns 0 if they are equal,
+    1 if the receiver is greater, or -1 if the receiver is less than the operand
+  </td>
+</tr>
+</tbody>
+</table>
 
 Examples:
 
-{{< table caption="Examples of CEL expressions using URL library functions" >}}
-| CEL Expression                                                            | Purpose                                               |
-|---------------------------------------------------------------------------|-------------------------------------------------------|
-| `quantity("500000G").isInteger()`                                         | Test if conversion to integer would throw an error    |
-| `quantity("50k").asInteger()`                                             | Precise conversion to integer                         |
-| `quantity("9999999999999999999999999999999999999G").asApproximateFloat()` | Lossy conversion to float                              |
-| `quantity("50k").add(quantity("20k"))`                                   | Add two quantities                                    |
-| `quantity("50k").sub(20000)`                                              | Subtract an integer from a quantity                   |
-| `quantity("50k").add(20).sub(quantity("100k")).sub(-50000)`               | Chain adding and subtracting integers and quantities  |
-| `quantity("200M").compareTo(quantity("0.2G"))`                            | Compare two quantities                                |
-| `quantity("150Mi").isGreaterThan(quantity("100Mi"))`                      | Test if a quantity is greater than the receiver       |
-| `quantity("50M").isLessThan(quantity("100M"))`                            | Test if a quantity is less than the receiver          |
-{{< /table >}}
+<table>
+<caption>Examples of CEL expressions using URL library functions</caption>
+<thead>
+<tr>
+  <th>CEL Expression</th>
+  <th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>quantity("500000G").isInteger()</tt></td>
+  <td>Test if conversion to integer would throw an error</td>
+</tr>
+<tr>
+  <td><tt>quantity("50k").asInteger()</tt></td>
+  <td>Precise conversion to integer</td>
+</tr>
+<tr>
+  <td><tt>quantity("9999999999999999999999999999999999999G").asApproximateFloat()</tt></td>
+  <td>Lossy conversion to float</td>
+</tr>
+<tr>
+  <td><tt>quantity("50k").add(quantity("20k"))</tt></td>
+  <td>Add two quantities</td>
+</tr>
+<tr>
+  <td><tt>quantity("50k").sub(20000)</tt></td>
+  <td>Subtract an integer from a quantity</td>
+</tr>
+<tr>
+  <td><tt>quantity("50k").add(20).sub(quantity("100k")).sub(-50000)</tt></td>
+  <td>Chain adding and subtracting integers and quantities</td>
+</tr>
+<tr>
+  <td><tt>quantity("200M").compareTo(quantity("0.2G"))</tt></td>
+  <td>Compare two quantities</td>
+</tr>
+<tr>
+  <td><tt>quantity("150Mi").isGreaterThan(quantity("100Mi"))</tt></td>
+  <td>Test if a quantity is greater than the receiver</td>
+</tr>
+<tr>
+  <td><tt>quantity("50M").isLessThan(quantity("100M"))</tt></td>
+  <td>Test if a quantity is less than the receiver</td>
+</tr>
+</tbody>
+</table>
 
 ## Type checking
 
@@ -287,28 +623,100 @@ has(object.namex) ? object.namex == 'special' : request.name == 'special'
 
 ## Type system integration
 
-{{< table caption="Table showing the relationship between OpenAPIv3 types and CEL types" >}}
-| OpenAPIv3 type                                     | CEL type |
-|----------------------------------------------------|----------|
-| 'object' with Properties                           | object / "message type" (`type(<object>)` evaluates to `selfType<uniqueNumber>.path.to.object.from.self`) |
-| 'object' with AdditionalProperties                 | map |
-| 'object' with x-kubernetes-embedded-type           | object / "message type", 'apiVersion', 'kind', 'metadata.name' and 'metadata.generateName' are implicitly included in schema |
-| 'object' with x-kubernetes-preserve-unknown-fields | object / "message type", unknown fields are NOT accessible in CEL expression |
-| x-kubernetes-int-or-string                         | union of int or string, `self.intOrString < 100 \|\| self.intOrString == '50%'` evaluates to true for both `50` and `"50%"` |
-| 'array'                                            | list |
-| 'array' with x-kubernetes-list-type=map            | list with map based Equality & unique key guarantees |
-| 'array' with x-kubernetes-list-type=set            | list with set based Equality & unique entry guarantees |
-| 'boolean'                                          | boolean |
-| 'number' (all formats)                             | double |
-| 'integer' (all formats)                            | int (64) |
-| _no equivalent_                                    | uint (64) |
-| 'null'                                             | null_type |
-| 'string'                                           | string |
-| 'string' with format=byte (base64 encoded)         | bytes |
-| 'string' with format=date                          | timestamp (google.protobuf.Timestamp) |
-| 'string' with format=datetime                      | timestamp (google.protobuf.Timestamp) |
-| 'string' with format=duration                      | duration (google.protobuf.Duration) |
-{{< /table >}}
+<table>
+<caption>Table showing the relationship between OpenAPIv3 types and CEL types</caption>
+<thead>
+<tr>
+  <th>OpenAPIv3 type</th>
+  <th>CEL type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>'object' with Properties</td>
+  <td>
+    object / "message type"
+    (<tt>type(&lt;object&gt;)</tt> evaluates to
+     <tt>selfType&lt;uniqueNumber&gt;.path.to.object.from.self</tt>)
+  </td>
+</tr>
+<tr>
+  <td>'object' with <tt>additionalProperties</tt></td>
+  <td>map</td>
+</tr>
+<tr>
+  <td>'object' with <tt>x-kubernetes-embedded-type</tt></td>
+  <td>
+    object / "message type", 'apiVersion', 'kind', 'metadata.name'
+    and 'metadata.generateName' are implicitly included in schema
+  </td>
+</tr>
+<tr>
+  <td>'object' with x-kubernetes-preserve-unknown-fields</td>
+  <td>object / "message type", unknown fields are NOT accessible in CEL expression</td>
+</tr>
+<tr>
+  <td><tt>x-kubernetes-int-or-string</tt></td>
+  <td>
+    Union of <tt>int</tt> or <tt>string</tt>,
+    <tt>self.intOrString < 100 | self.intOrString == '50%'</tt>
+    evaluates to true for both <tt>50</tt> and <tt>"50%"</tt>
+  </td>
+</tr>
+<tr>
+  <td>'array'</td>
+  <td>list</td>
+</tr>
+<tr>
+  <td>'array' with <tt>x-kubernetes-list-type=map</tt></td>
+  <td>list with map based Equality & unique key guarantees</td>
+</tr>
+<tr>
+  <td>'array' with <tt>x-kubernetes-list-type=set</tt></td>
+  <td>list with set based Equality & unique entry guarantees</td>
+</tr>
+<tr>
+  <td>'boolean'</td>
+  <td>boolean</td>
+</tr>
+<tr>
+  <td>'number' (all formats)</td>
+  <td>double</td>
+</tr>
+<tr>
+  <td>'integer' (all formats)</td>
+  <td>int (64)</td>
+</tr>
+<tr>
+  <td><i>no equivalent</i></td>
+  <td>uint (64)</td>
+</tr>
+<tr>
+  <td>'null'</td>
+  <td>null_type</td>
+</tr>
+<tr>
+  <td>'string'</td>
+  <td>string</td>
+</tr>
+<tr>
+  <td>'string' with format=byte (base64 encoded)</td>
+  <td>bytes</td>
+</tr>
+<tr>
+  <td>'string' with format=date</td>
+  <td>timestamp (<tt>google.protobuf.Timestamp</tt>)</td>
+</tr>
+<tr>
+  <td>'string' with format=datetime</td>
+  <td>timestamp (<tt>google.protobuf.Timestamp</tt>)</td>
+</tr>
+<tr>
+  <td>'string' with format=duration</td>
+  <td>duration (<tt>google.protobuf.Duration</tt>)</td>
+</tr>
+</tbody>
+</table>
 
 Also see: [CEL types](https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#values),
 [OpenAPI types](https://swagger.io/specification/#data-types),
@@ -338,15 +746,41 @@ Only Kubernetes resource property names of the form
 names are escaped according to the following rules when accessed in the
 expression:
 
-{{< table caption="Table of CEL identifier escaping rules" >}}
-| escape sequence   | property name equivalent                                                                     |
-|-------------------|----------------------------------------------------------------------------------------------|
-| `__underscores__` | `__`                                                                                         |
-| `__dot__`         | `.`                                                                                          |
-| `__dash__`        | `-`                                                                                          |
-| `__slash__`       | `/`                                                                                          |
-| `__{keyword}__`   | [CEL **RESERVED** keyword](https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#syntax) |
-{{< /table >}}
+<table>
+<caption>Table of CEL identifier escaping rules</caption>
+<thead>
+<tr>
+  <th>escape sequence</th>
+  <th>property name equivalent</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>__underscores__</tt></td>
+  <td><tt>__</tt></td>
+</tr>
+<tr>
+  <td><tt>__dot__</tt></td>
+  <td><tt>.</tt></td>
+</tr>
+<tr>
+  <td><tt>__dash__</tt></td>
+  <td><tt>-</tt></td>
+</tr>
+<tr>
+  <td><tt>__slash__</tt></td>
+  <td><tt>/</tt></td>
+</tr>
+<tr>
+  <td><tt>__{keyword}__</tt></td>
+  <td>
+    <a href="https://github.com/google/cel-spec/blob/v0.6.0/doc/langdef.md#syntax">
+      CEL <b>RESERVED</b> keyword
+    </a>
+  </td>
+</tr>
+</tbody>
+</table>
 
 When you escape any of CEL's **RESERVED** keywords you need to match the exact property name
 use the underscore escaping
@@ -354,14 +788,33 @@ use the underscore escaping
 
 Examples on escaping:
 
-{{< table caption="Examples escaped CEL identifiers" >}}
-| property name | rule with escaped property name   |
-|---------------|-----------------------------------|
-| `namespace`   | `self.__namespace__ > 0`          |
-| `x-prop`      | `self.x__dash__prop > 0`          |
-| `redact__d`   | `self.redact__underscores__d > 0` |
-| `string`      | `self.startsWith('kube')`         |
-{{< /table >}}
+<table>
+<caption>Examples escaped CEL identifiers</caption>
+<thead>
+<tr>
+  <th>property name</th>
+  <th>rule with escaped property name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>namespace</tt></td>
+  <td><tt>self.__namespace__ &gt; 0</tt></td>
+</tr>
+<tr>
+  <td><tt>x-prop</tt></td>
+  <td><tt>self.x__dash__prop &gt; 0</tt></td>
+</tr>
+<tr>
+  <td><tt>redact_d</tt></td>
+  <td><tt>self.redact__underscores__d &gt; 0</tt></td>
+</tr>
+<tr>
+  <td><tt>string</tt></td>
+  <td><tt>self.startsWith('kube')</tt></td>
+</tr>
+</tbody>
+</table>
 
 ## Resource constraints
 


### PR DESCRIPTION
The markdown tables have too many constraints for no good reason.
Using HTML tables directly would be more appropriate.