### PR TITLE
docs(id): Add missing linktitle for docs index page

### DIFF
--- a/content/id/docs/_index.md
+++ b/content/id/docs/_index.md
@@ -1,3 +1,4 @@
 ---
+linktitle: Dokumentasi Kubernetes
 title: Dokumentasi
 ---


### PR DESCRIPTION
### Description

Adds the `linktitle` to the Indonesian docs index page to match other localizations and ensure correct navigation rendering.

### Issue



Closes: #