### PR TITLE
docs: improve CustomResourceDefinition link to point to specific section

### DIFF
--- a/content/bn/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/bn/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -5,7 +5,7 @@ weight: 30
 
 কাস্টম রিসোর্স হলো কুবারনেটিস API এর এক্সটেনশন। কুবারনেটিস আপনার ক্লাস্টারে কাস্টম রিসোর্স যোগ করার দুটি উপায় প্রদান করে:
 
-- [CustomResourceDefinition](bn/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRD) 
+- [CustomResourceDefinition](bn/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) (CRD) 
   মেকানিজম আপনাকে একটি API গ্রুপ, ধরনের, এবং স্কিমা দিয়ে ঘোষণামূলকভাবে একটি নতুন কাস্টম API সংজ্ঞায়িত করতে দেয় 
   যা আপনি নির্দিষ্ট করেছেন।
   কুবারনেটিস কন্ট্রোল প্লেন আপনার কাস্টম রিসোর্সের স্টোরেজ পরিবেশন  এবং পরিচালনা করে। CRD গুলো আপনাকে আপনার 

--- a/content/en/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -5,7 +5,7 @@ weight: 30
 
 Custom resources are extensions of the Kubernetes API. Kubernetes provides two ways to add custom resources to your cluster:
 
-- The [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+- The [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
   (CRD) mechanism allows you to declaratively define a new custom API with an API group, kind, and
   schema that you specify.
   The Kubernetes control plane serves and handles the storage of your custom resource. CRDs allow you to

--- a/content/pl/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/pl/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -5,7 +5,7 @@ weight: 30
 
 Niestandardowe zasoby Kubernetesa (ang. Custom Resources) stanowią rozszerzenie API. Kubernetes udostępnia dwie metody ich integracji z klastrem:
 
-- Mechanizm [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+- Mechanizm [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
   (CRD) pozwala deklaratywnie zdefiniować nowe niestandardowe API z
   grupą API, rodzajem i schematem, który określisz. Warstwa sterowania Kubernetesa
   obsługuje i zarządza przechowywaniem twojego niestandardowego zasobu. CRD pozwalają tworzyć

--- a/content/zh-cn/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -10,7 +10,7 @@ Custom resources are extensions of the Kubernetes API. Kubernetes provides two w
 Kubernetes 提供了两种将自定义资源添加到集群的方法：
 
 <!--
-- The [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+- The [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
   (CRD) mechanism allows you to declaratively define a new custom API with an API group, kind, and
   schema that you specify.
   The Kubernetes control plane serves and handles the storage of your custom resource. CRDs allow you to


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Update the CustomResourceDefinition link to directly point to the #customresourcedefinitions section, making it easier for users to find relevant information.

The current link `/docs/concepts/extend-kubernetes/api-extension/custom-resources/` points to a page that contains not only CRD (CustomResourceDefinition) content but also other related information. By updating the link to point directly to the #customresourcedefinitions section, users can immediately access the specific CRD information they need without having to scroll through the entire page.

**In the current documentation, new users may easily confuse "custom resource" with "CustomResourceDefinition". In fact, creating a custom resource can be achieved through two approaches: CustomResourceDefinition (CRD) and API Aggregation (AA). This change helps clarify the distinction and guides users directly to the relevant section.**

This change improves the documentation's usability by:

- Providing direct access to the specific CustomResourceDefinitions section
- Reducing the time users need to find relevant information
- Following documentation best practices for deep linking
- Helping users avoid confusion with other content on the same page

The change is small but meaningful, as it helps users navigate the documentation more efficiently.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->


<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

