### PR TITLE
Add Kubernetes 1.34 to release schedule

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,13 +4,30 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 schedules:
+- endOfLifeDate: "2026-10-27"
+  maintenanceModeStartDate: "2026-08-27"
+  next:
+    cherryPickDeadline: "2025-10-10"
+    release: 1.34.2
+    targetDate: "2025-10-14"
+  previousPatches:
+  - cherryPickDeadline: "2025-09-05"
+    release: 1.34.1
+    targetDate: "2025-09-09"
+  - release: 1.34.0
+    targetDate: "2025-08-27"
+  release: "1.34"
+  releaseDate: "2025-08-27"
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2025-09-05"
+    cherryPickDeadline: "2025-10-10"
+    release: 1.33.6
+    targetDate: "2025-10-14"
+  previousPatches:
+  - cherryPickDeadline: "2025-09-05"
     release: 1.33.5
     targetDate: "2025-09-09"
-  previousPatches:
   - cherryPickDeadline: "2025-08-08"
     release: 1.33.4
     targetDate: "2025-08-12"
@@ -28,10 +45,13 @@ schedules:
 - endOfLifeDate: "2026-02-28"
   maintenanceModeStartDate: "2025-12-28"
   next:
-    cherryPickDeadline: "2025-09-05"
+    cherryPickDeadline: "2025-10-10"
+    release: 1.32.10
+    targetDate: "2025-10-14"
+  previousPatches:
+  - cherryPickDeadline: "2025-09-05"
     release: 1.32.9
     targetDate: "2025-09-09"
-  previousPatches:
   - cherryPickDeadline: "2025-08-08"
     release: 1.32.8
     targetDate: "2025-08-12"
@@ -63,10 +83,13 @@ schedules:
 - endOfLifeDate: "2025-10-28"
   maintenanceModeStartDate: "2025-08-28"
   next:
-    cherryPickDeadline: "2025-09-05"
+    cherryPickDeadline: "2025-10-10"
+    release: 1.31.14
+    targetDate: "2025-10-14"
+  previousPatches:
+  - cherryPickDeadline: "2025-09-05"
     release: 1.31.13
     targetDate: "2025-09-09"
-  previousPatches:
   - cherryPickDeadline: "2025-08-08"
     release: 1.31.12
     targetDate: "2025-08-12"
@@ -108,9 +131,9 @@ schedules:
   release: "1.31"
   releaseDate: "2024-08-13"
 upcoming_releases:
-- cherryPickDeadline: "2025-09-05"
-  targetDate: "2025-09-09"
 - cherryPickDeadline: "2025-10-10"
   targetDate: "2025-10-14"
 - cherryPickDeadline: "2025-11-07"
   targetDate: "2025-11-11"
+- cherryPickDeadline: "2025-12-05"
+  targetDate: "2025-12-09"


### PR DESCRIPTION
### Description
Added 1.34.0 release (2025-08-27) to schedule

validated with schedule builder

1. Updating schedule.yaml and eol.yaml This updates the upcoming release section (max at 3) 

<img width="1976" height="426" alt="image" src="https://github.com/user-attachments/assets/811217e9-ffaf-457b-9bf8-ab61acf9c181" />


2. For Patch Release Schedule:

<img width="1490" height="1208" alt="image" src="https://github.com/user-attachments/assets/1fdfa26b-11d0-48c2-9847-ea0751e1d6f9" />


### Issue

#52220

Closes: #52220 