### PR TITLE
[ko] Sync /includes/task-tutorial-prereqs.md with latest EN

### DIFF
--- a/content/ko/includes/task-tutorial-prereqs.md
+++ b/content/ko/includes/task-tutorial-prereqs.md
@@ -4,6 +4,7 @@
 [minikube](/ko/docs/tasks/tools/#minikube)를 사용해서 생성하거나
 다음 쿠버네티스 플레이그라운드 중 하나를 사용할 수 있다.
 
+* [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes) 
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
 * [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Add `iximiuz Labs` option in /ko/includes/task-tutorial-prereqs include.

Follows Korean localization guidelines and terminology
All Hugo shortcodes and internal links properly localized

- `/ko/includes/task-tutorial-prereqs.md`

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #52227