### PR TITLE
[en] add note about immutable secret issue

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -638,6 +638,10 @@ Existing Pods maintain a mount point to the deleted Secret - it is recommended t
 these pods.
 {{< /note >}}
 
+{{< note >}}
+There have been reports of an issue where, after deleting and recreating an immutable secret, some pods that are started after the recreation may mount the previous secret. For more details, please see [here](https://github.com/kubernetes/kubernetes/issues/131589).
+{{< /note >}}
+
 ## Information security for Secrets
 
 Although ConfigMap and Secret work similarly, Kubernetes applies some additional


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

There has been an issue where immutable secrets aren't refreshed when they are recreated. I've added documentation to inform readers about this issue.
https://github.com/kubernetes/kubernetes/issues/131589

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #