### PR TITLE
Simplify the "Performing a Rolling Update" tutorial by removing repetitive sentences.

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.md
@@ -47,14 +47,11 @@ versioned and any Deployment update can be reverted to a previous (stable) versi
 {{< /tutorials/carousel >}}
 
 {{% alert %}}
-_If a Deployment is exposed publicly, the Service will load-balance the traffic
-only to available Pods during the update._
+If a Deployment is publicly exposed, the Service will send traffic only to Pods that can handle requests.  
+This ensures users continue to access the application during an update.
 {{% /alert %}}
 
-Similar to application Scaling, if a Deployment is exposed publicly, the Service
-will load-balance the traffic only to available Pods during the update. An available
-Pod is an instance that is available to the users of the application.
-
+During a rolling update, this behavior keeps the application available by routing traffic only to Pods that are serving requests.
 Rolling updates allow the following actions:
 
 * Promote an application from one environment to another (via container image updates)


### PR DESCRIPTION
We avoid technical terms like “ready” or “available.”

The focus is on user-facing behavior.

It flows naturally for someone following a tutorial.