### PR TITLE
Sync en -> ja about systemd Containerd configuration

### DIFF
--- a/content/ja/docs/setup/production-environment/container-runtimes.md
+++ b/content/ja/docs/setup/production-environment/container-runtimes.md
@@ -172,14 +172,26 @@ Kubernetes {{< skew currentVersion >}}は、デフォルトでCRI APIのv1を使
 Linuxでは、containerd用のデフォルトのCRIソケットは`/run/containerd/containerd.sock`です。
 Windowsでは、デフォルトのCRIエンドポイントは`npipe://./pipe/containerd-containerd`です。
 
-#### `systemd` cgroupドライバーを構成する
+#### `systemd` cgroupドライバーを構成する {#containerd-systemd}
 
-`/etc/containerd/config.toml`内で`runc`が`systemd` cgroupドライバーを使うようにするには、次のように設定します。
+`/etc/containerd/config.toml`内で`runc`が`systemd` cgroupドライバーを使うようにするには、
+Containerdのバージョンに基づいて以下の設定を行ってください。
+
+Containerd バージョン 1.x:
 
 ```
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
   ...
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+```
+
+Containerd バージョン 2.x:
+
+```
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+  ...
+  [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
     SystemdCgroup = true
 ```
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Updated [ /ja/docs/setup/production-environment/container-runtimes/](https://kubernetes.io/ja/docs/setup/production-environment/container-runtimes/) to sync Conatinerd systemd configuration based on Containerd version.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #51939 