### PR TITLE
Update Ukrainian to support Docsy-style menus

### DIFF
--- a/content/uk/docs/home/_index.md
+++ b/content/uk/docs/home/_index.md
@@ -11,7 +11,7 @@ hide_feedback: true
 menu:
   main:
     title: "Документація"
-    weight: 20
+    weight: 10
 description: >
   Kubernetes — рушій оркестрування контейнерів, створений для автоматичного розгортання, масштабування і управління контейнеризованими застосунками, є проєктом з відкритим вихідним кодом. Цей проєкт знаходиться під егідою Cloud Native Computing Foundation.
 overview: >


### PR DESCRIPTION
### Description

Update the front matter for Ukrainian pages so that if we align more with Docsy, the top nav still works how we want. Currently, the top nav sections are hard coded:
- https://github.com/kubernetes/website/blob/c07ffdf392aa3448d343a46d5ff744e482c5c52d/layouts/partials/navbar.html#L28
- https://github.com/kubernetes/website/blob/c07ffdf392aa3448d343a46d5ff744e482c5c52d/layouts/404.html#L9 

[Original](https://k8s.io/uk/) vs [preview](https://deploy-preview-51945--kubernetes-io-main-staging.netlify.app/uk/) (no visible difference; this is an enabling change)

### Issue

Helps with issues https://github.com/kubernetes/website/issues/41171 and https://github.com/kubernetes/website/issues/50228
