### PR TITLE
Schedule KEP-3619 blog for publication

### DIFF
--- a/content/en/blog/_posts/XXXX-XX-XX-fine-grained-supplementalgroups-control-beta/index.md
+++ b/content/en/blog/_posts/XXXX-XX-XX-fine-grained-supplementalgroups-control-beta/index.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
 title: 'Kubernetes v1.33: Fine-grained SupplementalGroups Control Graduates to Beta'
-date: 2025-04-23
-draft: true
-slug: fine-grained-supplementalgroups-control-beta
+date: 2025-05-06T10:30:00-08:00
+slug: kubernetes-v1-33-fine-grained-supplementalgroups-control-beta
 author: >
   Shingo Omura (LY Corporation)
 


### PR DESCRIPTION
Schedule KEP-3619 blog for publication on May 6th. Removing the `draft` flag and adding publication date. 