### PR TITLE
rename APIServingWithRoute typo to APIServingWithRoutine

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/APIServingWithRoutine.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/APIServingWithRoutine.md
@@ -1,5 +1,5 @@
 ---
-title: APIServingWithRoute
+title: APIServingWithRoutine
 content_type: feature_gate
 _build:
   list: never
@@ -10,13 +10,7 @@ stages:
     defaultValue: false
     fromVersion: "1.30"
 ---
-
-<!--
 This feature gate enables an API server performance improvement:
 the API server can use separate goroutines (lightweight threads managed by the Go runtime)
 to serve [**watch**](/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
 requests.
--->
-这个特性门控可以启用一项 API 服务器性能提升：API 服务器可以使用独立的 Goroutine
-（由 Go 运行时管理的轻量级线程）来处理
-[**watch**](/zh-cn/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) 请求。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/APIServingWithRoutine.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/APIServingWithRoutine.md
@@ -1,5 +1,5 @@
 ---
-title: APIServingWithRoute
+title: APIServingWithRoutine
 content_type: feature_gate
 _build:
   list: never
@@ -10,7 +10,13 @@ stages:
     defaultValue: false
     fromVersion: "1.30"
 ---
+
+<!--
 This feature gate enables an API server performance improvement:
 the API server can use separate goroutines (lightweight threads managed by the Go runtime)
 to serve [**watch**](/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
 requests.
+-->
+这个特性门控可以启用一项 API 服务器性能提升：API 服务器可以使用独立的 Goroutine
+（由 Go 运行时管理的轻量级线程）来处理
+[**watch**](/zh-cn/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) 请求。


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

There's no feature flag in code called `APIServingWithRoute`, but there is `APIServingWithRoutine`. I believe this was a typo, correcting

### Issue

Closes: #51639