### PR TITLE
docs(i18n): traducir guía de instalación y configuración de kubectl en Windows al español

### DIFF
--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
@@ -15,9 +15,9 @@ Para hacerlo en todas tus sesiones de shell, agrega la siguiente línea a tu arc
 ```powershell
 kubectl completion powershell | Out-String | Invoke-Expression
 ```
-Este commando agragará el script de autocompletado en cada sesión de PowerShell. También puedes añadir el script generado directamente en tu archivo `$PROFILE`.
+Este comando agregará el script de autocompletado en cada sesión de PowerShell. También puedes añadir el script generado directamente en tu archivo `$PROFILE`.
 
-Para agregar el escript generado a tu archivo `$PROFILE`, ejecuta el siguiente comando en el prompt de tu powershell
+Para agregar el script generado a tu archivo `$PROFILE`, ejecute el siguiente comando en el prompt de tu PowerShell:
 
 ```powershell
 kubectl completion powershell >> $PROFILE

--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
@@ -1,0 +1,26 @@
+---
+title: "Autocompletado de PowerShell"
+description: "Algunas configuraciones opcionales para el autocompletado de PowerShell."
+headless: true
+_build:
+  list: never
+  render: never
+  publishResources: false
+---
+
+El script de autocompletado de kubectl para PowerShell se puede generar con el comando `kubectl completion powershell`.
+
+Para hacerlo en todas tus sesiones de shell, agrega la siguiente línea a tu archivo `$PROFILE`:
+
+```powershell
+kubectl completion powershell | Out-String | Invoke-Expression
+```
+Este commando agragará el script de autocompletado en cada sesión de PowerShell. También puedes añadir el script generado directamente en tu archivo `$PROFILE`.
+
+Para agregar el escript generado a tu archivo `$PROFILE`, ejecuta el siguiente comando en el prompt de tu powershell
+
+```powershell
+kubectl completion powershell >> $PROFILE
+```
+
+Después de recargar tu shell, el autocompletado de kubectl debería funcionar.

--- a/content/es/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/install-kubectl-windows.md
@@ -7,7 +7,7 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-Debes usar una versión de kubectl que este dentro de una diferencia de versión menor de tu clúster. Por ejemplo, un cliente v{{< skew latestVersion >}} puede comunicarse con versiones v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, y v{{< skew nextMinorVersion >}} del plano de control.
+Debes usar una versión de kubectl que esté dentro de una diferencia de versión menor de tu clúster. Por ejemplo, un cliente v{{< skew latestVersion >}} puede comunicarse con versiones v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, y v{{< skew nextMinorVersion >}} del plano de control.
 
 El uso de la última versión de kubectl ayuda a evitar problemas imprevistos.
 
@@ -24,7 +24,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
 1. Tiene dos opciones para instalar kubectl en su dispositivo Windows:
 
    - Descarga directa:
-      Descarga la última versión {{< skew currentPatchVersion >}} del binario  directamente según tu arquitetura visitando [Kubernetes release page](https://kubernetes.io/releases/download/#binaries). Asegúrate de seleccionar el binario correcto para tu arquitectura (e.g., amd64, arm64, etc.).
+      Descargue la última versión {{< skew currentPatchVersion >}} del binario  directamente según tu arquitectura visitando [Kubernetes release page](https://kubernetes.io/releases/download/#binaries). Asegúrese de seleccionar el binario correcto para tu arquitectura (e.g., amd64, arm64, etc.).
 
    - Usando curl: 
 
@@ -113,7 +113,7 @@ Si ha instalado Docker Desktop antes, es posible que deba colocar su entrada del
 3. Navegue a su directorio de inicio:
 
    ```powershell
