### PR TITLE
Update redirects.js

### DIFF
--- a/static/js/redirects.js
+++ b/static/js/redirects.js
@@ -15,7 +15,7 @@ $( document ).ready(function() {
      */
     var forwardingRules = [];
 
-    var getMatcharyByRule = (rule) => {
+    var getMatchArrayByRule = (rule) => {
       var re = new RegExp(rule.pattern, 'g');
       return re.exec(forwardingURL);
     };
@@ -24,7 +24,7 @@ $( document ).ready(function() {
         if (forwardingURL.indexOf(rule.from) > -1) {
             var newURL = rule.to;
             var matchary;
-            if (rule.postfix && (matchary = getMatcharyByRule(rule))) {
+            if (rule.postfix && (matchary = getMatchArrayByRule(rule))) {
                 newURL += rule.postfix.replace("<token>", matchary[1]);
             }
             notHere = true;

--- a/static/js/redirects.js
+++ b/static/js/redirects.js
@@ -1,10 +1,8 @@
 $( document ).ready(function() {
-    var doRedirect = false;
     var notHere = false;
     var forwardingURL = window.location.href;
 
-    var oldURLs = ["/README.md","/README.html","/index.md",".html",".md"];
-
+    
     /* var:  forwardingRules
      * type: array of objects
      * example rule object:
@@ -17,12 +15,16 @@ $( document ).ready(function() {
      */
     var forwardingRules = [];
 
+    var getMatcharyByRule = (rule) => {
+      var re = new RegExp(rule.pattern, 'g');
+      return re.exec(forwardingURL);
+    };
+
     forwardingRules.forEach(function(rule) {
         if (forwardingURL.indexOf(rule.from) > -1) {
             var newURL = rule.to;
-            var re = new RegExp(rule.pattern, 'g');
-            var matchary = re.exec(forwardingURL);
-            if (matchary !== null && rule.postfix) {
+            var matchary;
+            if (rule.postfix && (matchary = getMatcharyByRule(rule))) {
                 newURL += rule.postfix.replace("<token>", matchary[1]);
             }
             notHere = true;
@@ -32,6 +34,9 @@ $( document ).ready(function() {
     });
 
     if (!notHere) {
+        var oldURLs = ["/README.md","/README.html","/index.md",".html",".md"];
+        var doRedirect = false;
+
         for (var i = 0; i < oldURLs.length; i++) {
             if (forwardingURL.indexOf(oldURLs[i]) > -1 &&
                     forwardingURL.indexOf("404.html") < 0){


### PR DESCRIPTION
Avoiding redundant operation

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Moved `oldURLs` and `doRedirect` variables inside block when `notHere` is true, because we do not use them outside and created `getMatcharyByRule` function where we apply regex for `forwardingURL` in this case first of all will be checked if `rule.postfix` is true and only afterwords exec regex for `forwardingURL`, so by this changes we can avoid redundant operation regex if `rule.postfix` is false.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #