### PR TITLE
fix(training): mobile spacing and width

### DIFF
--- a/layouts/shortcodes/cncf-landscape.html
+++ b/layouts/shortcodes/cncf-landscape.html
@@ -56,9 +56,9 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 </script>
 {{- end -}}
-<div id="frameHolder">
+<div id="frameHolder" style="display:flex;justify-content:center;">
   {{ if ( .Get "category" ) }}
-  <iframe id="iframe-landscape" src="https://landscape.cncf.io/embed/embed.html?key={{ .Get "category" }}&headers=false&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 100%; min-height: 100px; border: 0;"></iframe>
+  <iframe id="iframe-landscape" src="https://landscape.cncf.io/embed/embed.html?key={{ .Get "category" }}&headers=false&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 0; min-height: 100px; border: 0; flex: 0 1 80%; max-width: 1200px;"></iframe>
   <script>
     iFrameResize({ }, '#iframe-landscape');
   </script>
@@ -69,9 +69,9 @@ document.addEventListener("DOMContentLoaded", function () {
       scroll-margin-top: 35px;
     }
   </style>
-  <iframe id="iframe-landscape-kcsp" src="https://landscape.cncf.io/embed/embed.html?key=special--kubernetes-certified-service-provider&headers=true&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 100%; min-height: 100px; border: 0;"></iframe>
-  <iframe id="iframe-landscape-conformance" src="https://landscape.cncf.io/embed/embed.html?key=platform&headers=true&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 100%; min-height: 100px; border: 0;"></iframe>
-  <iframe id="iframe-landscape-ktp" src="https://landscape.cncf.io/embed/embed.html?key=special--kubernetes-training-partner&headers=true&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 100%; min-height: 100px; border: 0;"></iframe>
+  <iframe id="iframe-landscape-kcsp" src="https://landscape.cncf.io/embed/embed.html?key=special--kubernetes-certified-service-provider&headers=true&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 0; min-height: 100px; border: 0; flex: 0 1 80%; max-width: 1200px;"></iframe>
+  <iframe id="iframe-landscape-conformance" src="https://landscape.cncf.io/embed/embed.html?key=platform&headers=true&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 0; min-height: 100px; border: 0; flex: 0 1 80%; max-width: 1200px;"></iframe>
+  <iframe id="iframe-landscape-ktp" src="https://landscape.cncf.io/embed/embed.html?key=special--kubernetes-training-partner&headers=true&style=shadowed&size=md&bg-color=%233371e3&fg-color=%23ffffff&iframe-resizer=true" style="width: 1px; min-width: 0; min-height: 100px; border: 0; flex: 0 1 80%; max-width: 1200px;"></iframe>
   <script>
     iFrameResize({ }, '#iframe-landscape-kcsp');
     iFrameResize({ }, '#iframe-landscape-conformance');

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -45,7 +45,7 @@ body.cid-training section.call-to-action .main-section .cta-text > * {
   text-align: center;
   /* if max() and min() are available, use them */
   min-width: min(20em, 50vw);
-  max-width: min(1000px, 50vw);
+  max-width: min(1000px, 80vw);
 }
 
 /*Image Container for further position of image in smaller devices*/
@@ -120,25 +120,38 @@ body.cid-training #get-certified .col-nav a.button {
   body.cid-training   section.call-to-action .main-section .cta-image > img {
     width: 7rem;
   }
+  
+  /* Ensure kubestronaut image maintains proper size */
+  body.cid-training #cta-kubestronaut .cta-image > img {
+    width: 150px;
+    margin: 0 auto;
+    display: block;
+  }
   body.cid-training section.call-to-action .main-section > div.call-to-action > div {
-    padding: 0 2rem 0 2rem;
+    padding: 0 1rem 0 1rem;
   }
-  body.cid-training section.call-to-action .main-section > div.call-to-action div.cta-image {
-    padding: 0 2rem 0 2rem;
-    /* Change display to CSS Grid layout with 2 columns that autofill */
-    display: grid; 
-    grid-template-columns: repeat(auto-fill, minmax(50%, 1fr));
-  }
-  /* Make the CTA text fill 100% of the viewport */
-  body.cid-training section.call-to-action .main-section > div.call-to-action > div.cta-text {
+ 
+  
+  /* Updated styles for CTA text content at 945px breakpoint */
+  body.cid-training #cta-kubestronaut .cta-text,
+  body.cid-training #cta-certification .cta-text {
     width: 100%;
+    max-width: 700px;
+    margin: 0 auto;
+  }
+  
+  body.cid-training #cta-kubestronaut .cta-text > *,
+  body.cid-training #cta-certification .cta-text > * {
+    text-align: center;
+    max-width: 100%;
+    min-width: auto;
   }
 
   /* Resize the div that contains the images so that the images wrap 2 at a time
  and have no margin issues */
 
+ /* sizing here */
   body.cid-training section.call-to-action .main-section > div.call-to-action {
-    width: 60%;
     margin: auto;
     padding-top: 20px;
   }
@@ -148,6 +161,19 @@ body.cid-training #get-certified .col-nav a.button {
     display: grid;
     grid-template-columns: repeat(2, 120px);
     gap: 0;
+  }
+  
+  /* Special handling for kubestronaut container with single image */
+  body.cid-training #cta-kubestronaut .cta-img-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+  }
+  
+  body.cid-training #cta-kubestronaut .logo-certification {
+    padding: 0;
+    margin: 0 auto;
   }
 
   body.cid-training  #logo-kcnf{
@@ -204,6 +230,10 @@ body.cid-training #get-certified .col-nav a.button {
   }
   body.cid-training .col-container {display: flex; flex-direction: column; }
   body.cid-training .col-container .col-nav:last-child{width: 100%;}
+
+  body.cid-training section.call-to-action .main-section > div.call-to-action > div {
+    padding: 0 .5rem 0 .5rem;
+  }
 }
 
 body.cid-training .button {


### PR DESCRIPTION
### Description

There is a related group of mobile formatting issues on the "training" page for three sections including two CTA blocks and a Partnership logo grid iframe. The issues are a lack of consistent centering of elements that are unintentionally offset (including the logo grid hugging the left page margin) and an overly narrow width constraining the CTA text elements affecting page balance and readability.

**Solutions**
- Remove offset to properly center CTA text and images.
- Expand CTA text width for better page balance and readability.
- Center iframe logo grid (Note: this iframe's column rendering behavior will ALWAYS result in a slight offset in certain intermittent screen sizes).
- Modifications made in `training.css` and inline style for `cncf-landscape.html`; no content is modified.


### Screenshots

#### CTA - Section 1

**Before**
![before-topCTA](https://github.com/user-attachments/assets/21f826bd-f24a-4d09-83f4-22d97bacf919)

**After**
![after-topCTA](https://github.com/user-attachments/assets/2de62f64-5448-40e9-b89f-64c11c54f4ad)

#### CTA - Section 2

**Before**
![before-bottomCTA](https://github.com/user-attachments/assets/1325fdfa-b624-42f3-9139-11175b778432)

**After**
![after-bottomCTA](https://github.com/user-attachments/assets/01ae73ed-6992-46ac-8f99-eb9f3ed87b98)

#### iframe Logo Grid - Section 3

**Before**
![before-logogrid](https://github.com/user-attachments/assets/867a9372-7f23-417f-bb5e-a6d555a72ce6)

**After**
![after-logogrid](https://github.com/user-attachments/assets/e99ecf29-e0ad-4a39-ae44-c1c4003e714d)
