### PR TITLE
Add note about temporarily broken upcoming release schedule link

### DIFF
--- a/content/en/releases/_index.md
+++ b/content/en/releases/_index.md
@@ -31,6 +31,11 @@ More information in the [version skew policy](/releases/version-skew-policy/) do
 Check out the [schedule](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew nextMinorVersion >}})
 for the upcoming **{{< skew nextMinorVersion >}}** Kubernetes release!
 
+{{< note >}}
+This schedule link may be temporarily unavailable during early release planning phases.  
+Check the [SIG Release repository](https://github.com/kubernetes/sig-release/tree/master/releases) for the latest updates.
+{{< /note >}}
+
 ## Helpful Resources
 
 Refer to the [Kubernetes Release Team](https://github.com/kubernetes/sig-release/tree/master/release-team) resources 


### PR DESCRIPTION
The "schedule" link for upcoming Kubernetes releases occasionally breaks during the early stages of release preparation on [releases page.](https://kubernetes.io/releases/) See discussion [here](https://github.com/kubernetes/website/issues/50883)

Added a note that explains when the link might be temporarily unavailable and provides alternative resources for users to track release progress.

**Screenshot**
<img width="829" height="216" alt="Screenshot from 2025-08-21 04-37-48" src="https://github.com/user-attachments/assets/54b9874e-b370-4295-914d-e1243a67fdbb" />

Close #50883 