-   # Si estas usando cmd.exe, correr: cd %USERPROFILE%
+   # Si estás usando cmd.exe, correr: cd %USERPROFILE%
    cd ~
    ```
 

--- a/content/es/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/install-kubectl-windows.md
@@ -203,4 +203,4 @@ A continuación se muestran los procedimientos para configurar el autocompletado
 
 ## {{% heading "whatsnext" %}}
 
-{{< include "kubectl-whats-next.md" >}}
+{{< include "included/kubectl-whats-next.md" >}}

--- a/content/es/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/install-kubectl-windows.md
@@ -47,7 +47,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
    Descargue el archivo de comprobación de kubectl:
 
    ```powershell
-   curl -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe.sha256
+   curl.exe -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe.sha256
    ```
 
    Valide el binario kubectl con el archivo de comprobación:
@@ -65,7 +65,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
       $(Get-FileHash -Algorithm SHA256 .\kubectl.exe).Hash -eq $(Get-Content .\kubectl.exe.sha256))
      ```
 
-1. Agregue el binario a su `PATH`.
+1. Agregue el binario `kubectl` a su `PATH` en las variables de entorno.
 
 1. Para asegurar que la versión de `kubectl` es la misma que descargada, ejecute:
 
@@ -73,19 +73,19 @@ Existen los siguientes métodos para instalar kubectl en Windows:
    kubectl version --client
    ```
 
-O para obtener una vista detallada de la versión, ejecute:
+O para una vista detallada de la versión, ejecute:
 ```cmd
 kubectl version --client --output=yaml
 ```
 
 {{< note >}}
-[Docker Desktop para Windows](https://docs.docker.com/docker-for-windows/#kubernetes) agrega su propia versión de `kubectl` a el `PATH`.
-Si ha instalado Docker Desktop antes, es posible que deba colocar su entrada en el `PATH` antes de la agregada por el instalador de Docker Desktop o elimine el `kubectl`.
+[Docker Desktop para Windows](https://docs.docker.com/docker-for-windows/#kubernetes) agrega su propia versión de `kubectl` al `PATH`.
+Si ha instalado Docker Desktop antes, es posible que deba colocar su entrada del `PATH` antes de la agregada por el instalador de Docker Desktop o elimine el `kubectl` de Docker Desktop.
 {{< /note >}}
 
-### Instalar en Windows usando Chocolatey, Scoop o winget
+### Instalar en Windows usando Chocolatey, Scoop o winget {#install-nonstandard-package-tools}
 
-1. Para instalar kubectl en Windows, puede usar [Chocolatey](https://chocolatey.org), [Scoop](https://scoop.sh) o [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
+1. Para instalar kubectl en Windows, puede usar el gestor de paquetes [Chocolatey](https://chocolatey.org), el instalador por línea de comandos [Scoop](https://scoop.sh) o el gestor de paquetes [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
 
    {{< tabs name="kubectl_win_install" >}}
    {{% tab name="choco" %}}
@@ -143,17 +143,15 @@ Edite el archivo de configuración con un editor de texto de su elección, como 
 
 ## Verificar la configuración de kubectl
 
-{{< include "verify-kubectl.md" >}}
+{{< include "included/verify-kubectl.md" >}}
 
 ## Plugins y configuraciones opcionales de kubectl
 
 ### Habilitar el autocompletado de shell
 
-kubectl proporciona soporte de autocompletado para Bash y Zsh, lo que puede ahorrarle mucho tiempo al escribir.
+kubectl proporciona soporte de autocompletado para Bash, Zsh, Fish, y PowerShell, lo que puede ahorrarle mucho tiempo al escribir.
 
-A continuación se muestran los procedimientos para configurar el autocompletado para Zsh, si lo está ejecutando en Windows.
-
-Además, si utiliza PowerShell, puede habilitar el autocompletado. A continuación se muestran los procedimientos para configurar el autocompletado en PowerShell:
+A continuación se muestran los procedimientos para configurar el autocompletado para PowerShell.
 
 {{< include "included/optional-kubectl-configs-pwsh.md" >}}
 

--- a/content/es/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/install-kubectl-windows.md
@@ -1,0 +1,210 @@
+---
+reviewers:
+title: Instalar y configurar kubectl en Windows
+content_type: task
+weight: 10
+card:
+  name: tasks
+  weight: 20
+  title: Instalar kubectl en Windows
+---
+
+## {{% heading "prerequisites" %}}
+
+Debes usar una versión de kubectl que este dentro de una diferencia de versión menor de tu clúster. Por ejemplo, un cliente v{{< skew latestVersion >}} puede comunicarse con versiones v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, y v{{< skew nextMinorVersion >}} del plano de control.
+
+El uso de la última versión de kubectl ayuda a evitar problemas imprevistos.
+
+## Instalar kubectl en Windows
+
+Existen los siguientes métodos para instalar kubectl en Windows:
+
+- [Instalar el binario de kubectl con curl en Windows](#install-kubectl-binary-with-curl-on-windows)
+- [Instalar en Windows usando Chocolatey o Scoop](#install-on-windows-using-chocolatey-or-scoop)
+
+
+### Instalar el binario de kubectl en Windows (mediante descarga directa o usando curl)
+
+1. Tiene dos opciones para instalar kubectl en su dispositivo Windows:
+
+   - Descarga directa:
+      Descarga la última versión {{< skew currentPatchVersion >}} del binario  directamente según tu arquitetura visitando [Kubernetes release page](https://kubernetes.io/releases/download/#binaries). Asegúrate de seleccionar el binario correcto para tu arquitectura (e.g., amd64, arm64, etc.).
+
+   - Usando curl: 
+
+     Si tiene `curl` instalado, use este comando:
+
+     ```powershell
+     curl.exe -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe
+     ```
+
+   {{< note >}}
+   Para conocer la última versión estable (por ejemplo, para secuencias de comandos), eche un vistazo a [https://dl.k8s.io/release/stable.txt](https://dl.k8s.io/release/stable.txt).
+   {{< /note >}}
+
+1. Validar el binario (opcional)
+
+   Descargue el archivo de comprobación de kubectl:
+
+   ```powershell
+   curl -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe.sha256
+   ```
+
+   Valide el binario kubectl con el archivo de comprobación:
+
+   - Usando la consola del sistema para comparar manualmente la salida de `CertUtil` con el archivo de comprobación descargado:
+
+     ```cmd
+     CertUtil -hashfile kubectl.exe SHA256
+     type kubectl.exe.sha256
+     ```
+
+   - Usando PowerShell puede automatizar la verificación usando el operador `-eq` para obtener un resultado de `True` o `False`:
+
+     ```powershell
+      $(Get-FileHash -Algorithm SHA256 .\kubectl.exe).Hash -eq $(Get-Content .\kubectl.exe.sha256))
+     ```
+
+1. Agregue el binario a su `PATH`.
+
+1. Para asegurar que la versión de `kubectl` es la misma que descargada, ejecute:
+
+   ```cmd
+   kubectl version --client
+   ```
+
+O para obtener una vista detallada de la versión, ejecute:
+```cmd
+kubectl version --client --output=yaml
+```
+
+{{< note >}}
+[Docker Desktop para Windows](https://docs.docker.com/docker-for-windows/#kubernetes) agrega su propia versión de `kubectl` a el `PATH`.
+Si ha instalado Docker Desktop antes, es posible que deba colocar su entrada en el `PATH` antes de la agregada por el instalador de Docker Desktop o elimine el `kubectl`.
+{{< /note >}}
+
+### Instalar en Windows usando Chocolatey, Scoop o winget
+
+1. Para instalar kubectl en Windows, puede usar [Chocolatey](https://chocolatey.org), [Scoop](https://scoop.sh) o [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
+
+   {{< tabs name="kubectl_win_install" >}}
+   {{% tab name="choco" %}}
+   ```powershell
+   choco install kubernetes-cli
+   ```
+   {{% /tab %}}
+   {{% tab name="scoop" %}}
+   ```powershell
+   scoop install kubectl
+   ```
+   {{% /tab %}}
+   {{% tab name="winget" %}}
+   ```powershell
+   winget install -e --id Kubernetes.kubectl
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
+
+
+1. Para asegurarse de que la versión que instaló esté actualizada, ejecute:
+
+   ```powershell
+   kubectl version --client
+   ```
+
+1. Navegue a su directorio de inicio:
+
+   ```powershell
+   # Si estas usando cmd.exe, correr: cd %USERPROFILE%
+   cd ~
+   ```
+
+1. Cree el directorio `.kube`:
+
+   ```powershell
+   mkdir .kube
+   ```
+
+1. Cambie al directorio `.kube` que acaba de crear:
+
+   ```powershell
+   cd .kube
+   ```
+
+1. Configure kubectl para usar un clúster de Kubernetes remoto:
+
+   ```powershell
+   New-Item config -type file
+   ```
+
+{{< note >}}
+Edite el archivo de configuración con un editor de texto de su elección, como el Bloc de notas.
+{{< /note >}}
+
+## Verificar la configuración de kubectl
+
+{{< include "verify-kubectl.md" >}}
+
+## Plugins y configuraciones opcionales de kubectl
+
+### Habilitar el autocompletado de shell
+
+kubectl proporciona soporte de autocompletado para Bash y Zsh, lo que puede ahorrarle mucho tiempo al escribir.
+
+A continuación se muestran los procedimientos para configurar el autocompletado para Zsh, si lo está ejecutando en Windows.
+
+Además, si utiliza PowerShell, puede habilitar el autocompletado. A continuación se muestran los procedimientos para configurar el autocompletado en PowerShell:
+
+{{< include "included/optional-kubectl-configs-pwsh.md" >}}
+
+### Instalar el plugin `kubectl-convert`
+
+1. Descargue la última versión con el comando:
+
+   ```powershell
+   curl -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe
+   ```
+
+1. Validar el binario (opcional)
+
+   Descargue el archivo de comprobación kubectl-convert:
+
+   ```powershell
+   curl -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe.sha256
+   ```
+
+   Valide el binario kubectl-convert con el archivo de comprobación:
+
+   - Usando la consola del sistema puede comparar manualmente la salida de `CertUtil` con el archivo de comprobación descargado:
+
+     ```cmd
+     CertUtil -hashfile kubectl-convert.exe SHA256
+     type kubectl-convert.exe.sha256
+     ```
+
+   - Usando PowerShell puede automatizar la verificación usando el operador `-eq` 
+     para obtener un resultado de `True` o `False`:
+
+     ```powershell
+     $($(CertUtil -hashfile .\kubectl-convert.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl-convert.exe.sha256)
+     ```
+
+1. Agregue el binario a su `PATH`.
+
+1. Verifique que el plugin se haya instalado correctamente
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   Si no ve un error, significa que el plugin se instaló correctamente.
+
+5. Después de instalar el plugin, elimine los archivos de instalación:
+   ```powershell
+   del kubectl-convert.exe
+   del kubectl-convert.exe.sha256
+   ```
+
+## {{% heading "whatsnext" %}}
+
+{{< include "kubectl-whats-next.md" >}}

