### PR TITLE
docs: Fix RFC 1123 label names documentation

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -59,8 +59,13 @@ This means the name must:
 
 - contain at most 63 characters
 - contain only lowercase alphanumeric characters or '-'
-- start with an alphanumeric character
+- start with an alphabetic character
 - end with an alphanumeric character
+
+{{< note >}}
+When the `RelaxedServiceNameValidation` feature gate is enabled,
+Service object names are allowed to start with a digit.
+{{< /note >}}
 
 ### RFC 1035 Label Names
 
@@ -74,10 +79,10 @@ This means the name must:
 - end with an alphanumeric character
 
 {{< note >}}
-The only difference between the RFC 1035 and RFC 1123
-label standards is that RFC 1123 labels are allowed to
-start with a digit, whereas RFC 1035 labels can start
-with a lowercase alphabetic character only.
+While RFC 1123 technically allows labels to start with digits, the current
+Kubernetes implementation requires both RFC 1035 and RFC 1123 labels to start
+with an alphabetic character. The exception is when the `RelaxedServiceNameValidation`
+feature gate is enabled for Service objects, which allows Service names to start with digits.
 {{< /note >}}
 
 ### Path Segment Names


### PR DESCRIPTION
Correct RFC 1123 label names to require starting with alphabetic character to match the actual Kubernetes implementation regex [a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?.

Add note about RelaxedServiceNameValidation feature gate exception for Services.

Update explanation of RFC differences to reflect actual implementation where both RFC 1035 and RFC 1123 require starting with alphabetic characters, with the exception being the RelaxedServiceNameValidation feature gate for Service objects.

This addresses issue 52578.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #