### PR TITLE
Replace deprecated API version of `kubescheduler.config.k8s.io` in `my-scheduler.yaml`.

### DIFF
--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -51,7 +51,7 @@ metadata:
   namespace: kube-system
 data:
   my-scheduler-config.yaml: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     profiles:
       - schedulerName: my-scheduler


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

When the example file [examples/admin/sched/my-scheduler.yaml](https://github.com/kubernetes/website/blob/main/content/en/examples/admin/sched/my-scheduler.yaml) is used as is, I see the following error which indicates that the deprecated API version is not recognized:

```
"command failed" err="no kind \"KubeSchedulerConfiguration\" is registered for version \"kubescheduler.config.k8s.io/v1beta2\" in scheme \"pkg/runtime/scheme.go:110\""
```

Replace deprecated API version `kubescheduler.config.k8s.io/v1beta2` with `kubescheduler.config.k8s.io/v1` so the example can be directly run without modifications.
