### PR TITLE
fix(footer): rebalance mobile columns

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -296,21 +296,41 @@ footer {
   }
 }
 
-
 @media (max-width: 799px) {
-  footer ul.footer-icons {
-    display: flex;
-    flex-wrap: nowrap;
-    flex-direction: column;
-    align-items: flex-start;
-    row-gap: 0.5em;
-  }
-  footer div.order-1 ul.footer-icons {
-    margin-left: auto;
-  }
-  footer div.order-3 ul.footer-icons {
-    margin-right: auto;
-  }
+footer ul.footer-icons {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: column;
+  row-gap: 0.5em;
+}
+
+footer div.order-1 ul.footer-icons {
+  align-items: flex-start;
+  margin-left: 0;
+  margin-right: auto;
+}
+
+footer div.order-3 ul.footer-icons {
+  align-items: flex-end;
+  margin-left: auto;
+  margin-right: 0;
+}
+
+// These character icons are bigger than the others and creates an offset, this restores centeredness
+.fa-laptop-code {
+  font-size: 1.1rem;
+}
+.fa-youtube {
+  font-size: 1.3rem;
+}
+.fa-envelope {
+  font-size: 1.3rem;
+}
+
+// Makes the text column wider on mobile while leaving the inline bootstrap code for desktop
+footer .row > .order-1 { flex: 0 0 16.6667%; max-width: 16.6667%; }
+footer .row > .order-2 { flex: 0 0 66.6667%; max-width: 66.6667%; }
+footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
 /* SIDE-DRAWER MENU */


### PR DESCRIPTION
### Description

**Issue**
The balance of space and positioning was off for the mobile footer layout:
- The right column of icons was pushed too close to the center compared to the left column.
- The middle text column was overly narrow, affecting readability, leaving awkward whitespace.
- Some larger icons made the columns look misaligned.

**Update**
- Positions the third column proportionally to the first for symmetry.
- Resizes column widths so the center text has more room instead of leaving empty space.
- Reduces visual offset in icon columns by adjusting size of larger characters.
- Implemented as SCSS only; no Bootstrap HTML was modified.

### Screenshots

**Before**

![before-footer](https://github.com/user-attachments/assets/aa195ff2-6f3b-4d5c-b481-c2919429b5b7)

**After**

![after-footer](https://github.com/user-attachments/assets/d61ac12c-85ea-40c2-b8e8-0c8519af73a1)
