### PR TITLE
Fix deployment with capacity reservation yaml

### DIFF
--- a/content/en/examples/deployments/deployment-with-capacity-reservation.yaml
+++ b/content/en/examples/deployments/deployment-with-capacity-reservation.yaml
@@ -20,10 +20,12 @@ spec:
                 # if possible
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: placeholder
-            topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: capacity-placeholder
+              topologyKey: topology.kubernetes.io/hostname
       containers:
       - name: pause
         image: registry.k8s.io/pause:3.6


### PR DESCRIPTION
### Description
The deployment manifest on the page [Overprovision Node Capacity For A Cluster](https://kubernetes.io/docs/tasks/administer-cluster/node-overprovisioning/) is invalid:
```bash
$ kubectl -apply -f https://k8s.io/examples/deployments/deployment-with-capacity-reservation.yaml
Error from server (BadRequest): error when creating "https://k8s.io/examples/deployments/deployment-with-capacity-reservation.yaml":
Deployment in version "v1" cannot be handled as a Deployment: strict decoding error: unknown field "spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].labelSelector",
unknown field "spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].topologyKey"
```
This PR contains the fix for the affinity rules.