### PR TITLE
Kubeadm upgrade phase navigation

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade-phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade-phase.md
@@ -9,7 +9,7 @@ content_type: concept
 Using the phases of `kubeadm upgrade apply`, you can choose to execute the separate steps of the initial upgrade
 of a control plane node.
 
-{{< tabs name="tab-phase" >}}
+{{< tabs name="tab-apply-phase" >}}
 {{< tab name="phase" include="generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase.md" />}}
 {{< tab name="preflight" include="generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_preflight.md" />}}
 {{< tab name="control-plane" include="generated/kubeadm_upgrade/kubeadm_upgrade_apply_phase_control-plane.md" />}}
@@ -25,7 +25,7 @@ of a control plane node.
 Using the phases of `kubeadm upgrade node` you can choose to execute the separate steps of the upgrade of
 secondary control-plane or worker nodes.
 
-{{< tabs name="tab-phase" >}}
+{{< tabs name="tab-upgrade-phase" >}}
 {{< tab name="phase" include="generated/kubeadm_upgrade/kubeadm_upgrade_node_phase.md" />}}
 {{< tab name="preflight" include="generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_preflight.md" />}}
 {{< tab name="control-plane" include="generated/kubeadm_upgrade/kubeadm_upgrade_node_phase_control-plane.md" />}}

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -135,7 +135,7 @@ body.cid-training #get-certified .col-nav a.button {
   body.cid-training section.call-to-action .main-section > div.call-to-action div.cta-image {
     padding: 0 2rem 0 2rem;
     /* Change display to CSS Grid layout with 2 columns that autofill */
-    display: grid;
+    display: grid; 
     grid-template-columns: repeat(auto-fill, minmax(50%, 1fr));
   }
   /* Make the CTA text fill 100% of the viewport */
@@ -170,7 +170,7 @@ body.cid-training #get-certified .col-nav a.button {
   }
 
   .cta-image:nth-child(-n+2) {
-    grid-row: 1;
+    grid-row: 1; 
   }
 
 
@@ -178,9 +178,9 @@ body.cid-training #get-certified .col-nav a.button {
   body.cid-training .col-container {
     display: grid;
     grid-template-columns: auto auto;
-
+    
   }
-
+  
   body.cid-training .col-nav {
     width: 100%;
     height: 100%;
@@ -190,7 +190,7 @@ body.cid-training #get-certified .col-nav a.button {
     justify-self: center;
     width: 50%;
     grid-column-start: span 2;
-
+    
   }
 }
 
@@ -232,7 +232,7 @@ body.cid-training .button {
 }
 
 body.cid-training .button:hover {
-  background-color: #2357b0;
+  background-color: #2357b0; 
 }
 
 

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -135,7 +135,7 @@ body.cid-training #get-certified .col-nav a.button {
   body.cid-training section.call-to-action .main-section > div.call-to-action div.cta-image {
     padding: 0 2rem 0 2rem;
     /* Change display to CSS Grid layout with 2 columns that autofill */
-    display: grid; 
+    display: grid;
     grid-template-columns: repeat(auto-fill, minmax(50%, 1fr));
   }
   /* Make the CTA text fill 100% of the viewport */
@@ -170,7 +170,7 @@ body.cid-training #get-certified .col-nav a.button {
   }
 
   .cta-image:nth-child(-n+2) {
-    grid-row: 1; 
+    grid-row: 1;
   }
 
 
@@ -178,9 +178,9 @@ body.cid-training #get-certified .col-nav a.button {
   body.cid-training .col-container {
     display: grid;
     grid-template-columns: auto auto;
-    
+
   }
-  
+
   body.cid-training .col-nav {
     width: 100%;
     height: 100%;
@@ -190,7 +190,7 @@ body.cid-training #get-certified .col-nav a.button {
     justify-self: center;
     width: 50%;
     grid-column-start: span 2;
-    
+
   }
 }
 
@@ -232,7 +232,7 @@ body.cid-training .button {
 }
 
 body.cid-training .button:hover {
-  background-color: #2357b0; 
+  background-color: #2357b0;
 }
 
 


### PR DESCRIPTION
### Description
The "kubeadm upgrade node phase" section tabs were not updating content when clicked due to a name collision with the "kubeadm upgrade apply phase" section. Both tab groups were using the same name attribute, causing unexpected behavior.

Changes:
Changed the tab name for the "kubeadm upgrade node phase" section from name="tab-upgrade-phase" to name="tab-node-phase" to ensure unique tab group identifiers
This ensures each tab group has a unique name and prevents state sharing between different tab sections

### Issue

Closes: #51358 