### PR TITLE
Fix typo: EndppointSlice -> EndpointSlice

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -331,7 +331,7 @@ spec:
 ```
 
 A Pod with Always restart policy with an init container that only execute once. If the init
-container fails, the Pod fails. This allows the Pod to fail if the initialiaztion failed,
+container fails, the Pod fails. This allows the Pod to fail if the initialization failed,
 but also keep running once the initialization succeeds:
 
 ```yaml
@@ -485,7 +485,7 @@ spec:
     - conditionType: "www.example.com/feature-1"
 status:
   conditions:
-    - type: Ready                              # a built in PodCondition
+    - type: Ready                              # a built-in PodCondition
       status: "False"
       lastProbeTime: null
       lastTransitionTime: 2018-01-01T00:00:00Z

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -683,7 +683,7 @@ processing its startup data, you might prefer a readiness probe.
 {{< note >}}
 If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; when the Pod is deleted, the corresponding endpoint
-in the `EndppointSlice` will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions):
+in the `EndpointSlice` will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions):
 the endpoint `ready` condition will be set to `false`, so load balancers
 will not use the Pod for regular traffic. See [Pod termination](#pod-termination)
 for more information about how the kubelet handles Pod deletion.


### PR DESCRIPTION
Edit:

Corrected some spelling mistakes in the Pod lifecycle documentation.

Changes:

EndppointSlice -> EndpointSlice

initialiaztion -> initialization

built in PodCondition -> built-in PodCondition