### PR TITLE
docs: improve NodePort collision section with example and reference

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -529,6 +529,14 @@ To avoid this problem, the port range for NodePort services is divided into two 
 Dynamic port assignment uses the upper band by default, and it may use the lower band once the 
 upper band has been exhausted. Users can then allocate from the lower band with a lower risk of port collision.
 
+When using the default NodePort range 30000-32767, the bands are partitioned as follows: 
+
+- Static band: 30000-30085
+- Dynamic band: 30086-32767
+
+See [Avoid Collisions Assigning Ports to NodePort Services](/blog/2023/05/11/nodeport-dynamic-and-static-allocation/)
+for more details on how the static and dynamic bands are calculated.
+
 #### Custom IP address configuration for `type: NodePort` Services {#service-nodeport-custom-listen-address}
 
 You can set up nodes in your cluster to use a particular IP address for serving node port


### PR DESCRIPTION
### Description

Changes:
- Clarify the default NodePort range partition in the [Service documentation](https://kubernetes.io/docs/concepts/services-networking/service/#avoid-nodeport-collisions/), specifically under the "Reserve Nodeport ranges to avoid collisions" section.
- Include a link to [the feature contributor's blog post](https://kubernetes.io/blog/2023/05/11/nodeport-dynamic-and-static-allocation/).

To complement the existing explanation of static and dynamic NodePort bands, add the default range breakdown and a link to the related blog post. This provides users with a clearer understanding and the key information they'd otherwise need to search for separately.

Verified with `make container-serve`.