### PR TITLE
Switch target of landing page "self-healing" feature

### DIFF
--- a/content/en/docs/concepts/architecture/self-healing.md
+++ b/content/en/docs/concepts/architecture/self-healing.md
@@ -1,7 +1,14 @@
 ---
 title: Kubernetes Self-Healing  
 content_type: concept  
-Weight: 50  
+weight: 50  
+feature:
+  title: Self-healing
+  anchor: Automated recovery from damage
+  description: >
+    Kubernetes restarts containers that crash, replaces entire Pods where needed,
+    reattaches storage in response to wider failures, and can integrate with
+    node autoscalers to self-heal even at the node level.
 ---
 <!-- overview -->
 

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -1,4 +1,10 @@
 ---
+# NOTE TO LOCALIZATION TEAMS
+#
+# If updating front matter for your localization because there is still
+# a "feature" key in this page, then you also need to update
+# content/??/docs/concepts/architecture/self-healing.md (which is where
+# it moved to)
 reviewers:
 - Kashomon
 - bprashanth

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -7,13 +7,6 @@ title: ReplicaSet
 api_metadata:
 - apiVersion: "apps/v1"
   kind: "ReplicaSet"
-feature:
-  title: Self-healing
-  anchor: How a ReplicaSet works
-  description: >
-    Restarts containers that fail, replaces and reschedules containers when nodes die,
-    kills containers that don't respond to your user-defined health check,
-    and doesn't advertise them to clients until they are ready to serve.
 content_type: concept
 description: >-
   A ReplicaSet's purpose is to maintain a stable set of replica Pods running at any given time.


### PR DESCRIPTION
- Move where landing page self-healing refers to [[preview](https://deploy-preview-50263--kubernetes-io-main-staging.netlify.app/)]
- Add a note for localizers

Replaces PR https://github.com/kubernetes/website/pull/50263

/kind cleanup