### PR TITLE
Add dynamic redirect for latest Kubernetes API docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,14 @@ module-init: ## Initialize required submodules.
 all: build ## Build site with production settings and put deliverables in ./public
 
 build: module-check ## Build site with non-production settings and put deliverables in ./public
+	scripts/generate-api-redirects.sh
 	hugo --cleanDestinationDir --minify --environment development
 
 build-preview: module-check ## Build site with drafts and future posts enabled
 	hugo --cleanDestinationDir --buildDrafts --buildFuture --environment preview
 
 deploy-preview: ## Deploy preview site via netlify
+	scripts/generate-api-redirects.sh
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --buildDrafts --buildFuture --environment preview -b $(DEPLOY_PRIME_URL)
 
 functions-build:
@@ -62,10 +64,12 @@ check-headers-file:
 	scripts/check-headers-file.sh
 
 production-build: module-check ## Build the production site and ensure that noindex headers aren't added
+	scripts/generate-api-redirects.sh
 	GOMAXPROCS=1 hugo --cleanDestinationDir --minify --environment production
 	HUGO_ENV=production $(MAKE) check-headers-file
 
 non-production-build: module-check ## Build the non-production site, which adds noindex headers to prevent indexing
+	scripts/generate-api-redirects.sh
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --environment nonprod
 
 serve: module-check ## Boot the development server.

--- a/layouts/shortcodes/api-reference-link.html
+++ b/layouts/shortcodes/api-reference-link.html
@@ -1,0 +1,13 @@
+{{/*
+Shortcode to generate links to the Kubernetes API reference.
+Usage: {{< api-reference-link version="latest" >}}
+       {{< api-reference-link version="v1.33" >}}
+       {{< api-reference-link >}} (defaults to latest)
+*/}}
+{{- $version := .Get "version" | default "latest" -}}
+{{- $baseURL := "/docs/reference/generated/kubernetes-api" -}}
+{{- if eq $version "latest" -}}
+  {{- printf "%s/latest/" $baseURL -}}
+{{- else -}}
+  {{- printf "%s/%s/" $baseURL $version -}}
+{{- end -}}

--- a/scripts/README-api-redirects.md
+++ b/scripts/README-api-redirects.md
@@ -1,0 +1,93 @@
+# Kubernetes API Reference Dynamic Redirects
+
+This directory contains scripts to automatically generate dynamic redirects for the Kubernetes API reference documentation.
+
+## Problem
+
+The Kubernetes website needs to provide a stable URL (`/docs/reference/generated/kubernetes-api/latest/`) that automatically redirects to the latest version of the API reference (e.g., `/docs/reference/generated/kubernetes-api/v1.33/`).
+
+## Solution
+
+### Scripts
+
+1. **`generate-api-redirects.sh`** - Main script that:
+   - Reads the latest version from `hugo.toml`
+   - Updates the `static/_redirects` file with the appropriate redirect rule
+   - Removes any existing redirect to prevent duplicates
+   - Validates version format and file existence
+
+2. **`test-api-redirects.sh`** - Test script that validates the redirect generation works correctly
+
+### Integration
+
+The redirect generation is integrated into the build process via the `Makefile`. The script runs automatically during:
+- `make build`
+- `make production-build` 
+- `make non-production-build`
+- `make deploy-preview`
+
+### Hugo Shortcode
+
+A Hugo shortcode `api-reference-link` is provided to generate version-aware API reference links:
+
+```hugo
+{{< api-reference-link >}}                    <!-- /docs/reference/generated/kubernetes-api/latest/ -->
+{{< api-reference-link version="latest" >}}   <!-- /docs/reference/generated/kubernetes-api/latest/ -->
+{{< api-reference-link version="v1.33" >}}    <!-- /docs/reference/generated/kubernetes-api/v1.33/ -->
+```
+
+## Usage
+
+### Manual Execution
+```bash
+# From the website root directory
+./scripts/generate-api-redirects.sh
+```
+
+### Testing
+```bash
+# Run the test suite
+./scripts/test-api-redirects.sh
+```
+
+### Build Integration
+The script runs automatically during builds, but you can also run specific build targets:
+```bash
+make build                # Includes redirect generation
+make production-build     # Includes redirect generation
+```
+
+## Configuration
+
+The script reads the latest version from the `latest` parameter in `hugo.toml`:
+```toml
+latest = "v1.33"
+```
+
+## Generated Redirect
+
+The script generates a redirect rule in `static/_redirects`:
+```
+/docs/reference/generated/kubernetes-api/latest/   /docs/reference/generated/kubernetes-api/v1.33/   301!
+```
+
+This redirect:
+- Uses HTTP 301 (permanent redirect)
+- Includes the `!` flag for Netlify to force the redirect
+- Is placed after the header comments in the `_redirects` file
+
+## Validation
+
+The script includes validation for:
+- Existence of `hugo.toml` and `static/_redirects` files
+- Proper version format (e.g., `v1.33`)
+- Prevention of duplicate redirects
+- Idempotent execution (can be run multiple times safely)
+
+## Troubleshooting
+
+If the script fails:
+1. Ensure you're running from the website root directory
+2. Check that `hugo.toml` contains a valid `latest = "v1.xx"` line
+3. Verify `static/_redirects` file exists and is writable
+4. Run the test script to validate functionality

