### PR TITLE
docs(operators): update URI to KubeOps

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -117,7 +117,7 @@ operator.
 * [Kopf](https://github.com/nolar/kopf) (Kubernetes Operator Pythonic Framework)
 * [kube-rs](https://kube.rs/) (Rust)
 * [kubebuilder](https://book.kubebuilder.io/)
-* [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (.NET operator SDK)
+* [KubeOps](https://dotnet.github.io/dotnet-operator-sdk/) (.NET operator SDK)
 * [Mast](https://docs.ansi.services/mast/user_guide/operator/)
 * [Metacontroller](https://metacontroller.github.io/metacontroller/intro.html) along with WebHooks that
   you implement yourself


### PR DESCRIPTION
### Description

The repository (KubeOps) has been approved and
adopted by the .NET Foundation. As such, the repository was moved and we need to update the URI.

### Issue

Wrong URI pointing currently to a 404 site.
