### PR TITLE
docs: Remove misleading info about SYS_PTRACE

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -62,7 +62,7 @@ Process namespace sharing is enabled using the `shareProcessNamespace` field of
    ```
 
 You can signal processes in other containers. For example, send `SIGHUP` to
-`nginx` to restart the worker process. This requires the `SYS_PTRACE` capability.
+`nginx` to restart the worker process.
 
 ```shell
 # run this inside the "shell" container

--- a/content/en/examples/pods/share-process-namespace.yaml
+++ b/content/en/examples/pods/share-process-namespace.yaml
@@ -10,9 +10,5 @@ spec:
   - name: shell
     image: busybox:1.28
     command: ["sleep", "3600"]
-    securityContext:
-      capabilities:
-        add:
-        - SYS_PTRACE
     stdin: true
     tty: true


### PR DESCRIPTION
This caused some confusion when someone in our org attempted to set this up, as the capability isn't allowed by our use of the baseline Pod Security Standard. On testing - it would appear this capability isn't actually required.
