### PR TITLE
[ja] Fix broken links in connect-applications-service.md

### DIFF
--- a/content/ja/docs/tutorials/services/connect-applications-service.md
+++ b/content/ja/docs/tutorials/services/connect-applications-service.md
@@ -234,7 +234,7 @@ Serviceをインターネットに公開する前に、通信経路がセキュ�
 * 証明書を使うよう設定されたnginxサーバー
 * 証明書をPodからアクセスできるようにする[Secret](/ja/docs/concepts/configuration/secret/)
 
-これら全ては[nginx https example](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/)から取得できます。
+これら全ては[nginx https example](https://github.com/kubernetes/examples/tree/master/_archived/https-nginx/)から取得できます。
 go環境とmakeツールのインストールが必要です
 (もしこれらをインストールしたくないときには、後述の手動手順に従ってください)。簡潔には:
 
@@ -309,7 +309,7 @@ Secretにある証明書を使ってhttpsサーバーを開始するために、
 nginx-secure-appマニフェストの注目すべきポイント:
 
 - DeploymentとServiceの指定の両方が同じファイルに含まれています。
-- [nginxサーバー](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf)は、ポート80でHTTPトラフィック、ポート443でHTTPSトラフィックをサービスし、nginx Serviceは両方のポートを公開します。
+- [nginxサーバー](https://github.com/kubernetes/examples/blob/master/_archived/https-nginx/default.conf)は、ポート80でHTTPトラフィック、ポート443でHTTPSトラフィックをサービスし、nginx Serviceは両方のポートを公開します。
 - 各コンテナは、`/etc/nginx/ssl`にマウントされたボリューム経由で鍵にアクセスできます。
   これはnginxサーバーが開始する*前*にセットアップされます。
 


### PR DESCRIPTION
### Description

This PR fixes broken links to the `https-nginx` example in the following localized document:
`content/ja/docs/tutorials/services/connect-applications-service.md`.

The original links were pointing to the now-removed `staging/` directory:
- https://github.com/kubernetes/examples/tree/master/staging/https-nginx/
- https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf

These have been updated to:
- https://github.com/kubernetes/examples/tree/master/_archived/https-nginx/
- https://github.com/kubernetes/examples/blob/master/_archived/https-nginx/default.conf

### Related Issue

Part of: #51758
