### PR TITLE
[de] Fix large cluster guidelines page

### DIFF
--- a/content/de/docs/setup/best-practices/cluster-large.md
+++ b/content/de/docs/setup/best-practices/cluster-large.md
@@ -1,6 +1,4 @@
 ---
-reviewers:
-- lavalamp
 title: Überlegungen für große Cluster
 weight: 10
 ---


### PR DESCRIPTION
- Fix URL for [Überlegungen für große Cluster](https://kubernetes.io/de/docs/setup/best-practices/grosser-cluster/)
- Drop @lavalamp as reviewer

/language de

Fixup for PR https://github.com/kubernetes/website/pull/51995