### PR TITLE
[pt-br] Add /tasks/run-application/

### DIFF
--- a/content/pt-br/docs/tasks/run-application/_index.md
+++ b/content/pt-br/docs/tasks/run-application/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Executar Aplicações"
+description: Execute e gerencie aplicações com estado e sem estado.
+weight: 80
+---
+

--- a/content/pt-br/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/content/pt-br/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -1,0 +1,156 @@
+---
+title: Executar uma Aplicação Sem Estado com um Deployment
+min-kubernetes-server-version: v1.9
+content_type: tutorial
+weight: 10
+---
+
+<!-- overview -->
+
+Esta página mostra como executar uma aplicação usando um objeto Deployment do Kubernetes.
+
+## {{% heading "objectives" %}}
+
+- Criar uma instalação do nginx com um Deployment.
+- Usar o kubectl para listar informações sobre o Deployment.
+- Atualizar o Deployment.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+<!-- lessoncontent -->
+
+## Criando e explorando uma instalação do nginx com um Deployment
+
+Você pode executar uma aplicação criando um objeto Deployment do Kubernetes, e pode descrever um Deployment em um arquivo YAML. Por exemplo, este arquivo YAML descreve um Deployment que executa a imagem do contêiner nginx:1.14.2:
+
+{{% code_sample file="application/deployment.yaml" %}}
+
+1. Crie um Deployment com base no arquivo YAML:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/application/deployment.yaml
+   ```
+
+1. Exiba informações sobre o Deployment:
+
+   ```shell
+   kubectl describe deployment nginx-deployment
+   ```
+
+   A saída é semelhante a esta:
+
+   ```
+   Name:     nginx-deployment
+   Namespace:    default
+   CreationTimestamp:  Tue, 30 Aug 2016 18:11:37 -0700
+   Labels:     app=nginx
+   Annotations:    deployment.kubernetes.io/revision=1
+   Selector:   app=nginx
+   Replicas:   2 desired | 2 updated | 2 total | 2 available | 0 unavailable
+   StrategyType:   RollingUpdate
+   MinReadySeconds:  0
+   RollingUpdateStrategy:  1 max unavailable, 1 max surge
+   Pod Template:
+     Labels:       app=nginx
+     Containers:
+       nginx:
+       Image:              nginx:1.14.2
+       Port:               80/TCP
+       Environment:        <none>
+       Mounts:             <none>
+     Volumes:              <none>
+   Conditions:
+     Type          Status  Reason
+     ----          ------  ------
+     Available     True    MinimumReplicasAvailable
+     Progressing   True    NewReplicaSetAvailable
+   OldReplicaSets:   <none>
+   NewReplicaSet:    nginx-deployment-1771418926 (2/2 replicas created)
+   No events.
+   ```
+
+1. Liste os Pods criados pelo Deployment:
+
+   ```shell
+   kubectl get pods -l app=nginx
+   ```
+
+   The output is similar to this:
+
+   ```
+   NAME                                READY     STATUS    RESTARTS   AGE
+   nginx-deployment-1771418926-7o5ns   1/1       Running   0          16h
+   nginx-deployment-1771418926-r18az   1/1       Running   0          16h
+   ```
+
+1. Exiba informações sobre um Pod:
+
+   ```shell
+   kubectl describe pod <pod-name>
+   ```
+
+   onde `<pod-name>` é o nome de um dos seus Pods.
+
+## Atualizando o Deployment
+
+Você pode atualizar o Deployment aplicando um novo arquivo YAML. Este arquivo YAML especifica que o Deployment deve ser atualizado para usar o nginx:1.16.1.
+
+{{% code_sample file="application/deployment-update.yaml" %}}
+
+1. Aplique o novo arquivo YAML:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/application/deployment-update.yaml
+   ```
+
+1. Observe o Deployment criar Pods com novos nomes e excluir os Pods antigos:
+
+   ```shell
+   kubectl get pods -l app=nginx
+   ```
+
+## Escalonando a aplicação aumentando a contagem de réplicas
+
+Você pode aumentar o número de Pods no seu Deployment aplicando um novo arquivo YAML. Este arquivo YAML define `replicas` como 4, o que especifica que o Deployment deve ter quatro Pods:
+
+{{% code_sample file="application/deployment-scale.yaml" %}}
+
+1. Aplique o novo arquivo YAML:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/application/deployment-scale.yaml
+   ```
+
+1. Verifique se o Deployment possui quatro Pods:
+
+   ```shell
+   kubectl get pods -l app=nginx
+   ```
+
+   A saída é semelhante a esta:
+
+   ```
+   NAME                               READY     STATUS    RESTARTS   AGE
+   nginx-deployment-148880595-4zdqq   1/1       Running   0          25s
+   nginx-deployment-148880595-6zgi1   1/1       Running   0          25s
+   nginx-deployment-148880595-fxcez   1/1       Running   0          2m
+   nginx-deployment-148880595-rwovn   1/1       Running   0          2m
+   ```
+
+## Excluindo um Deployment
+
+Exclua o Deployment pelo nome:
+
+```shell
+kubectl delete deployment nginx-deployment
+```
+
+## Controladores de Replicação -- a Forma Antiga
+
+A forma preferida de criar uma aplicação replicada é usar um Deployment, que por sua vez utiliza um ReplicaSet. Antes do Deployment e do ReplicaSet serem adicionados ao Kubernetes, aplicações replicadas eram configuradas usando um [Controlador de Replicação (ReplicationController)](/docs/concepts/workloads/controllers/replicationcontroller/).
+
+## {{% heading "whatsnext" %}}
+
+- Saiba mais sobre [objeto Deployment](/docs/concepts/workloads/controllers/deployment/).

--- a/content/pt-br/examples/application/deployment-scale.yaml
+++ b/content/pt-br/examples/application/deployment-scale.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 4 # Atualiza a contagem de réplicas de 2 para 4
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.16.1
+        ports:
+        - containerPort: 80

--- a/content/pt-br/examples/application/deployment-update.yaml
+++ b/content/pt-br/examples/application/deployment-update.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.16.1 # Atualiza a versão do nginx de 1.14.2 para 1.16.1
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
### Description

Esse PR traz a localização da página https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/ para **PT-BR**.
Adicionado a raiz de `/content/pt-br/docs/tasks/run-application` o arquivo `run-stateless-application-deployment.md`, ficando localizado como `/content/pt-br/docs/tasks/run-application/run-stateless-application-deployment.md` no repositório. Também foram adicionados os arquivos de exemplo `deployment-scale.yaml` e `deployment-update.yaml` em `content/pt-br/examples/application/` sendo cópias de `content/en/examples/application/`.
Criado o `_index.md` para `content/pt-br/docs/tasks/run-application`.

---

This PR introduces the localization of the page https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/ to **PT-BR**.
The file `run-stateless-application-deployment.md` was added under the root of `/content/pt-br/docs/tasks/run-application`, and is located at `/content/pt-br/docs/tasks/run-application/run-stateless-application-deployment.md` in the repository. The example files `deployment-scale.yaml` and `deployment-update.yaml` were also added to `content/pt-br/examples/application/` as copies of `content/en/examples/application/`.
Created the `_index.md` file for `content/pt-br/docs/tasks/run-application`.

### Issue

Closes: #50136
Closes: #50135
