### PR TITLE
Update kuberc documentation for 1.34 beta

### DIFF
--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -129,14 +129,14 @@ compiled-in default value.
 apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
 defaults:
-- command: delete
+- command: plugin list
   options:
-    - name: interactive
+    - name: name-only
       default: "true"
 ```
 
-With this defaults, running `kubectl delete pod/test-pod` will default to prompting for confirmation. 
-However, `kubectl delete pod/test-pod --interactive=false` will bypass the confirmation.
+With this override, running `kubectl plugin list` will default to showing only plugin names without their full paths. 
+However, `kubectl plugin list --name-only=false` will display the full paths to each plugin.
 
 The kubectl maintainers encourage you to adopt kuberc with the given defaults:
 

--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -4,6 +4,13 @@ content_type: concept
 weight: 70
 ---
 
+{{< note >}}
+You cannot use `kuberc` to override the value of a command line argument to take precedence over
+what the user specifies on the command line. The term `overrides`
+in this context refers to specifying a default value that is different from the
+compiled-in default value.
+{{< /note >}}
+
 {{< feature-state state="beta" for_k8s_version="1.34" >}}
 
 A Kubernetes `kuberc` configuration file allows you to define preferences for kubectl, such as default options and command aliases.
@@ -34,7 +41,7 @@ If you explicitly specify a command line option when you run kubectl, the value 
 In kuberc v1alpha1, these were called `flags`. For v1beta1, they are called `options`.
 {{< /note >}} 
 
-#### Example  {#flags-example}
+#### Example  {#options-example}
 
 ```yaml
 apiVersion: kubectl.config.k8s.io/v1beta1
@@ -94,9 +101,9 @@ aliases:
 
 `kubectl runx test-pod` will be translated to `kubectl run test-pod --namespace test-ns --image busybox -- custom-arg`.
 
-## Command overrides
+## Command defaults
 
-Within a `kuberc` configuration, _command overrides_ let you specify custom values for command line arguments.
+Within a `kuberc` configuration, _command defaultss_ let you specify custom values for command line arguments.
 
 ### command
 
@@ -106,12 +113,12 @@ Specify the built-in command. This includes support for subcommands like `create
 
 You can use `options` to specify default values for command line options.
 
-If you explicitly specify a flag on your terminal, explicit value will always take precedence over
+If you explicitly specify a `options` on your terminal, explicit value will always take precedence over
 the value you defined in kuberc using `defaults`.
 
 {{< note >}}
 You cannot use `kuberc` to override the value of a command line argument to take precedence over
-what the user specifies on the command line. The term `overrides`
+what the user specifies on the command line. The term `defaults`
 in this context refers to specifying a default value that is different from the
 compiled-in default value.
 {{< /note >}}
@@ -128,7 +135,7 @@ defaults:
       default: "true"
 ```
 
-With this override, running `kubectl delete pod/test-pod` will default to prompting for confirmation. 
+With this defaults, running `kubectl delete pod/test-pod` will default to prompting for confirmation. 
 However, `kubectl delete pod/test-pod --interactive=false` will bypass the confirmation.
 
 The kubectl maintainers encourage you to adopt kuberc with the given defaults:

--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -47,14 +47,14 @@ In kuberc v1alpha1, these were called `flags`. For v1beta1, they are called `opt
 apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
 aliases:
-- name: getn
-  command: get
+- name: rolloutwatch
+  command: rollout status
   options:
-   - name: output
-     default: json
+   - name: watch
+     default: "true"
 ```
 
-With this alias, running `kubectl getn pods` will default JSON output. However, if you execute `kubectl getn pods -oyaml`, the output will be in YAML format.
+With this alias, running `kubectl rolloutwatch deployments/nginx` will be translated to `kubectl rollout status deployments/nginx --watch`. This demonstrates how aliases can work with multi-word commands like `rollout status`.
 
 ### prependArgs
 

--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -27,11 +27,11 @@ Specify the underlying built-in command that your alias will execute. This inclu
 
 ### options
 
-Specify default values for command line arguments (which the kuberc format terms _options_ in v1beta1). 
-If you explicitly specify a command line argument when you run kubectl, the value you provide takes precedence over the default one defined in kuberc.
+You can use `options` to specify default command line arguments for an alias.
+If you explicitly specify a command line option when you run kubectl, the value you provide takes precedence over the default one defined in kuberc.
 
 {{< note >}}
-In kuberc v1alpha1, these are called `flags`. In v1beta1 and later, they are called `options`.
+In kuberc v1alpha1, these were called `flags`. For v1beta1, they are called `options`.
 {{< /note >}} 
 
 #### Example  {#flags-example}
@@ -104,11 +104,10 @@ Specify the built-in command. This includes support for subcommands like `create
 
 ### options
 
-Within a `kuberc` configuration, command line arguments are termed _options_ in v1beta1 (even if they do not represent a boolean type).
-You can use `options` to set the default value of a command line argument.
+You can use `options` to specify default values for command line options.
 
 If you explicitly specify a flag on your terminal, explicit value will always take precedence over
-the value you defined in kuberc using `overrides`.
+the value you defined in kuberc using `defaults`.
 
 {{< note >}}
 You cannot use `kuberc` to override the value of a command line argument to take precedence over

--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -4,7 +4,7 @@ content_type: concept
 weight: 70
 ---
 
-{{< feature-state state="alpha" for_k8s_version="1.33" >}}
+{{< feature-state state="beta" for_k8s_version="1.34" >}}
 
 A Kubernetes `kuberc` configuration file allows you to define preferences for kubectl, such as default options and command aliases.
 Unlike the kubeconfig file, a `kuberc` configuration file does **not** contain cluster details, usernames or passwords.
@@ -25,20 +25,24 @@ Alias name must not collide with the built-in commands.
 
 Specify the underlying built-in command that your alias will execute. This includes support for subcommands like `create role`.
 
-### flags
+### options
 
-Specify default values for command line arguments (which the kuberc format terms _flags_). 
-If you explicitly specify a command line argument when you run kubectl, the value you provide takes precedence over the default one defined in kuberc. 
+Specify default values for command line arguments (which the kuberc format terms _options_ in v1beta1). 
+If you explicitly specify a command line argument when you run kubectl, the value you provide takes precedence over the default one defined in kuberc.
+
+{{< note >}}
+In kuberc v1alpha1, these are called `flags`. In v1beta1 and later, they are called `options`.
+{{< /note >}} 
 
 #### Example  {#flags-example}
 
 ```yaml
-apiVersion: kubectl.config.k8s.io/v1alpha1
+apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
 aliases:
 - name: getn
   command: get
-  flags:
+  options:
    - name: output
      default: json
 ```
@@ -52,14 +56,14 @@ Insert arbitrary arguments immediately after the kubectl command and its subcomm
 #### Example {#prependArgs-example}
 
 ```yaml
-apiVersion: kubectl.config.k8s.io/v1alpha1
+apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
 aliases:
   - name: getn
     command: get
     prependArgs:
       - namespace
-    flags:
+    options:
       - name: output
         default: json
 ```
@@ -73,12 +77,12 @@ Append arbitrary arguments to the end of the kubectl command.
 #### Example {#appendArgs-example}
 
 ```yaml
-apiVersion: kubectl.config.k8s.io/v1alpha1
+apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
 aliases:
 - name: runx
   command: run
-  flags:
+  options:
     - name: image
       default: busybox
     - name: namespace
@@ -98,10 +102,10 @@ Within a `kuberc` configuration, _command overrides_ let you specify custom valu
 
 Specify the built-in command. This includes support for subcommands like `create role`.
 
-### flags
+### options
 
-Within a `kuberc`, configuration, command line arguments are termed _flags_ (even if they do not represent a boolean type).
-You can use `flags` to set the default value of a command line argument.
+Within a `kuberc` configuration, command line arguments are termed _options_ in v1beta1 (even if they do not represent a boolean type).
+You can use `options` to set the default value of a command line argument.
 
 If you explicitly specify a flag on your terminal, explicit value will always take precedence over
 the value you defined in kuberc using `overrides`.
@@ -116,11 +120,11 @@ compiled-in default value.
 #### Example
 
 ```yaml
-apiVersion: kubectl.config.k8s.io/v1alpha1
+apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
-overrides:
+defaults:
 - command: delete
-  flags:
+  options:
     - name: interactive
       default: "true"
 ```
@@ -131,15 +135,15 @@ However, `kubectl delete pod/test-pod --interactive=false` will bypass the confi
 The kubectl maintainers encourage you to adopt kuberc with the given defaults:
 
 ```yaml
-apiVersion: kubectl.config.k8s.io/v1alpha1
+apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
-overrides:
+defaults:
   - command: apply
-    flags:
+    options:
       - name: server-side
         default: "true"
   - command: delete
-    flags:
+    options:
       - name: interactive
         default: "true"
 ```


### PR DESCRIPTION


### Issue https://github.com/kubernetes/enhancements/issues/3104

Update kuberc documentation for 1.34 beta

  - Update feature state from alpha to beta
  - Change version from 1.33 to 1.34  
  - Update API examples from v1alpha1 to v1beta1
  - Fix terminology: flags -> options for v1beta1