### PR TITLE
Revise DRA Updates blog and schedule for publication

### DIFF
--- a/content/en/blog/_posts/2025-05-02-dra-133-updates.md
+++ b/content/en/blog/_posts/2025-05-02-dra-133-updates.md
@@ -2,14 +2,13 @@
 layout: blog
 title: "Kubernetes v1.33: New features in DRA"
 slug: dra-133-updates
-draft: true
-date: XXXX-XX-XX
+date: 2025-05-02T10:30:00-08:00
 author: >
   [Morten Torkildsen](https://github.com/mortent) (Google)
   [Patrick Ohly](https://github.com/pohly) (Intel)
 ---
 
-Kubernetes [Dynamic Resource Allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) (DRA) was originally introduced as an alpha feature in the v1.26 release, and then went through a significant redesign for Kubernetes v1.31. The main DRA feature went to beta in v1.32 and the project hopes it will be generally available in Kubernetes v1.34.
+Kubernetes [Dynamic Resource Allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) (DRA) was originally introduced as an alpha feature in the v1.26 release, and then went through a significant redesign for Kubernetes v1.31. The main DRA feature went to beta in v1.32, and the project hopes it will be generally available in Kubernetes v1.34.
 
 The basic feature set of DRA provides a far more powerful and flexible API for requesting devices than Device Plugin. And while DRA remains a beta feature for v1.33, the DRA team has been hard at work implementing a number of new features and UX improvements. One feature has been promoted to beta, while a number of new features have been added in alpha. The team has also made progress towards getting DRA ready for GA.
 
@@ -19,7 +18,7 @@ The basic feature set of DRA provides a far more powerful and flexible API for r
 
 ### New alpha features
 
-[Partitionable Devices](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#partitionable-devices) lets a driver advertise several overlapping logical devices (“partitions”) and the driver can reconfigure the physical device dynamically based on the actual devices allocated. This makes it possible to partition devices on-demand to meet the need of the workloads and therefore increase the utilization.
+[Partitionable Devices](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#partitionable-devices) lets a driver advertise several overlapping logical devices (“partitions”), and the driver can reconfigure the physical device dynamically based on the actual devices allocated. This makes it possible to partition devices on-demand to meet the needs of the workloads and therefore increase the utilization.
 
 [Device Taints and Tolerations](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations) allow devices to be tainted and for workloads to tolerate those taints. This makes it possible for drivers or cluster administrators to mark devices as unavailable. Depending on the effect of the taint, this can prevent devices from being allocated or cause eviction of pods that are using the device.
 
@@ -39,13 +38,13 @@ The alpha features that were added in v1.33 will be brought to beta in v1.34.
 
 ### Getting involved
 
-A good starting point is joining the WG Device Management [Slack channel](https://kubernetes.slack.com/archives/C0409NGC1TK) and [meetings](https://docs.google.com/document/d/1qxI87VqGtgN7EAJlqVfxx86HGKEAc2A3SKru8nJHNkQ/edit?tab=t.0#heading=h.tgg8gganowxq) which happens at US/EU and EU/APAC friendly time slots.
+A good starting point is joining the WG Device Management [Slack channel](https://kubernetes.slack.com/archives/C0409NGC1TK) and [meetings](https://docs.google.com/document/d/1qxI87VqGtgN7EAJlqVfxx86HGKEAc2A3SKru8nJHNkQ/edit?tab=t.0#heading=h.tgg8gganowxq), which happen at US/EU and EU/APAC friendly time slots.
 
-Not all enhancement ideas are tracked as issues yet, so come talk to us if you want to help or have some ideas yourself! We have work to do at all levels, from difficult core changes to usability enhancements in kubectl which could be picked up by newcomers.
+Not all enhancement ideas are tracked as issues yet, so come talk to us if you want to help or have some ideas yourself! We have work to do at all levels, from difficult core changes to usability enhancements in kubectl, which could be picked up by newcomers.
 
 ### Acknowledgments
 
-A huge thanks to everyone who have contributed:
+A huge thanks to everyone who has contributed:
 
 * Cici Huang ([cici37](https://github.com/cici37))
 * Ed Bartosh ([bart0sh](https://github.com/bart0sh])

--- a/content/en/blog/_posts/2025-05-02-kubernetes-v1-33-dra-updates.md
+++ b/content/en/blog/_posts/2025-05-02-kubernetes-v1-33-dra-updates.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.33: New features in DRA"
-slug: dra-133-updates
+slug: kubernetes-v1-33-dra-updates
 date: 2025-05-02T10:30:00-08:00
 author: >
   [Morten Torkildsen](https://github.com/mortent) (Google)


### PR DESCRIPTION
This schedules [DRA Updates in v1.33 blog](https://github.com/kubernetes/website/pull/49993 ) for publication on Friday, 2nd May, 2025.