### PR TITLE
Link to Latest CNCF CoC Instead of Commit Hash

### DIFF
--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -6,11 +6,9 @@ cid: code-of-conduct
 
 _Kubernetes follows the
 [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
-The text of the CNCF CoC is replicated below, as of
-[commit 71412bb02](https://github.com/cncf/foundation/blob/71412bb029090d42ecbeadb39374a337bfb48a9c/code-of-conduct.md)._
 
 <div id="cncf-code-of-conduct">
-{{< include "static/cncf-code-of-conduct.md" >}}
+{{< cncf-coc >}}
 </div>
 
 ---

--- a/layouts/shortcodes/cncf-coc.html
+++ b/layouts/shortcodes/cncf-coc.html
@@ -1,0 +1,15 @@
+{{/*
+remote-coc shortcode: Fetches remote Markdown, cleans up 'Other languages' section, renders as HTML
+*/}}
+
+{{ $url := "https://raw.githubusercontent.com/cncf/foundation/main/code-of-conduct.md" }}
+{{ with resources.GetRemote $url }}
+    {{ $raw := .Content }}
+    {{ $clean := replaceRE "(?ms)^Other languages available:\\s*\\n(?:- .+\\n)*- \\[Vietnamese/Tiếng Việt\\]\\(code-of-conduct-languages/vi\\.md\\)\\n*" "" $raw }}
+    {{ $html := $clean | markdownify }}
+    {{ $html }}
+{{ else }}
+    {{ warnf "remote-coc shortcode: Failed to fetch remote resource from %s" $url }}
+    <p><em>Content temporarily unavailable. Please try again later.</em></p>
+{{ end }}
+    


### PR DESCRIPTION

### Description

Right now, the Kubernetes CoC inherits the CNCF CoC. We place the content of the CNCF CoC in a static folder and source it from there, which means that every time the CNCF CoC is updated, we need to raise a PR updating the CoC on the Kubernetes side in the static folders.

### Issue

Now using the hugo function resources.GetRemote we can get the CNCF CoC content during the hugo build. No need to create new PRs everytime CNCF CoC is updated.

Closes: #49595 