### PR TITLE
Update managing-secret-using-kubectl.md

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -127,7 +127,7 @@ accidentally, or from being stored in a terminal log.
 
 Although verifying secrets could be performed using 'kubectl get secret' command, a broader view of the 
 secret information needs the Secret to be outputted in JSON or YAML format. The below command can be used to 
-output a detailed information of the secret. This will display the content of the secret file explicitly,
+output a detailed information about the Secret. This will display the content of the Secret explicitly,
 and as stated in the previous section, it is not advised to run it unless it is absolutely necessary to view the file.
 
 ```shell


### PR DESCRIPTION
Updating to include output the secret in yaml format.

### Description

Updating secret documentation to get output using -o flag and yaml which will include more details on the secret. An advisory has been added stating that content of the file will be displayed and is not advised to output the secret on terminal.