--- a/content/es/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/install-kubectl-windows.md
@@ -3,10 +3,6 @@ reviewers:
 title: Instalar y configurar kubectl en Windows
 content_type: task
 weight: 10
-card:
-  name: tasks
-  weight: 20
-  title: Instalar kubectl en Windows
 ---
 
 ## {{% heading "prerequisites" %}}
@@ -42,7 +38,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
    Para conocer la última versión estable (por ejemplo, para secuencias de comandos), eche un vistazo a [https://dl.k8s.io/release/stable.txt](https://dl.k8s.io/release/stable.txt).
    {{< /note >}}
 
-1. Validar el binario (opcional)
+2. Validar el binario (opcional)
 
    Descargue el archivo de comprobación de kubectl:
 
@@ -65,9 +61,9 @@ Existen los siguientes métodos para instalar kubectl en Windows:
       $(Get-FileHash -Algorithm SHA256 .\kubectl.exe).Hash -eq $(Get-Content .\kubectl.exe.sha256))
      ```
 
-1. Agregue el binario `kubectl` a su `PATH` en las variables de entorno.
+3. Agregue el binario `kubectl` a su `PATH` en las variables de entorno.
 
-1. Para asegurar que la versión de `kubectl` es la misma que descargada, ejecute:
+4. Para asegurar que la versión de `kubectl` es la misma que descargada, ejecute:
 
    ```cmd
    kubectl version --client
