### PR TITLE
[jp] Remove the /ja prefix from japanese docs

### DIFF
--- a/content/ja/docs/concepts/_index.md
+++ b/content/ja/docs/concepts/_index.md
@@ -30,18 +30,18 @@ Kubernetesには、デプロイ済みのコンテナ化されたアプリケー�
 
 基本的なKubernetesのオブジェクトは次のとおりです。
 
-* [Pod](/ja/docs/concepts/workloads/pods/pod-overview/)
-* [Service](/ja/docs/concepts/services-networking/service/)
+* [Pod](/docs/concepts/workloads/pods/)
+* [Service](/docs/concepts/services-networking/service/)
 * [Volume](/docs/concepts/storage/volumes/)
-* [Namespace](/ja/docs/concepts/overview/working-with-objects/namespaces/)
+* [Namespace](/docs/concepts/overview/working-with-objects/namespaces/)
 
-Kubernetesには、[コントローラー](/ja/docs/concepts/architecture/controller/)に依存して基本オブジェクトを構築し、追加の機能と便利な機能を提供する高レベルの抽象化も含まれています。これらには以下のものを含みます:
+Kubernetesには、[コントローラー](/docs/concepts/architecture/controller/)に依存して基本オブジェクトを構築し、追加の機能と便利な機能を提供する高レベルの抽象化も含まれています。これらには以下のものを含みます:
 
-* [Deployment](/ja/docs/concepts/workloads/controllers/deployment/)
-* [DaemonSet](/ja/docs/concepts/workloads/controllers/daemonset/)
-* [StatefulSet](/ja/docs/concepts/workloads/controllers/statefulset/)
-* [ReplicaSet](/ja/docs/concepts/workloads/controllers/replicaset/)
-* [Job](/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+* [Deployment](/docs/concepts/workloads/controllers/deployment/)
+* [DaemonSet](/docs/concepts/workloads/controllers/daemonset/)
+* [StatefulSet](/docs/concepts/workloads/controllers/statefulset/)
+* [ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)
+* [Job](/docs/concepts/workloads/controllers/job/)
 
 ## Kubernetesコントロールプレーン {#kubernetes-control-plane}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
Remove the /ja prefix from text links on concepts _index.md.

### Issue
https://github.com/kubernetes/website/issues/51260

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #