### PR TITLE
Publish blog article "Announcing Changed Block Tracking API support (alpha)"

### DIFF
--- a/content/en/blog/_posts/2025-09-25-csi-changed-block-tracking.md
+++ b/content/en/blog/_posts/2025-09-25-csi-changed-block-tracking.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: 'Announcing Changed Block Tracking API support (alpha)'
-date: 2025-05-14T18:30:00+05:30
-draft: true
+date: 2025-09-25T05:00:00-08:00
 slug: csi-changed-block-tracking
 author: >
    [Prasad Ghangal](https://github.com/PrasadG193) (Veeam Kasten)


### PR DESCRIPTION
Mark it for publication on 2025-09-25. See PR #48456

/area blog