### PR TITLE
Bump up schedule of blogs ready to publish

### DIFF
--- a/content/en/blog/_posts/2025-05-13-jobs-backofflimitperindex-goes-ga.md
+++ b/content/en/blog/_posts/2025-05-13-jobs-backofflimitperindex-goes-ga.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.33: Job's Backoff Limit Per Index Goes GA"
-date: 2025-04-23
-draft: true
+date: 2025-05-13T10:30:00-08:00
 slug: kubernetes-v1-33-jobs-backoff-limit-per-index-goes-ga
 author: >
   [Michał Woźniak](https://github.com/mimowo) (Google)
@@ -12,7 +11,7 @@ In Kubernetes v1.33, the _Backoff Limit Per Index_ feature reaches general
 availability (GA). This blog describes the Backoff Limit Per Index feature and
 its benefits.
 
-## About Backoff Limit Per Index
+## About backoff limit per index
 
 When you run workloads on Kubernetes, you must consider scenarios where Pod
 failures can affect the completion of your workloads. Ideally, your workload
@@ -31,10 +30,10 @@ In that setup, a fast-failing index  (test suite) is likely to consume your
 entire budget for tolerating Pod failures, and you might not be able to run the
 other indexes.
 
-In order to address this limitation, we introduce _Backoff Limit Per Index_,
+In order to address this limitation, Kubernetes introduced _backoff limit per index_,
 which allows you to control the number of retries per index.
 
-## How Backoff Limit Per Index works
+## How backoff limit per index works
 
 To use Backoff Limit Per Index for Indexed Jobs, specify the number of tolerated
 Pod failures per index with the `spec.backoffLimitPerIndex` field. When you set
@@ -46,15 +45,15 @@ Additionally, to fine-tune the error handling:
   terminated.
 * Define a short-circuit to detect a failed index by using the `FailIndex` action in the
   [Pod Failure Policy](/docs/concepts/workloads/controllers/job/#pod-failure-policy)
-  feature.
+  mechanism.
 
 When the number of tolerated failures is exceeded, the Job marks that index as
 failed and lists it in the Job's `status.failedIndexes` field.
 
 ### Example
 
-The following Job spec snippet is an example of how to combine Backoff Limit Per
-Index with the _Pod Failure Policy_ feature:
+The following Job spec snippet is an example of how to combine backoff limit per
+index with the _Pod Failure Policy_ feature:
 
 ```yaml
 completions: 10
@@ -98,7 +97,7 @@ In this example, the Job handles Pod failures as follows:
 
 ## Get involved
 
-This work was sponsored by
+This work was sponsored by the Kubernetes
 [batch working group](https://github.com/kubernetes/community/tree/master/wg-batch)
 in close collaboration with the
 [SIG Apps](https://github.com/kubernetes/community/tree/master/sig-apps) community.

--- a/content/en/blog/_posts/2025-05-14-Container-Stop-Signals.md
+++ b/content/en/blog/_posts/2025-05-14-Container-Stop-Signals.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.33: Updates to Container Lifecycle in Kubernetes v1.33"
-date: 2025-05-15T10:30:00-08:00
+date: 2025-05-14T10:30:00-08:00
 slug: kubernetes-v1-33-updates-to-container-lifecycle
 author: >
   Sreeram Venkitesh (DigitalOcean)

--- a/content/en/blog/_posts/2025-05-15-jobs-successpolicy-goes-ga.md
+++ b/content/en/blog/_posts/2025-05-15-jobs-successpolicy-goes-ga.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes 1.33: Job's SuccessPolicy Goes GA"
-date: 2025-04-23
-draft: true
+date: 2025-05-15T10:30:00-08:00
 slug: kubernetes-1-33-jobs-success-policy-goes-ga
 authors: >
   [Yuki Iwai](https://github.com/tenzen-y) (CyberAgent, Inc)

--- a/content/en/blog/_posts/2025-05-16-in-place-pod-resize-beta.md
+++ b/content/en/blog/_posts/2025-05-16-in-place-pod-resize-beta.md
@@ -1,8 +1,8 @@
 ---
 layout: blog
 title: "Kubernetes v1.33: In-Place Pod Resize Graduating to Beta"
-slug: in-place-pod-resize-beta
-date: 2025-05-19T10:30:00-08:00
+slug: kubernetes-v1-33-in-place-pod-resize-beta
+date: 2025-05-16T10:30:00-08:00
 author: "Tim Allclair (Google)"
 ---
 


### PR DESCRIPTION
This updates the following blogs

- KEP-3850: to be published on Tuesday, 13th May ([original PR](https://github.com/kubernetes/website/pull/49982))
- KEP-4960: to be published on Wednesday, 14th May ([original PR](https://github.com/kubernetes/website/pull/49967))
- KEP-3998: to be published on Thursday, 15th May ([original PR](https://github.com/kubernetes/website/pull/49998))
- KEP-1287: to be published on Friday, 16th May ([original PR](https://github.com/kubernetes/website/pull/50024))

For KEP-3850, there are also a few wording updates that were mentioned in the original PR.