### PR TITLE
Add CoreDNS rebalance note to kubeadm HA guide + remove parallel join note

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -265,6 +265,12 @@ For each additional control plane node you should:
 
 You can join multiple control-plane nodes in parallel.
 
+{{< note >}}
+As the cluster nodes are usually initialized sequentially, the CoreDNS Pods are likely to all run
+on the first control plane node. To provide higher availability, please rebalance the CoreDNS Pods
+with `kubectl -n kube-system rollout restart deployment coredns` after at least one new node is joined.
+{{< /note >}}
+
 ## External etcd nodes
 
 Setting up a cluster with external etcd nodes is similar to the procedure used for stacked etcd

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -263,7 +263,6 @@ For each additional control plane node you should:
    - The `--certificate-key ...` will cause the control plane certificates to be downloaded
      from the `kubeadm-certs` Secret in the cluster and be decrypted using the given key.
 
-You can join multiple control-plane nodes in parallel.
 
 {{< note >}}
 As the cluster nodes are usually initialized sequentially, the CoreDNS Pods are likely to all run


### PR DESCRIPTION
### Description

Adds a note to the kubeadm high-availability setup guide advising users to restart the CoreDNS Deployment to redistribute Pods after additional control plane nodes join.

Inserted the same coredns rebalance note from https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/adding-linux-nodes/ after additional control plane add instructions

Removes parallel join note 

### Issue

Closes: #52089