### PR TITLE
fix layout balance for docs/home on tablet and mobile

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -431,7 +431,11 @@ body.glossary {
       grid-template-columns: 1fr;
       .launch-card {
         width: 100%;
+        padding: 0;
       }
+      .launch-card .card-content {
+    width: 100%;
+  }
     }
   }
 }


### PR DESCRIPTION
### Description

1. The cards on mobile are positioned to be centered but appear noticeably offset to the left due to padding applied on the right side only, throwing off the visual balance. Removing it on the tablet and mobile breakpoint so neither side has padding eliminates the offset to center the cards proportionally; there is already sufficient space around the cards, so adding proportional padding to the left side instead does not seem the preferred approach.

2. Each card's button width is the same size on desktop, but on mobile and tablet screens, the button sizes vary, and especially since cards are generally expected to appear uniform, it looks visually unbalanced rather than a deliberate stylistic choice. On mobile and tablet, because all the cards' content are aligned to the left creating significant whitespace on the right side, I felt the natural solution in achieving uniformity is to allow all the buttons to span the entire card width and fill parts of that whitespace.

The result of the fixes should be a more purposeful and uniform card layout on tablet and mobile.

**The fixes are in `_documentation.scss` to:**
- remove padding causing offset to properly center the cards on mobile.
- make button width consistent on tablet and mobile screens by spanning full card width.

### Before and After

**Before - centering**
![docs-BEFORE-mobile](https://github.com/user-attachments/assets/ac25eb10-92ad-493b-be8f-b02d2bdd4e30)

**After - centering**
![docs-AFTER-mobile](https://github.com/user-attachments/assets/8d815d8c-ef58-4cd7-9cca-bae4084bc004)

**Before - button width**
![docs-BEFORE-tablet](https://github.com/user-attachments/assets/b5d91d3f-775c-4736-84ae-363b9a6a8359)

**After - button width**
![docs-AFTER-tablet](https://github.com/user-attachments/assets/1e065d1e-b04b-4496-8801-9fbab331d27b)
