### PR TITLE
docs(es): Fix broken link in statefulset tutorial

### DIFF
--- a/content/es/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/es/docs/concepts/workloads/controllers/statefulset.md
@@ -36,7 +36,7 @@ proporcione un conjunto de réplicas sin estado, como un
 
 ## Limitaciones
 
-* El almacenamiento de un determinado Pod debe provisionarse por un [Provisionador de PersistentVolume](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/README.md) basado en la `storage class` requerida, o pre-provisionarse por un administrador.
+* El almacenamiento de un determinado Pod debe provisionarse por un [Provisionador de PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) basado en la `storage class` requerida, o pre-provisionarse por un administrador.
 * Eliminar y/o reducir un StatefulSet *no* eliminará los volúmenes asociados con el StatefulSet. Este comportamiento es intencional y sirve para garantizar la seguridad de los datos, que da más valor que la purga automática de los recursos relacionados del StatefulSet.
 * Los StatefulSets actualmente necesitan un [Servicio Headless](/docs/concepts/services-networking/service/#headless-services) como responsable de la identidad de red de los Pods. Es tu responsabilidad crear este Service.
 * Los StatefulSets no proporcionan ninguna garantía de la terminación de los pods cuando se elimina un StatefulSet. Para conseguir un término de los pods ordenado y controlado en el StatefulSet, es posible reducir el StatefulSet a 0 réplicas justo antes de eliminarlo.


### PR DESCRIPTION
This PR updates a broken link in the Spanish statefulset tutorial (`statefulset.md`). The old link pointed to a README file in the now-removed examples directory.

Fixes kubernetes/kubernetes#134305