### PR TITLE
[vi] add glossaries disruption, dockershim, downstream, downward-api,…

### DIFF
--- a/content/vi/docs/reference/glossary/disruption.md
+++ b/content/vi/docs/reference/glossary/disruption.md
@@ -1,0 +1,24 @@
+---
+title: Disruption
+id: disruption
+date: 2019-09-10
+full_link: /docs/concepts/workloads/pods/disruptions/
+short_description: >
+  Một sự kiện dẫn đến Pod(s) bị ngừng hoạt động
+aka:
+tags:
+- fundamental
+---
+ Gián đoạn là các sự kiện dẫn đến một hoặc một vài
+{{< glossary_tooltip term_id="pod" text="Pods" >}} bị ngừng hoạt động.
+Một sự gián đoạn gây ảnh hưởng cho các tài nguyên phụ thuộc vào các Pod bị ảnh hướng,
+như là {{< glossary_tooltip term_id="deployment" >}}.
+
+<!--more-->
+
+Nếu bạn, với vai trò là người vận hành, chủ động xóa một Pod thuộc về một ứng dụng,
+Kubernetes gọi đó là một gián đoạn tự nguyện (_voluntary disruption_). Nếu một Pod bị mất kết nối
+do Node bị lỗi, hoặc do sự cố ảnh hưởng đến vùng hạ tầng lớn hơn,
+Kubernetes gọi đó là một gián đoạn không tự nguyện (_involuntary disruption_).
+
+Truy cập [Disruptions](/docs/concepts/workloads/pods/disruptions/) để tìm kiếm được nhiều thông tin hơn.

--- a/content/vi/docs/reference/glossary/dockershim.md
+++ b/content/vi/docs/reference/glossary/dockershim.md
@@ -1,0 +1,18 @@
+---
+title: Dockershim
+id: dockershim
+date: 2022-04-15
+full_link: /dockershim
+short_description: >
+   Một thành phần của Kubernetes v1.23 và cũ hơn, cho phép các thành phần trong hệ thống Kubernetes giao tiếp với Docker Engine.
+
+aka:
+tags:
+- fundamental
+---
+Dockershim là một thành phần của Kubernetes v1.23 và cũ hơn. Nó cho phép {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}
+giao tiếp với {{< glossary_tooltip text="Docker Engine" term_id="docker" >}}.
+
+<!--more-->
+
+Bắt đầu từ phiên bản 1.24, dockershim đã được loại bỏ khỏi Kubernetes. Để thêm thông tin chi tiết, truy cập [Dockershim FAQ](/dockershim).

--- a/content/vi/docs/reference/glossary/downstream.md
+++ b/content/vi/docs/reference/glossary/downstream.md
@@ -1,0 +1,18 @@
+---
+title: Downstream (disambiguation)
+id: downstream
+date: 2018-04-12
+full_link: 
+short_description: >
+  Có thể đề cập đến: mã nguồn trong hệ sinh thái Kubernetes phụ thuộc vào mã nguồn lõi của Kubernetes hoặc một repo được forked.
+
+aka: 
+tags:
+- community
+---
+ Có thể đề cập đến: mã nguồn trong hệ sinh thái Kubernetes phụ thuộc vào mã nguồn lõi của Kubernetes hoặc một repo được forked.
+
+<!--more--> 
+
+* Trong **Kubernetes Community**: Các cuộc thảo luận thường dùng *downstream* để chỉ hệ sinh thái, mã nguồn hoặc các công cụ bên thứ ba phụ thuộc vào mã nguồn lõi của Kubernetes. Ví dụ, một tính năng mới trong Kubernetes có thể được các ứng dụng *downstream* áp dụng nhằm cải thiện chức năng.
+* Trong **GitHub** or **git**: Theo quy ước, một repo được fork được gọi là *downstream*, trong khi repo gốc được xem là *upstream*.

