### PR TITLE
Update KubeCon 2025 events after KubeCon EU

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -45,11 +45,11 @@ To download Kubernetes, visit the [download](/releases/download/) section.
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
 
     <h3>Attend upcoming KubeCon + CloudNativeCon events</h3>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" class="desktopKCButton"><strong>Europe</strong> (London, Apr 1-4)</a>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Hong Kong, Jun 10-11)</a>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Tokyo, Jun 16-17)</a>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Hyderabad, Aug 6-7)</a>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2025/" class="desktopKCButton"><strong>North America</strong> (Atlanta, Nov 10-13)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" class="desktopKCButton"><strong>North America</strong> (Atlanta, Nov 10-13)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Amsterdam, Mar 23-26, 2026)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Since KubeCon Europe 2025 has passed, it's time to update the events list on the main page. I think we can not only remove the old event but also feature the next KubeCon Europe (2026 in Amsterdam) already? If others think it's too early, please let me know.