### PR TITLE
Fix broken link in container images concept

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -423,7 +423,7 @@ which previously resulted in a successful image pull will not need to re-pull fr
 the registry and are instead validated locally without accessing the registry
 (provided the image is available locally).
 This is controlled by the`imagePullCredentialsVerificationPolicy` field in the
-[Kubelet configuration](/docs/reference/config-api/kubelet-config.v1beta1#ImagePullCredentialsVerificationPolicy).
+[Kubelet configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#imagepullcredentialsverificationpolicy).
 
 This configuration controls when image pull credentials must be verified if the
 image is already present on the node:

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -423,7 +423,7 @@ which previously resulted in a successful image pull will not need to re-pull fr
 the registry and are instead validated locally without accessing the registry
 (provided the image is available locally).
 This is controlled by the`imagePullCredentialsVerificationPolicy` field in the
-[Kubelet configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#imagepullcredentialsverificationpolicy).
+[Kubelet configuration](/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-ImagePullCredentialsVerificationPolicy).
 
 This configuration controls when image pull credentials must be verified if the
 image is already present on the node:


### PR DESCRIPTION
This is controlled by the`imagePullCredentialsVerificationPolicy` field in the

[Kubelet configuration](/docs/reference/config-api/kubelet-config.v1beta1#ImagePullCredentialsVerificationPolicy).

to 

[Kubelet configuration]https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#imagepullcredentialsverificationpolicy

#correction - 

[Kubelet configuration](/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-ImagePullCredentialsVerificationPolicy).

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
imagePullCredentialsVerificationPolicy field is missing in the /docs/reference/config-api/kubelet-config.v1beta1
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #50681