### PR TITLE
Add fallback to default language for code_sample shortcode

### DIFF
--- a/layouts/shortcodes/code_sample.html
+++ b/layouts/shortcodes/code_sample.html
@@ -3,20 +3,26 @@
 {{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }}
 {{ $fileDir := path.Split $file }}
 {{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
-{{ $filename := printf "/content/%s/examples/%s" .Page.Lang $file | safeURL }}
-{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
+{{ $.Scratch.Set "filename" (printf "/content/%s/examples/%s" .Page.Lang $file) }}
 {{/* First assume this is a bundle and the file is inside it. */}}
-{{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}
-{{ with $resource }}
+{{ with $p.Resources.GetMatch (printf "%s*" $file) }}
 {{ $.Scratch.Set "content" .Content }}
-{{ else }}
+{{ end }}
 {{/* Read the file relative to the content root. */}}
-{{ $resource := readFile $filename}}
-{{ with $resource }}{{ $.Scratch.Set "content" . }}{{ end }}
+{{ with readFile ($.Scratch.Get "filename")}}
+{{ $.Scratch.Set "content" . }}
+{{ end }}
+{{/* If not found, try the default language */}}
+{{ $defaultLang := (index (sort site.Languages "Weight") 0).Lang }}
+{{ with readFile (printf "/content/%s/examples/%s" $defaultLang $file) }}
+{{ $.Scratch.Set "content" . }}
+{{ $.Scratch.Set "filename" (printf "/content/%s/examples/%s" $defaultLang $file) }}
 {{ end }}
 {{ if not ($.Scratch.Get "content") }}
 {{ errorf "[%s] %q not found in %q" site.Language.Lang $fileDir.File $bundlePath }}
 {{ end }}
+{{ $filename := printf ($.Scratch.Get "filename") | safeURL }}
+{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
 {{ with $.Scratch.Get "content" }}
 <div class="highlight code-sample">
     <div class="copy-code-icon">


### PR DESCRIPTION


<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->

### Description

This imporves internationalization support by falling back to the default language's examples when a translation doesn't exist, prevention build errors for missing localized code samples.

- Refactor code_sample.html to handle missing files more gracefully
- Move filename generation to scratch variable for reusability
- Add fallback logic to try default language when file not found in current language
- Reorganize source lookup flow with proper conditional blocks
- Maintain existing ghlink generation with updated filename variable
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
#51920

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #51920