### PR TITLE
Fix typo: identitiy ➔ identity in security context docs

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -288,7 +288,7 @@ See the Pod's status:
 kubectl get pod security-context-demo -o yaml
 ```
 
-You can see that the `status.containerStatuses[].user.linux` field exposes the process identitiy
+You can see that the `status.containerStatuses[].user.linux` field exposes the process identity
 attached to the first container process.
 
 ```none


### PR DESCRIPTION
Description
This pull request fixes a minor typo in the Kubernetes documentation.
The word “identitiy” was corrected to “identity” in the section describing the process identity exposed in status.containerStatuses[].user.linux.

This improves the clarity and professionalism of the documentation.

Issue
No related issue. This is a minor typo fix noticed during reading.