### PR TITLE
Improve bin packing concept page

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -559,6 +559,17 @@ body.docs-portal {
   }
 }
 
+// scrolling for formulae
+@media (max-width: 799px) {
+  #maindoc > main div.math {
+    overflow-x: auto;
+    max-width: 99vw;
+    > span:first-child:last-child {
+      min-width: calc(max(100vw-15em, 30em))
+    }
+  }
+}
+
 /* SCSS related to the list of metrics in Kubernetes */
 main {
 

--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -517,6 +517,17 @@ body.docs-portal {
   }
 }
 
+// scrolling for formulae
+@media (max-width: 799px) {
+  #maindoc > main div.math {
+    overflow-x: auto;
+    max-width: 99vw;
+    > span:first-child:last-child {
+      min-width: calc(max(100vw-15em, 30em))
+    }
+  }
+}
+
 /* SCSS related to the list of metrics in Kubernetes */
 main {
 

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -16,11 +16,13 @@ This article applies to resource bin packing in context of scheduling of a singl
 {{< /note >}}
 
 In the [scheduling-plugin](/docs/reference/scheduling/config/#scheduling-plugins) `NodeResourcesFit` of kube-scheduler, there are two
-scoring strategies that support the bin packing of resources: `MostAllocated` and `RequestedToCapacityRatio`.
+scoring strategies that aim to make efficient use of infrastructure resources:
+`MostAllocated` and `RequestedToCapacityRatio`.
 
 <!-- body -->
 
-## Bin packing using MostAllocated strategy
+## Placement using MostAllocated strategy {#strategy-MostAllocated}
+
 The `MostAllocated` strategy scores the nodes based on the utilization of resources, favoring the ones with higher allocation.
 For each resource type, you can set a weight to modify its influence in the node score.
 
@@ -50,15 +52,16 @@ profiles:
 To learn more about other parameters and their default configuration, see the API documentation for
 [`NodeResourcesFitArgs`](/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-NodeResourcesFitArgs).
 
-## Bin packing using RequestedToCapacityRatio
+## Placement using RequestedToCapacityRatio strategy {#strategy-RequestedToCapacityRatio}
 
-The `RequestedToCapacityRatio` strategy allows the users to specify the resources along with weights for
+The `RequestedToCapacityRatio` strategy allows you to specify the resources along with weights for
 each resource to score nodes based on the request to capacity ratio. This
-allows users to bin pack extended resources by using appropriate parameters
+approximates efficient _bin packing_ of infrastructure resources (notably, extended resources) by using appropriate parameters
 to improve the utilization of scarce resources in large clusters. It favors nodes according to a
 configured function of the allocated resources. The behavior of the `RequestedToCapacityRatio` in
 the `NodeResourcesFit` score function can be controlled by the
 [scoringStrategy](/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-ScoringStrategy) field.
+
 Within the `scoringStrategy` field, you can configure two parameters: `requestedToCapacityRatio` and
 `resources`. The `shape` in the `requestedToCapacityRatio`
 parameter allows the user to tune the function as least requested or most
@@ -66,8 +69,8 @@ requested based on `utilization` and `score` values. The `resources` parameter
 comprises both the `name` of the resource to be considered during scoring and
 its corresponding `weight`, which specifies the weight of each resource.
 
-Below is an example configuration that sets
-the bin packing behavior for extended resources `intel.com/foo` and `intel.com/bar`
+Below is an example configuration that adjusts
+the Pod scheduling preferences associated with the extended resources `intel.com/foo` and `intel.com/bar`
 using the `requestedToCapacityRatio` field.
 
 ```yaml
@@ -112,8 +115,8 @@ shape:
 ```
 
 The above arguments give the node a `score` of 0 if `utilization` is 0% and 10 for
-`utilization` 100%, thus enabling bin packing behavior. To enable least
-requested the score value must be reversed as follows.
+`utilization` 100%, as an approximation of ideal bin packing. To enable **least**
+requested the score value must be reversed, as follows:
 
 ```yaml
 shape:

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -49,7 +49,7 @@ profiles:
 To learn more about other parameters and their default configuration, see the API documentation for
 [`NodeResourcesFitArgs`](/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-NodeResourcesFitArgs).
 
-## Enabling bin packing using RequestedToCapacityRatio
+## Bin packing using RequestedToCapacityRatio
 
 The `RequestedToCapacityRatio` strategy allows the users to specify the resources along with weights for
 each resource to score nodes based on the request to capacity ratio. This
@@ -150,13 +150,13 @@ The `weight` parameter is optional and is set to 1 if not specified. Also, the
 ### Node scoring for capacity allocation
 
 This section is intended for those who want to understand the internal details
-of this feature.
+of this mechanism.
 Below is an example of how the node score is calculated for a given set of values.
 
 Requested resources:
 
 ```
-intel.com/foo : 2
+intel.com/foo: 2
 memory: 256MB
 cpu: 2
 ```
@@ -164,14 +164,12 @@ cpu: 2
 Resource weights:
 
 ```
-intel.com/foo : 5
+intel.com/foo: 5
 memory: 1
 cpu: 3
 ```
 
-FunctionShapePoint {{0, 0}, {100, 10}}
-
-Node 1 spec:
+#### Scoring example: node 1 {#node-scoring-node1}
 
 ```
 Available:
@@ -185,7 +183,8 @@ Used:
   cpu: 1
 ```
 
-Node score:
+
+##### Foo (example extended resource), node 1 {#node-scoring-n1-example-resource}
 
 ```
 intel.com/foo  = resourceScoringFunction((2+1),4)
@@ -194,13 +193,20 @@ intel.com/foo  = resourceScoringFunction((2+1),4)
                = 75                       # requested + used = 75% * available
                = rawScoringFunction(75)
                = 7                        # floor(75/10)
+```
 
+##### Memory, node 1 {#node-scoring-n1-memory}
+
+```
 memory         = resourceScoringFunction((256+256),1024)
                = (100 -((1024-512)*100/1024))
                = 50                       # requested + used = 50% * available
                = rawScoringFunction(50)
                = 5                        # floor(50/10)
 
+##### CPU, node 1 {#node-scoring-n1-cpu}
+
+```
 cpu            = resourceScoringFunction((2+1),8)
                = (100 -((8-3)*100/8))
                = 37.5                     # requested + used = 37.5% * available
@@ -210,6 +216,8 @@ cpu            = resourceScoringFunction((2+1),8)
 NodeScore   =  ((7 * 5) + (5 * 1) + (3 * 3)) / (5 + 1 + 3)
             =  5
 ```
+
+#### Scoring example: node 2 {#node-scoring-node2}
 
 Node 2 spec:
 
@@ -224,7 +232,7 @@ Used:
   cpu: 6
 ```
 
-Node score:
+##### Foo (example extended resource), node 2 {#node-scoring-n2-example-resource}
 
 ```
 intel.com/foo  = resourceScoringFunction((2+2),8)
@@ -234,12 +242,22 @@ intel.com/foo  = resourceScoringFunction((2+2),8)
                =  rawScoringFunction(50)
                = 5
 
+```
+
+##### Memory, node 2 {#node-scoring-n2-memory}
+
+```
 memory         = resourceScoringFunction((256+512),1024)
                = (100 -((1024-768)*100/1024))
                = 75
                = rawScoringFunction(75)
                = 7
 
+```
+
+##### CPU, node 2 {#node-scoring-n2-cpu}
+
+```
 cpu            = resourceScoringFunction((2+6),8)
                = (100 -((8-8)*100/8))
                = 100

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -20,7 +20,7 @@ scoring strategies that support the bin packing of resources: `MostAllocated` an
 
 <!-- body -->
 
-## Enabling bin packing using MostAllocated strategy
+## Bin packing using MostAllocated strategy
 The `MostAllocated` strategy scores the nodes based on the utilization of resources, favoring the ones with higher allocation.
 For each resource type, you can set a weight to modify its influence in the node score.
 

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -6,6 +6,7 @@ reviewers:
 title: Resource Bin Packing
 content_type: concept
 weight: 80
+math: true
 ---
 
 <!-- overview -->
@@ -184,38 +185,59 @@ Used:
 ```
 
 
-##### Foo (example extended resource), node 1 {#node-scoring-n1-example-resource}
+##### Foo _(example extended resource)_, node 1 {#node-scoring-n1-example-resource}
 
-```
-intel.com/foo  = resourceScoringFunction((2+1),4)
-               = (100 - ((4-3)*100/4))
-               = (100 - 25)
-               = 75                       # requested + used = 75% * available
-               = rawScoringFunction(75)
-               = 7                        # floor(75/10)
+```math
+  \begin{align}
+    { \text{intel.com/foo} } &\Longrightarrow { resourceScoringFunction((2 + 1), 4)} \tag*{} \\
+                             &= { 100 - \left( {4 - 3 \over 4} \times 100 \right) } \tag*{} \\
+
+
+                             &= 100 - 25 \tag*{} \\
+                             &= 75 \tag*{requested + used = 0.75 (of available)} \\
+                             & \models { rawScoringFunction(75) } \tag*{} \\
+                             &= \boxed{\bold{\Large 7}}
+  \end{align}
 ```
 
 ##### Memory, node 1 {#node-scoring-n1-memory}
 
+```math
+  \begin{align}
+           { \text{memory} } &\Longrightarrow { resourceScoringFunction((256 + 256), 1024)} \tag*{} \\
+                             &= { 100 - \left( {1024 - 512 \over 1024} \times 100 \right) } \tag*{} \\
+
+                             &= 50 \tag*{requested + used = 0.5 (of available)} \\
+                             &\models { rawScoringFunction(50) } \tag*{} \\
+                             &= \boxed{\bold{\Large 5}}
+  \end{align}
 ```
-memory         = resourceScoringFunction((256+256),1024)
-               = (100 -((1024-512)*100/1024))
-               = 50                       # requested + used = 50% * available
-               = rawScoringFunction(50)
-               = 5                        # floor(50/10)
 
 ##### CPU, node 1 {#node-scoring-n1-cpu}
 
+```math
+  \begin{align}
+           { \text{cpu} } &\Longrightarrow { resourceScoringFunction((2 + 1), 8)} \tag*{} \\
+                             &= { 100 - \left( {8 - 3 \over 8} \times 100 \right) } \tag*{} \\
+                             &= 37.5 \tag*{requested + used = 0.375 (of available)} \\
+                             &\models { rawScoringFunction(37.5) } \tag*{} \\
+                             &= \boxed{\bold{\Large 3}}
+  \end{align}
 ```
-cpu            = resourceScoringFunction((2+1),8)
-               = (100 -((8-3)*100/8))
-               = 37.5                     # requested + used = 37.5% * available
-               = rawScoringFunction(37.5)
-               = 3                        # floor(37.5/10)
 
-NodeScore   =  ((7 * 5) + (5 * 1) + (3 * 3)) / (5 + 1 + 3)
-            =  5
+##### Final scoring (node 1) {#node-scoring-n1-sum}
+
+```math
+{  \begin{align}
+           { \text{NodeScore} } &= \left\lfloor { { (\bold{7} \times 5) + (\bold{5} \times 1) + (\bold{3} \times 3) } \over { 5 + 1 + 3 } } \right\rfloor \tag*{} \\
+                                &= 5 \tag*{}
+  \end{align}
+} \atop \textnormal{numbers in bold come from formula lines 1, 2 and 3}
 ```
+
+<!-- localization note: use any appropriate technique so that the next line does not
+     resemble a heading -->
+\\( \\hspace{3em} \\) **Score for node 1:** \\( \boxed{5} \\)
 
 #### Scoring example: node 2 {#node-scoring-node2}
 
@@ -232,44 +254,54 @@ Used:
   cpu: 6
 ```
 
-##### Foo (example extended resource), node 2 {#node-scoring-n2-example-resource}
+##### Foo _(example extended resource)_, node 2 {#node-scoring-n2-example-resource}
 
-```
-intel.com/foo  = resourceScoringFunction((2+2),8)
-               =  (100 - ((8-4)*100/8)
-               =  (100 - 50)
-               =  50
-               =  rawScoringFunction(50)
-               = 5
-
-```
-
-##### Memory, node 2 {#node-scoring-n2-memory}
-
-```
-memory         = resourceScoringFunction((256+512),1024)
-               = (100 -((1024-768)*100/1024))
-               = 75
-               = rawScoringFunction(75)
-               = 7
-
+```math
+  \begin{align}
+    { \text{intel.com/foo} } &\Longrightarrow { resourceScoringFunction((2 + 2), 8)} \tag*{} \\
+                             &= { 100 - \left( {8 - 4 \over 8} \times 100 \right) } \tag*{} \\
+                             &= 100 - 50 \tag*{} \\
+                             &= 50 \tag*{requested + used = 0.5 (of available)} \\
+                             &\models { rawScoringFunction(50) } \tag*{} \\
+                             &= \boxed{\bold{\Large 5}}
+  \end{align}
 ```
 
-##### CPU, node 2 {#node-scoring-n2-cpu}
+##### Memory, node 2 {#node-scoring-n1-memory}
 
+
+```math
+  \begin{align}
+           { \text{memory} } &\Longrightarrow { resourceScoringFunction((256 + 512), 1024)} \tag*{} \\
+                             &= { 100 - \left( {1024 - 768 \over 1024} \times 100 \right) } \tag*{} \\
+                             &= 75 \tag*{requested + used = 0.75 (of available)} \\
+                             &\models { rawScoringFunction(75) } \tag*{} \\
+                             &= \boxed{\bold{\Large 7}}
+  \end{align}
 ```
-cpu            = resourceScoringFunction((2+6),8)
-               = (100 -((8-8)*100/8))
-               = 100
-               = rawScoringFunction(100)
-               = 10
 
-NodeScore   =  ((5 * 5) + (7 * 1) + (10 * 3)) / (5 + 1 + 3)
-            =  7
+##### CPU, node 2 {#node-scoring-n1-cpu}
 
+```math
+  \begin{align}
+              { \text{cpu} } &\Longrightarrow { resourceScoringFunction((2 + 6), 8)} \tag*{} \\
+                             &= { 100 - \left( {8 - 8 \over 8} \times 100 \right) } \tag*{} \\
+                             &= 100 \tag*{requested + used = 1.0 (of available)} \\
+                             &\models { rawScoringFunction(100) } \tag*{} \\
+                             &= \boxed{\bold{\Large 10}}
+  \end{align}
 ```
 
-## {{% heading "whatsnext" %}}
+##### Final scoring (node 2) {#node-scoring-n2-sum}
 
-- Read more about the [scheduling framework](/docs/concepts/scheduling-eviction/scheduling-framework/)
-- Read more about [scheduler configuration](/docs/reference/scheduling/config/)
+```math
+{ \begin{align}
+           { \text{NodeScore} } &= \left\lfloor { { (\bold{5} \times 5) + (\bold{7} \times 1) + (\bold{10} \times 3) } \over { (5 + 1 + 3) } } \right\rfloor \tag*{} \\
+                                &= 7 \tag*{}
+  \end{align}
+} \atop { \textnormal{numbers in bold come from formula lines 4, 5, and 6}}
+```
+
+<!-- localization note: use any appropriate technique so that the next line does not
+     resemble a heading -->
+\\( \\hspace{3em} \\) **Score for node 2:** \\( \boxed{7} \\)

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -55,7 +55,7 @@ highly utilized nodes. This helps prepare for scale-down of the least utilized n
 To learn more about other parameters and their default configuration, see the API documentation for
 [`NodeResourcesFitArgs`](/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-NodeResourcesFitArgs).
 
-## Enabling bin packing using RequestedToCapacityRatio
+## Bin packing using RequestedToCapacityRatio
 
 The `RequestedToCapacityRatio` strategy allows the users to specify the resources along with weights for
 each resource to score nodes based on the request to capacity ratio. This
@@ -167,13 +167,13 @@ The `weight` parameter is optional and is set to 1 if not specified. Also, the
 ### Node scoring for capacity allocation
 
 This section is intended for those who want to understand the internal details
-of this feature.
+of this mechanism.
 Below is an example of how the node score is calculated for a given set of values.
 
 Requested resources:
 
 ```
-intel.com/foo : 2
+intel.com/foo: 2
 memory: 256MB
 cpu: 2
 ```
@@ -181,14 +181,12 @@ cpu: 2
 Resource weights:
 
 ```
-intel.com/foo : 5
+intel.com/foo: 5
 memory: 1
 cpu: 3
 ```
 
-FunctionShapePoint {{0, 0}, {100, 10}}
-
-Node 1 spec:
+#### Scoring example: node 1 {#node-scoring-node1}
 
 ```
 Available:
@@ -202,7 +200,8 @@ Used:
   cpu: 1
 ```
 
-Node score:
+
+##### Foo (example extended resource), node 1 {#node-scoring-n1-example-resource}
 
 ```
 intel.com/foo  = resourceScoringFunction((2+1),4)
@@ -211,13 +210,20 @@ intel.com/foo  = resourceScoringFunction((2+1),4)
                = 75                       # requested + used = 75% * available
                = rawScoringFunction(75)
                = 7                        # floor(75/10)
+```
 
+##### Memory, node 1 {#node-scoring-n1-memory}
+
+```
 memory         = resourceScoringFunction((256+256),1024)
                = (100 -((1024-512)*100/1024))
                = 50                       # requested + used = 50% * available
                = rawScoringFunction(50)
                = 5                        # floor(50/10)
 
+##### CPU, node 1 {#node-scoring-n1-cpu}
+
+```
 cpu            = resourceScoringFunction((2+1),8)
                = (100 -((8-3)*100/8))
                = 37.5                     # requested + used = 37.5% * available
@@ -227,6 +233,8 @@ cpu            = resourceScoringFunction((2+1),8)
 NodeScore   =  ((7 * 5) + (5 * 1) + (3 * 3)) / (5 + 1 + 3)
             =  5
 ```
+
+#### Scoring example: node 2 {#node-scoring-node2}
 
 Node 2 spec:
 
@@ -241,7 +249,7 @@ Used:
   cpu: 6
 ```
 
-Node score:
+##### Foo (example extended resource), node 2 {#node-scoring-n2-example-resource}
 
 ```
 intel.com/foo  = resourceScoringFunction((2+2),8)
@@ -251,12 +259,22 @@ intel.com/foo  = resourceScoringFunction((2+2),8)
                =  rawScoringFunction(50)
                = 5
 
+```
+
+##### Memory, node 2 {#node-scoring-n2-memory}
+
+```
 memory         = resourceScoringFunction((256+512),1024)
                = (100 -((1024-768)*100/1024))
                = 75
                = rawScoringFunction(75)
                = 7
 
+```
+
+##### CPU, node 2 {#node-scoring-n2-cpu}
+
+```
 cpu            = resourceScoringFunction((2+6),8)
                = (100 -((8-8)*100/8))
                = 100

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -6,6 +6,7 @@ reviewers:
 title: Resource Bin Packing
 content_type: concept
 weight: 80
+math: true
 ---
 
 <!-- overview -->
@@ -201,38 +202,59 @@ Used:
 ```
 
 
-##### Foo (example extended resource), node 1 {#node-scoring-n1-example-resource}
+##### Foo _(example extended resource)_, node 1 {#node-scoring-n1-example-resource}
 
-```
-intel.com/foo  = resourceScoringFunction((2+1),4)
-               = (100 - ((4-3)*100/4))
-               = (100 - 25)
-               = 75                       # requested + used = 75% * available
-               = rawScoringFunction(75)
-               = 7                        # floor(75/10)
+```math
+  \begin{align}
+    { \text{intel.com/foo} } &\Longrightarrow { resourceScoringFunction((2 + 1), 4)} \tag*{} \\
+                             &= { 100 - \left( {4 - 3 \over 4} \times 100 \right) } \tag*{} \\
+
+
+                             &= 100 - 25 \tag*{} \\
+                             &= 75 \tag*{requested + used = 0.75 (of available)} \\
+                             & \models { rawScoringFunction(75) } \tag*{} \\
+                             &= \boxed{\bold{\Large 7}}
+  \end{align}
 ```
 
 ##### Memory, node 1 {#node-scoring-n1-memory}
 
+```math
+  \begin{align}
+           { \text{memory} } &\Longrightarrow { resourceScoringFunction((256 + 256), 1024)} \tag*{} \\
+                             &= { 100 - \left( {1024 - 512 \over 1024} \times 100 \right) } \tag*{} \\
+
+                             &= 50 \tag*{requested + used = 0.5 (of available)} \\
+                             &\models { rawScoringFunction(50) } \tag*{} \\
+                             &= \boxed{\bold{\Large 5}}
+  \end{align}
 ```
-memory         = resourceScoringFunction((256+256),1024)
-               = (100 -((1024-512)*100/1024))
-               = 50                       # requested + used = 50% * available
-               = rawScoringFunction(50)
-               = 5                        # floor(50/10)
 
 ##### CPU, node 1 {#node-scoring-n1-cpu}
 
+```math
+  \begin{align}
+           { \text{cpu} } &\Longrightarrow { resourceScoringFunction((2 + 1), 8)} \tag*{} \\
+                             &= { 100 - \left( {8 - 3 \over 8} \times 100 \right) } \tag*{} \\
+                             &= 37.5 \tag*{requested + used = 0.375 (of available)} \\
+                             &\models { rawScoringFunction(37.5) } \tag*{} \\
+                             &= \boxed{\bold{\Large 3}}
+  \end{align}
 ```
-cpu            = resourceScoringFunction((2+1),8)
-               = (100 -((8-3)*100/8))
-               = 37.5                     # requested + used = 37.5% * available
-               = rawScoringFunction(37.5)
-               = 3                        # floor(37.5/10)
 
-NodeScore   =  ((7 * 5) + (5 * 1) + (3 * 3)) / (5 + 1 + 3)
-            =  5
+##### Final scoring (node 1) {#node-scoring-n1-sum}
+
+```math
+{  \begin{align}
+           { \text{NodeScore} } &= \left\lfloor { { (\bold{7} \times 5) + (\bold{5} \times 1) + (\bold{3} \times 3) } \over { 5 + 1 + 3 } } \right\rfloor \tag*{} \\
+                                &= 5 \tag*{}
+  \end{align}
+} \atop \textnormal{numbers in bold come from formula lines 1, 2 and 3}
 ```
+
+<!-- localization note: use any appropriate technique so that the next line does not
+     resemble a heading -->
+\\( \\hspace{3em} \\) **Score for node 1:** \\( \boxed{5} \\)
 
 #### Scoring example: node 2 {#node-scoring-node2}
 
@@ -249,44 +271,54 @@ Used:
   cpu: 6
 ```
 
-##### Foo (example extended resource), node 2 {#node-scoring-n2-example-resource}
+##### Foo _(example extended resource)_, node 2 {#node-scoring-n2-example-resource}
 
-```
-intel.com/foo  = resourceScoringFunction((2+2),8)
-               =  (100 - ((8-4)*100/8)
-               =  (100 - 50)
-               =  50
-               =  rawScoringFunction(50)
-               = 5
-
-```
-
-##### Memory, node 2 {#node-scoring-n2-memory}
-
-```
-memory         = resourceScoringFunction((256+512),1024)
-               = (100 -((1024-768)*100/1024))
-               = 75
-               = rawScoringFunction(75)
-               = 7
-
+```math
+  \begin{align}
+    { \text{intel.com/foo} } &\Longrightarrow { resourceScoringFunction((2 + 2), 8)} \tag*{} \\
+                             &= { 100 - \left( {8 - 4 \over 8} \times 100 \right) } \tag*{} \\
+                             &= 100 - 50 \tag*{} \\
+                             &= 50 \tag*{requested + used = 0.5 (of available)} \\
+                             &\models { rawScoringFunction(50) } \tag*{} \\
+                             &= \boxed{\bold{\Large 5}}
+  \end{align}
 ```
 
-##### CPU, node 2 {#node-scoring-n2-cpu}
+##### Memory, node 2 {#node-scoring-n1-memory}
 
+
+```math
+  \begin{align}
+           { \text{memory} } &\Longrightarrow { resourceScoringFunction((256 + 512), 1024)} \tag*{} \\
+                             &= { 100 - \left( {1024 - 768 \over 1024} \times 100 \right) } \tag*{} \\
+                             &= 75 \tag*{requested + used = 0.75 (of available)} \\
+                             &\models { rawScoringFunction(75) } \tag*{} \\
+                             &= \boxed{\bold{\Large 7}}
+  \end{align}
 ```
-cpu            = resourceScoringFunction((2+6),8)
-               = (100 -((8-8)*100/8))
-               = 100
-               = rawScoringFunction(100)
-               = 10
 
-NodeScore   =  ((5 * 5) + (7 * 1) + (10 * 3)) / (5 + 1 + 3)
-            =  7
+##### CPU, node 2 {#node-scoring-n1-cpu}
 
+```math
+  \begin{align}
+              { \text{cpu} } &\Longrightarrow { resourceScoringFunction((2 + 6), 8)} \tag*{} \\
+                             &= { 100 - \left( {8 - 8 \over 8} \times 100 \right) } \tag*{} \\
+                             &= 100 \tag*{requested + used = 1.0 (of available)} \\
+                             &\models { rawScoringFunction(100) } \tag*{} \\
+                             &= \boxed{\bold{\Large 10}}
+  \end{align}
 ```
 
-## {{% heading "whatsnext" %}}
+##### Final scoring (node 2) {#node-scoring-n2-sum}
 
-- Read more about the [scheduling framework](/docs/concepts/scheduling-eviction/scheduling-framework/)
-- Read more about [scheduler configuration](/docs/reference/scheduling/config/)
+```math
+{ \begin{align}
+           { \text{NodeScore} } &= \left\lfloor { { (\bold{5} \times 5) + (\bold{7} \times 1) + (\bold{10} \times 3) } \over { (5 + 1 + 3) } } \right\rfloor \tag*{} \\
+                                &= 7 \tag*{}
+  \end{align}
+} \atop { \textnormal{numbers in bold come from formula lines 4, 5, and 6}}
+```
+
+<!-- localization note: use any appropriate technique so that the next line does not
+     resemble a heading -->
+\\( \\hspace{3em} \\) **Score for node 2:** \\( \boxed{7} \\)

--- a/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
+++ b/content/en/docs/concepts/scheduling-eviction/resource-bin-packing.md
@@ -16,11 +16,13 @@ This article applies to resource bin packing in context of scheduling of a singl
 {{< /note >}}
 
 In the [scheduling-plugin](/docs/reference/scheduling/config/#scheduling-plugins) `NodeResourcesFit` of kube-scheduler, there are two
-scoring strategies that support the bin packing of resources: `MostAllocated` and `RequestedToCapacityRatio`.
+scoring strategies that aim to make efficient use of infrastructure resources:
+`MostAllocated` and `RequestedToCapacityRatio`.
 
 <!-- body -->
 
-## Bin packing using MostAllocated strategy
+## Placement using MostAllocated strategy {#strategy-MostAllocated}
+
 The `MostAllocated` strategy scores the nodes based on the utilization of resources, favoring the ones with higher allocation.
 For each resource type, you can set a weight to modify its influence in the node score.
 
@@ -56,15 +58,16 @@ highly utilized nodes. This helps prepare for scale-down of the least utilized n
 To learn more about other parameters and their default configuration, see the API documentation for
 [`NodeResourcesFitArgs`](/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-NodeResourcesFitArgs).
 
-## Bin packing using RequestedToCapacityRatio
+## Placement using RequestedToCapacityRatio strategy {#strategy-RequestedToCapacityRatio}
 
-The `RequestedToCapacityRatio` strategy allows the users to specify the resources along with weights for
+The `RequestedToCapacityRatio` strategy allows you to specify the resources along with weights for
 each resource to score nodes based on the request to capacity ratio. This
-allows users to bin pack extended resources by using appropriate parameters
+approximates efficient _bin packing_ of infrastructure resources (notably, extended resources) by using appropriate parameters
 to improve the utilization of scarce resources in large clusters. It favors nodes according to a
 configured function of the allocated resources. The behavior of the `RequestedToCapacityRatio` in
 the `NodeResourcesFit` score function can be controlled by the
 [scoringStrategy](/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-ScoringStrategy) field.
+
 Within the `scoringStrategy` field, you can configure two parameters: `requestedToCapacityRatio` and
 `resources`. The `shape` in the `requestedToCapacityRatio`
 parameter allows the user to tune the function as least requested or most
@@ -72,8 +75,8 @@ requested based on `utilization` and `score` values. The `resources` parameter
 comprises both the `name` of the resource to be considered during scoring and
 its corresponding `weight`, which specifies the weight of each resource.
 
-Below is an example configuration that sets
-the bin packing behavior for extended resources `intel.com/foo` and `intel.com/bar`
+Below is an example configuration that adjusts
+the Pod scheduling preferences associated with the extended resources `intel.com/foo` and `intel.com/bar`
 using the `requestedToCapacityRatio` field.
 
 ```yaml
@@ -129,8 +132,8 @@ shape:
 ```
 
 The above arguments give the node a `score` of 0 if `utilization` is 0% and 10 for
-`utilization` 100%, thus enabling bin packing behavior. To enable least
-requested the score value must be reversed as follows.
+`utilization` 100%, as an approximation of ideal bin packing. To enable **least**
+requested the score value must be reversed, as follows:
 
 ```yaml
 shape:


### PR DESCRIPTION
Improve the concept explanation of bin packing
- Use formulae per [style guide](https://kubernetes.io/docs/contribute/style/style-guide/#formulae-and-equations)
- Add page structure so that formulae make sense
- Don't make it so much about bin packing per se; explain that what Kubernetes provides is a quite rough approximation to ideal bin packing.
  _Counterargument_: humans packing actual bins also approximate an ideal solution,  rather than performing true NP-complete optimisation.
- Tweak a heading to align with the concept approach (it's not a task page)

:information_source: This was originally PR #49795; please also see the review history on that PR.

To make the idea work, this PR changes the styling for formulae on narrow viewports, so that they gain auto scroll bars.

[Original](https://kubernetes.io/docs/concepts/scheduling-eviction/resource-bin-packing/) vs [preview](https://deploy-preview-50664--kubernetes-io-main-staging.netlify.app/docs/concepts/scheduling-eviction/resource-bin-packing/)