### PR TITLE
Fix EOL MCR links in CRI and Windows Installation Pages

### DIFF
--- a/content/en/docs/concepts/windows/intro.md
+++ b/content/en/docs/concepts/windows/intro.md
@@ -324,10 +324,10 @@ kernel patch.
 
 ### Mirantis Container Runtime {#mcr}
 
-[Mirantis Container Runtime](https://docs.mirantis.com/mcr/20.10/overview.html) (MCR)
+[Mirantis Container Runtime](https://docs.mirantis.com/mcr/25.0/overview.html) (MCR)
 is available as a container runtime for all Windows Server 2019 and later versions.
 
-See [Install MCR on Windows Servers](https://docs.mirantis.com/mcr/20.10/install/mcr-windows.html) for more information.
+See [Install MCR on Windows Servers](https://docs.mirantis.com/mcr/25.0/install/mcr-windows.html) for more information.
 
 ## Windows OS version compatibility {#windows-os-version-support}
 

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -316,14 +316,14 @@ For `cri-dockerd`, the CRI socket is `/run/cri-dockerd.sock` by default.
 
 ### Mirantis Container Runtime {#mcr}
 
-[Mirantis Container Runtime](https://docs.mirantis.com/mcr/20.10/overview.html) (MCR) is a commercially
+[Mirantis Container Runtime](https://docs.mirantis.com/mcr/25.0/overview.html) (MCR) is a commercially
 available container runtime that was formerly known as Docker Enterprise Edition.
 
 You can use Mirantis Container Runtime with Kubernetes using the open source
 [`cri-dockerd`](https://mirantis.github.io/cri-dockerd/) component, included with MCR.
 
 To learn more about how to install Mirantis Container Runtime,
-visit [MCR Deployment Guide](https://docs.mirantis.com/mcr/20.10/install.html).
+visit [MCR Deployment Guide](https://docs.mirantis.com/mcr/25.0/install.html).
 
 Check the systemd unit named `cri-docker.socket` to find out the path to the CRI
 socket.


### PR DESCRIPTION
### Description

Currently, in:

- https://kubernetes.io/docs/setup/production-environment/container-runtimes/#mcr
- https://kubernetes.io/docs/concepts/windows/intro/#mcr

when clicking on [Mirantis Container Runtime](https://docs.mirantis.com/mcr/20.10/overview.html) and "visit [MCR Deployment Guide](https://docs.mirantis.com/mcr/20.10/install.html)" the links are for Mirantis Container Runtime (MCR) 20.10 which is EOL.
The most recent one and supported by Mirantis is MCR 25.0.

This PR updates all of the `https://docs.mirantis.com/mcr/20.10` URLs with `https://docs.mirantis.com/mcr/25.0` in pages (English-only)

### Issue
https://github.com/kubernetes/website/issues/51216