### PR TITLE
Fix grammar in service.md: remove unnecessary article before 'code'

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -186,7 +186,8 @@ supported path types:
 
 * `Exact`: Matches the URL path exactly and with case sensitivity.
 
-* `Prefix`: Matches based on a URL path prefix split by `/`. Matching is case sensitive and done element by element on the path. A path element refers
+* `Prefix`: Matches based on a URL path prefix split by `/`. Matching is case
+  sensitive and done on a path element by element basis. A path element refers
   to the list of labels in the path split by the `/` separator. A request is a
   match for path _p_ if every _p_ is an element-wise prefix of _p_ of the
   request path.

--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -186,8 +186,7 @@ supported path types:
 
 * `Exact`: Matches the URL path exactly and with case sensitivity.
 
-* `Prefix`: Matches based on a URL path prefix split by `/`. Matching is case
-  sensitive and done on a path element by element basis. A path element refers
+* `Prefix`: Matches based on a URL path prefix split by `/`. Matching is case sensitive and done element by element on the path. A path element refers
   to the list of labels in the path split by the `/` separator. A request is a
   match for path _p_ if every _p_ is an element-wise prefix of _p_ of the
   request path.

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -23,7 +23,7 @@ weight: 10
 
 A key aim of Services in Kubernetes is that you don't need to modify your existing
 application to use an unfamiliar service discovery mechanism.
-You can run code in Pods, whether this is a code designed for a cloud-native world, or
+You can run code in Pods, whether this is code designed for a cloud-native world, or
 an older app you've containerized. You use a Service to make that set of Pods available
 on the network so that clients can interact with it.
 

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -23,7 +23,7 @@ weight: 10
 
 A key aim of Services in Kubernetes is that you don't need to modify your existing
 application to use an unfamiliar service discovery mechanism.
-You can run code in Pods, whether this is code designed for a cloud-native world, or
+You can run code in Pods, whether this is code designed for a cloud-native world, or 
 an older app you've containerized. You use a Service to make that set of Pods available
 on the network so that clients can interact with it.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
This PR fixes a minor grammar issue in the Services documentation by removing an unnecessary article ("a") before the word "code."

-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #