### PR TITLE
fix(fr): correct broken minikube link and "prérequis" heading

### DIFF
--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -27,7 +27,7 @@ Voir __Étape 1__ dans [minikube start](https://minikube.sigs.k8s.io/docs/start/
 Exécutez uniquement les instructions de l'__Étape 1, Installation__. Le reste est couvert sur cette page. 
 {{< /note >}}
 
-Vous devez également installer `kubectl`.  
+Vous devez également installer `kubectl`. 
 Voir [Installer les outils](/docs/tasks/tools/#kubectl) pour les instructions d'installation.
 
 


### PR DESCRIPTION
This commit fixes two issues in the French "Hello Minikube" tutorial:

- The installation link to minikube was broken (`https://minikube.pour`).
- Updated to the correct official link: https://minikube.sigs.k8s.io/docs/start/
- Removed the extra character `²` in the "prérequis²" heading.

These changes bring the French version in line with the English tutorial and ensure the documentation renders properly.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #