### PR TITLE
Improve glossary entries for EndpointSlice and Endpoints

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -18,8 +18,7 @@ description: >-
 
 {{< feature-state for_k8s_version="v1.21" state="stable" >}}
 
-Kubernetes' _EndpointSlice_ API provides a way to track network endpoints
-within a Kubernetes cluster.
+{{< glossary_definition term_id="endpoint-slice" length="short" >}}
 
 <!-- body -->
 

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -514,9 +514,9 @@ containers:
 
 `readinessProbe`
 : Indicates whether the container is ready to respond to requests.
-  If the readiness probe fails, the EndpointSlice controller removes the Pod's IP
-  address from the EndpointSlices of all Services that match the Pod. The default
-  state of readiness before the initial delay is `Failure`. If a container does
+  If the readiness probe fails, the {{< glossary_tooltip term_id="endpoint-slice" text="EndpointSlice" >}}
+  controller removes the Pod's IP address from the EndpointSlices of all Services that match the Pod.
+  The default state of readiness before the initial delay is `Failure`. If a container does
   not provide a readiness probe, the default state is `Success`.
 
 `startupProbe`

--- a/content/en/docs/reference/glossary/endpoint-slice.md
+++ b/content/en/docs/reference/glossary/endpoint-slice.md
@@ -4,13 +4,22 @@ id: endpoint-slice
 date: 2018-04-12
 full_link: /docs/concepts/services-networking/endpoint-slices/
 short_description: >
-  EndpointSlices track the IP addresses of Pods with matching Service selectors.
+  EndpointSlices track the IP addresses of Pods for Services.
 
 aka:
 tags:
 - networking
 ---
- EndpointSlices track the IP addresses of Pods with matching  {{< glossary_tooltip text="selectors" term_id="selector" >}}.
+EndpointSlices track the IP addresses of backend endpoints.
+EndpointSlices are normally associated with a
+{{< glossary_tooltip text="Service" term_id="service" >}} and the backend endpoints typically represent
+{{< glossary_tooltip text="Pods" term_id="pod" >}}.
 
 <!--more-->
-EndpointSlices can be configured manually for {{< glossary_tooltip text="Services" term_id="service" >}} without selectors specified.
+One Service can be backed by multiple Pods. Kubernetes represents the backing endpoints of a Service
+with a set of EndpointSlices that are associated with that Service.
+The backing endpoints are usually, but not always, pods running in the cluster.
+
+The control plane usually manages EndpointSlices for you automatically. However,
+EndpointSlices can be defined manually for {{< glossary_tooltip text="Services" term_id="service" >}} without
+{{< glossary_tooltip text="selectors" term_id="selector" >}} specified.

--- a/content/en/docs/reference/glossary/endpoint.md
+++ b/content/en/docs/reference/glossary/endpoint.md
@@ -2,21 +2,20 @@
 title: Endpoints
 id: endpoints
 date: 2020-04-23
-full_link: 
+full_link: /docs/concepts/services-networking/service/#endpoints
 short_description: >
-  An endpoint of a Service is one of the Pods (or external servers) that implements the Service.
-
-aka:
+  (Deprecated) API representing endpoints of a Service
 tags:
 - networking
 ---
- An endpoint of a {{< glossary_tooltip text="Service" term_id="service" >}} is one of the {{< glossary_tooltip text="Pods" term_id="pod" >}} (or external servers) that implements the Service.
+A deprecated API that represents the set of all endpoints for a
+{{< glossary_tooltip text="Service" term_id="service" >}}.
 
 <!--more-->
-For Services with {{< glossary_tooltip text="selectors" term_id="selector" >}},
-the EndpointSlice controller will automatically create one or more {{<
-glossary_tooltip text="EndpointSlices" term_id="endpoint-slice" >}} giving the
-IP addresses of the selected endpoint Pods.
 
-EndpointSlices can also be created manually to indicate the endpoints of
-Services that have no selector specified.
+Since v1.21, Kubernetes uses 
+{{< glossary_tooltip text="EndpointSlices" term_id="endpoint-slice" >}}
+rather than Endpoints; the original Endpoints API was deprecated due to
+concerns about scalability.
+
+To learn more about Endpoints, read [Endpoints](/docs/concepts/services-networking/service/#endpoints).

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -16,7 +16,7 @@ of `type` other than
 [`ExternalName`](/docs/concepts/services-networking/service/#externalname).
 Each instance of kube-proxy watches the Kubernetes
 {{< glossary_tooltip term_id="control-plane" text="control plane" >}}
-for the addition and removal of Service and EndpointSlice
+for the addition and removal of Service and {{< glossary_tooltip term_id="endpoint-slice" text="EndpointSlice" >}}
 {{< glossary_tooltip term_id="object" text="objects" >}}. For each Service, kube-proxy
 calls appropriate APIs (depending on the kube-proxy mode) to configure
 the node to capture traffic to the Service's `clusterIP` and `port`,


### PR DESCRIPTION
* Reword the entry for EndpointSlice
* Use the glossary entry in the EndpointSlice concept page
* Add some glossary tooltips

---

* Explain what an Endpoints is
* Explain that Endpoints is deprecated (in the glossary entry)
* Reinstate link to relevant docs about Endpoints

/language en