### PR TITLE
Update training.css

### DIFF
--- a/static/css/training.css
+++ b/static/css/training.css
@@ -26,8 +26,7 @@ body.cid-training section.call-to-action .main-section > div.call-to-action {
   justify-content: center;
   align-items: center;
   margin: initial;
-  padding-top: 5rem;
-  padding-bottom: 5rem;
+  padding-block: 5rem;
 }
 
 body.cid-training section.call-to-action .main-section > div.call-to-action > div {
@@ -40,8 +39,7 @@ body.cid-training section.call-to-action .main-section .cta-text {
 }
 
 body.cid-training section.call-to-action .main-section .cta-text > * {
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
   text-align: center;
   /* if max() and min() are available, use them */
   min-width: min(20em, 50vw);


### PR DESCRIPTION
Changed top and bottom to block and right left to inline to decrease size of css

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

in **css** when `-top` and `-bottom` are equal we can change it to `-block`, this statement will be include both and by this changes we can decrease size of **css** file. The same for `-left` and `-right` is `-inline`.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #