### PR TITLE
Now docker engine use containerd by itself.

### DIFF
--- a/content/en/docs/setup/best-practices/node-conformance.md
+++ b/content/en/docs/setup/best-practices/node-conformance.md
@@ -18,7 +18,7 @@ To run node conformance test, a node must satisfy the same prerequisites as a
 standard Kubernetes node. At a minimum, the node should have the following
 daemons installed:
 
-* CRI-compatible container runtimes such as Docker, containerd and CRI-O
+* CRI-compatible container runtimes such as containerd and CRI-O
 * kubelet
 
 ## Running Node Conformance Test


### PR DESCRIPTION
### Description

In the history, docker was a big container runtime, now it is not. When we install docker components in the official way: `sudo apt-get install docker-ce`, we must install the `containerd.io` package, and `containerd.io` is a docker corp distribution for `containerd` by themselves.