### PR TITLE
[ko] Fix broken link in docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/

### DIFF
--- a/content/ko/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/ko/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -82,7 +82,7 @@ L3/L4(예, IP 주소 + 포트) 모두의 보안 정책뿐만 아니라 L7(예, H
 ## 실리움을 실 서비스 용도로 배포하기
 
 실리움을 실 서비스 용도의 배포에 관련한 자세한 방법은
-[실리움 쿠버네티스 설치 안내](https://docs.cilium.io/en/stable/concepts/kubernetes/intro/)를 살펴본다.
+[실리움 쿠버네티스 설치 안내](https://docs.cilium.io/en/stable/network/kubernetes/concepts/)를 살펴본다.
 이 문서는 자세한 요구사항, 방법과
 실제 데몬셋 예시를 포함한다.
 


### PR DESCRIPTION

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

The "Using Cilium for Network Policy" page in the Korean (ko) localized documentation contains a broken link in the "Deploying Cilium in production" section for the Cilium Kubernetes installation guide.

Broken Link: https://docs.cilium.io/en/stable/concepts/kubernetes/intro/

-> Correct Link: https://docs.cilium.io/en/stable/network/kubernetes/concepts/

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #52279