### PR TITLE
Update Japanese to support Docsy-style menus

### DIFF
--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -4,9 +4,7 @@ linkTitle: ブログ
 menu:
   main:
     title: "ブログ"
-    weight: 40
-    post: >
-       <p>Kubernetesやコンテナ全般に関する最新ニュースを読んで、技術的なハウツーをいち早く入手しましょう。</p>
+    weight: 20
 ---
 {{< comment >}}
 

--- a/content/ja/community/_index.html
+++ b/content/ja/community/_index.html
@@ -2,6 +2,9 @@
 title: コミュニティ
 layout: basic
 cid: community
+menu:
+  main:
+    weight: 50
 ---
 
 <div class="newcommunitywrapper">

--- a/content/ja/docs/home/_index.md
+++ b/content/ja/docs/home/_index.md
@@ -12,9 +12,7 @@ hide_feedback: true
 menu:
   main:
     title: "ドキュメント"
-    weight: 20
-    post: >
-      <p>チュートリアル、サンプルやドキュメントのリファレンスを使って Kubernetes の利用方法を学んでください。あなたは<a href="/editdocs/" data-auto-burger-exclude>ドキュメントへコントリビュートをする</a>こともできます!</p>
+    weight: 10
 description: >
   Kubernetesは、コンテナ化されたアプリケーションの展開、スケーリング、また管理を自動化するためのオープンソースコンテナプラットフォームです。このオープンソースプロジェクトは、Cloud Native Computing Foundationによってホストされています。
 overview: >

--- a/content/ja/partners/_index.html
+++ b/content/ja/partners/_index.html
@@ -4,6 +4,9 @@ bigheader: Kubernetesパートナー
 abstract: Kubernetesエコシステムの成長を支えるパートナー
 class: gridPage
 cid: partners
+menu:
+  main:
+    weight: 40
 ---
 
 <section id="users">


### PR DESCRIPTION
### Description

Update the front matter for Japanese pages so that if we align more with Docsy, the top nav still works how we want. Currently, the top nav sections are hard coded:
- https://github.com/kubernetes/website/blob/c07ffdf392aa3448d343a46d5ff744e482c5c52d/layouts/partials/navbar.html#L28
- https://github.com/kubernetes/website/blob/c07ffdf392aa3448d343a46d5ff744e482c5c52d/layouts/404.html#L9 

[Original](https://k8s.io/ja/) vs [preview](https://deploy-preview-51875--kubernetes-io-main-staging.netlify.app/ja/) (no visible difference; this is an enabling change)

### Issue

Helps with issue https://github.com/kubernetes/website/issues/41171
