### PR TITLE
Update Portuguese translation of Namespace documentation to include missing sections from the English version

### DIFF
--- a/content/pt-br/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/pt-br/docs/concepts/overview/working-with-objects/namespaces.md
@@ -20,13 +20,33 @@ Namespaces nos permitem dividir os recursos do cluster entre diferentes usuário
 
 Não é necessário utilizar múltiplos namespaces para separar recursos levemente diferentes, como diferentes versões de um mesmo software: use {{< glossary_tooltip text="labels" term_id="label" >}} para distinguir recursos dentro de um mesmo namespace.
 
+{{< note >}}
+Para clusters em produção, considere _não_ utilizar o namespace `default`. Em vez disso, crie e utilize outros namespaces.
+{{< /note >}}
+
+## Namespaces Iniciais
+
+O Kubernetes é inicializado com quatro namespaces:
+
+`default`
+: O namespace padrão para objetos sem namespace
+
+`kube-node-lease`
+: Este namespace contém os objetos de [Lease](/docs/concepts/architecture/leases/) associados com cada node. Node leases permitem que o kubelet envie [heartbeats](/docs/concepts/architecture/nodes/#node-heartbeats) para que a camada de gerenciamento detecte falhas nos nodes.
+
+`kube-public`
+: Este namespace é criado automaticamente e é legível por todos os usuários (incluindo usuários não autenticados). Este namespace é reservado principalmente para uso do cluster, no caso de alguns recursos que precisem ser visíveis e legíveis publicamente por todo o cluster. O aspecto público deste namespace é apenas uma convenção, não um requisito.
+
+`kube-system`
+: O namespace para objetos criados pelo sistema Kubernetes
+
 ## Trabalhando com Namespaces
 
 Criação e eliminação de namespaces estão descritas na 
 [documentação de namespaces do guia de administradores](/docs/tasks/administer-cluster/namespaces).
 
 {{< note >}}
-    Evite criar namespaces com o prefixo `kube-`, já que este prefixo é reservado para namespaces do sistema Kubernetes.
+Evite criar namespaces com o prefixo `kube-`, já que este prefixo é reservado para namespaces do sistema Kubernetes.
 {{< /note >}}
 
 ### Visualizando namespaces
@@ -43,13 +63,6 @@ kube-node-lease   Active   1d
 kube-public       Active   1d
 kube-system       Active   1d
 ```
-
-O Kubernetes é inicializado com quatro namespaces:
-
-   * `default` O namespace padrão para objetos sem namespace
-   * `kube-system` O namespace para objetos criados pelo sistema Kubernetes
-   * `kube-public` Este namespace é criado automaticamente e é legível por todos os usuários (incluindo usuários não autenticados). Este namespace é reservado principalmente para uso do cluster, no caso de alguns recursos que precisem ser visíveis e legíveis publicamente por todo o cluster. O aspecto público deste namespace é apenas uma convenção, não um requisito.
-   * `kube-node-lease` Este namespace contém os objetos de [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) associados com cada node. Node leases permitem que o kubelet envie [heartbeats](/docs/concepts/architecture/nodes/#heartbeats) para que a camada de gerenciamento detecte falhas nos nodes.
 
 ### Preparando o namespace para uma requisição
 
@@ -77,9 +90,17 @@ Quando você cria um [Serviço](/docs/concepts/services-networking/service/), el
 Esta entrada possui o formato: `<service-name>.<namespace-name>.svc.cluster.local`, de forma que se um contêiner utilizar apenas `<service-name>` ele será resolvido para um serviço que é local ao namespace.
 Isso é útil para utilizar a mesma configuração em vários namespaces, por exemplo em Desenvolvimento, `Staging` e Produção. Se você quiser acessar múltiplos namespaces, precisará utilizar um _Fully Qualified Domain Name_ (FQDN).
 
+Nomes de namespaces devem ser válidos conforme a [RFC 1123 para rótulos DNS](/docs/concepts/overview/working-with-objects/names/#dns-label-names).
+
+{{< warning >}}  
+Ao criar namespaces com o mesmo nome de [domínios de topo públicos (TLDs)](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), os *Services* dentro desses namespaces podem ter nomes DNS curtos que colidem com registros DNS públicos. Com isso, _workloads_ de qualquer namespace que realizem consultas DNS sem um [ponto final (trailing dot)](https://datatracker.ietf.org/doc/html/rfc1034#page-8) podem ser redirecionadas para esses serviços, tendo precedência sobre o DNS público.
+
+Para mitigar esse risco, limite a criação de namespaces apenas a usuários confiáveis. Se necessário, você também pode configurar controles de segurança de terceiros, como [admission webhooks](/docs/reference/access-authn-authz/extensible-admission-controllers/), para bloquear a criação de namespaces com nomes que coincidam com [TLDs públicos](https://data.iana.org/TLD/tlds-alpha-by-domain.txt).
+{{< /warning >}}
+
 ## Nem todos os objetos pertencem a algum Namespace
 
-A maior parte dos recursos Kubernetes (como Pods, Services, controladores de replicação e outros) pertencem a algum namespace. Entretanto, recursos de namespaces não pertencem a nenhum namespace. Além deles, recursos de baixo nível, como [nodes](/docs/concepts/architecture/nodes/) e persistentVolumes, também não pertencem a nenhum namespace.
+A maior parte dos recursos Kubernetes (como Pods, Services, controladores de replicação e outros) pertencem a algum namespace. Entretanto, recursos de namespaces não pertencem a nenhum namespace. Além deles, recursos de baixo nível, como [nodes](/docs/concepts/architecture/nodes/) e [persistentVolumes](/docs/concepts/storage/persistent-volumes/), também não pertencem a nenhum namespace.
 
 Para visualizar quais recursos Kubernetes pertencem ou não a algum namespace, utilize:
 
@@ -93,7 +114,7 @@ kubectl api-resources --namespaced=false
 
 ## Rotulamento Automático
 
-{{< feature-state state="beta" for_k8s_version="1.21" >}}
+{{< feature-state for_k8s_version="1.22" state="stable" >}}
 
 A camada de gerenciamento Kubernetes configura um {{< glossary_tooltip text="label" term_id="label" >}} imutável `kubernetes.io/metadata.name` em todos os namespaces se a 
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)


### PR DESCRIPTION
##  Update Portuguese "Namespaces" documentation to match English source content

This pull request updates the Portuguese translation of the **Namespaces** documentation to bring it in line with the current English version. The previous translation was missing several important sections and conceptual explanations that have been added to the English page over time.

### 🔍 Improvements included:

- Addition of the **“When to Use Multiple Namespaces”** section, including a note about avoiding the use of the `default` namespace in production environments
- Inclusion of the **“Initial namespaces”** section describing the four default namespaces (`default`, `kube-system`, `kube-public`, `kube-node-lease`)
- Addition of the **warning block** about conflicts between namespace names and **public top-level domains (TLDs)**
- Updated **links** to reference correct and up-to-date pages (e.g., replacing outdated references to Lease objects, correcting glossary and concept links)

### ✅ Purpose

Ensure that Portuguese-speaking users have access to the same up-to-date, accurate, and complete documentation available in English, improving the overall consistency and quality of Kubernetes internationalization.