### PR TITLE
Update the description of PodTopologySpread matchLabelKeys implementation change since v1.34

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -131,18 +131,24 @@ your cluster. Those fields are:
   See [Label Selectors](/docs/concepts/overview/working-with-objects/labels/#label-selectors)
   for more details.
 
-- **matchLabelKeys** is a list of pod label keys to select the pods over which
-  spreading will be calculated. The keys are used to lookup values from the pod labels,
-  those key-value labels are ANDed with `labelSelector` to select the group of existing
-  pods over which spreading will be calculated for the incoming pod. The same key is
-  forbidden to exist in both `matchLabelKeys` and `labelSelector`. `matchLabelKeys` cannot
-  be set when `labelSelector` isn't set. Keys that don't exist in the pod labels will be
-  ignored. A null or empty list means only match against the `labelSelector`.
+- **matchLabelKeys** is a list of pod label keys to select the group of pods over which 
+  the spreading skew will be calculated. At a pod creation, 
+  the kube-apiserver uses those keys to lookup values from the incoming pod labels,
+  and those key-value labels will be merged with any existing `labelSelector`.
+  The same key is forbidden to exist in both `matchLabelKeys` and `labelSelector`. 
+  `matchLabelKeys` cannot be set when `labelSelector` isn't set. 
+  Keys that don't exist in the pod labels will be ignored. 
+  A null or empty list means only match against the `labelSelector`.
+
+  {{< caution >}}
+  It's not recommended to use `matchLabelKeys` with labels that might be updated directly on pods.
+  Even if you edit the pod's label that is specified at `matchLabelKeys` **directly**, (that is, not via a deployment),
+  kube-apiserver doesn't reflect the label update onto the merged `labelSelector`.
+  {{< /caution >}}
 
   With `matchLabelKeys`, you don't need to update the `pod.spec` between different revisions.
   The controller/operator just needs to set different values to the same label key for different
-  revisions. The scheduler will assume the values automatically based on `matchLabelKeys`. For
-  example, if you are configuring a Deployment, you can use the label keyed with
+  revisions. For example, if you are configuring a Deployment, you can use the label keyed with
   [pod-template-hash](/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label), which
   is added automatically by the Deployment controller, to distinguish between different revisions
   in a single Deployment.
@@ -162,6 +168,11 @@ your cluster. Those fields are:
   {{< note >}}
   The `matchLabelKeys` field is a beta-level field and enabled by default in 1.27. You can disable it by disabling the
   `MatchLabelKeysInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
+
+  Before v1.34, kube-scheduler just internally handled `matchLabelKeys` before the calculation of scheduling results.
+  Since v1.34, merging selectors built from `matchLabelKeys` into `labelSelector` is enabled by default. 
+  You can disable it and revert to the previous behavior by disabling the `MatchLabelKeysInPodTopologySpreadSelectorMerge` 
+  [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) of kube-apiserver.  
   {{< /note >}}
 
 - **nodeAffinityPolicy** indicates how we will treat Pod's nodeAffinity/nodeSelector

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MatchLabelKeysInPodTopologySpreadSelectorMerge.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MatchLabelKeysInPodTopologySpreadSelectorMerge.md
@@ -1,0 +1,14 @@
+---
+title: MatchLabelKeysInPodTopologySpreadSelectorMerge
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.34"
+---
+Enable merging of selectors built from `matchLabelKeys` into `labelSelector` of 
+[Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/).


### PR DESCRIPTION
#### Description
This PR is a follow-up to #49607 and #50122, resubmitted for the v1.34 release because the code change missed v1.33.

related:
- https://github.com/kubernetes/enhancements/pull/5205
- https://github.com/kubernetes/kubernetes/pull/129874