### PR TITLE
Fix docs command: list all container images

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -33,7 +33,7 @@ of Containers for each.
   - Use `uniq` to aggregate image counts
 
 ```shell
-kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec['initContainers', 'containers'][*].image}" |\
+kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec['initContainers','containers'][*].image}" |\
 tr -s '[[:space:]]' '\n' |\
 sort |\
 uniq -c


### PR DESCRIPTION
### Description

This pull request fixes an incorrect `kubectl` command in the [documentation](https://kubernetes.io/docs/tasks/access-application-cluster/list-all-running-container-images/) for listing all container images across all namespaces. The original `jsonpath` expression included a space between `['initContainers', 'containers']`, which causes the command to fail. This PR removes the space to ensure the command executes correctly.

```txt
Error from server (NotFound): pods "'initContainers'][*].image}" not found
```

### Issue

No related issue.