### PR TITLE
Fix top nav for Not Found errors

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -6,7 +6,7 @@
     {{ T "error_404_were_you_looking_for" }}
     </p>
     <ul id="error-sections">
-        {{ $sections := slice "docs" "blog" "training" "partners" "community" "case-studies" }}
+        {{ $sections := slice "docs" "blog" "training" "careers" "partners" "community" }}
         {{ range $sections }}
         {{ with site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>{{ end }}
         {{ end }}


### PR DESCRIPTION
The 404 page layout had a stale list of the sections for the top navigation.
Fix that.

/area web-development