### PR TITLE
Update DRA terminology API version to resource.k8s.io/v1

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -103,7 +103,7 @@ users:
 
 DRA uses the following Kubernetes API kinds to provide the core allocation
 functionality. All of these API kinds are included in the
-`resource.k8s.io/v1beta1`
+`resource.k8s.io/v1`
 {{< glossary_tooltip text="API group" term_id="api-group" >}}.
 
 DeviceClass


### PR DESCRIPTION
Fixes #52087

Dynamic Resource Allocation (DRA) APIs (DeviceClass, ResourceClaim,
ResourceClaimTemplate, ResourceSlice) graduated to GA in Kubernetes v1.34
under `resource.k8s.io/v1` as defined in KEP-4381.

The docs currently state `resource.k8s.io/v1beta1` in the terminology
section, which is outdated. 
This PR updates the reference to the correct
stable API version.
