### PR TITLE
fixing broken markdown for hyperlink on network configuration page

### DIFF
--- a/content/en/docs/tasks/network/reconfigure-default-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/reconfigure-default-service-ip-ranges.md
@@ -66,7 +66,7 @@ We can categorize Service CIDR reconfiguration into the following scenarios:
   replacing the default ServiceCIDR is a complex operation. If the new
   ServiceCIDR does not overlap with the existing one, [it will require
   renumbering all existing Services and changing the `kubernetes.default`
-  service](#Illustrative Reconfiguration Steps). The case where the primary IP
+  service](#illustrative-reconfiguration-steps). The case where the primary IP
   family also changes is even more complicated, and may require to change
   multiple cluster components (kubelet, network plugins, etc.) to match the new
   primary IP family.


### PR DESCRIPTION
Description
This is a simple fix on the markdown that had a broken link. I've followed the other links on the same page that use the full url reference to the section

Issue
There is no open issue created (afaik) but the markdown is incorrect or incomplete in the section:
https://kubernetes.io/docs/tasks/network/reconfigure-default-service-ip-ranges/#kubernetes-service-cidr-reconfiguration-categories ----> Anything that results in changing the primary service CIDR