### PR TITLE
fix: remove unnecessary "and"

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -76,7 +76,7 @@ operator to use or manage a cluster.
 
 * [kubeconfig (v1)](/docs/reference/config-api/kubeconfig.v1/)
 * [kuberc (v1alpha1)](/docs/reference/config-api/kuberc.v1alpha1/) and
-  [kuberc (v1beta1)](/docs/reference/config-api/kuberc.v1beta1/) and
+  [kuberc (v1beta1)](/docs/reference/config-api/kuberc.v1beta1/)
 * [kube-apiserver admission (v1)](/docs/reference/config-api/apiserver-admission.v1/)
 * [kube-apiserver configuration (v1alpha1)](/docs/reference/config-api/apiserver-config.v1alpha1/) and
   [kube-apiserver configuration (v1beta1)](/docs/reference/config-api/apiserver-config.v1beta1/) and


### PR DESCRIPTION
fix typo: remove unnecessary "and" at the end of a sentence