### PR TITLE
[FR] Sync run-single-instance-stateful-application.md Upgrade mysql image

### DIFF
--- a/content/fr/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/fr/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -74,7 +74,7 @@ pour une approche sécurisée.
      Labels:       app=mysql
      Containers:
        mysql:
-       Image:      mysql:5.6
+       Image:      mysql:9
        Port:       3306/TCP
        Environment:
          MYSQL_ROOT_PASSWORD:      password
@@ -146,7 +146,7 @@ d'augmenter le nombre de pods.
 Exécutez un client MySQL pour vous connecter au serveur :
 
 ```shell
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:9 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 Cette commande crée un nouveau pod dans le cluster exécutant 

--- a/content/fr/examples/application/mysql/mysql-deployment.yaml
+++ b/content/fr/examples/application/mysql/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:9
         name: mysql
         env:
           # Use secret in real usage


### PR DESCRIPTION
The `Run a Single-Instance Stateful Application` tutorial uses an old version of mysql that does not provide an ARM version of the image.  
**This pull request includes changes only for the FR version of the website, now MR #50991 (EN version change)  has been accepted**

See #50991 for more info about the change itself.