### PR TITLE
fix: correct YAML syntax in resourceclaim.yaml

### DIFF
--- a/content/en/examples/dra/resourceclaim.yaml
+++ b/content/en/examples/dra/resourceclaim.yaml
@@ -11,6 +11,6 @@ spec:
         allocationMode: All
         selectors:
         - cel:
-          expression: |-
+            expression: |-
               device.attributes["driver.example.com"].type == "gpu" &&
               device.capacity["driver.example.com"].memory == quantity("64Gi")


### PR DESCRIPTION
correct YAML syntax in content/en/examples/dra/resourceclaim.yaml