### PR TITLE
[ja] remove `/ja` in links: configure-multiple-schedulers.md

### DIFF
--- a/content/ja/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/ja/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -54,13 +54,13 @@ gcloud docker -- push gcr.io/my-gcp-project/my-kube-scheduler:1.0 # used in here
 ## スケジューラー用のKubernetes Deploymentを定義する
 
 スケジューラーをコンテナイメージとして用意できたら、それ用のPodの設定を作成してクラスター上で動かします。
-この例では、直接Podをクラスターに作成する代わりに、[Deployment](/ja/docs/concepts/workloads/controllers/deployment/)を使用します。
-[Deployment](/ja/docs/concepts/workloads/controllers/deployment/)は[ReplicaSet](/ja/docs/concepts/workloads/controllers/replicaset/)を管理し、そのReplicaSetがPodを管理することで、スケジューラーを障害に対して堅牢にします。
+この例では、直接Podをクラスターに作成する代わりに、[Deployment](/docs/concepts/workloads/controllers/deployment/)を使用します。
+[Deployment](/docs/concepts/workloads/controllers/deployment/)は[ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)を管理し、そのReplicaSetがPodを管理することで、スケジューラーを障害に対して堅牢にします。
 `my-scheduler.yaml`として保存するDeploymentの設定を示します:
 
 {{% code_sample file="admin/sched/my-scheduler.yaml" %}}
 
-上に示したマニフェストでは、[KubeSchedulerConfiguration](/ja/docs/reference/scheduling/config/)を使用してあなたのスケジューラー実装の振る舞いを変更できます。
+上に示したマニフェストでは、[KubeSchedulerConfiguration](/docs/reference/scheduling/config/)を使用してあなたのスケジューラー実装の振る舞いを変更できます。
 この設定ファイルは`kube-scheduler`の初期化時に`--config`オプションから渡されます。
 この設定ファイルは`my-scheduler-config` ConfigMapに格納されており、`my-scheduler` DeploymentのPodは`my-scheduler-config` ConfigMapをボリュームとしてマウントします。
 
@@ -186,4 +186,4 @@ kubectl edit clusterrole system:kube-scheduler
 kubectl get events
 ```
 
-クラスターのメインのスケジューラーについては、[独自のスケジューラー設定](/ja/docs/reference/scheduling/config/#multiple-profiles)を適用することや、関連するコントロールプレーンノードにある静的Podのマニフェストを変更し独自のコンテナイメージを使うことができます。
+クラスターのメインのスケジューラーについては、[独自のスケジューラー設定](/docs/reference/scheduling/config/#multiple-profiles)を適用することや、関連するコントロールプレーンノードにある静的Podのマニフェストを変更し独自のコンテナイメージを使うことができます。


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Remove `/ja` prefixes from link of this page.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#51260