### PR TITLE
remove duplicate table row in cel.md

### DIFF
--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -123,11 +123,6 @@ introduced at the specified Kubernetes versions:
 </thead>
 <tbody>
 <tr>
-  <td>CEL option, library or language feature</td>
-  <td>Included</td>
-  <td>Availablity</td>
-</tr>
-<tr>
   <td><a href="https://github.com/google/cel-spec/blob/v0.7.0/doc/langdef.md#macros">Standard macros</a></td>
   <td><code>has</code>, <code>all</code>, <code>exists</code>, <code>exists_one</code>, <code>map</code>, <code>filter</code></td>
   <td>All Kubernetes versions</td>


### PR DESCRIPTION
### Description

CEL options, features, and libraries table contains a row in the table body that is a duplicate of the table header:
<img width="894" alt="image" src="https://github.com/user-attachments/assets/aada11e1-c31c-4721-a4eb-0eecfbb51795" />
