### PR TITLE
feat: add auto-generated llms.txt file for all localizations

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -81,7 +81,7 @@ blog = "/:section/:year/:month/:day/:slug/"
 
 # Be explicit about the output formats. We (currently) only want an RSS feed for the home page.
 [outputs]
-home = [ "HTML", "RSS", "HEADERS" ]
+home = [ "HTML", "RSS", "HEADERS", "TXT" ]
 page = [ "HTML"]
 section = [ "HTML", "print" ]
 
@@ -100,6 +100,11 @@ mediatype = "text/netlify"
 baseName = "_headers"
 isPlainText = true
 notAlternative = true
+
+[outputFormats.TXT]
+mediaType = "text/plain"
+baseName = "llms"
+isPlainText = true
 
 # Image processing configuration.
 [imaging]

--- a/layouts/_default/index.txt
+++ b/layouts/_default/index.txt
@@ -1,0 +1,98 @@
+{{ with .Site.Title -}}
+    # {{ . }}
+{{- end }}
+
+{{ with .Site.Params.Description -}}
+> {{ . }}
+{{- end }}
+
+{{ range (sort ((.Site.GetPage "/").Pages) "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+    - [{{ .Title }}]({{ .Permalink }})
+{{ end -}}
+
+{{/* Sections */}}
+{{ range (sort ((.Site.GetPage "/").Sections) "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+{{ with .Title -}}
+    ## {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+    > {{ . }}
+{{- end }}
+
+{{ range (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end -}}
+
+{{/* Sections-L1 */}}
+{{ range (sort .Sections "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+{{ with .Title -}}
+    ### {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+    > {{ . }}
+{{- end }}
+
+{{ range (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end }}
+
+{{/* Sections-L2 */}}
+{{ range (sort .Sections "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+{{ with .Title -}}
+    #### {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+    > {{ . }}
+{{- end }}
+
+{{ range (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end }}
+
+{{/* Sections-L3 */}}
+{{ range (sort .Sections "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+{{ with .Title -}}
+    ##### {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+    > {{ . }}
+{{- end }}
+
+{{ range (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end }}
+
+{{/* Sections-L4 */}}
+{{ range (sort .Sections "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+{{ with .Title -}}
+    ###### {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+    > {{ . }}
+{{- end }}
+
+{{ range (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+


### PR DESCRIPTION
add auto-generated llms.txt file for all localizations.
<img width="3024" height="1964" alt="Screenshot 2025-07-26 at 6 59 30 PM" src="https://github.com/user-attachments/assets/e4ecafdc-f8bd-4ad2-b310-b3345040a3ae" />
<img width="1512" height="982" alt="Screenshot 2025-07-26 at 7 01 22 PM" src="https://github.com/user-attachments/assets/7945f8b8-0e6f-479f-bd5c-2bc416e606b1" />
<img width="1512" height="982" alt="Screenshot 2025-07-26 at 7 01 41 PM" src="https://github.com/user-attachments/assets/1b031576-d6dd-48c7-bba5-1ee82aaecba9" />

Closes: #51544