### PR TITLE
[zh-cn] Sync self-healing node-pressure-eviction taint-and-toleration

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/self-healing.md
+++ b/content/zh-cn/docs/concepts/architecture/self-healing.md
@@ -1,12 +1,26 @@
 ---
 title: Kubernetes 自我修复
 content_type: concept  
-Weight: 50  
+weight: 50
+feature:
+  title: 自我修复
+  anchor: 自动化故障恢复
+  description: >
+    Kubernetes 会自动重启崩溃的容器，在必要时替换整个 Pod，
+    在发生更大范围的故障时重新挂载存储，
+    并且能够与节点自动扩缩容器集成，实现节点级别的自我修复能力。
 ---
 <!--
 title: Kubernetes Self-Healing  
 content_type: concept  
-Weight: 50  
+weight: 50
+feature:
+  title: Self-healing
+  anchor: Automated recovery from damage
+  description: >
+    Kubernetes restarts containers that crash, replaces entire Pods where needed,
+    reattaches storage in response to wider failures, and can integrate with
+    node autoscalers to self-heal even at the node level.
 -->
 
 <!-- overview -->

--- a/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -435,11 +435,16 @@ These default values of hard eviction thresholds will only be set if none
 of the parameters is changed. If you change the value of any parameter,
 then the values of other parameters will not be inherited as the default
 values and will be set to zero. In order to provide custom values, you
-should provide all the thresholds respectively.
+should provide all the thresholds respectively. You can also set the kubelet config
+MergeDefaultEvictionSettings to true in the kubelet configuration file.
+If set to true and any paramater is changed, then the other parameters will
+inherit their default values instead of 0.
 -->
 只有在没有更改任何参数的情况下，硬驱逐阈值才会被设置成这些默认值。
 如果你更改了任何参数的值，则其他参数的取值不会继承其默认值设置，而将被设置为零。
 为了提供自定义值，你应该分别设置所有阈值。
+你也可以在 kubelet 配置文件中设置 `mergeDefaultEvictionSettings` 为 `true`。
+如果该值设为 `true`，并且某个参数被修改，则其他参数将继承其默认值，而不是被设为 0。
 
 <!--
 The `containerfs.available` and `containerfs.inodesFree` (Linux nodes) default

--- a/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -578,6 +578,23 @@ arbitrary tolerations to DaemonSets.
 -->
 添加上述容忍度确保了向后兼容，你也可以选择自由向 DaemonSet 添加容忍度。
 
+<!--
+## Device taints and tolerations
+
+Instead of tainting entire nodes, administrators can also [taint individual devices](/docs/concepts/scheduling-eviction/dynamic-resource-allocation#device-taints-and-tolerations)
+when the cluster uses [dynamic resource allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation)
+to manage special hardware. The advantage is that tainting can be targeted towards exactly the hardware that
+is faulty or needs maintenance. Tolerations are also supported and can be specified when requesting
+devices. Like taints they apply to all pods which share the same allocated device.
+-->
+## 设备污点与容忍度    {#device-taints-and-tolerations}
+
+在使用[动态资源分配](/zh-cn/docs/concepts/scheduling-eviction/dynamic-resource-allocation)管理特殊硬件的集群中，
+管理员可以选择[为单个设备设置污点](/zh-cn/docs/concepts/scheduling-eviction/dynamic-resource-allocation#device-taints-and-tolerations)，
+而不是为整个节点打污点。这样做的好处是，污点可以精确地作用于出现故障或需要维护的硬件。
+同时也支持容忍度配置，并且可以在请求设备时指定。
+与污点类似，容忍度会应用于共享同一分配设备的所有 Pod。
+
 ## {{% heading "whatsnext" %}}
 
 <!--


### PR DESCRIPTION
sync
`
content/zh-cn/docs/concepts/architecture/self-healing.md
`
`content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
`
`content/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration.md`