### PR TITLE
Add missing closing round bracket in deploy-intro.md

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
@@ -61,7 +61,7 @@ discuss how you can scale and update your Deployments.
 For your first Deployment, you'll use a hello-node application packaged in a Docker
 container that uses NGINX to echo back all the requests. (If you didn't already try
 creating a hello-node application and deploying it using a container, you can do
-that first by following the instructions from the [Hello Minikube tutorial](/docs/tutorials/hello-minikube/).
+that first by following the instructions from the [Hello Minikube tutorial](/docs/tutorials/hello-minikube/)).
 
 You will need to have installed kubectl as well. If you need to install it, visit
 [install tools](/docs/tasks/tools/#kubectl).

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
@@ -61,7 +61,7 @@ discuss how you can scale and update your Deployments.
 For your first Deployment, you'll use a hello-node application packaged in a Docker
 container that uses NGINX to echo back all the requests. (If you didn't already try
 creating a hello-node application and deploying it using a container, you can do
-that first by following the instructions from the [Hello Minikube tutorial](/docs/tutorials/hello-minikube/)).
+that first by following the instructions from the [Hello Minikube tutorial](/docs/tutorials/hello-minikube/).)
 
 You will need to have installed kubectl as well. If you need to install it, visit
 [install tools](/docs/tasks/tools/#kubectl).


### PR DESCRIPTION
add missing closing round bracket in deploy-intro.md .

the original sentence in the HTML version was :

"
For your first Deployment, you'll use a hello-node application packaged in a Docker container that uses NGINX to echo back all the requests. (If you didn't already try creating a hello-node application and deploying it using a container, you can do that first by following the instructions from the <a href="/docs/tutorials/hello-minikube/">Hello Minikube tutorial</a>).
"

the clossing braket was probably missed when the `<a>` was replaced with a MD-style link `[]()`.