### PR TITLE
docs: use latest API syntax in JavaScript client example

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -353,8 +353,8 @@ kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-k8sApi.listNamespacedPod('default').then((res) => {
-    console.log(res.body);
+k8sApi.listNamespacedPod({ namespace: 'default' }).then((res) => {
+    console.log(res);
 });
 ```
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The previous example in the documentation used an outdated syntax for the Kubernetes JavaScript client. This update replaces:

  `listNamespacedPod('default')`

with the correct and current usage:

  `listNamespacedPod({ namespace: 'default' })`

as referenced in the official kubernetes-client/javascript repository. This change ensures that the example works with the latest version of the client library and avoids potential runtime errors.


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #50729 