### PR TITLE
Clarify documentation for ValidatingAdmissionPolicy and contents of CEL context

### DIFF
--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -336,7 +336,6 @@ You can access any field in the object's schema, such as `object.metadata.labels
 For any Kubernetes object, including schemaless Custom Resources, CEL guarantees access to a minimal set of properties:
 `apiVersion`, `kind`, `metadata.name`, and `metadata.generateName`.
 
-
 Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].
 Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
 


### PR DESCRIPTION
### Description

The current documentation for `ValidatingAdmissionPolicy` is misleading. It states that "No other metadata properties are accessible" besides `name` and `generateName`. This is incorrect in the context of the `object` variable, which is strongly-typed and allows access to all metadata fields, including `labels` and `annotations`. New users can be easily confused by this statement when their valid expressions (e.g., `object.metadata.labels['app'] == 'my-app'`) work as expected.

This PR clarifies this behavior by:
1.  Explaining that the `object` variable is strongly-typed, allowing full access to all schema-defined fields.
2.  Rephrasing the original sentence to clarify that it refers to the *guaranteed minimal set* of fields available for *any* Kubernetes object, which is the sentence's original intent.

This change improves accuracy and prevents confusion for users learning about CEL in admission policies.

### Issue
https://github.com/kubernetes/website/issues/39368
<!-- If you created an issue, uncomment the line below and add the issue number. -->
<!-- Closes: #<YOUR_ISSUE_NUMBER> -->

<!-- If you did not create an issue, you can write "None" or delete this whole section. -->
None. This is a minor documentation clarification that does not require a tracking issue.
