### PR TITLE
Add documentation for promoting the NodeLocalCRISocket to Beta

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -2691,7 +2691,7 @@ See more details on [Audit Annotations](/docs/reference/labels-annotations-taint
 
 ## kubeadm
 
-### kubeadm.alpha.kubernetes.io/cri-socket
+### kubeadm.alpha.kubernetes.io/cri-socket (deprecated) {#kubeadm-alpha-kubernetes-io-cri-socket}
 
 Type: Annotation
 
@@ -2699,10 +2699,10 @@ Example: `kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/contain
 
 Used on: Node
 
-Annotation that kubeadm uses to preserve the CRI socket information given to kubeadm at
-`init`/`join` time for later use. kubeadm annotates the Node object with this information.
-The annotation remains "alpha", since ideally this should be a field in KubeletConfiguration
-instead.
+{{< note >}}
+Starting from v1.34, this annotation is deprecated, kubeadm will no longer actively set and use it.
+{{< /note >}}
+
 
 ### kubeadm.kubernetes.io/etcd.advertise-client-urls
 

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -674,7 +674,10 @@ upgrades the control plane node where it's run. The steps it performs are:
   for the kubelet to restart the components if the files have changed.
 - Uploads the updated kubeadm and kubelet configurations to the cluster in the `kubeadm-config`
   and the `kubelet-config` ConfigMaps (both in the `kube-system` namespace).
-- Writes updated kubelet configuration for this node in `/var/lib/kubelet/config.yaml`.
+- Writes updated kubelet configuration for this node in `/var/lib/kubelet/config.yaml`,
+  and read the node's `/var/lib/kubelet/instance-config.yaml` file
+  and patch fields like `containerRuntimeEndpoint`
+  from this instance configuration into `/var/lib/kubelet/config.yaml`. 
 - Configures bootstrap token and the `cluster-info` ConfigMap for RBAC rules. This is the same as
   in the `kubeadm init` stage and ensures that the cluster continues to support nodes joining with bootstrap tokens.
 - Upgrades the kube-proxy and CoreDNS addons conditionally if all existing kube-apiservers in the cluster
@@ -691,7 +694,10 @@ infers that there is a running kube-apiserver Pod on this node.
 - Runs preflight checks similarly to `kubeadm upgrade apply`.
 - For control plane nodes, upgrades the control plane manifest files on disk in `/etc/kubernetes/manifests`
   and waits for the kubelet to restart the components if the files have changed.
-- Writes the updated kubelet configuration for this node in `/var/lib/kubelet/config.yaml`.
+- Writes updated kubelet configuration for this node in `/var/lib/kubelet/config.yaml`,
+  and read the node's `/var/lib/kubelet/instance-config.yaml` file and
+  patch fields like `containerRuntimeEndpoint`
+  from this instance configuration into `/var/lib/kubelet/config.yaml`. 
 - (For control plane nodes) upgrades the kube-proxy and CoreDNS
   {{< glossary_tooltip text="addons" term_id="addons" >}} conditionally, provided that all existing
   API servers in the cluster have already been upgraded to the target version.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -156,7 +156,7 @@ List of feature gates:
 Feature | Default | Alpha | Beta | GA
 :-------|:--------|:------|:-----|:----
 `ControlPlaneKubeletLocalMode` | `true` | 1.31 | 1.33 | -
-`NodeLocalCRISocket` | `false` | 1.32 | - | -
+`NodeLocalCRISocket` | `true` | 1.32 | 1.34 | -
 `WaitForAllControlPlaneComponents` | `true` | 1.30 | 1.33 | 1.34
 {{< /table >}}
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -106,8 +106,11 @@ for more details.
 ### Workflow when using `kubeadm init`
 
 When you call `kubeadm init`, the kubelet configuration is marshalled to disk
-at `/var/lib/kubelet/config.yaml`, and also uploaded to a `kubelet-config` ConfigMap in the `kube-system`
-namespace of the cluster. A kubelet configuration file is also written to `/etc/kubernetes/kubelet.conf`
+at `/var/lib/kubelet/config.yaml`, and also uploaded to a `kubelet-config` 
+ConfigMap in the `kube-system` namespace of the cluster. 
+Additionally, the kubeadm tool detects the CRI socket on the node and writes its details
+(including the socket path) into a local configuration, `/var/lib/kubelet/instance-config.yaml`.
+A kubelet configuration file is also written to `/etc/kubernetes/kubelet.conf`
 with the baseline cluster-wide configuration for all kubelets in the cluster. This configuration file
 points to the client certificates that allow the kubelet to communicate with the API server. This
 addresses the need to
@@ -123,8 +126,7 @@ KUBELET_KUBEADM_ARGS="--flag1=value1 --flag2=value2 ..."
 ```
 
 In addition to the flags used when starting the kubelet, the file also contains dynamic
-parameters such as the cgroup driver and whether to use a different container runtime socket
-(`--cri-socket`).
+parameters such as the cgroup driver.
 
 After marshalling these two files to disk, kubeadm attempts to run the following two
 commands, if you are using systemd:
@@ -139,8 +141,10 @@ If the reload and restart are successful, the normal `kubeadm init` workflow con
 
 When you run `kubeadm join`, kubeadm uses the Bootstrap Token credential to perform
 a TLS bootstrap, which fetches the credential needed to download the
-`kubelet-config` ConfigMap and writes it to `/var/lib/kubelet/config.yaml`. The dynamic
-environment file is generated in exactly the same way as `kubeadm init`.
+`kubelet-config` ConfigMap and writes it to `/var/lib/kubelet/config.yaml`.
+Additionally, the kubeadm tool detects the CRI socket on the node and writes its details
+(including the socket path) into a local configuration, `/var/lib/kubelet/instance-config.yaml`.
+The dynamic environment file is generated in exactly the same way as `kubeadm init`.
 
 Next, `kubeadm` runs the following two commands to load the new configuration into the kubelet:
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -70,6 +70,10 @@ object under the `kube-system` namespace.
 Executing the sub commands `init`, `join` and `upgrade` would result in kubeadm
 writing the `KubeletConfiguration` as a file under `/var/lib/kubelet/config.yaml`
 and passing it to the local node kubelet.
+
+On each node, kubeadm detects the CRI socket and stores its details into the `/var/lib/kubelet/instance-config.yaml` file.
+When executing the `init`, `join`, or `upgrade` subcommands, 
+kubeadm patches the `containerRuntimeEndpoint` value from this instance configuration into `/var/lib/kubelet/config.yaml`.
 {{< /note >}}
 
 ## Using the `cgroupfs` driver

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
@@ -101,23 +101,13 @@ then run the following commands:
 Edit the file `/var/lib/kubelet/kubeadm-flags.env` and add the containerd runtime to the flags;
 `--container-runtime-endpoint=unix:///run/containerd/containerd.sock`.
 
-Users using kubeadm should be aware that the `kubeadm` tool stores the CRI socket for each host as
-an annotation in the Node object for that host. To change it you can execute the following command
-on a machine that has the kubeadm `/etc/kubernetes/admin.conf` file.
+Users using kubeadm should be aware that the kubeadm tool stores the host's CRI socket in the 
 
-```shell
-kubectl edit no <node-name>
-```
+`/var/lib/kubelet/instance-config.yaml` file on each node. You can create this `/var/lib/kubelet/instance-config.yaml` file on the node.
 
-This will start a text editor where you can edit the Node object.
-To choose a text editor you can set the `KUBE_EDITOR` environment variable.
+The `/var/lib/kubelet/instance-config.yaml` file allows setting the `containerRuntimeEndpoint` parameter. 
 
-- Change the value of `kubeadm.alpha.kubernetes.io/cri-socket` from `/var/run/dockershim.sock`
-  to the CRI socket path of your choice (for example `unix:///run/containerd/containerd.sock`).
-   
-  Note that new CRI socket paths must be prefixed with `unix://` ideally.
-
-- Save the changes in the text editor, which will update the Node object.
+You can set this parameter's value to the path of your chosen CRI socket (for example `unix:///run/containerd/containerd.sock`).
 
 ## Restart the kubelet
 

--- a/content/en/docs/tasks/debug/debug-cluster/_index.md
+++ b/content/en/docs/tasks/debug/debug-cluster/_index.md
@@ -71,7 +71,6 @@ Labels:             beta.kubernetes.io/arch=amd64
                     kubernetes.io/arch=amd64
                     kubernetes.io/hostname=kube-worker-1
                     kubernetes.io/os=linux
-Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
                     node.alpha.kubernetes.io/ttl: 0
                     volumes.kubernetes.io/controller-managed-attach-detach: true
 CreationTimestamp:  Thu, 17 Feb 2022 16:46:30 -0500
@@ -144,7 +143,6 @@ apiVersion: v1
 kind: Node
 metadata:
   annotations:
-    kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
     node.alpha.kubernetes.io/ttl: "0"
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   creationTimestamp: "2022-02-17T21:46:30Z"


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This document includes the docs changes to upgrade the kubeadm NodeLocalCRISocket Feature Gate to the beta stage and removes references to `kubeadm.alpha.kubernetes.io/cri-socket`.

relate: https://github.com/kubernetes/kubeadm/issues/3042

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #