### PR TITLE
Grammar fix in volumes.md: media -> medium

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -975,7 +975,7 @@ spec:
 
 ## Resources
 
-The storage media (such as Disk or SSD) of an `emptyDir` volume is determined by the
+The storage medium (such as Disk or SSD) of an `emptyDir` volume is determined by the
 medium of the filesystem holding the kubelet root dir (typically
 `/var/lib/kubelet`). There is no limit on how much space an `emptyDir` or
 `hostPath` volume can consume, and no isolation between containers or


### PR DESCRIPTION
### Description

Grammar fix of "media" to "medium": "The storage media (such as Disk or SSD) of an `emptyDir` volume is determined" -> "The storage medium (such as Disk or SSD) of an `emptyDir` volume is determined"