### PR TITLE
Ensure to add v1.33 prefix for title

### DIFF
--- a/content/en/blog/_posts/2025-04-24-endpoints-deprecation.md
+++ b/content/en/blog/_posts/2025-04-24-endpoints-deprecation.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Continuing the transition from Endpoints to EndpointSlices"
+title: "Kubernetes v1.33: Continuing the transition from Endpoints to EndpointSlices"
 slug: endpoints-deprecation
 date: 2025-04-24T10:30:00-08:00
 author: >


### PR DESCRIPTION
This seems to be the convention we used to use for the previous cycles. I will document in the handbook about how the future Feature Blogs should be created with correct front matter to begin with (including `draft: true`)