### PR TITLE
correct advertiseAddress typo

### DIFF
--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
@@ -945,7 +945,7 @@ directories during &quot;reset&quot;. This flag can be one of: <code>&quot;MNT_F
 <code>string</code>
 </td>
 <td>
-   <p><code>dvertiseAddress</code> sets the IP address for the API server to advertise.</p>
+   <p><code>advertiseAddress</code> sets the IP address for the API server to advertise.</p>
 </td>
 </tr>
 <tr><td><code>bindPort</code><br/>


### PR DESCRIPTION
### Description

Correct a typo in the documentation where the `advertiseAddress` field was missing the initial 'a':

```diff
-   <p><code>dvertiseAddress</code> sets the IP address for the API server to advertise.</p>
+   <p><code>advertiseAddress</code> sets the IP address for the API server to advertise.</p>
```