### PR TITLE
Schedule KEP-4988 blog for publication

### DIFF
--- a/content/en/blog/_posts/2025-09-09-kubernetes-v1-34-snapshottable-api-server-cache.md
+++ b/content/en/blog/_posts/2025-09-09-kubernetes-v1-34-snapshottable-api-server-cache.md
@@ -1,11 +1,10 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: Snapshottable API server cache"
-date: XXX
+date: 2025-09-09T10:30:00-08:00
 slug: kubernetes-v1-34-snapshottable-api-server-cache
 author: >
   [Marek Siarkowicz](https://github.com/serathius) (Google)
-draft: true
 ---
 
 For years, the Kubernetes community has been on a mission to improve the stability and performance predictability of the API server.


### PR DESCRIPTION
### Description

Schedules https://github.com/kubernetes/website/pull/51582 for publication on Tuesday, 9 September 2025

cc Comms Lead: @aibarbetta 