### PR TITLE
Schedule KEP-3104 blog for publication

### DIFF
--- a/content/en/blog/_posts/2025-08-28-kubectl-kuberc-beta.md
+++ b/content/en/blog/_posts/2025-08-28-kubectl-kuberc-beta.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: User preferences (kuberc) are available for testing in kubectl 1.34"
-draft: true
+date: 2025-08-28T10:30:00-08:00
 slug: kubernetes-v1-34-kubectl-kuberc-beta
 Author: >
   [Maciej Szulik](https://github.com/soltysh) (Defense Unicorns, Inc.)


### PR DESCRIPTION
### Description
Schedules https://github.com/kubernetes/website/pull/51376 for publication on Thursday, 28th August, 2025.