### PR TITLE
Mention Service Internal Traffic Policy in Daemon Pod communication

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -196,7 +196,8 @@ Some possible patterns for communicating with Pods in a DaemonSet are:
   with the same pod selector, and then discover DaemonSets using the `endpoints`
   resource or retrieve multiple A records from DNS.
 - **Service**: Create a service with the same Pod selector, and use the service to reach a
-  daemon on a random node. (No way to reach specific node.)
+  daemon on a random node. Use [Service Internal Traffic Policy](/docs/concepts/services-networking/service-traffic-policy/)
+  to limit to pods on the same node.
 
 ## Updating a DaemonSet
 


### PR DESCRIPTION
### Description

Adding a mention of the stable feature for services to limit pod-to-pod networking to the same node. This is useful for daemonsets that are created specifically to reduce latency for certain operations.