### PR TITLE
Update site landing page

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -2,6 +2,7 @@
 title: "Production-Grade Container Orchestration"
 abstract: "Automated container deployment, scaling, and management"
 cid: home
+layout: home
 sitemap:
   priority: 1.0
 ---

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -14,21 +14,21 @@ It groups containers that make up an application into logical units for easy man
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="scalable" %}}
-#### Planet Scale
+#### Planet scale
 
 Designed on the same principles that allow Google to run billions of containers a week, Kubernetes can scale without increasing your operations team.
 
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="blocks" %}}
-#### Never Outgrow
+#### Never outgrow
 
 Whether testing locally or running a global enterprise, Kubernetes flexibility grows with you to deliver your applications consistently and easily no matter how complex your need is.
 
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="suitcase" %}}
-#### Run K8s Anywhere
+#### Run K8s anywhere
 
 Kubernetes is open source giving you the freedom to take advantage of on-premises, hybrid, or public cloud infrastructure, letting you effortlessly move workloads to where it matters to you.
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -59,5 +59,3 @@ To download Kubernetes, visit the [download](/releases/download/) section.
 {{< blocks/kubernetes-features >}}
 
 {{< blocks/case-studies >}}
-
-{{< kubeweekly id="kubeweekly" >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,35 +6,7 @@
 <section id="cncf">
     {{ partial "cncf.html" . }}
 </section>
-
-{{/* legacy kubeweekly support */}}
-{{/* allows localizations to catch up */}}
-{{- if not (.HasShortcode "kubeweekly") -}}
-<section id="kubeweekly">
-      <div class="main-section">
-        <!-- Begin MailChimp Signup Form -->
-        <link href="https://cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-        <br>
-        <div id="mc_embed_signup">
-        <form action="https://kubeweekly.us10.list-manage.com/subscribe/post?u=3885586f8f1175194017967d6&amp;id=11c1b8bcb2" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <div id="mc_embed_signup_scroll">
-                <p style="font-size: 20px">{{ T "main_kubeweekly_baseline" }}</p>
-
-                <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="{{ T "input_placeholder_email_address" }}" aria-label="email" required>
-            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_3885586f8f1175194017967d6_11c1b8bcb2" tabindex="-1" value=""></div>
-            <div class="clear"><input type="submit" value="{{ T "subscribe_button" }}" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-            </div>
-        </form>
-        <h5 style="text-align: center"><a href="https://www.cncf.io/kubeweekly/" aria-label="Kube Weekly" style="color: #3371E3; font-weight: 400; font-size: 20px">{{ T "main_kubeweekly_past_link" }}</a></h5>
-        </div>
-
-        <!--End mc_embed_signup-->
-    </div>
-</section>
 {{- end -}}
-{{- end -}}
-
 
 {{ define "hero-more" }}
 {{ with site.GetPage "section" "docs/tutorials/kubernetes-basics" }}


### PR DESCRIPTION
- Align with our style guide: use sentence case for headings.
- Set layout for landing page (`home`).
  This helps prepare for Docsy theme adoption (making the site compatible with upstream Docsy layouts and styles).
  It's useful to use layouts that are 100% compatible with Docsy, even if we actually choose to style it further. See issue https://github.com/kubernetes/website/issues/41171
- Drop the form for subscribing to KubeWeekly, which has ceased publication.
