### PR TITLE
Tweak working-with-objects/field-selectors and namespaces

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -5,70 +5,81 @@ weight: 70
 ---
 
 _Field selectors_ let you select Kubernetes {{< glossary_tooltip text="objects" term_id="object" >}} based on the
-value of one or more resource fields. Here are some examples of field selector queries:
+values of one or more resource fields. Here are some examples of field selector queries:
 
 * `metadata.name=my-service`
 * `metadata.namespace!=default`
 * `status.phase=Pending`
 
-This `kubectl` command selects all Pods for which the value of the [`status.phase`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) field is `Running`:
+This `kubectl` command selects all Pods for which the value of the
+[`status.phase`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) field is `Running`:
 
 ```shell
 kubectl get pods --field-selector status.phase=Running
 ```
 
 {{< note >}}
-Field selectors are essentially resource *filters*. By default, no selectors/filters are applied, meaning that all resources of the specified type are selected. This makes the `kubectl` queries `kubectl get pods` and `kubectl get pods --field-selector ""` equivalent.
+Field selectors are essentially resource *filters*. By default, no selectors/filters are applied,
+meaning that all resources of the specified type are selected. This means that
+`kubectl get pods` and `kubectl get pods --field-selector ""` produce the same result.
 {{< /note >}}
 
 ## Supported fields
 
-Supported field selectors vary by Kubernetes resource type. All resource types support the `metadata.name` and `metadata.namespace` fields. Using unsupported field selectors produces an error. For example:
+Supported field selectors vary by Kubernetes resource type. All resource types support the
+`metadata.name` and `metadata.namespace` fields. Using unsupported field selectors produces an error. For example:
 
 ```shell
 kubectl get ingress --field-selector foo.bar=baz
 ```
+
 ```
 Error from server (BadRequest): Unable to find "ingresses" that match label selector "", field selector "foo.bar=baz": "foo.bar" is not a known field selector: only "metadata.name", "metadata.namespace"
 ```
 
 ### List of supported fields
 
-| Kind                      | Fields                                                                                                                                                                                                                                                          |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Pod                       | `spec.nodeName`<br>`spec.restartPolicy`<br>`spec.schedulerName`<br>`spec.serviceAccountName`<br>`spec.hostNetwork`<br>`status.phase`<br>`status.podIP`<br>`status.nominatedNodeName`                                                                            |
-| Event                     | `involvedObject.kind`<br>`involvedObject.namespace`<br>`involvedObject.name`<br>`involvedObject.uid`<br>`involvedObject.apiVersion`<br>`involvedObject.resourceVersion`<br>`involvedObject.fieldPath`<br>`reason`<br>`reportingComponent`<br>`source`<br>`type` |
-| Secret                    | `type`                                                                                                                                                                                                                                                          |
-| Namespace                 | `status.phase`                                                                                                                                                                                                                                                  |
-| ReplicaSet                | `status.replicas`                                                                                                                                                                                                                                               |
-| ReplicationController     | `status.replicas`                                                                                                                                                                                                                                               |
-| Job                       | `status.successful`                                                                                                                                                                                                                                             |
-| Node                      | `spec.unschedulable`                                                                                                                                                                                                                                            |
-| CertificateSigningRequest | `spec.signerName`                                                                                                                                                                                                                                               |
+| Kind | Fields |
+| ---- | ------ |
+| Pod | `spec.nodeName`<br>`spec.restartPolicy`<br>`spec.schedulerName`<br>`spec.serviceAccountName`<br>`spec.hostNetwork`<br>`status.phase`<br>`status.podIP`<br>`status.nominatedNodeName` |
+| Event | `involvedObject.kind`<br>`involvedObject.namespace`<br>`involvedObject.name`<br>`involvedObject.uid`<br>`involvedObject.apiVersion`<br>`involvedObject.resourceVersion`<br>`involvedObject.fieldPath`<br>`reason`<br>`reportingComponent`<br>`source`<br>`type` |
+| Secret | `type` |
+| Namespace | `status.phase` |
+| ReplicaSet | `status.replicas` |
+| ReplicationController | `status.replicas` |
+| Job | `status.successful` |
+| Node | `spec.unschedulable` |
+| CertificateSigningRequest | `spec.signerName` |
 
 ### Custom resources fields
 
 All custom resource types support the `metadata.name` and `metadata.namespace` fields.
 
