### PR TITLE
KEP-4800: move to beta

### DIFF
--- a/content/en/docs/concepts/policy/node-resource-managers.md
+++ b/content/en/docs/concepts/policy/node-resource-managers.md
@@ -207,7 +207,7 @@ listed in alphabetical order:
 : Prevent all the pods regardless of their Quality of Service class to run on reserved CPUs
   (available since Kubernetes v1.32)
 
-`prefer-align-cpus-by-uncorecache` (alpha, hidden by default)
+`prefer-align-cpus-by-uncorecache` (beta, visible by default)
 : Align CPUs by uncore (Last-Level) cache boundary on a best-effort way
   (available since Kubernetes v1.32)
 

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -156,7 +156,7 @@ The following policy options exist for the static `CPUManager` policy:
 * `align-by-socket` (alpha, hidden by default) (1.25 or higher)
 * `distribute-cpus-across-cores` (alpha, hidden by default) (1.31 or higher)
 * `strict-cpu-reservation` (beta, visible by default) (1.32 or higher)
-* `prefer-align-cpus-by-uncorecache` (alpha, hidden by default) (1.32 or higher)
+* `prefer-align-cpus-by-uncorecache` (beta, visible by default) (1.34 or higher)
 
 The `full-pcpus-only` option can be enabled by adding `full-pcpus-only=true` to
 the CPUManager policy options.


### PR DESCRIPTION

### Description
Trivial graduation to beta. We expect no user-visible changes.

### Issue
https://github.com/kubernetes/enhancements/issues/5109

Closes: #N/A (issue 5109 will close once the feature is GA)