### PR TITLE
[pt-br] Add tasks/run-application/scale-stateful-set.md

### DIFF
--- a/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
+++ b/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
@@ -13,11 +13,11 @@ Esta tarefa mostra como escalar um StatefulSet. Escalar um StatefulSet refere-se
 - Os StatefulSets estão disponíveis apenas no Kubernetes na versão 1.5 ou superior.
   Para verificar sua versão do Kubernetes, execute `kubectl version`.
 
-- Nem todas as aplicações com estado escalonam de forma adequada. Se você não tem certeza se deve escalar seus StatefulSets,
+- Nem todas as aplicações com estado escalam de forma adequada. Se você não tem certeza se deve escalar seus StatefulSets,
   consulte [Conceitos de StatefulSet](/docs/concepts/workloads/controllers/statefulset/)
   ou [Tutorial de StatefulSet](/docs/tutorials/stateful-application/basic-stateful-set/) para mais informações.
 
-- Você deve realizar o escalonamento apenas quando tiver certeza de que o cluster da sua aplicação com estado
+- Você deve realizar o redimensionamento apenas quando tiver certeza de que o cluster da sua aplicação com estado
   está completamente íntegro.
 
 <!-- steps -->
@@ -65,10 +65,10 @@ kubectl patch statefulsets <stateful-set-name> -p '{"spec":{"replicas":<new-repl
 
 ## Solução de problemas
 
-### Reduzir o escalonamento não funciona corretamente
+### Reduzir o número de réplicas não funciona corretamente
 
-Você não pode reduzir o escalonamento de um StatefulSet enquanto qualquer um dos Pods
-com estado que ele gerencia não estiver íntegro. A redução do escalonamento
+Você não pode reduzir o número de réplicas de um StatefulSet enquanto qualquer um dos Pods
+com estado que ele gerencia não estiver íntegro. A redução do número de réplicas
 só ocorre depois que esses Pods com estado estiverem em execução e prontos.
 
 Se `spec.replicas` > 1, o Kubernetes não consegue determinar o motivo de um Pod com estado
@@ -81,9 +81,9 @@ do número mínimo de réplicas necessário para funcionar corretamente.
 Isso pode fazer com que seu StatefulSet se torne indisponível.
 
 Se o Pod não estiver íntegro devido a uma falha transitória e o Pod possa voltar a ficar disponível,
-o erro transitório pode interferir na sua operação de aumento ou redução de escalonamento.
+o erro transitório pode interferir na sua operação de aumento ou redução do número de réplicas.
 Alguns bancos de dados distribuídos apresentam problemas quando nós entram e saem ao mesmo tempo. Nesses casos,
-é melhor analisar as operações de escalonamento no nível da aplicação e realizar o escalonamento apenas quando
+é melhor analisar as operações de redimensionamento no nível da aplicação e realizar o ajuste apenas quando
 você tiver certeza de que o cluster da sua aplicação com estado está completamente íntegro.
 
 ## {{% heading "whatsnext" %}}

--- a/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
+++ b/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
@@ -18,7 +18,7 @@ Esta tarefa mostra como escalonar um StatefulSet. Escalonar um StatefulSet refer
   ou [Tutorial de StatefulSet](/docs/tutorials/stateful-application/basic-stateful-set/) para mais informações.
 
 - Você deve realizar o escalonamento apenas quando tiver certeza de que o cluster da sua aplicação com estado
-  está completamente saudável.
+  está completamente íntegro.
 
 <!-- steps -->
 
@@ -68,23 +68,23 @@ kubectl patch statefulsets <stateful-set-name> -p '{"spec":{"replicas":<new-repl
 ### Reduzir o escalonamento não funciona corretamente
 
 Você não pode reduzir o escalonamento de um StatefulSet enquanto qualquer um dos Pods
-com estado que ele gerencia estiver com problemas de saúde. A redução do escalonamento
+com estado que ele gerencia não estiver íntegro. A redução do escalonamento
 só ocorre depois que esses Pods com estado estiverem em execução e prontos.
 
 Se `spec.replicas` > 1, o Kubernetes não consegue determinar o motivo de um Pod com estado
-estar com problemas de saúde. Isso pode ser resultado de uma falha permanente ou de uma falha transitória.
+não estar íntegro. Isso pode ser resultado de uma falha permanente ou de uma falha transitória.
 Uma falha transitória pode ser causada por uma reinicialização necessária devido a uma atualização ou manutenção.
 
-Se o Pod estiver com problemas de saúde devido a uma falha permanente, escalonar sem corrigir
+Se o Pod não estiver íntegro devido a uma falha permanente, escalonar sem corrigir
 a falha pode levar a um estado em que a quantidade de membros do StatefulSet fique abaixo
 do número mínimo de réplicas necessário para funcionar corretamente.
 Isso pode fazer com que seu StatefulSet se torne indisponível.
 
