### PR TITLE
Add April 2025 patch releases

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,10 +7,13 @@ schedules:
 - endOfLifeDate: "2026-02-28"
   maintenanceModeStartDate: "2025-12-28"
   next:
-    cherryPickDeadline: "2025-04-11"
+    cherryPickDeadline: "2025-05-09"
+    release: 1.32.5
+    targetDate: "2025-05-13"
+  previousPatches:
+  - cherryPickDeadline: "2025-04-11"
     release: 1.32.4
     targetDate: "2025-04-22"
-  previousPatches:
   - cherryPickDeadline: "2025-03-07"
     release: 1.32.3
     targetDate: "2025-03-11"
@@ -27,10 +30,13 @@ schedules:
 - endOfLifeDate: "2025-10-28"
   maintenanceModeStartDate: "2025-08-28"
   next:
-    cherryPickDeadline: "2025-04-11"
+    cherryPickDeadline: "2025-05-09"
+    release: 1.31.9
+    targetDate: "2025-05-13"
+  previousPatches:
+  - cherryPickDeadline: "2025-04-11"
     release: 1.31.8
     targetDate: "2025-04-22"
-  previousPatches:
   - cherryPickDeadline: "2025-03-07"
     release: 1.31.7
     targetDate: "2025-03-11"
@@ -59,10 +65,13 @@ schedules:
 - endOfLifeDate: "2025-06-28"
   maintenanceModeStartDate: "2025-04-28"
   next:
-    cherryPickDeadline: "2025-04-11"
+    cherryPickDeadline: "2025-05-09"
+    release: 1.30.13
+    targetDate: "2025-05-13"
+  previousPatches:
+  - cherryPickDeadline: "2025-04-11"
     release: 1.30.12
     targetDate: "2025-04-22"
-  previousPatches:
   - cherryPickDeadline: "2025-03-07"
     release: 1.30.11
     targetDate: "2025-03-11"
@@ -101,9 +110,9 @@ schedules:
   release: "1.30"
   releaseDate: "2024-04-17"
 upcoming_releases:
-- cherryPickDeadline: "2025-04-11"
-  targetDate: "2025-04-22"
 - cherryPickDeadline: "2025-05-09"
   targetDate: "2025-05-13"
 - cherryPickDeadline: "2025-06-06"
   targetDate: "2025-06-10"
+- cherryPickDeadline: "2025-07-11"
+  targetDate: "2025-07-15"


### PR DESCRIPTION
This PR adds the April 2025 patch releases to the release calendar.

/assign @saschagrunert @jeremyrickard 
cc @kubernetes/release-engineering 