### PR TITLE
Update French to support Docsy-style menus

### DIFF
--- a/content/fr/blog/_index.md
+++ b/content/fr/blog/_index.md
@@ -4,9 +4,7 @@ linkTitle: Blog
 menu:
   main:
     title: "Blog"
-    weight: 40
-    post: >
-       <p>Lisez les dernières nouvelles à propos de Kubernetes et des conteneurs en général. Obtenez les derniers tutoriels techniques.</p>
+    weight: 20
 ---
 {{< comment >}}
 

--- a/content/fr/case-studies/_index.html
+++ b/content/fr/case-studies/_index.html
@@ -7,5 +7,8 @@ description: Une collection de cas d'utilisation de Kubernetes en production.
 layout: basic
 class: gridPage
 cid: caseStudies
+menu:
+  main:
+    weight: 60
 ---
 

--- a/content/fr/community/_index.html
+++ b/content/fr/community/_index.html
@@ -2,6 +2,9 @@
 title: Communauté
 layout: basic
 cid: community
+menu:
+  main:
+    weight: 50
 ---
 
 <div class="newcommunitywrapper">

--- a/content/fr/partners/_index.html
+++ b/content/fr/partners/_index.html
@@ -5,6 +5,9 @@ abstract: Croissance de l'écosystème Kubernetes.
 description: L'écosystème des partenaires Kubernetes
 class: gridPage
 cid: partners
+menu:
+  main:
+    weight: 40
 ---
 
 <section id="users">


### PR DESCRIPTION
### Description

Update the front matter for French pages so that if we align more with Docsy, the top nav still works how we want. Currently, the top nav sections are hard coded:
- https://github.com/kubernetes/website/blob/9e1a118ff5fbe93e99b28ac30b916a6fe5d4b35b/layouts/partials/navbar.html#L28
- https://github.com/kubernetes/website/blob/9e1a118ff5fbe93e99b28ac30b916a6fe5d4b35b/layouts/404.html#L9 _(stale)_

### Issue

Helps with issue https://github.com/kubernetes/website/issues/41171
