### PR TITLE
Update job.md to fix dead link to spark example

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -1186,7 +1186,7 @@ of custom controller for those Pods. This allows the most flexibility, but may b
 complicated to get started with and offers less integration with Kubernetes.
 
 One example of this pattern would be a Job which starts a Pod which runs a script that in turn
-starts a Spark master controller (see [spark example](https://github.com/kubernetes/examples/tree/master/staging/spark/README.md)),
+starts a Spark master controller (see [spark example](https://github.com/kubernetes/examples/tree/master/_archived/spark/README.md)),
 runs a spark driver, and then cleans up.
 
 An advantage of this approach is that the overall process gets the completion guarantee of a Job


### PR DESCRIPTION
### Description

Link to spark example points to a location which seems to have been moved to `_archived/` folder in that repo.
