### PR TITLE
Added types of podManagementPolicy to StatefulSet documentation

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -363,6 +363,18 @@ that are running with the `MaxUnavailableStatefulSet`
 enabled.
 {{< /note >}}
 
+#### PodManagementPolicy
+
+You can determine the order at which the pods are deleted by specifying the `.spec.PodManagementPolicy`
+field. There are two policies that you can configure for each StatefulSet: 
+
+`parallel`
+: When updating, there will always be maxUnavailable number of pods terminating except the last batch
+
+`orderedReady`
+: When updating, the number of pods terminating won't always be maxUnavailable, but sometimes less than 
+  that. This implementation avoids out of order Terminations of pods.
+
 ### Forced rollback
 
 When using [Rolling Updates](#rolling-updates) with the default


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Add `podManagementPolicy` field to StatefulSet documentation. Part of https://github.com/kubernetes/enhancements/pull/5228

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
