### PR TITLE
Documentation change for container restart rules

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ContainerRestartRules.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ContainerRestartRules.md
@@ -1,0 +1,14 @@
+---
+title: ContainerRestartRules
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.34"
+---
+Enables the ability to configure container-level restart policy and restart rules.
+See [Container Restart Policy and Rules](/docs/concepts/workloads/pods/pod-lifecycle/#container-restart-rules) for more details.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Add documentation for container restart policy and container restart rules for 1.34.

### Issue

https://github.com/kubernetes/enhancements/issues/5307

Closes: #