### PR TITLE
Prepare docs home page for Docsy

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -3,9 +3,8 @@ approvers:
 - chenopis
 title: Kubernetes Documentation
 noedit: true
-cid: docsHome
 layout: docsportal_home
-class: gridPage gridPageHome
+body_class: docs-portal
 linkTitle: "Documentation"
 main_menu: true
 weight: 10


### PR DESCRIPTION
For https://kubernetes.io/docs/home/, set front matter that will work if / when we switch to a near-vanilla Docsy theme.

[_Preview_](https://deploy-preview-51832--kubernetes-io-main-staging.netlify.app/docs/home/)

/area web-development

Helps with issue #41171