### PR TITLE
Fix HorizontalPodAutoscaler command in HPA walkthrough

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -100,7 +100,7 @@ on the algorithm.
 Create the HorizontalPodAutoscaler:
 
 ```shell
-kubectl autoscale deployment php-apache --cpu=50% --min=1 --max=10
+kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
 ```
 
 ```


### PR DESCRIPTION
### Description
Corrects the `kubectl autoscale` command in the Horizontal Pod Autoscaler (HPA) walkthrough documentation.

The previous command used:

```bash
kubectl autoscale deployment php-apache --cpu=50% --min=1 --max=10
