### PR TITLE
Add documentation for kubelet /statusz endpoints

### DIFF
--- a/content/en/docs/reference/node/node-status.md
+++ b/content/en/docs/reference/node/node-status.md
@@ -137,3 +137,19 @@ and for updating their related Leases.
   (the default update interval). Lease updates occur independently from
   updates to the Node's `.status`. If the Lease update fails, the kubelet retries,
   using exponential backoff that starts at 200 milliseconds and capped at 7 seconds.
+
+## Kubelet /statusz Endpoints
+
+The kubelet exposes several health endpoints under `/statusz` to indicate its current state.
+
+**Paths:**
+- `/livez` - Liveness endpoint
+- `/readyz` - Readiness endpoint
+- `/healthz` - Health endpoint (deprecated but remains supported)
+- `/metrics` - Metrics endpoint
+
+The following examples will show how you can interact with the health API endpoints.
+
+For all endpoints, you can use the `verbose` parameter to print out the checks and their status.  
+This can be useful for a human operator to debug the current status of the API server;  
+it is not intended to be consumed by a machine.

--- a/content/en/docs/reference/using-api/health-checks.md
+++ b/content/en/docs/reference/using-api/health-checks.md
@@ -22,16 +22,6 @@ Machines that check the `healthz`/`livez`/`readyz` of the API server should rely
 A status code `200` indicates the API server is `healthy`/`live`/`ready`, depending on the called endpoint.
 The more verbose options shown below are intended to be used by human operators to debug their cluster or understand the state of the API server.
 
-## Kubelet /statusz Endpoints
-
-The kubelet exposes several health endpoints under `/statusz` to indicate its current state.
-
-**Paths:**
-
-- `/livez` - Liveness endpoint
-- `/readyz` - Readiness endpoint
-- `/healthz` - Health endpoint (deprecated but remains supported)
-- `/metrics` - Metrics endpoint
 
 The following examples will show how you can interact with the health API endpoints.
 


### PR DESCRIPTION
This PR adds documentation for the kubelet /statusz endpoints:

- /livez - Liveness endpoint
- /readyz - Readiness endpoint
- /healthz - Health endpoint (deprecated but remains supported)
- /metrics - Metrics endpoint

These endpoints allow users and monitoring tools to check the kubelet's health and readiness.
