### PR TITLE
KEP-3015: PreferSameTrafficDistribution to Beta

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -1000,9 +1000,10 @@ following field value is supported:
 
 {{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
 
-Two additional values are available when the `PreferSameTrafficDistribution`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is
-enabled:
+In Kubernetes {{< skew currentVersion >}}, two additional values are
+available (unless the `PreferSameTrafficDistribution` [feature
+gate](/docs/reference/command-line-tools-reference/feature-gates/) is
+disabled):
 
 `PreferSameZone`
 : This is an alias for `PreferClose` that is clearer about the intended semantics.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/PreferSameTrafficDistribution.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/PreferSameTrafficDistribution.md
@@ -10,6 +10,10 @@ stages:
 - stage: alpha 
   defaultValue: false
   fromVersion: "1.33"
+  toVersion: "1.33"
+- stage: beta
+  defaultValue: true
+  fromVersion: "1.34"
 ---
 Allows usage of the values `PreferSameZone` and `PreferSameNode` in
 the Service [`trafficDistribution`](/docs/reference/networking/virtual-ips/#traffic-distribution)

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -694,9 +694,10 @@ express preferences for how traffic should be routed to Service endpoints.
 
 {{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
 
-Two additional values are available when the `PreferSameTrafficDistribution`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is
-enabled:
+In Kubernetes {{< skew currentVersion >}}, two additional values are
+available (unless the `PreferSameTrafficDistribution` [feature
+gate](/docs/reference/command-line-tools-reference/feature-gates/) is
+disabled):
 
 `PreferSameZone`
 : This means the same thing as `PreferClose`, but is more explicit. (Originally,


### PR DESCRIPTION
### Description
Update feature gate data for PreferSameTrafficDistribution for 1.34

Not doing any ~code/~ docs changes at this point; when we go to GA I'll update the docs to more clearly deprecate `PreferClose` in favor of `PreferSameZone`.

### Issue
https://github.com/kubernetes/enhancements/issues/3015

/hold
until KEP update merges (https://github.com/kubernetes/enhancements/pull/5376)