### PR TITLE
Update service-proxy-name comment to be more descriptive

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1391,7 +1391,11 @@ Example: `service.kubernetes.io/service-proxy-name: "foo-bar"`
 
 Used on: Service
 
-The kube-proxy has this label for custom proxy, which delegates service control to custom proxy.
+Setting a value for this label tells kube-proxy to ignore this service for proxying purposes.
+This allows for use of alternative proxy implementations for this service (e.g. running
+a DaemonSet that manages nftables its own way). Multiple alternative proxy implementations
+could be active simultaneously using this field, e.g. by having a value unique to each
+alternative proxy implementation to be responsible for their respective services.
 
 ### experimental.windows.kubernetes.io/isolation-type (deprecated) {#experimental-windows-kubernetes-io-isolation-type}
 


### PR DESCRIPTION
### Description

Clarifying what [service.kubernetes.io/service-proxy-name](https://kubernetes.io/docs/reference/labels-annotations-taints/#servicekubernetesioservice-proxy-name) does. See [this reference to lack of clarity](https://github.com/kubernetes/kubernetes/issues/132710#issuecomment-3052535236). And see the implementation [here](https://github.com/kubernetes/kubernetes/blob/93bb3858f381bed5c18f3ad53688f01d0013a42b/cmd/kube-proxy/app/server.go#L550).