### PR TITLE
KEP-3998: Updated slug, removed draft status and updated publish date

### DIFF
--- a/content/en/blog/_posts/2025-04-23-jobs-successpolicy-goes-ga.md
+++ b/content/en/blog/_posts/2025-04-23-jobs-successpolicy-goes-ga.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
-title: "Kubernetes 1.33: Job's SuccessPolicy Goes GA"
-date: 2025-04-23
-draft: true
-slug: kubernetes-1-33-jobs-success-policy-goes-ga
+title: "Kubernetes v1.33: Job's SuccessPolicy Goes GA"
+date: 2025-05-16T10:30:00-08:00
+slug: kubernetes-v1-33-jobs-success-policy-goes-ga
 authors: >
   [Yuki Iwai](https://github.com/tenzen-y) (CyberAgent, Inc)
 ---


### PR DESCRIPTION
This schedules https://github.com/kubernetes/website/pull/49998 for publication on 16th May, 2025.