### PR TITLE
Update deprecation version(1.34) for apiserver_storage_objects metric

### DIFF
--- a/content/en/docs/reference/instrumentation/metrics.md
+++ b/content/en/docs/reference/instrumentation/metrics.md
@@ -86,7 +86,7 @@ Stable metrics observe strict API contracts and no labels can be added or remove
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.34.0</span></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_storage_size_bytes</div>
 	<div class="metric_help">Size of the storage database file physically allocated in bytes.</div>


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
Small follow up to https://github.com/kubernetes/website/pull/52334 to reflect the Deprecated Version of the `apiserver_storage_objects` metric. Corresponding change was already merged in k/k via https://github.com/kubernetes/kubernetes/pull/134030
