### PR TITLE
Update DRA tutorial for K8s 1.34

### DIFF
--- a/content/en/docs/tutorials/cluster-management/install-use-dra.md
+++ b/content/en/docs/tutorials/cluster-management/install-use-dra.md
@@ -55,9 +55,9 @@ new fields in the Pod spec itself.
 ## {{% heading "prerequisites" %}}
 
 Your cluster should support [RBAC](/docs/reference/access-authn-authz/rbac/).
-You can try this tutorial with a cluster using
-a different authorization mechanism, but in that case you will have to adapt the
-steps around defining roles and permissions.
+You can try this tutorial with a cluster using a different authorization
+mechanism, but in that case you will have to adapt the steps around defining
+roles and permissions.
 
 {{< include "task-tutorial-prereqs.md" >}}
 
@@ -66,26 +66,9 @@ other types of nodes.
 
  {{< version-check >}}
 
-Your cluster also must be configured to use the Dynamic Resource Allocation
-feature.
-To enable the DRA feature, you must enable the following feature gates and API groups:
-
-1.  Enable the `DynamicResourceAllocation`
-    [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-    on all of the following components:
-   
-    * `kube-apiserver`
-    * `kube-controller-manager`
-    * `kube-scheduler`
-    * `kubelet`
-
-1.  Enable the following
-    {{< glossary_tooltip text="API groups" term_id="api-group" >}}:
-
-    * `resource.k8s.io/v1`
-     
-    For more information, see
-    [Enabling or disabling API groups](/docs/reference/using-api/#enabling-or-disabling).
+If your cluster is not currently running Kubernetes {{< skew currentVersion
+>}} then please check the documentation for the version of Kubernetes that you
+plan to use.
 
 
 <!-- lessoncontent -->

--- a/content/en/docs/tutorials/cluster-management/install-use-dra.md
+++ b/content/en/docs/tutorials/cluster-management/install-use-dra.md
@@ -173,7 +173,7 @@ dra-example-driver to simulate access to a DRA driver image.
 from within one of your cluster's nodes:
 
     ```shell
-    docker pull registry.k8s.io/dra-example-driver/dra-example-driver:v0.1.0-dev134
+    docker pull registry.k8s.io/dra-example-driver/dra-example-driver:v0.2.0
     ```
 
 ### Deploy the DRA driver components

--- a/content/en/docs/tutorials/cluster-management/install-use-dra.md
+++ b/content/en/docs/tutorials/cluster-management/install-use-dra.md
@@ -2,7 +2,7 @@
 title: Install Drivers and Allocate Devices with DRA
 content_type: tutorial
 weight: 60
-min-kubernetes-server-version: v1.32
+min-kubernetes-server-version: v1.34
 ---
 <!-- FUTURE MAINTAINERS: 
 The original point of this doc was for people (mainly cluster administrators) to
@@ -82,8 +82,7 @@ To enable the DRA feature, you must enable the following feature gates and API g
 1.  Enable the following
     {{< glossary_tooltip text="API groups" term_id="api-group" >}}:
 
-    * `resource.k8s.io/v1beta1`
-    * `resource.k8s.io/v1beta2`
+    * `resource.k8s.io/v1`
      
     For more information, see
     [Enabling or disabling API groups](/docs/reference/using-api/#enabling-or-disabling).
@@ -174,7 +173,7 @@ dra-example-driver to simulate access to a DRA driver image.
 from within one of your cluster's nodes:
 
     ```shell
-    docker pull registry.k8s.io/dra-example-driver/dra-example-driver:v0.1.0
+    docker pull registry.k8s.io/dra-example-driver/dra-example-driver:v0.1.0-dev134
     ```
 
 ### Deploy the DRA driver components
@@ -363,7 +362,7 @@ variables to see how the Pods have been handled by the system.
 
     The output is similar to this:
     ```
-    declare -x GPU_DEVICE_4="gpu-4"
+    declare -x GPU_DEVICE_0="gpu-0"
     ```
 
 1.  Check the state of the ResourceClaim object:
@@ -391,54 +390,48 @@ variables to see how the Pods have been handled by the system.
     ```
 
     The output is similar to this:
-    {{< highlight yaml "linenos=inline, hl_lines=30-33 41-44, style=emacs" >}}
-    apiVersion: v1
-    items:
-    - apiVersion: resource.k8s.io/v1beta2
-      kind: ResourceClaim
-      metadata:
-        creationTimestamp: "2025-07-29T05:11:52Z"
+    {{< highlight yaml "linenos=inline, hl_lines=27-30 38-41, style=emacs" >}}
+    apiVersion: resource.k8s.io/v1
+    kind: ResourceClaim
+    metadata:
+        creationTimestamp: "2025-08-20T18:17:31Z"
         finalizers:
         - resource.kubernetes.io/delete-protection
         name: some-gpu
         namespace: dra-tutorial
-        resourceVersion: "58357"
-        uid: 79e1e8d8-7e53-4362-aad1-eca97678339e
-      spec:
+        resourceVersion: "2326"
+        uid: d3e48dbf-40da-47c3-a7b9-f7d54d1051c3
+    spec:
         devices:
-          requests:
-          - exactly:
-              allocationMode: ExactCount
-              count: 1
-              deviceClassName: gpu.example.com
-              selectors:
-              - cel:
-                  expression: device.capacity['gpu.example.com'].memory.compareTo(quantity('10Gi'))
+            requests:
+            - exactly:
+                allocationMode: ExactCount
+                count: 1
+                deviceClassName: gpu.example.com
+                selectors:
+                - cel:
+                    expression: device.capacity['gpu.example.com'].memory.compareTo(quantity('10Gi'))
                     >= 0
             name: some-gpu
-      status:
+    status:
         allocation:
-          devices:
+            devices:
             results:
-            - adminAccess: null
-              device: gpu-4
-              driver: gpu.example.com
-              pool: kind-worker
-              request: some-gpu
-          nodeSelector:
+            - device: gpu-0
+                driver: gpu.example.com
+                pool: kind-worker
+                request: some-gpu
+            nodeSelector:
             nodeSelectorTerms:
             - matchFields:
-              - key: metadata.name
+                - key: metadata.name
                 operator: In
                 values:
                 - kind-worker
         reservedFor:
         - name: pod0
-          resource: pods
-          uid: fa55b59b-d28d-4f7d-9e5b-ef4c8476dff5
-    kind: List
-    metadata:
-      resourceVersion: ""
+            resource: pods
+            uid: c4dadf20-392a-474d-a47b-ab82080c8bd7
     {{< /highlight >}}
 
 1.  To check how the driver handled device allocation, get the logs for the
@@ -450,8 +443,8 @@ variables to see how the Pods have been handled by the system.
 
     The output is similar to this:
     ```
-    I0729 05:11:52.679057       1 driver.go:84] NodePrepareResource is called: number of claims: 1
-    I0729 05:11:52.684450       1 driver.go:112] Returning newly prepared devices for claim '79e1e8d8-7e53-4362-aad1-eca97678339e': [&Device{RequestNames:[some-gpu],PoolName:kind-worker,DeviceName:gpu-4,CDIDeviceIDs:[k8s.gpu.example.com/gpu=common k8s.gpu.example.com/gpu=79e1e8d8-7e53-4362-aad1-eca97678339e-gpu-4],}]
+    I0820 18:17:44.131324       1 driver.go:106] PrepareResourceClaims is called: number of claims: 1
+    I0820 18:17:44.135056       1 driver.go:133] Returning newly prepared devices for claim 'd3e48dbf-40da-47c3-a7b9-f7d54d1051c3': [{[some-gpu] kind-worker gpu-0 [k8s.gpu.example.com/gpu=common k8s.gpu.example.com/gpu=d3e48dbf-40da-47c3-a7b9-f7d54d1051c3-gpu-0]}]
     ```
 
 You have now successfully deployed a Pod that claims devices using DRA, verified
@@ -503,7 +496,7 @@ ResourceClaim has a `pending` state until it's referenced in a new Pod.
     ```
     The output is similar to this:
     ```
-    I0729 05:13:02.144623       1 driver.go:117] NodeUnPrepareResource is called: number of claims: 1
+    I0820 18:22:15.629376       1 driver.go:138] UnprepareResourceClaims is called: number of claims: 1
     ```
 
 You have now deleted a Pod that had a claim, and observed that the driver took