-Additionally, the `spec.versions[*].selectableFields` field of a {{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}}
-declares which other fields in a custom resource may be used in field selectors. See [selectable fields for custom resources](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields)
+Additionally, the `spec.versions[*].selectableFields` field of a
+{{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinition" >}}
+declares which other fields in a custom resource may be used in field selectors. See
+[selectable fields for custom resources](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields)
 for more information about how to use field selectors with CustomResourceDefinitions.
 
 ## Supported operators
 
-You can use the `=`, `==`, and `!=` operators with field selectors (`=` and `==` mean the same thing). This `kubectl` command, for example, selects all Kubernetes Services that aren't in the `default` namespace:
+You can use the `=`, `==`, and `!=` operators with field selectors (`=` and `==` mean the same thing).
+This `kubectl` command, for example, selects all Kubernetes Services that aren't in the `default` namespace:
 
 ```shell
-kubectl get services  --all-namespaces --field-selector metadata.namespace!=default
+kubectl get services --all-namespaces --field-selector metadata.namespace!=default
 ```
+
 {{< note >}}
 [Set-based operators](/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)
-(`in`, `notin`, `exists`) are not supported for field selectors. 
+(`in`, `notin`, `exists`) are not supported for field selectors.
 {{< /note >}}
 
 ## Chained selectors
 
-As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors, field selectors can be chained together as a comma-separated list. This `kubectl` command selects all Pods for which the `status.phase` does not equal `Running` and the `spec.restartPolicy` field equals `Always`:
+As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors,
+field selectors can be chained together as a comma-separated list. This `kubectl` command
+selects all Pods for which the `status.phase` does not equal `Running` and the `spec.restartPolicy` field equals `Always`:
 
 ```shell
 kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Always
@@ -76,7 +87,8 @@ kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Alway
 
 ## Multiple resource types
 
-You can use field selectors across multiple resource types. This `kubectl` command selects all Statefulsets and Services that are not in the `default` namespace:
+You can use field selectors across multiple resource types. This `kubectl` command selects
+all Statefulsets and Services that are not in the `default` namespace:
 
 ```shell
 kubectl get statefulsets,services --all-namespaces --field-selector metadata.namespace!=default

--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -13,22 +13,26 @@ weight: 45
 
 <!-- overview -->
 
-In Kubernetes, _namespaces_ provide a mechanism for isolating groups of resources within a single cluster. Names of resources need to be unique within a namespace, but not across namespaces. Namespace-based scoping is applicable only for namespaced {{< glossary_tooltip text="objects" term_id="object" >}} _(e.g. Deployments, Services, etc.)_ and not for cluster-wide objects _(e.g. StorageClass, Nodes, PersistentVolumes, etc.)_.
+In Kubernetes, _namespaces_ provide a mechanism for isolating groups of resources within a single cluster.
+Names of resources need to be unique within a namespace, but not across namespaces.
+Namespace-based scoping applies only to namespaced {{< glossary_tooltip text="objects" term_id="object" >}},
+such as Deployments and Services, but not to cluster-wide objects like StorageClasses, Nodes, or PersistentVolumes.
 
 <!-- body -->
 
-## When to Use Multiple Namespaces
+## When to use multiple namespaces
 
 Namespaces are intended for use in environments with many users spread across multiple
-teams, or projects.  For clusters with a few to tens of users, you should not
-need to create or think about namespaces at all.  Start using namespaces when you
+teams, or projects. For clusters with a few to tens of users, you should not
+need to create or think about namespaces at all. Start using namespaces when you
 need the features they provide.
 
-Namespaces provide a scope for names.  Names of resources need to be unique within a namespace,
-but not across namespaces. Namespaces cannot be nested inside one another and each Kubernetes 
+Namespaces provide a scope for names. Names of resources need to be unique within a namespace,
+but not across namespaces. Namespaces cannot be nested inside one another and each Kubernetes
 resource can only be in one namespace.
 
-Namespaces are a way to divide cluster resources between multiple users (via [resource quota](/docs/concepts/policy/resource-quotas/)).
+Namespaces are a way to divide cluster resources between multiple users
+(via [resource quota](/docs/concepts/policy/resource-quotas/)).
 
 It is not necessary to use multiple namespaces to separate slightly different
 resources, such as different versions of the same software: use
@@ -47,10 +51,14 @@ Kubernetes starts with four initial namespaces:
 : Kubernetes includes this namespace so that you can start using your new cluster without first creating a namespace.
 
 `kube-node-lease`
-: This namespace holds [Lease](/docs/concepts/architecture/leases/) objects associated with each node. Node leases allow the kubelet to send [heartbeats](/docs/concepts/architecture/nodes/#node-heartbeats) so that the control plane can detect node failure.
+: This namespace holds [Lease](/docs/concepts/architecture/leases/) objects associated with each node.
+  Node leases allow the kubelet to send [heartbeats](/docs/concepts/architecture/nodes/#node-heartbeats)
+  so that the control plane can detect node failure.
 
 `kube-public`
-: This namespace is readable by *all* clients (including those not authenticated). This namespace is mostly reserved for cluster usage, in case that some resources should be visible and readable publicly throughout the whole cluster. The public aspect of this namespace is only a convention, not a requirement.
+: This namespace is readable by *all* clients (including those not authenticated). This namespace is
+  mostly reserved for cluster usage, in case that some resources should be visible and readable publicly
+  throughout the whole cluster. The public aspect of this namespace is only a convention, not a requirement.
 
 `kube-system`
 : The namespace for objects created by the Kubernetes system.
@@ -71,6 +79,7 @@ You can list the current namespaces in a cluster using:
 ```shell
 kubectl get namespace
 ```
+
 ```
 NAME              STATUS   AGE
 default           Active   1d
@@ -78,7 +87,6 @@ kube-node-lease   Active   1d
 kube-public       Active   1d
 kube-system       Active   1d
 ```
-
 
 ### Setting the namespace for a request
 
@@ -98,6 +106,7 @@ context.
 
 ```shell
 kubectl config set-context --current --namespace=<insert-namespace-name-here>
+
 # Validate it
 kubectl config view --minify | grep namespace:
 ```
@@ -108,32 +117,31 @@ When you create a [Service](/docs/concepts/services-networking/service/),
 it creates a corresponding [DNS entry](/docs/concepts/services-networking/dns-pod-service/).
 This entry is of the form `<service-name>.<namespace-name>.svc.cluster.local`, which means
 that if a container only uses `<service-name>`, it will resolve to the service which
-is local to a namespace.  This is useful for using the same configuration across
-multiple namespaces such as Development, Staging and Production.  If you want to reach
+is local to a namespace. This is useful for using the same configuration across
+multiple namespaces such as Development, Staging and Production. If you want to reach
 across namespaces, you need to use the fully qualified domain name (FQDN).
 
 As a result, all namespace names must be valid
 [RFC 1123 DNS labels](/docs/concepts/overview/working-with-objects/names/#dns-label-names).
 
 {{< warning >}}
-By creating namespaces with the same name as [public top-level
-domains](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), Services in these
-namespaces can have short DNS names that overlap with public DNS records.
-Workloads from any namespace performing a DNS lookup without a [trailing dot](https://datatracker.ietf.org/doc/html/rfc1034#page-8) will
+By creating namespaces with the same name as
+[public top-level domains](https://data.iana.org/TLD/tlds-alpha-by-domain.txt),
+Services in these namespaces can have short DNS names that overlap with public DNS records.
+Workloads from any namespace performing a DNS lookup without a
+[trailing dot](https://datatracker.ietf.org/doc/html/rfc1034#page-8) will
 be redirected to those services, taking precedence over public DNS.
 
 To mitigate this, limit privileges for creating namespaces to trusted users. If
 required, you could additionally configure third-party security controls, such
-as [admission
-webhooks](/docs/reference/access-authn-authz/extensible-admission-controllers/),
-to block creating any namespace with the name of [public
-TLDs](https://data.iana.org/TLD/tlds-alpha-by-domain.txt).
+as [admission webhooks](/docs/reference/access-authn-authz/extensible-admission-controllers/),
+to block creating any namespace with the name of [public TLDs](https://data.iana.org/TLD/tlds-alpha-by-domain.txt).
 {{< /warning >}}
 
 ## Not all objects are in a namespace
 
 Most Kubernetes resources (e.g. pods, services, replication controllers, and others) are
-in some namespaces.  However namespace resources are not themselves in a namespace.
+in some namespaces. However, namespace resources are not themselves in a namespace.
 And low-level resources, such as
 [nodes](/docs/concepts/architecture/nodes/) and
 [persistentVolumes](/docs/concepts/storage/persistent-volumes/), are not in any namespace.
@@ -156,9 +164,7 @@ The Kubernetes control plane sets an immutable {{< glossary_tooltip text="label"
 `kubernetes.io/metadata.name` on all namespaces.
 The value of the label is the namespace name.
 
-
 ## {{% heading "whatsnext" %}}
 
 * Learn more about [creating a new namespace](/docs/tasks/administer-cluster/namespaces/#creating-a-new-namespace).
 * Learn more about [deleting a namespace](/docs/tasks/administer-cluster/namespaces/#deleting-a-namespace).
-


### PR DESCRIPTION
- wrap up long lines
- remove redundant spaces from markdown table
- put link text and url on a single line

/kind cleanup