### PR TITLE
Schedule KEP-4412 blog for publication

### DIFF
--- a/content/en/blog/_posts/2025-09-03-kubernetes-1-34-sa-tokens-image-pulls-beta.md
+++ b/content/en/blog/_posts/2025-09-03-kubernetes-1-34-sa-tokens-image-pulls-beta.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: Service Account Token Integration for Image Pulls Graduates to Beta"
-date: 2025-09-03
+date: 2025-09-03T10:30:00-08:00
 slug: kubernetes-v1-34-sa-tokens-image-pulls-beta
 author: >
   [Anish Ramasekar](https://github.com/aramase) (Microsoft)

--- a/content/en/blog/_posts/2025-09-03-kubernetes-1-34-sa-tokens-image-pulls-beta.md
+++ b/content/en/blog/_posts/2025-09-03-kubernetes-1-34-sa-tokens-image-pulls-beta.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: Service Account Token Integration for Image Pulls Graduates to Beta"
-date: 2025-08-15
+date: 2025-09-03
 slug: kubernetes-v1-34-sa-tokens-image-pulls-beta
-draft: true
 author: >
   [Anish Ramasekar](https://github.com/aramase) (Microsoft)
 ---


### PR DESCRIPTION
### Description
Schedules https://github.com/kubernetes/website/pull/51305 for publication on Wednesday, 3rd September, 2025.