### PR TITLE
remove archived account of sftim from docs owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,13 +3,11 @@ aliases:
     - mrbobbytables
     - natalisucks
     - nate-double-u
-    - sftim
   sig-docs-blog-reviewers: # Reviewers for blog content
     - Gauravpadam
     - mrbobbytables
     - natalisucks
     - nate-double-u
-    - sftim
   sig-docs-website-owners: # Admins for overall website
     - dipesh-rawat
     - divya-mohan0209
@@ -18,7 +16,6 @@ aliases:
     - nate-double-u
     - reylejano
     - salaxander
-    - sftim
     - tengqm
   sig-docs-localization-owners: # Admins for localization content
     - a-mccarthy
@@ -27,7 +24,6 @@ aliases:
     - nate-double-u
     - reylejano
     - salaxander
-    - sftim
     - seokho-son
     - tengqm
   sig-docs-localization-reviewers: # PR reviews for localization changes
@@ -37,7 +33,6 @@ aliases:
     - nate-double-u
     - reylejano
     - salaxander
-    - sftim
     - seokho-son
     - tengqm
   sig-docs-bn-owners: # Admins for Bengali content
@@ -64,7 +59,6 @@ aliases:
     - rayandas # RT 1.33 Docs Lead
     - reylejano
     - salaxander
-    - sftim
     - tengqm
   sig-docs-en-reviews: # PR reviews for English content
     - dipesh-rawat
@@ -76,7 +70,6 @@ aliases:
     - nate-double-u
     - reylejano
     - salaxander
-    - sftim
     - shannonxtreme
     - tengqm
     - windsonsea


### PR DESCRIPTION
Remove archived account of sftim from Docs owners, as this account should no longer be used

cc. sig docs leads: @divya-mohan0209 @reylejano @salaxander @tengqm @katcosgrove 

FYI: @lmktfy 