### PR TITLE
Migrating to CSS variables with SCSS as source of truth

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -41,3 +41,47 @@ $dark-bg-color-1: #303030;
 $dark-bg-color-2: #4f4f4f;
 $dark-text-color-1: #ffffff;
 $dark-text-color-2: #3371e3;
+
+/* CSS Custom Properties generated from SCSS variables */
+:root {
+  --primary: #{$primary};
+  --secondary: #{$secondary};
+  
+  --light-grey: #{$light-grey};
+  --medium-light-grey: #{$medium-light-grey};
+  --medium-grey: #{$medium-grey};
+  --dark-grey: #{$dark-grey};
+  --white: #{$white};
+  
+  // feature gate colors
+  --feature: #{$feature};
+  --feature-inset: #{$feature-inset};
+  
+  // metrics reference colors
+  --metric-labels-varying: #{$metric-labels-varying};
+  --metric-labels-varying-border: #{$metric-labels-varying-border};
+  
+  --td-sidebar-bg-color: #{$td-sidebar-bg-color};
+  
+  --link-color: #{$link-color};
+  
+  --link-hover-decoration: #{$link-hover-decoration};
+  
+  // tooltip
+  --tooltip-bg: #{$tooltip-bg};
+  --tooltip-arrow-color: #{$tooltip-arrow-color};
+  --tooltip-arrow-width: #{$tooltip-arrow-width};
+  --tooltip-opacity: #{$tooltip-opacity};
+  --tooltip-color: #{$tooltip-color};
+  --tooltip-max-width: #{$tooltip-max-width};
+  --tooltip-font-size: #{$tooltip-font-size};
+  --tooltip-padding: #{$tooltip-padding};
+  --tooltip-border-radius: #{$tooltip-border-radius};
+  --tooltip-font-weight: #{$tooltip-font-weight};
+  
+  // light / dark mode support
+  --dark-bg-color-1: #{$dark-bg-color-1};
+  --dark-bg-color-2: #{$dark-bg-color-2};
+  --dark-text-color-1: #{$dark-text-color-1};
+  --dark-text-color-2: #{$dark-text-color-2};
+}

--- a/content/de/includes/partner-style.css
+++ b/content/de/includes/partner-style.css
@@ -16,7 +16,7 @@
 	display: block;
 	float:left;
 	margin: 1% 0 1% 1.6%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 }
 .col:first-child { margin-left: 0; }
 
@@ -37,17 +37,17 @@
 /*  GRID OF THREE  */
 .span_3_of_3 {
 	width: 35%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 	padding: 20px;
 }
 .span_2_of_3 {
 	width: 35%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 	padding: 20px;
 }
 .span_1_of_3 {
 	width: 35%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 	padding: 20px;
 }
 
@@ -60,7 +60,7 @@
 .col-nav {
     display: table-cell; /* Make elements inside the container behave like table cells */
 		width: 18%;
-		background-color: #f9f9f9;
+		background-color: var(--light-grey);
 		padding: 20px;
 		border: 5px solid white;
 }
@@ -89,7 +89,7 @@
 	line-height: 40px;
 	color: #ffffff;
 	font-size: 16px;
-	background-color: #3371e3;
+	background-color: var(--dark-text-color-2);
 	text-decoration: none;
  }
 
@@ -101,7 +101,7 @@ h5 {
 
 #usersGrid a {
 	display: inline-block;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 }
 
 #ktpContainer, #distContainer, #kcspContainer, #isvContainer, #servContainer {
@@ -142,7 +142,7 @@ h5 {
 }
 
 .partner-box img {
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 }
 
 .partner-box > div {

--- a/content/fr/includes/partner-style.css
+++ b/content/fr/includes/partner-style.css
@@ -16,7 +16,7 @@
 	display: block;
 	float:left;
 	margin: 1% 0 1% 1.6%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 }
 .col:first-child { margin-left: 0; }
 
@@ -37,17 +37,17 @@
 /*  GRID OF THREE  */
 .span_3_of_3 {
 	width: 35%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 	padding: 20px;
 }
 .span_2_of_3 {
 	width: 35%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 	padding: 20px;
 }
 .span_1_of_3 {
 	width: 35%;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 	padding: 20px;
 }
 
@@ -60,7 +60,7 @@
 .col-nav {
     display: table-cell; /* Make elements inside the container behave like table cells */
 		width: 18%;
-		background-color: #f9f9f9;
+		background-color: var(--light-grey);
 		padding: 20px;
 		border: 5px solid white;
 }
