### PR TITLE
Add Accurate to the list of third party multi tenancy tools

### DIFF
--- a/content/en/docs/concepts/security/multi-tenancy.md
+++ b/content/en/docs/concepts/security/multi-tenancy.md
@@ -463,7 +463,8 @@ listed below.
 
 #### Multi-team tenancy
 
-* [Capsule](https://github.com/clastix/capsule)
+* [Accurate](https://github.com/cybozu-go/accurate)
+* [Capsule](https://github.com/projectcapsule/capsule)
 * [Multi Tenant Operator](https://docs.stakater.com/mto/)
 
 #### Multi-customer tenancy


### PR DESCRIPTION
### Description

With the PR to remove references to the archived HNC, https://github.com/kubernetes/website/pull/50544, I became aware of a list of references to third-party tools/operators to provide multi-tenant Kubernetes. We have been using [Accurate](https://github.com/cybozu-go/accurate) for a long time, and it solves most of our multi-tenancy use cases, and I think it should be added to this list of references.

I'm also fixing an outdated link to Capsule. CC: @prometherion