### PR TITLE
[ko] use latest API syntax in JavaScript client example

### DIFF
--- a/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
@@ -326,8 +326,8 @@ kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-k8sApi.listNamespacedPod('default').then((res) => {
-    console.log(res.body);
+k8sApi.listNamespacedPod({ namespace: 'default' }).then((res) => {
+  console.log(res);
 });
 ```
 


### PR DESCRIPTION
https://github.com/kubernetes/website/pull/50887/files