### PR TITLE
Add missing glossary in vi docs

### DIFF
--- a/content/vi/docs/reference/glossary/addons.md
+++ b/content/vi/docs/reference/glossary/addons.md
@@ -1,0 +1,16 @@
+---
+title: Add-ons
+id: addons
+date: 2019-12-15
+full_link: /docs/concepts/cluster-administration/addons/
+short_description: >
+  Resources that extend the functionality of Kubernetes.
+
+aka:
+tags:
+- tool
+---
+  Resources that extend the functionality of Kubernetes.
+
+<!--more-->
+[Installing addons](/docs/concepts/cluster-administration/addons/) explains more about using add-ons with your cluster, and lists some popular add-ons.

--- a/content/vi/docs/reference/glossary/admission-controller.md
+++ b/content/vi/docs/reference/glossary/admission-controller.md
@@ -1,0 +1,22 @@
+---
+title: Admission Controller
+id: admission-controller
+date: 2019-06-28
+full_link: /docs/reference/access-authn-authz/admission-controllers/
+short_description: >
+  A piece of code that intercepts requests to the Kubernetes API server prior to persistence of the object.
+
+aka:
+tags:
+- extension
+- security
+---
+A piece of code that intercepts requests to the Kubernetes API server prior to persistence of the object.
+
+<!--more-->
+
+Admission controllers are configurable for the Kubernetes API server and may be "validating", "mutating", or
+both. Any admission controller may reject the request. Mutating controllers may modify the objects they admit;
+validating controllers may not.
+
+* [Admission controllers in the Kubernetes documentation](/docs/reference/access-authn-authz/admission-controllers/)

--- a/content/vi/docs/reference/glossary/aggregation-layer.md
+++ b/content/vi/docs/reference/glossary/aggregation-layer.md
@@ -1,0 +1,19 @@
+---
+title: Aggregation Layer
+id: aggregation-layer
+date: 2018-10-08
+full_link: /docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
+short_description: >
+  The aggregation layer lets you install additional Kubernetes-style APIs in your cluster.
+
+aka: 
+tags:
+- architecture
+- extension
+- operation
+---
+ The aggregation layer lets you install additional Kubernetes-style APIs in your cluster.
+
+<!--more-->
+
+When you've configured the {{< glossary_tooltip text="Kubernetes API Server" term_id="kube-apiserver" >}} to [support additional APIs](/docs/tasks/extend-kubernetes/configure-aggregation-layer/), you can add `APIService` objects to "claim" a URL path in the Kubernetes API.

--- a/content/vi/docs/reference/glossary/api-eviction.md
+++ b/content/vi/docs/reference/glossary/api-eviction.md
@@ -1,0 +1,27 @@
+---
+title: API-initiated eviction
+id: api-eviction
+date: 2021-04-27
+full_link: /docs/concepts/scheduling-eviction/api-eviction/
+short_description: >
+  API-initiated eviction is the process by which you use the Eviction API to create an
+  Eviction object that triggers graceful pod termination.
+aka:
+tags:
+- operation
+---
+API-initiated eviction is the process by which you use the [Eviction API](/docs/reference/generated/kubernetes-api/{{<param "version">}}/#create-eviction-pod-v1-core)
+to create an `Eviction` object that triggers graceful pod termination.
+
+<!--more-->
+
+You can request eviction either by directly calling the Eviction API 
+using a client of the kube-apiserver, like the `kubectl drain` command. 
+When an `Eviction` object is created, the API server terminates the Pod. 
+
+API-initiated evictions respect your configured [`PodDisruptionBudgets`](/docs/tasks/run-application/configure-pdb/)
+and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination).
+
+API-initiated eviction is not the same as [node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/).
+
+* See [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/) for more information.

--- a/content/vi/docs/reference/glossary/application-architect.md
+++ b/content/vi/docs/reference/glossary/application-architect.md
@@ -1,0 +1,18 @@
+---
+title: Application Architect
+id: application-architect
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person responsible for the high-level design of an application.
+
+aka: 
+tags:
+- user-type
+---
+ A person responsible for the high-level design of an application.
+
+<!--more--> 
+
+An architect ensures that an app's implementation allows it to interact with its surrounding components in a scalable, maintainable way. Surrounding components include databases, logging infrastructure, and other microservices.
+

--- a/content/vi/docs/reference/glossary/application-developer.md
+++ b/content/vi/docs/reference/glossary/application-developer.md
@@ -1,0 +1,18 @@
+---
+title: Application Developer
+id: application-developer
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person who writes an application that runs in a Kubernetes cluster.
+
+aka: 
+tags:
+- user-type
+---
+ A person who writes an application that runs in a Kubernetes cluster.
+
+<!--more--> 
+
+An application developer focuses on one part of an application. The scale of their focus may vary significantly in size.
+

--- a/content/vi/docs/reference/glossary/approver.md
+++ b/content/vi/docs/reference/glossary/approver.md
@@ -1,0 +1,18 @@
+---
+title: Approver
+id: approver
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person who can review and approve Kubernetes code contributions.
+
+aka: 
+tags:
+- community
+---
+ A person who can review and approve Kubernetes code contributions.
+
+<!--more--> 
+
+While code review is focused on code quality and correctness, approval is focused on the holistic acceptance of a contribution. Holistic acceptance includes backwards/forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, and others. Approver status is scoped to a part of the codebase. Approvers were previously referred to as maintainers.
+

--- a/content/vi/docs/reference/glossary/cadvisor.md
+++ b/content/vi/docs/reference/glossary/cadvisor.md
@@ -1,0 +1,16 @@
+---
+title: cAdvisor
+id: cadvisor
+date: 2021-12-09
+full_link: https://github.com/google/cadvisor/
+short_description: >
+  Tool that provides understanding of the resource usage and performance characteristics for containers
+aka:
+tags:
+- tool
+---
+cAdvisor (Container Advisor) provides container users an understanding of the resource usage and performance characteristics of their running {{< glossary_tooltip text="containers" term_id="container" >}}.
+
+<!--more-->
+
+It is a running daemon that collects, aggregates, processes, and exports information about running containers. Specifically, for each container it keeps resource isolation parameters, historical resource usage, histograms of complete historical resource usage and network statistics. This data is exported by container and machine-wide.

--- a/content/vi/docs/reference/glossary/certificate.md
+++ b/content/vi/docs/reference/glossary/certificate.md
@@ -1,0 +1,18 @@
+---
+title: Certificate
+id: certificate
+date: 2018-04-12
+full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
+short_description: >
+  A cryptographically secure file used to validate access to the Kubernetes cluster.
+
+aka: 
+tags:
+- security
+---
+ A cryptographically secure file used to validate access to the Kubernetes cluster.
+
+<!--more--> 
+
+Certificates enable applications within a Kubernetes cluster to access the Kubernetes API securely. Certificates validate that clients are allowed to access the API.
+

--- a/content/vi/docs/reference/glossary/cidr.md
+++ b/content/vi/docs/reference/glossary/cidr.md
@@ -1,0 +1,18 @@
+---
+title: CIDR
+id: cidr
+date: 2019-11-12
+full_link: 
+short_description: >
+  CIDR is a notation for describing blocks of IP addresses and is used heavily in various networking configurations.
+
+aka:
+tags:
+- networking
+---
+CIDR (Classless Inter-Domain Routing) is a notation for describing blocks of IP addresses and is used heavily in various networking configurations.
+
+<!--more-->
+
+In the context of Kubernetes, each {{< glossary_tooltip text="Node" term_id="node" >}} is assigned a range of IP addresses through the start address and a subnet mask using CIDR. This allows Nodes to assign each {{< glossary_tooltip text="Pod" term_id="pod" >}} a unique IP address. Although originally a concept for IPv4, CIDR has also been expanded to include IPv6. 
+

--- a/content/vi/docs/reference/glossary/cla.md
+++ b/content/vi/docs/reference/glossary/cla.md
@@ -1,0 +1,18 @@
+---
+title: CLA (Contributor License Agreement)
+id: cla
+date: 2018-04-12
+full_link: https://github.com/kubernetes/community/blob/master/CLA.md
+short_description: >
+  Terms under which a contributor grants a license to an open source project for their contributions.
+
+aka: 
+tags:
+- community
+---
+ Terms under which a {{< glossary_tooltip text="contributor" term_id="contributor" >}} grants a license to an open source project for their contributions.
+
+<!--more--> 
+
+CLAs help resolve legal disputes involving contributed material and intellectual property (IP).
+

--- a/content/vi/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/vi/docs/reference/glossary/cloud-controller-manager.md
@@ -1,0 +1,23 @@
+---
+title: Cloud Controller Manager
+id: cloud-controller-manager
+date: 2018-04-12
+full_link: /docs/concepts/architecture/cloud-controller/
+short_description: >
+  Control plane component that integrates Kubernetes with third-party cloud providers.
+aka: 
+tags:
+- architecture
+- operation
+---
+ A Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}} component
+that embeds cloud-specific control logic. The cloud controller manager lets you link your
+cluster into your cloud provider's API, and separates out the components that interact
+with that cloud platform from components that only interact with your cluster.
+
+<!--more-->
+
+By decoupling the interoperability logic between Kubernetes and the underlying cloud
+infrastructure, the cloud-controller-manager component enables cloud providers to release
+features at a different pace compared to the main Kubernetes project.
+

--- a/content/vi/docs/reference/glossary/cloud-provider.md
+++ b/content/vi/docs/reference/glossary/cloud-provider.md
@@ -1,0 +1,31 @@
+---
+title: Cloud Provider
+id: cloud-provider
+date: 2018-04-12
+short_description: >
+  An organization that offers a cloud computing platform.
+
+aka:
+- Cloud Service Provider
+tags:
+- community
+---
+ A business or other organization that offers a cloud computing platform.
+
+<!--more-->
+
+Cloud providers, sometimes called Cloud Service Providers (CSPs), offer
+cloud computing platforms or services.
+
+Many cloud providers offer managed infrastructure (also called
+Infrastructure as a Service or IaaS).
+With managed infrastructure the cloud provider is responsible for
+servers, storage, and networking while you manage layers on top of that
+such as running a Kubernetes cluster.
+
+You can also find Kubernetes as a managed service; sometimes called
+Platform as a Service, or PaaS. With managed Kubernetes, your
+cloud provider is responsible for the Kubernetes control plane as well
+as the {{< glossary_tooltip term_id="node" text="nodes" >}} and the
+infrastructure they rely on: networking, storage, and possibly other
+elements such as load balancers.

--- a/content/vi/docs/reference/glossary/cluster-architect.md
+++ b/content/vi/docs/reference/glossary/cluster-architect.md
@@ -1,0 +1,18 @@
+---
+title: Cluster Architect
+id: cluster-architect
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person who designs infrastructure that involves one or more Kubernetes clusters.
+
+aka: 
+tags:
+- user-type
+---
+ A person who designs infrastructure that involves one or more Kubernetes clusters.
+
+<!--more--> 
+
+Cluster architects are concerned with best practices for distributed systems, for example&#58; high availability and security.
+

--- a/content/vi/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/vi/docs/reference/glossary/cluster-infrastructure.md
@@ -1,0 +1,13 @@
+---
+title: Cluster Infrastructure
+id: cluster-infrastructure
+date: 2019-05-12
+full_link:
+short_description: >
+ The infrastructure layer provides and maintains VMs, networking, security groups and others.
+
+aka:
+tags:
+- operation
+---
+ The infrastructure layer provides and maintains VMs, networking, security groups and others.

