### PR TITLE
PodObservedGenerationTracking promoted to beta in 1.34

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/PodObservedGenerationTracking.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/PodObservedGenerationTracking.md
@@ -9,5 +9,11 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.33"
+    toVersion: "1.33"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.34"
 ---
-Enables the kubelet to set `observedGeneration` in the pod status and other components to set `observedGeneration` in pod conditions to reflect the `metadata.generation` of the pod at the time that the status or condition is being recorded.
+Enables the kubelet to set `observedGeneration` in the Pod `.status`, and enables other components to set `observedGeneration` in pod conditions.
+This feature allows reflecting the `.metadata.generation` of the Pod at the time that the overall status, or some specific condition, was being recorded.
+Storing it helps avoid risks associated with _lost updates_.


### PR DESCRIPTION
### Description
Update docs to reflect that the FG `PodObservedGenerationTracking` is beta as of 1.34. 

Between v1.33 and 1.34, there were no behavioral changes, the FG was just updated from alpha -> beta, so this PR just updates the FG in the docs accordingly.

There is another PR https://github.com/kubernetes/website/pull/51371 that adds more details to the docs about how this feature works, that one is targeting the live docs and does not need to wait for 1.34. 

### KEP
https://github.com/kubernetes/enhancements/issues/5067