### PR TITLE
Upgrade mysql image version to allow multi-arch env

### DIFF
--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -76,7 +76,7 @@ for a secure solution.
      Labels:       app=mysql
      Containers:
        mysql:
-       Image:      mysql:5.6
+       Image:      mysql:9
        Port:       3306/TCP
        Environment:
          MYSQL_ROOT_PASSWORD:      password
@@ -146,7 +146,7 @@ behind a Service and you don't intend to increase the number of Pods.
 Run a MySQL client to connect to the server:
 
 ```shell
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 This command creates a new Pod in the cluster running a MySQL client

--- a/content/en/examples/application/mysql/mysql-deployment.yaml
+++ b/content/en/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage


### PR DESCRIPTION
The `Run a Single-Instance Stateful Application` tutorial uses an old version of mysql that does not provide an ARM version of the image.  
**This pull request includes changes only for the EN version of the website, while MR  #50822  contains changes for all languages**

--- 

I've upgraded the version of the image used as this is as simple as that to make it work on newest macbook pro. 

This is an effort of #45822 

Without this : 
```bash
➜ kubectl describe pods -l app=mysql | grep image
  Normal   Pulling    3s    kubelet            Pulling image "mysql:5.6"
  Warning  Failed     1s    kubelet            Failed to pull image "mysql:5.6": no matching manifest for linux/arm64/v8 in the manifest list entries
```


With this : 

```bash
➜ kubectl describe pods -l app=mysql | grep image
  Normal  Pulling    70s   kubelet            Pulling image "mysql:9"
  Normal  Pulled     69s   kubelet            Successfully pulled image "mysql:9" in 1.059s (1.059s including waiting). Image size: 876227616 bytes.
```

The rest of the service declaration is fine: 

```bash
➜ kubectl get pods -l app=mysql
NAME                     READY   STATUS    RESTARTS      AGE
mysql-6c7c777b75-vr7lt   1/1     Running   0             29s
```