### PR TITLE
[JA] Sync run-single-instance-stateful-application.md Upgrade mysql image

### DIFF
--- a/content/ja/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/ja/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -70,7 +70,7 @@ Kubernetes Deploymentを作成し、PersistentVolumeClaimを使用して既存�
           Labels:       app=mysql
           Containers:
            mysql:
-            Image:      mysql:5.6
+            Image:      mysql:9
             Port:       3306/TCP
             Environment:
               MYSQL_ROOT_PASSWORD:      password
@@ -125,7 +125,7 @@ Serviceのオプションで`clusterIP: None`を指定すると、ServiceのDNS�
 MySQLクライアントを実行してサーバーに接続します。
 
 ```
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 このコマンドは、クラスター内にMySQLクライアントを実行する新しいPodを作成し、Serviceを通じてMySQLサーバーに接続します。

--- a/content/ja/examples/application/mysql/mysql-deployment.yaml
+++ b/content/ja/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage

--- a/content/ja/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/ja/examples/application/wordpress/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress-mysql
@@ -45,10 +45,19 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.0
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        - name: MYSQL_DATABASE
+          value: wordpress
+        - name: MYSQL_USER
+          value: wordpress
+        - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: mysql-pass


### PR DESCRIPTION
The `Run a Single-Instance Stateful Application` tutorial uses an old version of mysql that does not provide an ARM version of the image.  
**This pull request includes changes only for the JA version of the website, now MR #50991 (EN version change)  has been accepted**

See #50991 for more info about the change itself.

Note:

I've also sync the content of mysql-deployment.yaml to version 8 (and not 9 !!) like the EN version