### PR TITLE
[pt-br] Localize /tasks/debug/debug-cluster/resource-usage-monitoring.md

### DIFF
--- a/content/pt-br/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
+++ b/content/pt-br/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
@@ -53,7 +53,7 @@ Um pipeline de métricas completas oferece acesso a métricas mais ricas. O Kube
 responder a essas métricas automaticamente escalonando ou adaptando o cluster
 baseado no seu estado atual, usando mecanismos como o Horizontal Pod
 Autoscaler. O pipeline de monitoramento busca métricas do kubelet e
-então as expõe ao Kubernetes via um adaptador implementando a API
+então as expõe ao Kubernetes através de um adaptador que implemente a API
 `custom.metrics.k8s.io` ou `external.metrics.k8s.io`.
 
 


### PR DESCRIPTION
### Description

Este PR traz a localização da página https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-usage-monitoring/ para PT-BR.

- Caminho da página EN no repositório: `content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md`
- Caminho proposto em PT-BR no repositório: `content/pt-br/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md`

---

This PR brings the localization of the page https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-usage-monitoring/ to PT-BR.

- EN page path in the repository: `content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md`
- Proposed PT-BR path in the repository: `content/pt-br/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md`

### Issue

Closes: #51951