### PR TITLE
[en] Update images.md to follow style guide recommendations

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -12,7 +12,7 @@ hide_summary: true # Listed separately in section index
 
 A container image represents binary data that encapsulates an application and all its
 software dependencies. Container images are executable software bundles that can run
-standalone and that make very well defined assumptions about their runtime environment.
+standalone and that make very well-defined assumptions about their runtime environment.
 
 You typically create a container image of your application and push it to a registry
 before referring to it in a {{< glossary_tooltip text="Pod" term_id="pod" >}}.
@@ -34,7 +34,7 @@ Images can also include a registry hostname; for example: `fictional.registry.ex
 and possibly a port number as well; for example: `fictional.registry.example:10443/imagename`.
 
 If you don't specify a registry hostname, Kubernetes assumes that you mean the [Docker public registry](https://hub.docker.com/).
-You can change this behaviour by setting default image registry in 
+You can change this behavior by setting a default image registry in the
 [container runtime](/docs/setup/production-environment/container-runtimes/) configuration.
 
 After the image name part you can add a _tag_ or _digest_ (in the same way you would when using with commands
@@ -43,40 +43,45 @@ Digests are a unique identifier for a specific version of an image. Digests are 
 and are immutable. Tags can be moved to point to different images, but digests are fixed.
 
 Image tags consist of lowercase and uppercase letters, digits, underscores (`_`),
-periods (`.`), and dashes (`-`). It can be up to 128 characters long. And must follow the
-next regex pattern: `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`
-You can read more about and find validation regex in the
+periods (`.`), and dashes (`-`). A tag can be up to 128 characters long, and must
+conform to the following regex pattern: `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`.
+You can read more about it and find the validation regex in the
 [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/master/spec.md#workflow-categories).
 If you don't specify a tag, Kubernetes assumes you mean the tag `latest`.
 
 Image digests consists of a hash algorithm (such as `sha256`) and a hash value. For example:
-`sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07`
-You can find more information about digests format in the 
+`sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07`.
+You can find more information about the digest format in the
 [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests).
 
 Some image name examples that Kubernetes can use are:
 
-- `busybox` - Image name only, no tag or digest. Kubernetes will use Docker public registry and latest tag. (Same as `docker.io/library/busybox:latest`)
-- `busybox:1.32.0` - Image name with tag. Kubernetes will use Docker public registry. (Same as `docker.io/library/busybox:1.32.0`)
-- `registry.k8s.io/pause:latest` - Image name with a custom registry and latest tag.
-- `registry.k8s.io/pause:3.5` - Image name with a custom registry and non-latest tag.
-- `registry.k8s.io/pause@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07` - Image name with digest.
-- `registry.k8s.io/pause:3.5@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07` - Image name with tag and digest. Only digest will be used for pulling.
+- `busybox` &mdash; Image name only, no tag or digest. Kubernetes will use the Docker
+    public registry and latest tag. Equivalent to `docker.io/library/busybox:latest`.
+- `busybox:1.32.0` &mdash; Image name with tag. Kubernetes will use the Docker
+    public registry. Equivalent to `docker.io/library/busybox:1.32.0`.
+- `registry.k8s.io/pause:latest` &mdash; Image name with a custom registry and latest tag.
+- `registry.k8s.io/pause:3.5` &mdash; Image name with a custom registry and non-latest tag.
+- `registry.k8s.io/pause@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07` &mdash;
+    Image name with digest.
+- `registry.k8s.io/pause:3.5@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07` &mdash;
+    Image name with tag and digest. Only the digest will be used for pulling.
 
 ## Updating images
 
 When you first create a {{< glossary_tooltip text="Deployment" term_id="deployment" >}},
 {{< glossary_tooltip text="StatefulSet" term_id="statefulset" >}}, Pod, or other
-object that includes a Pod template, then by default the pull policy of all
-containers in that pod will be set to `IfNotPresent` if it is not explicitly
-specified. This policy causes the
+object that includes a PodTemplate, and a pull policy was not explicitly specified,
+then by default the pull policy of all containers in that Pod will be set to
+`IfNotPresent`. This policy causes the
 {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} to skip pulling an
 image if it already exists.
 
 ### Image pull policy
 
-The `imagePullPolicy` for a container and the tag of the image affect when the
-[kubelet](/docs/reference/command-line-tools-reference/kubelet/) attempts to pull (download) the specified image.
+The `imagePullPolicy` for a container and the tag of the image both affect _when_ the
+[kubelet](/docs/reference/command-line-tools-reference/kubelet/) attempts to pull
+(download) the specified image.
 
 Here's a list of the values you can set for `imagePullPolicy` and the effects
 these values have:
@@ -119,12 +124,12 @@ When using image tags, if the image registry were to change the code that the ta
 represents, you might end up with a mix of Pods running the old and new code. An image digest
 uniquely identifies a specific version of the image, so Kubernetes runs the same code every time
 it starts a container with that image name and digest specified. Specifying an image by digest
-fixes the code that you run so that a change at the registry cannot lead to that mix of versions.
+pins the code that you run so that a change at the registry cannot lead to that mix of versions.
 
 There are third-party [admission controllers](/docs/reference/access-authn-authz/admission-controllers/)
-that mutate Pods (and pod templates) when they are created, so that the
+that mutate Pods (and PodTemplates) when they are created, so that the
 running workload is defined based on an image digest rather than a tag.
-That might be useful if you want to make sure that all your workload is
+That might be useful if you want to make sure that your entire workload is
 running the same code no matter what tag changes happen at the registry.
 
 #### Default image pull policy {#imagepullpolicy-defaulting}
@@ -135,11 +140,11 @@ When you (or a controller) submit a new Pod to the API server, your cluster sets
 - if you omit the `imagePullPolicy` field, and you specify the digest for the
   container image, the `imagePullPolicy` is automatically set to `IfNotPresent`.
 - if you omit the `imagePullPolicy` field, and the tag for the container image is
-  `:latest`, `imagePullPolicy` is automatically set to `Always`;
+  `:latest`, `imagePullPolicy` is automatically set to `Always`.
 - if you omit the `imagePullPolicy` field, and you don't specify the tag for the
-  container image, `imagePullPolicy` is automatically set to `Always`;
-- if you omit the `imagePullPolicy` field, and you specify the tag for the
-  container image that isn't `:latest`, the `imagePullPolicy` is automatically set to
+  container image, `imagePullPolicy` is automatically set to `Always`.
+- if you omit the `imagePullPolicy` field, and you specify a tag for the container
+  image that isn't `:latest`, the `imagePullPolicy` is automatically set to
   `IfNotPresent`.
 
 {{< note >}}
@@ -184,16 +189,18 @@ which is 300 seconds (5 minutes).
 Kubernetes includes alpha support for performing image pulls based on the RuntimeClass of a Pod.
 
 If you enable the `RuntimeClassInImageCriApi` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
-the kubelet references container images by a tuple of (image name, runtime handler) rather than just the
-image name or digest. Your {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
+the kubelet references container images by a tuple of image name and runtime handler
+rather than just the image name or digest. Your
+{{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
 may adapt its behavior based on the selected runtime handler.
-Pulling images based on runtime class will be helpful for VM based containers like windows hyperV containers.
+Pulling images based on runtime class is useful for VM-based containers, such as
+Windows Hyper-V containers.
 
 ## Serial and parallel image pulls
 
-By default, kubelet pulls images serially. In other words, kubelet sends only
-one image pull request to the image service at a time. Other image pull requests
-have to wait until the one being processed is complete.
+By default, the kubelet pulls images serially. In other words, the kubelet sends
+only one image pull request to the image service at a time. Other image pull
+requests have to wait until the one being processed is complete.
 
 Nodes make image pull decisions in isolation. Even when you use serialized image
 pulls, two different nodes can pull the same image in parallel.
@@ -203,64 +210,66 @@ If you would like to enable parallel image pulls, you can set the field
 With `serializeImagePulls` set to false, image pull requests will be sent to the image service immediately,
 and multiple images will be pulled at the same time.
 
-When enabling parallel image pulls, please make sure the image service of your
-container runtime can handle parallel image pulls.
+When enabling parallel image pulls, ensure that the image service of your container
+runtime can handle parallel image pulls.
 
 The kubelet never pulls multiple images in parallel on behalf of one Pod. For example,
 if you have a Pod that has an init container and an application container, the image
 pulls for the two containers will not be parallelized. However, if you have two
-Pods that use different images, the kubelet pulls the images in parallel on
-behalf of the two different Pods, when parallel image pulls is enabled.
+Pods that use different images, and the parallel image pull feature is enabled,
+the kubelet will pull the images in parallel on behalf of the two different Pods.
 
 ### Maximum parallel image pulls
 
 {{< feature-state for_k8s_version="v1.32" state="beta" >}}
 
-When `serializeImagePulls` is set to false, the kubelet defaults to no limit on the
-maximum number of images being pulled at the same time. If you would like to
+When `serializeImagePulls` is set to false, the kubelet defaults to no limit on
+the maximum number of images being pulled at the same time. If you would like to
 limit the number of parallel image pulls, you can set the field `maxParallelImagePulls`
-in kubelet configuration. With `maxParallelImagePulls` set to _n_, only _n_ images
-can be pulled at the same time, and any image pull beyond _n_ will have to wait
-until at least one ongoing image pull is complete.
+in the kubelet configuration. With `maxParallelImagePulls` set to _n_, only _n_
+images can be pulled at the same time, and any image pull beyond _n_ will have to
+wait until at least one ongoing image pull is complete.
 
-Limiting the number parallel image pulls would prevent image pulling from consuming
+Limiting the number of parallel image pulls prevents image pulling from consuming
 too much network bandwidth or disk I/O, when parallel image pulling is enabled.
 
 You can set `maxParallelImagePulls` to a positive number that is greater than or
-equal to 1. If you set `maxParallelImagePulls` to be greater than or equal to 2, you
-must set the `serializeImagePulls` to false. The kubelet will fail to start with invalid
-`maxParallelImagePulls` settings.
+equal to 1. If you set `maxParallelImagePulls` to be greater than or equal to 2,
+you must set `serializeImagePulls` to false. The kubelet will fail to start
+with an invalid `maxParallelImagePulls` setting.
 
 ## Multi-architecture images with image indexes
 
 As well as providing binary images, a container registry can also serve a
 [container image index](https://github.com/opencontainers/image-spec/blob/master/image-index.md).
 An image index can point to multiple [image manifests](https://github.com/opencontainers/image-spec/blob/master/manifest.md)
-for architecture-specific versions of a container. The idea is that you can have a name for an image
-(for example: `pause`, `example/mycontainer`, `kube-apiserver`) and allow different systems to
-fetch the right binary image for the machine architecture they are using.
+for architecture-specific versions of a container. The idea is that you can have
+a name for an image (for example: `pause`, `example/mycontainer`, `kube-apiserver`)
+and allow different systems to fetch the right binary image for the machine
+architecture they are using.
 
-Kubernetes itself typically names container images with a suffix `-$(ARCH)`. For backward
-compatibility, please generate the older images with suffixes. The idea is to generate say `pause`
-image which has the manifest for all the arch(es) and say `pause-amd64` which is backwards
-compatible for older configurations or YAML files which may have hard coded the images with
-suffixes.
+Kubernetes itself typically names container images with a suffix `-$(ARCH)`. For
+backward compatibility, generate older images with suffixes. For instance,
+an image named as `pause` would be a multi-architecture image containing manifests
+for all supported architectures, while `pause-amd64` would be a backward-compatible
+version for older configurations, or for YAML files with hardcoded image names
+containing suffixes.
 
 ## Using a private registry
 
-Private registries may require keys to read images from them.  
+Private registries may require keys to read images from them.
 Credentials can be provided in several ways:
 
-- Configuring Nodes to Authenticate to a Private Registry
+- [Configuring Nodes to Authenticate to a Private Registry](#configuring-nodes-to-authenticate-to-a-private-registry)
   - all pods can read any configured private registries
   - requires node configuration by cluster administrator
-- Kubelet Credential Provider to dynamically fetch credentials for private registries
-  - kubelet can be configured to use credential provider exec plugin 
+- [Kubelet Credential Provider to dynamically fetch credentials for private registries](#kubelet-credential-provider)
+  - kubelet can be configured to use credential provider exec plugin
     for the respective private registry.
-- Pre-pulled Images
+- [Pre-pulled Images](#pre-pulled-images)
   - all pods can use any images cached on a node
   - requires root access to all nodes to set up
-- Specifying ImagePullSecrets on a Pod
+- [Specifying ImagePullSecrets on a Pod](#specifying-imagepullsecrets-on-a-pod)
   - only pods which provide their own keys can access the private registry
 - Vendor-specific or local extensions
   - if you're using a custom node configuration, you (or your cloud
@@ -281,8 +290,9 @@ task. That example uses a private registry in Docker Hub.
 ### Kubelet credential provider for authenticated image pulls {#kubelet-credential-provider}
 
 {{< note >}}
-This approach is especially suitable when kubelet needs to fetch registry credentials dynamically.
-Most commonly used for registries provided by cloud providers where auth tokens are short-lived. 
+This approach is especially suitable when the kubelet needs to fetch registry credentials
+dynamically. Most commonly used for registries provided by cloud providers where
+authentication tokens are short-lived.
 {{< /note >}}
 
 You can configure the kubelet to invoke a plugin binary to dynamically fetch registry credentials for a container image.
@@ -299,10 +309,12 @@ prefix-matched paths. The only limitation is that glob patterns (`*`) have to
 include the dot (`.`) for each subdomain. The amount of matched subdomains has
 to be equal to the amount of glob patterns (`*.`), for example:
 
-- `*.kubernetes.io` will *not* match `kubernetes.io`, but `abc.kubernetes.io`
-- `*.*.kubernetes.io` will *not* match `abc.kubernetes.io`, but `abc.def.kubernetes.io`
-- `prefix.*.io` will match `prefix.kubernetes.io`
-- `*-good.kubernetes.io` will match `prefix-good.kubernetes.io`
+- `*.kubernetes.io` will *not* match `kubernetes.io`, but will match
+    `abc.kubernetes.io`.
+- `*.*.kubernetes.io` will *not* match `abc.kubernetes.io`, but will match
+    `abc.def.kubernetes.io`.
+- `prefix.*.io` will match `prefix.kubernetes.io`.
+- `*-good.kubernetes.io` will match `prefix-good.kubernetes.io`.
 
 This means that a `config.json` like this is valid:
 
@@ -315,22 +327,22 @@ This means that a `config.json` like this is valid:
 }
 ```
 
