### PR TITLE
Update ingress-nginx release links in 2024/03/24 security blog post for clarity

### DIFF
--- a/content/en/blog/_posts/2025-03-24-ingress-nginx-CVE-2025-1974.md
+++ b/content/en/blog/_posts/2025-03-24-ingress-nginx-CVE-2025-1974.md
@@ -7,7 +7,7 @@ author: >
   Tabitha Sable (Kubernetes Security Response Committee)
 ---
 
-Today, the ingress-nginx maintainers have [released patches for a batch of critical vulnerabilities](https://github.com/kubernetes/ingress-nginx/releases) that could make it easy for attackers to take over your Kubernetes cluster. If you are among the over 40% of Kubernetes administrators using [ingress-nginx](https://github.com/kubernetes/ingress-nginx/), you should take action immediately to protect your users and data.
+Today, the ingress-nginx maintainers have released patches for a batch of critical vulnerabilities that could make it easy for attackers to take over your Kubernetes cluster: [ingress-nginx v1.12.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.1) and [ingress-nginx v1.11.5](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.11.5). If you are among the over 40% of Kubernetes administrators using [ingress-nginx](https://github.com/kubernetes/ingress-nginx/), you should take action immediately to protect your users and data.
 
 ## Background
 
@@ -23,7 +23,7 @@ Four of today’s ingress-nginx vulnerabilities are improvements to how ingress-
 
 The most serious of today’s vulnerabilities, [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009), rated [9.8 CVSS](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H), allows anything on the Pod network to exploit configuration injection vulnerabilities via the Validating Admission Controller feature of ingress-nginx. This makes such vulnerabilities far more dangerous: ordinarily one would need to be able to create an Ingress object in the cluster, which is a fairly privileged action. When combined with today’s other vulnerabilities, **CVE-2025-1974 means that anything on the Pod network has a good chance of taking over your Kubernetes cluster, with no credentials or administrative access required**. In many common scenarios, the Pod network is accessible to all workloads in your cloud VPC, or even anyone connected to your corporate network\! This is a very serious situation.
 
-Today, we have [released ingress-nginx v1.12.1 and v1.11.5](https://github.com/kubernetes/ingress-nginx/releases), which have fixes for all five of these vulnerabilities.
+Today, we have released [ingress-nginx v1.12.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.1) and [ingress-nginx v1.11.5](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.11.5), which have fixes for all five of these vulnerabilities.
 
 ## Your next steps
 

--- a/content/en/blog/_posts/2025-03-24-ingress-nginx-CVE-2025-1974.md
+++ b/content/en/blog/_posts/2025-03-24-ingress-nginx-CVE-2025-1974.md
@@ -52,3 +52,5 @@ Thanks go out to Nir Ohfeld, Sagi Tzadik, Ronen Shustin, and Hillai Ben-Sasson f
 For further information about the maintenance and future of ingress-nginx, please see this [GitHub issue](https://github.com/kubernetes/ingress-nginx/issues/13002) and/or attend [James and Marco’s KubeCon/CloudNativeCon EU 2025 presentation](https://kccnceu2025.sched.com/event/1tcyc/).
 
 For further information about the specific vulnerabilities discussed in this article, please see the appropriate GitHub issue: [CVE-2025-24513](https://github.com/kubernetes/kubernetes/issues/131005), [CVE-2025-24514](https://github.com/kubernetes/kubernetes/issues/131006), [CVE-2025-1097](https://github.com/kubernetes/kubernetes/issues/131007), [CVE-2025-1098](https://github.com/kubernetes/kubernetes/issues/131008), or [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009)
+
+*This blog post was revised in May 2025 to update the hyperlinks.*


### PR DESCRIPTION
### Description
This PR updates the release note links in the 2024/03/24 ingress-nginx security blog post to point to specific release tags instead of the generic releases page.
This improves user experience by allowing readers to navigate directly to the relevant release information without manual searching.

### Issue
Closes: #50834 

### Notes
I apologize for submitting this PR before the issue was formally triaged.
Please let me know if you'd like any changes to the approach or if you'd prefer to wait for the issue triage before proceeding with the review.