--- a/content/en/examples/dra/driver-install/daemonset.yaml
+++ b/content/en/examples/dra/driver-install/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: plugin
         securityContext:
           privileged: true
-        image: registry.k8s.io/dra-example-driver/dra-example-driver:v.0.2.0
+        image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.2.0
         imagePullPolicy: IfNotPresent
         command: ["dra-example-kubeletplugin"]
         resources:

--- a/content/en/examples/dra/driver-install/daemonset.yaml
+++ b/content/en/examples/dra/driver-install/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: plugin
         securityContext:
           privileged: true
-        image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.1.0
+        image: registry.k8s.io/dra-example-driver/dra-example-driver:v.0.1.0-dev134
         imagePullPolicy: IfNotPresent
         command: ["dra-example-kubeletplugin"]
         resources:

--- a/content/en/examples/dra/driver-install/daemonset.yaml
+++ b/content/en/examples/dra/driver-install/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: plugin
         securityContext:
           privileged: true
-        image: registry.k8s.io/dra-example-driver/dra-example-driver:v.0.1.0-dev134
+        image: registry.k8s.io/dra-example-driver/dra-example-driver:v.0.2.0
         imagePullPolicy: IfNotPresent
         command: ["dra-example-kubeletplugin"]
         resources:

--- a/content/en/examples/dra/driver-install/deviceclass.yaml
+++ b/content/en/examples/dra/driver-install/deviceclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: resource.k8s.io/v1
 kind: DeviceClass
 metadata:
   name: gpu.example.com