-Image pull operations would now pass the credentials to the CRI container
-runtime for every valid pattern. For example the following container image names
-would match successfully:
+Image pull operations pass the credentials to the CRI container runtime for every
+valid pattern. For example, the following container image names would match
+successfully:
 
 - `my-registry.io/images`
 - `my-registry.io/images/my-image`
 - `my-registry.io/images/another-image`
 - `sub.my-registry.io/images/my-image`
 
-But not:
+However, these container image names would *not* match:
 
 - `a.sub.my-registry.io/images/my-image`
 - `a.b.sub.my-registry.io/images/my-image`
 
 The kubelet performs image pulls sequentially for every found credential. This
-means, that multiple entries in `config.json` for different paths are possible, too:
+means that multiple entries in `config.json` for different paths are possible, too:
 
 ```json
 {
@@ -346,8 +358,8 @@ means, that multiple entries in `config.json` for different paths are possible, 
 ```
 
 If now a container specifies an image `my-registry.io/images/subpath/my-image`
-to be pulled, then the kubelet will try to download them from both
-authentication sources if one of them fails.
+to be pulled, then the kubelet will try to download it using both authentication
+sources if one of them fails.
 
 ### Pre-pulled images
 
@@ -369,10 +381,10 @@ private registry.
 
 {{< note >}}
 {{< feature-state feature_gate_name="KubeletEnsureSecretPulledImages" >}}
