### PR TITLE
Add token revocation note and example to authentication docs

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -485,7 +485,17 @@ jwt:
   - expression: "user.groups.all(group, !group.startsWith('system:'))"
     message: 'groups cannot used reserved system: prefix'
 ```
+### Token Revocation
 
+Kubernetes does not currently support full token revocation for authentication tokens. To mitigate this, use short-lived tokens to reduce the risk of compromised tokens being used for an extended period. As an alternative, you can approximate revocation by writing user validation rules using Common Expression Language (CEL). For example, you can use the `jti` claim (if present) or any unique token identifier to check against a denylist or revocation list. Note that managing revocation this way can be complex and may not scale well for large systems.
+
+Example of a revocation rule using the `jti` claim:
+
+```yaml
+userValidationRules:
+  # This rule expects the jti claim to be present in the token and checks that the credential ID is not in the denylist
+  - expression: `has(user.extra.authentication__dot__x__dash__kubernetes__dot__io__slash__credential__dash__id) && !(user.extra.authentication__dot__x__dash__kubernetes__dot__io__slash__credential__dash__id[0] in ["JTI=e28ed49-2e11-4280-9ec5-bc3d1d84661a"])`
+    message: "credential id is revoked"
 * Claim validation rule expression
 
   `jwt.claimValidationRules[i].expression` represents the expression which will be evaluated by CEL.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This pull request adds a new subsection, "Token Revocation," to the Kubernetes authentication documentation under the "Using Authentication Configuration" section. The changes address the absence of full token revocation support in Kubernetes by:

- Explaining that Kubernetes does not currently support full token revocation for authentication tokens.
- Recommending the use of short-lived tokens to minimize risks from compromised tokens.
- Providing an example of a user validation rule using Common Expression Language (CEL) to approximate token revocation. The example uses the `jti` claim to check a token’s credential ID against a denylist.

These updates aim to guide users on managing token security effectively, based on discussions in issue #51015. The subsection is placed after an existing YAML example and includes a formatted code block for clarity.

### Issue

Closes: #51015

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #