### PR TITLE
[hi] Sync run-single-instance-stateful-application.md Upgrade mysql image

### DIFF
--- a/content/hi/examples/application/mysql/mysql-deployment.yaml
+++ b/content/hi/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage


### PR DESCRIPTION
The `Run a Single-Instance Stateful Application` tutorial uses an old version of mysql that does not provide an ARM version of the image.  
**This pull request includes changes only for the HI version of the website, now MR #50991 (EN version change)  has been accepted**

See #50991 for more info about the change itself.