### PR TITLE
[ja] Translate /docs/concepts/workloads/pods/pod-hostname.md into Japanese

### DIFF
--- a/content/ja/docs/concepts/workloads/pods/pod-hostname.md
+++ b/content/ja/docs/concepts/workloads/pods/pod-hostname.md
@@ -1,0 +1,100 @@
+---
+title: Pod Hostname
+content_type: concept
+weight: 85
+---
+
+<!-- overview -->
+
+このページでは、Podのhostnameを設定する方法、その設定後に起こり得る副作用、そして基盤となる仕組みについて説明します。
+
+<!-- body -->
+
+## デフォルトのPod hostname
+Podが作されると、そのhostname(Pod内部から見えるもの)は、Podのmetadata.nameの値から導き出されます。
+hostnameと、それに対応するfully qualified domain name (FQDN)の両方が(Podの視点からは)metadata.nameの値に設定されます。
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-1
+spec:
+  containers:
+  - image: busybox:1.28
+    command:
+      - sleep
+      - "3600"
+    name: busybox
+```
+
+このmanifestで作成されたPodは、hostnameとfully qualified domain name (FQDN)が`busybox-1`に設定されます。
+
+## Podのhostnameとsubdomainフィールド
+Podのspecには、オプションの`hostname`があります。
+この値が設定されると、Podの`metadata.name`よりも優先され、(Pod内部から見えるもの)hostnameとして使われます。
+例えば、spec.hostnameが`my-host`に設定されているPodは、hostnameが`my-host`です。
+
+また、Podのspecにはオプションの`subdomain`フィールドもあり、Podが自分のNamespace内のsubdomainに属していることを示します。
+もしPodの`spec.hostname`が"foo"、spec.subdomainが"bar"に設定され、さらにNamespaceが`my-namespace`の場合、hostnameは`foo`で、fully qualified domain name (FQDN)は(Podの内部から見える)`foo.bar.my-namespace.svc.cluster-domain.example`です。
+
+hostnameとsubdomainの両方が設定されていると、クラスターのDNSサーバーはこれらのフィールドに基づいてA and/or AAAAレコードを作成します。
+参照: [Podのhostnameとsubdomainフィールド](/ja/docs/concepts/services-networking/dns-pod-service/#podのhostnameとsubdomainフィールド).
+
+## PodのsetHostnameAsFQDNフィールド
+
+{{< feature-state for_k8s_version="v1.22" state="stable" >}}
+
+Podがfully qualified domain name (FQDN)を持つように設定されている場合、そのhostnameは短いhostnameです。
+例えば、Podのfully　qualified domain nameが`busybox-1.busybox-subdomain.my-namespace.svc.cluster-domain.example`の場合、デフォルトではそのPod内で`hostname`コマンドを実行すると`busybox-1`が返り、`hostname --fqdn`コマンドを実行するとFQDNが返ります。
+
+`setHostnameAsFQDN: true`とsubdomainフィールドがPodのspecに設定されている場合、kubeletはそのPodのNamespaceに対してFQDNをhostnameとして書き込みます。
+この場合、`hostname`と`hostname --fqdn`の両方がPodのFQDNを返します。
+
+PodのFDQNは前述と同じ方法で構築されます。
+つまり、Podの`spec.hostname`(設定されている場合)または`metadata.name`フィールド、`spec.subdomain`、`namespace`名、そしてクラスタードメインサフィックスで構成されます。
+
+{{< note >}}
+Linuxでは、kernelのhostnameフィールド(`struct utsname`の`nodename`フィールド)は64文字に制限されています。
+
+Podがこの機能を有効にし、そのFQDNが64文字を超える場合、起動に失敗します。
+そのPodは`Pending`ステータスのままになり(`kubectl`からは`ContainerCreating`と表示)、"Failed to construct FQDN from Pod hostname and cluster domain"などのエラーイベントが生成されます。
+
+つまり、このフィールドを使う場合、Podの`metadata.name`(または`spec.hostname`)と`spec.subdomain`フィールドを組み合わせた長さが64文字を超えないようにする必要があります。
+{{< /note >}}
+
+## PodのhostnameOverride
+{{< feature-state feature_gate_name="HostnameOverride" >}}
+
+Podのspecで`hostnameOverride`に値を設定すると、kubeletは無条件にその値をPodのhostnameとFQDN（フル クオリファイド ドメイン ネーム）両方に設定します。
+
+`hostnameOverride`フィールドには64文字の長さ制限があり、[RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123)で設定されているDNSのsubdomain名の基準に従う必要があります。
+
+例:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-2-busybox-example-domain
+spec:
+  hostnameOverride: busybox-2.busybox.example.domain
+  containers:
+  - image: busybox:1.28
+    command:
+      - sleep
+      - "3600"
+    name: busybox
+```
+{{< note >}}
+これはPod内のhostnameにのみ影響し、クラスターのDNSサーバーにおけるPodのAレコードやAAAAレコードには影響しません。
+{{< /note >}}
+
+`hostnameOverride`が`hostname`や`subdomain`フィールドと同時に設定されている場合:
+* Pod内のhostnameは`hostnameOverride`の値に上書きされます。
+
+* クラスターのDNSサーバーにおけるPodのA and/or AAAAレコードは、`hostname`と``subdomainフィールドに基づいて引き続き生成されます。
+
+Note: `hostnameOverride`が設定されている場合、`hostNetwork`と`setHostnameAsFQDN`フィールドを同時に設定することはできません。
+APIサーバーは、この組み合わせで作成要求が行われた場合、明示的に拒否します。
+
+`hostnameOverride`が他のフィールド(hostname, subdomain, setHostnameAsFQDN, hostNetwork)と組み合わされた時の動作の詳細については、[KEP-4762 設計詳細](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/4762-allow-arbitrary-fqdn-as-pod-hostname/README.md#design-details )内の表を参照してください。


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This pull request translates the following English documentation page into Japanese, 
following the Kubernetes Japanese Localization Team style guide.

[pod-hostname](https://kubernetes.io/docs/concepts/workloads/pods/pod-hostname/)

お疲れ様です。
何度も確認しましたが、不自然な部分が残っているかもしれません。
よろしくお願いいたします！

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #52356