### PR TITLE
docs: use appropriate markup for non-math elements

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -133,7 +133,7 @@ value:
 
 ```math
 \begin{equation*}
-desiredReplicas = ceil\left\lceil currentReplicas \times \frac{currentMetricValue}{desiredMetricValue} \right\rceil
+\text{desiredReplicas} = \mathrm{ceil}\left\lceil \text{currentReplicas} \times \frac{\text{currentMetricValue}}{\text{desiredMetricValue}} \right\rceil
 \end{equation*}
 ```
 
@@ -179,8 +179,9 @@ since it started. This value is configured with the
 `--horizontal-pod-autoscaler-cpu-initialization-period` command line option,
 and its default is 5 minutes.
 
-The \\( currentMetricValue \over desiredMetricValue \\) base scale ratio is then
-calculated, using the remaining pods not set aside or discarded from above.
+The \\( \text{currentMetricValue} \over \text{desiredMetricValue} \\) base scale
+ratio is then calculated, using the remaining pods not set aside or discarded
+from above.
 
 If there were any missing metrics, the control plane recomputes the average more
 conservatively, assuming those pods were consuming 100% of the desired

--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -139,7 +139,8 @@ value:
 
 For example, if the current metric value is `200m`, and the desired value
 is `100m`, the number of replicas will be doubled, since
-\\( { 200.0 \div 100.0 } = 2.0 \\).  
+\\( { 200.0 \div 100.0 } = 2.0 \\).
+
 If the current value is instead `50m`, you'll halve the number of
 replicas, since \\( { 50.0 \div 100.0 } = 0.5 \\). The control plane skips any scaling
 action if the ratio is sufficiently close to 1.0 (within a


### PR DESCRIPTION
When viewing this document in a browser, MathJax (or whatever tool is
typesetting the math bits) gives some pretty ugly output for these sections.

Use `\text` (and `\mathrm`, for the 'ceil' function) to avoid typesetting non-math
elements as math.

---

Compare:

<img width="644" height="190" alt="image" src="https://github.com/user-attachments/assets/9db70755-c51d-4ec7-9fad-c5f59a4abdfc" />

Fixed:

<img width="631" height="195" alt="image" src="https://github.com/user-attachments/assets/64499b40-55cf-46c0-9657-12645bcc249c" />
