### PR TITLE
Fix bug where some pages had two title elements

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -5,7 +5,6 @@
     <link rel="canonical" href="{{ . }}">
     {{ end }}
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-blog {{- with .Page.Params.body_class }} {{ . }}{{ end }}">
     <header>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js" dir="{{ or .Site.Language.LanguageDirection `ltr` }}">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
     <header>


### PR DESCRIPTION
Avoid having a `<title>` element twice in the `<head>` of some pages (documentation and blog sections).

Also helps with issue https://github.com/kubernetes/website/issues/41171

/area web-development