### PR TITLE
Fix typo in horizontal pod autoscale documentation

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -418,7 +418,7 @@ and [the walkthrough for using external metrics](/docs/tasks/run-application/hor
 If you use the `v2` HorizontalPodAutoscaler API, you can use the `behavior` field
 (see the [API reference](/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec))
 to configure separate scale-up and scale-down behaviors.
-You specify these behaviours by setting `scaleUp` and / or `scaleDown`
+You specify these behaviors by setting `scaleUp` and / or `scaleDown`
 under the `behavior` field.
 
 Scaling policies let you control the rate of change of replicas while scaling.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Change "behaviour" to "behavior" to match U.S English

https://kubernetes.io/docs/contribute/style/style-guide/#language