### PR TITLE
Try to clarify the status of ipvs kube-proxy

### DIFF
--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -204,10 +204,26 @@ create rules to redirect traffic from Service IPs to endpoint IPs.
 The IPVS proxy mode is based on netfilter hook function that is similar to
 iptables mode, but uses a hash table as the underlying data structure and works
 in the kernel space.
-That means kube-proxy in IPVS mode redirects traffic with lower latency than
-kube-proxy in iptables mode, with much better performance when synchronizing
-proxy rules. Compared to the iptables proxy mode, IPVS mode also supports a
-higher throughput of network traffic.
+
+{{< note >}}
+The `ipvs` proxy mode was an experiment in providing a Linux
+kube-proxy backend with better rule-synchronizing performance and
+higher network-traffic throughput than the `iptables` mode. While it
+succeeded in those goals, the kernel IPVS API turned out to be a bad
+match for the Kubernetes Services API, and the `ipvs` backend was
+never able to implement all of the edge cases of Kubernetes Service
+functionality correctly. At some point in the future, it is expected
+to be formally deprecated as a feature.
+
+The `nftables` proxy mode (described below) is essentially a
+replacement for both the `iptables` and `ipvs` modes, with better
+performance than either of them, and is recommended as a replacement
+for `ipvs`. If you are deploying onto Linux systems that are too old
+to run the `nftables` proxy mode, you should also consider trying the
+`iptables` mode rather than `ipvs`, since the performance of
+`iptables` mode has improved greatly since the `ipvs` mode was first
+introduced.
+{{< /note >}}
 
 IPVS provides more options for balancing traffic to backend Pods;
 these are:


### PR DESCRIPTION
OK, so the status of the kube-proxy ipvs backend is:
- It's faster than iptables in large clusters.
- It works on older Linux distros, unlike nftables
- It doesn't implement some corner cases of Service functionality correctly, and this is not likely to ever be fixed, because most remaining fixes would require heavy rearchitecting of the code, and all of the people in SIG Network who used to care about fixing ipvs bugs have drifted away, and the SIG leads would rather push people toward nftables than try to figure out how to fix ipvs.

So this tries to explain that some. I'm not particularly attached to any of the specific text here; consider this a starting point.

Fixes #51917

/assign @lmktfy @aojea 
/sig network