### PR TITLE
Clarify systemd configuration based on Containerd version

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -204,16 +204,20 @@ On Windows the default CRI endpoint is `npipe://./pipe/containerd-containerd`.
 
 #### Configuring the `systemd` cgroup driver {#containerd-systemd}
 
-To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc`, set the following config based on your Containerd version
+To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc`,
+set the following config based on your Containerd version
 
 Containerd versions 1.x:
+
 ```
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
   ...
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
     SystemdCgroup = true
 ```
+
 Containerd versions 2.x:
+
 ```
 [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
   ...


### PR DESCRIPTION
### Description

In versions 2 and up of Containerd(config version 3), systemd should be configured via the following instead: plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options

Supporting doc:
https://github.com/containerd/containerd/blob/main/docs/cri/config.md