### PR TITLE
fix dra resource slice example: boolean to bool

### DIFF
--- a/content/en/blog/_posts/2025-09-18-dra-consumable-capacity.md
+++ b/content/en/blog/_posts/2025-09-18-dra-consumable-capacity.md
@@ -140,7 +140,7 @@ spec:
     requests: # for devices
     - name: req0
       exactly:
-      - deviceClassName: resource.example.com
+        deviceClassName: resource.example.com
         capacity:
           requests: # for resources which must be provided by those devices
             memory: 10Gi

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -653,7 +653,7 @@ spec:
       requests:
       - name: req-0
         exactly:
-        - deviceClassName: resource.example.com
+          deviceClassName: resource.example.com
           capacity:
             requests:
               bandwidth: 1G

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -825,7 +825,12 @@ metadata:
 spec:
   driver: dra.example.com
   nodeSelector:
-    accelerator-type: high-performance
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: accelerator-type
+        operator: In
+        values:
+        - "high-performance"
   pool:
     name: gpu-pool
     generation: 1

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -291,7 +291,7 @@ spec:
       size:
         string: "large"
       cat:
-        boolean: true
+        bool: true
 ```
 This ResourceSlice is managed by the `resource-driver.example.com` driver in the
 `black-cat-pool` pool. The `allNodes: true` field indicates that any node in the


### PR DESCRIPTION
### Description

#### Commit 1

https://github.com/kubernetes/kubernetes/blob/2fc2c0a38df83f892d6c1010646ab1c4d2c7d95f/staging/src/k8s.io/api/resource/v1/types.go#L581-L586

```

	// BoolValue is a true/false value.
	//
	// +optional
	// +oneOf=ValueType
	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
```

#### Commit 2

https://github.com/kubernetes/kubernetes/blob/2fc2c0a38df83f892d6c1010646ab1c4d2c7d95f/staging/src/k8s.io/api/resource/v1/types.go#L783-L791
```
type DeviceRequest struct {
...
	// Exactly specifies the details for a single request that must
	// be met exactly for the request to be satisfied.
	//
	// One of Exactly or FirstAvailable must be set.
	//
	// +optional
	// +oneOf=deviceRequestType
	Exactly *ExactDeviceRequest `json:"exactly,omitempty" protobuf:"bytes,2,name=exactly"`
...
}

// ExactDeviceRequest is a request for one or more identical devices.
type ExactDeviceRequest struct {
	// DeviceClassName references a specific DeviceClass, which can define
	// additional configuration and selectors to be inherited by this
	// request.
	//
	// A DeviceClassName is required.
	//
	// Administrators may use this to restrict which devices may get
	// requested by only installing classes with selectors for permitted
	// devices. If users are free to request anything without restrictions,
	// then administrators can create an empty DeviceClass for users
	// to reference.
	//
	// +required
	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,1,name=deviceClassName"`
...
```

#### Commit 3

https://github.com/kubernetes/kubernetes/blob/2fc2c0a38df83f892d6c1010646ab1c4d2c7d95f/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable.yaml#L11-L17

```
// A node selector represents the union of the results of one or more label queries
// over a set of nodes; that is, it represents the OR of the selectors represented
// by the node selector terms.
// +structType=atomic
type NodeSelector struct {
	// Required. A list of node selector terms. The terms are ORed.
	// +listType=atomic
	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms" protobuf:"bytes,1,rep,name=nodeSelectorTerms"`
}

// A null or empty node selector term matches no objects. The requirements of
// them are ANDed.
// The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
// +structType=atomic
type NodeSelectorTerm struct {
	// A list of node selector requirements by node's labels.
	// +optional
	// +listType=atomic
	MatchExpressions []NodeSelectorRequirement `json:"matchExpressions,omitempty" protobuf:"bytes,1,rep,name=matchExpressions"`
	// A list of node selector requirements by node's fields.
	// +optional
	// +listType=atomic
	MatchFields []NodeSelectorRequirement `json:"matchFields,omitempty" protobuf:"bytes,2,rep,name=matchFields"`
}
```


### Issue

also many examples in k/k

https://github.com/kubernetes/kubernetes/blob/0e014fc8dd5312a5a0344005257946692061ac49/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable.yaml#L34

Closes: None

Using the wrong example, you will get the error below:

> [root@paco ~]# kubectl apply -f resourceslices.yaml
> Error from server (BadRequest): error when creating "resourceslices.yaml": ResourceSlice in version "v1" cannot be handled as a ResourceSlice: strict decoding error: unknown field "spec.devices[0].attributes.cat.boolean"
> 
> [root@paco ~]# kubectl apply -f template3.yaml
> Error from server (BadRequest): error when creating "template3.yaml": ResourceClaimTemplate in version "v1" cannot be handled as a ResourceClaimTemplate: json: cannot unmarshal array into Go struct field DeviceRequest.spec.spec.devices.requests.exactly of type v1.ExactDeviceRequest
>
> [root@paco ~]# kubectl apply -f resourceslices4.yaml
> Error from server (BadRequest): error when creating "resourceslices4.yaml": ResourceSlice in version "v1" cannot be handled as a ResourceSlice: strict decoding error: unknown field "spec.nodeSelector.accelerator-type"