### PR TITLE
[ru] Sync KubeCon 2025 events

### DIFF
--- a/content/ru/_index.html
+++ b/content/ru/_index.html
@@ -45,8 +45,6 @@ Kubernetes — это проект с открытым исходным кодо
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Смотреть видео</button>
 
     <h3>Посетите следующие KubeCon + CloudNativeCon</h3>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-china/" class="desktopKCButton"><strong>China</strong> (Гонконг, Июн 10-11)</a>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/" class="desktopKCButton"><strong>Japan</strong> (Токио, Июн 16-17)</a>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-india/" class="desktopKCButton"><strong>India</strong> (Хайдарабад, Авг 6-7)</a>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" class="desktopKCButton"><strong>North America</strong> (Атланта, Ноя 10-13)</a>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Амстердам, Мар 23-26, 2026)</a>


### PR DESCRIPTION
Based on #51406 for the English version, I removed two KubeCon events that had already passed from the Russian localisation. 
