### PR TITLE
Update expose command in expose-intro.md

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -104,17 +104,12 @@ Next, let’s list the current Services from our cluster:
 kubectl get services
 ```
 
-We have a Service called kubernetes that is created by default when minikube starts the cluster. 
-To create a new service and expose it to external traffic we'll use the expose command with NodePort as parameter.
+To expose the deployment to external traffic, we'll use the kubectl expose command with the --type=NodePort option:
 
 ```shell
 kubectl expose deployment/kubernetes-bootcamp --type="NodePort" --port 8080
 ```
-Let's run again the get services subcommand:
 
-```shell
-kubectl get services
-```
 We have now a running Service called kubernetes-bootcamp. Here we see that the Service
 received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).
 

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -104,8 +104,17 @@ Next, let’s list the current Services from our cluster:
 kubectl get services
 ```
 
-We have now a running Service called kubernetes-bootcamp. Here we see that the Service
-received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).
+We have a Service called kubernetes that is created by default when minikube starts the cluster. To create a new service and expose it to external traffic we'll use the expose command with NodePort as parameter.
+
+```shell
+kubectl expose deployment/kubernetes-bootcamp --type="NodePort" --port 8080
+```
+Let's run again the get services subcommand:
+
+```shell
+kubectl get services
+```
+We have now a running Service called kubernetes-bootcamp. Here we see that the Service received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).
 
 To find out what port was opened externally (for the `type: NodePort` Service) we’ll
 run the `describe service` subcommand:

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -104,7 +104,8 @@ Next, let’s list the current Services from our cluster:
 kubectl get services
 ```
 
-We have a Service called kubernetes that is created by default when minikube starts the cluster. To create a new service and expose it to external traffic we'll use the expose command with NodePort as parameter.
+We have a Service called kubernetes that is created by default when minikube starts the cluster. 
+To create a new service and expose it to external traffic we'll use the expose command with NodePort as parameter.
 
 ```shell
 kubectl expose deployment/kubernetes-bootcamp --type="NodePort" --port 8080

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -115,7 +115,8 @@ Let's run again the get services subcommand:
 ```shell
 kubectl get services
 ```
-We have now a running Service called kubernetes-bootcamp. Here we see that the Service received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).
+We have now a running Service called kubernetes-bootcamp. Here we see that the Service
+received a unique cluster-IP, an internal port and an external-IP (the IP of the Node).
 
 To find out what port was opened externally (for the `type: NodePort` Service) we’ll
 run the `describe service` subcommand:


### PR DESCRIPTION
Expose intro tutorial missing expose command #50418

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This is a Bug Report

Problem: On the Expose Intro Page the command to expose the pod created in the deploy tutorial is missing.

Proposed Solution: Add the kubectl expose command that previously existed in the [html documentation](https://github.com/kubernetes/website/blob/6ad170bf1720c77c7119e8174054c1791cd01e3c/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html#L106).

Page to Update:
https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
https://github.com/kubernetes/website/issues/50418

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: # https://github.com/kubernetes/website/issues/50418