### PR TITLE
Fix typo in German kubectl installation guide ("eelche" → "welche")

### DIFF
--- a/content/de/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/de/docs/tasks/tools/install-kubectl-linux.md
@@ -108,7 +108,7 @@ Um kubectl auf Linux zu installieren, gibt es die folgenden Möglichkeiten:
    WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.
    ```
 
-   Diese Warnung kann ignoriert werden. Prüfe lediglich die `kubectl` Version, eelche installiert wurde.
+   Diese Warnung kann ignoriert werden. Prüfe lediglich die `kubectl` Version, welche installiert wurde.
    
    {{< /note >}}
    


### PR DESCRIPTION
### Description

This PR fixes a minor typo in the German localization of the kubectl installation guide for Linux.  
The incorrect word “eelche” has been corrected to “welche” to improve the grammatical accuracy of the sentence and ensure better readability for German-speaking users.