### PR TITLE
Update preStop hook timing in pod lifecycle documentation

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -182,8 +182,8 @@ completion or failed for some reason. When you use `kubectl` to query a Pod with
 a container that is `Terminated`, you see a reason, an exit code, and the start and
 finish time for that container's period of execution.
 
-If a container has a `preStop` hook configured, this hook runs before the container enters
-the `Terminated` state.
+If a container has a `preStop` hook configured, this hook runs after the container enters
+the `Terminated` state, and pod will be remove from Subsets.addresses list of endponts.
 
 ## How Pods handle problems with containers {#container-restarts}
 


### PR DESCRIPTION
I just add sleep prestop hook for a deployment, and than I saw pod enter Terminated state first and do sleep and be remove from endpoints at same time, after sleep prestop hook done, container be kill. the behavior is not same as the offical docs.