### PR TITLE
Update quick-reference.md: add reusable kubectl aliases for on-call and restricted Kubernetes environments

### DIFF
--- a/content/en/docs/reference/kubectl/quick-reference.md
+++ b/content/en/docs/reference/kubectl/quick-reference.md
@@ -500,6 +500,91 @@ Verbosity | Description
 `--v=8` | Display HTTP request contents.
 `--v=9` | Display HTTP request contents without truncation of contents.
 
+### Aliases for Quick Response in Unknown Kubernetes Environments
+
+When working in unfamiliar, time-sensitive, or ephemeral Kubernetes environments—such as during production incidents or ad-hoc troubleshooting—having reliable and reusable kubectl aliases can reduce friction and improve response times.
+
+The following alias set has been tested across major Kubernetes distributions (including EKS, GKE, AKS, OpenShift, and self-managed clusters) and is designed to support:
+
+* Fast context and namespace switching
+* Retrieval and inspection of common Kubernetes resources
+* Quick access to logs, events, and resource YAML
+* Repeatable utility across diverse enterprise, multicloud, and sandbox environments
+
+To use this alias set, copy the content below into a file named `kubectl_aliases`, then source it:
+
+```bash
+touch ~/.kubectl_aliases
+nano ~/.kubectl_aliases   # or use any text editor
+# Paste the content below
+source ~/.kubectl_aliases
+```
+
+```bash
+# Short base alias
+alias k='kubectl'
+
+# Describe resource aliases
+alias kdp='k describe pod '
+alias kdcm='k describe configmap '
+alias kds='k describe daemonset '
+alias kdj='k describe job '
+alias kdcj='k describe cronjob '
+alias kdnode='k describe node '
+alias kdsec='k describe secret '
+alias kdes='k describe service '
+
+# Get resource aliases
+alias kgp='k get pods -o wide --all-namespaces'
+alias kgpn='k get pods -o wide '
+alias kgpg='k get pods --all-namespaces | grep --color=always'
+alias kgcm='k get configmaps'
+alias kgns='k get namespaces'
+alias kgn='k get nodes -o wide'
+alias kgds='k get daemonsets'
+alias kgcj='k get cronjobs'
+alias kgj='k get jobs'
+alias kgs='k get svc'
+alias kgsec='k get secrets'
+
+# Context and namespace management
+alias ksns='k config set-context --current --namespace '
+alias ksctx='k config use-context '
+alias klsctx='k config get-contexts'
+alias kgctx='k config current-context'
+alias kdctx='k config delete-context'
+alias krctx='k config rename-context '
+alias knks='k config set-context --current --namespace kube-system'
+alias knd='k config set-context --current --namespace default'
+alias knt='k config set-context --current --namespace tmp'
+
+# Events
+alias kget='k get events --sort-by=.metadata.creationTimestamp'
+alias kgeo='k get events --sort-by=.involvedObject.name'
+
+# Apply/delete resources
+alias kaf='k apply -f '
+alias kdf='k delete -f '
+
+# Logs
+alias klogs='k logs --tail=2000 -f'
+
+# Debug pods
+alias krun='k run debug --rm -i -t --image=busybox --restart=Never -- sh'
+
+# YAML output functions
+function kgpy()    { k get pod "$1" -o yaml; }
+function kgcmy()   { k get configmap "$1" -o yaml; }
+function kgdsy()   { k get daemonset "$1" -o yaml; }
+function kgdpy()   { k get deployment "$1" -o yaml; }
+function kgsvc()   { k get service "$1" -o yaml; }
+function kgjby()   { k get job "$1" -o yaml; }
+function kgcjy()   { k get cronjob "$1" -o yaml; }
+function kgsec()   { k get secret "$1" -o yaml; }
+function kgpyns()  { k get pod "$1" -n "$2" -o yaml; }
+function kgcmns()  { k get configmaps -n "$1" -o yaml; }
+```
+
 ## {{% heading "whatsnext" %}}
 
 * Read the [kubectl overview](/docs/reference/kubectl/) and learn about [JsonPath](/docs/reference/kubectl/jsonpath).


### PR DESCRIPTION
This pull request adds a new subsection to the kubectl quick reference guide:
"Aliases for Quick Response in Unknown Kubernetes Environments."

The goal is to provide a lightweight, reusable set of kubectl aliases for users operating in constrained, time-sensitive, or unfamiliar Kubernetes environments—such as during on-call incidents, ephemeral environments, or across diverse multicloud production setups (e.g., EKS, GKE, AKS, OpenShift).

This is my first time contributing to the Kubernetes documentation project. I've seen a recurring need for this kind of alias utility over time, and I’ve personally found it useful across environments with limited tooling or locked-down access to anything beyond the official Kubernetes resources.

If others find this helpful, I’d love to see it included as part of the quick-reference section. Let me know if anything is missing—happy to make adjustments.