### PR TITLE
Avoid YAML parsing error in kustomization.yaml

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -739,7 +739,7 @@ resources:
 images:
 - name: nginx
   newName: my.image.registry/nginx
-  newTag: 1.4.0
+  newTag: "1.4.0"
 EOF
 ```
 


### PR DESCRIPTION
Fixes #51465 

Updated the kustomization.yaml example to quote the `newTag` value ("1.9.1") to prevent YAML parsing errors when using `kustomize build`.