--- a/content/en/examples/dra/driver-install/example/resourceclaim.yaml
+++ b/content/en/examples/dra/driver-install/example/resourceclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: resource.k8s.io/v1beta2
+apiVersion: resource.k8s.io/v1
 kind: ResourceClaim
 metadata:
  name: some-gpu


### PR DESCRIPTION
### Description

DRA driver tutorial in 1.34 version. Cherry-picks the individual commits that are already in main [1] from [published 1.33 tutorial ](https://kubernetes.io/docs/tutorials/cluster-management/install-use-dra/) against 1.34 dev branch, and then adds commits on top to update the tutorial for 1.34. This is happening this way so we have the 1.33 version snapshotted today, and then this version will be snapshotted for 1.34+. cc @lmktfy 

* Updates prereqs/DRA enable directions to targets resource.k8s.io/v1
* Updates manifests to ResourceClaim and DeviceClass v1
* Uses a new example driver that is set to v1 (⚠️ THIS IS BLOCKED BY MERGE AND RELEASE OF https://github.com/kubernetes-sigs/dra-example-driver/pull/116 ⚠️ )

Quick link to preview page: https://deploy-preview-51979--kubernetes-io-main-staging.netlify.app/docs/tutorials/cluster-management/install-use-dra/

### Issue

Also Closes: #51179

### More info

[1] These are the commits cherry-picked from main:

```
$ git log --pretty=oneline --author=lauralorenz@google.com dev-1.34..51179-tutorial-dra-driver-install-and-observe-nits
63ede0aa61b9b8c21e5c3ad07bf2981c6eeae590 (HEAD -> 51179-tutorial-dra-driver-install-and-observe-nits, origin/51179-tutorial-dra-driver-install-and-observe-nits) More nits I missed under the fold
57667f566d9d9f0f068c243156baecb84f17ef25 Update content/en/docs/tutorials/cluster-management/install-use-dra.md
6eb32c904a27de1c68c1de52146fc8c7a726656e Loose backtick, rewrap
63d6a22ad24e54da6de5b748fc05603adcc849ba Add to top tutorials page
8087071fdc671c0fbf6a97169e061f23516eb00b Follow on nits for DRA driver tutorial
098eb145b9032eb935838b7539510432f2166496 (origin/51179-tutorial-dra-driver-install-and-observe, 51179-tutorial-dra-driver-install-and-observe) Use dedicated priorityclass
bc4e9378d72f2a9bc5c126e353d4cb62fd3d724c Tested on 1.33, manifest fixups, formatting
a5633a1668363f8f4a9ef2bb047a9b333f3c056e Remove inline prose about API types in preamble Considering moving this into the concepts page in a separate PR
5dd96454a09208d7831a529121df470874ab0e99 Reformat explore initial state section, but don't give up on the prose just yet
6bf1164f42488d01c5142b70e68f854fafcdf571 My manifesto
55b3ea39c9727c2ad317ade1fa9dd4744d99e8f0 Glossary tooltips instead of API reference at the beginning
fa515efd1f7d6902f3a491276e1116cd1966d9d1 Move synopsis-like info
f2143f0a1f67903734abfd23bacde1388c70d3f9 Pedantry party
857066555aeb3e5a82923c09ca6205eb69e55405 Typo, link outs
527ecd1ca056cb3f73b784ee1cb76afb716aa77b A few more easy comments and formatting fixes
3269457ee2355fa074754d213aa4bae89f79a3b0 A couple more easy review comments
409cdf8a1797cd8d44e9a972d520b2f4d89805a5 Easy review comments first
37047ba8ffd8c2b7603c3aeff7fcf934491f74cc Second half of review comments, manifest updates
d9d9003c20d80cdc6c35d308c2c2cd259c5fe32f First set of review updates
c90549e252bcc40a00f57542361cbc4e22102e54 Tutorial page: Using DRA and installing drivers
```