### PR TITLE
[ja] Remove /ja prefix from hello-minikube.md links

### DIFF
--- a/content/ja/docs/tutorials/hello-minikube.md
+++ b/content/ja/docs/tutorials/hello-minikube.md
@@ -28,7 +28,7 @@ card:
 {{< /note >}}
 
 また、`kubectl`をインストールする必要があります。
-インストール手順は[ツールのインストール](/ja/docs/tasks/tools/#kubectl)を参照してください。
+インストール手順は[ツールのインストール](/docs/tasks/tools/#kubectl)を参照してください。
 
 
 <!-- lessoncontent -->
@@ -87,7 +87,7 @@ URLをコピー&ペーストし、ブラウザーで開きます。
 
 ## Deploymentの作成
 
-Kubernetesの[*Pod*](/ja/docs/concepts/workloads/pods/)は、コンテナの管理やネットワーキングの目的でまとめられた、1つ以上のコンテナのグループです。このチュートリアルのPodがもつコンテナは1つのみです。Kubernetesの[*Deployment*](/ja/docs/concepts/workloads/controllers/deployment/)はPodの状態を確認し、Podのコンテナが停止した場合には再起動します。DeploymentはPodの作成やスケールを管理するために推奨される方法(手段)です。
+Kubernetesの[*Pod*](/docs/concepts/workloads/pods/)は、コンテナの管理やネットワーキングの目的でまとめられた、1つ以上のコンテナのグループです。このチュートリアルのPodがもつコンテナは1つのみです。Kubernetesの[*Deployment*](/docs/concepts/workloads/controllers/deployment/)はPodの状態を確認し、Podのコンテナが停止した場合には再起動します。DeploymentはPodの作成やスケールを管理するために推奨される方法(手段)です。
 
 1. `kubectl create`コマンドを使用してPodを管理するDeploymentを作成してください。Podは提供されたDockerイメージを元にコンテナを実行します。
 
@@ -154,12 +154,12 @@ Kubernetesの[*Pod*](/ja/docs/concepts/workloads/pods/)は、コンテナの管�
    ```
 
 {{< note >}}
-`kubectl`コマンドの詳細な情報は[コマンドラインツール(kubectl)](/ja/docs/reference/kubectl/)を参照してください。
+`kubectl`コマンドの詳細な情報は[コマンドラインツール(kubectl)](/docs/reference/kubectl/)を参照してください。
 {{< /note >}}
 
 ## Serviceの作成
 
-通常、PodはKubernetesクラスター内部のIPアドレスからのみアクセスすることができます。`hello-node`コンテナをKubernetesの仮想ネットワークの外部からアクセスするためには、Kubernetesの[*Service*](/ja/docs/concepts/services-networking/service/)としてPodを公開する必要があります。
+通常、PodはKubernetesクラスター内部のIPアドレスからのみアクセスすることができます。`hello-node`コンテナをKubernetesの仮想ネットワークの外部からアクセスするためには、Kubernetesの[*Service*](/docs/concepts/services-networking/service/)としてPodを公開する必要があります。
 
 {{< warning >}}
 agnhostコンテナには`/shell`エンドポイントがあり、デバッグには便利ですが、インターネットに公開するのは危険です。
@@ -337,7 +337,7 @@ Kubernetesの学習で再度minikubeを使用したい場合、minikubeのVMを�
 ## {{% heading "whatsnext" %}}
 
 
-* _[kubectlで初めてのアプリケーションをKubernetesにデプロイする](/ja/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/)_。
-* [Deploymentオブジェクト](/ja/docs/concepts/workloads/controllers/deployment/)について学ぶ。
-* [アプリケーションのデプロイ](/ja/docs/tasks/run-application/run-stateless-application-deployment/)について学ぶ。
-* [Serviceオブジェクト](/ja/docs/concepts/services-networking/service/)について学ぶ。
+* _[kubectlで初めてのアプリケーションをKubernetesにデプロイする](/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/)_。
+* [Deploymentオブジェクト](/docs/concepts/workloads/controllers/deployment/)について学ぶ。
+* [アプリケーションのデプロイ](/docs/tasks/run-application/run-stateless-application-deployment/)について学ぶ。
+* [Serviceオブジェクト](/docs/concepts/services-networking/service/)について学ぶ。


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
In the markdown file, hugo automatically insert /ja prefix if the localized page already exists.
Fix hello-minikube.md file.

### Issue
https://github.com/kubernetes/website/issues/51260
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #