### PR TITLE
[ja] Translate kms-provider.md into Japanese

### DIFF
--- a/content/ja/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/ja/docs/tasks/administer-cluster/kms-provider.md
@@ -1,0 +1,421 @@
+---
+reviewers:
+- aramase
+- enj
+title: データ暗号化にKMSプロバイダーを使用する
+content_type: task
+weight: 370
+---
+<!-- overview -->
+このページでは、秘密データの暗号化を有効にするために、Key Management Service（KMS）プロバイダーとプラグインを設定する方法について説明します。
+Kubernetes {{< skew currentVersion >}}では、KMS保存時暗号化の2つのバージョンがあります。
+KMS v1は非推奨（Kubernetes v1.28以降）であり、デフォルトで無効化されている（Kubernetes v1.29以降）ため、可能であればKMS v2を使用する必要があります。
+KMS v2は、KMS v1よりも大幅に優れたパフォーマンス特性を提供します。
+
+{{< caution >}}
+このドキュメントは、KMS v2の一般的に利用可能な実装（および非推奨のバージョン1実装）について記載しています。
+Kubernetes v1.29より古いコントロールプレーンコンポーネントを使用している場合は、クラスターが実行しているKubernetesのバージョンに対応するドキュメントの同等のページを確認してください。Kubernetesの以前のリリースでは、情報セキュリティに関連する可能性のある異なる動作がありました。
+{{< /caution >}}
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+必要なKubernetesのバージョンは、選択したKMS APIバージョンによって異なります。KubernetesではKMS v2の使用を推奨しています。
+
+- バージョンv1.27より前のクラスターをサポートするためにKMS API v1を選択した場合、
+  またはKMS v1のみをサポートするレガシーKMSプラグインを使用している場合、
+  サポートされている任意のKubernetesバージョンが動作します。このAPIはKubernetes v1.28時点で非推奨です。
+  KubernetesではこのAPIの使用を推奨していません。
+
+{{< version-check >}}
+
+### KMS v1
+{{< feature-state for_k8s_version="v1.28" state="deprecated" >}}
+
+* Kubernetesバージョン1.10.0以降が必要です
+
+* バージョン1.29以降では、KMSのv1実装はデフォルトで無効になっています。
+  この機能を有効にするには、`--feature-gates=KMSv1=true`を設定してKMS v1プロバイダーを構成してください。
+
+* クラスターはetcd v3以降を使用する必要があります
+
+### KMS v2
+{{< feature-state for_k8s_version="v1.29" state="stable" >}}
+
+* クラスターはetcd v3以降を使用する必要があります
+
+<!-- steps -->
+
+## KMS暗号化とオブジェクトごとの暗号化キー
+
+KMSプロバイダーは、etcd内のデータを暗号化するためにエンベロープ暗号化方式を使用します。
+データはデータ暗号化キー（DEK）を使用して暗号化されます。
+DEKは、リモートKMSで保存・管理されるキー暗号化キー（KEK）で暗号化されます。
+
+（非推奨の）KMSのv1実装を使用する場合、各暗号化ごとに新しいDEKが生成されます。
+
+KMS v2では、**暗号化ごと**に新しいDEKが生成されます：APIサーバーは
+_キー派生関数_を使用して、シークレットシードとランダムデータを組み合わせて
+単一用途のデータ暗号化キーを生成します。
+シードは、KEKがローテーションされるたびにローテーションされます
+（詳細については、以下の_key_idとキーローテーションの理解_セクションを参照してください）。
+
+KMSプロバイダーは、UNIXドメインソケット経由で特定のKMSプラグインと通信するためにgRPCを使用します。
+KMSプラグインは、gRPCサーバーとして実装され、Kubernetesコントロールプレーンと同じホストにデプロイされ、
+リモートKMSとのすべての通信を担当します。
+
+## KMSプロバイダーの設定
+
+APIサーバーでKMSプロバイダーを設定するには、暗号化設定ファイルの
+`providers`配列に`kms`タイプのプロバイダーを含め、以下のプロパティを設定してください：
+
+### KMS v1 {#configuring-the-kms-provider-kms-v1}
+
+* `apiVersion`: KMSプロバイダーのAPIバージョン。この値を空のままにするか、`v1`に設定してください。
+* `name`: KMSプラグインの表示名。一度設定すると変更できません。
+* `endpoint`: gRPCサーバー（KMSプラグイン）のリッスンアドレス。エンドポイントはUNIXドメインソケットです。
+* `cachesize`: 平文でキャッシュするデータ暗号化キー（DEK）の数。
+  キャッシュされた場合、DEKはKMSへの追加の呼び出しなしに使用できます；
+  一方、キャッシュされていないDEKは、アンラップするためにKMSへの呼び出しが必要です。
+* `timeout`: `kube-apiserver`がエラーを返す前にkms-pluginの応答を待つ時間
+  （デフォルトは3秒）。
+
+### KMS v2 {#configuring-the-kms-provider-kms-v2}
+
+* `apiVersion`: KMSプロバイダーのAPIバージョン。これを`v2`に設定してください。
+* `name`: KMSプラグインの表示名。一度設定すると変更できません。
+* `endpoint`: gRPCサーバー（KMSプラグイン）のリッスンアドレス。エンドポイントはUNIXドメインソケットです。
+* `timeout`: `kube-apiserver`がエラーを返す前にkms-pluginの応答を待つ時間
+  （デフォルトは3秒）。
+
+KMS v2は`cachesize`プロパティをサポートしていません。すべてのデータ暗号化キー（DEK）は、
+サーバーがKMSへの呼び出しを介してそれらをアンラップした後、平文でキャッシュされます。一度キャッシュされると、
+DEKはKMSへの呼び出しなしに無期限に復号化を実行するために使用できます。
+
+[保存時暗号化設定の理解](/docs/tasks/administer-cluster/encrypt-data)を参照してください。
+
+## KMSプラグインの実装
+
+KMSプラグインを実装するには、新しいプラグインgRPCサーバーを開発するか、
+クラウドプロバイダーによって既に提供されているKMSプラグインを有効にすることができます。
+その後、プラグインをリモートKMSと統合し、Kubernetesコントロールプレーンにデプロイします。
+
+### クラウドプロバイダーがサポートするKMSの有効化
+
+クラウドプロバイダー固有のKMSプラグインを有効にする手順については、
+お使いのクラウドプロバイダーを参照してください。
+
+### KMSプラグインgRPCサーバーの開発
+
+Go用に利用可能なスタブファイルを使用してKMSプラグインgRPCサーバーを開発できます。他の言語については、
+protoファイルを使用してgRPCサーバーコードの開発に使用できるスタブファイルを作成します。
+
+#### KMS v1 {#developing-a-kms-plugin-gRPC-server-kms-v1}
+
+* Goを使用する場合: スタブファイル内の関数とデータ構造を使用してください：
+  [api.pb.go](https://github.com/kubernetes/kms/blob/release-{{< skew currentVersion >}}/apis/v1beta1/api.pb.go)
+  gRPCサーバーコードを開発するため
+
+* Go以外の言語を使用する場合: protocコンパイラーとprotoファイルを使用してください：
+  [api.proto](https://github.com/kubernetes/kms/blob/release-{{< skew currentVersion >}}/apis/v1beta1/api.proto)
+  特定の言語用のスタブファイルを生成するため
+
+#### KMS v2 {#developing-a-kms-plugin-gRPC-server-kms-v2}
+
+* Goを使用する場合: プロセスを簡単にするために高レベルの
+  [ライブラリ](https://github.com/kubernetes/kms/blob/release-{{< skew currentVersion >}}/pkg/service/interface.go)
+  が提供されています。低レベルの実装では、
+  スタブファイル内の関数とデータ構造を使用できます：
+  [api.pb.go](https://github.com/kubernetes/kms/blob/release-{{< skew currentVersion >}}/apis/v2/api.pb.go)
+  gRPCサーバーコードを開発するため
+
+* Go以外の言語を使用する場合: protocコンパイラーとprotoファイルを使用してください：
+  [api.proto](https://github.com/kubernetes/kms/blob/release-{{< skew currentVersion >}}/apis/v2/api.proto)
+  特定の言語用のスタブファイルを生成するため
+
+その後、スタブファイル内の関数とデータ構造を使用してサーバーコードを開発してください。
+
+#### 注意事項
+
+##### KMS v1 {#developing-a-kms-plugin-gRPC-server-notes-kms-v1}
+
+* kmsプラグインバージョン: `v1beta1`
+
+  Version プロシージャーコールへの応答で、互換性のあるKMSプラグインは
+  `VersionResponse.version`として`v1beta1`を返す必要があります。
+
+* メッセージバージョン: `v1beta1`
+
+  KMSプロバイダーからのすべてのメッセージには、バージョンフィールドが`v1beta1`に設定されています。
+
+* プロトコル: UNIXドメインソケット（`unix`）
+
+  プラグインは、UNIXドメインソケットでリッスンするgRPCサーバーとして実装されます。プラグインのデプロイメントは、gRPC UNIXドメインソケット接続を実行するためにファイルシステム上にファイルを作成する必要があります。APIサーバー（gRPCクライアント）は、通信するためにKMSプロバイダー（gRPCサーバー）のUNIXドメインソケットエンドポイントで設定されます。抽象Linuxソケットは、エンドポイントを`/@`で開始することで使用できます。例：`unix:///@foo`。このタイプのソケットを使用する際は注意が必要です。従来のファイルベースのソケットとは異なり、ACLの概念がないためです。ただし、Linuxネットワーキング名前空間の対象となるため、ホストネットワーキングが使用されていない限り、同じポッド内のコンテナーからのみアクセスできます。
+
+##### KMS v2 {#developing-a-kms-plugin-gRPC-server-notes-kms-v2}
+
+* KMSプラグインバージョン: `v2`
+
+  `Status`リモートプロシージャーコールへの応答で、互換性のあるKMSプラグインは
+  `StatusResponse.version`としてKMS互換性バージョンを返す必要があります。そのステータス応答には
+  `StatusResponse.healthz`として"ok"と、`StatusResponse.key_id`として`key_id`（リモートKMS KEK ID）も含める必要があります。
+  Kubernetesプロジェクトでは、プラグインを
+  安定した`v2` KMS APIと互換性があるようにすることを推奨します。Kubernetes {{< skew currentVersion >}}は
+  KMS用の`v2beta1` APIもサポートしています；将来のKubernetesリリースでもそのベータバージョンのサポートが継続される可能性があります。
+
+  APIサーバーは、すべてが正常な場合は約1分ごと、
+  プラグインが正常でない場合は10秒ごとに`Status`プロシージャーコールをポーリングします。プラグインは、この呼び出しが
+  常に負荷がかかることを考慮して最適化する必要があります。
+
+* 暗号化
+
+  `EncryptRequest`プロシージャーコールは、プレーンテキストとログ目的のUIDを提供します。応答には
+  暗号文、使用されたKEKの`key_id`、および任意でKMSプラグインが将来の
+  `DecryptRequest`呼び出しを支援するために必要なメタデータ（`annotations`フィールド経由）を含める必要があります。プラグインは、任意の異なるプレーンテキストが
+  異なる応答`(ciphertext, key_id, annotations)`になることを保証する必要があります。
+
+  プラグインが空でない`annotations`マップを返す場合、すべてのマップキーは
+  `example.com`のような完全修飾ドメイン名である必要があります。`annotation`の使用例は
+  `{"kms.example.io/remote-kms-auditid":"<audit ID used by the remote KMS>"}`です。
+
+  APIサーバーは高い頻度で`EncryptRequest`プロシージャーコールを実行しません。プラグインの実装でも
+  各リクエストのレイテンシを100ミリ秒未満に保つことを目指す必要があります。
+
+* 復号化
+
+  `DecryptRequest`プロシージャーコールは、`EncryptRequest`からの`(ciphertext, key_id, annotations)`と
+  ログ目的のUIDを提供します。期待される通り、これは`EncryptRequest`呼び出しの逆です。プラグインは
+  `key_id`が理解できるものであることを検証する必要があります - 以前の時点で自分が暗号化したデータであることを確信していない限り、
+  データの復号化を試みてはいけません。
+
+  APIサーバーは、ウォッチキャッシュを満たすために起動時に何千もの`DecryptRequest`プロシージャーコールを実行する可能性があります。したがって、
+  プラグインの実装はこれらの呼び出しを可能な限り迅速に実行する必要があり、各リクエストのレイテンシを
+  10ミリ秒未満に保つことを目指す必要があります。
+
+* `key_id`とキーローテーションの理解
+
+  `key_id`は、現在使用中のリモートKMS KEKの公開された非秘密の名前です。APIサーバーの
+  通常の動作中にログに記録される可能性があるため、プライベートデータを含んではいけません。プラグインの実装では、
+  データの漏洩を避けるためにハッシュの使用が推奨されます。KMS v2メトリクスは、
+  `/metrics`エンドポイント経由で公開する前にこの値をハッシュ化するよう注意しています。
+
+  APIサーバーは、`Status`プロシージャーコールから返される`key_id`を信頼できるものと見なします。したがって、
+  この値の変更は、リモートKEKが変更されたことをAPIサーバーに通知し、古いKEKで暗号化されたデータは
+  no-op書き込みが実行されたときに古いものとしてマークされる必要があります（以下で説明）。`EncryptRequest`プロシージャーコールが
+  `Status`とは異なる`key_id`を返す場合、応答は破棄され、プラグインは正常でないと見なされます。したがって、
+  実装は`Status`から返される`key_id`が`EncryptRequest`によって返されるものと
+  同じであることを保証する必要があります。さらに、プラグインは`key_id`が安定しており、
+  値間で変動しないことを確保する必要があります（つまり、リモートKEKローテーション中）。
+
+  プラグインは、以前に使用されたリモートKEKが復元された状況でも、`key_id`を再利用してはいけません。
+  例えば、プラグインが`key_id=A`を使用していて、`key_id=B`に切り替え、その後`key_id=A`に戻った場合 - 
+  `key_id=A`を報告する代わりに、プラグインは`key_id=A_001`のような派生値を報告するか、
+  `key_id=C`のような新しい値を使用する必要があります。
+
+  APIサーバーは約1分ごとに`Status`をポーリングするため、`key_id`ローテーションは即座には行われません。さらに、
+  APIサーバーは約3分間最後の有効な状態で継続します。したがって、ユーザーがストレージ移行に対して
+  受動的なアプローチ（つまり、待機による）を取りたい場合、リモートKEKがローテーションされた後の
+  `3 + N + M`分でマイグレーションを予定する必要があります（`N`はプラグインが`key_id`変更を観察するのにかかる時間、
+  `M`は設定変更が処理されることを許可するための望ましいバッファです - 最低5分の`M`が推奨されます）。
+  KEKローテーションを実行するためにAPIサーバーの再起動は必要ないことに注意してください。
+
+  {{< caution >}}
+  DEKで実行される書き込み数を制御できないため、
+  Kubernetesプロジェクトでは、KEKを少なくとも90日ごとにローテーションすることを推奨します。
+  {{< /caution >}}
+
+* プロトコル: UNIXドメインソケット（`unix`）
+
+  プラグインは、UNIXドメインソケットでリッスンするgRPCサーバーとして実装されます。
+  プラグインのデプロイメントは、gRPC UNIXドメインソケット接続を実行するために
+  ファイルシステム上にファイルを作成する必要があります。
+  APIサーバー（gRPCクライアント）は、通信するためにKMSプロバイダー（gRPCサーバー）の
+  UNIXドメインソケットエンドポイントで設定されます。
+  抽象Linuxソケットは、エンドポイントを`/@`で開始することで使用できます。例：`unix:///@foo`。
+  このタイプのソケットを使用する際は、従来のファイルベースのソケットとは異なり、
+  ACLの概念がないため注意が必要です。
+  ただし、Linuxネットワーキング名前空間の対象となるため、
+  ホストネットワーキングが使用されていない限り、同じポッド内のコンテナーからのみアクセスできます。
+
+### KMSプラグインとリモートKMSの統合
+
+KMSプラグインは、KMSがサポートする任意のプロトコルを使用してリモートKMSと通信できます。
+KMSプラグインがリモートKMSとの通信に使用する認証資格情報を含むすべての設定データは、
+KMSプラグインによって独立して保存・管理されます。
+KMSプラグインは、復号化のためにKMSに送信する前に必要な追加のメタデータで暗号文をエンコードできます
+（KMS v2は専用の`annotations`フィールドを提供することでこのプロセスを簡単にします）。
+
+### KMSプラグインのデプロイ
+
+KMSプラグインがKubernetes APIサーバーと同じホストで実行されることを確認してください。
+
+## KMSプロバイダーでデータを暗号化する
+
+データを暗号化するには：
+
+1. SecretやConfigMapなどのリソースを暗号化するために、`kms`プロバイダーの適切なプロパティを使用して
+新しい`EncryptionConfiguration`ファイルを作成します。CustomResourceDefinitionで定義された拡張APIを暗号化したい場合、
+クラスターはKubernetes v1.26以降を実行している必要があります。
+
+1. kube-apiserverの`--encryption-provider-config`フラグを設定ファイルの場所を指すように設定します。
+
+1. `--encryption-provider-config-automatic-reload`ブール引数は、
+   `--encryption-provider-config`で設定されたファイルが
+   ディスクの内容が変更された場合に
+   [自動的にリロード](/docs/tasks/administer-cluster/encrypt-data/#configure-automatic-reloading)
+   されるかどうかを決定します。
+
+1. APIサーバーを再起動します。
+
+### KMS v1 {#encrypting-your-data-with-the-kms-provider-kms-v1}
+
+   ```yaml
+   apiVersion: apiserver.config.k8s.io/v1
+   kind: EncryptionConfiguration
+   resources:
+     - resources:
+         - secrets
+         - configmaps
+         - pandas.awesome.bears.example
+       providers:
+         - kms:
+             name: myKmsPluginFoo
+             endpoint: unix:///tmp/socketfile-foo.sock
+             cachesize: 100
+             timeout: 3s
+         - kms:
+             name: myKmsPluginBar
+             endpoint: unix:///tmp/socketfile-bar.sock
+             cachesize: 100
+             timeout: 3s
+   ```
+
+### KMS v2 {#encrypting-your-data-with-the-kms-provider-kms-v2}
+
+   ```yaml
+   apiVersion: apiserver.config.k8s.io/v1
+   kind: EncryptionConfiguration
+   resources:
+     - resources:
+         - secrets
+         - configmaps
+         - pandas.awesome.bears.example
+       providers:
+         - kms:
+             apiVersion: v2
+             name: myKmsPluginFoo
+             endpoint: unix:///tmp/socketfile-foo.sock
+             timeout: 3s
+         - kms:
+             apiVersion: v2
+             name: myKmsPluginBar
+             endpoint: unix:///tmp/socketfile-bar.sock
+             timeout: 3s
+   ```
+
+`--encryption-provider-config-automatic-reload`を`true`に設定すると、すべてのヘルスチェックが単一のヘルスチェックエンドポイントに統合されます。個別のヘルスチェックは、KMS v1プロバイダーが使用されており、暗号化設定が自動リロードされない場合にのみ利用できます。
+
+以下の表は、各KMSバージョンのヘルスチェックエンドポイントをまとめています：
+
+| KMS設定 | 自動リロードなし | 自動リロードあり |
+| ------------------ | ------------------------ | --------------------- |
+| KMS v1のみ        | 個別ヘルスチェック  | 単一ヘルスチェック    |
+| KMS v2のみ        | 単一ヘルスチェック       | 単一ヘルスチェック    |
+| KMS v1とv2の両方 | 個別ヘルスチェック  | 単一ヘルスチェック    |
+| KMSなし             | なし                     | 単一ヘルスチェック    |
+
+`単一ヘルスチェック`は、唯一のヘルスチェックエンドポイントが`/healthz/kms-providers`であることを意味します。
+
+`個別ヘルスチェック`は、各KMSプラグインが暗号化設定での位置に基づいて関連するヘルスチェックエンドポイントを持つことを意味します：`/healthz/kms-provider-0`、`/healthz/kms-provider-1`など。
+
+これらのヘルスチェックエンドポイントパスはハードコードされており、サーバーによって生成/制御されます。個別ヘルスチェックのインデックスは、KMS暗号化設定が処理される順序に対応します。
+
+[すべての秘密が暗号化されていることを確認する](#ensuring-all-secrets-are-encrypted)で定義された手順が実行されるまで、`providers`リストは暗号化されていないデータの読み取りを許可するために`identity: {}`プロバイダーで終わる必要があります。すべてのリソースが暗号化されたら、APIサーバーが暗号化されていないデータを受け入れることを防ぐために`identity`プロバイダーを削除する必要があります。
+
+`EncryptionConfiguration`形式の詳細については、
+[APIサーバー暗号化API参照](/docs/reference/config-api/apiserver-config.v1/)を確認してください。
+
+## データが暗号化されていることを確認する
+
+保存時暗号化が正しく設定されている場合、リソースは書き込み時に暗号化されます。
+`kube-apiserver`を再起動した後、新しく作成または更新されたSecretや`EncryptionConfiguration`で
+設定されたその他のリソースタイプは、保存時に暗号化される必要があります。確認するには、
+`etcdctl`コマンドラインプログラムを使用して秘密データの内容を取得できます。
+
+1. `default`名前空間に`secret1`という新しい秘密を作成します：
+
+   ```shell
+   kubectl create secret generic secret1 -n default --from-literal=mykey=mydata
+   ```
+
+1. `etcdctl`コマンドラインを使用して、etcdからその秘密を読み取ります：
+
+   ```shell
+   ETCDCTL_API=3 etcdctl get /kubernetes.io/secrets/default/secret1 [...] | hexdump -C
+   ```
+
+   ここで`[...]`にはetcdサーバーに接続するための追加の引数が含まれます。
+
+1. 保存された秘密がKMS v1の場合は`k8s:enc:kms:v1:`で、KMS v2の場合は`k8s:enc:kms:v2:`で
+プレフィックスされていることを確認します。これは`kms`プロバイダーが結果データを暗号化したことを示します。
+
+1. API経由で取得されたときに秘密が正しく復号化されることを確認します：
+
+   ```shell
+   kubectl describe secret secret1 -n default
+   ```
+
+   Secretには`mykey: mydata`が含まれている必要があります
+
+## すべての秘密が暗号化されていることを確認する
+
+保存時暗号化が正しく設定されている場合、リソースは書き込み時に暗号化されます。
+したがって、データが暗号化されることを確保するために、インプレースでno-op更新を実行できます。
+
+以下のコマンドは、すべての秘密を読み取り、その後サーバーサイド暗号化を適用するために更新します。
+競合する書き込みによるエラーが発生した場合は、コマンドを再試行してください。
+大きなクラスターの場合、名前空間によって秘密を細分化するか、更新をスクリプト化することをお勧めします。
+
+```shell
+kubectl get secrets --all-namespaces -o json | kubectl replace -f -
+```
+
+## ローカル暗号化プロバイダーからKMSプロバイダーへの切り替え
+
+ローカル暗号化プロバイダーから`kms`プロバイダーに切り替えて、すべての秘密を再暗号化するには：
+
+1. 以下の例に示すように、`kms`プロバイダーを設定ファイルの最初のエントリとして追加します。
+
+   ```yaml
+   apiVersion: apiserver.config.k8s.io/v1
+   kind: EncryptionConfiguration
+   resources:
+     - resources:
+         - secrets
+       providers:
+         - kms:
+             apiVersion: v2
+             name : myKmsPlugin
+             endpoint: unix:///tmp/socketfile.sock
+         - aescbc:
+             keys:
+               - name: key1
+                 secret: <BASE 64 ENCODED SECRET>
+   ```
+
+1. すべての`kube-apiserver`プロセスを再起動します。
+
+1. 以下のコマンドを実行して、`kms`プロバイダーを使用してすべての秘密を強制的に再暗号化します。
+
+   ```shell
+   kubectl get secrets --all-namespaces -o json | kubectl replace -f -
+   ```
+
+## {{% heading "whatsnext" %}}
+
+<!-- preserve legacy hyperlinks -->
+<a id="disabling-encryption-at-rest" />
+
+Kubernetes APIに永続化されたデータの暗号化をもう使用したくない場合は、
+[既に保存時に保存されているデータの復号化](/docs/tasks/administer-cluster/decrypt-data/)を読んでください。


### PR DESCRIPTION
#### Description
This PR provides a complete Japanese translation of the KMS provider documentation ([kms-provider.md] to improve accessibility for Japanese-speaking Kubernetes users. The translation maintains technical accuracy while preserving all code examples, YAML configurations, Hugo shortcodes, and markdown structure. All technical terminology is appropriately translated following existing Japanese documentation conventions in the repository.

#### File added: [kms-provider.md]

This translation is added to the Japanese documentation tree under the administration cluster tasks section, following the same structure as the English documentation.

#### Issue
Closes: #51634