### PR TITLE
Fix broken link to guestbook example

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -307,7 +307,7 @@ best practice. There are many scenarios where multiple labels should be used to
 distinguish resource sets from one another.
 
 For instance, different applications would use different values for the `app` label, but a
-multi-tier application, such as the [guestbook example](https://github.com/kubernetes/examples/tree/master/guestbook/),
+multi-tier application, such as the [guestbook example](https://github.com/kubernetes/examples/tree/master/web/guestbook/),
 would additionally need to distinguish each tier. The frontend could carry the following labels:
 
 ```yaml


### PR DESCRIPTION
### Description

This PR fixes broken link to the guestbook example in the following document:
content/en/docs/concepts/overview/working-with-objects/labels.md

The original link was pointing to the /guestbook directory, which has now been moved to /web/guestbook

[https://github.com/kubernetes/examples/tree/master/guestbook/](https://github.com/kubernetes/examples/tree/master/guestbook/)
These have been updated to point to the correct path:

[https://github.com/kubernetes/examples/tree/master/guestbook/](https://github.com/kubernetes/examples/tree/master/web/guestbook/)

### Issue

no issue found

Closes: #