### PR TITLE
cluster trust bundles: use correct version/feature maturity stage

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -378,7 +378,7 @@ you like. If you want to add a note for human consumption, use the
 
 ## Cluster trust bundles {#cluster-trust-bundles}
 
-{{< feature-state for_k8s_version="v1.27" state="alpha" >}}
+{{< feature-state feature_gate_name="ClusterTrustBundle" >}}
 
 {{< note >}}
 In Kubernetes {{< skew currentVersion >}}, you must enable the `ClusterTrustBundle`
@@ -484,7 +484,7 @@ signer-unlinked ClusterTrustBundles **must not** contain a colon (`:`).
 
 ### Accessing ClusterTrustBundles from pods {#ctb-projection}
 
-{{<feature-state for_k8s_version="v1.29" state="alpha" >}}
+{{< feature-state feature_gate_name="ClusterTrustBundleProjection" >}}
 
 The contents of ClusterTrustBundles can be injected into the container filesystem, similar to ConfigMaps and Secrets.
 See the [clusterTrustBundle projected volume source](/docs/concepts/storage/projected-volumes#clustertrustbundle) for more details.


### PR DESCRIPTION
### Description

The ClusterTrustBundles were being documented as alpha in some parts of the documentation.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Related-to: https://github.com/kubernetes/enhancements/issues/3257#issuecomment-2856617519