### PR TITLE
Create missingaliases

### DIFF
--- a/missingaliases
+++ b/missingaliases
@@ -1,0 +1,53 @@
+**Title**: Correction needed in kubectl quick reference - missing essential aliases for CKA exam
+
+**Description**:
+I found an issue in the kubectl quick reference documentation that affects CKA exam preparation. The documentation is missing several essential aliases that are commonly used in exam scenarios.
+
+**Current Issue**:
+The quick reference page doesn't include some critical aliases that CKA candidates need:
+
+**Missing Aliases:**
+- `krun` - kubectl run (for imperative pod creation)
+- `kcn` - kubectl create namespace
+- `kdelns` - kubectl delete namespace
+- `kexec` - kubectl exec -it
+- `klogs` - kubectl logs
+- `kap` - kubectl apply -f
+
+**Impact:**
+- CKA candidates may encounter "command not found" errors
+- Inconsistent with exam environment expectations
+- Missing essential shortcuts for time-sensitive exam scenarios
+
+**Proposed Solution:**
+Add these aliases to the quick reference page:
+
+```bash
+# Imperative commands
+alias krun='kubectl run'
+alias kcn='kubectl create namespace'
+alias kdelns='kubectl delete namespace'
+
+# Interactive commands
+alias kexec='kubectl exec -it'
+alias klogs='kubectl logs'
+
+# Apply commands
+alias kap='kubectl apply -f'
+```
+
+**Location**: https://kubernetes.io/docs/reference/kubectl/quick-reference/
+
+**Priority**: Medium (affects CKA exam preparation)
+
+**Additional Context**:
+These aliases are essential for CKA exam scenarios where candidates need to:
+- Quickly create pods imperatively (`krun`)
+- Manage namespaces (`kcn`, `kdelns`)
+- Debug pods interactively (`kexec`, `klogs`)
+- Apply YAML manifests (`kap`)
+
+**References**:
+- CKA exam environment requirements
+- Common kubectl usage patterns in production
+- Time-sensitive troubleshooting scenarios


### PR DESCRIPTION
**Note**: Some aliases like `krun`, `kcn`, `kdelns`, `kexec`, `klogs`, and `kap` are not included in the official Kubernetes quick reference but are essential for CKA exam preparation. These have been added to our local alias setup.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #