### PR TITLE
Fix: Correct sidecar container termination order in pod lifecycle doc

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -69,10 +69,9 @@ That status either becomes true because there is a process running in the
 container and no startup probe defined, or as a result of its `startupProbe` succeeding.
 
 Upon Pod [termination](/docs/concepts/workloads/pods/pod-lifecycle/#termination-with-sidecars),
-the kubelet postpones terminating sidecar containers until the main application container has fully stopped.
-The sidecar containers are then shut down in the opposite order of their appearance in the Pod specification.
-This approach ensures that the sidecars remain operational, supporting other containers within the Pod,
-until their service is no longer required.
+the sidecar containers are stopped first, before the main application container.
+This ensures that the main application logic can complete without interference
+after the sidecars providing auxiliary functionality have been shut down.
 
 ### Jobs with sidecar containers
 


### PR DESCRIPTION
This PR corrects a documentation bug where the shutdown order of containers in a Pod was previously stated incorrectly.

### Problem
The earlier version claimed that sidecar containers are terminated after the main container, which contradicts the actual behavior.

### Fix
Updated the doc to reflect that sidecar containers are stopped *before* the main application container, as per Kubernetes implementation.

###  References
- Kubernetes code: https://github.com/kubernetes/kubernetes/blob/master/pkg%2Fkubelet%2Fkuberuntime%2Fkuberuntime_manager.go#L1110-L1120
- Original issue: #50859 
- Slack thread : https://kubernetes.slack.com/archives/C0BP8PW9G/p1746008313521029?thread_ts=1746008313.521029&cid=C0BP8PW9G

/sig node
