### PR TITLE
Update Redis version in redis-pod.yaml to 8.0.2

### DIFF
--- a/content/en/examples/pods/config/redis-pod.yaml
+++ b/content/en/examples/pods/config/redis-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: redis
-    image: redis:5.0.4
+    image: redis:8.0.2
     command:
       - redis-server
       - "/redis-master/redis.conf"


### PR DESCRIPTION
Description
Updated the Redis image version in the redis-pod.yaml example from 5.0.4 to the latest stable version 8.0.2.

This ensures that the example uses a supported and up-to-date Redis image available on Docker Hub.
The example was tested on a Kubernetes v1.32.0 cluster and the Pod successfully started with the new version, reading the configuration from the ConfigMap as expected.

Issue
No related issue.