### PR TITLE
Fix PodTopologyLabels note not rendering

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -776,11 +776,11 @@ The labels available as a result of this controller are the
 [topology.kubernetes.io/region](docs/reference/labels-annotations-taints/#topologykubernetesioregion) and
 [topology.kuberentes.io/zone](docs/reference/labels-annotations-taints/#topologykubernetesiozone) labels.
 
-{{ <note> }}
+{{<note>}}
 If any mutating admission webhook adds or modifies labels of the `pods/binding` subresource,
 these changes will propagate to pod labels as a result of this controller,
 overwriting labels with conflicting keys.
-{{ </note> }}
+{{</note>}}
 
 This admission controller is enabled when the `PodTopologyLabelsAdmission` feature gate is enabled.
 


### PR DESCRIPTION
The additional whitespace caused the site to not render the note, displaying[ the literal "{{ }}" instead](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podtopologylabels).

Before:
<img width="600" alt="Screenshot 2025-06-16 at 13 51 33" src="https://github.com/user-attachments/assets/13d2a6ec-37ed-4be5-83d9-21b08e1cfe0c" />

After:
<img width="600" alt="Screenshot 2025-06-16 at 13 50 32" src="https://github.com/user-attachments/assets/157f93af-d2cd-454f-a8ca-08a4c95e9fe2" />
