### PR TITLE
KEP-4049: Updated slug, removed draft status and updated publish date

### DIFF
--- a/content/en/blog/_posts/2025-05-01-storage-capacity-scoring.md
+++ b/content/en/blog/_posts/2025-05-01-storage-capacity-scoring.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
-title: "Kubernetes 1.33: Storage Capacity Scoring of Nodes for Dynamic Provisioning (alpha)"
-date: 2025-04-23
-draft: true
-slug: kubernetes-1-33-storage-capacity-scoring-feature
+title: "Kubernetes v1.33: Storage Capacity Scoring of Nodes for Dynamic Provisioning (alpha)"
+date: 2025-05-01
+slug: kubernetes-v1-33-storage-capacity-scoring-feature
 author: >
   Yuma Ogami (Cybozu)
 ---


### PR DESCRIPTION
This schedules https://github.com/kubernetes/website/pull/49992 for publication on Thursday, 1st May, 2025.