### PR TITLE
Update Russian to support Docsy-style menus

### DIFF
--- a/content/ru/case-studies/_index.html
+++ b/content/ru/case-studies/_index.html
@@ -7,8 +7,5 @@ layout: basic
 class: gridPage
 body_class: caseStudies
 cid: caseStudies
-menu:
-  main:
-    weight: 60
 ---
 

--- a/content/ru/community/_index.html
+++ b/content/ru/community/_index.html
@@ -2,6 +2,9 @@
 title: Сообщество
 layout: basic
 cid: community
+menu:
+  main:
+    weight: 50
 ---
 
 <div class="newcommunitywrapper">

--- a/content/ru/docs/home/_index.md
+++ b/content/ru/docs/home/_index.md
@@ -13,9 +13,7 @@ hide_feedback: true
 menu:
   main:
     title: "Документация"
-    weight: 20
-    post: >
-      <p>Научитесь использовать Kubernetes и узнайте основные понятия, изучите примеры и справочную информацию. Также вы можете <a href="/editdocs/" data-auto-burger-exclude>помочь в создании документации</a>!</p>
+    weight: 10
 overview: >
   Kubernetes - это открытое программное обеспечение для автоматизации развёртывания, масштабирования и управления контейнеризированными приложениями. Проект с открытым исходным кодом размещён на серверах Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
 cards:


### PR DESCRIPTION
### Description

Update the front matter for Russian pages so that if we align more with Docsy, the top nav still works how we want. Currently, the top nav sections are hard coded:
- https://github.com/kubernetes/website/blob/c07ffdf392aa3448d343a46d5ff744e482c5c52d/layouts/partials/navbar.html#L28
- https://github.com/kubernetes/website/blob/c07ffdf392aa3448d343a46d5ff744e482c5c52d/layouts/404.html#L9 

[Original](https://k8s.io/ru/) vs [preview](https://deploy-preview-51944--kubernetes-io-main-staging.netlify.app/ru/) (no visible difference; this is an enabling change)

### Issue

Helps with issues https://github.com/kubernetes/website/issues/41171 and https://github.com/kubernetes/website/issues/50228
