### PR TITLE
OWNERS_ALIASES cleanup activity from previous cycles

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -68,7 +68,6 @@ aliases:
     - dipesh-rawat
     - divya-mohan0209
     - katcosgrove
-    - kbhawkey
     - lmktfy
     - mengjiao-liu
     - natalisucks
@@ -78,8 +77,6 @@ aliases:
     - shannonxtreme
     - tengqm
     - windsonsea
-    - Princesso
-    - drewhagen
   sig-docs-es-owners: # Admins for Spanish content
     - electrocucaracha
     - krol3


### PR DESCRIPTION
Removing the following folks since they've been inactive and/or have stepped away from contributing to the kubernetes/website repo in the past year

- @Princesso 
- @drewhagen 
- @kbhawkey 

Please note: 

- If you wish to restart your contribution journey, we're happy for you to pick up from where you left off. If you'd like to discuss this privately before publicly commenting here, please start a group DM with all the chairs included. 

- Since these are named roles, the PR will be open for comment until **13th May 2025** EOD. Kindly comment on the PR, failing which we will merge as-is. 

cc: @reylejano @natalisucks 