### PR TITLE
Fix broken links to https-nginx example

### DIFF
--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -270,7 +270,7 @@ channel is secure. For this, you will need:
 * A [secret](/docs/concepts/configuration/secret/) that makes the certificates accessible to pods
 
 You can acquire all these from the
-[nginx https example](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/).
+[nginx https example](https://github.com/kubernetes/examples/tree/master/_archived/https-nginx/).
 This requires having go and make tools installed. If you don't want to install those,
 then follow the manual steps later. In short:
 
@@ -393,7 +393,7 @@ in the secret, and the Service, to expose both ports (80 and 443):
 Noteworthy points about the nginx-secure-app manifest:
 
 - It contains both Deployment and Service specification in the same file.
-- The [nginx server](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf)
+- The [nginx server](https://github.com/kubernetes/examples/blob/master/_archived/https-nginx/default.conf)
   serves HTTP traffic on port 80 and HTTPS traffic on 443, and nginx Service
   exposes both ports.
 - Each container has access to the keys through a volume mounted at `/etc/nginx/ssl`.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR fixes broken links to the `https-nginx` example in the following document:
`content/en/docs/tutorials/services/connect-applications-service.md`.

The original links were pointing to the staging/ directory, which has now been moved to _archived/
- https://github.com/kubernetes/examples/tree/master/staging/https-nginx/
- https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf

These have been updated to point to the correct archived paths:
- https://github.com/kubernetes/examples/tree/master/_archived/https-nginx/
- https://github.com/kubernetes/examples/blob/master/_archived/https-nginx/default.conf

### Issue

Closes: #51682
