### PR TITLE
Add missing env var (KUBECTL_KYAML) for kubectl, used for enabling kyaml output format

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -362,7 +362,7 @@ kubectl [flags]
 <td colspan="2">KUBECTL_ENABLE_CMD_SHADOW</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, external plugins can be used as subcommands for builtin commands if subcommand does not exist. In alpha stage, this feature can only be used for create command(e.g. kubectl create networkpolicy). 
+<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, external plugins can be used as subcommands for builtin commands if subcommand does not exist. In alpha stage, this feature can only be used for create command(e.g. kubectl create networkpolicy).
 </td>
 </tr>
 
@@ -386,7 +386,15 @@ kubectl [flags]
 <td colspan="2">KUBECTL_KUBERC</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, kuberc file is taken into account to define user specific preferences.  
+<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, kuberc file is taken into account to define user specific preferences.
+</td>
+</tr>
+
+<tr>
+<td colspan="2">KUBECTL_KYAML</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, kubectl is capable of producing Kubernetes-specific dialect of YAML output format.
 </td>
 </tr>
 


### PR DESCRIPTION

### Description

We missed documenting the `KUBECTL_KYAML` env var, available for kubectl users. 

### Issue
Related to https://github.com/kubernetes/enhancements/issues/5295

/cc @thockin 