### PR TITLE
[vi] add certificate, cidr and cla glossaries

### DIFF
--- a/content/vi/docs/reference/glossary/certificate.md
+++ b/content/vi/docs/reference/glossary/certificate.md
@@ -1,0 +1,17 @@
+---
+title: Certificate
+id: certificate
+date: 2018-04-12
+full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
+short_description: >
+  Một tệp bảo mật bằng mật mã được sử dụng để xác thực quyền truy cập vào cụm Kubernets.
+
+aka: 
+tags:
+- security
+---
+ Một tệp bảo mật bằng mật mã được sử dụng để xác thực quyền truy cập vào cụm Kubernets.
+
+<!--more-->
+
+Chứng chỉ cho phép các ứng dụng trong cụm Kubernets truy cập Kubernets API một cách an toàn. Chứng chỉ xác nhận người dùng được phép truy cập API.

--- a/content/vi/docs/reference/glossary/cidr.md
+++ b/content/vi/docs/reference/glossary/cidr.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - networking
 ---
-CIDR (Classless Inter-Domain Routing) là một dải dùng để mô tả các khối địa chỉ IP và được sử dụng rộng rãi trong nhiều cấu hình mạng khác nhau.
+_Classless Inter-Domain Routing_ (CIDR) là một dải dùng để mô tả các khối địa chỉ IP và được sử dụng rộng rãi trong nhiều cấu hình mạng khác nhau.
 
 <!--more-->
 

--- a/content/vi/docs/reference/glossary/cidr.md
+++ b/content/vi/docs/reference/glossary/cidr.md
@@ -1,0 +1,17 @@
+---
+title: CIDR
+id: cidr
+date: 2019-11-12
+full_link: 
+short_description: >
+  CIDR là một dải dùng để mô tả các khối địa chỉ IP và được sử dụng rộng rãi trong nhiều cấu hình mạng khác nhau.
+
+aka:
+tags:
+- networking
+---
+CIDR (Classless Inter-Domain Routing) là một dải dùng để mô tả các khối địa chỉ IP và được sử dụng rộng rãi trong nhiều cấu hình mạng khác nhau.
+
+<!--more-->
+
+Trong bối cảnh của Kubernetes, mỗi {{< glossary_tooltip text="Node" term_id="node" >}} được gán một dải địa chỉ IP thông qua địa chỉ đầu tiên và mặt nạ mạng con sử dụng CIDR. Điều này cho phép các node gán cho mỗi {{< glossary_tooltip text="Pod" term_id="pod" >}} một địa chỉ IP duy nhất. Mặc dù ban đầu là một khái niệm cho IPv4, CIDR cũng đã mở rộng để bao gồm cả IPv6.

--- a/content/vi/docs/reference/glossary/cla.md
+++ b/content/vi/docs/reference/glossary/cla.md
@@ -6,7 +6,7 @@ full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   Các điều khoản mà theo đó người đóng góp cấp giấy phép cho dự án mã nguồn mở cho các đóng góp của họ.
 
-aka: 
+aka: ["CLA"]
 tags:
 - community
 ---

--- a/content/vi/docs/reference/glossary/cla.md
+++ b/content/vi/docs/reference/glossary/cla.md
@@ -1,0 +1,17 @@
+---
+title: CLA (Contributor License Agreement)
+id: cla
+date: 2018-04-12 
+full_link: https://github.com/kubernetes/community/blob/master/CLA.md
+short_description: >
+  Các điều khoản mà theo đó người đóng góp cấp giấy phép cho dự án mã nguồn mở cho các đóng góp của họ.
+
+aka: 
+tags:
+- community
+---
+ Các điều khoản mà theo đó {{< glossary_tooltip text="contributor" term_id="contributor" >}} người đóng góp cấp giấy phép cho dự án mã nguồn mở cho các đóng góp của họ.
+
+<!--more-->
+
+CLAs giúp giải quyết các tranh chấp pháp lý liên quan đến tài liệu được đóng góp và sở hữu trí tuệ (IP).


### PR DESCRIPTION
Description
Add certificate, cidr and cla glossaries
Origin: https://kubernetes.io/docs/reference/glossary/?user-type=true&tool=true&community=true