### PR TITLE
[id] Fix remove the duplicated word `dan`

### DIFF
--- a/content/id/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/id/docs/concepts/overview/what-is-kubernetes.md
@@ -54,7 +54,7 @@ proses pengembangan aplikasi dapat ditambahkan pada <i>streamline</i> untuk meni
 produktivitas developer. Orkestrasi ad-hoc yang dapat diterima biasanya membutuhkan desain
 otomatisasi yang kokoh agar bersifat <i>scalable</i>. Hal inilah yang membuat
 Kubernetes juga didesain sebagai <i>platform</i> untuk membangun ekosistem komponen dan
-dan perkakas untuk memudahkan proses <i>deployment</i>, <i>scale</i>, dan juga manajemen
+perkakas untuk memudahkan proses <i>deployment</i>, <i>scale</i>, dan juga manajemen
 aplikasi.
 
 [Labels]() memudahkan pengguna mengkategorisasikan <i>resources</i> yang mereka miliki


### PR DESCRIPTION
### Description
This pull request addresses a typographical error in the Kubernetes documentation by removing the duplicated word "dan." This enhances the clarity and readability of the text.