### PR TITLE
[uk] sync task-tutorial-prereqs.md

### DIFF
--- a/content/uk/includes/task-tutorial-prereqs.md
+++ b/content/uk/includes/task-tutorial-prereqs.md
@@ -1,5 +1,6 @@
 Вам треба мати кластер Kubernetes, а також інструмент командного рядка kubectl має бути налаштований для роботи з вашим кластером. Рекомендується виконувати ці настанови у кластері, що має щонайменше два вузли, які не виконують роль вузлів управління. Якщо у вас немає кластера, ви можете створити його, за допомогою [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) або використовувати одну з цих пісочниць:
 
+* [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
 * [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
Sync content/uk/includes/task-tutorial-prereqs.md with upstream
https://github.com/kubernetes/website/blob/5622fb7bedbd3253d643f96f00b3fe2a80bd85c3/content/en/includes/task-tutorial-prereqs.md?plain=1#L7