### PR TITLE
nit-fix: Add empty value for host field in probes PSA

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -197,6 +197,7 @@ fail validation.
 				<p><strong>Allowed Values</strong></p>
 				<ul>
 					<li>Undefined/nil</li>
+					<li>""</li>
 				</ul>
 			</td>
 		</tr>


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/pull/51498#discussion_r2257241323
We do allow for the host field to be empty - forgot to update this part of docs.

/cc @liggitt 