### PR TITLE
Use HorizontalPodAutoscaler when referring to the API object in 2024-04-28 HPA blog post

### DIFF
--- a/content/en/blog/_posts/2025-04-28-hpa-configurable-tolerance.md
+++ b/content/en/blog/_posts/2025-04-28-hpa-configurable-tolerance.md
@@ -18,7 +18,7 @@ automatically resize by adding or removing replicas based on resource
 utilization.
 
 Let's say you have a web application running in a Kubernetes cluster with 50
-replicas. You configure the Horizontal Pod Autoscaler (HPA) to scale based on
+replicas. You configure the HorizontalPodAutoscaler (HPA) to scale based on
 CPU utilization, with a target of 75% utilization. Now, imagine that the current
 CPU utilization across all replicas is 90%, which is higher than the desired
 75%. The HPA will calculate the required number of replicas using the formula:


### PR DESCRIPTION
**Description**

This pull request updates the term "Horizontal Pod Autoscaler" to "HorizontalPodAutoscaler" in the 2024-05-07 blog post to use the correct Kubernetes API object name when referring to the resource.

The update ensures consistency with how other Kubernetes resource kinds are written (e.g., Deployment, StatefulSet) and avoids ambiguity between the general concept and the actual object.

**Issue**

/close #50835 