### PR TITLE
Update Vietnamese to support Docsy-style menus

### DIFF
--- a/content/vi/blog/_index.md
+++ b/content/vi/blog/_index.md
@@ -1,10 +1,4 @@
 ---
 title: Kubernetes Blog
 linkTitle: Blog
-menu:
-  main:
-    title: "Blog"
-    weight: 40
-    post: >
-       <p>Đọc những tin tức mới nhất về Kubernetes, container và nhận được những hướng dẫn kỹ thuật hữu ích.</p>
 ---

--- a/content/vi/case-studies/_index.html
+++ b/content/vi/case-studies/_index.html
@@ -7,8 +7,5 @@ layout: basic
 class: gridPage
 body_class: caseStudies
 cid: caseStudies
-menu:
-  main:
-    weight: 60
 ---
 

--- a/content/vi/community/_index.html
+++ b/content/vi/community/_index.html
@@ -2,6 +2,9 @@
 title: Community
 layout: basic
 cid: community
+menu:
+  main:
+    weight: 50
 ---
 
 <div class="newcommunitywrapper">

--- a/content/vi/docs/home/_index.md
+++ b/content/vi/docs/home/_index.md
@@ -10,10 +10,8 @@ weight: 10
 hide_feedback: true
 menu:
   main:
-    title: "Tài liệu tham khảo"
-    weight: 20
-    post: >
-      <p>Tìm hiểu cách sử dụng Kubernetes với mức khái niệm, các hướng dẫn và tài liệu tham khảo. Bạn thậm chí có thể <a href="/editdocs/" data-auto-burger-exclude>đóng góp cho các tài liệu</a>!</p>
+    title: "Tài liệu"
+    weight: 10
 overview: >
   Kubernetes là một công cụ điều phối container mã nguồn mở giúp tự động hóa triển khai, nhân rộng và quản lý các ứng dụng containerization. Dự án mã nguồn mở được host bởi Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
 cards:

--- a/content/vi/partners/_index.html
+++ b/content/vi/partners/_index.html
@@ -4,6 +4,9 @@ bigheader: Các đối tác của Kubernetes
 abstract: Phát triển hệ sinh thái Kubernetes.
 class: gridPage
 cid: partners
+menu:
+  main:
+    weight: 40
 ---
 
 <section id="users">


### PR DESCRIPTION
### Description

Update the front matter for Vietnamese pages so that if we align more with Docsy, the top nav still works how we want. Currently, the top nav sections are hard coded:
- https://github.com/kubernetes/website/blob/7fe1afd6140c97a2c6c5c30d5a0124f551a92e89/layouts/partials/navbar.html#L28
- https://github.com/kubernetes/website/blob/7fe1afd6140c97a2c6c5c30d5a0124f551a92e89/layouts/404.html#L9 

[Original](https://k8s.io/vi/) vs [preview](https://deploy-preview-52595--kubernetes-io-main-staging.netlify.app/vi/) (no visible difference; this is an enabling change)

### Issue

Helps with issues https://github.com/kubernetes/website/issues/41171 and https://github.com/kubernetes/website/issues/50228

/area localization