### PR TITLE
fix typo in expose-external-ip-address.md

### DIFF
--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -79,7 +79,7 @@ external IP address.
 
    {{< note >}}
 
-   The `type=LoadBalancer` service is backed by external cloud providers, which is not covered in this example, please refer to [this page](/docs/concepts/services-networking/service/#loadbalancer) for the details.
+   The `type=LoadBalancer` service is backed by external cloud providers, which is not covered in this example. Please refer to [Service](/docs/concepts/services-networking/service/#loadbalancer) for the details.
 
    {{< /note >}}
 
@@ -153,7 +153,7 @@ external IP address.
 
    The response to a successful request is a hello message:
 
-   ```shell
+   ```console
    Hello, world!
    Version: 2.0.0
    Hostname: 0bd46b45f32f


### PR DESCRIPTION
1. change type "shell" to "console" because it is an output . I changed it to "console" only because in the previous part of this file the author used "console".
2. replace "this page" with "Service" - according to : https://kubernetes.io/docs/contribute/style/style-guide/#links .