### PR TITLE
[ja] added a note about pod rejection released on KEP-3619(Beta) in content/ja/docs/tasks/configure-pod-container/security-context.md

### DIFF
--- a/content/ja/docs/tasks/configure-pod-container/security-context.md
+++ b/content/ja/docs/tasks/configure-pod-container/security-context.md
@@ -298,6 +298,25 @@ status:
     supplementalGroupsPolicy: true
 ```
 
+{{<note>}}
+アルファリリース(v1.31, v1.32)では、`SupplementalGroupsPolicy=Strict`を指定されたPodが、この機能をサポートされていないノード(`.status.features.supplementalGroupsPolicy=false`なノード)にスケジュールされた場合、そのPodのSupplementalGroupsPolicyは`Merge`に暗黙的にフォールバックされていました。
+
+しかし、ベータリリース(v1.33)以降は、ポリシーをより厳格に強制するため、そのようなPodの作成は、ノードによるポリシーの強制が不可能なためkubeletによって拒否されます。Podの作成が拒否された場合、下記のような`reason=SupplementalGroupsPolicyNotSupported`を持つWarningイベントが作成されます。
+
+```yaml
+apiVersion: v1
+kind: Event
+...
+type: Warning
+reason: SupplementalGroupsPolicyNotSupported
+message: "SupplementalGroupsPolicy=Strict is not supported in this node"
+involvedObject:
+  apiVersion: v1
+  kind: Pod
+  ...
+```
+{{</note>}}
+
 ## Podのボリュームパーミッションと所有権変更ポリシーを設定する
 
 {{< feature-state for_k8s_version="v1.23" state="stable" >}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Added a note about pod rejection released on KEP-3619(Beta) in content/ja/docs/tasks/configure-pod-container/security-context.md

related PRs of `en` contents: 
- https://github.com/kubernetes/website/pull/49880

Preview: https://deploy-preview-50877--kubernetes-io-main-staging.netlify.app/ja/docs/tasks/configure-pod-container/security-context/#implementations-supplementalgroupspolicy

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
