### PR TITLE
Fix indentation of kubelet, kubeadm, kubectl install commands

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -309,11 +309,11 @@ exist by default, and it should be created before the curl command.
 
 3. Install kubelet, kubeadm and kubectl:
 
-For systems with DNF:
+   For systems with DNF:
    ```shell
    sudo yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
    ```
-For systems with DNF5:
+   For systems with DNF5:
    ```shell
    sudo yum install -y kubelet kubeadm kubectl --setopt=disable_excludes=kubernetes
    ```


### PR DESCRIPTION
### Description

#52027 introduced new examples for systems using DNF5. One of the areas introduced incorrect indentation for the commands on this page: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/

<img width="1595" height="1179" alt="image" src="https://github.com/user-attachments/assets/a7bc1c79-d376-4892-ac92-6db33dfe1830" />

This PR fixes that:

<img width="1517" height="1498" alt="image" src="https://github.com/user-attachments/assets/7b146ed3-18a8-475f-96b4-a55c1036ec4a" />
