### PR TITLE
Pod Certificate: Document PodCertificate and podCertificate projected volumes

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/PodCertificateRequests.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/PodCertificateRequests.md
@@ -1,0 +1,15 @@
+---
+title: PodCertificateRequest
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.34"
+    toVersion: "1.37"
+---
+Enable PodCertificateRequest objects and podCertificate projected volume
+sources.

--- a/content/en/examples/pods/storage/projected-podcertificate.yaml
+++ b/content/en/examples/pods/storage/projected-podcertificate.yaml
@@ -1,0 +1,26 @@
+# Sample Pod spec that uses a podCertificate projection to request an ED25519
+# private key, a certificate from the `coolcert.example.com/foo` signer, and
+# write the results to `/var/run/my-x509-credentials/credentialbundle.pem`.
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+  name: podcertificate-pod
+spec:
+  serviceAccountName: default
+  containers:
+  - image: debian
+    name: main
+    command: ["sleep", "infinity"]
+    volumeMounts:
+    - name: my-x509-credentials
+      mountPath: /var/run/my-x509-credentials
+  volumes:
+  - name: my-x509-credentials
+    projected:
+      defaultMode: 420
+      sources:
+      - podCertificate:
+          keyType: ED25519
+          signerName: coolcert.example.com/foo
+          credentialBundlePath: credentialbundle.pem


### PR DESCRIPTION
This is a narrow change that just adds documentation for the new PodCertificate type and podCertificate projected volumes.

The "Certificates" page is now very unwieldy, and needs to be split up.  This is being pursued in a separate PR (https://github.com/kubernetes/website/pull/51487)