### PR TITLE
Fix incorrect apiGroup for pods in MutatingAdmissionPolicy example

### DIFF
--- a/content/en/examples/mutatingadmissionpolicy/applyconfiguration-example.yaml
+++ b/content/en/examples/mutatingadmissionpolicy/applyconfiguration-example.yaml
@@ -8,7 +8,7 @@ spec:
     apiVersion: mutations.example.com/v1
   matchConstraints:
     resourceRules:
-    - apiGroups:   ["apps"]
+    - apiGroups:   [""]
       apiVersions: ["v1"]
       operations:  ["CREATE"]
       resources:   ["pods"]


### PR DESCRIPTION
### Description

The MutatingAdmissionPolicy example indicates that "pods" are in the "apps" ApiGroup, but they're in the "" ApiGroup.
