### PR TITLE
[en] Add missing namespace in resize-container-resources

### DIFF
--- a/content/en/examples/pods/resource/pod-resize.yaml
+++ b/content/en/examples/pods/resource/pod-resize.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: resize-demo
+  namespace: qos-example
 spec:
   containers:
   - name: pause


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
- Fix missing namespace `qos-example` in `resize-container-resources`.
- I found the namespace `qos-example` mentioned [here](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/#:~:text=%23%20Alternative%20methods%3A,resize%20%2D%2Dserver%2Dside), but it was not defined before.
- Link: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

None