### PR TITLE
docs: document known issue with CRD scope changes and workaround

### DIFF
--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -577,6 +577,28 @@ sudo mv ./kubectl-whoami /usr/local/bin
 kubectl whoami
 Current user: plugins-user
 ```
+## Known Issues with Custom Resources
+
+### CRD Scope Changes
+
+If you delete and recreate a CustomResourceDefinition (CRD) with a different scope (switching between namespaced and cluster-scoped, or vice versa), you may encounter the following error when using `kubectl` to create or manage custom resources:
+
+```
+Error from server (NotFound): error when creating "<file.yaml>": the server could not find the requested resource (post <resource>)
+```
+
+This occurs because `kubectl` caches discovery information about API resources, and does not automatically detect changes to the scope of a CRD after deletion and recreation.
+
+**Workaround:**  
+To refresh the discovery cache and resolve this error, run:
+
+```
+kubectl api-resources
+```
+
+This command forces `kubectl` to refresh its API resource cache. After running it, retry your previous `kubectl` command.
+
+For more details, see [kubernetes/kubernetes#132437](https://github.com/kubernetes/kubernetes/issues/132437).
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
### Document known issue with CRD scope changes and workaround

#### What this PR does / why we need it

This PR adds a "Known Issues with Custom Resources" section to the kubectl reference documentation, describing a temporary workaround for users who encounter errors after changing the scope (namespaced ↔ cluster) of a CustomResourceDefinition (CRD). It does **not** fix the underlying issue in kubectl or apiserver, but helps users unblock themselves.

#### Related issue(s)

References [kubernetes/kubernetes#132437](https://github.com/kubernetes/kubernetes/issues/132437)

#### Details

- Documents that deleting and recreating a CRD with a different scope may result in kubectl returning "the server could not find the requested resource".
- Provides the workaround: run `kubectl api-resources` to refresh discovery cache.
- Clarifies that this is a temporary solution and the underlying bug remains.

#### Special notes for reviewers

- This is **documentation only**; it does not change kubectl or server behavior.
- The known issue and workaround are added to `content/en/docs/reference/kubectl/_index.md`.

---

/sig cli
/area kubectl
/kind documentation