### PR TITLE
Clarify that readiness probes are not just for startup.

### DIFF
--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -26,7 +26,7 @@ Liveness probes do not wait for readiness probes to succeed. If you want to wait
 
 ## Readiness probe
 
-Readiness probes determine when a container is ready to start accepting traffic. This is useful when waiting for an application to perform time-consuming initial tasks, such as establishing network connections, loading files, and warming caches.
+Readiness probes determine whether a container is able to accept traffic. This is useful when waiting for an application to perform time-consuming tasks be it at startup, such as establishing network connections, loading files, and warming caches, or when recovering from a fault or overload situation that does not require the container to be restarted.
 
 If the readiness probe returns a failed state, Kubernetes removes the pod from all matching service endpoints.
 


### PR DESCRIPTION
A casual reading of the description of readiness probe description suggests it is specific to startup. There is one sentence at the end of the section saying otherwise but that's easy to overlook.

This change makes it clearer that readiness probes may also be appropriate to let the container recover from a fault or overload long after it started.