### PR TITLE
[id] Correct Prometheus text format link in system-metrics page

### DIFF
--- a/content/id/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/id/docs/concepts/cluster-administration/system-metrics.md
@@ -162,5 +162,5 @@ pada penjadwal. Kamu harus menggunakan opsi `--show-hidden-metrics-for-version=1
 
 ## {{% heading "whatsnext" %}}
 
-* Baca tentang [format teks Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md#text-based-format) untuk berbagai metrik
+* Baca tentang [format teks Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md#text-based-format) untuk berbagai metrik
 * Baca tentang [kebijakan _deprecation_ Kubernetes](/docs/reference/using-api/deprecation-policy/#deprecating-a-feature-or-behavior)


### PR DESCRIPTION
Update the "What's next" section in the Indonesian system-metrics page to correct the Prometheus text format link.

Fixes #52091