@@ -89,7 +89,7 @@
 	line-height: 40px;
 	color: #ffffff;
 	font-size: 16px;
-	background-color: #3371e3;
+	background-color: var(--dark-text-color-2);
 	text-decoration: none;
  }
 
@@ -101,7 +101,7 @@ h5 {
 
 #usersGrid a {
 	display: inline-block;
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 }
 
 #ktpContainer, #distContainer, #kcspContainer, #isvContainer, #servContainer {
@@ -142,7 +142,7 @@ h5 {
 }
 
 .partner-box img {
-	background-color: #f9f9f9;
+	background-color: var(--light-grey);
 }
 
 .partner-box > div {

--- a/static/css/case-studies-gradient.css
+++ b/static/css/case-studies-gradient.css
@@ -1,5 +1,5 @@
 .flip-nav ul.global-nav li a, .open-nav ul.global-nav li a {
-  color:#303030 !important;
+  color:var(--dark-grey) !important;
 }
 
 
@@ -10,7 +10,7 @@
   vertical-align: top;
   position: relative;
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:10%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -106,7 +106,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -116,7 +116,7 @@ h1 {
 
 .greybanner {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -130,7 +130,7 @@ h1 {
 
 .quotetext {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:0%;
   margin-top:0;
   padding-bottom:3%;
@@ -145,7 +145,7 @@ h1 {
 
 .greyquotetext {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -343,7 +343,7 @@ hr {
     vertical-align: top;
     position: relative;
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:20%;
     padding-bottom:0.5%;
     padding-left:10%;

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -71,7 +71,7 @@ p.attrib {
 }
 
 .gridPage #video {
-    background: #f9f9f9;
+    background: var(--light-grey);
     height: auto;
     /*height: 340px;*/
     display: flex;
@@ -191,7 +191,7 @@ p.attrib {
 }
 
 section.bullets {
-    background-color: #eeeeee;
+    background-color: var(--feature-inset);
     margin-bottom: 50px;
 }
 

--- a/static/css/legacy_community.css
+++ b/static/css/legacy_community.css
@@ -58,12 +58,12 @@ code {
 
 .fa {
   font-size: 25px;
-  color: #FFFFFF;
+  color: var(--white);
 }
 
 .panel-title {
   font-size: 25px;
-  color: #FFFFFF;
+  color: var(--white);
   font-family: 'Open Sans', sans-serif;
 }
 
@@ -133,7 +133,7 @@ body {
   text-decoration: none;
   text-transform: uppercase;
   font-weight: 400;
-  color: #303030;
+  color: var(--dark-grey);
   font-size: 14px;
   margin-top: 1%;
   margin-bottom: 4%;
@@ -146,7 +146,7 @@ body {
 
 a {
   text-decoration: none;
-  color: #303030;
+  color: var(--dark-grey);
 }
 
 
@@ -283,7 +283,7 @@ a {
   width: 100%;
   padding-top: 5%;
   padding-bottom: 5%;
-  background-color: #eeeeee;
+  background-color: var(--feature-inset);
 
 }
 
@@ -646,7 +646,7 @@ h2:after {
   .events {
     float: left;
     width: 100%;
-    background-color: #eeeeee;
+    background-color: var(--feature-inset);
     margin-top: 3%;
     padding-bottom: 5%;
 
@@ -713,7 +713,7 @@ h2:after {
     width: 100%;
     padding-top: 5%;
     padding-bottom: 5%;
-    background-color: #eeeeee;
+    background-color: var(--feature-inset);
 
   }
 

--- a/static/css/style_amadeus.css
+++ b/static/css/style_amadeus.css
@@ -41,7 +41,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -53,7 +53,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -68,7 +68,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -82,7 +82,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -94,7 +94,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -107,7 +107,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -115,7 +115,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -123,7 +123,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -131,7 +131,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -280,7 +280,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -291,7 +291,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -305,7 +305,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -318,7 +318,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -331,7 +331,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -345,19 +345,19 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-bottom:1%;
     padding-top:1%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:5%;
@@ -367,7 +367,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;
@@ -377,7 +377,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;

--- a/static/css/style_ancestry.css
+++ b/static/css/style_ancestry.css
@@ -34,7 +34,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10.9%;
@@ -46,7 +46,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:19px;
@@ -60,7 +60,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:6%;
@@ -74,7 +74,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -86,7 +86,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -99,7 +99,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -107,7 +107,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -115,7 +115,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -123,7 +123,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -269,7 +269,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -280,7 +280,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0%;
@@ -295,7 +295,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -308,7 +308,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -321,7 +321,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -335,17 +335,17 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:5%;
     padding-top:5%;
@@ -355,7 +355,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     padding-top:3%;
@@ -365,12 +365,12 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .fullcol {

--- a/static/css/style_apiref.css
+++ b/static/css/style_apiref.css
@@ -1,10 +1,10 @@
 /*
 Kubernetes colors (assets/scss/_skin.scss)
 
-$blue: #326ce5;
+$blue: var(--primary);
 $light-grey: #f7f7f7;
-$dark-grey: #303030;
-$medium-grey: #4c4c4c;
+$dark-grey: var(--dark-grey);
+$medium-grey: var(--medium-grey);
 */
 
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700,700i&display=swap");
@@ -18,7 +18,7 @@ body > #wrapper {
 }
 
 a {
-  color: #326ce5;
+  color: var(--primary);
 }
 
 a:hover {
@@ -31,15 +31,15 @@ a:hover {
 }
 
 h1 {
-  border-bottom: 3px solid #303030;
+  border-bottom: 3px solid var(--dark-grey);
 }
 
 h2 {
-  border-bottom: 2px solid #303030;
+  border-bottom: 2px solid var(--dark-grey);
 }
 
 h3.toc-item {
-  border-bottom: 1px solid #303030;
+  border-bottom: 1px solid var(--dark-grey);
 }
 
 h1, h2, h3, h4 {
@@ -122,7 +122,7 @@ code {
 }
 
 #navigation a:hover {
-  color: #326ce5;
+  color: var(--primary);
   text-decoration: none;
 }
 
@@ -247,7 +247,7 @@ pre {
   }
 
   body.theme-auto #navigation a:hover {
-    color: #326ce5;
+    color: var(--primary);
   }
 
   body.theme-auto pre {
@@ -256,7 +256,7 @@ pre {
   }
 
   body.theme-auto .alert a {
-    color: #326ce5;
+    color: var(--primary);
   }
 }
 
@@ -309,7 +309,7 @@ body.theme-dark #navigation a.selected {
 }
 
 body.theme-dark #navigation a:hover {
-  color: #326ce5;
+  color: var(--primary);
 }
 
 body.theme-dark pre {
@@ -318,5 +318,5 @@ body.theme-dark pre {
 }
 
 body.theme-dark .alert a {
-  color: #326ce5;
+  color: var(--primary);
 }

--- a/static/css/style_blablacar.css
+++ b/static/css/style_blablacar.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -50,7 +50,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding: 1%;
   width:100%;
   font-size:24px;
@@ -64,7 +64,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -78,7 +78,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:25px;
@@ -90,7 +90,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -103,7 +103,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -113,7 +113,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -121,7 +121,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -129,7 +129,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -274,7 +274,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -285,7 +285,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -299,7 +299,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -312,7 +312,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -325,7 +325,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -339,19 +339,19 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-bottom:1%;
     padding-top:1%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:5%;
@@ -361,7 +361,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;
@@ -371,7 +371,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;

--- a/static/css/style_blackrock.css
+++ b/static/css/style_blackrock.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -50,7 +50,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -64,7 +64,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -78,7 +78,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -90,7 +90,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -103,7 +103,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -111,7 +111,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   padding-left:13%;
   text-align:center;
@@ -119,7 +119,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   padding-left:17%;
   text-align:center;
@@ -127,7 +127,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -272,7 +272,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -283,7 +283,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -297,7 +297,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -310,7 +310,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -323,7 +323,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -337,19 +337,19 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-bottom:1%;
     padding-top:1%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:5%;
@@ -359,7 +359,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;
@@ -369,7 +369,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;

--- a/static/css/style_box.css
+++ b/static/css/style_box.css
@@ -3,7 +3,7 @@
 }
 
 body {
-  background-color:#ffffff;
+  background-color:var(--white);
 }
 
 p {
@@ -35,7 +35,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:9.9%;
@@ -47,7 +47,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -60,7 +60,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -72,7 +72,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -84,7 +84,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -97,7 +97,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -105,7 +105,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:55%;
   text-align:center;
   margin:0 auto;
@@ -113,7 +113,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:55%;
   text-align:center;
   margin:0 auto;
@@ -121,7 +121,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -262,7 +262,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -273,7 +273,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0%;
@@ -288,7 +288,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -301,7 +301,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -314,7 +314,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0%;
@@ -329,17 +329,17 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     text-align:center;
@@ -347,7 +347,7 @@ h4 {
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     text-align:center;
@@ -355,12 +355,12 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .fullcol {

--- a/static/css/style_buffer.css
+++ b/static/css/style_buffer.css
@@ -13,11 +13,11 @@ a {
 
 body {
   margin:0;
-  background-color:#ffffff !important;
+  background-color:var(--white) !important;
 }
 
 footer {
-background-color:#ffffff !important;
+background-color:var(--white) !important;
 }
 
 h1 {
@@ -37,7 +37,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:9.9%;
@@ -49,7 +49,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -62,7 +62,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:6%;
@@ -76,7 +76,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -88,7 +88,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -101,7 +101,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -109,7 +109,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -117,7 +117,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:55%;
   text-align:center;
   margin:0 auto;
@@ -125,7 +125,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -266,7 +266,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -277,7 +277,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -292,7 +292,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -307,7 +307,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -320,7 +320,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -335,17 +335,17 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:2%;
     padding-right:10%;
@@ -356,7 +356,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     text-align:center;
@@ -364,12 +364,12 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .fullcol {

--- a/static/css/style_case_studies.css
+++ b/static/css/style_case_studies.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -48,7 +48,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -62,7 +62,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -75,7 +75,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -86,7 +86,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -100,7 +100,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -108,7 +108,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -116,7 +116,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -124,7 +124,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -271,7 +271,7 @@ h4 {
 
   .banner1 {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     padding-top: 15%;
     padding-bottom: 2%;
     padding-left: 10%;
@@ -281,7 +281,7 @@ h4 {
 
   .banner2 {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     padding-top: 4%;
     padding-bottom: 4%;
     font-size: 18px;
@@ -294,7 +294,7 @@ h4 {
 
   .banner3 {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     padding-top: 5%;
     padding-bottom: 5%;
     font-size: 16px;
@@ -305,7 +305,7 @@ h4 {
 
   .banner4 {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     padding-top: 4%;
     padding-bottom: 4%;
     font-size: 18px;
@@ -316,7 +316,7 @@ h4 {
 
   .banner5 {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     padding-top: 4%;
     padding-bottom: 4%;
     font-size: 16px;
@@ -329,18 +329,18 @@ h4 {
 
   .banner2text {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     width: 90%;
     padding-left: 5%;
     padding-bottom: 1%;
     padding-top: 1%;
     text-align: center;
-    color: #ffffff;
+    color: var(--white);
   }
 
   .banner3text {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     width: 90%;
     padding-left: 5%;
     padding-top: 5%;
@@ -350,7 +350,7 @@ h4 {
 
   .banner4text {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     width: 90%;
     padding-left: 5%;
     padding-top: 3%;
@@ -360,7 +360,7 @@ h4 {
 
   .banner5text {
     font-weight: 300;
-    color: #ffffff;
+    color: var(--white);
     width: 90%;
     padding-left: 5%;
     padding-top: 3%;

--- a/static/css/style_crowdfire.css
+++ b/static/css/style_crowdfire.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -50,7 +50,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -64,7 +64,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -78,7 +78,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -90,7 +90,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -103,7 +103,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -111,7 +111,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -119,7 +119,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -127,7 +127,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -272,7 +272,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -283,7 +283,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -297,7 +297,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -310,7 +310,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -323,7 +323,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -337,19 +337,19 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     padding-bottom:1%;
     padding-top:1%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     padding-top:5%;
@@ -359,7 +359,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     padding-right:10%;
@@ -370,7 +370,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     padding-top:3%;

--- a/static/css/style_golfnow.css
+++ b/static/css/style_golfnow.css
@@ -13,11 +13,11 @@ a {
 
 body {
   margin:0;
-  background-color:#ffffff !important;
+  background-color:var(--white) !important;
 }
 
 footer {
-  background-color:#ffffff !important;
+  background-color:var(--white) !important;
 }
 
 h1 {
@@ -36,7 +36,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:9.9%;
@@ -48,7 +48,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -61,7 +61,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:6%;
@@ -75,7 +75,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -87,7 +87,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -100,7 +100,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -108,7 +108,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -116,7 +116,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:55%;
   text-align:center;
   margin:0 auto;
@@ -124,7 +124,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -265,7 +265,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -276,7 +276,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -291,7 +291,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -306,7 +306,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -319,7 +319,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -338,12 +338,12 @@ h4 {
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:2%;
     padding-right:10%;
@@ -354,7 +354,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     text-align:center;
@@ -366,7 +366,7 @@ h4 {
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .fullcol {

--- a/static/css/style_haufegroup.css
+++ b/static/css/style_haufegroup.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -50,7 +50,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -64,7 +64,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -78,7 +78,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -90,7 +90,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -103,7 +103,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -111,7 +111,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -119,7 +119,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -127,7 +127,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -272,7 +272,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -283,7 +283,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -297,7 +297,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -310,7 +310,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -323,7 +323,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -337,19 +337,19 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-bottom:1%;
     padding-top:1%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:5%;
@@ -359,7 +359,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;
@@ -369,7 +369,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;

--- a/static/css/style_huawei.css
+++ b/static/css/style_huawei.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -50,7 +50,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -64,7 +64,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -78,7 +78,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -90,7 +90,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -103,7 +103,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -111,7 +111,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -119,7 +119,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -127,7 +127,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -272,7 +272,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -283,7 +283,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -297,7 +297,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -310,7 +310,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -323,7 +323,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -337,19 +337,19 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-bottom:1%;
     padding-top:1%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:5%;
@@ -359,7 +359,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;
@@ -369,7 +369,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;

--- a/static/css/style_peardeck.css
+++ b/static/css/style_peardeck.css
@@ -13,11 +13,11 @@ a {
 
 body {
   margin:0;
-  background-color:#ffffff !important;
+  background-color:var(--white) !important;
 }
 
 footer {
-  background-color:#ffffff !important;
+  background-color:var(--white) !important;
 }
 
 h1 {
@@ -36,7 +36,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -48,7 +48,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -61,7 +61,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:6%;
@@ -75,7 +75,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -87,7 +87,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -100,7 +100,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -108,7 +108,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -116,7 +116,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:55%;
   text-align:center;
   margin:0 auto;
@@ -124,7 +124,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -265,7 +265,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -276,7 +276,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -291,7 +291,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -306,7 +306,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -319,7 +319,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -334,17 +334,17 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:2%;
     padding-right:10%;
@@ -355,7 +355,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     text-align:center;
@@ -363,12 +363,12 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .fullcol {

--- a/static/css/style_wink.css
+++ b/static/css/style_wink.css
@@ -31,7 +31,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:9.9%;
@@ -43,7 +43,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:19px;
@@ -56,7 +56,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:6%;
@@ -70,7 +70,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:21px;
@@ -82,7 +82,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:21px;
@@ -95,7 +95,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:62%;
   text-align:center;
   margin:0 auto;
@@ -103,7 +103,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -111,7 +111,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:60%;
   text-align:center;
   margin:0 auto;
@@ -119,7 +119,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -260,7 +260,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -271,7 +271,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -286,7 +286,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -301,7 +301,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:18px;
@@ -314,7 +314,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     padding-left:0;
@@ -329,17 +329,17 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:2%;
     padding-right:10%;
@@ -350,7 +350,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     text-align:center;
@@ -358,12 +358,12 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:80%;
     padding-left:10%;
     float:left;
     text-align:center;
-    color:#ffffff;
+    color:var(--white);
   }
 
   .fullcol {

--- a/static/css/style_zalando.css
+++ b/static/css/style_zalando.css
@@ -38,7 +38,7 @@ h1 {
 
 .banner1 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:12%;
   padding-bottom:0.5%;
   padding-left:10%;
@@ -50,7 +50,7 @@ h1 {
 
 .banner2 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:4%;
   padding-bottom:4%;
   width:100%;
@@ -64,7 +64,7 @@ h1 {
 
 .banner3 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-left:5%;
   padding-right:5%;
   padding-top:4%;
@@ -78,7 +78,7 @@ h1 {
 
 .banner4 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:5%;
   padding-bottom:5%;
   font-size:24px;
@@ -90,7 +90,7 @@ h1 {
 
 .banner5 {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   padding-top:3%;
   padding-bottom:3%;
   font-size:24px;
@@ -103,7 +103,7 @@ h1 {
 
 .banner2text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:70%;
   text-align:center;
   margin:0 auto;
@@ -111,7 +111,7 @@ h1 {
 
 .banner3text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:75%;
   text-align:center;
   margin:0 auto;
@@ -119,7 +119,7 @@ h1 {
 
 .banner4text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:65%;
   text-align:center;
   margin:0 auto;
@@ -127,7 +127,7 @@ h1 {
 
 .banner5text {
   font-weight:300;
-  color:#ffffff;
+  color:var(--white);
   width:68%;
   text-align:center;
   margin:0 auto;
@@ -272,7 +272,7 @@ h4 {
 
   .banner1 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:15%;
     padding-bottom:2%;
     padding-left:10%;
@@ -283,7 +283,7 @@ h4 {
 
   .banner2 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -297,7 +297,7 @@ h4 {
 
   .banner3 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:5%;
     padding-bottom:5%;
     font-size:16px;
@@ -310,7 +310,7 @@ h4 {
 
   .banner4 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:18px;
@@ -323,7 +323,7 @@ h4 {
 
   .banner5 {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     padding-top:4%;
     padding-bottom:4%;
     font-size:16px;
@@ -337,7 +337,7 @@ h4 {
 
   .banner2text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-bottom:1%;
@@ -348,7 +348,7 @@ h4 {
 
   .banner3text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:5%;
@@ -358,7 +358,7 @@ h4 {
 
   .banner4text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;
@@ -368,7 +368,7 @@ h4 {
 
   .banner5text {
     font-weight:300;
-    color:#ffffff;
+    color:var(--white);
     width:90%;
     padding-left:5%;
     padding-top:3%;

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -11,8 +11,8 @@ body.cid-training body.cid-training .section {
 }
 
 body.cid-training section.call-to-action {
-  color: #ffffff;
-  background-color: #326ce5;
+  color: var(--white);
+  background-color: var(--primary);
 }
 
 body.cid-training section.call-to-action .main-section {
@@ -83,7 +83,7 @@ body.cid-training .col-nav {
   display: flex;
   flex-grow: 1;
   width: 18%;
-  background-color: #f9f9f9;
+  background-color: var(--light-grey);
   padding: 20px;
   border: 5px solid white;
 }
@@ -214,9 +214,9 @@ body.cid-training .button {
   border-radius: 6px;
   padding: 0 20px;
   line-height: 40px;
-  color: #ffffff;
+  color: var(--white);
   font-size: 16px;
-  background-color: #326ce5;
+  background-color: var(--primary);
   text-decoration: none;
   text-align: center;
 }
@@ -244,7 +244,7 @@ body.cid-training .padded {
 }
 
 body.cid-training .blue-bg {
-  background-color: #326ce5;
+  background-color: var(--primary);
 }
 
 body.cid-training .lighter-gray-bg {

--- a/static/docs/reference/generated/kubectl/stylesheet.css
+++ b/static/docs/reference/generated/kubectl/stylesheet.css
@@ -280,7 +280,7 @@ hr {
 /* Large display, split examples into the far right column */
 @media screen and (min-width: 992px) {
     #wrapper {
-        background-image: linear-gradient(90deg, #FFFFFF 63%, rgb(48, 48, 48) 63%);
+        background-image: linear-gradient(90deg, var(--white) 63%, rgb(48, 48, 48) 63%);
     }
 
     #sidebar-wrapper {


### PR DESCRIPTION
### Description

In reference to issue #52505, this implements a migration to using CSS variables for hex color values (brand and utilities) that are already established as SCSS variables in `_variables_project.scss`. It creates a bridge in that file to assign CSS variables that can be used in CSS files instead of hardcoded values like the brand's blue #326ce5. This improves site-wide granular control and maintainability of CSS properties, as explained in the issue.

### What & Why
- Establish a clear bridge from SCSS values to CSS variables for use in CSS files.
- Improve maintainability and site-wide consistency by avoiding duplicated hex codes.

### Scope
- Add CSS variables corresponding to existing SCSS color values.
- Replace hardcoded brand/utility hex values in CSS with the new variables.

### Non-Goals
- No new colors or renaming of existing tokens.
- No changes to layout tokens (spacing, etc.).

### Impact
- **No visual changes intended**; this only changes references, not values.

### Acceptance Criteria
- CSS files reference CSS variables for brand/utility colors instead of hardcoded hex values.
- Build/tests pass as before; visual diffs are unchanged.
- `_variables_project.scss` documents the variable mapping clearly.