### PR TITLE
Schedule v1.34 DRA updates blog for publication

### DIFF
--- a/content/en/blog/_posts/2025-09-01-dra-134-update.md
+++ b/content/en/blog/_posts/2025-09-01-dra-134-update.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: DRA has graduated to GA"
-slug: dra-134-updates
-draft: true
-date: XXXX-XX-XX
+slug: kubernetes-v1-34-dra-updates
+date: 2025-09-01T10:30:00-08:00
 author: >
   The DRA team
 ---
@@ -70,6 +69,7 @@ device sharing model where multiple, independent resource claims from unrelated
 pods can each be allocated a share of the same underlying physical device. This new capability is managed through optional,
 administrator-defined sharing policies that govern how a device's total capacity is divided and enforced by the platform for
 each request. This allows for sharing of devices in scenarios where pre-defined partitions are not viable.
+A blog about this feature is coming soon.
 
 [Binding conditions](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#binding-conditions) improve scheduling
 reliability for certain classes of devices by allowing the Kubernetes scheduler to delay binding a pod to a node until its
@@ -80,6 +80,7 @@ readiness before the pod is committed to a node.
 _Resource health status_ for DRA improves observability by exposing the health status of devices allocated to a Pod via Pod Status.
 This works whether the device is allocated through DRA or Device Plugin. This makes it easier to understand the cause of an
 unhealthy device and respond properly.
+A blog about this feature is coming soon.
 
 ## What’s next?
 


### PR DESCRIPTION
### Description
Schedules https://github.com/kubernetes/website/pull/51488 for publication on Monday, 1st September, 2025.