### PR TITLE
Prevent git commit message display at bottom of pages unless enabled

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -223,6 +223,10 @@ navbar_logo = true
 # Set to true to disable the About link in the site footer
 footer_about_disable = false
 
+# Set to true to display the "Last modified" commit message on pages.
+# If false, the "Last modified" section will not be rendered.
+show_last_modified = false
+
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -43,7 +43,9 @@
               {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) }}
                 {{ partial "feedback.html" .Site.Params.ui.feedback }}
               {{ end }}
-              {{ partial "page-meta-lastmod.html" . }}
+              {{ if .Site.Params.ui.show_last_modified }}
+                {{ partial "page-meta-lastmod.html" . }}
+              {{ end }}
               {{ if (.Site.Config.Services.Disqus.Shortname) }}
                 <br />
                 {{ partial "disqus-comment.html" . }}


### PR DESCRIPTION

### **Description**  
This pull request introduces a condition to control the rendering of the "Last modified" commit messages on the website. The change ensures that commit references are not displayed in the final HTML unless explicitly intended. 

#### **Key Changes**:
1. Condition added in `baseof.html`:
   - A condition was added to check the `ui.show_last_modified` parameter in the `hugo.toml` file. If this parameter is set to `true`, the `page-meta-lastmod.html` partial will be rendered. By default, this parameter is set to `false`.

2. New parameter in `hugo.toml`:
   - Added the `ui.show_last_modified` parameter under the `[params.ui]` section in `hugo.toml`:
     ```toml
     [params.ui]
     show_last_modified = false
     ```
   - This ensures that the "Last modified" section is disabled by default, avoiding unnecessary or confusing commit references.

3. No changes to Docsy:
   - Since the `page-meta-lastmod.html` file is inherited from the Docsy theme, no changes were made to the theme itself. 

---

#### **Related Issues**:

Closes: #52221  

#### **Result**:

<img width="1523" height="731" alt="Screenshot 2025-09-12 020812" src="https://github.com/user-attachments/assets/84e533f8-322e-48d3-8a31-a55faacb989a" />