### PR TITLE
Fix config API reference

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-config.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1.md
@@ -72,8 +72,8 @@ Must be at least one.</p>
 
 <p>EncryptionConfiguration stores the complete configuration for encryption providers.
 It also allows the use of wildcards to specify the resources that should be encrypted.
-Use '<em>.<!-- raw HTML omitted -->' to encrypt all resources within a group or '</em>.<em>' to encrypt all resources.
-'</em>.' can be used to encrypt all resource in the core group.  '<em>.</em>' will encrypt all
+Use '&ast;.&lt;group&gt;' to encrypt all resources within a group or '&ast;.&ast;' to encrypt all resources.
+'&ast;.' can be used to encrypt all resource in the core group.  '&ast;.&ast;' will encrypt all
 resources, even custom resources that are added after API server start.
 Use of wildcards that overlap within the same resource list or across multiple
 entries are not allowed since part of the configuration would be ineffective.
@@ -426,8 +426,8 @@ Set to a negative value to disable caching. This field is only allowed for KMS v
 <td>
    <p>resources is a list of kubernetes resources which have to be encrypted. The resource names are derived from <code>resource</code> or <code>resource.group</code> of the group/version/resource.
 eg: pandas.awesome.bears.example is a custom resource with 'group': awesome.bears.example, 'resource': pandas.
-Use '<em>.</em>' to encrypt all resources and '<em>.<!-- raw HTML omitted -->' to encrypt all resources in a specific group.
-eg: '</em>.awesome.bears.example' will encrypt all resources in the group 'awesome.bears.example'.
+Use '&ast;.&ast;' to encrypt all resources and '&ast;.&lt;group&gt;' to encrypt all resources in a specific group.
+eg: '&ast;.awesome.bears.example' will encrypt all resources in the group 'awesome.bears.example'.
 eg: '*.' will encrypt all resources in the core group (such as pods, configmaps, etc).</p>
 </td>
 </tr>

--- a/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
@@ -398,7 +398,7 @@ The claim's value must be a singular string.
 Same as the --oidc-username-claim and --oidc-username-prefix flags.
 If username.expression is set, the expression must produce a string value.
 If username.expression uses 'claims.email', then 'claims.email_verified' must be used in
-username.expression or extra[<em>].valueExpression or claimValidationRules[</em>].expression.
+username.expression or extra[&ast;].valueExpression or claimValidationRules[<&ast;>].expression.
 An example claim validation rule expression that matches the validation automatically
 applied when username.claim is set to 'email' is 'claims.?email_verified.orValue(true) == true'. By explicitly comparing
 the value to true, we let type-checking see the result will be a boolean, and to make sure a non-boolean email_verified

--- a/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
@@ -331,7 +331,7 @@ The claim's value must be a singular string.
 Same as the --oidc-username-claim and --oidc-username-prefix flags.
 If username.expression is set, the expression must produce a string value.
 If username.expression uses 'claims.email', then 'claims.email_verified' must be used in
-username.expression or extra[<em>].valueExpression or claimValidationRules[</em>].expression.
+username.expression or extra[&ast;].valueExpression or claimValidationRules[&ast;].expression.
 An example claim validation rule expression that matches the validation automatically
 applied when username.claim is set to 'email' is 'claims.?email_verified.orValue(true) == true'. By explicitly comparing
 the value to true, we let type-checking see the result will be a boolean, and to make sure a non-boolean email_verified

--- a/content/en/docs/reference/config-api/kubelet-config.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1.md
@@ -81,7 +81,7 @@ to provide credentials. Images are expected to contain the registry domain
 and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
 Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
 a single subdomain segment, so *.io does not match *.k8s.io.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
@@ -93,9 +93,9 @@ a single subdomain segment, so *.io does not match *.k8s.io.</p>
 <p>Example values of matchImages:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -639,7 +639,7 @@ can be used without reverifying pull credentials</li>
    <p>preloadedImagesVerificationAllowlist specifies a list of images that are
 exempted from credential reverification for the &quot;NeverVerifyAllowlistedImages&quot;
 <code>imagePullCredentialsVerificationPolicy</code>.
-The list accepts a full path segment wildcard suffix &quot;/*&quot;.
+The list accepts a full path segment wildcard suffix &quot;/&ast;&quot;.
 Only use image specs without an image tag or digest.</p>
 </td>
 </tr>
@@ -1795,9 +1795,9 @@ to provide credentials. Images are expected to contain the registry domain
 and URL path.</p>
 <p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so *.io does not match *.k8s.io.</p>
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so '&ast;.io' does not match '&ast;.k8s.io'.</p>
 <p>A match exists between an image and a matchImage when all of the below are true:</p>
 <ul>
 <li>Both contain the same number of domain parts and each part matches.</li>
@@ -1807,9 +1807,9 @@ a single subdomain segment, so *.io does not match *.k8s.io.</p>
 <p>Example values of matchImages:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>

--- a/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
+++ b/content/en/docs/reference/config-api/kubelet-credentialprovider.v1.md
@@ -108,8 +108,8 @@ should be valid for all images that match against this key. A plugin should set
 this field to null if no valid credentials can be returned for the requested image.</p>
 <p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
-Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
+as subdomains like '&ast;.k8s.io' or 'k8s.&ast;.io', and top-level-domains such as 'k8s.&ast;'.
+Matching partial subdomains like 'app&ast;.k8s.io' is also supported. Each glob can only match
 a single subdomain segment, so *.io does not match *.k8s.io.</p>
 <p>The kubelet will match images against the key when all of the below are true:</p>
 <ul>
@@ -127,9 +127,9 @@ stopping after the first successfully authenticated pull.</p>
 <p>Example keys:</p>
 <ul>
 <li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
-<li>*.azurecr.io</li>
+<li>&ast;.azurecr.io</li>
 <li>gcr.io</li>
-<li><em>.</em>.registry.io</li>
+<li>&ast;.&ast;.registry.io</li>
 <li>registry.io:8080/path</li>
 </ul>
 </td>


### PR DESCRIPTION
Some of the config API references contain strings that are not properly escaped. These could have been fixed in the upstream source code in the future, because the generator cannot properly handle them.
