### PR TITLE
[ko] fix mistranslation in kubelet description

### DIFF
--- a/content/ko/docs/concepts/overview/components.md
+++ b/content/ko/docs/concepts/overview/components.md
@@ -49,7 +49,7 @@ card:
 모든 노드에서 실행되며, 실행 중인 파드를 유지하고 쿠버네티스 런타임 환경을 제공한다.
 
 [kubelet](/docs/concepts/architecture/#kubelet)
-: 파드와 그 안의 컨트롤러가 실행 중임을 보장한다.
+: 파드와 그 안의 컨테이너가 실행 중임을 보장한다.
 
 [kube-proxy](/docs/concepts/architecture/#kube-proxy) (선택 사항)
 : 노드에서 네트워크 규칙을 유지하여 {{< glossary_tooltip text="서비스" term_id="service" >}}를 구현한다.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Fixes a mistranslation in the Korean documentation for the kubelet component.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
In the Korean documentation for the Node Components section, the kubelet description incorrectly says:
“파드와 그 안의 컨트롤러가 실행 중임을 보장한다.”
The word 컨트롤러 (“controller”) is a mistranslation.
The English source says “Ensures that Pods are running, including their containers.”
so it should say 컨테이너 (“container”) instead of 컨트롤러.

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #52515 