### PR TITLE
Refer to `etcd-backup-restore` project for taking automated etcd cluster backups & restoration

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -568,7 +568,12 @@ data and may need to be recreated from scratch.
 Workarounds:
 
 * Regularly [back up etcd](https://etcd.io/docs/v3.5/op-guide/recovery/). The
-  etcd data directory configured by kubeadm is at `/var/lib/etcd` on the control-plane node.
+  etcd data directory configured by kubeadm is at `/var/lib/etcd` on the control-plane node. A popular choice for etcd backups is to use [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore).
+  According to the project, Etcd-backup-restore provides automated, reliable backups and recovery for etcd clusters, keeping your Kubernetes data safe and resilient.
+
+  {{< note >}}
+  The project has not released a major version yet. Kindly go through the project to learn more prior to using it in production.
+  {{< /note >}}
 
 * Use multiple control-plane nodes. You can read
   [Options for Highly Available topology](/docs/setup/production-environment/tools/kubeadm/ha-topology/) to pick a cluster


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR enhances the cluster creation documentation using Kubeadm. It adds a reference to the [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) project for taking automated etcd backups and restoration features. A note has also been added mentioning that the project has not released a major version yet, this is for it to act as disclaimer for people to take a look at the project before blindly using it in production scenarios.

The project is actively maintained, and have many features. Below is a non-exhaustive list of them: 

- Backup and restore of etcd
- Multi-Cloud Support
- Automated & Scheduled Operations
- Disaster Recovery
- Data Security

### Notes for Reviewers

I'm one of the maintainers of the [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) project. Please feel free to shoot any questions/objections you might have in adding this as a potential solution that helps people to land at a solution that is actively maintained by the community for etcd related operations.