### PR TITLE
Add 1.33 to the release schedule for 1.33 release

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,6 +4,15 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 schedules:
+- endOfLifeDate: "2026-06-28"
+  maintenanceModeStartDate: "2026-04-28"
+  next:
+    release: 1.33.1
+    cherryPickDeadline: "2025-05-09"
+    targetDate: "2025-05-13"
+  previousPatches: []
+  release: "1.33"
+  releaseDate: "2025-04-23"
 - endOfLifeDate: "2026-02-28"
   maintenanceModeStartDate: "2025-12-28"
   next:


### PR DESCRIPTION
This PR adds 1.33 to the releases schedule for the 1.33.0 release.

/milestone 1.33
cc: @npolshakova @dipesh-rawat @chanieljdan @katcosgrove @kubernetes/release-managers 