--- a/content/vi/docs/reference/glossary/downward-api.md
+++ b/content/vi/docs/reference/glossary/downward-api.md
@@ -1,0 +1,26 @@
+---
+title: Downward API
+id: downward-api
+date: 2022-03-21
+short_description: >
+  Một cơ chế để cung cấp các trường giá trị của Pod và container cho đoạn mã đang chạy bên trong container.
+aka:
+full_link: /docs/concepts/workloads/pods/downward-api/
+tags:
+- architecture
+---
+Cơ chế của Kubernetesdùng để cung cấp các trường giá trị của Pod và container cho mã đang chạy bên trong container.
+<!--more-->
+Đôi khi, việc một container biết thông tin về chính nó là điều hữu ích, mà không cần
+sửa đổi mã nguồn của container theo cách ràng buộc trực tiếp với Kubernetes.
+
+Downward API của Kubernetes cho phép các container truy cập thông tin của bản thân chúng
+hoặc context của chúng trong một cụm Kubernetes. Các ứng dụng chạy trong có thể truy cập
+các thông tin này mà không cần hoạt động như một client của Kubernetes API.
+
+Có hai cách để cung cấp các trường của Pod và container cho một container đang chạy:
+
+- sử dụng [environment variables](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)
+- sử dụng [a `downwardAPI` volume](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)
+
+Tóm lại, có hai cách cung cấp các trường của Pod và container được gọi là _downward API_.

--- a/content/vi/docs/reference/glossary/drain.md
+++ b/content/vi/docs/reference/glossary/drain.md
@@ -1,0 +1,18 @@
+---
+title: Drain
+id: drain
+date: 2024-12-27
+full_link:
+short_description: >
+  Thực hiện việc loại bỏ các Pod khỏi một Node một cách an toàn để chuẩn bị cho việc bảo trì hoặc gỡ bỏ.
+tags:
+- fundamental
+- operation
+---
+Quy trình của việc loại bỏ {{< glossary_tooltip text="Pods" term_id="pod" >}} từ một {{< glossary_tooltip text="Node" term_id="node" >}} để chuẩn bị cho việc bảo trì hoặc loại bỏ Node đó từ một {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
+
+<!--more-->
+
+Câu lệnh `kubectl drain` được dùng để đánh dấu một {{< glossary_tooltip text="Node" term_id="node" >}} sẽ tạm dựng dịch vụ.
+Khi được thao tác, câu lệnh loại bỏ toàn bộ {{< glossary_tooltip text="Pods" term_id="pod" >}} từ {{< glossary_tooltip text="Node" term_id="node" >}}.
+Nếu yêu cầu loại bỏ tạm thời bị từ chối, `kubectl drain` thực hiện lại đến khi toàn bộ {{< glossary_tooltip text="Pods" term_id="pod" >}} được xóa hoặc hết thời gian chờ được cấu hình sẵn.

--- a/content/vi/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/vi/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,0 +1,17 @@
+---
+title: Cấp phát volume động
+id: dynamicvolumeprovisioning
+date: 2018-04-12
+full_link: /docs/concepts/storage/dynamic-provisioning
+short_description: >
+  Cho phép người dùng yêu cầu hệ thống tự động tạo các Volume lưu trũ.
+
+aka: 
+tags:
+- storage
+---
+ Cho phép người dùng yêu cầu hệ thống tự động tạo các {{< glossary_tooltip text="Volumes" term_id="volume" >}} lưu trữ.
+
+<!--more--> 
+
+Cấp phát tự động loại bỏ yêu cầu quản trị viên cần cấp phát sẵn dung lượng lưu trữ. Thay vào đó, hệ thống tự động cấp phát dung lượng lưu trữ theo yêu cầu của người dùng. Cấp phát volume tự đọng được dựa trên một đối tượng API, {{< glossary_tooltip text="StorageClass" term_id="storage-class" >}}, tham chiếu đến một {{< glossary_tooltip text="Volume Plugin" term_id="volume-plugin" >}} mà sẽ cấp phát một {{< glossary_tooltip text="Volume" term_id="volume" >}} và tập hợp các tham số cần truyền cho Volume Plugin.


### PR DESCRIPTION
Description
Add Vietnamese translation for disruption, dockershim, downstream, downward-api, drain and dynamic-volume-provisioning
Link: https://kubernetes.io/docs/reference/glossary/?security=true&architecture=true
Issue
Closes: #