### PR TITLE
KEP-4412: update blog to add v1.33 prefix for title

### DIFF
--- a/content/en/blog/_posts/2025-05-07-kubernetes-1-33-wi-for-image-pulls.md
+++ b/content/en/blog/_posts/2025-05-07-kubernetes-1-33-wi-for-image-pulls.md
@@ -1,9 +1,9 @@
 ---
 layout: blog
 title: "Kubernetes v1.33: From Secrets to Service Accounts: Kubernetes Image Pulls Evolved"
-date: 2025-05-07
+date: 2025-05-07T10:30:00-08:00
 draft: true
-slug: kubernetes-1-33-wi-for-image-pulls
+slug: kubernetes-v1-33-wi-for-image-pulls
 author: >
   [Anish Ramasekar](https://github.com/aramase) (Microsoft)
 ---

--- a/content/en/blog/_posts/2025-05-07-kubernetes-1-33-wi-for-image-pulls.md
+++ b/content/en/blog/_posts/2025-05-07-kubernetes-1-33-wi-for-image-pulls.md
@@ -2,7 +2,6 @@
 layout: blog
 title: "Kubernetes v1.33: From Secrets to Service Accounts: Kubernetes Image Pulls Evolved"
 date: 2025-05-07T10:30:00-08:00
-draft: true
 slug: kubernetes-v1-33-wi-for-image-pulls
 author: >
   [Anish Ramasekar](https://github.com/aramase) (Microsoft)

--- a/content/en/blog/_posts/2025-05-07-kubernetes-1-33-wi-for-image-pulls.md
+++ b/content/en/blog/_posts/2025-05-07-kubernetes-1-33-wi-for-image-pulls.md
@@ -1,9 +1,9 @@
 ---
 layout: blog
-title: "From Secrets to Service Accounts: Kubernetes Image Pulls Evolved"
-date: 2025-04-23
+title: "Kubernetes v1.33: From Secrets to Service Accounts: Kubernetes Image Pulls Evolved"
+date: 2025-05-07
 draft: true
-slug: wi-for-image-pulls
+slug: kubernetes-1-33-wi-for-image-pulls
 author: >
   [Anish Ramasekar](https://github.com/aramase) (Microsoft)
 ---


### PR DESCRIPTION
Following the same convention as other to have `Kubernetes v1.33:` in the title. Also changed the publication date based on [this project view](https://github.com/orgs/kubernetes/projects/200/views/5). The PR is still marked as `draft: true`.

follow-up PR based on https://github.com/kubernetes/website/pull/49924#issuecomment-2844360182