### PR TITLE
Enhance PSI example CPU stress pod; fix PSI Prometheus metrics grep regex

### DIFF
--- a/content/en/docs/reference/instrumentation/understand-psi-metrics.md
+++ b/content/en/docs/reference/instrumentation/understand-psi-metrics.md
@@ -62,6 +62,11 @@ spec:
     - "stress"
     - "--cpus"
     - "1"
+    resources:
+      limits:
+        cpu: "500m"
+      requests:
+        cpu: "500m"
 ```
 
 Apply it to your cluster: `kubectl apply -f cpu-pressure-pod.yaml`
@@ -85,7 +90,7 @@ Query the `/metrics/cadvisor` endpoint to see the `container_pressure_cpu_waitin
 ```shell
 # Replace <node-name> with the name of the node where the pod is running
 kubectl get --raw "/api/v1/nodes/<node-name>/proxy/metrics/cadvisor" | \
-    grep 'container_pressure_cpu_waiting_seconds_total{container="cpu-stress",pod="cpu-pressure-pod"}'
+    grep 'container_pressure_cpu_waiting_seconds_total{container="cpu-stress"'
 ```
 The output should show an increasing value, indicating that the container is spending time stalled waiting for CPU resources.
 
@@ -139,7 +144,7 @@ Query the `/metrics/cadvisor` endpoint to see the `container_pressure_memory_wai
 ```shell
 # Replace <node-name> with the name of the node where the pod is running
 kubectl get --raw "/api/v1/nodes/<node-name>/proxy/metrics/cadvisor" | \
-    grep 'container_pressure_memory_waiting_seconds_total{container="memory-stress",pod="memory-pressure-pod"}'
+    grep 'container_pressure_memory_waiting_seconds_total{container="memory-stress"'
 ```
 In the output, you will observe an increasing value for the metric, indicating that the system is under significant memory pressure.
 
@@ -188,7 +193,7 @@ Query the `/metrics/cadvisor` endpoint to see the `container_pressure_io_waiting
 ```shell
 # Replace <node-name> with the name of the node where the pod is running
 kubectl get --raw "/api/v1/nodes/<node-name>/proxy/metrics/cadvisor" | \
-    grep 'container_pressure_io_waiting_seconds_total{container="io-stress",pod="io-pressure-pod"}'
+    grep 'container_pressure_io_waiting_seconds_total{container="io-stress"'
 ```
 You will see the metric's value increase as the Pod continuously writes to disk.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Followup of https://github.com/kubernetes/website/pull/51541

Some enhancement and fix to the "understanding PSI" doc:
1. Add CPU resource requests and limits to the example CPU stress pod to produce more reliable CPU stress. This is a best practice that we're also [adding to the k/k E2E test](https://github.com/kubernetes/kubernetes/pull/133473). Also see evidence of PSI results for pods [without the limit](https://gist.github.com/roycaihw/2f9e256cede94be24fffa9c0a74d94ec) v.s. [with the limit](https://gist.github.com/roycaihw/a600c9a5e9d461a53b6b0257ed31a8b1). Users will observe more visible PSI data for the latter. 
1. Fix PSI Prometheus metrics grep regex so that users can correctly query the metrics for the target containers. This was an oversight in the doc. See [evidence](https://gist.github.com/roycaihw/6a7eac43d91664655e7c99105f1a0028) of the actual metrics format. 

Ref https://github.com/kubernetes/enhancements/issues/4205

/cc @lmktfy @haircommander