--- a/content/vi/docs/reference/glossary/cluster-operations.md
+++ b/content/vi/docs/reference/glossary/cluster-operations.md
@@ -1,0 +1,21 @@
+---
+title: Cluster Operations
+id: cluster-operations
+date: 2019-05-12
+full_link:
+short_description: >
+ The work involved in managing a Kubernetes cluster.
+
+aka:
+tags:
+- operation
+---
+ The work involved in managing a Kubernetes cluster: managing
+day-to-day operations, and co-ordinating upgrades.
+
+<!--more-->
+
+ Examples of cluster operations work include: deploying new Nodes to
+scale the cluster; performing software upgrades; implementing security
+controls; adding or removing storage; configuring cluster networking;
+managing cluster-wide observability; and responding to events.

--- a/content/vi/docs/reference/glossary/cluster-operator.md
+++ b/content/vi/docs/reference/glossary/cluster-operator.md
@@ -1,0 +1,22 @@
+---
+title: Cluster Operator
+id: cluster-operator
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person who configures, controls, and monitors clusters.
+
+aka: 
+tags:
+- user-type
+---
+ A person who configures, controls, and monitors clusters.
+
+<!--more--> 
+
+Their primary responsibility is keeping a cluster up and running, which may involve periodic maintenance activities or upgrades.<br>
+
+{{< note >}}
+Cluster operators are different from the [Operator pattern](/docs/concepts/extend-kubernetes/operator/) that extends the Kubernetes API.
+{{< /note >}}
+

--- a/content/vi/docs/reference/glossary/code-contributor.md
+++ b/content/vi/docs/reference/glossary/code-contributor.md
@@ -1,0 +1,19 @@
+---
+title: Code Contributor
+id: code-contributor
+date: 2018-04-12
+full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
+short_description: >
+  A person who develops and contributes code to the Kubernetes open source codebase.
+
+aka: 
+tags:
+- community
+- user-type
+---
+ A person who develops and contributes code to the Kubernetes open source codebase.
+
+<!--more--> 
+
+They are also an active {{< glossary_tooltip text="community member" term_id="member" >}} who participates in one or more {{< glossary_tooltip text="Special Interest Groups (SIGs)" term_id="sig" >}}.
+

--- a/content/vi/docs/reference/glossary/configmap.md
+++ b/content/vi/docs/reference/glossary/configmap.md
@@ -1,0 +1,20 @@
+---
+title: ConfigMap
+id: configmap
+date: 2018-04-12
+full_link: /docs/concepts/configuration/configmap/
+short_description: >
+  An API object used to store non-confidential data in key-value pairs. Can be consumed as environment variables, command-line arguments, or configuration files in a volume.
+
+aka: 
+tags:
+- core-object
+---
+ An API object used to store non-confidential data in key-value pairs.
+{{< glossary_tooltip text="Pods" term_id="pod" >}} can consume ConfigMaps as
+environment variables, command-line arguments, or as configuration files in a
+{{< glossary_tooltip text="volume" term_id="volume" >}}.
+
+<!--more--> 
+
+A ConfigMap allows you to decouple environment-specific configuration from your {{< glossary_tooltip text="container images" term_id="image" >}}, so that your applications are easily portable.

--- a/content/vi/docs/reference/glossary/container-lifecycle-hooks.md
+++ b/content/vi/docs/reference/glossary/container-lifecycle-hooks.md
@@ -1,0 +1,17 @@
+---
+title: Container Lifecycle Hooks
+id: container-lifecycle-hooks
+date: 2018-10-08
+full_link: /docs/concepts/containers/container-lifecycle-hooks/
+short_description: >
+  The lifecycle hooks expose events in the container management lifecycle and let the user run code when the events occur.
+
+aka:
+tags:
+- extension
+---
+  The lifecycle hooks expose events in the {{< glossary_tooltip text="Container" term_id="container" >}} management lifecycle and let the user run code when the events occur.
+
+<!--more-->
+
+Two hooks are exposed to Containers: PostStart which executes immediately after a container is created and PreStop which is blocking and is called immediately before a container is terminated.

