### PR TITLE
corrected route for Summary API

### DIFF
--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -10,7 +10,7 @@ description: >-
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
 gathers metric statistics at the node, volume, pod and container level,
 and emits this information in the
-[Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/).
+[Summary API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go).
 
 You can send a proxied request to the stats summary API via the
 Kubernetes API server.
@@ -50,7 +50,7 @@ the kubelet [fetches Pod- and container-level metric data using CRI](/docs/refer
 As an alpha feature, Kubernetes lets you configure kubelet to collect Linux kernel
 [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
 (PSI) for CPU, memory and IO usage. The information is collected at node, pod and container level.
-See [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/) for detailed schema.
+See [Summary API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go) for detailed schema.
 You must enable the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 to use this feature. The information is also exposed in
 [Prometheus metrics](/docs/concepts/cluster-administration/system-metrics#psi-metrics).

--- a/content/zh-cn/docs/reference/instrumentation/node-metrics.md
+++ b/content/zh-cn/docs/reference/instrumentation/node-metrics.md
@@ -22,7 +22,7 @@ and emits this information in the
 -->
 [kubelet](/zh-cn/docs/reference/command-line-tools-reference/kubelet/)
 在节点、卷、Pod 和容器级别收集统计信息，
-并在[概要 API](zh-cn/docs/reference/config-api/kubelet-stats.v1alpha1/)
+并在[概要 API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go)
 中输出这些信息。
 
 <!--
@@ -103,7 +103,7 @@ to use this feature. The information is also exposed in
 作为 Alpha 级别特性，Kubernetes 允许你配置 kubelet 来收集 Linux
 内核的[压力停滞信息](https://docs.kernel.org/accounting/psi.html)（PSI）
 的 CPU、内存和 IO 使用情况。这些信息是在节点、Pod 和容器级别上收集的。
-详细模式请参见 [Summary API](/zh-cn/docs/reference/config-api/kubelet-stats.v1alpha1/)。
+详细模式请参见 [Summary API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go)。
 你必须启用 `KubeletPSI`
 [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)才能使用此特性。
 这些信息也在


### PR DESCRIPTION
### Description
Updated the summary API route to point to the file in repo, which contains definition for Summary API.
Currently mentioned doc is not present in the repo, hence cue was taken from previous versions.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #  [131986](https://github.com/kubernetes/kubernetes/issues/131986)