### PR TITLE
Fix doc link in kubernetes-v1-34-per-container-restart-policy

### DIFF
--- a/content/en/blog/_posts/2025-08-29-Per-Container-Restart-Policy.md
+++ b/content/en/blog/_posts/2025-08-29-Per-Container-Restart-Policy.md
@@ -177,7 +177,7 @@ spec:
 ## Learn more
 
 - Read the documentation for
-  [container restart policy](/docs/concepts/workloads/pod-lifecycle/#container-restart-rules).
+  [container restart policy](/docs/concepts/workloads/pods/pod-lifecycle/#container-restart-rules).
 - Read the KEP for the
   [Container Restart Rules](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5307-container-restart-policy)
 


### PR DESCRIPTION
Fixes broken documentation link reported [here](https://kubernetes.slack.com/archives/C0BP8PW9G/p1756524297925099)