### PR TITLE
Include drafts in preview deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-preview: module-check ## Build site with drafts and future posts enabled
 	hugo --cleanDestinationDir --buildDrafts --buildFuture --environment preview
 
 deploy-preview: ## Deploy preview site via netlify
-	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --buildFuture --environment preview -b $(DEPLOY_PRIME_URL)
+	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --buildDrafts --buildFuture --environment preview -b $(DEPLOY_PRIME_URL)
 
 functions-build:
 	$(NETLIFY_FUNC) build functions-src


### PR DESCRIPTION
The flag now mirrors the build-preview setup. This would allow having the preview for draft blogs.

Ref: https://gohugo.io/methods/page/draft/