### PR TITLE
Schedule KEP-2644 blog for publication

### DIFF
--- a/content/en/blog/_posts/2025-05-05-Honor-Persistent-Volume-Reclaim-Policy-Graduate-to-GA.md
+++ b/content/en/blog/_posts/2025-05-05-Honor-Persistent-Volume-Reclaim-Policy-Graduate-to-GA.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
 title: 'Kubernetes v1.33: Prevent PersistentVolume Leaks When Deleting out of Order graduates to GA'
-date: 2025-04-02
-draft: true
-slug: kubernetes-1-33-prevent-persistentvolume-leaks-when-deleting-out-of-order-graduate-to-ga
+date: 2025-05-05T10:30:00-08:00
+slug: kubernetes-v1-33-prevent-persistentvolume-leaks-when-deleting-out-of-order-graduate-to-ga
 author: >
   Deepak Kinni (Broadcom)
 ---


### PR DESCRIPTION
This schedules https://github.com/kubernetes/website/pull/49948 for publication on Monday, 5th May, 2025.