### PR TITLE
Add blog post for PSAT for Kubelet Image Credential Providers beta

### DIFF
--- a/content/en/blog/_posts/XXXX-XX-XX-kubernetes-1-34-sa-tokens-image-pulls-beta.md
+++ b/content/en/blog/_posts/XXXX-XX-XX-kubernetes-1-34-sa-tokens-image-pulls-beta.md
@@ -3,7 +3,7 @@ layout: blog
 title: "Kubernetes v1.34: Service Account Token Integration for Image Pulls Graduates to Beta"
 date: 2025-08-15
 slug: kubernetes-v1-34-sa-tokens-image-pulls-beta
-draft: false
+draft: true
 author: >
   [Anish Ramasekar](https://github.com/aramase) (Microsoft)
 ---


### PR DESCRIPTION
Feature blog post for KEP 4412 beta: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/README.md
KEP issue: https://github.com/kubernetes/enhancements/issues/4412