### PR TITLE
Updated image links at Kubernetes basic tutorial

### DIFF
--- a/content/zh-cn/docs/tutorials/kubernetes-basics/_index.md
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/_index.md
@@ -79,7 +79,7 @@ Kubernetes 是一个可用于生产环境的开源平台，基于 Google 在容�
       title="1. Create a Kubernetes cluster" >}}
   -->
   {{< tutorials/module
-      path="/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"
+      path="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"
       image="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347"
       alt="模块一"
       title="1.  创建一个 Kubernetes 集群" >}}
@@ -92,7 +92,7 @@ Kubernetes 是一个可用于生产环境的开源平台，基于 Google 在容�
       title="2. Deploy an app" >}}
   -->
   {{< tutorials/module
-      path="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"
+      path="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"
       image="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347"
       alt="模块二"
       title="2. 部署一个应用" >}}
@@ -105,7 +105,7 @@ Kubernetes 是一个可用于生产环境的开源平台，基于 Google 在容�
       title="3. Explore your app" >}}
   -->
   {{< tutorials/module
-      path="/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro/"
+      path="/docs/tutorials/kubernetes-basics/explore/explore-intro/"
       image="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347"
       alt="模块三"
       title="3. 访问你的应用" >}}
@@ -118,7 +118,7 @@ Kubernetes 是一个可用于生产环境的开源平台，基于 Google 在容�
       title="4. Expose your app publicly" >}}
   -->
   {{< tutorials/module
-      path="/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-intro/"
+      path="/docs/tutorials/kubernetes-basics/expose/expose-intro/"
       image="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347"
       alt="模块四"
       title="4. 公开发布你的应用" >}}
@@ -131,7 +131,7 @@ Kubernetes 是一个可用于生产环境的开源平台，基于 Google 在容�
       title="5. Scale up your app" >}}
   -->
   {{< tutorials/module
-      path="/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-intro/"
+      path="/docs/tutorials/kubernetes-basics/scale/scale-intro/"
       image="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347"
       alt="模块五"
       title="5. 扩大你的应用规模" >}}
@@ -144,7 +144,7 @@ Kubernetes 是一个可用于生产环境的开源平台，基于 Google 在容�
       title="6. Update your app" >}}
   -->
   {{< tutorials/module
-      path="/zh-cn/docs/tutorials/kubernetes-basics/update/update-intro/"
+      path="/docs/tutorials/kubernetes-basics/update/update-intro/"
       image="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347"
       alt="模块六"
       title="6. 更新你的应用" >}}


### PR DESCRIPTION
### Description
Fixed incorrect double language prefix in Chinese Kubernetes tutorial navigation links. The tutorial module paths were manually including `/zh-cn/` prefix, but Hugo was automatically adding the language prefix again based on the current page context, resulting in invalid URLs with `/zh-cn/zh-cn/` double prefix.

**Changes made:**
- Removed manual `/zh-cn/` prefix from all tutorial module paths in the Chinese localization
- Links now follow the same pattern as the English version, allowing Hugo to handle language prefixing automatically
- All 6 tutorial modules updated: create cluster, deploy app, explore app, expose app, scale app, and update app

### Issue
Closes #51643

**Root cause:** Hugo automatically prepends language-specific URL prefixes (`/zh-cn/`) when serving localized content. The manual inclusion of `/zh-cn/` in the shortcode paths caused double prefixing, creating invalid URLs like:
- **Before:** `https://kubernetes.io/zh-cn/zh-cn/docs/tutorials/kubernetes-basics/...`
- **After:** `https://kubernetes.io/zh-cn/docs/tutorials/kubernetes-basics/...`