--- a/scripts/generate-api-redirects.sh
+++ b/scripts/generate-api-redirects.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Generate dynamic redirects for Kubernetes API reference
+# This script detects the latest version from hugo.toml and updates the _redirects file
+# to redirect /docs/reference/generated/kubernetes-api/latest/ to the current latest version.
+#
+# Usage: ./scripts/generate-api-redirects.sh
+# 
+# This script is automatically called during the build process via Makefile targets.
+
+set -euo pipefail
+
+# Get the latest version from hugo.toml
+if [[ ! -f "hugo.toml" ]]; then
+    echo "Error: hugo.toml not found. Run this script from the website root directory." >&2
+    exit 1
+fi
+
+LATEST_VERSION=$(grep '^latest = ' hugo.toml | cut -d '"' -f 2 | tr -d '\n\r')
+
+if [[ -z "$LATEST_VERSION" ]]; then
+    echo "Error: Could not detect latest version from hugo.toml" >&2
+    echo "Expected format: latest = \"v1.xx\"" >&2
+    exit 1
+fi
+
+# Validate version format
+if [[ ! "$LATEST_VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid version format: $LATEST_VERSION" >&2
+    echo "Expected format: v1.xx" >&2
+    exit 1
+fi
+
+echo "Detected latest version: $LATEST_VERSION"
+
+# Define the redirect rule
+REDIRECT_RULE="/docs/reference/generated/kubernetes-api/latest/   /docs/reference/generated/kubernetes-api/$LATEST_VERSION/   301!"
+
+# Check if _redirects file exists
+REDIRECTS_FILE="static/_redirects"
+if [[ ! -f "$REDIRECTS_FILE" ]]; then
+    echo "Error: $REDIRECTS_FILE not found" >&2
+    exit 1
+fi
+
+# Remove any existing latest API redirect
+sed -i.bak '/^\/docs\/reference\/generated\/kubernetes-api\/latest\//d' "$REDIRECTS_FILE"
+
+# Add the new redirect at the top of the file (after the header comments)
+# Find the line number after the header comments
+HEADER_END=$(grep -n "^$" "$REDIRECTS_FILE" | head -1 | cut -d: -f1)
+if [[ -z "$HEADER_END" ]]; then
+    HEADER_END=1
+fi
+
+# Insert the redirect after the header
+{
+    head -n "$HEADER_END" "$REDIRECTS_FILE"
+    echo "$REDIRECT_RULE"
+    tail -n +$((HEADER_END + 1)) "$REDIRECTS_FILE"
+} > "${REDIRECTS_FILE}.tmp" && mv "${REDIRECTS_FILE}.tmp" "$REDIRECTS_FILE"
+
+# Clean up backup file
+rm -f "${REDIRECTS_FILE}.bak"
+
+echo "Added redirect: $REDIRECT_RULE"
+echo "Updated $REDIRECTS_FILE successfully"

--- a/scripts/test-api-redirects.sh
+++ b/scripts/test-api-redirects.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Test script for API redirect generation
+# This script validates that the redirect generation works correctly
+
+set -euo pipefail
+
+echo "Testing API redirect generation..."
+
+# Save original _redirects file
+cp static/_redirects static/_redirects.test-backup
+
+# Test 1: Generate redirects
+echo "Test 1: Generating redirects..."
+bash scripts/generate-api-redirects.sh
+
+# Test 2: Check redirect exists
+echo "Test 2: Checking redirect exists..."
+if grep -q "kubernetes-api/latest/" static/_redirects; then
+    echo "✓ Redirect found in _redirects file"
+else
+    echo "✗ Redirect not found in _redirects file"
+    exit 1
+fi
+
+# Test 3: Check redirect format
+echo "Test 3: Checking redirect format..."
+REDIRECT_LINE=$(grep "kubernetes-api/latest/" static/_redirects)
+if [[ "$REDIRECT_LINE" =~ ^/docs/reference/generated/kubernetes-api/latest/[[:space:]]+/docs/reference/generated/kubernetes-api/v[0-9]+\.[0-9]+/[[:space:]]+301! ]]; then
+    echo "✓ Redirect format is correct: $REDIRECT_LINE"
+else
+    echo "✗ Redirect format is incorrect: $REDIRECT_LINE"
+    exit 1
+fi
+
+# Test 4: Check no duplicates
+echo "Test 4: Checking for duplicates..."
+REDIRECT_COUNT=$(grep -c "kubernetes-api/latest/" static/_redirects)
+if [[ "$REDIRECT_COUNT" -eq 1 ]]; then
+    echo "✓ No duplicate redirects found"
+else
+    echo "✗ Found $REDIRECT_COUNT redirects (expected 1)"
+    exit 1
+fi
+
+# Test 5: Run script again to test idempotency
+echo "Test 5: Testing idempotency..."
+bash scripts/generate-api-redirects.sh
+REDIRECT_COUNT_AFTER=$(grep -c "kubernetes-api/latest/" static/_redirects)
+if [[ "$REDIRECT_COUNT_AFTER" -eq 1 ]]; then
+    echo "✓ Script is idempotent (no duplicates after second run)"
+else
+    echo "✗ Script created duplicates on second run"
+    exit 1
+fi
+
+# Restore original file
+mv static/_redirects.test-backup static/_redirects
+
+echo "All tests passed! ✓"

--- a/static/_redirects
+++ b/static/_redirects
@@ -4,7 +4,7 @@
 # test at https://play.netlify.com/redirects  #
 ###############################################
 
-/concepts/containers/container-lifecycle-hooks/     /docs/concepts/containers/container-lifecycle-hooks/ 301
+/docs/reference/generated/kubernetes-api/latest/   /docs/reference/generated/kubernetes-api/v1.33/   301!
 /docs/     /docs/home/ 301!
 /bn/docs/     /bn/docs/home/ 301!
 /de/docs/     /de/docs/home/ 301!


### PR DESCRIPTION
This PR adds a dynamic redirect so that /docs/reference/generated/kubernetes-api/latest/
will point to the latest version folder (e.g., v1.33). 

This is helpful for bookmarks or general links that shouldn't point to a fixed version.
