### PR TITLE
Removing Brad Topol's name from the PR Wrangler contact

### DIFF
--- a/content/en/docs/contribute/participate/pr-wranglers.md
+++ b/content/en/docs/contribute/participate/pr-wranglers.md
@@ -132,9 +132,8 @@ The program was introduced to help new contributors understand the PR wrangling 
   to see the PR wrangling schedule for this year and sign up.
 
 - Others can reach out on the [#sig-docs Slack channel](https://kubernetes.slack.com/messages/sig-docs)
-  for requesting to shadow an assigned PR Wrangler for a specific week. Feel free to reach out to
-  Brad Topol (`@bradtopol`) or one of the
-  [SIG Docs co-chairs/leads](https://github.com/kubernetes/community/tree/master/sig-docs#leadership).
+  for requesting to shadow an assigned PR Wrangler for a specific week. Feel free to reach out to one of
+  the [SIG Docs co-chairs/leads](https://github.com/kubernetes/community/tree/master/sig-docs#leadership).
 
 - Once you've signed up to shadow a PR Wrangler, introduce yourself to the PR Wrangler on the
   [Kubernetes Slack](https://slack.k8s.io).


### PR DESCRIPTION
Since Brad is no longer the point of contact for coming up with the PR Wrangling schedule, I am removing his name from the official website to avoid confusion for newer contributors.

cc: @natalisucks @reylejano 