### PR TITLE
Schedule KEP-5307 blog for publication

### DIFF
--- a/content/en/blog/_posts/2025-08-29-Per-Container-Restart-Policy.md
+++ b/content/en/blog/_posts/2025-08-29-Per-Container-Restart-Policy.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: Finer-Grained Control Over Container Restarts"
-date: 2025-0X-XX
-draft: true
+date: 2025-08-29T10:30:00-08:00
 slug: kubernetes-v1-34-per-container-restart-policy
 author: >
   [Yuan Wang](https://github.com/yuanwang04)


### PR DESCRIPTION
### Description
Schedules https://github.com/kubernetes/website/pull/51745 for publication on Friday, 29th August, 2025.