### PR TITLE
HNC project is being shut down

### DIFF
--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -451,7 +451,7 @@ customize policies to individual workloads, and secondly, it may be challenging 
 single level of "tenancy" that should be given a namespace. For example, an organization may have
 divisions, teams, and subteams - which should be assigned a namespace?
 
-To solve this, you could use a third-party solution listed below which allows you to organize your
+To solve this, you could use a third-party project listed below which allows you to organize your
 namespaces into hierarchies, and share certain policies and resources between them. These can also
 help you manage namespace labels, namespace lifecycles, and delegated management, and share resource
 quotas across related namespaces. These capabilities can be useful in both multi-team and

--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -444,38 +444,6 @@ namespace names that are unique across your entire fleet (that is, even if they 
 clusters), as this gives you the flexibility to switch between dedicated and shared clusters in
 the future, or to use multi-cluster tooling such as service meshes.
 
-Conversely, there are also advantages to assigning namespaces at the tenant level, not just the
-workload level, since there are often policies that apply to all workloads owned by a single
-tenant. However, this raises its own problems. Firstly, this makes it difficult or impossible to
-customize policies to individual workloads, and secondly, it may be challenging to come up with a
-single level of "tenancy" that should be given a namespace. For example, an organization may have
-divisions, teams, and subteams - which should be assigned a namespace?
-
-To solve this, you could use a third-party project listed below which allows you to organize your
-namespaces into hierarchies, and share certain policies and resources between them. These can also
-help you manage namespace labels, namespace lifecycles, and delegated management, and share resource
-quotas across related namespaces. These capabilities can be useful in both multi-team and
-multi-customer scenarios.
-
-#### Multi-team tenancy
-
-{{% thirdparty-content %}}
-
-* [Accurate](https://github.com/cybozu-go/accurate)
-* [Capsule](https://github.com/clastix/capsule)
-* [Multi Tenant Operator](https://docs.stakater.com/mto/)
-
-#### Multi-customer tenancy
-
-* [Kubeplus](https://github.com/cloud-ark/kubeplus)
-
-#### Policy engines
-
-Policy engines provide features to validate and generate tenant configurations:
-
-* [Kyverno](https://kyverno.io/)
-* [OPA/Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
-
 ### Virtual control plane per tenant
 
 Another form of control-plane isolation is to use Kubernetes extensions to provide each tenant a

--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -461,9 +461,9 @@ multi-customer scenarios.
 
 {{% thirdparty-content %}}
 
+* [Accurate](https://github.com/cybozu-go/accurate)
 * [Capsule](https://github.com/clastix/capsule)
 * [Multi Tenant Operator](https://docs.stakater.com/mto/)
-* [Accurate](https://github.com/cybozu-go/accurate)
 
 #### Multi-customer tenancy
 

--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -451,14 +451,11 @@ customize policies to individual workloads, and secondly, it may be challenging 
 single level of "tenancy" that should be given a namespace. For example, an organization may have
 divisions, teams, and subteams - which should be assigned a namespace?
 
-To solve this, Kubernetes provides the [Hierarchical Namespace Controller (HNC)](https://github.com/kubernetes-sigs/hierarchical-namespaces),
-which allows you to organize your namespaces into hierarchies, and share certain policies and
-resources between them. It also helps you manage namespace labels, namespace lifecycles, and
-delegated management, and share resource quotas across related namespaces. These capabilities can
-be useful in both multi-team and multi-customer scenarios.
-
-Other projects that provide similar capabilities and aid in managing namespaced resources are
-listed below.
+To solve this, you could use a third-party solution listed below which allows you to organize your
+namespaces into hierarchies, and share certain policies and resources between them. These can also
+help you manage namespace labels, namespace lifecycles, and delegated management, and share resource
+quotas across related namespaces. These capabilities can be useful in both multi-team and
+multi-customer scenarios.
 
 #### Multi-team tenancy
 
@@ -466,6 +463,7 @@ listed below.
 
 * [Capsule](https://github.com/clastix/capsule)
 * [Multi Tenant Operator](https://docs.stakater.com/mto/)
+* [Accurate](https://github.com/cybozu-go/accurate)
 
 #### Multi-customer tenancy
 

--- a/content/en/docs/setup/production-environment/_index.md
+++ b/content/en/docs/setup/production-environment/_index.md
@@ -53,8 +53,8 @@ are influenced by the following issues:
   [container resources](/docs/concepts/configuration/manage-resources-containers/).
 
 Before building a Kubernetes production environment on your own, consider
-handing off some or all of this job to 
-[Turnkey Cloud Solutions](/docs/setup/production-environment/turnkey-solutions/) 
+handing off some or all of this job to
+[Turnkey Cloud Solutions](/docs/setup/production-environment/turnkey-solutions/)
 providers or other [Kubernetes Partners](/partners/).
 Options include:
 
@@ -109,7 +109,7 @@ consider these steps:
   during deployment or you can generate them using your own certificate authority.
   See [PKI certificates and requirements](/docs/setup/best-practices/certificates/) for details.
 - *Configure load balancer for apiserver*: Configure a load balancer
-  to distribute external API requests to the apiserver service instances running on different nodes. See 
+  to distribute external API requests to the apiserver service instances running on different nodes. See
   [Create an External Load Balancer](/docs/tasks/access-application-cluster/create-external-load-balancer/)
   for details.
 - *Separate and backup etcd service*: The etcd services can either run on the
@@ -130,7 +130,7 @@ consider these steps:
   The scheduler should be fault tolerant,
   but not highly available. Some deployment tools set up [Raft](https://raft.github.io/)
   consensus algorithm to do leader election of Kubernetes services. If the
-  primary goes away, another service elects itself and take over. 
+  primary goes away, another service elects itself and take over.
 - *Span multiple zones*: If keeping your cluster available at all times is
   critical, consider creating a cluster that runs across multiple data centers,
   referred to as zones in cloud environments. Groups of zones are referred to as regions.
@@ -163,7 +163,7 @@ Production-quality workloads need to be resilient and anything they rely
 on needs to be resilient (such as CoreDNS). Whether you manage your own
 control plane or have a cloud provider do it for you, you still need to
 consider how you want to manage your worker nodes (also referred to
-simply as *nodes*).  
+simply as *nodes*).
 
 - *Configure nodes*: Nodes can be physical or virtual machines. If you want to
   create and manage your own nodes, you can install a supported operating system,
@@ -260,9 +260,7 @@ needs of your cluster's workloads:
 
 - *Set namespace limits*: Set per-namespace quotas on things like memory and CPU. See
   [Manage Memory, CPU, and API Resources](/docs/tasks/administer-cluster/manage-resources/)
-  for details. You can also set
-  [Hierarchical Namespaces](/blog/2020/08/14/introducing-hierarchical-namespaces/)
-  for inheriting limits.
+  for details.
 - *Prepare for DNS demand*: If you expect workloads to massively scale up,
   your DNS service must be ready to scale up as well. See
   [Autoscale the DNS service in a Cluster](/docs/tasks/administer-cluster/dns-horizontal-autoscaling/).
@@ -299,4 +297,3 @@ needs of your cluster's workloads:
   [resource limits](/docs/tasks/administer-cluster/manage-resources/),
   [DNS autoscaling](/docs/tasks/administer-cluster/dns-horizontal-autoscaling/)
   and [service accounts](/docs/reference/access-authn-authz/service-accounts-admin/).
-


### PR DESCRIPTION
The HNC project is unmaintained and pending archival, so the docs should no longer recommend it and instead reference the fact that this is not considered a core Kubernetes feature, listing the de-facto replacements for HNC.

See:
* https://github.com/kubernetes/org/issues/5484#issuecomment-2809749464