### PR TITLE
Added examples for DNF5

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -309,8 +309,13 @@ exist by default, and it should be created before the curl command.
 
 3. Install kubelet, kubeadm and kubectl:
 
+For systems with DNF:
    ```shell
    sudo yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
+   ```
+For systems with DNF5:
+   ```shell
+   sudo yum install -y kubelet kubeadm kubectl --setopt=disable_excludes=kubernetes
    ```
 
 4. (Optional) Enable the kubelet service before running kubeadm:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -104,10 +104,17 @@ sudo apt-cache madison kubeadm
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
 
+For systems with DNF:
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
 # It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
 sudo yum list --showduplicates kubeadm --disableexcludes=kubernetes
+```
+For systems with DNF5:
+```shell
+# Find the latest {{< skew currentVersion >}} version in the list.
+# It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
+sudo yum list --showduplicates kubeadm --setopt=disable_excludes=kubernetes
 ```
 
 {{% /tab %}}
@@ -139,9 +146,15 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
 
+   For systems with DNF:
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   ```
+   For systems with DNF5:
+   ```shell
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+   sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
 
    {{% /tab %}}
@@ -243,9 +256,15 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
 
+   For systems with DNF:   
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   ```
+   For systems with DNF5:   
+   ```shell
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+   sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
 
    {{% /tab %}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -42,9 +42,15 @@ sudo apt-mark hold kubeadm
 ```
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
+For systems with DNF:
 ```shell
 # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
 sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+```
+For systems with DNF5:
+```shell
+# replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -81,9 +87,15 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    ```
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
+   For systems with DNF:
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
    sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   ```
+   For systems with DNF5:
+   ```shell
+   # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
+   sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
    {{% /tab %}}
    {{< /tabs >}}


### PR DESCRIPTION
### Description
Version 2 of #51986 which I accidentally broke.

dnf5 no longer supports --disableexcludes  (https://github.com/rpm-software-management/dnf5/issues/581) which leads to an error when running the example commands:
```
yum list --showduplicates kubeadm --disableexcludes=kubernetes
Unknown argument "--disableexcludes=kubernetes" for command "list". Add "--help" for more information about the arguments.
```

This PR adds additional samples for dnf5 using `--setopt=disable_excludes=kubernetes` instead

dnf5 shipped in Fedora 41 (https://fedoraproject.org/wiki/Releases/41/ChangeSet#Switch_to_dnf5) so without this change any user on Fedora 41 or newer will receive an error when following the guide