### PR TITLE
Fix video width/horizontal scroll on the main page

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -312,7 +312,6 @@ $ocean-nodes-h3-margin-bottom: 30px;
 
 // Video thingy
 #video {
-  width: 100vw;
   position: relative;
   overflow: hidden;
 


### PR DESCRIPTION
Due to `width: 100vw;` in `#video`, this block doesn't fit a normal screen width in Chrome/Linux, and an unnecessary horizontal scroll appears:
<img width="1136" height="608" alt="image" src="https://github.com/user-attachments/assets/2023f71a-c7a5-45ce-92f4-af8eb822d342" />

Removing this style leaves the video at 100% width, with no scrolling involved. I checked it in Firefox and Chrome in Linux (including small screens), but validating this change in other browsers/platforms will be much appreciated.