### PR TITLE
Clarify behavior of initialDelaySeconds in probes

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -397,10 +397,11 @@ liveness and readiness checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started before startup,
   liveness or readiness probes are initiated. If a startup  probe is defined, liveness and
-  readiness probe delays do not begin until the startup probe has succeeded. Older versions
-  of Kubernetes might have ignored initialDelaySeconds if periodSeconds was larger. However,
-  in current versions, initialDelaySeconds is always honored and the probe will not start
-  until after this initial delay. Defaults to 0 seconds. Minimum value is 0. 
+  readiness probe delays do not begin until the startup probe has succeeded. In some older
+  Kubernetes versions, the initialDelaySeconds might be ignored if periodSeconds was set to
+  a value higher than initialDelaySeconds. However, in current versions, initialDelaySeconds
+  is always honored and the probe will not start until after this initial delay. Defaults to
+  0 seconds. Minimum value is 0. 
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds.
   The minimum value is 1.
   While a container is not Ready, the `ReadinessProbe` may be executed at times other than


### PR DESCRIPTION
The previous documentation for initialDelaySeconds could be misleading as it described an outdated behavior.

This change clarifies that initialDelaySeconds is always honored in current versions, regardless of periodSeconds. It also adds a note about the behavior in older versions to avoid confusion for users who might have encountered the old logic.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
https://github.com/kubernetes/website/issues/52218#event-19649664413

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #