### PR TITLE
Standardize control plane terminology in controller page

### DIFF
--- a/content/pt-br/docs/concepts/architecture/controller.md
+++ b/content/pt-br/docs/concepts/architecture/controller.md
@@ -59,7 +59,7 @@ O controlador Job não executa nenhum Pod ou container
 ele próprio. Em vez disso, o controlador Job informa o servidor de API para criar ou remover
 Pods.
 Outros componentes no
-{{< glossary_tooltip text="control plane" term_id="control-plane" >}}
+{{< glossary_tooltip text="camada de gerenciamento" term_id="control-plane" >}}
 atuam na nova informação (existem novos Pods para serem agendados e executados),
 e eventualmente o trabalho é feito.
 
@@ -97,7 +97,7 @@ seu estado desejado, e então relata o estado atual de volta ao servidor de API 
 Outros ciclos de controle podem observar esses dados relatados e tomar suas próprias ações.
 
 No exemplo do termostato, se a sala estiver muito fria, então um controlador diferente
-pode também ligar um aquecedor de proteção contra geada. Com clusters Kubernetes, o control plane
+pode também ligar um aquecedor de proteção contra geada. Com clusters Kubernetes, a camada de gerenciamento
 indiretamente trabalha com ferramentas de gerenciamento de endereços IP, serviços de armazenamento,
 APIs de provedores de nuvem, e outros serviços através de
 [estender o Kubernetes](/docs/concepts/extend-kubernetes/) para implementar isso.
@@ -147,10 +147,10 @@ controladores embutidos fornecem comportamentos centrais importantes.
 
 O controlador Deployment e o controlador Job são exemplos de controladores que
 vêm como parte do próprio Kubernetes (controladores "embutidos").
-O Kubernetes permite que você execute um control plane resiliente, para que se qualquer
-um dos controladores embutidos falhar, outra parte do control plane assumirá o trabalho.
+O Kubernetes permite que você execute uma camada de gerenciamento resiliente, para que se qualquer
+um dos controladores embutidos falhar, outra parte da camada de gerenciamento assumirá o trabalho.
 
-Você pode encontrar controladores que executam fora do control plane, para estender o Kubernetes.
+Você pode encontrar controladores que executam fora da camada de gerenciamento, para estender o Kubernetes.
 Ou, se quiser, pode escrever um novo controlador você mesmo.
 Você pode executar seu próprio controlador como um conjunto de Pods,
 ou externamente ao Kubernetes. O que se encaixa melhor dependerá do que esse
@@ -158,7 +158,7 @@ controlador particular faz.
 
 ## {{% heading "whatsnext" %}}
 
-- Leia sobre o [control plane do Kubernetes](/docs/concepts/architecture/#control-plane-components)
+- Leia sobre a [camada de gerenciamento do Kubernetes](/docs/concepts/architecture/#control-plane-components)
 - Descubra alguns dos [objetos Kubernetes](/docs/concepts/overview/working-with-objects/) básicos
 - Saiba mais sobre a [API do Kubernetes](/docs/concepts/overview/kubernetes-api/)
 - Se quiser escrever seu próprio controlador, veja


### PR DESCRIPTION
### Description

Este PR padroniza a terminologia de "control plane" para **"camada de gerenciamento"** na página de controladores em PT-BR, seguindo as diretrizes oficiais de localização do projeto Kubernetes.

**Motivação:**
Este ajuste foi solicitado durante a revisão do [PR](https://github.com/kubernetes/website/pull/51721) anterior, onde foi destacado que o projeto tem um termo padronizado para "control plane" em português brasileiro.

**Alterações realizadas:**
- Substituído "control plane" por "camada de gerenciamento" em todas as ocorrências
- Atualizado glossary tooltip para usar o termo padronizado em português
- Ajustado link na seção "O que vem a seguir" para consistência terminológica

**Base da padronização:**
O termo "camada de gerenciamento" está definido oficialmente no glossário do projeto em `content/pt-br/docs/reference/glossary/control-plane.md` e é amplamente usado em toda a documentação pt-br.

O arquivo `content/pt-br/docs/concepts/architecture/controller.md` agora mantém consistência terminológica com o restante da documentação em português brasileiro.

---

This PR standardizes the terminology from "control plane" to **"camada de gerenciamento"** in the controllers page for PT-BR, following the official Kubernetes project localization guidelines.

**Motivation:**
This adjustment was requested during the review of the previous [PR](https://github.com/kubernetes/website/pull/51721), where it was highlighted that the project has a standardized term for "control plane" in Brazilian Portuguese.

**Changes made:**
- Replaced "control plane" with "camada de gerenciamento" in all occurrences
- Updated glossary tooltip to use the standardized Portuguese term
- Adjusted link in "What's next" section for terminological consistency

**Standardization basis:**
The term "camada de gerenciamento" is officially defined in the project glossary at `content/pt-br/docs/reference/glossary/control-plane.md` and is widely used throughout the pt-br documentation.

The file `content/pt-br/docs/concepts/architecture/controller.md` now maintains terminological consistency with the rest of the Brazilian Portuguese documentation.

### Issue

Related to the feedback received on the controller page translation regarding terminology standardization.