### PR TITLE
Fix grammatical errors and improve clarity in names.md

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -34,9 +34,9 @@ In cases when objects represent a physical entity, like a Node representing a ph
 
 The server may generate a name when `generateName` is provided instead of `name` in a resource create request.
 When `generateName` is used, the provided value is used as a name prefix, which server appends a generated suffix
-to. Even though the name is generated, it may conflict with existing names resulting in a HTTP 409 response. This
-became far less likely to happen in Kubernetes v1.31 and later, since the server will make up to 8 attempt to generate a
-unique name before returning a HTTP 409 response.
+to. Even though the name is generated, it may conflict with existing names resulting in an HTTP 409 response. This
+became far less likely to happen in Kubernetes v1.31 and later, since the server will make up to 8 attempts to generate a
+unique name before returning an HTTP 409 response.
 
 Below are four types of commonly used name constraints for resources.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description


 Fixed grammatical errors and improved clarity in the `names.md` documentation file. The changes include:

1. Corrected "attempt" to "attempts" for proper subject-verb agreement in the section describing name generation in Kubernetes v1.31 and later.
2. Changed "a HTTP 409 response" to "an HTTP 409 response" for correct article usage.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #