### PR TITLE
[zh-cn] Fix broken links to https-nginx example

### DIFF
--- a/content/zh-cn/docs/tutorials/services/connect-applications-service.md
+++ b/content/zh-cn/docs/tutorials/services/connect-applications-service.md
@@ -418,7 +418,7 @@ then follow the manual steps later. In short:
 * 使 Pod 可以访问证书的 [Secret](/zh-cn/docs/concepts/configuration/secret/)
 
 你可以从
-[Nginx https 示例](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/)获取所有上述内容。
+[Nginx https 示例](https://github.com/kubernetes/examples/tree/master/_archived/https-nginx/)获取所有上述内容。
 你需要安装 go 和 make 工具。如果你不想安装这些软件，可以按照后文所述的手动执行步骤执行操作。简要过程如下：
 
 ```shell
@@ -594,7 +594,7 @@ Noteworthy points about the nginx-secure-app manifest:
 关于 nginx-secure-app 清单，值得注意的几点如下：
 
 - 它将 Deployment 和 Service 的规约放在了同一个文件中。
-- [Nginx 服务器](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf)通过
+- [Nginx 服务器](https://github.com/kubernetes/examples/blob/master/_archived/https-nginx/default.conf)通过
   80 端口处理 HTTP 流量，通过 443 端口处理 HTTPS 流量，而 Nginx Service 则暴露了这两个端口。
 - 每个容器能通过挂载在 `/etc/nginx/ssl` 的卷访问密钥。卷和密钥需要在 Nginx 服务器启动 **之前** 配置好。
 


### PR DESCRIPTION
### Description

**Part of: #51758** 

This PR fixes broken links to the `https-nginx` example in the following localized document:
`content/zh-cn/docs/tutorials/services/connect-applications-service.md`.

The original links were pointing to the staging/ directory, which has now been moved to _archived/
- https://github.com/kubernetes/examples/tree/master/staging/https-nginx/
- https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf

These have been updated to:
- https://github.com/kubernetes/examples/tree/master/_archived/https-nginx/
- https://github.com/kubernetes/examples/blob/master/_archived/https-nginx/default.conf

### Related Issue