-Access to pre-pulled images may be authorized according to [image pull credential verification](#ensureimagepullcredentialverification)
+Access to pre-pulled images may be authorized according to [image pull credential verification](#ensureimagepullcredentialverification).
 {{< /note >}}
 
-### Specifying imagePullSecrets on a Pod
+### Specifying `imagePullSecrets` on a Pod
 
 {{< note >}}
 This is the recommended approach to run containers based on images
@@ -380,21 +392,21 @@ in private registries.
 {{< /note >}}
 
 Kubernetes supports specifying container image registry keys on a Pod.
-`imagePullSecrets` must all be in the same namespace as the Pod. The referenced
-Secrets must be of type `kubernetes.io/dockercfg` or `kubernetes.io/dockerconfigjson`.
+All `imagePullSecrets` must be Secrets that exist in the same namespace as the
+Pod. These Secrets must be of type `kubernetes.io/dockercfg` or `kubernetes.io/dockerconfigjson`.
 
 #### Ensure Image Pull Credential Verification {#ensureimagepullcredentialverification}
 
 {{< feature-state feature_gate_name="KubeletEnsureSecretPulledImages" >}}
 
-If the `KubeletEnsureSecretPulledImages` feature gate is enabled, Kubernetes will validate 
-image credentials for every image that requires credentials to be pulled,
-even if that image is already present on the node.
-This validation ensures that images in a pod request which have not been successfully pulled
+If the `KubeletEnsureSecretPulledImages` feature gate is enabled, Kubernetes will
+validate image credentials for every image that requires credentials to be pulled,
+even if that image is already present on the node. This validation ensures that
+images in a Pod request which have not been successfully pulled
 with the provided credentials must re-pull the images from the registry.
 Additionally, image pulls that re-use the same credentials
-which previously resulted in a successful image pull will not need to re-pull from the registry
-and are instead validated locally without accessing the registry
+which previously resulted in a successful image pull will not need to re-pull from
+the registry and are instead validated locally without accessing the registry
 (provided the image is available locally).
 This is controlled by the`imagePullCredentialsVerificationPolicy` field in the
 [Kubelet configuration](/docs/reference/config-api/kubelet-config.v1beta1#ImagePullCredentialsVerificationPolicy).
@@ -406,13 +418,13 @@ image is already present on the node:
    If the image is present locally, image pull credentials are not verified.
  * `NeverVerifyPreloadedImages`: Images pulled outside the kubelet are not verified,
  but all other images will have their credentials verified. This is the default behavior.
- * `NeverVerifyAllowListedImages`: Images pulled outside the kubelet and mentioned within the 
+ * `NeverVerifyAllowListedImages`: Images pulled outside the kubelet and mentioned within the
    `preloadedImagesVerificationAllowlist` specified in the kubelet config are not verified.
  * `AlwaysVerify`: All images will have their credentials verified
    before they can be used.
 
 This verification applies to [pre-pulled images](#pre-pulled-images),
-images pulled using node-wide secrets, and images pulled using pod-level secrets.
+images pulled using node-wide secrets, and images pulled using Pod-level secrets.
 
 {{< note >}}
 In the case of credential rotation, the credentials previously used to pull the image
@@ -424,19 +436,19 @@ will require the image to be re-pulled from the registry.
 
 You need to know the username, registry password and client email address for authenticating
 to the registry, as well as its hostname.
-Run the following command, substituting the appropriate uppercase values:
+Run the following command, substituting placeholders with the appropriate values:
 
 ```shell
 kubectl create secret docker-registry <name> \
-  --docker-server=DOCKER_REGISTRY_SERVER \
-  --docker-username=DOCKER_USER \
-  --docker-password=DOCKER_PASSWORD \
-  --docker-email=DOCKER_EMAIL
+  --docker-server=<docker-registry-server> \
+  --docker-username=<docker-user> \
+  --docker-password=<docker-password> \
+  --docker-email=<docker-email>
 ```
 
 If you already have a Docker credentials file then, rather than using the above
 command, you can import the credentials file as a Kubernetes
-{{< glossary_tooltip text="Secrets" term_id="secret" >}}.  
+{{< glossary_tooltip text="Secret" term_id="secret" >}}.
 [Create a Secret based on existing Docker credentials](/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials)
 explains how to set this up.
 
@@ -449,11 +461,11 @@ Pods can only reference image pull secrets in their own namespace,
 so this process needs to be done one time per namespace.
 {{< /note >}}
 
-#### Referring to an imagePullSecrets on a Pod
+#### Referring to `imagePullSecrets` on a Pod
 
-Now, you can create pods which reference that secret by adding an `imagePullSecrets`
+Now, you can create pods which reference that secret by adding the `imagePullSecrets`
 section to a Pod definition. Each item in the `imagePullSecrets` array can only
-reference a Secret in the same namespace.
+reference one Secret in the same namespace.
 
 For example:
 
@@ -478,15 +490,14 @@ resources:
 EOF
 ```
 
-This needs to be done for each pod that is using a private registry.
+This needs to be done for each Pod that is using a private registry.
 
-However, setting of this field can be automated by setting the imagePullSecrets
-in a [ServiceAccount](/docs/tasks/configure-pod-container/configure-service-account/) resource.
-
-Check [Add ImagePullSecrets to a Service Account](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
+However, you can automate this process by specifying the `imagePullSecrets` section
+in a [ServiceAccount](/docs/tasks/configure-pod-container/configure-service-account/)
+resource. See [Add ImagePullSecrets to a Service Account](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
 for detailed instructions.
 
-You can use this in conjunction with a per-node `.docker/config.json`.  The credentials
+You can use this in conjunction with a per-node `.docker/config.json`. The credentials
 will be merged.
 
 ## Use cases
@@ -502,7 +513,7 @@ common use cases and suggested solutions.
 1. Cluster running some proprietary images which should be hidden to those outside the company, but
    visible to all cluster users.
    - Use a hosted private registry
-     - Manual configuration may be required on the nodes that need to access to private registry
+     - Manual configuration may be required on the nodes that need to access to private registry.
    - Or, run an internal private registry behind your firewall with open read access.
      - No Kubernetes configuration is required.
    - Use a hosted container image registry service that controls image access
@@ -511,16 +522,16 @@ common use cases and suggested solutions.
 1. Cluster with proprietary images, a few of which require stricter access control.
    - Ensure [AlwaysPullImages admission controller](/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages)
      is active. Otherwise, all Pods potentially have access to all images.
-   - Move sensitive data into a "Secret" resource, instead of packaging it in an image.
+   - Move sensitive data into a Secret resource, instead of packaging it in an image.
 1. A multi-tenant cluster where each tenant needs own private registry.
    - Ensure [AlwaysPullImages admission controller](/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages)
      is active. Otherwise, all Pods of all tenants potentially have access to all images.
    - Run a private registry with authorization required.
-   - Generate registry credential for each tenant, put into secret, and populate secret to each
-     tenant namespace.
-   - The tenant adds that secret to imagePullSecrets of each namespace.
+   - Generate registry credentials for each tenant, store into a Secret, and propagate
+     the Secret to every tenant namespace.
+   - The tenant then adds that Secret to `imagePullSecrets` of each namespace.
 
-If you need access to multiple registries, you can create one secret for each registry.
+If you need access to multiple registries, you can create one Secret per registry.
 
 ## Legacy built-in kubelet credential provider
 
@@ -538,6 +549,6 @@ you would need to either:
 
 ## {{% heading "whatsnext" %}}
 
-* Read the [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/master/manifest.md).
+* Read the [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md).
 * Learn about [container image garbage collection](/docs/concepts/architecture/garbage-collection/#container-image-garbage-collection).
 * Learn more about [pulling an Image from a Private Registry](/docs/tasks/configure-pod-container/pull-image-private-registry).


### PR DESCRIPTION
### Description

While reviewing #50183, I noticed some missing punctuation in https://k8s.io/docs/concepts/containers/images, as well as some parts that were not following the recommendations described in the [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/). This PR aims to address these points.

### Changes

The following changes were made to this page:
* Updated punctuation to make it consistent across list items.
* Updated wording of API types to use upper camel case.
* Removed unnecessary phrases.
* Included links to content within the same page.
* Fixed grammar and typos in some sentences, including missing periods.
* Updated placeholders to use angle brackets, as described in the style guide.
* Updated the words Windows and Hyper-V to use the exact same spelling used in the product name.
* Removed trailing whitespace.