### PR TITLE
Fix: Replace external paywall link in macOS kubectl autocompletion instructions

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -22,7 +22,7 @@ There are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2
 script **doesn't work** correctly with bash-completion v1 and Bash 3.2.
 It requires **bash-completion v2** and **Bash 4.1+**. Thus, to be able to
 correctly use kubectl completion on macOS, you have to install and use
-Bash 4.1+ ([*instructions*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)).
+Bash 4.1+ ([*instructions*](https://apple.stackexchange.com/a/292760)).
 The following instructions assume that you use Bash 4.1+
 (that is, any Bash version of 4.1 or newer).
 {{< /warning >}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR replaces a paywalled Medium article link with a publicly accessible Stack Exchange post in the macOS shell autocompletion section of the "Install and Set Up kubectl" guide.

### Issue
The original external link for upgrading Bash on macOS pointed to a Medium article that is behind a paywall, which impacts the user experience.

### Solution
Updated the link to a Stack Exchange post:
https://apple.stackexchange.com/a/292760

The new link is publicly accessible, still relevant, and recently verified.

Closes: #51107

/sig docs