-Se o Pod estiver com problemas de saúde devido a uma falha transitória e o Pod possa voltar a ficar disponível,
+Se o Pod não estiver íntegro devido a uma falha transitória e o Pod possa voltar a ficar disponível,
 o erro transitório pode interferir na sua operação de aumento ou redução de escalonamento.
 Alguns bancos de dados distribuídos apresentam problemas quando nós entram e saem ao mesmo tempo. Nesses casos,
 é melhor analisar as operações de escalonamento no nível da aplicação e realizar o escalonamento apenas quando
-você tiver certeza de que o cluster da sua aplicação com estado está completamente saudável.
+você tiver certeza de que o cluster da sua aplicação com estado está completamente íntegro.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
+++ b/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
@@ -1,19 +1,19 @@
 ---
-title: Escalonar um StatefulSet
+title: Escalar um StatefulSet
 content_type: task
 weight: 50
 ---
 
 <!-- overview -->
 
-Esta tarefa mostra como escalonar um StatefulSet. Escalonar um StatefulSet refere-se a aumentar ou diminuir o número de réplicas.
+Esta tarefa mostra como escalar um StatefulSet. Escalar um StatefulSet refere-se a aumentar ou diminuir o número de réplicas.
 
 ## {{% heading "prerequisites" %}}
 
 - Os StatefulSets estão disponíveis apenas no Kubernetes na versão 1.5 ou superior.
   Para verificar sua versão do Kubernetes, execute `kubectl version`.
 
-- Nem todas as aplicações com estado escalonam de forma adequada. Se você não tem certeza se deve escalonar seus StatefulSets,
+- Nem todas as aplicações com estado escalonam de forma adequada. Se você não tem certeza se deve escalar seus StatefulSets,
   consulte [Conceitos de StatefulSet](/docs/concepts/workloads/controllers/statefulset/)
   ou [Tutorial de StatefulSet](/docs/tutorials/stateful-application/basic-stateful-set/) para mais informações.
 
@@ -22,11 +22,11 @@ Esta tarefa mostra como escalonar um StatefulSet. Escalonar um StatefulSet refer
 
 <!-- steps -->
 
-## Escalonando StatefulSets
+## Escalando StatefulSets
 
-### Use kubectl para escalonar StatefulSets
+### Use kubectl para escalar StatefulSets
 
-Primeiro, encontre o StatefulSet que você deseja escalonar:
+Primeiro, encontre o StatefulSet que você deseja escalar:
 
 ```shell
 kubectl get statefulsets <stateful-set-name>
@@ -75,7 +75,7 @@ Se `spec.replicas` > 1, o Kubernetes não consegue determinar o motivo de um Pod
 não estar íntegro. Isso pode ser resultado de uma falha permanente ou de uma falha transitória.
 Uma falha transitória pode ser causada por uma reinicialização necessária devido a uma atualização ou manutenção.
 
-Se o Pod não estiver íntegro devido a uma falha permanente, escalonar sem corrigir
+Se o Pod não estiver íntegro devido a uma falha permanente, escalar sem corrigir
 a falha pode levar a um estado em que a quantidade de membros do StatefulSet fique abaixo
 do número mínimo de réplicas necessário para funcionar corretamente.
 Isso pode fazer com que seu StatefulSet se torne indisponível.

--- a/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
+++ b/content/pt-br/docs/tasks/run-application/scale-stateful-set.md
@@ -75,7 +75,7 @@ Se `spec.replicas` > 1, o Kubernetes não consegue determinar o motivo de um Pod
 não estar íntegro. Isso pode ser resultado de uma falha permanente ou de uma falha transitória.
 Uma falha transitória pode ser causada por uma reinicialização necessária devido a uma atualização ou manutenção.
 
-Se o Pod não estiver íntegro devido a uma falha permanente, escalar sem corrigir
+Se o Pod não estiver íntegro devido a uma falha permanente, redimensionar sem corrigir
 a falha pode levar a um estado em que a quantidade de membros do StatefulSet fique abaixo
 do número mínimo de réplicas necessário para funcionar corretamente.
 Isso pode fazer com que seu StatefulSet se torne indisponível.


### PR DESCRIPTION
Esse PR traz a localização da página https://kubernetes.io/docs/tasks/run-application/scale-stateful-set/ para PT-BR.
Adicionado a raiz de /content/pt-br/docs/tasks/run-application o arquivo scale-stateful-set.md, ficando localizado como `/content/pt-br/docs/tasks/run-application/scale-stateful-set.md` no repositório.

---

This PR brings the localization of the page https://kubernetes.io/docs/tasks/run-application/scale-stateful-set/ to PT-BR.
The file scale-stateful-set.md was added to the root of /content/pt-br/docs/tasks/run-application, resulting in the path `/content/pt-br/docs/tasks/run-application/scale-stateful-set.md` in the repository.

### Issue

Closes: #50951