--- a/content/vi/docs/reference/glossary/cronjob.md
+++ b/content/vi/docs/reference/glossary/cronjob.md
@@ -1,0 +1,19 @@
+---
+title: CronJob
+id: cronjob
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/cron-jobs/
+short_description: >
+  A repeating task (a Job) that runs on a regular schedule.
+
+aka: 
+tags:
+- core-object
+- workload
+---
+ Manages a [Job](/docs/concepts/workloads/controllers/job/) that runs on a periodic schedule.
+
+<!--more-->
+
+Similar to a line in a *crontab* file, a CronJob object specifies a schedule using the [cron](https://en.wikipedia.org/wiki/Cron) format.
+

--- a/content/vi/docs/reference/glossary/csi.md
+++ b/content/vi/docs/reference/glossary/csi.md
@@ -1,0 +1,21 @@
+---
+title: Container Storage Interface (CSI)
+id: csi
+date: 2018-06-25
+full_link: /docs/concepts/storage/volumes/#csi
+short_description: >
+    The Container Storage Interface (CSI) defines a standard interface to expose storage systems to containers.
+
+
+aka: 
+tags:
+- storage 
+---
+ The Container Storage Interface (CSI) defines a standard interface to expose storage systems to containers.
+
+<!--more--> 
+
+CSI allows vendors to create custom storage plugins for Kubernetes without adding them to the Kubernetes repository (out-of-tree plugins). To use a CSI driver from a storage provider, you must first [deploy it to your cluster](https://kubernetes-csi.github.io/docs/deploying.html). You will then be able to create a {{< glossary_tooltip text="Storage Class" term_id="storage-class" >}} that uses that CSI driver.
+
+* [CSI in the Kubernetes documentation](/docs/concepts/storage/volumes/#csi)
+* [List of available CSI drivers](https://kubernetes-csi.github.io/docs/drivers.html)

--- a/content/vi/docs/reference/glossary/data-plane.md
+++ b/content/vi/docs/reference/glossary/data-plane.md
@@ -1,0 +1,13 @@
+---
+title: Data Plane
+id: data-plane
+date: 2019-05-12
+full_link:
+short_description: >
+  The layer that provides capacity such as CPU, memory, network, and storage so that the containers can run and connect to a network.
+
+aka:
+tags:
+- fundamental
+---
+ The layer that provides capacity such as CPU, memory, network, and storage so that the containers can run and connect to a network.

--- a/content/vi/docs/reference/glossary/developer.md
+++ b/content/vi/docs/reference/glossary/developer.md
@@ -1,0 +1,19 @@
+---
+title: Developer (disambiguation)
+id: developer
+date: 2018-04-12
+full_link: 
+short_description: >
+  May refer to&#58; Application Developer, Code Contributor, or Platform Developer.
+
+aka: 
+tags:
+- community
+- user-type
+---
+ May refer to&#58; {{< glossary_tooltip text="Application Developer" term_id="application-developer" >}}, {{< glossary_tooltip text="Code Contributor" term_id="code-contributor" >}}, or {{< glossary_tooltip text="Platform Developer" term_id="platform-developer" >}}.
+
+<!--more--> 
+
+This overloaded term may have different meanings depending on the context
+

--- a/content/vi/docs/reference/glossary/disruption.md
+++ b/content/vi/docs/reference/glossary/disruption.md
@@ -1,0 +1,25 @@
+---
+title: Disruption
+id: disruption
+date: 2019-09-10
+full_link: /docs/concepts/workloads/pods/disruptions/
+short_description: >
+  An event that leads to Pod(s) going out of service
+aka:
+tags:
+- fundamental
+---
+ Disruptions are events that lead to one or more
+{{< glossary_tooltip term_id="pod" text="Pods" >}} going out of service.
+A disruption has consequences for workload resources, such as
+{{< glossary_tooltip term_id="deployment" >}}, that rely on the affected
+Pods.
+
+<!--more-->
+
+If you, as cluster operator, destroy a Pod that belongs to an application,
+Kubernetes terms that a _voluntary disruption_. If a Pod goes offline
+because of a Node failure, or an outage affecting a wider failure zone,
+Kubernetes terms that an _involuntary disruption_.
+
+See [Disruptions](/docs/concepts/workloads/pods/disruptions/) for more information.

--- a/content/vi/docs/reference/glossary/dockershim.md
+++ b/content/vi/docs/reference/glossary/dockershim.md
@@ -1,0 +1,18 @@
+---
+title: Dockershim
+id: dockershim
+date: 2022-04-15
+full_link: /dockershim
+short_description: >
+   A component of Kubernetes v1.23 and earlier, which allows Kubernetes system components to communicate with Docker Engine.
+
+aka:
+tags:
+- fundamental
+---
+The dockershim is a component of Kubernetes version 1.23 and earlier. It allows the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}
+to communicate with {{< glossary_tooltip text="Docker Engine" term_id="docker" >}}.
+
+<!--more-->
+
+Starting with version 1.24, dockershim has been removed from Kubernetes. For more information, see [Dockershim FAQ](/dockershim).

--- a/content/vi/docs/reference/glossary/downstream.md
+++ b/content/vi/docs/reference/glossary/downstream.md
@@ -1,0 +1,19 @@
+---
+title: Downstream (disambiguation)
+id: downstream
+date: 2018-04-12
+full_link: 
+short_description: >
+  May refer to: code in the Kubernetes ecosystem that depends upon the core Kubernetes codebase or a forked repo.
+
+aka: 
+tags:
+- community
+---
+ May refer to: code in the Kubernetes ecosystem that depends upon the core Kubernetes codebase or a forked repo.
+
+<!--more--> 
+
+* In the **Kubernetes Community**: Conversations often use *downstream* to mean the ecosystem, code, or third-party tools that rely on the core Kubernetes codebase. For example, a new feature in Kubernetes may be adopted by applications *downstream* to improve their functionality.
+* In **GitHub** or **git**: The convention is to refer to a forked repo as *downstream*, whereas the source repo is considered *upstream*.
+

--- a/content/vi/docs/reference/glossary/downward-api.md
+++ b/content/vi/docs/reference/glossary/downward-api.md
@@ -1,0 +1,28 @@
+---
+title: Downward API
+id: downward-api
+date: 2022-03-21
+short_description: >
+  A mechanism to expose Pod and container field values to code running in a container.
+aka:
+full_link: /docs/concepts/workloads/pods/downward-api/
+tags:
+- architecture
+---
+Kubernetes' mechanism to expose Pod and container field values to code running in a container.
+<!--more-->
+It is sometimes useful for a container to have information about itself, without
+needing to make changes to the container code that directly couple it to Kubernetes.
+
+The Kubernetes downward API allows containers to consume information about themselves
+or their context in a Kubernetes cluster. Applications in containers can have
+access to that information, without the application needing to act as a client of
+the Kubernetes API.
+
+There are two ways to expose Pod and container fields to a running container:
+
+- using [environment variables](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)
+- using [a `downwardAPI` volume](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)
+
+Together, these two ways of exposing Pod and container fields are called the _downward API_.
+

--- a/content/vi/docs/reference/glossary/drain.md
+++ b/content/vi/docs/reference/glossary/drain.md
@@ -1,0 +1,18 @@
+---
+title: Drain
+id: drain
+date: 2024-12-27
+full_link:
+short_description: >
+  Safely evicts Pods from a Node to prepare for maintenance or removal.
+tags:
+- fundamental
+- operation
+---
+The process of safely evicting {{< glossary_tooltip text="Pods" term_id="pod" >}} from a {{< glossary_tooltip text="Node" term_id="node" >}} to prepare it for maintenance or removal from a {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
+
+<!--more-->
+
+The `kubectl drain` command is used to mark a {{< glossary_tooltip text="Node" term_id="node" >}} as going out of service. 
+When executed, it evicts all {{< glossary_tooltip text="Pods" term_id="pod" >}} from the {{< glossary_tooltip text="Node" term_id="node" >}}. 
+If an eviction request is temporarily rejected, `kubectl drain` retries until all {{< glossary_tooltip text="Pods" term_id="pod" >}} are terminated or a configurable timeout is reached.

--- a/content/vi/docs/reference/glossary/duration.md
+++ b/content/vi/docs/reference/glossary/duration.md
@@ -1,0 +1,24 @@
+---
+title: Duration
+id: duration
+date: 2024-10-05
+full_link:
+short_description: >
+  A string value representing an amount of time.
+tags:
+- fundamental
+---
+A string value representing an amount of time.
+
+<!--more-->
+
+The format of a (Kubernetes) duration is based on the
+[`time.Duration`](https://pkg.go.dev/time#Duration) type from the Go programming language.
+
+In Kubernetes APIs that use durations, the value is expressed as series of a non-negative
+integers combined with a time unit suffix. You can have more than one time quantity and
+the duration is the sum of those time quantities.
+The valid time units are "ns", "µs" (or "us"), "ms", "s", "m", and "h".
+
+For example: `5s` represents a duration of five seconds, and `1m30s` represents a duration
+of one minute and thirty seconds.

--- a/content/vi/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/vi/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,0 +1,18 @@
+---
+title: Dynamic Volume Provisioning
+id: dynamicvolumeprovisioning
+date: 2018-04-12
+full_link: /docs/concepts/storage/dynamic-provisioning
+short_description: >
+  Allows users to request automatic creation of storage  Volumes.
+
+aka: 
+tags:
+- storage
+---
+ Allows users to request automatic creation of storage  {{< glossary_tooltip text="Volumes" term_id="volume" >}}.
+
+<!--more--> 
+
+Dynamic provisioning eliminates the need for cluster administrators to pre-provision storage. Instead, it automatically provisions storage by user request. Dynamic volume provisioning is based on an API object, {{< glossary_tooltip text="StorageClass" term_id="storage-class" >}}, referring to a {{< glossary_tooltip text="Volume Plugin" term_id="volume-plugin" >}} that provisions a {{< glossary_tooltip text="Volume" term_id="volume" >}} and the set of parameters to pass to the Volume Plugin.
+

--- a/content/vi/docs/reference/glossary/endpoint-slice.md
+++ b/content/vi/docs/reference/glossary/endpoint-slice.md
@@ -1,0 +1,16 @@
+---
+title: EndpointSlice
+id: endpoint-slice
+date: 2018-04-12
+full_link: /docs/concepts/services-networking/endpoint-slices/
+short_description: >
+  EndpointSlices track the IP addresses of Pods with matching Service selectors.
+
+aka:
+tags:
+- networking
+---
+ EndpointSlices track the IP addresses of Pods with matching  {{< glossary_tooltip text="selectors" term_id="selector" >}}.
+
+<!--more-->
+EndpointSlices can be configured manually for {{< glossary_tooltip text="Services" term_id="service" >}} without selectors specified.

--- a/content/vi/docs/reference/glossary/endpoint.md
+++ b/content/vi/docs/reference/glossary/endpoint.md
@@ -1,0 +1,22 @@
+---
+title: Endpoints
+id: endpoints
+date: 2020-04-23
+full_link: 
+short_description: >
+  An endpoint of a Service is one of the Pods (or external servers) that implements the Service.
+
+aka:
+tags:
+- networking
+---
+ An endpoint of a {{< glossary_tooltip text="Service" term_id="service" >}} is one of the {{< glossary_tooltip text="Pods" term_id="pod" >}} (or external servers) that implements the Service.
+
+<!--more-->
+For Services with {{< glossary_tooltip text="selectors" term_id="selector" >}},
+the EndpointSlice controller will automatically create one or more {{<
+glossary_tooltip text="EndpointSlices" term_id="endpoint-slice" >}} giving the
+IP addresses of the selected endpoint Pods.
+
+EndpointSlices can also be created manually to indicate the endpoints of
+Services that have no selector specified.

--- a/content/vi/docs/reference/glossary/ephemeral-container.md
+++ b/content/vi/docs/reference/glossary/ephemeral-container.md
@@ -1,0 +1,19 @@
+---
+title: Ephemeral Container
+id: ephemeral-container
+date: 2019-08-26
+full_link: /docs/concepts/workloads/pods/ephemeral-containers/
+short_description: >
+  A type of container type that you can temporarily run inside a Pod
+
+aka:
+tags:
+- fundamental
+---
+A {{< glossary_tooltip term_id="container" >}} type that you can temporarily run inside a {{< glossary_tooltip term_id="pod" >}}.
+
+<!--more-->
+
+If you want to investigate a Pod that's running with problems, you can add an ephemeral container to that Pod and carry out diagnostics. Ephemeral containers have no resource or scheduling guarantees, and you should not use them to run any part of the workload itself.
+
+Ephemeral containers are not supported by {{< glossary_tooltip text="static pods" term_id="static-pod" >}}.

--- a/content/vi/docs/reference/glossary/event.md
+++ b/content/vi/docs/reference/glossary/event.md
@@ -1,0 +1,24 @@
+---
+title: Event
+id: event
+date: 2022-01-16
+full_link: /docs/reference/kubernetes-api/cluster-resources/event-v1/
+short_description: >
+   Events are Kubernetes objects that describe some state change in the system.
+aka: 
+tags:
+- core-object
+- fundamental
+---
+Event is a Kubernetes object that describes state change/notable occurrences in the system.
+
+<!--more-->
+Events have a limited retention time and triggers and messages may evolve with time. 
+Event consumers should not rely on the timing of an event with a given reason reflecting a consistent underlying trigger, 
+or the continued existence of events with that reason. 
+
+
+Events should be treated as informative, best-effort, supplemental data.
+
+In Kubernetes, [auditing](/docs/tasks/debug/debug-cluster/audit/) generates a different kind of
+Event record (API group `audit.k8s.io`).

--- a/content/vi/docs/reference/glossary/eviction.md
+++ b/content/vi/docs/reference/glossary/eviction.md
@@ -1,0 +1,18 @@
+---
+title: Eviction
+id: eviction
+date: 2021-05-08
+full_link: /docs/concepts/scheduling-eviction/
+short_description: >
+    Process of terminating one or more Pods on Nodes
+aka:
+tags:
+- operation
+---
+
+Eviction is the process of terminating one or more Pods on Nodes.
+
+<!--more-->
+There are two kinds of eviction:
+* [Node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+* [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/)

--- a/content/vi/docs/reference/glossary/extensions.md
+++ b/content/vi/docs/reference/glossary/extensions.md
@@ -1,0 +1,21 @@
+---
+title: Extensions
+id: Extensions
+date: 2019-02-01
+full_link: /docs/concepts/extend-kubernetes/#extensions
+short_description: >
+  Extensions are software components that extend and deeply integrate with Kubernetes to support
+  new types of hardware.
+
+aka:
+tags:
+- fundamental
+- extension
+---
+ Extensions are software components that extend and deeply integrate with Kubernetes to support new types of hardware.
+
+<!--more-->
+
+Many cluster administrators use a hosted or distribution instance of Kubernetes. These clusters
+come with extensions pre-installed. As a result, most Kubernetes users will not need to install
+[extensions](/docs/concepts/extend-kubernetes/) and even fewer users will need to author new ones. 

--- a/content/vi/docs/reference/glossary/feature-gates.md
+++ b/content/vi/docs/reference/glossary/feature-gates.md
@@ -1,0 +1,23 @@
+---
+title: Feature gate
+id: feature-gate
+date: 2023-01-12
+full_link: /docs/reference/command-line-tools-reference/feature-gates/
+short_description: >
+  A way to control whether or not a particular Kubernetes feature is enabled.
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+
+Feature gates are a set of keys (opaque string values) that you can use to control which
+Kubernetes features are enabled in your cluster.
+
+<!--more-->
+
+You can turn these features on or off using the `--feature-gates` command line flag on each Kubernetes component.
+Each Kubernetes component lets you enable or disable a set of feature gates that are relevant to that component.
+The Kubernetes documentation lists all current 
+[feature gates](/docs/reference/command-line-tools-reference/feature-gates/) and what they control.

--- a/content/vi/docs/reference/glossary/finalizer.md
+++ b/content/vi/docs/reference/glossary/finalizer.md
@@ -1,0 +1,31 @@
+---
+title: Finalizer
+id: finalizer
+date: 2021-07-07
+full_link: /docs/concepts/overview/working-with-objects/finalizers/
+short_description: >
+  A namespaced key that tells Kubernetes to wait until specific conditions are met
+  before it fully deletes an object marked for deletion.
+aka: 
+tags:
+- fundamental
+- operation
+---
+Finalizers are namespaced keys that tell Kubernetes to wait until specific
+conditions are met before it fully deletes resources marked for deletion.
+Finalizers alert {{<glossary_tooltip text="controllers" term_id="controller">}}
+to clean up resources the deleted object owned.
+
+<!--more-->
+
+When you tell Kubernetes to delete an object that has finalizers specified for
+it, the Kubernetes API marks the object for deletion by populating `.metadata.deletionTimestamp`,
+and returns a `202` status code (HTTP "Accepted"). The target object remains in a terminating state while the
+control plane, or other components, take the actions defined by the finalizers.
+After these actions are complete, the controller removes the relevant finalizers
+from the target object. When the `metadata.finalizers` field is empty,
+Kubernetes considers the deletion complete and deletes the object.
+
+You can use finalizers to control {{<glossary_tooltip text="garbage collection" term_id="garbage-collection">}}
+of resources. For example, you can define a finalizer to clean up related resources or
+infrastructure before the controller deletes the target resource.

--- a/content/vi/docs/reference/glossary/flexvolume.md
+++ b/content/vi/docs/reference/glossary/flexvolume.md
@@ -1,0 +1,22 @@
+---
+title: FlexVolume
+id: flexvolume
+date: 2018-06-25
+full_link: /docs/concepts/storage/volumes/#flexvolume
+short_description: >
+    FlexVolume is a deprecated interface for creating out-of-tree volume plugins. The {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}} is a newer interface that addresses several problems with FlexVolume.
+
+
+aka: 
+tags:
+- storage 
+---
+ FlexVolume is a deprecated interface for creating out-of-tree volume plugins. The {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}} is a newer interface that addresses several problems with FlexVolume.
+
+<!--more--> 
+
+FlexVolumes enable users to write their own drivers and add support for their volumes in Kubernetes. FlexVolume driver binaries and dependencies must be installed on host machines. This requires root access. The Storage SIG suggests implementing a {{< glossary_tooltip text="CSI" term_id="csi" >}} driver if possible since it addresses the limitations with FlexVolumes.
+
+* [FlexVolume in the Kubernetes documentation](/docs/concepts/storage/volumes/#flexvolume)
+* [More information on FlexVolumes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md)
+* [Volume Plugin FAQ for Storage Vendors](https://github.com/kubernetes/community/blob/master/sig-storage/volume-plugin-faq.md)

--- a/content/vi/docs/reference/glossary/garbage-collection.md
+++ b/content/vi/docs/reference/glossary/garbage-collection.md
@@ -1,0 +1,27 @@
+---
+title: Garbage Collection
+id: garbage-collection
+date: 2021-07-07
+full_link: /docs/concepts/architecture/garbage-collection/
+short_description: >
+  A collective term for the various mechanisms Kubernetes uses to clean up cluster
+  resources.
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+
+Garbage collection is a collective term for the various mechanisms Kubernetes uses to clean up
+cluster resources. 
+
+<!--more-->
+
+Kubernetes uses garbage collection to clean up resources like
+[unused containers and images](/docs/concepts/architecture/garbage-collection/#containers-images),
+[failed Pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection),
+[objects owned by the targeted resource](/docs/concepts/overview/working-with-objects/owners-dependents/),
+[completed Jobs](/docs/concepts/workloads/controllers/ttlafterfinished/), and resources
+that have expired or failed.
+

--- a/content/vi/docs/reference/glossary/gateway.md
+++ b/content/vi/docs/reference/glossary/gateway.md
@@ -1,0 +1,20 @@
+---
+title: Gateway API
+id: gateway-api
+date: 2023-10-19
+full_link: /docs/concepts/services-networking/gateway/
+short_description: >
+  An API for modeling service networking in Kubernetes.
+
+aka:
+tags:
+- networking
+- architecture
+- extension
+---
+ A family of API kinds for modeling service networking in Kubernetes.
+
+<!--more--> 
+
+Gateway API provides a family of extensible, role-oriented, protocol-aware
+API kinds for modeling service networking in Kubernetes.

--- a/content/vi/docs/reference/glossary/group-version-resource.md
+++ b/content/vi/docs/reference/glossary/group-version-resource.md
@@ -1,0 +1,18 @@
+---
+title: Group Version Resource
+id: gvr
+date: 2023-07-24
+short_description: >
+  The API group, API version and name of a Kubernetes API. 
+
+aka: ["GVR"]
+tags:
+- architecture
+---
+Means of representing unique Kubernetes API resource.
+
+<!--more-->
+
+Group Version Resources (GVRs) specify the API group, API version, and resource (name for the object kind as it appears in the URI) associated with accessing a particular id of object in Kubernetes.
+GVRs let you define and distinguish different Kubernetes objects, and to specify a way of accessing
+objects that is stable even as APIs change.

--- a/content/vi/docs/reference/glossary/helm-chart.md
+++ b/content/vi/docs/reference/glossary/helm-chart.md
@@ -1,0 +1,19 @@
+---
+title: Helm Chart
+id: helm-chart
+date: 2018-04-12
+full_link: https://helm.sh/docs/topics/charts/
+short_description: >
+  A package of pre-configured Kubernetes resources that can be managed with the Helm tool.
+
+aka: 
+tags:
+- tool
+---
+ A package of pre-configured Kubernetes resources that can be managed with the Helm tool.
+
+<!--more--> 
+
+Charts provide a reproducible way of creating and sharing Kubernetes applications.
+A single chart can be used to deploy something simple, like a memcached Pod, or something complex, like a full web app stack with HTTP servers, databases, caches, and so on.
+

--- a/content/vi/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/vi/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,0 +1,19 @@
+---
+title: Horizontal Pod Autoscaler
+id: horizontal-pod-autoscaler
+date: 2018-04-12
+full_link: /docs/tasks/run-application/horizontal-pod-autoscale/
+short_description: >
+  An API resource that automatically scales the number of pod replicas based on targeted CPU utilization or custom metric targets.
+
+aka: 
+- HPA
+tags:
+- operation
+---
+ An API resource that automatically scales the number of {{< glossary_tooltip term_id="pod" >}} replicas based on targeted CPU utilization or custom metric targets.
+
+<!--more--> 
+
+HPA is typically used with {{< glossary_tooltip text="ReplicationControllers" term_id="replication-controller" >}}, {{< glossary_tooltip text="Deployments" term_id="deployment" >}}, or {{< glossary_tooltip text="ReplicaSets" term_id="replica-set" >}}. It cannot be applied to objects that cannot be scaled, for example {{< glossary_tooltip text="DaemonSets" term_id="daemonset" >}}.
+

--- a/content/vi/docs/reference/glossary/host-aliases.md
+++ b/content/vi/docs/reference/glossary/host-aliases.md
@@ -1,0 +1,17 @@
+---
+title: HostAliases
+id: HostAliases
+date: 2019-01-31
+full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
+short_description: >
+  A HostAliases is a mapping between the IP address and hostname to be injected into a Pod's hosts file.
+
+aka:
+tags:
+- operation
+---
+ A HostAliases is a mapping between the IP address and hostname to be injected into a {{< glossary_tooltip text="Pod" term_id="pod" >}}'s hosts file.
+
+<!--more-->
+
+[HostAliases](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core) is an optional list of hostnames and IP addresses that will be injected into the Pod's hosts file if specified. This is only valid for non-hostNetwork Pods.

--- a/content/vi/docs/reference/glossary/image.md
+++ b/content/vi/docs/reference/glossary/image.md
@@ -1,0 +1,18 @@
+---
+title: Image
+id: image
+date: 2018-04-12
+full_link: 
+short_description: >
+  Stored instance of a container that holds a set of software needed to run an application.
+
+aka: 
+tags:
+- fundamental
+---
+ Stored instance of a {{< glossary_tooltip term_id="container" >}} that holds a set of software needed to run an application.
+
+<!--more-->
+
+A way of packaging software that allows it to be stored in a container registry, pulled to a local system, and run as an application. Meta data is included in the image that can indicate what executable to run, who built it, and other information.
+

--- a/content/vi/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/vi/docs/reference/glossary/immutable-infrastructure.md
@@ -1,0 +1,26 @@
+---
+title: Immutable Infrastructure
+id: immutable-infrastructure
+date: 2024-03-25
+full_link:
+short_description: >
+  Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed
+
+aka: 
+tags:
+- architecture
+---
+ Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed.
+
+<!--more-->
+
+Immutability can be enforced by an automated process that overwrites unauthorized changes or through a system that won’t allow changes in the first place.
+{{< glossary_tooltip text="Containers" term_id="container" >}} are a good example of immutable infrastructure because persistent changes to containers
+can only be made by creating a new version of the container or recreating the existing container from its image.
+
+By preventing or identifying unauthorized changes, immutable infrastructures make it easier to identify and mitigate security risks. 
+Operating such a system becomes a lot more straightforward because administrators can make assumptions about it.
+After all, they know no one made mistakes or changes they forgot to communicate.
+Immutable infrastructure goes hand-in-hand with infrastructure as code where all automation needed
+to create infrastructure is stored in version control (such as Git).
+This combination of immutability and version control means that there is a durable audit log of every authorized change to a system.

--- a/content/vi/docs/reference/glossary/infrastructure-resource.md
+++ b/content/vi/docs/reference/glossary/infrastructure-resource.md
@@ -1,0 +1,24 @@
+---
+title: Resource (infrastructure)
+id: infrastructure-resource
+date: 2025-02-09
+short_description: >
+  A defined amount of infrastructure available for consumption (CPU, memory, etc).
+
+aka:
+tags:
+- architecture
+---
+Capabilities provided to one or more {{< glossary_tooltip text="nodes" term_id="node" >}} (CPU, memory, GPUs, etc), and made available for consumption by
+{{< glossary_tooltip text="Pods" term_id="pod" >}} running on those nodes.
+
+Kubernetes also uses the term _resource_ to describe an {{< glossary_tooltip text="API resource" term_id="api-resource" >}}.
+
+<!--more-->
+Computers provide fundamental hardware facilities: processing power, storage memory, network, etc.
+These resources have finite capacity, measured in a unit applicable to that resource (number of CPUs, bytes of memory, etc).
+Kubernetes abstracts common [resources](/docs/concepts/configuration/manage-resources-containers/)
+for allocation to workloads and utilizes operating system primitives (for example, Linux {{< glossary_tooltip text="cgroups" term_id="cgroup" >}}) to manage consumption by {{< glossary_tooltip text="workloads" term_id="workload" >}}).
+
+You can also use [dynamic resource allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) to
+manage complex resource allocations automatically.

--- a/content/vi/docs/reference/glossary/ingress.md
+++ b/content/vi/docs/reference/glossary/ingress.md
@@ -1,0 +1,20 @@
+---
+title: Ingress
+id: ingress
+date: 2018-04-12
+full_link: /docs/concepts/services-networking/ingress/
+short_description: >
+  An API object that manages external access to the services in a cluster, typically HTTP.
+
+aka: 
+tags:
+- networking
+- architecture
+- extension
+---
+ An API object that manages external access to the services in a cluster, typically HTTP.
+
+<!--more--> 
+
+Ingress may provide load balancing, SSL termination and name-based virtual hosting.
+

--- a/content/vi/docs/reference/glossary/istio.md
+++ b/content/vi/docs/reference/glossary/istio.md
@@ -1,0 +1,19 @@
+---
+title: Istio
+id: istio
+date: 2018-04-12
+full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
+short_description: >
+  An open platform (not Kubernetes-specific) that provides a uniform way to integrate microservices, manage traffic flow, enforce policies, and aggregate telemetry data.
+
+aka: 
+tags:
+- networking
+- architecture
+- extension
+---
+ An open platform (not Kubernetes-specific) that provides a uniform way to integrate microservices, manage traffic flow, enforce policies, and aggregate telemetry data.
+
+<!--more--> 
+
+Adding Istio does not require changing application code. It is a layer of infrastructure between a service and the network, which when combined with service deployments, is commonly referred to as a service mesh. Istio's control plane abstracts away the underlying cluster management platform, which may be Kubernetes, Mesosphere, etc.

--- a/content/vi/docs/reference/glossary/job.md
+++ b/content/vi/docs/reference/glossary/job.md
@@ -1,0 +1,20 @@
+---
+title: Job
+id: job
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/job/
+short_description: >
+  A finite or batch task that runs to completion.
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ A finite or batch task that runs to completion.
+
+<!--more--> 
+
+Creates one or more {{< glossary_tooltip term_id="pod" >}} objects and ensures that a specified number of them successfully terminate. As Pods successfully complete, the Job tracks the successful completions.
+

--- a/content/vi/docs/reference/glossary/jwt.md
+++ b/content/vi/docs/reference/glossary/jwt.md
@@ -1,0 +1,20 @@
+---
+title: JSON Web Token (JWT)
+id: jwt
+date: 2023-01-17
+full_link: https://www.rfc-editor.org/rfc/rfc7519
+short_description: >
+  A means of representing claims to be transferred between two parties.
+
+aka:
+tags:
+- security
+- architecture
+---
+ A means of representing claims to be transferred between two parties.
+
+<!--more-->
+
+JWTs can be digitally signed and encrypted. Kubernetes uses JWTs as
+authentication tokens to verify the identity of entities that want to perform
+actions in a cluster.

--- a/content/vi/docs/reference/glossary/kops.md
+++ b/content/vi/docs/reference/glossary/kops.md
@@ -1,0 +1,29 @@
+---
+title: kOps (Kubernetes Operations)
+id: kops
+date: 2018-04-12
+full_link: /docs/setup/production-environment/kops/
+short_description: >
+  kOps will not only help you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes cluster, but it will also provision the necessary cloud infrastructure.
+
+aka: 
+tags:
+- tool
+- operation
+---
+
+`kOps` will not only help you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes cluster, but it will also provision the necessary cloud infrastructure.
+
+<!--more--> 
+
+{{< note >}}
+AWS (Amazon Web Services) is currently officially supported, with DigitalOcean, GCE and OpenStack in beta support, and Azure in alpha.
+{{< /note >}}
+
+`kOps` is an automated provisioning system:
+  * Fully automated installation
+  * Uses DNS to identify clusters
+  * Self-healing: everything runs in Auto-Scaling Groups
+  * Multiple OS support (Amazon Linux, Debian, Flatcar, RHEL, Rocky and Ubuntu)
+  * High-Availability support
+  * Can directly provision, or generate terraform manifests

--- a/content/vi/docs/reference/glossary/kube-controller-manager.md
+++ b/content/vi/docs/reference/glossary/kube-controller-manager.md
@@ -1,0 +1,18 @@
+---
+title: kube-controller-manager
+id: kube-controller-manager
+date: 2018-04-12
+full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
+short_description: >
+  Control Plane component that runs controller processes.
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+ Control plane component that runs {{< glossary_tooltip text="controller" term_id="controller" >}} processes.
+
+<!--more-->
+
+Logically, each {{< glossary_tooltip text="controller" term_id="controller" >}} is a separate process, but to reduce complexity, they are all compiled into a single binary and run in a single process.

--- a/content/vi/docs/reference/glossary/kubectl.md
+++ b/content/vi/docs/reference/glossary/kubectl.md
@@ -1,0 +1,24 @@
+---
+title: Kubectl
+id: kubectl
+date: 2018-04-12
+full_link: /docs/reference/kubectl/
+short_description: >
+  A command line tool for communicating with a Kubernetes cluster.
+
+aka:
+- kubectl
+tags:
+- tool
+- fundamental
+---
+Command line tool for communicating with a Kubernetes cluster's
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}},
+using the Kubernetes API.
+
+<!--more--> 
+
+You can use `kubectl` to create, inspect, update, and delete Kubernetes objects.
+
+<!-- localization note: OK to omit the rest of this entry -->
+In English, `kubectl` is (officially) pronounced /kjuːb/ /kənˈtɹəʊl/ (like "cube control").

--- a/content/vi/docs/reference/glossary/limitrange.md
+++ b/content/vi/docs/reference/glossary/limitrange.md
@@ -1,0 +1,23 @@
+---
+title: LimitRange
+id: limitrange
+date: 2019-04-15
+full_link:  /docs/concepts/policy/limit-range/
+short_description: >
+  Provides constraints to limit resource consumption per Containers or Pods in a namespace.
+
+aka: 
+tags:
+- core-object
+- fundamental
+- architecture
+related:
+ - pod
+ - container
+
+---
+ Provides constraints to limit resource consumption per {{< glossary_tooltip text="Containers" term_id="container" >}} or {{< glossary_tooltip text="Pods" term_id="pod" >}} in a namespace.
+
+<!--more--> 
+LimitRange limits the quantity of objects that can be created  by type, 
+as well as the amount of compute resources that may be requested/consumed by individual {{< glossary_tooltip text="Containers" term_id="container" >}} or {{< glossary_tooltip text="Pods" term_id="pod" >}} in a namespace.

--- a/content/vi/docs/reference/glossary/logging.md
+++ b/content/vi/docs/reference/glossary/logging.md
@@ -1,0 +1,18 @@
+---
+title: Logging
+id: logging
+date: 2019-04-04
+full_link: /docs/concepts/cluster-administration/logging/
+short_description: >
+  Logs are the list of events that are logged by cluster or application.
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+ Logs are the list of events that are logged by {{< glossary_tooltip text="cluster" term_id="cluster" >}} or application.
+
+<!--more--> 
+
+Application and systems logs can help you understand what is happening inside your cluster. The logs are particularly useful for debugging problems and monitoring cluster activity. 

--- a/content/vi/docs/reference/glossary/manifest.md
+++ b/content/vi/docs/reference/glossary/manifest.md
@@ -1,0 +1,17 @@
+---
+title: Manifest
+id: manifest
+date: 2019-06-28
+short_description: >
+  A serialized specification of one or more Kubernetes API objects.
+
+aka:
+tags:
+- fundamental
+---
+Specification of a Kubernetes API object in [JSON](https://www.json.org/json-en.html)
+or [YAML](https://yaml.org/) format.
+
+<!--more-->
+A manifest specifies the desired state of an object that Kubernetes will maintain when you apply the manifest.
+For YAML format, each file can contain multiple manifests.

--- a/content/vi/docs/reference/glossary/master.md
+++ b/content/vi/docs/reference/glossary/master.md
@@ -1,0 +1,15 @@
+---
+title: Master
+id: master
+date: 2020-04-16
+short_description: >
+  Legacy term, used as synonym for nodes running the control plane.
+
+aka:
+tags:
+- fundamental
+---
+ Legacy term, used as synonym for {{< glossary_tooltip text="nodes" term_id="node" >}} hosting the {{< glossary_tooltip text="control plane" term_id="control-plane" >}}.
+
+<!--more-->
+The term is still being used by some provisioning tools, such as {{< glossary_tooltip text="kubeadm" term_id="kubeadm" >}}, and managed services, to {{< glossary_tooltip text="label" term_id="label" >}} {{< glossary_tooltip text="nodes" term_id="node" >}} with `kubernetes.io/role` and control placement of {{< glossary_tooltip text="control plane" term_id="control-plane" >}} {{< glossary_tooltip text="pods" term_id="pod" >}}.

--- a/content/vi/docs/reference/glossary/minikube.md
+++ b/content/vi/docs/reference/glossary/minikube.md
@@ -1,0 +1,20 @@
+---
+title: Minikube
+id: minikube
+date: 2018-04-12
+full_link: /docs/tasks/tools/#minikube
+short_description: >
+  A tool for running Kubernetes locally.
+
+aka: 
+tags:
+- fundamental
+- tool
+---
+ A tool for running Kubernetes locally.
+
+<!--more--> 
+
+Minikube runs an all-in-one or a multi-node local Kubernetes cluster inside a VM on your computer.
+You can use Minikube to
+[try Kubernetes in a learning environment](/docs/tasks/tools/#minikube).

--- a/content/vi/docs/reference/glossary/mirror-pod.md
+++ b/content/vi/docs/reference/glossary/mirror-pod.md
@@ -1,0 +1,21 @@
+---
+title: Mirror Pod
+id: mirror-pod
+date: 2019-08-06
+short_description: >
+  An object in the API server that tracks a static pod on a kubelet.
+
+aka: 
+tags:
+- fundamental
+---
+ A {{< glossary_tooltip text="pod" term_id="pod" >}} object that a {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} uses
+ to represent a {{< glossary_tooltip text="static pod" term_id="static-pod" >}}
+
+<!--more--> 
+
+When the kubelet finds a static pod in its configuration, it automatically tries to
+create a Pod object on the Kubernetes API server for it. This means that the pod
+will be visible on the API server, but cannot be controlled from there.
+
+(For example, removing a mirror pod will not stop the kubelet daemon from running it).

--- a/content/vi/docs/reference/glossary/mixed-version-proxy.md
+++ b/content/vi/docs/reference/glossary/mixed-version-proxy.md
@@ -1,0 +1,21 @@
+---
+title: Mixed Version Proxy (MVP)
+id: mvp
+date: 2023-07-24
+full_link: /docs/concepts/architecture/mixed-version-proxy/
+short_description: >
+  Feature that lets a kube-apiserver proxy a resource request to a different peer API server. 
+aka: ["MVP"]
+tags:
+- architecture
+---
+Feature to let a kube-apiserver proxy a resource request to a different peer API server.
+
+<!--more-->
+
+When a cluster has multiple API servers running different versions of Kubernetes, this 
+feature enables resource requests to be served by the correct API server.
+
+MVP is disabled by default and can be activated by enabling
+the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) named `UnknownVersionInteroperabilityProxy` when 
+the {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}} is started.

--- a/content/vi/docs/reference/glossary/name.md
+++ b/content/vi/docs/reference/glossary/name.md
@@ -1,0 +1,18 @@
+---
+title: Name
+id: name
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/names
+short_description: >
+  A client-provided string that refers to an object in a resource URL, such as `/api/v1/pods/some-name`.
+
+aka: 
+tags:
+- fundamental
+---
+ A client-provided string that refers to an object in a resource URL, such as `/api/v1/pods/some-name`.
+
+<!--more--> 
+
+Only one object of a given kind can have a given name at a time. However, if you delete the object, you can make a new object with the same name.
+

--- a/content/vi/docs/reference/glossary/namespace.md
+++ b/content/vi/docs/reference/glossary/namespace.md
@@ -1,0 +1,18 @@
+---
+title: Namespace
+id: namespace
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/namespaces
+short_description: >
+  An abstraction used by Kubernetes to support isolation of groups of resources within a single cluster.
+
+aka: 
+tags:
+- fundamental
+---
+ An abstraction used by Kubernetes to support isolation of groups of resources within a single {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
+
+<!--more--> 
+
+Namespaces are used to organize objects in a cluster and provide a way to divide cluster resources. Names of resources need to be unique within a namespace, but not across namespaces. Namespace-based scoping is applicable only for namespaced objects _(e.g. Deployments, Services, etc)_ and not for cluster-wide objects _(e.g. StorageClass, Nodes, PersistentVolumes, etc)_.
+

--- a/content/vi/docs/reference/glossary/network-policy.md
+++ b/content/vi/docs/reference/glossary/network-policy.md
@@ -1,0 +1,21 @@
+---
+title: Network Policy
+id: network-policy
+date: 2018-04-12
+full_link: /docs/concepts/services-networking/network-policies/
+short_description: >
+  A specification of how groups of Pods are allowed to communicate with each other and with other network endpoints.
+
+aka: 
+tags:
+- networking
+- architecture
+- extension
+- core-object
+---
+ A specification of how groups of Pods are allowed to communicate with each other and with other network endpoints.
+
+<!--more--> 
+
+Network Policies help you declaratively configure which Pods are allowed to connect to each other, which namespaces are allowed to communicate, and more specifically which port numbers to enforce each policy on. `NetworkPolicy` resources use labels to select Pods and define rules which specify what traffic is allowed to the selected Pods. Network Policies are implemented by a supported network plugin provided by a network provider. Be aware that creating a network resource without a controller to implement it will have no effect.
+

--- a/content/vi/docs/reference/glossary/node-pressure-eviction.md
+++ b/content/vi/docs/reference/glossary/node-pressure-eviction.md
@@ -1,0 +1,24 @@
+---
+title: Node-pressure eviction
+id: node-pressure-eviction
+date: 2021-05-13
+full_link: /docs/concepts/scheduling-eviction/node-pressure-eviction/
+short_description: >
+  Node-pressure eviction is the process by which the kubelet proactively fails
+  pods to reclaim resources on nodes.
+aka:
+- kubelet eviction
+tags:
+- operation
+---
+Node-pressure eviction is the process by which the {{<glossary_tooltip term_id="kubelet" text="kubelet">}} proactively terminates
+pods to reclaim resources on nodes.
+
+<!--more-->
+
+The kubelet monitors resources like CPU, memory, disk space, and filesystem 
+inodes on your cluster's nodes. When one or more of these resources reach
+specific consumption levels, the kubelet can proactively fail one or more pods
+on the node to reclaim resources and prevent starvation. 
+
+Node-pressure eviction is not the same as [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/).

--- a/content/vi/docs/reference/glossary/operator-pattern.md
+++ b/content/vi/docs/reference/glossary/operator-pattern.md
@@ -1,0 +1,24 @@
+---
+title: Operator pattern
+id: operator-pattern
+date: 2019-05-21
+full_link: /docs/concepts/extend-kubernetes/operator/
+short_description: >
+  A specialized controller used to manage a custom resource
+
+aka:
+tags:
+- architecture
+---
+ The [operator pattern](/docs/concepts/extend-kubernetes/operator/) is a system
+design that links a {{< glossary_tooltip term_id="controller" >}} to one or more custom
+resources.
+
+<!--more-->
+
+You can extend Kubernetes by adding controllers to your cluster, beyond the built-in
+controllers that come as part of Kubernetes itself.
+
+If a running application acts as a controller and has API access to carry out tasks
+against a custom resource that's defined in the control plane, that's an example of
+the Operator pattern.

--- a/content/vi/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/vi/docs/reference/glossary/persistent-volume-claim.md
@@ -1,0 +1,18 @@
+---
+title: Persistent Volume Claim
+id: persistent-volume-claim
+date: 2018-04-12
+full_link: /docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+short_description: >
+  Claims storage resources defined in a PersistentVolume so that it can be mounted as a volume in a container.
+
+aka: 
+tags:
+- core-object
+- storage
+---
+ Claims storage resources defined in a {{< glossary_tooltip text="PersistentVolume" term_id="persistent-volume" >}} so that it can be mounted as a volume in a {{< glossary_tooltip text="container" term_id="container" >}}.
+
+<!--more--> 
+
+Specifies the amount of storage, how the storage will be accessed (read-only, read-write and/or exclusive) and how it is reclaimed (retained, recycled or deleted). Details of the storage itself are described in the PersistentVolume object.

--- a/content/vi/docs/reference/glossary/persistent-volume.md
+++ b/content/vi/docs/reference/glossary/persistent-volume.md
@@ -1,0 +1,21 @@
+---
+title: Persistent Volume
+id: persistent-volume
+date: 2018-04-12
+full_link: /docs/concepts/storage/persistent-volumes/
+short_description: >
+  An API object that represents a piece of storage in the cluster. Available as a general, pluggable resource that persists beyond the lifecycle of any individual Pod.
+
+aka: 
+tags:
+- core-object
+- storage
+---
+ An API object that represents a piece of storage in the cluster. Available as a general, pluggable resource that persists beyond the lifecycle of any individual {{< glossary_tooltip text="Pod" term_id="pod" >}}.
+
+<!--more--> 
+
+PersistentVolumes (PVs) provide an API that abstracts details of how storage is provided from how it is consumed.
+PVs are used directly in scenarios where storage can be created ahead of time (static provisioning).
+For scenarios that require on-demand storage (dynamic provisioning), PersistentVolumeClaims (PVCs) are used instead.
+

--- a/content/vi/docs/reference/glossary/platform-developer.md
+++ b/content/vi/docs/reference/glossary/platform-developer.md
@@ -1,0 +1,23 @@
+---
+title: Platform Developer
+id: platform-developer
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person who customizes the Kubernetes platform to fit the needs of their project.
+
+aka: 
+tags:
+- user-type
+---
+ A person who customizes the Kubernetes platform to fit the needs of their project.
+
+<!--more--> 
+
+A platform developer may, for example, use [Custom Resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/) or
+[Extend the Kubernetes API with the aggregation layer](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)
+to add functionality to their instance of Kubernetes, specifically for their application.
+Some Platform Developers are also {{< glossary_tooltip text="contributors" term_id="contributor" >}} and
+develop extensions which are contributed to the Kubernetes community.
+Others develop closed-source commercial or site-specific extensions.
+

--- a/content/vi/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/vi/docs/reference/glossary/pod-disruption-budget.md
@@ -1,0 +1,26 @@
+---
+id: pod-disruption-budget
+title: Pod Disruption Budget
+full-link: /docs/concepts/workloads/pods/disruptions/
+date: 2019-02-12
+short_description: >
+ An object that limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions.
+
+aka:
+ - PDB
+related:
+ - pod
+ - container
+tags:
+ - operation
+---
+
+ A [Pod Disruption Budget](/docs/concepts/workloads/pods/disruptions/) allows an 
+ application owner to create an object for a replicated application, that ensures 
+ a certain number or percentage of {{< glossary_tooltip text="Pods" term_id="pod" >}}
+ with an assigned label will not be voluntarily evicted at any point in time.
+
+<!--more--> 
+
+Involuntary disruptions cannot be prevented by PDBs; however they 
+do count against the budget.

--- a/content/vi/docs/reference/glossary/pod-disruption.md
+++ b/content/vi/docs/reference/glossary/pod-disruption.md
@@ -1,0 +1,24 @@
+---
+id: pod-disruption
+title: Pod Disruption
+full_link: /docs/concepts/workloads/pods/disruptions/
+date: 2021-05-12
+short_description: >
+  The process by which Pods on Nodes are terminated either voluntarily or involuntarily.
+
+aka:
+related:
+ - pod
+ - container
+tags:
+ - operation
+---
+
+[Pod disruption](/docs/concepts/workloads/pods/disruptions/) is the process by which 
+Pods on Nodes are terminated either voluntarily or involuntarily. 
+
+<!--more--> 
+
+Voluntary disruptions are started intentionally by application owners or cluster 
+administrators. Involuntary disruptions are unintentional and can be triggered by 
+unavoidable issues like Nodes running out of resources, or by accidental deletions. 

--- a/content/vi/docs/reference/glossary/pod-lifecycle.md
+++ b/content/vi/docs/reference/glossary/pod-lifecycle.md
@@ -1,0 +1,19 @@
+---
+title: Pod Lifecycle
+id: pod-lifecycle
+date: 2019-02-17
+full-link: /docs/concepts/workloads/pods/pod-lifecycle/
+related:
+ - pod
+ - container
+tags:
+ - fundamental
+short_description: >
+  The sequence of states through which a Pod passes during its lifetime.
+ 
+---
+ The sequence of states through which a Pod passes during its lifetime.
+
+<!--more--> 
+
+The [Pod Lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/) is defined by the states or phases of a Pod. There are five possible Pod phases: Pending, Running, Succeeded, Failed, and Unknown. A high-level description of the Pod state is summarized in the [PodStatus](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podstatus-v1-core) `phase` field.

--- a/content/vi/docs/reference/glossary/pod-priority.md
+++ b/content/vi/docs/reference/glossary/pod-priority.md
@@ -1,0 +1,17 @@
+---
+title: Pod Priority
+id: pod-priority
+date: 2019-01-31
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+short_description: >
+  Pod Priority indicates the importance of a Pod relative to other Pods.
+
+aka:
+tags:
+- operation
+---
+ Pod Priority indicates the importance of a {{< glossary_tooltip term_id="pod" >}} relative to other Pods.
+
+<!--more-->
+
+[Pod Priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) gives the ability to set scheduling priority of a Pod to be higher and lower than other Pods — an important feature for production clusters workload.

--- a/content/vi/docs/reference/glossary/pod-security-policy.md
+++ b/content/vi/docs/reference/glossary/pod-security-policy.md
@@ -1,0 +1,21 @@
+---
+title: Pod Security Policy
+id: pod-security-policy
+date: 2018-04-12
+full_link: /docs/concepts/security/pod-security-policy/
+short_description: >
+  Enables fine-grained authorization of pod creation and updates.
+
+aka: 
+tags:
+- core-object
+- fundamental
+---
+ Enables fine-grained authorization of {{< glossary_tooltip term_id="pod" >}} creation and updates.
+
+<!--more--> 
+
+A cluster-level resource that controls security sensitive aspects of the Pod specification. The `PodSecurityPolicy` objects define a set of conditions that a Pod must run with in order to be accepted into the system, as well as defaults for the related fields. Pod Security Policy control is implemented as an optional admission controller.
+
+PodSecurityPolicy was deprecated as of Kubernetes v1.21, and removed in v1.25.
+As an alternative, use [Pod Security Admission](/docs/concepts/security/pod-security-admission/) or a 3rd party admission plugin.

--- a/content/vi/docs/reference/glossary/pod-template.md
+++ b/content/vi/docs/reference/glossary/pod-template.md
@@ -1,0 +1,28 @@
+---
+title: PodTemplate
+id: pod-template
+date: 2024-10-13
+short_description: >
+  A template for creating Pods.
+
+aka: 
+  - pod template
+tags:
+- core-object
+
+---
+An API object that defines a template for creating {{< glossary_tooltip text="Pods" term_id="pod" >}}.
+The PodTemplate API is also embedded in API definitions for workload management, such as 
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}} or
+{{< glossary_tooltip text="StatefulSets" term_id="StatefulSet" >}}.
+
+<!--more--> 
+
+Pod templates allow you to define common metadata (such as labels, or a template for the name of a
+new Pod) as well as to specify a pod's desired state.
+[Workload management](/docs/concepts/workloads/controllers/) controllers use Pod templates
+(embedded into another object, such as a Deployment or StatefulSet)
+to define and manage one or more {{< glossary_tooltip text="Pods" term_id="pod" >}}.
+When there can be multiple Pods based on the same template, these are called
+{{< glossary_tooltip term_id="replica" text="replicas" >}}.
+Although you can create a PodTemplate object directly, you rarely need to do so.

--- a/content/vi/docs/reference/glossary/preemption.md
+++ b/content/vi/docs/reference/glossary/preemption.md
@@ -1,0 +1,17 @@
+---
+title: Preemption
+id: preemption
+date: 2019-01-31
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
+short_description: >
+  Preemption logic in Kubernetes helps a pending Pod to find a suitable Node by evicting low priority Pods existing on that Node.
+
+aka:
+tags:
+- operation
+---
+ Preemption logic in Kubernetes helps a pending {{< glossary_tooltip term_id="pod" >}} to find a suitable {{< glossary_tooltip term_id="node" >}} by evicting low priority Pods existing on that Node.
+
+<!--more-->
+
+If a Pod cannot be scheduled, the scheduler tries to [preempt](/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption) lower priority Pods to make scheduling of the pending Pod possible.

--- a/content/vi/docs/reference/glossary/priority-class.md
+++ b/content/vi/docs/reference/glossary/priority-class.md
@@ -1,0 +1,20 @@
+---
+title: PriorityClass
+id: priority-class
+date: 2024-03-19
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+short_description: >
+  A mapping from a class name to the scheduling priority that a Pod should have.
+aka:
+tags:
+- core-object
+---
+A PriorityClass is a named class for the scheduling priority that should be assigned to a Pod
+in that class.
+
+<!--more-->
+
+A [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption)
+is a non-namespaced object mapping a name to an integer priority, used for a Pod. The name is
+specified in the `metadata.name` field, and the priority value in the `value` field. Priorities range from
+-2147483648 to 1000000000 inclusive. Higher values indicate higher priority.

--- a/content/vi/docs/reference/glossary/probe.md
+++ b/content/vi/docs/reference/glossary/probe.md
@@ -1,0 +1,18 @@
+---
+title: Probe
+id: probe
+date: 2023-03-21
+full_link: /docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+
+short_description: >
+  A check performed periodically by the kubelet on a container in a Pod.
+
+tags:
+- tool
+---
+A check that the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} periodically performs against a container that is 
+running in a pod, that will define container's state and health and informing container's lifecycle.
+
+<!--more-->
+ 
+To learn more, read [container probes](/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).

--- a/content/vi/docs/reference/glossary/proxy.md
+++ b/content/vi/docs/reference/glossary/proxy.md
@@ -1,0 +1,27 @@
+---
+title: Proxy
+id: proxy
+date: 2019-09-10
+short_description: >
+  An application acting as an intermediary between clients and servers
+
+aka:
+tags:
+- networking
+---
+ In computing, a proxy is a server that acts as an intermediary for a remote
+service.
+
+<!--more-->
+
+A client interacts with the proxy; the proxy copies the client's data to the
+actual server; the actual server replies to the proxy; the proxy sends the
+actual server's reply to the client.
+
+[kube-proxy](/docs/reference/command-line-tools-reference/kube-proxy/) is a
+network proxy that runs on each node in your cluster, implementing part of
+the Kubernetes {{< glossary_tooltip term_id="service">}} concept.
+
+You can run kube-proxy as a plain userland proxy service. If your operating
+system supports it, you can instead run kube-proxy in a hybrid mode that
+achieves the same overall effect using less system resources.

--- a/content/vi/docs/reference/glossary/qos-class.md
+++ b/content/vi/docs/reference/glossary/qos-class.md
@@ -1,0 +1,23 @@
+---
+title: QoS Class
+id: qos-class
+date: 2019-04-15
+full_link: /docs/concepts/workloads/pods/pod-qos/
+short_description: >
+  QoS Class (Quality of Service Class) provides a way for Kubernetes to classify pods within the cluster into several classes and make decisions about scheduling and eviction.
+
+aka: 
+tags:
+- fundamental
+- architecture
+related:
+ - pod
+
+---
+ QoS Class (Quality of Service Class) provides a way for Kubernetes to classify Pods within the cluster into several classes and make decisions about scheduling and eviction.
+
+<!--more--> 
+QoS Class of a Pod is set at creation time  based on its compute resources requests and limits settings. QoS classes are used to make decisions about Pods scheduling and eviction.
+Kubernetes can assign one of the following  QoS classes to a Pod: `Guaranteed`, `Burstable` or `BestEffort`.
+
+

--- a/content/vi/docs/reference/glossary/quantity.md
+++ b/content/vi/docs/reference/glossary/quantity.md
@@ -1,0 +1,33 @@
+---
+title: Quantity
+id: quantity
+date: 2018-08-07
+full_link:
+short_description: >
+  A whole-number representation of small or large numbers using SI suffixes.
+
+aka: 
+tags:
+- fundamental
+
+---
+ A whole-number representation of small or large numbers using [SI](https://en.wikipedia.org/wiki/International_System_of_Units) suffixes.
+
+<!--more-->
+
+Quantities are representations of small or large numbers using a compact,
+whole-number notation with SI suffixes.  Fractional numbers are represented
+using milli units, while large numbers can be represented using kilo,
+mega, or giga units.
+
+For instance, the number `1.5` is represented as `1500m`, while the number `1000`
+can be represented as `1k`, and `1000000` as `1M`. You can also specify
+[binary-notation](https://en.wikipedia.org/wiki/Binary_prefix) suffixes; the number 2048 can be written as `2Ki`.
+
+The accepted decimal (power-of-10) units are `m` (milli), `k` (kilo,
+intentionally lowercase), `M` (mega), `G` (giga), `T` (tera), `P` (peta),
+`E` (exa).
+
+The accepted binary (power-of-2) units are `Ki` (kibi), `Mi` (mebi), `Gi` (gibi),
+`Ti` (tebi), `Pi` (pebi), `Ei` (exbi).
+

--- a/content/vi/docs/reference/glossary/rbac.md
+++ b/content/vi/docs/reference/glossary/rbac.md
@@ -1,0 +1,32 @@
+---
+title: RBAC (Role-Based Access Control)
+id: rbac
+date: 2018-04-12
+full_link: /docs/reference/access-authn-authz/rbac/
+short_description: >
+  Manages authorization decisions, allowing admins to dynamically configure access policies through the Kubernetes API.
+
+aka: 
+tags:
+- security
+- fundamental
+---
+ Manages authorization decisions, allowing admins to dynamically configure access policies through the {{< glossary_tooltip text="Kubernetes API" term_id="kubernetes-api" >}}.
+
+<!--more--> 
+
+RBAC utilizes four kinds of Kubernetes objects:
+
+Role
+: Defines permission rules in a specific namespace.
+
+ClusterRole
+: Defines permission rules cluster-wide.
+
+RoleBinding
+: Grants the permissions defined in a role to a set of users in a specific namespace.
+
+ClusterRoleBinding
+: Grants the permissions defined in a role to a set of users cluster-wide.
+
+For more information, see [RBAC](/docs/reference/access-authn-authz/rbac/).

--- a/content/vi/docs/reference/glossary/replica-set.md
+++ b/content/vi/docs/reference/glossary/replica-set.md
@@ -1,0 +1,21 @@
+---
+title: ReplicaSet
+id: replica-set
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/replicaset/
+short_description: >
+ ReplicaSet ensures that a specified number of Pod replicas are running at one time
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ A ReplicaSet (aims to) maintain a set of replica Pods running at any given time.
+
+<!--more-->
+
+Workload objects such as {{< glossary_tooltip term_id="deployment" >}} make use of ReplicaSets
+to ensure that the configured number of {{< glossary_tooltip term_id="pod" text="Pods" >}} are
+running in your cluster, based on the spec of that ReplicaSet.

--- a/content/vi/docs/reference/glossary/replica.md
+++ b/content/vi/docs/reference/glossary/replica.md
@@ -1,0 +1,26 @@
+---
+title: Replica
+id: replica
+date: 2023-06-11
+full_link: 
+short_description: >
+  Replicas are copies of pods, ensuring availability, scalability, and fault tolerance by maintaining identical instances.
+aka: 
+tags:
+- fundamental
+- workload
+---
+A copy or duplicate of a {{< glossary_tooltip text="Pod" term_id="pod" >}} or
+a set of pods. Replicas ensure high availability, scalability, and fault tolerance
+by maintaining multiple identical instances of a pod.
+
+<!--more-->
+Replicas are commonly used in Kubernetes to achieve the desired application state and reliability.
+They enable workload scaling and distribution across multiple nodes in a cluster.
+
+By defining the number of replicas in a Deployment or ReplicaSet, Kubernetes ensures that
+the specified number of instances are running, automatically adjusting the count as needed.
+
+Replica management allows for efficient load balancing, rolling updates, and
+self-healing capabilities in a Kubernetes cluster.
+

--- a/content/vi/docs/reference/glossary/replication-controller.md
+++ b/content/vi/docs/reference/glossary/replication-controller.md
@@ -1,0 +1,25 @@
+---
+title: ReplicationController
+id: replication-controller
+date: 2018-04-12
+full_link: 
+short_description: >
+  A (deprecated) API object that manages a replicated application.
+
+aka: 
+tags:
+- workload
+- core-object
+---
+ A workload resource that manages a replicated application, ensuring that
+a specific number of instances of a {{< glossary_tooltip text="Pod" term_id="pod" >}} are running.
+
+<!--more-->
+
+The control plane ensures that the defined number of Pods are running, even if some
+Pods fail, if you delete Pods manually, or if too many are started by mistake.
+
+{{< note >}}
+ReplicationController is deprecated. See
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}}, which is similar.
+{{< /note >}}

--- a/content/vi/docs/reference/glossary/resource-quota.md
+++ b/content/vi/docs/reference/glossary/resource-quota.md
@@ -1,0 +1,20 @@
+---
+title: Resource Quotas
+id: resource-quota
+date: 2018-04-12
+full_link: /docs/concepts/policy/resource-quotas/
+short_description: >
+  Provides constraints that limit aggregate resource consumption per namespace.
+
+aka: 
+tags:
+- fundamental
+- operation
+- architecture
+---
+ Provides constraints that limit aggregate resource consumption per {{< glossary_tooltip term_id="namespace" >}}.
+
+<!--more--> 
+
+Limits the quantity of objects that can be created in a namespace by type, as well as the total amount of compute resources that may be consumed by resources in that project.
+

--- a/content/vi/docs/reference/glossary/reviewer.md
+++ b/content/vi/docs/reference/glossary/reviewer.md
@@ -1,0 +1,18 @@
+---
+title: Reviewer
+id: reviewer
+date: 2018-04-12
+full_link: 
+short_description: >
+  A person who reviews code for quality and correctness on some part of the project.
+
+aka: 
+tags:
+- community
+---
+ A person who reviews code for quality and correctness on some part of the project.
+
+<!--more--> 
+
+Reviewers are knowledgeable about both the codebase and software engineering principles. Reviewer status is scoped to a part of the codebase.
+

--- a/content/vi/docs/reference/glossary/secret.md
+++ b/content/vi/docs/reference/glossary/secret.md
@@ -1,0 +1,27 @@
+---
+title: Secret
+id: secret
+date: 2018-04-12
+full_link: /docs/concepts/configuration/secret/
+short_description: >
+  Stores sensitive information, such as passwords, OAuth tokens, and ssh keys.
+
+aka:
+tags:
+- core-object
+- security
+---
+ Stores sensitive information, such as passwords, OAuth tokens, and SSH keys.
+
+<!--more-->
+
+Secrets give you more control over how sensitive information is used and reduces
+the risk of accidental exposure. Secret values are encoded as base64 strings and
+are stored unencrypted by default, but can be configured to be
+[encrypted at rest](/docs/tasks/administer-cluster/encrypt-data/#ensure-all-secrets-are-encrypted).
+
+A {{< glossary_tooltip text="Pod" term_id="pod" >}} can reference the Secret in
+a variety of ways, such as in a volume mount or as an environment variable.
+Secrets are designed for confidential data and
+[ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/) are
+designed for non-confidential data.

--- a/content/vi/docs/reference/glossary/security-context.md
+++ b/content/vi/docs/reference/glossary/security-context.md
@@ -1,0 +1,23 @@
+---
+title: Security Context
+id: security-context
+date: 2018-04-12
+full_link: /docs/tasks/configure-pod-container/security-context/
+short_description: >
+  The securityContext field defines privilege and access control settings for a Pod or container.
+
+aka: 
+tags:
+- security
+---
+ The `securityContext` field defines privilege and access control settings for
+a {{< glossary_tooltip text="Pod" term_id="pod" >}} or
+{{< glossary_tooltip text="container" term_id="container" >}}.
+
+<!--more-->
+
+In a `securityContext`, you can define: the user that processes run as,
+the group that processes run as, and privilege settings.
+You can also configure security policies (for example: SELinux, AppArmor or seccomp).
+
+The `PodSpec.securityContext` setting applies to all containers in a Pod.

--- a/content/vi/docs/reference/glossary/service-account.md
+++ b/content/vi/docs/reference/glossary/service-account.md
@@ -1,0 +1,18 @@
+---
+title: ServiceAccount
+id: service-account
+date: 2018-04-12
+full_link: /docs/tasks/configure-pod-container/configure-service-account/
+short_description: >
+  Provides an identity for processes that run in a Pod.
+
+aka: 
+tags:
+- fundamental
+- core-object
+---
+ Provides an identity for processes that run in a {{< glossary_tooltip text="Pod" term_id="pod" >}}.
+
+<!--more--> 
+
+When processes inside Pods access the cluster, they are authenticated by the API server as a particular service account, for example, `default`. When you create a Pod, if you do not specify a service account, it is automatically assigned the default service account in the same {{< glossary_tooltip text="Namespace" term_id="namespace" >}}.

--- a/content/vi/docs/reference/glossary/service-catalog.md
+++ b/content/vi/docs/reference/glossary/service-catalog.md
@@ -1,0 +1,18 @@
+---
+title: Service Catalog
+id: service-catalog
+date: 2018-04-12
+full_link: 
+short_description: >
+  A former extension API that enabled applications running in Kubernetes clusters to easily use external managed software offerings, such as a datastore service offered by a cloud provider.
+
+aka: 
+tags:
+- extension
+---
+ A former extension API that enabled applications running in Kubernetes clusters to easily use external managed software offerings, such as a datastore service offered by a cloud provider.
+
+<!--more--> 
+
+It provided a way to list, provision, and bind with external {{< glossary_tooltip text="Managed Services" term_id="managed-service" >}} without needing detailed knowledge about how those services would be created or managed.
+

--- a/content/vi/docs/reference/glossary/shuffle-sharding.md
+++ b/content/vi/docs/reference/glossary/shuffle-sharding.md
@@ -1,0 +1,45 @@
+---
+title: Shuffle-sharding
+id: shuffle-sharding
+date: 2020-03-04
+full_link:
+short_description: >
+  A technique for assigning requests to queues that provides better isolation than hashing modulo the number of queues.
+
+aka:
+tags:
+- fundamental
+---
+A technique for assigning requests to queues that provides better isolation than hashing modulo the number of queues.
+
+<!--more--> 
+
+We are often concerned with insulating different flows of requests
+from each other, so that a high-intensity flow does not crowd out low-intensity flows.
+A simple way to put requests into queues is to hash some
+characteristics of the request, modulo the number of queues, to get
+the index of the queue to use. The hash function uses as input
+characteristics of the request that align with flows. For example, in
+the Internet this is often the 5-tuple of source and destination
+address, protocol, and source and destination port.
+
+That simple hash-based scheme has the property that any high-intensity flow
+will crowd out all the low-intensity flows that hash to the same queue.
+Providing good insulation for a large number of flows requires a large
+number of queues, which is problematic. Shuffle-sharding is a more
+nimble technique that can do a better job of insulating the low-intensity
+flows from the high-intensity flows. The terminology of shuffle-sharding uses
+the metaphor of dealing a hand from a deck of cards; each queue is a
+metaphorical card. The shuffle-sharding technique starts with hashing
+the flow-identifying characteristics of the request, to produce a hash
+value with dozens or more of bits. Then the hash value is used as a
+source of entropy to shuffle the deck and deal a hand of cards
+(queues). All the dealt queues are examined, and the request is put
+into one of the examined queues with the shortest length. With a
+modest hand size, it does not cost much to examine all the dealt cards
+and a given low-intensity flow has a good chance to dodge the effects of a
+given high-intensity flow. With a large hand size it is expensive to examine
+the dealt queues and more difficult for the low-intensity flows to dodge the
+collective effects of a set of high-intensity flows. Thus, the hand size
+should be chosen judiciously.
+

--- a/content/vi/docs/reference/glossary/spec.md
+++ b/content/vi/docs/reference/glossary/spec.md
@@ -1,0 +1,21 @@
+---
+title: Spec
+id: spec
+date: 2023-12-17
+full_link: /docs/concepts/overview/working-with-objects/#object-spec-and-status
+short_description: >
+  This field in Kubernetes manifests defines the desired state or configuration for specific Kubernetes objects.
+
+aka:
+tags:
+- fundamental
+- architecture
+---
+  Defines how each object, like Pods or Services, should be configured and its desired state.
+
+<!--more-->
+Almost every Kubernetes object includes two nested object fields that govern the object's configuration: the object spec and the object status. For objects that have a spec, you have to set this when you create the object, providing a description of the characteristics you want the resource to have: its desired state.
+
+It varies for different objects like Pods, StatefulSets, and Services, detailing settings such as containers, volumes, replicas, ports,   
+and other specifications unique to each object type. This field encapsulates what state Kubernetes should maintain for the defined   
+object.

--- a/content/vi/docs/reference/glossary/static-pod.md
+++ b/content/vi/docs/reference/glossary/static-pod.md
@@ -1,0 +1,20 @@
+---
+title: Static Pod
+id: static-pod
+date: 2019-02-12
+full_link: /docs/tasks/configure-pod-container/static-pod/
+short_description: >
+  A pod managed directly by the kubelet daemon on a specific node.
+
+aka: 
+tags:
+- fundamental
+---
+
+A {{< glossary_tooltip text="pod" term_id="pod" >}} managed directly by the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}
+ daemon on a specific node,
+<!--more-->
+
+without the API server observing it.
+
+Static Pods do not support {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}}.

--- a/content/vi/docs/reference/glossary/storage-class.md
+++ b/content/vi/docs/reference/glossary/storage-class.md
@@ -1,0 +1,19 @@
+---
+title: Storage Class
+id: storageclass
+date: 2018-04-12
+full_link: /docs/concepts/storage/storage-classes
+short_description: >
+  A StorageClass provides a way for administrators to describe different available storage types.
+
+aka: 
+tags:
+- core-object
+- storage
+---
+ A StorageClass provides a way for administrators to describe different available storage types.
+
+<!--more--> 
+
+StorageClasses can map to quality-of-service levels, backup policies, or to arbitrary policies determined by cluster administrators. Each StorageClass contains the fields `provisioner`, `parameters`, and `reclaimPolicy`, which are used when a {{< glossary_tooltip text="Persistent Volume" term_id="persistent-volume" >}} belonging to the class needs to be dynamically provisioned. Users can request a particular class using the name of a StorageClass object.
+

--- a/content/vi/docs/reference/glossary/sysctl.md
+++ b/content/vi/docs/reference/glossary/sysctl.md
@@ -1,0 +1,23 @@
+---
+title: sysctl
+id: sysctl
+date: 2019-02-12
+full_link: /docs/tasks/administer-cluster/sysctl-cluster/
+short_description: >
+  An interface for getting and setting Unix kernel parameters
+
+aka:
+tags:
+- tool
+---
+ `sysctl` is a semi-standardized interface for reading or changing the
+ attributes of the running Unix kernel.
+
+<!--more-->
+
+On Unix-like systems, `sysctl` is both the name of the tool that administrators
+use to view and modify these settings, and also the system call that the tool
+uses.
+
+{{< glossary_tooltip text="Container" term_id="container" >}} runtimes and
+network plugins may rely on `sysctl` values being set a certain way.

--- a/content/vi/docs/reference/glossary/toleration.md
+++ b/content/vi/docs/reference/glossary/toleration.md
@@ -1,0 +1,18 @@
+---
+title: Toleration
+id: toleration
+date: 2019-01-11
+full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
+short_description: >
+  A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have a matching taint.
+
+aka:
+tags:
+- core-object
+- fundamental
+---
+ A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
+
+<!--more-->
+
+Tolerations and {{< glossary_tooltip text="taints" term_id="taint" >}} work together to ensure that pods are not scheduled onto inappropriate nodes. One or more tolerations are applied to a {{< glossary_tooltip text="pod" term_id="pod" >}}. A toleration indicates that the {{< glossary_tooltip text="pod" term_id="pod" >}} is allowed (but not required) to be scheduled on nodes or node groups with matching {{< glossary_tooltip text="taints" term_id="taint" >}}.

--- a/content/vi/docs/reference/glossary/uid.md
+++ b/content/vi/docs/reference/glossary/uid.md
@@ -1,0 +1,18 @@
+---
+title: UID
+id: uid
+date: 2018-04-12
+full_link: /docs/concepts/overview/working-with-objects/names
+short_description: >
+  A Kubernetes systems-generated string to uniquely identify objects.
+
+aka: 
+tags:
+- fundamental
+---
+ A Kubernetes systems-generated string to uniquely identify objects.
+
+<!--more--> 
+
+Every object created over the whole lifetime of a Kubernetes cluster has a distinct UID. It is intended to distinguish between historical occurrences of similar entities.
+

--- a/content/vi/docs/reference/glossary/upstream.md
+++ b/content/vi/docs/reference/glossary/upstream.md
@@ -1,0 +1,19 @@
+---
+title: Upstream (disambiguation)
+id: upstream
+date: 2018-04-12
+full_link: 
+short_description: >
+  May refer to: core Kubernetes or the source repo from which a repo was forked.
+
+aka: 
+tags:
+- community
+---
+ May refer to: core Kubernetes or the source repo from which a repo was forked.
+
+<!--more--> 
+
+* In the **Kubernetes Community**: Conversations often use *upstream* to mean the core Kubernetes codebase, which the general ecosystem, other code, or third-party tools rely upon. For example, [community members](#term-member) may suggest that a feature is moved upstream so that it is in the core codebase instead of in a plugin or third-party tool.
+* In **GitHub** or **git**: The convention is to refer to a source repo as *upstream*, whereas the forked repo is considered *downstream*.
+

--- a/content/vi/docs/reference/glossary/userns.md
+++ b/content/vi/docs/reference/glossary/userns.md
@@ -1,0 +1,28 @@
+---
+title: user namespace
+id: userns
+date: 2021-07-13
+full_link: https://man7.org/linux/man-pages/man7/user_namespaces.7.html
+short_description: >
+  A Linux kernel feature to emulate superuser privilege for unprivileged users.
+
+aka:
+tags:
+- security
+---
+
+A kernel feature to emulate root. Used for "rootless containers".
+
+<!--more-->
+
+User namespaces are a Linux kernel feature that allows a non-root user to
+emulate superuser ("root") privileges,
+for example in order to run containers without being a superuser outside the container.
+
+User namespace is effective for mitigating damage of potential container break-out attacks.
+
+In the context of user namespaces, the namespace is a Linux kernel feature, and not a
+{{< glossary_tooltip text="namespace" term_id="namespace" >}} in the Kubernetes sense
+of the term.
+
+<!-- TODO: https://kinvolk.io/blog/2020/12/improving-kubernetes-and-container-security-with-user-namespaces/ -->

--- a/content/vi/docs/reference/glossary/volume-plugin.md
+++ b/content/vi/docs/reference/glossary/volume-plugin.md
@@ -1,0 +1,18 @@
+---
+title: Volume Plugin
+id: volumeplugin
+date: 2018-04-12
+full_link: 
+short_description: >
+  A Volume Plugin enables integration of storage within a Pod.
+
+aka: 
+tags:
+- storage
+---
+ A Volume Plugin enables integration of storage within a {{< glossary_tooltip text="Pod" term_id="pod" >}}.
+
+<!--more--> 
+
+A Volume Plugin lets you attach and mount storage volumes for use by a {{< glossary_tooltip text="Pod" term_id="pod" >}}. Volume plugins can be _in tree_ or _out of tree_. _In tree_ plugins are part of the Kubernetes code repository and follow its release cycle. _Out of tree_ plugins are developed independently.
+

--- a/content/vi/docs/reference/glossary/volume.md
+++ b/content/vi/docs/reference/glossary/volume.md
@@ -1,0 +1,19 @@
+---
+title: Volume
+id: volume
+date: 2018-04-12
+full_link: /docs/concepts/storage/volumes/
+short_description: >
+  A directory containing data, accessible to the containers in a pod.
+
+aka:
+tags:
+- fundamental
+---
+ A directory containing data, accessible to the {{< glossary_tooltip text="containers" term_id="container" >}} in a {{< glossary_tooltip term_id="pod" >}}.
+
+<!--more-->
+
+A Kubernetes volume lives as long as the Pod that encloses it. Consequently, a volume outlives any containers that run within the Pod, and data in the volume is preserved across container restarts.
+
+See [storage](/docs/concepts/storage/) for more information.

--- a/content/vi/docs/reference/glossary/watch.md
+++ b/content/vi/docs/reference/glossary/watch.md
@@ -1,0 +1,24 @@
+---
+title: Watch
+id: watch
+date: 2024-07-02
+full_link: /docs/reference/using-api/api-concepts/#api-verbs
+short_description: >
+  A verb that is used to track changes to an object in Kubernetes as a stream.
+
+aka:
+tags:
+- API verb
+- fundamental
+---
+A verb that is used to track changes to an object in Kubernetes as a stream.
+It is used for the efficient detection of changes.
+
+<!--more-->
+
+A verb that is used to track changes to an object in Kubernetes as a stream. Watches allow
+efficient detection of changes; for example, a
+{{< glossary_tooltip term_id="controller" text="controller">}} that needs to know whenever a
+ConfigMap has changed can use a watch rather than polling.
+
+See [Efficient Detection of Changes in API Concepts](/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) for more information.

--- a/content/vi/docs/reference/glossary/wg.md
+++ b/content/vi/docs/reference/glossary/wg.md
@@ -1,0 +1,19 @@
+---
+title: WG (working group)
+id: wg
+date: 2018-04-12
+full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
+short_description: >
+  Facilitates the discussion and/or implementation of a short-lived, narrow, or decoupled project for a committee, SIG, or cross-SIG effort.
+
+aka: 
+tags:
+- community
+---
+ Facilitates the discussion and/or implementation of a short-lived, narrow, or decoupled project for a committee, {{< glossary_tooltip text="SIG" term_id="sig" >}}, or cross-SIG effort.
+
+<!--more-->
+
+Working groups are a way of organizing people to accomplish a discrete task.
+
+For more information, see the [kubernetes/community](https://github.com/kubernetes/community) repo and the current list of [SIGs and working groups](https://github.com/kubernetes/community/blob/master/sig-list.md).


### PR DESCRIPTION
### Description

There are a lot of missing glossary docs in vi language, and it blocks the translation process due to CI failed on building pages. Also the dependencies between glossary pages is complicated, thus it's hard to figure out where to start translating that not slow down the team translation process.

As discussed in vi language sync MTG, by this PR, I want to sync all the term from en glossary to vi glossary first to resolve translation block first, then we will translate all en term in vi dir later

ref: [vi docs meeting note](https://docs.google.com/document/d/11dhE3-x8vrNOAPvSNQBWjtfFya2jwdgcOfabDGC0vmA/edit?tab=t.0#heading=h.nm7itlurhc6o)

### Issue

Closes: #