### PR TITLE
Fix guestbook redis image

### DIFF
--- a/content/bn/examples/application/guestbook/redis-leader-deployment.yaml
+++ b/content/bn/examples/application/guestbook/redis-leader-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: "docker.io/redis:6.0.5"
+        image: "registry.k8s.io/redis:v1.7.9"
         resources:
           requests:
             cpu: 100m

--- a/content/en/examples/application/guestbook/redis-leader-deployment.yaml
+++ b/content/en/examples/application/guestbook/redis-leader-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: "docker.io/redis:6.0.5"
+        image: "registry.k8s.io/redis:v1.7.9"
         resources:
           requests:
             cpu: 100m

--- a/content/es/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/es/docs/concepts/workloads/controllers/statefulset.md
@@ -36,7 +36,7 @@ proporcione un conjunto de réplicas sin estado, como un
 
 ## Limitaciones
 
-* El almacenamiento de un determinado Pod debe provisionarse por un [Provisionador de PersistentVolume](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/README.md) basado en la `storage class` requerida, o pre-provisionarse por un administrador.
+* El almacenamiento de un determinado Pod debe provisionarse por un [Provisionador de PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) basado en la `storage class` requerida, o pre-provisionarse por un administrador.
 * Eliminar y/o reducir un StatefulSet *no* eliminará los volúmenes asociados con el StatefulSet. Este comportamiento es intencional y sirve para garantizar la seguridad de los datos, que da más valor que la purga automática de los recursos relacionados del StatefulSet.
 * Los StatefulSets actualmente necesitan un [Servicio Headless](/docs/concepts/services-networking/service/#headless-services) como responsable de la identidad de red de los Pods. Es tu responsabilidad crear este Service.
 * Los StatefulSets no proporcionan ninguna garantía de la terminación de los pods cuando se elimina un StatefulSet. Para conseguir un término de los pods ordenado y controlado en el StatefulSet, es posible reducir el StatefulSet a 0 réplicas justo antes de eliminarlo.

--- a/content/hi/examples/application/guestbook/redis-leader-deployment.yaml
+++ b/content/hi/examples/application/guestbook/redis-leader-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: "docker.io/redis:6.0.5"
+        image: "registry.k8s.io/redis:v1.7.9"
         resources:
           requests:
             cpu: 100m

--- a/content/ko/examples/application/guestbook/redis-leader-deployment.yaml
+++ b/content/ko/examples/application/guestbook/redis-leader-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: "docker.io/redis:6.0.5"
+        image: "registry.k8s.io/redis:v1.7.9"
         resources:
           requests:
             cpu: 100m

--- a/content/ru/examples/application/guestbook/redis-leader-deployment.yaml
+++ b/content/ru/examples/application/guestbook/redis-leader-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: "docker.io/redis:6.0.5"
+        image: "registry.k8s.io/redis:v1.7.9"
         resources:
           requests:
             cpu: 100m

--- a/content/zh-cn/examples/application/guestbook/redis-leader-deployment.yaml
+++ b/content/zh-cn/examples/application/guestbook/redis-leader-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: "docker.io/redis:6.0.5"
+        image: "registry.k8s.io/redis:v1.7.9"
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Fixes #52427

This PR updates the container image for Redis in the PHP Guestbook example.

* The previous image, `docker.io/redis:6.0.5`, is outdated and no longer available at that location, which causes deployment failures (`ImagePullBackOff`).
* This is replaced with a current, official image from the Kubernetes registry: `registry.k8s.io/redis:v1.7.9`.
* The fix has been applied to all available translations of the example file (`en`, `ru`, `hi`, `ko`, `bn`, `zh-cn`) for consistency.