### PR TITLE
Update the streaming list blog to reflect disablement in 1.33

### DIFF
--- a/content/en/blog/_posts/2024-12-17-api-streaming/index.md
+++ b/content/en/blog/_posts/2024-12-17-api-streaming/index.md
@@ -90,3 +90,9 @@ In the test, we created 400 Secrets, each containing 1 MB of data, and used info
 The results were alarming, only 16 informers were needed to cause the test server to run out of memory and crash, demonstrating how quickly memory consumption can grow under such conditions.
 
 Special shout out to [@deads2k](https://github.com/deads2k) for his help in shaping this feature.
+
+## 1.33 Update
+Since this feature was started, [Marek Siarkowicz](https://github.com/serathius) integrated a new technology into the kube-apiserver called `StreamingCollectionEncodingToJSON` and `StreamingCollectionEncodingToProtobuf`.
+These features encode via a stream and avoid allocating all the memory at once.
+This functionality is bit-for-bit compatible with existing **list** encodings, produces even greater server-side memory savings, and doesn't require any changes to client code.
+In 1.33, the `WatchList` feature gate is disabled by default.

--- a/content/en/blog/_posts/2024-12-17-api-streaming/index.md
+++ b/content/en/blog/_posts/2024-12-17-api-streaming/index.md
@@ -91,8 +91,11 @@ The results were alarming, only 16 informers were needed to cause the test serve
 
 Special shout out to [@deads2k](https://github.com/deads2k) for his help in shaping this feature.
 
-## 1.33 Update
-Since this feature was started, [Marek Siarkowicz](https://github.com/serathius) integrated a new technology into the kube-apiserver called `StreamingCollectionEncodingToJSON` and `StreamingCollectionEncodingToProtobuf`.
+## Kubernetes 1.33 update
+
+Since this feature was started, [Marek Siarkowicz](https://github.com/serathius) integrated a new technology into the
+Kubernetes API server: _streaming collection encoding_.
+Kubernetes v1.33 introduced two related feature gates, `StreamingCollectionEncodingToJSON` and `StreamingCollectionEncodingToProtobuf`.
 These features encode via a stream and avoid allocating all the memory at once.
 This functionality is bit-for-bit compatible with existing **list** encodings, produces even greater server-side memory savings, and doesn't require any changes to client code.
 In 1.33, the `WatchList` feature gate is disabled by default.


### PR DESCRIPTION

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The streaming collection encoders appear more efficient, don't require client changes, and avoid much complexity. The more technical reasons are listed in the disablement PR: https://github.com/kubernetes/kubernetes/pull/131359

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #