### PR TITLE
[vi] add translation for Glossary HostAliases

### DIFF
--- a/content/vi/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/vi/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,0 +1,19 @@
+---
+title: Tự động điều chỉnh Pod theo chiều ngang (Horizontal Pod Autoscaler)
+id: horizontal-pod-autoscaler
+date: 2018-04-12
+full_link: /docs/tasks/run-application/horizontal-pod-autoscale/
+short_description: >
+  Một tài nguyên API tự động điều chỉnh số lượng bản sao (replica) của pod dựa vào mức sử dụng CPU mục tiêu hoặc các chỉ số tùy chỉnh.
+
+aka:
+- HPA
+tags:
+- operation
+---
+
+Một tài nguyên API tự động điều chỉnh số lượng bản sao (replica) của {{< glossary_tooltip term_id="pod" >}} dựa vào mức sử dụng CPU mong muốn hoặc các ngưỡng chỉ số tùy chỉnh.
+
+<!--more--> 
+
+HPA thường dùng với {{< glossary_tooltip text="ReplicationControllers" term_id="replication-controller" >}}, {{< glossary_tooltip text="Deployments" term_id="deployment" >}}, hoặc {{< glossary_tooltip text="ReplicaSets" term_id="replica-set" >}}. HPA không áp dụng cho các đối tượng không thể thay đổi số bản sao, ví dụ {{< glossary_tooltip text="DaemonSets" term_id="daemonset" >}}.

--- a/content/vi/docs/reference/glossary/host-aliases.md
+++ b/content/vi/docs/reference/glossary/host-aliases.md
@@ -1,0 +1,18 @@
+---
+title: Khai báo hosts tùy chỉnh cho Pod (HostAliases)
+id: HostAliases
+date: 2019-01-31
+full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
+short_description: >
+  HostAliases là danh sách ánh xạ giữa địa chỉ IP và tên máy (hostname) sẽ được chèn vào tệp hosts của Pod.
+
+aka:
+tags:
+- operation
+---
+
+HostAliases là danh sách ánh xạ giữa địa chỉ IP và tên máy (hostname) sẽ được chèn vào tệp hosts của {{< glossary_tooltip text="Pod" term_id="pod" >}}.
+
+<!--more-->
+
+[HostAliases](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core) là một danh sách tùy chọn gồm các cặp hostname và địa chỉ IP; nếu bạn cấu hình, các mục này sẽ được chèn vào tệp hosts của Pod. Tính năng này chỉ dùng được với các Pod không bật hostNetwork (tức là Pod không dùng chung mạng của Node).


### PR DESCRIPTION
# Description
- Add Vietnamese translation for Glossary HostAliases
- Link: https://kubernetes.io/docs/reference/glossary/?user-type=true

# Issue
NONE

Closes: #