### PR TITLE
Schedule Feature Blogs for publication

### DIFF
--- a/content/en/blog/_posts/2025-05-02-mutable-csi-node-allocatable.md
+++ b/content/en/blog/_posts/2025-05-02-mutable-csi-node-allocatable.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
 title: "Kubernetes v1.33: Mutable CSI Node Allocatable Count"
-date: 2025-04-30
+date: 2025-05-02T10:30:00-08:00
 slug: kubernetes-1-33-mutable-csi-node-allocatable-count
-draft: true
 author: Eddie Torres (Amazon Web Services)
 ---
 

--- a/content/en/blog/_posts/2025-05-08-volume-populators-ga/index.md
+++ b/content/en/blog/_posts/2025-05-08-volume-populators-ga/index.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes 1.33: Volume Populators Graduate to GA"
-date: 2025-06-23
-draft: true
+date: 2025-05-08T10:30:00-08:00
 slug: kubernetes-v1-33-volume-populators-ga
 author: >
   Danna Wang (Google)

--- a/content/en/blog/_posts/2025-05-15-Container-Stop-Signals.md
+++ b/content/en/blog/_posts/2025-05-15-Container-Stop-Signals.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
-title: "Updates to Container Lifecycle in Kubernetes v1.33"
-date: 2025-04-23
-slug: updates-to-container-lifecycle
-draft: true
+title: "Kubernetes v1.33: Updates to Container Lifecycle in Kubernetes v1.33"
+date: 2025-05-15T10:30:00-08:00
+slug: kubernetes-v1-33-updates-to-container-lifecycle
 author: >
   Sreeram Venkitesh (DigitalOcean)
 ---


### PR DESCRIPTION
This includes the following KEPs:

- KEP-4876: For Friday, 2nd May ([original blog PR](https://github.com/kubernetes/website/pull/50016))
- KEP-1495: For Thursday, 8th May ([original blog PR](https://github.com/kubernetes/website/pull/49542))
- KEP-4960: For Thursday, 15th May ([original blog PR](https://github.com/kubernetes/website/pull/49967))