### PR TITLE
[vi] add configmap, image and volume glossary

### DIFF
--- a/content/vi/docs/reference/glossary/configmap.md
+++ b/content/vi/docs/reference/glossary/configmap.md
@@ -1,0 +1,20 @@
+---
+title: ConfigMap
+id: configmap
+date: 2018-04-12
+full_link: /docs/concepts/configuration/configmap/
+short_description: >
+  Một đối tượng API được sử dụng để lưu trữ dữ liệu không bảo mật trong cặp giá trị key-value. Có thể được dùng như các biến môi trường, các tham số dòng lệnh, hoặc các file cấu hình trong một volume.
+
+aka:
+tags:
+- core-object
+---
+ Một đối tượng API được sử dụng để lưu trữ dữ liệu không bảo mật trong cặp giá trị key-value.
+Các {{< glossary_tooltip text="Pod" term_id="pod" >}} có thể dùng các ConfigMap như
+các biến môi trường, các tham số dòng lệnh, hoặc các file cấu hình trong một
+{{< glossary_tooltip text="volume" term_id="volume" >}}.
+
+<!--more-->
+
+Một ConfigMap cho phép bạn tách rời cấu hình môi trường cụ thể khỏi các {{< glossary_tooltip text="container image" term_id="image" >}} của bạn, nhờ đó các ứng dụng của bạn có thể có khả năng di động dễ dàng.

--- a/content/vi/docs/reference/glossary/image.md
+++ b/content/vi/docs/reference/glossary/image.md
@@ -1,0 +1,17 @@
+---
+title: Image
+id: image
+date: 2018-04-12
+full_link:
+short_description: >
+  Lưu trữ instance của một container chứa một tập hợp các phần mềm cần thiết để chạy một ứng dụng.
+
+aka:
+tags:
+- fundamental
+---
+ Lưu trữ instance của một {{< glossary_tooltip term_id="container" >}} chứa một tập hợp các phần mềm cần thiết để chạy một ứng dụng.
+
+<!--more-->
+
+Một cách đóng gói phần mềm cho phép nó được lưu trữ trong một container registry, được pull về một hệ thống cục bộ, và chạy như một ứng dụng. Siêu dữ liệu được chứa trong image có thể chỉ ra những gì có thể chạy được, ai đã build nó, và những thông tin khác.

--- a/content/vi/docs/reference/glossary/volume.md
+++ b/content/vi/docs/reference/glossary/volume.md
@@ -1,0 +1,19 @@
+---
+title: Volume
+id: volume
+date: 2018-04-12
+full_link: /docs/concepts/storage/volumes/
+short_description: >
+  Một thư mục chứa dữ liệu, có thể truy cập tới các container trong một pod.
+
+aka:
+tags:
+- fundamental
+---
+ Một thư mục chứa dữ liệu, có thể truy cập tới các {{< glossary_tooltip text="container" term_id="container" >}} trong một {{< glossary_tooltip term_id="pod" >}}.
+
+<!--more-->
+
+Một Kubernetes volume tồn tại cùng với Pod bao quanh nó. Do đó, một volume tồn tại lâu hơn bất kỳ container nào chạy trong Pod, và dữ liệu trong volume được bảo toàn qua các lần container tái khởi động.
+
+Xem [kho lưu trữ](/docs/concepts/storage/) để biết thêm thông tin.


### PR DESCRIPTION
### Description
Hi @truongnh1992 , I added 3 glossaries: `configmap`, `image` and `volume`.
Here are some links will help you review this PR:
- [K8s docs live website](https://kubernetes.io/docs/reference/glossary/?core-object=true&fundamental=true)
- EN md files:
  - [configmap.md](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/configmap.md?plain=1)
  - [image.md](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/image.md?plain=1)
  - [volume.md](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/volume.md?plain=1)
  
  cc @khanhtc1202 , @ntheanh201 