### PR TITLE
fixes - sidecar containers graduated to stable  in 1.33

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 <!-- overview -->
-{{< feature-state for_k8s_version="v1.29" state="beta" >}}
+{{< feature-state feature_gate_name="SidecarContainers" >}}
 
 Sidecar containers are the secondary containers that run along with the main
 application container within the same {{< glossary_tooltip text="Pod" term_id="pod" >}}.


### PR DESCRIPTION
According to [documentation](https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/#stable-sidecar-containers), sidecar containers is now stable