### PR TITLE
fix(scripts/lsync): fix show diff output if changes exist

### DIFF
--- a/scripts/lsync.sh
+++ b/scripts/lsync.sh
@@ -37,7 +37,7 @@ if [ -d "$1" ] ; then
     echo "$1 is still in sync"
     exit 0
   fi
-  exit 1
+  exit 0
 fi
 
 LOCALIZED="$1"
@@ -52,9 +52,11 @@ fi
 # Last commit for the localized path
 LASTCOMMIT=$(git log -n 1 --pretty=format:%h -- "$LOCALIZED")
 
-diff_output=$(git diff --quiet "$LASTCOMMIT...HEAD" -- "$EN_VERSION" || echo "changed")
+DIFF_OUTPUT=$(git diff --color=always "$LASTCOMMIT...HEAD" -- "$EN_VERSION")
 
-if [ -z "$diff_output" ]; then
+if [ -z "$DIFF_OUTPUT" ]; then
   echo "$LOCALIZED is still in sync"
   exit 0
+else
+  printf "%s\n" "$DIFF_OUTPUT"
 fi


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This PR fixes the issue of git diff output assigned to diff_output not displaying automatically. Previously required explicit echo, now switched to printf for proper formatting.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #51489