### PR TITLE
Upgrade mysql image version to allow multi-arch env

### DIFF
--- a/content/bn/examples/application/mysql/mysql-deployment.yaml
+++ b/content/bn/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -76,7 +76,7 @@ for a secure solution.
      Labels:       app=mysql
      Containers:
        mysql:
-       Image:      mysql:5.6
+       Image:      mysql:9
        Port:       3306/TCP
        Environment:
          MYSQL_ROOT_PASSWORD:      password
@@ -146,7 +146,7 @@ behind a Service and you don't intend to increase the number of Pods.
 Run a MySQL client to connect to the server:
 
 ```shell
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 This command creates a new Pod in the cluster running a MySQL client

--- a/content/en/examples/application/mysql/mysql-deployment.yaml
+++ b/content/en/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/fr/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/fr/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -74,7 +74,7 @@ pour une approche sécurisée.
      Labels:       app=mysql
      Containers:
        mysql:
-       Image:      mysql:5.6
+       Image:      mysql:9
        Port:       3306/TCP
        Environment:
          MYSQL_ROOT_PASSWORD:      password
@@ -146,7 +146,7 @@ d'augmenter le nombre de pods.
 Exécutez un client MySQL pour vous connecter au serveur :
 
 ```shell
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 Cette commande crée un nouveau pod dans le cluster exécutant 

--- a/content/fr/examples/application/mysql/mysql-deployment.yaml
+++ b/content/fr/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/hi/examples/application/mysql/mysql-deployment.yaml
+++ b/content/hi/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/ja/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/ja/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -70,7 +70,7 @@ Kubernetes Deploymentを作成し、PersistentVolumeClaimを使用して既存�
           Labels:       app=mysql
           Containers:
            mysql:
-            Image:      mysql:5.6
+            Image:      mysql:9
             Port:       3306/TCP
             Environment:
               MYSQL_ROOT_PASSWORD:      password
@@ -125,7 +125,7 @@ Serviceのオプションで`clusterIP: None`を指定すると、ServiceのDNS�
 MySQLクライアントを実行してサーバーに接続します。
 
 ```
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 このコマンドは、クラスター内にMySQLクライアントを実行する新しいPodを作成し、Serviceを通じてMySQLサーバーに接続します。

--- a/content/ja/examples/application/mysql/mysql-deployment.yaml
+++ b/content/ja/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/ja/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/ja/examples/application/wordpress/mysql-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/content/ko/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/ko/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -80,7 +80,7 @@ MySQL을 실행하고 퍼시스턴트볼륨클레임을 참조하는 디플로�
           Labels:       app=mysql
           Containers:
            mysql:
-            Image:      mysql:5.6
+            Image:      mysql:9
             Port:       3306/TCP
             Environment:
               MYSQL_ROOT_PASSWORD:      password
@@ -141,7 +141,7 @@ MySQL을 실행하고 퍼시스턴트볼륨클레임을 참조하는 디플로�
 서버에 접속하기 위하여 MySQL 클라이언트를 실행한다.
 
 ```
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 이 명령어는 MySQL 클라이언트를 실행하는 파드를 클러스터에 생성하고, 

--- a/content/ko/examples/application/mysql/mysql-deployment.yaml
+++ b/content/ko/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/ko/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/ko/examples/application/wordpress/mysql-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/content/ru/examples/application/mysql/mysql-deployment.yaml
+++ b/content/ru/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/ru/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/ru/examples/application/wordpress/mysql-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/content/zh-cn/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/zh-cn/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -107,7 +107,7 @@ for a secure solution.
      Labels:       app=mysql
      Containers:
       mysql:
-       Image:      mysql:5.6
+       Image:      mysql:9
        Port:       3306/TCP
        Environment:
          MYSQL_ROOT_PASSWORD:      password
@@ -198,7 +198,7 @@ Run a MySQL client to connect to the server:
 运行 MySQL 客户端以连接到服务器：
 
 ```shell
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 <!--

--- a/content/zh-cn/examples/application/mysql/mysql-deployment.yaml
+++ b/content/zh-cn/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # 在实际中使用 secret


### PR DESCRIPTION
The `Run a Single-Instance Stateful Application` tutorial uses an old version of mysql that does not provide an ARM version of the image.

I've upgraded the version of the image used as this is as simple as that to make it work on newest macbook pro. 

This is an effort of #45822 

Without this : 
```bash
➜ kubectl describe pods -l app=mysql | grep image
  Normal   Pulling    3s    kubelet            Pulling image "mysql:5.6"
  Warning  Failed     1s    kubelet            Failed to pull image "mysql:5.6": no matching manifest for linux/arm64/v8 in the manifest list entries
```


With this : 

```bash
➜ kubectl describe pods -l app=mysql | grep image
  Normal  Pulling    70s   kubelet            Pulling image "mysql:9"
  Normal  Pulled     69s   kubelet            Successfully pulled image "mysql:9" in 1.059s (1.059s including waiting). Image size: 876227616 bytes.
```

The rest of the service declaration is fine: 

```bash
➜ kubectl get pods -l app=mysql
NAME                     READY   STATUS    RESTARTS      AGE
mysql-6c7c777b75-vr7lt   1/1     Running   0             29s
```
