### PR TITLE
[zh-cn] sync kubernetes-api/authentication-resources/*

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
@@ -21,11 +21,6 @@ weight: 4
 auto_generated: true
 -->
 
-<!--
-`apiVersion: certificates.k8s.io/v1`
-
-`import "k8s.io/api/certificates/v1"`
--->
 `apiVersion: certificates.k8s.io/v1`
 
 `import "k8s.io/api/certificates/v1"`
@@ -44,7 +39,7 @@ Kubelets use this API to obtain:
 -->
 CertificateSigningRequest 对象提供了一种通过提交证书签名请求并异步批准和颁发 x509 证书的机制。
 
-Kubelets 使用 CertificateSigningRequest API 来获取：
+kubelet 使用 CertificateSigningRequest API 来获取：
 
 1. 向 kube-apiserver 进行身份认证的客户端证书（使用 “kubernetes.io/kube-apiserver-client-kubelet” signerName）。
 2. kube-apiserver 可以安全连接到 TLS 端点的服务证书（使用 “kubernetes.io/kubelet-serving” signerName）。
@@ -81,7 +76,7 @@ or to obtain certificates from custom non-Kubernetes signers.
   Other fields are derived by Kubernetes and cannot be modified by users.
 -->
 - **spec** (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequestSpec" >}}">
-   CertificateSigningRequestSpec</a>)，必需
+  CertificateSigningRequestSpec</a>)，必需
 
   spec 包含证书请求，并且在创建后是不可变的。
   只有 request、signerName、expirationSeconds 和 usages 字段可以在创建时设置。
@@ -109,6 +104,7 @@ CertificateSigningRequestSpec contains the certificate request.
 CertificateSigningRequestSpec 包含证书请求。
 
 <hr>
+
 <!--
 - **request** ([]byte), required
 
@@ -220,7 +216,7 @@ CertificateSigningRequestSpec 包含证书请求。
   
   The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.  
   -->
-  由于各种原因，证书签名者可能忽略此字段:
+  由于各种原因，证书签名者可能忽略此字段：
 
   1. 不认识此字段的旧签名者(如 v1.22 版本之前的实现)
   2. 配置的最大持续时间小于请求持续时间的签名者
@@ -321,8 +317,6 @@ CertificateSigningRequestSpec 包含证书请求。
 
 CertificateSigningRequestStatus contains conditions used to indicate approved/denied/failed status of the request, 
 and the issued certificate.
-
-<hr>
 -->
 ## CertificateSigningRequestStatus {#CertificateSigningRequestStatus}
 
@@ -358,7 +352,7 @@ CertificateSigningRequestStatus 包含用于指示请求的批准/拒绝/失败�
    3. Non-PEM content may appear before or after the "CERTIFICATE" PEM blocks and is unvalidated,
     to allow for explanatory text as described in section 5.2 of RFC7468.
   -->
-  验证要求:
+  验证要求：
 
   1. 证书必须包含一个或多个 PEM 块。
   2. 所有的 PEM 块必须有 “CERTIFICATE” 标签，不包含头和编码的数据，
@@ -387,7 +381,7 @@ CertificateSigningRequestStatus 包含用于指示请求的批准/拒绝/失败�
   -->
   证书编码为 PEM 格式。
   
-  当序列化为 JSON 或 YAML 时，数据额外采用 base64 编码，它包括:
+  当序列化为 JSON 或 YAML 时，数据额外采用 base64 编码，它包括：
 
   ```
   base64(
@@ -1432,6 +1426,10 @@ DELETE /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
 
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
+
 - **pretty** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
@@ -1443,6 +1441,10 @@ DELETE /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
 
 - **pretty** (**查询参数**): string
 
@@ -1520,6 +1522,10 @@ DELETE /apis/certificates.k8s.io/v1/certificatesigningrequests
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
 
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
+
 - **labelSelector** (*in query*): string
 
   <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
@@ -1535,6 +1541,10 @@ DELETE /apis/certificates.k8s.io/v1/certificatesigningrequests
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
 
 - **labelSelector** (**查询参数**): string
 

--- a/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/cluster-trust-bundle-v1alpha1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/cluster-trust-bundle-v1alpha1.md
@@ -132,7 +132,8 @@ ClusterTrustBundleSpec 包含签名程序和信任锚。
   
   如果 signerName 为空，则 ClusterTrustBundle 对象的名称不能具有此类前缀。
   
-  针对 ClusterTrustBundles 的列举/监视请求可以使用 `spec.signerName=NAME` 字段选择算符针对此字段进行过滤。
+  针对 ClusterTrustBundles 的列举/监视请求可以使用 `spec.signerName=NAME`
+  字段选择算符针对此字段进行过滤。
 
 ## ClusterTrustBundleList {#ClusterTrustBundleList}
 
@@ -489,6 +490,7 @@ DELETE /apis/certificates.k8s.io/v1alpha1/clustertrustbundles/{name}
 - **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
 - **dryRun** (*in query*): string
 - **gracePeriodSeconds** (*in query*): integer
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (*in query*): boolean
 - **pretty** (*in query*): string
 - **propagationPolicy** (*in query*): string
 -->
@@ -507,6 +509,10 @@ DELETE /apis/certificates.k8s.io/v1alpha1/clustertrustbundles/{name}
 - **gracePeriodSeconds**（**查询参数**）：integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
 
 - **pretty**（**查询参数**）：string
 
@@ -546,6 +552,7 @@ DELETE /apis/certificates.k8s.io/v1alpha1/clustertrustbundles
 - **dryRun** (*in query*): string
 - **fieldSelector** (*in query*): string
 - **gracePeriodSeconds** (*in query*): integer
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (*in query*): boolean
 - **labelSelector** (*in query*): string
 - **limit** (*in query*): integer
 - **pretty** (*in query*): string
@@ -574,6 +581,10 @@ DELETE /apis/certificates.k8s.io/v1alpha1/clustertrustbundles
 - **gracePeriodSeconds**（**查询参数**）：integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+- **ignoreStoreReadErrorWithClusterBreakingPotential**（**查询参数**）：boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
 
 - **labelSelector**（**查询参数**）：string
 

--- a/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
@@ -78,12 +78,13 @@ ServiceAccount 将以下内容绑定在一起：
 
   *Map: unique values on key name will be kept during a merge*
   
-  Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
-  Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use
-  Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountabl
-  -secrets" annotation set to "true". This field should not be used to find auto-generated service accoun
-  token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or servic
-  account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
+  Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use.
+  Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true".
+  The "kubernetes.io/enforce-mountable-secrets" annotation is deprecated since v1.32.
+  Prefer separate namespaces to isolate access to mounted secrets.
+  This field should not be used to find auto-generated service account token secrets for use outside of pods.
+  Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created.
+  More info: https://kubernetes.io/docs/concepts/configuration/secret
   -->
   **补丁策略：基于键 `name` 合并**
 
@@ -91,9 +92,11 @@ ServiceAccount 将以下内容绑定在一起：
 
   secrets 是允许使用此 ServiceAccount 运行的 Pod 使用的同一命名空间中的秘密列表。
   仅当此服务帐户的 “kubernetes.io/enforce-mountable-secrets” 注释设置为 “true” 时，Pod 才限于此列表。
+  **已弃用：**自 v1.32 起，`kubernetes.io/enforce-mountable-secrets` 注解已被弃用。
+  建议使用单独的命名空间来隔离对挂载密钥的访问。
   此字段不应用于查找自动生成的服务帐户令牌机密以在 Pod 之外使用。
   相反，可以使用 TokenRequest API 直接请求令牌，或者可以手动创建服务帐户令牌 Secret。
-  更多信息： https://kubernetes.io/zh-cn/docs/concepts/configuration/secret
+  更多信息：https://kubernetes.io/zh-cn/docs/concepts/configuration/secret
 
 ## ServiceAccountList {#ServiceAccountList}
 
@@ -155,7 +158,7 @@ GET /api/v1/namespaces/{namespace}/serviceaccounts/{name}
 
   name of the ServiceAccount
 -->
-- **name** (**路径参数**): string, 必需
+- **name** (**路径参数**): string，必需
 
   ServiceAccount 的名称。
 
@@ -226,7 +229,6 @@ GET /api/v1/namespaces/{namespace}/serviceaccounts
 
   <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
 
-
 <!--
 - **labelSelector** (*in query*): string
 -->
@@ -287,7 +289,6 @@ GET /api/v1/namespaces/{namespace}/serviceaccounts
 #### Response
 -->
 #### 响应
-
 
 200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccountList" >}}">ServiceAccountList</a>): OK
 
@@ -370,7 +371,7 @@ GET /api/v1/serviceaccounts
 -->
 - **sendInitialEvents** (**查询参数**): boolean
 
-<a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
+  <a href="{{< ref "../common-parameters/common-parameters#sendInitialEvents" >}}">sendInitialEvents</a>
 
 <!--
 - **timeoutSeconds** (*in query*): integer
@@ -572,7 +573,6 @@ PATCH /api/v1/namespaces/{namespace}/serviceaccounts/{name}
 
   <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
 
-
 - **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
 
 <!--
@@ -670,6 +670,13 @@ DELETE /api/v1/namespaces/{namespace}/serviceaccounts/{name}
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
 
 <!--
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (*in query*): boolean
+-->
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
+
+<!--
 - **pretty** (*in query*): string
 -->
 - **pretty** (**查询参数**): string
@@ -743,6 +750,13 @@ DELETE /api/v1/namespaces/{namespace}/serviceaccounts
 - **gracePeriodSeconds** (**查询参数**): integer
 
   <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+<!--
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (*in query*): boolean
+-->
+- **ignoreStoreReadErrorWithClusterBreakingPotential** (**查询参数**): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#ignoreStoreReadErrorWithClusterBreakingPotential" >}}">ignoreStoreReadErrorWithClusterBreakingPotential</a>
 
 <!--
 - **labelSelector** (*in query*): string

--- a/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
@@ -25,6 +25,7 @@ auto_generated: true
 `import "k8s.io/api/authentication/v1"`
 
 ## TokenRequest {#TokenRequest}
+
 <!--
 TokenRequest requests a token for a given service account.
 -->
@@ -60,6 +61,7 @@ TokenRequest 为给定的服务账号请求一个令牌。
   status 由服务器填充，表示该令牌是否可用于身份认证。
 
 ## TokenRequestSpec {#TokenRequestSpec}
+
 <!--
 TokenRequestSpec contains client provided parameters of a token request.
 -->
@@ -110,6 +112,7 @@ TokenRequestSpec 包含客户端提供的令牌请求参数。
   - **boundObjectRef.uid** (string)
     UID of the referent.
   -->
+
   - **boundObjectRef.apiVersion** (string)
 
     引用对象的 API 版本。
@@ -136,6 +139,7 @@ TokenRequestSpec 包含客户端提供的令牌请求参数。
   令牌签发方可能返回一个生效期不同的令牌，因此客户端需要检查响应中的 “expiration” 字段。
 
 ## TokenRequestStatus {#TokenRequestStatus}
+
 <!--
 TokenRequestStatus is the result of a token request.
 -->
@@ -171,10 +175,13 @@ TokenRequestStatus 是一个令牌请求的结果。
 #### HTTP Request
 -->
 ## 操作 {#Operations}
+
 <hr>
 
 ### `create` 创建 ServiceAccount 的令牌
+
 #### HTTP 请求
+
 POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token
 
 <!--
@@ -189,6 +196,7 @@ POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token
 - **pretty** (*in query*): string
 -->
 #### 参数
+
 - **name** (**路径参数**): string，必需
 
   TokenRequest 的名称
@@ -219,6 +227,7 @@ POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token
 #### Response
 -->
 #### 响应
+
 200 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): OK
 
 201 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): Created
@@ -226,4 +235,3 @@ POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token
 202 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): Accepted
 
 401: Unauthorized
-

--- a/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
@@ -33,7 +33,7 @@ TokenReview attempts to authenticate a token to a known user. Note: TokenReview 
 ## TokenReview {#TokenReview}
 
 TokenReview 尝试通过验证令牌来确认已知用户。
-注意：TokenReview 请求可能会被 kube-apiserver 中的 webhook 令牌验证器插件缓存。
+注意：TokenReview 请求可能会被 kube-apiserver 中的 Webhook 令牌验证器插件缓存。
 
 <hr>
 
@@ -63,7 +63,6 @@ TokenReview 尝试通过验证令牌来确认已知用户。
   Status is filled in by the server and indicates whether the request can be authenticated.
   -->
   status 由服务器填写，指示请求是否可以通过身份验证。
-
 
 ## TokenReviewSpec {#TokenReviewSpec}
 
@@ -151,7 +150,7 @@ TokenReviewStatus 是令牌认证请求的结果。
     <!--
     Any additional information provided by the authenticator.
     -->
-   验证者提供的任何附加信息。
+    验证者提供的任何附加信息。
 
   - **user.groups** ([]string)
 
@@ -171,14 +170,14 @@ TokenReviewStatus 是令牌认证请求的结果。
     <!--
     A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
     -->
-   跨时间标识此用户的唯一值。如果删除此用户并添加另一个同名用户，他们将拥有不同的 UID。
+    跨时间标识此用户的唯一值。如果删除此用户并添加另一个同名用户，他们将拥有不同的 UID。
 
   - **user.username** (string)
 
     <!--
     The name that uniquely identifies this user among all active users.
     -->
-   在所有活跃用户中唯一标识此用户的名称。
+    在所有活跃用户中唯一标识此用户的名称。
 
 <!--
 ## Operations {#Operations}
@@ -234,4 +233,3 @@ POST /apis/authentication.k8s.io/v1/tokenreviews
 202 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): Accepted
 
 401: Unauthorized
-


### PR DESCRIPTION
```
# Changes to be committed:
#       modified:   content/zh-cn/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/authentication-resources/cluster-trust-bundle-v1alpha1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
#       modified:   content/zh-cn/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md

```