### PR TITLE
Add cgroup v2 to PSI requirements

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/en/docs/concepts/cluster-administration/system-metrics.md
@@ -202,7 +202,10 @@ to use this feature. The information is also exposed in the
 
 #### Requirements
 
-Pressure Stall Information requires [Linux kernel versions 4.20 or later](/docs/reference/node/kernel-version-requirements#requirements-psi).
+Pressure Stall Information requires:
+
+- [Linux kernel versions 4.20 or later](/docs/reference/node/kernel-version-requirements#requirements-psi).
+- [cgroup v2](/docs/concepts/architecture/cgroups)
 
 ## Disabling metrics
 

--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -57,7 +57,10 @@ to use this feature. The information is also exposed in
 
 ### Requirements
 
-Pressure Stall Information requires [Linux kernel versions 4.20 or later](/docs/reference/node/kernel-version-requirements#requirements-psi).
+Pressure Stall Information requires:
+
+- [Linux kernel versions 4.20 or later](/docs/reference/node/kernel-version-requirements#requirements-psi).
+- [cgroup v2](/docs/concepts/architecture/cgroups)
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
A followup of https://github.com/kubernetes/website/pull/49895. PSI requires cgroup v2. 

Ref: 
- https://github.com/kubernetes/enhancements/issues/4205
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4205-psi-metric/README.md

/assign @tengqm @kannon92 @haircommander