### PR TITLE
add dedicate date for blog env files: 09-06

### DIFF
--- a/content/en/blog/_posts/2025-09-10-introducing-env-files/index.md
+++ b/content/en/blog/_posts/2025-09-10-introducing-env-files/index.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: Use An Init Container To Define App Environment Variables"
-date: 2025-0X-XX
+date: 2025-09-10
 draft: true
 slug: kubernetes-v1-34-env-files
 author: >

--- a/content/en/blog/_posts/2025-09-10-introducing-env-files/index.md
+++ b/content/en/blog/_posts/2025-09-10-introducing-env-files/index.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.34: Use An Init Container To Define App Environment Variables"
-date: 2025-09-10
-draft: true
+date: 2025-09-10T10:30:00-08:00
 slug: kubernetes-v1-34-env-files
 author: >
   HirazawaUi


### PR DESCRIPTION
### Description

The blog is not in https://kubernetes.io/blog/, but in https://kubernetes.io/zh-cn/blog/.

Change date from 09-01 to 09-06.

- I will send a following PR to change the date of zh blog as well.

### Issue


Closes: None

