### PR TITLE
Removed duplicated command descriptions under kubeadm upgrade phase documentations

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Use this command to invoke single phase of the "apply" workflow
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_addon.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_addon.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upgrade the default kubeadm addons
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_bootstrap-token.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_bootstrap-token.md
@@ -10,8 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Configures bootstrap token and cluster-info RBAC rules
-
 ### Synopsis
 
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_control-plane.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_control-plane.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upgrade the control plane
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_kubelet-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_kubelet-config.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upgrade the kubelet configuration for this node
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_post-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_post-upgrade.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Run post upgrade tasks
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_preflight.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_preflight.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Run preflight checks before upgrade
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_upload-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_upload-config.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upload the kubeadm and kubelet configurations to ConfigMaps
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Use this command to invoke single phase of the "node" workflow
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_addon.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_addon.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upgrade the default kubeadm addons
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_control-plane.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_control-plane.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upgrade the control plane instance deployed on this node, if any
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_kubelet-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_kubelet-config.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Upgrade the kubelet configuration for this node
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_post-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_post-upgrade.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Run post upgrade tasks
 
 ### Synopsis
 

--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_preflight.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_preflight.md
@@ -10,7 +10,6 @@ guide. You can file document formatting bugs against the
 -->
 
 
-Run upgrade node pre-flight checks
 
 ### Synopsis
 


### PR DESCRIPTION
**Description**
This PR is for to remove duplicated command descriptions above the Synopsis section for both phase - `kubeadm upgrade apply phase`  and  `kubeadm upgrade node phase` in the kubeadm upgrade documentation. It solves the same issue for the subphases also in both section.

Main Page: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade-phase/

Closes: ##51172
