### PR TITLE
Doc for setting custom path to kuberc using KUBERC environment variable

### DIFF
--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -12,8 +12,8 @@ such as default options and command aliases. Unlike the kubeconfig file, a `kube
 configuration file does **not** contain cluster details, usernames or passwords.
 
 The default location of this configuration file is `$HOME/.kube/kuberc`.
-You can instruct `kubectl` to look at a custom path for this configuration using
-the `--kuberc` command line argument.
+To provide kubectl with a path to a custom kuberc file, use the `--kuberc` command line option,
+or set the `KUBERC` environment variable.
 
 A `kuberc` using the `kubectl.config.k8s.io/v1beta1` format allows you to define
 two types of user preferences:


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Adds missing information about the `KUBERC` environment variable to set a custom path to the kuberc file.  
Inspired by https://github.com/kubernetes/kubectl/issues/1776#issuecomment-3233727343

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->