### PR TITLE
Mark SeparateTaintEvictionController feature gate as stable

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -289,6 +289,13 @@ Nodes for 5 minutes after one of these problems is detected.
 
 This ensures that DaemonSet pods are never evicted due to these problems.
 
+{{< note >}}
+The node controller was responsible for adding taints to nodes and evicting pods. But after 1.29,
+the taint-based eviction implementation has been moved out of node controller into a separate,
+and independent component called taint-eviction-controller. Users can optionally disable taint-based
+eviction by setting `--controllers=-taint-eviction-controller` in kube-controller-manager.
+{{< /note >}}
+
 ## Taint Nodes by Condition
 
 The control plane, using the node {{<glossary_tooltip text="controller" term_id="controller">}},

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/SeparateTaintEvictionController.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/SeparateTaintEvictionController.md
@@ -9,9 +9,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.29"
+    toVersion: "1.33"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.34"
 ---
-Enables running `TaintEvictionController`,
+Enables running the _taint based eviction_ controller,
 that performs [Taint-based Evictions](/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions),
-in a controller separated from `NodeLifecycleController`. When this feature is
-enabled, users can optionally disable Taint-based Eviction setting the
-`--controllers=-taint-eviction-controller` flag on the `kube-controller-manager`.
+as a standalone controller (separate from the _node lifecycle_ controller).


### PR DESCRIPTION
/hold
until https://github.com/kubernetes/kubernetes/pull/122634 is merged.