### PR TITLE
Updates hugo.toml for v1.32 ahead of v1.34 release

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -132,10 +132,10 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.33"
+latest = "v1.34"
 
 version = "v1.32"
-githubbranch = "v1.32.4"
+githubbranch = "v1.32.8"
 docsbranch = "release-1.32"
 # Should be changed to Docsy provided `archived_version` in the future.
 deprecated = true
@@ -175,34 +175,34 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.33"
-githubbranch = "v1.33.0"
+version = "v1.34"
+githubbranch = "v1.34.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
+version = "v1.33"
+githubbranch = "v1.33.4"
+docsbranch = "release-1.33"
+url = "https://v1-33.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.32"
-githubbranch = "v1.32.4"
+githubbranch = "v1.32.8"
 docsbranch = "release-1.32"
 url = "https://v1-32.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.31"
-githubbranch = "v1.31.8"
+githubbranch = "v1.31.12"
 docsbranch = "release-1.31"
 url = "https://v1-31.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.30"
-githubbranch = "v1.30.12"
+githubbranch = "v1.30.14"
 docsbranch = "release-1.30"
 url = "https://v1-30.docs.kubernetes.io"
-
-[[params.versions]]
-version = "v1.29"
-githubbranch = "v1.29.14"
-docsbranch = "release-1.29"
-url = "https://v1-29.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Updating hugo.toml for release v1.34.

/hold until v1.34 release.