### PR TITLE
Fix non-functional link for Generating Reference Documentation for kubectl Commands page

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/kubectl.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubectl.md
@@ -94,7 +94,7 @@ git pull https://github.com/kubernetes/kubernetes {{< skew prevMinorVersion >}}.
 ```
 
 If you do not need to edit the `kubectl` source code, follow the instructions for
-[Setting build variables](#setting-build-variables).
+[Setting build variables](#set-build-variables).
 
 ## Edit the kubectl source code
 


### PR DESCRIPTION
This PR fix the link functionality. Now this is working as expected. 

Closes: #51417