### PR TITLE
[dev-1.33] Update image volume example to use `v2`

### DIFF
--- a/content/en/examples/pods/image-volumes-subpath.yaml
+++ b/content/en/examples/pods/image-volumes-subpath.yaml
@@ -14,5 +14,5 @@ spec:
   volumes:
   - name: volume
     image:
-      reference: quay.io/crio/artifact:v1
+      reference: quay.io/crio/artifact:v2
       pullPolicy: IfNotPresent

--- a/content/en/examples/pods/image-volumes.yaml
+++ b/content/en/examples/pods/image-volumes.yaml
@@ -13,5 +13,5 @@ spec:
   volumes:
   - name: volume
     image:
-      reference: quay.io/crio/artifact:v1
+      reference: quay.io/crio/artifact:v2
       pullPolicy: IfNotPresent


### PR DESCRIPTION
Use the `v2` version of the artifact to allow compatibility with containerd.

/cc @kubernetes/sig-node-pr-reviews @mikebrow 