### PR TITLE
Add Graziano Casto as blog editor

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,13 @@
 aliases:
   sig-docs-blog-owners: # Approvers for blog content
     - lmktfy
+    - graz-dev
     - mrbobbytables
     - natalisucks
     - nate-double-u
   sig-docs-blog-reviewers: # Reviewers for blog content
     - Gauravpadam
+    - graz-dev
     - lmktfy
     - mrbobbytables
     - natalisucks


### PR DESCRIPTION
I recommend that @graz-dev joins as an editor for the blog. Graziano has already been a significantly helpful contributor to the team's work, and I'm confident he'll provide great value as an editor.

/area blog