### PR TITLE
update service cidr docs validation admission policy example

### DIFF
--- a/content/en/examples/service/networking/vap-servicecidr-default.yaml
+++ b/content/en/examples/service/networking/vap-servicecidr-default.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "servicecidrs.default"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["networking.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["servicecidrs"]
+  matchConditions:
+  - name: 'exclude-default-servicecidr'
+    expression: "object.metadata.name != 'kubernetes'"
+  variables:
+  - name: allowed
+    expression: "['10.96.0.0/16','2001:db8::/64']"
+  validations:
+  - expression: "object.spec.cidrs.all(newCIDR, variables.allowed.exists(allowedCIDR, cidr(allowedCIDR).containsCIDR(newCIDR)))"
+  # For all CIDRs (newCIDR) listed in the spec.cidrs of the submitted ServiceCIDR
+  # object, check if there exists at least one CIDR (allowedCIDR) in the `allowed`
+  # list of the VAP such that the allowedCIDR fully contains the newCIDR.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "servicecidrs-binding"
+spec:
+  policyName: "servicecidrs.default"
+  validationActions: [Deny,Audit]

--- a/content/en/examples/service/networking/vap-servicecidr-default.yaml
+++ b/content/en/examples/service/networking/vap-servicecidr-default.yaml
@@ -25,7 +25,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: "servicecidrs-binding"
+  name: "servicecidrs-default-binding"
 spec:
   policyName: "servicecidrs.default"
   validationActions: [Deny,Audit]

--- a/content/en/examples/service/networking/vap-servicecidr-deny.yaml
+++ b/content/en/examples/service/networking/vap-servicecidr-deny.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "servicecidrs.deny"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["networking.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["servicecidrs"]
+  validations:
+  - expression: "object.metadata.name == 'kubernetes'"
+    message: "you can only create or update the default ServiceCIDR"
+  - expression: "request.userInfo.username == 'system:apiserver' && 'system:masters' in request.userInfo.groups"
+    message: "you can not create or update ServiceCIDR objects"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "servicecidrs-deny-binding"
+spec:
+  policyName: "servicecidrs.deny"
+  validationActions: [Deny,Audit]

--- a/content/en/examples/service/networking/vap-servicecidr-deny.yaml
+++ b/content/en/examples/service/networking/vap-servicecidr-deny.yaml
@@ -11,8 +11,10 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["servicecidrs"]
   validations:
+  # Deny changes to all ServiceCIDRs except the default one
   - expression: "object.metadata.name == 'kubernetes'"
     message: "you can only create or update the default ServiceCIDR"
+  # Deny changes from all users except kube-apiserver
   - expression: "request.userInfo.username == 'system:apiserver' && 'system:masters' in request.userInfo.groups"
     message: "you can not create or update ServiceCIDR objects"
 ---


### PR DESCRIPTION
### Issue 

As expressed in https://github.com/kubernetes/kubernetes/issues/133031 , to avoid breaking existing behaviors we had to allow the apiserver to update the default ServiceCIDR during a migration from single to dual stack.

This new mutation broke some of the existing guardrails we had for improving the consistency of the configuration about defined service ranges, so we must provide a ValidationAdmissionPolicy that cluster admins can use to enforce the previous behavior, basically this new VAP:

- only allows apiserver to create or update the default serviceCIDR
- does not allow to create any new ServiceCIDR

/sig network
/assign @danwinship 

This VAP is also submitted as integration test to avoid regression for admins that depend on it https://github.com/kubernetes/kubernetes/pull/133339