### PR TITLE
Remove duplicate words with anchor text

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
@@ -64,7 +64,7 @@ creating a hello-node application and deploying it using a container, you can do
 that first by following the instructions from the [Hello Minikube tutorial](/docs/tutorials/hello-minikube/).
 
 You will need to have installed kubectl as well. If you need to install it, visit
-[install tools](/docs/tasks/tools/#kubectl) install tools.
+[install tools](/docs/tasks/tools/#kubectl).
 
 Now that you know what Deployments are, let's deploy our first app!
 


### PR DESCRIPTION
### Description

The current text on the website is:

> You will need to have installed kubectl as well. If you need to install it, visit [install tools](https://kubernetes.io/docs/tasks/tools/#kubectl) install tools.

This removes the duplicate "install tools" text.