### PR TITLE
fix(api-concepts): Typo - Change JSON to binary

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -248,7 +248,7 @@ For example:
    200 OK
    Content-Type: application/vnd.kubernetes.protobuf
 
-   … JSON encoded collection of Pods (PodList object)
+   … binary encoded collection of Pods (PodList object)
    ```
 
 1. Create a pod by sending Protobuf encoded data to the server, but request a response


### PR DESCRIPTION
### Overview

This PR fixes a typo in the API concepts reference docs that says a `JSON` encoded response is returned when using `Accept: application/vnd.kubernetes.protobuf`, while it is a `binary` encoded response.