### PR TITLE
Sync encryption docs reviewers with kubernetes sig-auth-encryption-at-rest-reviewers

### DIFF
--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -1,7 +1,7 @@
 ---
 title: Encrypting Confidential Data at Rest
 reviewers:
-- smarterclayton
+- aramase
 - enj
 content_type: task
 weight: 210

--- a/content/en/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kms-provider.md
@@ -1,6 +1,6 @@
 ---
 reviewers:
-- smarterclayton
+- aramase
 - enj
 title: Using a KMS provider for data encryption
 content_type: task


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/blob/7017be7b0823ce56de2d4c78e402931ec817d3be/OWNERS_ALIASES#L57C2-L59

/sig auth
/assign enj