### PR TITLE
Fix incorrect /security alias

### DIFF
--- a/content/id/docs/reference/issues-security/security.md
+++ b/content/id/docs/reference/issues-security/security.md
@@ -1,6 +1,6 @@
 ---
 title: Informasi Keamanan dan Pengungkapan Kubernetes
-aliases: [/security/]
+aliases: [/id/security/]
 reviewers:
 - eparis
 - erictune


### PR DESCRIPTION
https://kubernetes.io/security must route to the EN docs.

fixes https://github.com/kubernetes/website/issues/50656