### PR TITLE
Fix typo in kubeadm upgrade guide: remove duplicate "to"

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -23,7 +23,7 @@ please refer to following pages instead:
 
 The Kubernetes project recommends upgrading to the latest patch releases promptly, and
 to ensure that you are running a supported minor release of Kubernetes.
-Following this recommendation helps you to to stay secure.
+Following this recommendation helps you to stay secure.
 
 The upgrade workflow at high level is the following:
 


### PR DESCRIPTION
Description
This pull request fixes a small typo in the kubeadm upgrade documentation.
It removes a duplicate word "to" in the sentence to improve readability.
No functional changes were made.

Issue
No related issue.