### PR TITLE
[pt-br] Add docs/reference/glossary/duration.md

### DIFF
--- a/content/pt-br/docs/reference/glossary/duration.md
+++ b/content/pt-br/docs/reference/glossary/duration.md
@@ -1,0 +1,24 @@
+---
+title: Duração
+id: duration
+date: 2024-10-05
+full_link:
+short_description: >
+  Um valor em forma de string que representa uma quantidade de tempo.
+tags:
+- fundamental
+---
+Um valor em forma de string que representa uma quantidade de tempo.
+
+<!--more-->
+
+O formato de uma duração (no Kubernetes) é baseado no tipo
+[`time.Duration`](https://pkg.go.dev/time#Duration) da linguagem de programação Go.
+
+Nas APIs do Kubernetes que usam durações, o valor é expresso como uma série de inteiros
+não-negativos combinados com um sufixo de unidade de tempo. É possível ter mais de uma
+quantidade de tempo, e a duração total é a soma dessas quantidades.  
+As unidades de tempo válidas são: "ns", "µs" (ou "us"), "ms", "s", "m" e "h".
+
+Por exemplo: `5s` representa uma duração de cinco segundos, e `1m30s` representa uma
+duração de um minuto e trinta segundos.

--- a/content/pt-br/docs/reference/glossary/duration.md
+++ b/content/pt-br/docs/reference/glossary/duration.md
@@ -16,7 +16,7 @@ O formato de uma duração (no Kubernetes) é baseado no tipo
 [`time.Duration`](https://pkg.go.dev/time#Duration) da linguagem de programação Go.
 
 Nas APIs do Kubernetes que usam durações, o valor é expresso como uma série de inteiros
-não-negativos combinados com um sufixo de unidade de tempo. É possível ter mais de uma
+não negativos combinados com um sufixo de unidade de tempo. É possível ter mais de uma
 quantidade de tempo, e a duração total é a soma dessas quantidades.  
 As unidades de tempo válidas são: "ns", "µs" (ou "us"), "ms", "s", "m" e "h".
 


### PR DESCRIPTION
/kind documentation

### Description

Tradução do documento "Duration" para português (pt-BR) no Kubernetes Docs.
Este PR adiciona a versão em português do conteúdo, mantendo a estrutura e links originais.

### Issue

Closes: #52499

### Special notes for your reviewer

Primeiro PR de tradução para PT-BR.

### Does this PR introduce a user-facing change?

```release-note
NONE