@@ -85,7 +81,9 @@ Si ha instalado Docker Desktop antes, es posible que deba colocar su entrada del
 
 ### Instalar en Windows usando Chocolatey, Scoop o winget {#install-nonstandard-package-tools}
 
-1. Para instalar kubectl en Windows, puede usar el gestor de paquetes [Chocolatey](https://chocolatey.org), el instalador por línea de comandos [Scoop](https://scoop.sh) o el gestor de paquetes [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
+1. Para instalar kubectl en Windows puede usar el gestor de paquetes [Chocolatey](https://chocolatey.org), 
+   el instalador por línea de comandos [Scoop](https://scoop.sh) o 
+   el gestor de paquetes [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
 
    {{< tabs name="kubectl_win_install" >}}
    {{% tab name="choco" %}}
@@ -106,32 +104,32 @@ Si ha instalado Docker Desktop antes, es posible que deba colocar su entrada del
    {{< /tabs >}}
 
 
-1. Para asegurarse de que la versión que instaló esté actualizada, ejecute:
+2. Para asegurarse de que la versión que instaló esté actualizada, ejecute:
 
    ```powershell
    kubectl version --client
    ```
 
-1. Navegue a su directorio de inicio:
+3. Navegue a su directorio de inicio:
 
    ```powershell
    # Si estas usando cmd.exe, correr: cd %USERPROFILE%
    cd ~
    ```
 
-1. Cree el directorio `.kube`:
+4. Cree el directorio `.kube`:
 
    ```powershell
    mkdir .kube
    ```
 
-1. Cambie al directorio `.kube` que acaba de crear:
+5. Cambie al directorio `.kube` que acaba de crear:
 
    ```powershell
    cd .kube
    ```
 
-1. Configure kubectl para usar un clúster de Kubernetes remoto:
+6. Configure kubectl para usar un clúster de Kubernetes remoto:
 
    ```powershell
    New-Item config -type file
@@ -149,7 +147,7 @@ Edite el archivo de configuración con un editor de texto de su elección, como 
 
 ### Habilitar el autocompletado de shell
 
-kubectl proporciona soporte de autocompletado para Bash, Zsh, Fish, y PowerShell, lo que puede ahorrarle mucho tiempo al escribir.
+kubectl proporciona soporte de autocompletado para Bash, Zsh, Fish, y PowerShell, lo que puede ahorrarle mucho tiempo de escritura.
 
 A continuación se muestran los procedimientos para configurar el autocompletado para PowerShell.
 
@@ -160,18 +158,18 @@ A continuación se muestran los procedimientos para configurar el autocompletado
 1. Descargue la última versión con el comando:
 
    ```powershell
-   curl -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe
+   curl.exe -LO "https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe"
    ```
 
-1. Validar el binario (opcional)
+2. Validar el binario (opcional) 
 
-   Descargue el archivo de comprobación kubectl-convert:
+   Descargue el archivo de comprobación `kubectl-convert`:
 
    ```powershell
-   curl -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe.sha256
+   curl.exe -LO "https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe.sha256"
    ```
 
-   Valide el binario kubectl-convert con el archivo de comprobación:
+   Valide el binario `kubectl-conver` con el archivo de comprobación:
 
    - Usando la consola del sistema puede comparar manualmente la salida de `CertUtil` con el archivo de comprobación descargado:
 
@@ -180,16 +178,16 @@ A continuación se muestran los procedimientos para configurar el autocompletado
      type kubectl-convert.exe.sha256
      ```
 
-   - Usando PowerShell puede automatizar la verificación usando el operador `-eq` 
-     para obtener un resultado de `True` o `False`:
+   - Usando PowerShell puede automatizar la verificación usando el operador `-eq` para obtener 
+      un resultado de `True` o `False`:
 
      ```powershell
      $($(CertUtil -hashfile .\kubectl-convert.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl-convert.exe.sha256)
      ```
 
-1. Agregue el binario a su `PATH`.
+3. Agregue el binario a su `PATH`.
 
-1. Verifique que el plugin se haya instalado correctamente
+4. Verifique que el plugin se haya instalado correctamente
 
    ```shell
    kubectl convert --help

--- a/content/es/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/es/docs/tasks/tools/install-kubectl-windows.md
@@ -16,7 +16,7 @@ El uso de la última versión de kubectl ayuda a evitar problemas imprevistos.
 Existen los siguientes métodos para instalar kubectl en Windows:
 
 - [Instalar el binario de kubectl con curl en Windows](#install-kubectl-binary-with-curl-on-windows)
-- [Instalar en Windows usando Chocolatey o Scoop](#install-on-windows-using-chocolatey-or-scoop)
+- [Instalar en Windows usando Chocolatey, Scoop o winget](#install-on-windows-using-chocolatey-o-scoop)
 
 
 ### Instalar el binario de kubectl en Windows (mediante descarga directa o usando curl)
@@ -31,7 +31,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
      Si tiene `curl` instalado, use este comando:
 
      ```powershell
-     curl.exe -LO https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe
+     curl.exe -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe
      ```
 
    {{< note >}}
@@ -43,7 +43,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
    Descargue el archivo de comprobación de kubectl:
 
    ```powershell
-   curl.exe -LO https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl.exe.sha256
+   curl.exe -LO https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe.sha256
    ```
 
    Valide el binario kubectl con el archivo de comprobación:
@@ -58,7 +58,7 @@ Existen los siguientes métodos para instalar kubectl en Windows:
    - Usando PowerShell puede automatizar la verificación usando el operador `-eq` para obtener un resultado de `True` o `False`:
 
      ```powershell
-      $(Get-FileHash -Algorithm SHA256 .\kubectl.exe).Hash -eq $(Get-Content .\kubectl.exe.sha256))
+     $(Get-FileHash -Algorithm SHA256 .\kubectl.exe).Hash -eq $(Get-Content .\kubectl.exe.sha256)
      ```
 
 3. Agregue el binario `kubectl` a su `PATH` en las variables de entorno.
@@ -158,7 +158,7 @@ A continuación se muestran los procedimientos para configurar el autocompletado
 1. Descargue la última versión con el comando:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/release/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe"
+   curl.exe -LO "https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl-convert.exe"
    ```
 
 2. Validar el binario (opcional) 
@@ -166,10 +166,10 @@ A continuación se muestran los procedimientos para configurar el autocompletado
    Descargue el archivo de comprobación `kubectl-convert`:
 
    ```powershell
-   curl.exe -LO "https://dl.k8s.io/v{{% skew currentPatchVersion %}}/bin/windows/amd64/kubectl-convert.exe.sha256"
+   curl.exe -LO "https://dl.k8s.io/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl-convert.exe.sha256"
    ```
 
-   Valide el binario `kubectl-conver` con el archivo de comprobación:
+   Valide el binario `kubectl-convert` con el archivo de comprobación:
 
    - Usando la consola del sistema puede comparar manualmente la salida de `CertUtil` con el archivo de comprobación descargado:
 


### PR DESCRIPTION
Se traduce y revisa completamente al español la página “Install and configure kubectl on Windows”:

- Todos los bloques de notas y ejemplos de comandos
- Enlaces internos y referencias