### PR TITLE
fix broken mobile layout for case studies sections

### DIFF
--- a/assets/scss/case_studies.scss
+++ b/assets/scss/case_studies.scss
@@ -288,3 +288,91 @@ body.td-section.cid-casestudies {
     }
   }
 }
+
+@media (max-width: 767px) {
+  body.td-section.cid-casestudies {
+    main > section,
+    main > section:first-child {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+
+    section#case-studies {
+      margin-bottom: 3rem;
+    }
+
+    /* Featured grid stacks vertically */
+    #case-studies {
+      .case-studies {
+        flex-direction: column;
+        width: 100%;
+        max-width: 100%;
+        margin-top: 2rem;
+        gap: 1.5rem;
+      }
+    }
+
+    .case-study {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+      flex-basis: 100%;
+      min-height: initial;
+      padding: 0;          
+
+      /* Center images inside each card (leave sizes sane) */
+      img {
+        position: static;
+        display: block;
+        margin: 0 auto 0.75rem;
+        width: auto;
+        max-width: 215px;
+        height: auto;
+        align-self: center;
+      }
+
+      .quote {
+        width: 100%;
+        margin: 0 0 0.5rem;
+      }
+
+      a {
+        float: none;
+      }
+    }
+
+    .video-quote,
+    .case-study-video {
+      width: 100%;
+      flex-basis: 100%;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+    }
+
+    .video-quote {
+      max-width: 400px;          
+      margin-left: auto;
+      margin-right: auto;
+      text-align: center;        
+    }
+
+    .case-study-video {
+      max-width: 400px;          
+      margin-left: auto;
+      margin-right: auto;
+
+      iframe {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        display: block;
+        margin: 0 auto;
+      }
+    }
+
+    /* Prevent horizontal scroll from desktop vw constraints */
+    #usersGrid {
+      max-width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
### Description

The `case-studies` and `video-quote` sections are not mobile optimized. 
- `case-studies`: text is scrunched into a narrow column and overflows past the right page margin breaking the normal page width.
- `video-quote`: content is also constrained narrowly and misaligned off-center, with the iframe tiny.

This fix:
- stacks the `case-studies` grid vertically and centers images.
- balances and constrains `video-quote` content width dimensions.
- prevents page overflow/scroll issues.
- scoped to mobile breakpoint only, larger screen sizes unchanged.

Modifications made by appending to only `case_studies.scss`.

### Before and After

**Before - `case-studies` Section**
![case-study-BEFORE-Brands](https://github.com/user-attachments/assets/8a123c2a-ddee-4e94-918a-d162ea0e0013)

**After - `case-studies` Section**
![case-study-AFTER-Brands](https://github.com/user-attachments/assets/cadbdf63-eac1-450f-9afc-4bd9aa530646)

**Before - `video-quote` Section**

![case-study-BEFORE-video](https://github.com/user-attachments/assets/63f876de-07bd-4dab-87a4-f0d08d1bcbca)

**After - `video-quote` Section**

![case-study-AFTER-video](https://github.com/user-attachments/assets/f6ecdfab-1165-4b53-a3ec-fa8281fc402a)


