### PR TITLE
Update resource API 1.34 with enum values

### DIFF
--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
@@ -64,7 +64,7 @@ TokenRequestSpec contains client provided parameters of a token request.
 
   *Atomic: will be replaced during a merge*
   
-  Audiences are the intended audiences of the token. A recipient of a token must identify themself with an identifier in the list of audiences of the token, and otherwise should reject the token. A token issued for multiple audiences may be used to authenticate against any of the audiences listed but implies a high degree of trust between the target audiences.
+  Audiences are the intendend audiences of the token. A recipient of a token must identify themself with an identifier in the list of audiences of the token, and otherwise should reject the token. A token issued for multiple audiences may be used to authenticate against any of the audiences listed but implies a high degree of trust between the target audiences.
 
 - **boundObjectRef** (BoundObjectReference)
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
@@ -113,6 +113,10 @@ NamespaceStatus is information about the current status of a Namespace.
 - **phase** (string)
 
   Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+  
+  Possible enum values:
+   - `"Active"` means the namespace is available for use in the system
+   - `"Terminating"` means the namespace is undergoing graceful termination
 
 
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
@@ -124,6 +124,11 @@ NodeSpec describes the attributes that a node is created with.
   - **taints.effect** (string), required
 
     Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+    
+    Possible enum values:
+     - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+     - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+     - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
 
   - **taints.key** (string), required
 
@@ -444,6 +449,11 @@ NodeStatus is information about the current status of a node.
 - **phase** (string)
 
   NodePhase is the recently observed lifecycle phase of the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#phase The field is never populated, and now is deprecated.
+  
+  Possible enum values:
+   - `"Pending"` means the node has been created/added by the system, but not configured.
+   - `"Running"` means the node has been configured and has Kubernetes components running.
+   - `"Terminated"` means the node has been removed from the cluster.
 
 - **runtimeHandlers** ([]NodeRuntimeHandler)
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
@@ -85,6 +85,10 @@ RuntimeClass defines a class of container runtime supported in the cluster. The 
     - **scheduling.tolerations.operator** (string)
 
       Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+      
+      Possible enum values:
+       - `"Equal"`
+       - `"Exists"`
 
     - **scheduling.tolerations.value** (string)
 
@@ -93,6 +97,11 @@ RuntimeClass defines a class of container runtime supported in the cluster. The 
     - **scheduling.tolerations.effect** (string)
 
       Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+      
+      Possible enum values:
+       - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+       - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+       - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
 
     - **scheduling.tolerations.tolerationSeconds** (int64)
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
@@ -37,6 +37,14 @@ A node selector requirement is a selector that contains values, a key, and an op
 - **operator** (string), required
 
   Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+  
+  Possible enum values:
+   - `"DoesNotExist"`
+   - `"Exists"`
+   - `"Gt"`
+   - `"In"`
+   - `"Lt"`
+   - `"NotIn"`
 
 - **values** ([]string)
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1.md
@@ -96,6 +96,10 @@ PersistentVolumeClaimSpec describes the common attributes of storage devices and
 - **volumeMode** (string)
 
   volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+  
+  Possible enum values:
+   - `"Block"` means the volume will not be formatted with a filesystem and will remain a raw block device.
+   - `"Filesystem"` means the volume will be or is formatted with a filesystem.
 
 
 
@@ -269,6 +273,11 @@ PersistentVolumeClaimStatus is the current status of a persistent volume claim.
       Infeasible indicates that the request has been rejected as invalid by the CSI driver. To
     	  resolve the error, a valid VolumeAttributesClass needs to be specified.
     Note: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.
+    
+    Possible enum values:
+     - `"InProgress"` InProgress indicates that the volume is being modified
+     - `"Infeasible"` Infeasible indicates that the request has been rejected as invalid by the CSI driver. To resolve the error, a valid VolumeAttributesClass needs to be specified
+     - `"Pending"` Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as the specified VolumeAttributesClass not existing
 
   - **modifyVolumeStatus.targetVolumeAttributesClassName** (string)
 
@@ -277,6 +286,11 @@ PersistentVolumeClaimStatus is the current status of a persistent volume claim.
 - **phase** (string)
 
   phase represents the current phase of PersistentVolumeClaim.
+  
+  Possible enum values:
+   - `"Bound"` used for PersistentVolumeClaims that are bound
+   - `"Lost"` used for PersistentVolumeClaims that lost their underlying PersistentVolume. The claim was bound to a PersistentVolume and this volume does not exist any longer and all data on it was lost.
+   - `"Pending"` used for PersistentVolumeClaims that are not yet bound
 
 
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -118,6 +118,11 @@ PersistentVolumeSpec is the specification of a persistent volume.
 - **persistentVolumeReclaimPolicy** (string)
 
   persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+  
+  Possible enum values:
+   - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+   - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+   - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
 
 - **storageClassName** (string)
 
@@ -130,6 +135,10 @@ PersistentVolumeSpec is the specification of a persistent volume.
 - **volumeMode** (string)
 
   volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
+  
+  Possible enum values:
+   - `"Block"` means the volume will not be formatted with a filesystem and will remain a raw block device.
+   - `"Filesystem"` means the volume will be or is formatted with a filesystem.
 
 
 
@@ -150,6 +159,16 @@ PersistentVolumeSpec is the specification of a persistent volume.
   - **hostPath.type** (string)
 
     type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+    
+    Possible enum values:
+     - `""` For backwards compatible, leave it empty if unset
+     - `"BlockDevice"` A block device must exist at the given path
+     - `"CharDevice"` A character device must exist at the given path
+     - `"Directory"` A directory must exist at the given path
+     - `"DirectoryOrCreate"` If nothing exists at the given path, an empty directory will be created there as needed with file mode 0755, having the same group and ownership with Kubelet.
+     - `"File"` A file must exist at the given path
+     - `"FileOrCreate"` If nothing exists at the given path, an empty file will be created there as needed with file mode 0644, having the same group and ownership with Kubelet.
+     - `"Socket"` A UNIX socket must exist at the given path
 
 - **local** (LocalVolumeSource)
 
@@ -212,6 +231,11 @@ PersistentVolumeSpec is the specification of a persistent volume.
   - **azureDisk.cachingMode** (string)
 
     cachingMode is the Host Caching mode: None, Read Only, Read Write.
+    
+    Possible enum values:
+     - `"None"`
+     - `"ReadOnly"`
+     - `"ReadWrite"`
 
   - **azureDisk.fsType** (string)
 
@@ -220,6 +244,11 @@ PersistentVolumeSpec is the specification of a persistent volume.
   - **azureDisk.kind** (string)
 
     kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+    
+    Possible enum values:
+     - `"Dedicated"`
+     - `"Managed"`
+     - `"Shared"`
 
   - **azureDisk.readOnly** (boolean)
 
@@ -890,6 +919,13 @@ PersistentVolumeStatus is the current status of a persistent volume.
 - **phase** (string)
 
   phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
+  
+  Possible enum values:
+   - `"Available"` used for PersistentVolumes that are not yet bound Available volumes are held by the binder and matched to PersistentVolumeClaims
+   - `"Bound"` used for PersistentVolumes that are bound
+   - `"Failed"` used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+   - `"Pending"` used for PersistentVolumes that are not available
+   - `"Released"` used for PersistentVolumes where the bound PersistentVolumeClaim was deleted released volumes must be recycled before becoming available again this phase is used by the persistent volume claim binder to signal to another process to reclaim the resource
 
 - **reason** (string)
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1.md
@@ -93,10 +93,19 @@ StorageClasses are non-namespaced; the name of the storage class according to et
 - **reclaimPolicy** (string)
 
   reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class. Defaults to Delete.
+  
+  Possible enum values:
+   - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+   - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+   - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
 
 - **volumeBindingMode** (string)
 
   volumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
+  
+  Possible enum values:
+   - `"Immediate"` indicates that PersistentVolumeClaims should be immediately provisioned and bound. This is the default mode.
+   - `"WaitForFirstConsumer"` indicates that PersistentVolumeClaims should not be provisioned and bound until the first Pod is created that references the PeristentVolumeClaim. The volume provisioning and binding will occur during Pod scheduing.
 
 
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
@@ -354,6 +354,16 @@ Volume represents a named volume in a pod that may be accessed by any container 
   - **hostPath.type** (string)
 
     type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+    
+    Possible enum values:
+     - `""` For backwards compatible, leave it empty if unset
+     - `"BlockDevice"` A block device must exist at the given path
+     - `"CharDevice"` A character device must exist at the given path
+     - `"Directory"` A directory must exist at the given path
+     - `"DirectoryOrCreate"` If nothing exists at the given path, an empty directory will be created there as needed with file mode 0755, having the same group and ownership with Kubelet.
+     - `"File"` A file must exist at the given path
+     - `"FileOrCreate"` If nothing exists at the given path, an empty file will be created there as needed with file mode 0644, having the same group and ownership with Kubelet.
+     - `"Socket"` A UNIX socket must exist at the given path
 
 ### Persistent volumes
 
@@ -401,6 +411,11 @@ Volume represents a named volume in a pod that may be accessed by any container 
   - **azureDisk.cachingMode** (string)
 
     cachingMode is the Host Caching mode: None, Read Only, Read Write.
+    
+    Possible enum values:
+     - `"None"`
+     - `"ReadOnly"`
+     - `"ReadWrite"`
 
   - **azureDisk.fsType** (string)
 
@@ -409,6 +424,11 @@ Volume represents a named volume in a pod that may be accessed by any container 
   - **azureDisk.kind** (string)
 
     kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+    
+    Possible enum values:
+     - `"Dedicated"`
+     - `"Managed"`
+     - `"Shared"`
 
   - **azureDisk.readOnly** (boolean)
 
@@ -741,6 +761,11 @@ Volume represents a named volume in a pod that may be accessed by any container 
   - **image.pullPolicy** (string)
 
     Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+    
+    Possible enum values:
+     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
 
   - **image.reference** (string)
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -187,7 +187,7 @@ CustomResourceDefinitionSpec describes how a user wants their resource to appear
 
     - **versions.selectableFields.jsonPath** (string), required
 
-      jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metadata fields. Required.
+      jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metdata fields. Required.
 
   - **versions.subresources** (CustomResourceSubresources)
 
@@ -602,6 +602,12 @@ JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-sc
   - **x-kubernetes-validations.reason** (string)
 
     reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule. The HTTP status code returned to the caller will match the reason of the reason of the first failed validation rule. The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate". If not set, default to use "FieldValueInvalid". All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+    
+    Possible enum values:
+     - `"FieldValueDuplicate"` is used to report collisions of values that must be unique (e.g. unique IDs).
+     - `"FieldValueForbidden"` is used to report valid (as per formatting rules) values which would be accepted under some conditions, but which are not permitted by the current conditions (such as security policy).
+     - `"FieldValueInvalid"` is used to report malformed values (e.g. failed regex match, too long, out of bounds).
+     - `"FieldValueRequired"` is used to report required values that are not provided (e.g. empty strings, null values, or empty arrays).
 
 
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/device-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/device-class-v1.md
@@ -66,7 +66,7 @@ DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and h
 
   *Atomic: will be replaced during a merge*
   
-  Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.
+  Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.
   
   They are passed to the driver, but are not considered while allocating the claim.
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
@@ -116,10 +116,20 @@ MutatingWebhookConfiguration describes the configuration of and admission webhoo
   - **webhooks.sideEffects** (string), required
 
     SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission chain and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+    
+    Possible enum values:
+     - `"None"` means that calling the webhook will have no side effects.
+     - `"NoneOnDryRun"` means that calling the webhook will possibly have side effects, but if the request being reviewed has the dry-run attribute, the side effects will be suppressed.
+     - `"Some"` means that calling the webhook will possibly have side effects. If a request with the dry-run attribute would trigger a call to this webhook, the request will instead fail.
+     - `"Unknown"` means that no information is known about the side effects of calling the webhook. If a request with the dry-run attribute would trigger a call to this webhook, the request will instead fail.
 
   - **webhooks.failurePolicy** (string)
 
     FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+    
+    Possible enum values:
+     - `"Fail"` means that an error calling the webhook causes the admission to fail.
+     - `"Ignore"` means that an error calling the webhook is ignored.
 
   - **webhooks.matchConditions** ([]MatchCondition)
 
@@ -166,6 +176,10 @@ MutatingWebhookConfiguration describes the configuration of and admission webhoo
     - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
     
     Defaults to "Equivalent"
+    
+    Possible enum values:
+     - `"Equivalent"` means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
+     - `"Exact"` means requests should only be sent to the webhook if they exactly match a given rule.
 
   - **webhooks.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
@@ -116,10 +116,20 @@ ValidatingWebhookConfiguration describes the configuration of and admission webh
   - **webhooks.sideEffects** (string), required
 
     SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission chain and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+    
+    Possible enum values:
+     - `"None"` means that calling the webhook will have no side effects.
+     - `"NoneOnDryRun"` means that calling the webhook will possibly have side effects, but if the request being reviewed has the dry-run attribute, the side effects will be suppressed.
+     - `"Some"` means that calling the webhook will possibly have side effects. If a request with the dry-run attribute would trigger a call to this webhook, the request will instead fail.
+     - `"Unknown"` means that no information is known about the side effects of calling the webhook. If a request with the dry-run attribute would trigger a call to this webhook, the request will instead fail.
 
   - **webhooks.failurePolicy** (string)
 
     FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+    
+    Possible enum values:
+     - `"Fail"` means that an error calling the webhook causes the admission to fail.
+     - `"Ignore"` means that an error calling the webhook is ignored.
 
   - **webhooks.matchConditions** ([]MatchCondition)
 
@@ -166,6 +176,10 @@ ValidatingWebhookConfiguration describes the configuration of and admission webh
     - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
     
     Defaults to "Equivalent"
+    
+    Possible enum values:
+     - `"Equivalent"` means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
+     - `"Exact"` means requests should only be sent to the webhook if they exactly match a given rule.
 
   - **webhooks.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/mutating-admission-policy-binding-v1alpha1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/mutating-admission-policy-binding-v1alpha1.md
@@ -118,6 +118,10 @@ Adding/removing policies, bindings, or params can not affect whether a given (po
       - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, the admission policy **does** consider requests made to apps/v1beta1 or extensions/v1beta1 API groups. The API server translates the request to a matched resource API if necessary.
       
       Defaults to "Equivalent"
+      
+      Possible enum values:
+       - `"Equivalent"` means requests should be sent to the admission webhook or admission policy if they modify a resource listed in rules via an equivalent API group or version. For example, `autoscaling/v1` and `autoscaling/v2` HorizontalPodAutoscalers are equivalent: the same set of resources appear via both APIs.
+       - `"Exact"` means requests should only be sent to the admission webhook or admission policy if they exactly match a given rule.
 
     - **spec.matchResources.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
@@ -234,6 +238,10 @@ Adding/removing policies, bindings, or params can not affect whether a given (po
       `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
       
       Allowed values are `Allow` or `Deny` Default to `Deny`
+      
+      Possible enum values:
+       - `"Allow"` Ignore means that an error finding params for a binding is ignored
+       - `"Deny"` Fail means that an error finding params for a binding is ignored
 
     - **spec.paramRef.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
@@ -285,6 +293,10 @@ MutatingAdmissionPolicy describes the definition of an admission mutation policy
     failurePolicy does not define how validations that evaluate to false are handled.
     
     Allowed values are Ignore or Fail. Defaults to Fail.
+    
+    Possible enum values:
+     - `"Fail"` means that an error calling the admission webhook or admission policy causes resource admission to fail.
+     - `"Ignore"` means that an error calling the admission webhook or admission policy is ignored.
 
   - **spec.matchConditions** ([]MatchCondition)
 
@@ -389,6 +401,10 @@ MutatingAdmissionPolicy describes the definition of an admission mutation policy
       - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, the admission policy **does** consider requests made to apps/v1beta1 or extensions/v1beta1 API groups. The API server translates the request to a matched resource API if necessary.
       
       Defaults to "Equivalent"
+      
+      Possible enum values:
+       - `"Equivalent"` means requests should be sent to the admission webhook or admission policy if they modify a resource listed in rules via an equivalent API group or version. For example, `autoscaling/v1` and `autoscaling/v2` HorizontalPodAutoscalers are equivalent: the same set of resources appear via both APIs.
+       - `"Exact"` means requests should only be sent to the admission webhook or admission policy if they exactly match a given rule.
 
     - **spec.matchConstraints.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
@@ -489,6 +505,11 @@ MutatingAdmissionPolicy describes the definition of an admission mutation policy
     - **spec.mutations.patchType** (string), required
 
       patchType indicates the patch strategy used. Allowed values are "ApplyConfiguration" and "JSONPatch". Required.
+      
+      
+      Possible enum values:
+       - `"ApplyConfiguration"` ApplyConfiguration indicates that the mutation is using apply configuration to mutate the object.
+       - `"JSONPatch"` JSONPatch indicates that the object is mutated through JSON Patch.
 
     - **spec.mutations.applyConfiguration** (ApplyConfiguration)
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/mutating-admission-policy-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/mutating-admission-policy-v1beta1.md
@@ -262,6 +262,11 @@ MutatingAdmissionPolicy describes the definition of an admission mutation policy
     - **spec.mutations.patchType** (string), required
 
       patchType indicates the patch strategy used. Allowed values are "ApplyConfiguration" and "JSONPatch". Required.
+      
+      
+      Possible enum values:
+       - `"ApplyConfiguration"` ApplyConfiguration indicates that the mutation is using apply configuration to mutate the object.
+       - `"JSONPatch"` JSONPatch indicates that the object is mutated through JSON Patch.
 
     - **spec.mutations.applyConfiguration** (ApplyConfiguration)
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
@@ -136,6 +136,11 @@ NetworkPolicySpec provides the specification of a NetworkPolicy
     - **ingress.ports.protocol** (string)
 
       protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+      
+      Possible enum values:
+       - `"SCTP"` is the SCTP protocol.
+       - `"TCP"` is the TCP protocol.
+       - `"UDP"` is the UDP protocol.
 
 - **egress** ([]NetworkPolicyEgressRule)
 
@@ -207,6 +212,11 @@ NetworkPolicySpec provides the specification of a NetworkPolicy
     - **egress.ports.protocol** (string)
 
       protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+      
+      Possible enum values:
+       - `"SCTP"` is the SCTP protocol.
+       - `"TCP"` is the TCP protocol.
+       - `"UDP"` is the UDP protocol.
 
 
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1.md
@@ -89,6 +89,10 @@ PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
   AlwaysAllow policy means that all running pods (status.phase="Running"), but not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB is met. This means perspective running pods of a disrupted application might not get a chance to become healthy. Healthy pods will be subject to the PDB for eviction.
   
   Additional policies may be added in the future. Clients making eviction decisions should disallow eviction of unhealthy pods if they encounter an unrecognized policy in this field.
+  
+  Possible enum values:
+   - `"AlwaysAllow"` policy means that all running pods (status.phase="Running"), but not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB is met. This means perspective running pods of a disrupted application might not get a chance to become healthy. Healthy pods will be subject to the PDB for eviction.
+   - `"IfHealthyBudget"` policy means that running pods (status.phase="Running"), but not yet healthy can be evicted only if the guarded application is not disrupted (status.currentHealthy is at least equal to status.desiredHealthy). Healthy pods will be subject to the PDB for eviction.
 
 
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/resource-quota-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/resource-quota-v1.md
@@ -83,10 +83,25 @@ ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
     - **scopeSelector.matchExpressions.operator** (string), required
 
       Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+      
+      Possible enum values:
+       - `"DoesNotExist"`
+       - `"Exists"`
+       - `"In"`
+       - `"NotIn"`
 
     - **scopeSelector.matchExpressions.scopeName** (string), required
 
       The name of the scope that the selector applies to.
+      
+      Possible enum values:
+       - `"BestEffort"` Match all pod objects that have best effort quality of service
+       - `"CrossNamespacePodAffinity"` Match all pod objects that have cross-namespace pod (anti)affinity mentioned.
+       - `"NotBestEffort"` Match all pod objects that do not have best effort quality of service
+       - `"NotTerminating"` Match all pod objects where spec.activeDeadlineSeconds is nil
+       - `"PriorityClass"` Match all pod objects that have priority class mentioned
+       - `"Terminating"` Match all pod objects where spec.activeDeadlineSeconds >=0
+       - `"VolumeAttributesClass"` Match all pvc objects that have volume attributes class mentioned.
 
     - **scopeSelector.matchExpressions.values** ([]string)
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-binding-v1.md
@@ -118,6 +118,10 @@ The CEL expressions of a policy must have a computed CEL cost below the maximum 
       - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
       
       Defaults to "Equivalent"
+      
+      Possible enum values:
+       - `"Equivalent"` means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
+       - `"Exact"` means requests should only be sent to the webhook if they exactly match a given rule.
 
     - **spec.matchResources.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
@@ -342,6 +346,10 @@ ValidatingAdmissionPolicy describes the definition of an admission validation po
     When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
     
     Allowed values are Ignore or Fail. Defaults to Fail.
+    
+    Possible enum values:
+     - `"Fail"` means that an error calling the webhook causes the admission to fail.
+     - `"Ignore"` means that an error calling the webhook is ignored.
 
   - **spec.matchConditions** ([]MatchCondition)
 
@@ -446,6 +454,10 @@ ValidatingAdmissionPolicy describes the definition of an admission validation po
       - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
       
       Defaults to "Equivalent"
+      
+      Possible enum values:
+       - `"Equivalent"` means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
+       - `"Exact"` means requests should only be sent to the webhook if they exactly match a given rule.
 
     - **spec.matchConstraints.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/validating-admission-policy-v1.md
@@ -87,6 +87,10 @@ ValidatingAdmissionPolicy describes the definition of an admission validation po
     When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
     
     Allowed values are Ignore or Fail. Defaults to Fail.
+    
+    Possible enum values:
+     - `"Fail"` means that an error calling the webhook causes the admission to fail.
+     - `"Ignore"` means that an error calling the webhook is ignored.
 
   - **spec.matchConditions** ([]MatchCondition)
 
@@ -191,6 +195,10 @@ ValidatingAdmissionPolicy describes the definition of an admission validation po
       - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
       
       Defaults to "Equivalent"
+      
+      Possible enum values:
+       - `"Equivalent"` means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
+       - `"Exact"` means requests should only be sent to the webhook if they exactly match a given rule.
 
     - **spec.matchConstraints.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
@@ -560,6 +568,10 @@ The CEL expressions of a policy must have a computed CEL cost below the maximum 
       - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
       
       Defaults to "Equivalent"
+      
+      Possible enum values:
+       - `"Equivalent"` means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
+       - `"Exact"` means requests should only be sent to the webhook if they exactly match a given rule.
 
     - **spec.matchResources.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1.md
@@ -45,6 +45,11 @@ EndpointSlice represents a set of service endpoints. Most EndpointSlices are cre
 - **addressType** (string), required
 
   addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name. (Deprecated) The EndpointSlice controller only generates, and kube-proxy only processes, slices of addressType "IPv4" and "IPv6". No semantics are defined for the "FQDN" type.
+  
+  Possible enum values:
+   - `"FQDN"` represents a FQDN.
+   - `"IPv4"` represents an IPv4 Address.
+   - `"IPv6"` represents an IPv6 Address.
 
 - **endpoints** ([]Endpoint), required
 
@@ -149,6 +154,11 @@ EndpointSlice represents a set of service endpoints. Most EndpointSlices are cre
   - **ports.protocol** (string)
 
     protocol represents the IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+    
+    Possible enum values:
+     - `"SCTP"` is the SCTP protocol.
+     - `"TCP"` is the TCP protocol.
+     - `"UDP"` is the UDP protocol.
 
   - **ports.name** (string)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/endpoints-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/endpoints-v1.md
@@ -145,6 +145,11 @@ Deprecated: This API is deprecated in v1.33+. Use discoveryv1.EndpointSlice.
     - **subsets.ports.protocol** (string)
 
       The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+      
+      Possible enum values:
+       - `"SCTP"` is the SCTP protocol.
+       - `"TCP"` is the TCP protocol.
+       - `"UDP"` is the UDP protocol.
 
     - **subsets.ports.name** (string)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/ingress-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/ingress-v1.md
@@ -120,6 +120,11 @@ IngressSpec describes the Ingress the user wishes to exist.
           the IngressClass. Implementations can treat this as a separate PathType
           or treat it identically to Prefix or Exact path types.
         Implementations are required to support all path types.
+        
+        Possible enum values:
+         - `"Exact"` matches the URL path exactly and with case sensitivity.
+         - `"ImplementationSpecific"` matching is up to the IngressClass. Implementations can treat this as a separate PathType or treat it identically to Prefix or Exact path types.
+         - `"Prefix"` matches based on a URL path prefix split by '/'. Matching is case sensitive and done on a path element by element basis. A path element refers to the list of labels in the path split by the '/' separator. A request is a match for path p if every p is an element-wise prefix of p of the request path. Note that if the last element of the path is a substring of the last element in request path, it is not a match (e.g. /foo/bar matches /foo/bar/baz, but does not match /foo/barbaz). If multiple matching paths exist in an Ingress spec, the longest matching path is given priority. Examples: - /foo/bar does not match requests to /foo/barbaz - /foo/bar matches request to /foo/bar and /foo/bar/baz - /foo and /foo/ both match requests to /foo and /foo/. If both paths are present in an Ingress spec, the longest matching path (/foo/) is given priority.
 
       - **rules.http.paths.path** (string)
 
@@ -234,6 +239,11 @@ IngressStatus describe the current state of the Ingress.
       - **loadBalancer.ingress.ports.protocol** (string), required
 
         protocol is the protocol of the ingress port. The supported values are: "TCP", "UDP", "SCTP"
+        
+        Possible enum values:
+         - `"SCTP"` is the SCTP protocol.
+         - `"TCP"` is the TCP protocol.
+         - `"UDP"` is the UDP protocol.
 
       - **loadBalancer.ingress.ports.error** (string)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -89,6 +89,11 @@ ServiceSpec describes the attributes that a user creates on a service.
   - **ports.protocol** (string)
 
     The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+    
+    Possible enum values:
+     - `"SCTP"` is the SCTP protocol.
+     - `"TCP"` is the TCP protocol.
+     - `"UDP"` is the UDP protocol.
 
   - **ports.name** (string)
 
@@ -114,6 +119,12 @@ ServiceSpec describes the attributes that a user creates on a service.
 - **type** (string)
 
   type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  
+  Possible enum values:
+   - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+   - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+   - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+   - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
 
 - **ipFamilies** ([]string)
 
@@ -126,6 +137,11 @@ ServiceSpec describes the attributes that a user creates on a service.
 - **ipFamilyPolicy** (string)
 
   IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+  
+  Possible enum values:
+   - `"PreferDualStack"` indicates that this service prefers dual-stack when the cluster is configured for dual-stack. If the cluster is not configured for dual-stack the service will be assigned a single IPFamily. If the IPFamily is not set in service.spec.ipFamilies then the service will be assigned the default IPFamily configured on the cluster
+   - `"RequireDualStack"` indicates that this service requires dual-stack. Using IPFamilyPolicyRequireDualStack on a single stack cluster will result in validation errors. The IPFamilies (and their order) assigned to this service is based on service.spec.ipFamilies. If service.spec.ipFamilies was not provided then it will be assigned according to how they are configured on the cluster. If service.spec.ipFamilies has only one entry then the alternative IPFamily will be added by apiserver
+   - `"SingleStack"` indicates that this service is required to have a single IPFamily. The IPFamily assigned is based on the default IPFamily used by the cluster or as identified by service.spec.ipFamilies field
 
 - **clusterIP** (string)
 
@@ -148,6 +164,10 @@ ServiceSpec describes the attributes that a user creates on a service.
 - **sessionAffinity** (string)
 
   Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  
+  Possible enum values:
+   - `"ClientIP"` is the Client IP based.
+   - `"None"` - no session affinity.
 
 - **loadBalancerIP** (string)
 
@@ -170,10 +190,18 @@ ServiceSpec describes the attributes that a user creates on a service.
 - **externalTrafficPolicy** (string)
 
   externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+  
+  Possible enum values:
+   - `"Cluster"` routes traffic to all endpoints.
+   - `"Local"` preserves the source IP of the traffic by routing only to endpoints on the same node as the traffic was received on (dropping the traffic if there are no local endpoints).
 
 - **internalTrafficPolicy** (string)
 
   InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+  
+  Possible enum values:
+   - `"Cluster"` routes traffic to all endpoints.
+   - `"Local"` routes traffic only to endpoints on the same node as the client pod (dropping the traffic if there are no local endpoints).
 
 - **healthCheckNodePort** (int32)
 
@@ -301,6 +329,11 @@ ServiceStatus represents the current status of a service.
       - **loadBalancer.ingress.ports.protocol** (string), required
 
         Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+        
+        Possible enum values:
+         - `"SCTP"` is the SCTP protocol.
+         - `"TCP"` is the TCP protocol.
+         - `"UDP"` is the UDP protocol.
 
       - **loadBalancer.ingress.ports.error** (string)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/cron-job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/cron-job-v1.md
@@ -88,6 +88,11 @@ CronJobSpec describes how the job execution will look like and when it will actu
   Specifies how to treat concurrent executions of a Job. Valid values are:
   
   - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+  
+  Possible enum values:
+   - `"Allow"` allows CronJobs to run concurrently.
+   - `"Forbid"` forbids concurrent runs, skipping next run if previous hasn't finished yet.
+   - `"Replace"` cancels currently running job and replaces it with a new one.
 
 - **startingDeadlineSeconds** (int64)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
@@ -82,6 +82,10 @@ DaemonSetSpec is the specification of a daemon set.
   - **updateStrategy.type** (string)
 
     Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+    
+    Possible enum values:
+     - `"OnDelete"` Replace the old daemons only when it's killed
+     - `"RollingUpdate"` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
 
   - **updateStrategy.rollingUpdate** (RollingUpdateDaemonSet)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
@@ -88,6 +88,10 @@ DeploymentSpec is the specification of the desired behavior of the Deployment.
   - **strategy.type** (string)
 
     Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+    
+    Possible enum values:
+     - `"Recreate"` Kill all existing pods before creating new ones.
+     - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
 
   - **strategy.rollingUpdate** (RollingUpdateDeployment)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/device-taint-rule-v1alpha3.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/device-taint-rule-v1alpha3.md
@@ -68,6 +68,11 @@ DeviceTaintRuleSpec specifies the selector and one taint.
   - **taint.effect** (string), required
 
     The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them. Valid effects are NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here.
+    
+    
+    Possible enum values:
+     - `"NoExecute"` Evict any already-running pods that do not tolerate the device taint.
+     - `"NoSchedule"` Do not allow new pods to schedule which use a tainted device unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running.
 
   - **taint.key** (string), required
 
@@ -86,7 +91,7 @@ DeviceTaintRuleSpec specifies the selector and one taint.
 
 - **deviceSelector** (DeviceTaintSelector)
 
-  DeviceSelector defines which device(s) the taint is applied to. All selector criteria must be satisfied for a device to match. The empty selector matches all devices. Without a selector, no devices are matches.
+  DeviceSelector defines which device(s) the taint is applied to. All selector criteria must be satified for a device to match. The empty selector matches all devices. Without a selector, no devices are matches.
 
   <a name="DeviceTaintSelector"></a>
   *DeviceTaintSelector defines which device(s) a DeviceTaintRule applies to. The empty selector matches all devices. Without a selector, no devices are matched.*

--- a/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -89,6 +89,10 @@ JobSpec describes how the job execution will look like.
   `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
   
   More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+  
+  Possible enum values:
+   - `"Indexed"` is a Job completion mode. In this mode, the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1). The Job is considered complete when a Pod completes for each completion index.
+   - `"NonIndexed"` is a Job completion mode. In this mode, the Job is considered complete when there have been .spec.completions successfully completed Pods. Pod completions are homologous to each other.
 
 - **backoffLimit** (int32)
 
@@ -149,6 +153,12 @@ JobSpec describes how the job execution will look like.
       - Count: indicates that the pod is handled in the default way - the
         counter towards the .backoffLimit is incremented.
       Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+      
+      Possible enum values:
+       - `"Count"` This is an action which might be taken on a pod failure - the pod failure is handled in the default way - the counter towards .backoffLimit, represented by the job's .status.failed field, is incremented.
+       - `"FailIndex"` This is an action which might be taken on a pod failure - mark the Job's index as failed to avoid restarts within this index. This action can only be used when backoffLimitPerIndex is set.
+       - `"FailJob"` This is an action which might be taken on a pod failure - mark the pod's job as Failed and terminate all running pods.
+       - `"Ignore"` This is an action which might be taken on a pod failure - the counter towards .backoffLimit, represented by the job's .status.failed field, is not incremented and a replacement pod is created.
 
     - **podFailurePolicy.rules.onExitCodes** (PodFailurePolicyOnExitCodesRequirement)
 
@@ -168,6 +178,10 @@ JobSpec describes how the job execution will look like.
           (might be multiple if there are multiple containers not restricted
           by the 'containerName' field) is not in the set of specified values.
         Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+        
+        Possible enum values:
+         - `"In"`
+         - `"NotIn"`
 
       - **podFailurePolicy.rules.onExitCodes.values** ([]int32), required
 
@@ -245,6 +259,10 @@ JobSpec describes how the job execution will look like.
     Failed or Succeeded) before creating a replacement Pod.
   
   When using podFailurePolicy, Failed is the the only allowed value. TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
+  
+  Possible enum values:
+   - `"Failed"` means to wait until a previously created Pod is fully terminated (has phase Failed or Succeeded) before creating a replacement Pod.
+   - `"TerminatingOrFailed"` means that we recreate pods when they are terminating (has a metadata.deletionTimestamp) or failed.
 
 
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
@@ -173,6 +173,10 @@ PodSpec is a description of a pod.
   - **tolerations.operator** (string)
 
     Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+    
+    Possible enum values:
+     - `"Equal"`
+     - `"Exists"`
 
   - **tolerations.value** (string)
 
@@ -181,6 +185,11 @@ PodSpec is a description of a pod.
   - **tolerations.effect** (string)
 
     Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+    
+    Possible enum values:
+     - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+     - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+     - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
 
   - **tolerations.tolerationSeconds** (int64)
 
@@ -205,6 +214,10 @@ PodSpec is a description of a pod.
 - **preemptionPolicy** (string)
 
   PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+  
+  Possible enum values:
+   - `"Never"` means that pod never preempts other pods with lower priority.
+   - `"PreemptLowerPriority"` means that pod can preempt other pods with lower priority.
 
 - **topologySpreadConstraints** ([]TopologySpreadConstraint)
 
@@ -231,6 +244,10 @@ PodSpec is a description of a pod.
       but giving higher precedence to topologies that would help reduce the
       skew.
     A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+    
+    Possible enum values:
+     - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+     - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
 
   - **topologySpreadConstraints.labelSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
 
@@ -255,12 +272,20 @@ PodSpec is a description of a pod.
     NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
     
     If this value is nil, the behavior is equivalent to the Honor policy.
+    
+    Possible enum values:
+     - `"Honor"` means use this scheduling directive when calculating pod topology spread skew.
+     - `"Ignore"` means ignore this scheduling directive when calculating pod topology spread skew.
 
   - **topologySpreadConstraints.nodeTaintsPolicy** (string)
 
     NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
     
     If this value is nil, the behavior is equivalent to the Ignore policy.
+    
+    Possible enum values:
+     - `"Honor"` means use this scheduling directive when calculating pod topology spread skew.
+     - `"Ignore"` means ignore this scheduling directive when calculating pod topology spread skew.
 
 - **overhead** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
 
@@ -272,6 +297,11 @@ PodSpec is a description of a pod.
 - **restartPolicy** (string)
 
   Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+  
+  Possible enum values:
+   - `"Always"`
+   - `"Never"`
+   - `"OnFailure"`
 
 - **terminationGracePeriodSeconds** (int64)
 
@@ -375,6 +405,12 @@ PodSpec is a description of a pod.
 - **dnsPolicy** (string)
 
   Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+  
+  Possible enum values:
+   - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+   - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+   - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+   - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
 
 ### Hosts namespaces
 
@@ -429,6 +465,11 @@ PodSpec is a description of a pod.
         Localhost - a profile pre-loaded on the node.
         RuntimeDefault - the container runtime's default profile.
         Unconfined - no AppArmor enforcement.
+      
+      Possible enum values:
+       - `"Localhost"` indicates that a profile pre-loaded on the node should be used.
+       - `"RuntimeDefault"` indicates that the container runtime's default AppArmor profile should be used.
+       - `"Unconfined"` indicates that no AppArmor profile should be enforced.
 
     - **securityContext.appArmorProfile.localhostProfile** (string)
 
@@ -445,6 +486,10 @@ PodSpec is a description of a pod.
   - **securityContext.fsGroupChangePolicy** (string)
 
     fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.
+    
+    Possible enum values:
+     - `"Always"` indicates that volume's ownership and permissions should always be changed whenever volume is mounted inside a Pod. This the default behavior.
+     - `"OnRootMismatch"` indicates that volume's ownership and permissions will be changed only when permission and ownership of root directory does not match with expected permissions on the volume. This can help shorten the time it takes to change ownership and permissions of a volume.
 
   - **securityContext.runAsUser** (int64)
 
@@ -470,6 +515,11 @@ PodSpec is a description of a pod.
       type indicates which kind of seccomp profile will be applied. Valid options are:
       
       Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+      
+      Possible enum values:
+       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to \<kubelet-root-dir>/seccomp.
+       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
 
     - **securityContext.seccompProfile.localhostProfile** (string)
 
@@ -521,6 +571,10 @@ PodSpec is a description of a pod.
   - **securityContext.supplementalGroupsPolicy** (string)
 
     Defines how supplemental groups of the first container processes are calculated. Valid values are "Merge" and "Strict". If not specified, "Merge" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.
+    
+    Possible enum values:
+     - `"Merge"` means that the container's provided SupplementalGroups and FsGroup (specified in SecurityContext) will be merged with the primary user's groups as defined in the container image (in /etc/group).
+     - `"Strict"` means that the container's provided SupplementalGroups and FsGroup (specified in SecurityContext) will be used instead of any groups defined in the container image.
 
   - **securityContext.sysctls** ([]Sysctl)
 
@@ -694,6 +748,11 @@ A single application container that you want to run within a pod.
 - **imagePullPolicy** (string)
 
   Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+  
+  Possible enum values:
+   - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+   - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+   - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
 
 ### Entrypoint
 
@@ -747,6 +806,11 @@ A single application container that you want to run within a pod.
   - **ports.protocol** (string)
 
     Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+    
+    Possible enum values:
+     - `"SCTP"` is the SCTP protocol.
+     - `"TCP"` is the TCP protocol.
+     - `"UDP"` is the UDP protocol.
 
 ### Environment variables
 
@@ -920,6 +984,11 @@ A single application container that you want to run within a pod.
   - **volumeMounts.mountPropagation** (string)
 
     mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+    
+    Possible enum values:
+     - `"Bidirectional"` means that the volume in a container will receive new mounts from the host or other containers, and its own mounts will be propagated from the container to the host or other containers. Note that this mode is recursively applied to all mounts in the volume ("rshared" in Linux terminology).
+     - `"HostToContainer"` means that the volume in a container will receive new mounts from the host or other containers, but filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode is recursively applied to all mounts in the volume ("rslave" in Linux terminology).
+     - `"None"` means that the volume in a container will not receive new mounts from the host or other containers, and filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode corresponds to "private" in Linux terminology.
 
   - **volumeMounts.readOnly** (boolean)
 
@@ -1041,6 +1110,73 @@ A single application container that you want to run within a pod.
   - **lifecycle.stopSignal** (string)
 
     StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name
+    
+    Possible enum values:
+     - `"SIGABRT"`
+     - `"SIGALRM"`
+     - `"SIGBUS"`
+     - `"SIGCHLD"`
+     - `"SIGCLD"`
+     - `"SIGCONT"`
+     - `"SIGFPE"`
+     - `"SIGHUP"`
+     - `"SIGILL"`
+     - `"SIGINT"`
+     - `"SIGIO"`
+     - `"SIGIOT"`
+     - `"SIGKILL"`
+     - `"SIGPIPE"`
+     - `"SIGPOLL"`
+     - `"SIGPROF"`
+     - `"SIGPWR"`
+     - `"SIGQUIT"`
+     - `"SIGRTMAX"`
+     - `"SIGRTMAX-1"`
+     - `"SIGRTMAX-10"`
+     - `"SIGRTMAX-11"`
+     - `"SIGRTMAX-12"`
+     - `"SIGRTMAX-13"`
+     - `"SIGRTMAX-14"`
+     - `"SIGRTMAX-2"`
+     - `"SIGRTMAX-3"`
+     - `"SIGRTMAX-4"`
+     - `"SIGRTMAX-5"`
+     - `"SIGRTMAX-6"`
+     - `"SIGRTMAX-7"`
+     - `"SIGRTMAX-8"`
+     - `"SIGRTMAX-9"`
+     - `"SIGRTMIN"`
+     - `"SIGRTMIN+1"`
+     - `"SIGRTMIN+10"`
+     - `"SIGRTMIN+11"`
+     - `"SIGRTMIN+12"`
+     - `"SIGRTMIN+13"`
+     - `"SIGRTMIN+14"`
+     - `"SIGRTMIN+15"`
+     - `"SIGRTMIN+2"`
+     - `"SIGRTMIN+3"`
+     - `"SIGRTMIN+4"`
+     - `"SIGRTMIN+5"`
+     - `"SIGRTMIN+6"`
+     - `"SIGRTMIN+7"`
+     - `"SIGRTMIN+8"`
+     - `"SIGRTMIN+9"`
+     - `"SIGSEGV"`
+     - `"SIGSTKFLT"`
+     - `"SIGSTOP"`
+     - `"SIGSYS"`
+     - `"SIGTERM"`
+     - `"SIGTRAP"`
+     - `"SIGTSTP"`
+     - `"SIGTTIN"`
+     - `"SIGTTOU"`
+     - `"SIGURG"`
+     - `"SIGUSR1"`
+     - `"SIGUSR2"`
+     - `"SIGVTALRM"`
+     - `"SIGWINCH"`
+     - `"SIGXCPU"`
+     - `"SIGXFSZ"`
 
 - **terminationMessagePath** (string)
 
@@ -1049,6 +1185,10 @@ A single application container that you want to run within a pod.
 - **terminationMessagePolicy** (string)
 
   Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+  
+  Possible enum values:
+   - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+   - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
 
 - **livenessProbe** (<a href="{{< ref "../workload-resources/pod-v1#Probe" >}}">Probe</a>)
 
@@ -1126,6 +1266,11 @@ A single application container that you want to run within a pod.
         Localhost - a profile pre-loaded on the node.
         RuntimeDefault - the container runtime's default profile.
         Unconfined - no AppArmor enforcement.
+      
+      Possible enum values:
+       - `"Localhost"` indicates that a profile pre-loaded on the node should be used.
+       - `"RuntimeDefault"` indicates that the container runtime's default AppArmor profile should be used.
+       - `"Unconfined"` indicates that no AppArmor profile should be enforced.
 
     - **securityContext.appArmorProfile.localhostProfile** (string)
 
@@ -1153,6 +1298,10 @@ A single application container that you want to run within a pod.
   - **securityContext.procMount** (string)
 
     procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
+    
+    Possible enum values:
+     - `"Default"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.
+     - `"Unmasked"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.
 
   - **securityContext.privileged** (boolean)
 
@@ -1209,6 +1358,11 @@ A single application container that you want to run within a pod.
       type indicates which kind of seccomp profile will be applied. Valid options are:
       
       Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+      
+      Possible enum values:
+       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to \<kubelet-root-dir>/seccomp.
+       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
 
     - **securityContext.seccompProfile.localhostProfile** (string)
 
@@ -1284,6 +1438,11 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
 - **imagePullPolicy** (string)
 
   Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+  
+  Possible enum values:
+   - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+   - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+   - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
 
 ### Entrypoint
 
@@ -1476,6 +1635,11 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
   - **volumeMounts.mountPropagation** (string)
 
     mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+    
+    Possible enum values:
+     - `"Bidirectional"` means that the volume in a container will receive new mounts from the host or other containers, and its own mounts will be propagated from the container to the host or other containers. Note that this mode is recursively applied to all mounts in the volume ("rshared" in Linux terminology).
+     - `"HostToContainer"` means that the volume in a container will receive new mounts from the host or other containers, but filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode is recursively applied to all mounts in the volume ("rslave" in Linux terminology).
+     - `"None"` means that the volume in a container will not receive new mounts from the host or other containers, and filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode corresponds to "private" in Linux terminology.
 
   - **volumeMounts.readOnly** (boolean)
 
@@ -1550,6 +1714,10 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
 - **terminationMessagePolicy** (string)
 
   Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+  
+  Possible enum values:
+   - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+   - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
 
 - **restartPolicy** (string)
 
@@ -1630,6 +1798,11 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
         Localhost - a profile pre-loaded on the node.
         RuntimeDefault - the container runtime's default profile.
         Unconfined - no AppArmor enforcement.
+      
+      Possible enum values:
+       - `"Localhost"` indicates that a profile pre-loaded on the node should be used.
+       - `"RuntimeDefault"` indicates that the container runtime's default AppArmor profile should be used.
+       - `"Unconfined"` indicates that no AppArmor profile should be enforced.
 
     - **securityContext.appArmorProfile.localhostProfile** (string)
 
@@ -1657,6 +1830,10 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
   - **securityContext.procMount** (string)
 
     procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
+    
+    Possible enum values:
+     - `"Default"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.
+     - `"Unmasked"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.
 
   - **securityContext.privileged** (boolean)
 
@@ -1713,6 +1890,11 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
       type indicates which kind of seccomp profile will be applied. Valid options are:
       
       Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+      
+      Possible enum values:
+       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to \<kubelet-root-dir>/seccomp.
+       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
 
     - **securityContext.seccompProfile.localhostProfile** (string)
 
@@ -1774,6 +1956,11 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
   - **ports.protocol** (string)
 
     Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+    
+    Possible enum values:
+     - `"SCTP"` is the SCTP protocol.
+     - `"TCP"` is the TCP protocol.
+     - `"UDP"` is the UDP protocol.
 
 - **resources** (ResourceRequirements)
 
@@ -1829,6 +2016,73 @@ To add an ephemeral container, use the ephemeralcontainers subresource of an exi
   - **lifecycle.stopSignal** (string)
 
     StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name
+    
+    Possible enum values:
+     - `"SIGABRT"`
+     - `"SIGALRM"`
+     - `"SIGBUS"`
+     - `"SIGCHLD"`
+     - `"SIGCLD"`
+     - `"SIGCONT"`
+     - `"SIGFPE"`
+     - `"SIGHUP"`
+     - `"SIGILL"`
+     - `"SIGINT"`
+     - `"SIGIO"`
+     - `"SIGIOT"`
+     - `"SIGKILL"`
+     - `"SIGPIPE"`
+     - `"SIGPOLL"`
+     - `"SIGPROF"`
+     - `"SIGPWR"`
+     - `"SIGQUIT"`
+     - `"SIGRTMAX"`
+     - `"SIGRTMAX-1"`
+     - `"SIGRTMAX-10"`
+     - `"SIGRTMAX-11"`
+     - `"SIGRTMAX-12"`
+     - `"SIGRTMAX-13"`
+     - `"SIGRTMAX-14"`
+     - `"SIGRTMAX-2"`
+     - `"SIGRTMAX-3"`
+     - `"SIGRTMAX-4"`
+     - `"SIGRTMAX-5"`
+     - `"SIGRTMAX-6"`
+     - `"SIGRTMAX-7"`
+     - `"SIGRTMAX-8"`
+     - `"SIGRTMAX-9"`
+     - `"SIGRTMIN"`
+     - `"SIGRTMIN+1"`
+     - `"SIGRTMIN+10"`
+     - `"SIGRTMIN+11"`
+     - `"SIGRTMIN+12"`
+     - `"SIGRTMIN+13"`
+     - `"SIGRTMIN+14"`
+     - `"SIGRTMIN+15"`
+     - `"SIGRTMIN+2"`
+     - `"SIGRTMIN+3"`
+     - `"SIGRTMIN+4"`
+     - `"SIGRTMIN+5"`
+     - `"SIGRTMIN+6"`
+     - `"SIGRTMIN+7"`
+     - `"SIGRTMIN+8"`
+     - `"SIGRTMIN+9"`
+     - `"SIGSEGV"`
+     - `"SIGSTKFLT"`
+     - `"SIGSTOP"`
+     - `"SIGSYS"`
+     - `"SIGTERM"`
+     - `"SIGTRAP"`
+     - `"SIGTSTP"`
+     - `"SIGTTIN"`
+     - `"SIGTTOU"`
+     - `"SIGURG"`
+     - `"SIGUSR1"`
+     - `"SIGUSR2"`
+     - `"SIGVTALRM"`
+     - `"SIGWINCH"`
+     - `"SIGXCPU"`
+     - `"SIGXFSZ"`
 
 - **livenessProbe** (<a href="{{< ref "../workload-resources/pod-v1#Probe" >}}">Probe</a>)
 
@@ -1905,6 +2159,10 @@ LifecycleHandler defines a specific action that should be taken in a lifecycle h
   - **httpGet.scheme** (string)
 
     Scheme to use for connecting to the host. Defaults to HTTP.
+    
+    Possible enum values:
+     - `"HTTP"` means that the scheme used will be http://
+     - `"HTTPS"` means that the scheme used will be https://
 
 - **sleep** (SleepAction)
 
@@ -2268,6 +2526,10 @@ Probe describes a health check to be performed against a container to determine 
   - **httpGet.scheme** (string)
 
     Scheme to use for connecting to the host. Defaults to HTTP.
+    
+    Possible enum values:
+     - `"HTTP"` means that the scheme used will be http://
+     - `"HTTPS"` means that the scheme used will be https://
 
 - **tcpSocket** (TCPSocketAction)
 
@@ -2375,6 +2637,13 @@ PodStatus represents information about the status of a pod. Status may trail the
   Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
   
   More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+  
+  Possible enum values:
+   - `"Failed"` means that all containers in the pod have terminated, and at least one container has terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+   - `"Pending"` means the pod has been accepted by the system, but one or more of the containers has not been started. This includes time before being bound to a node, as well as time spent pulling images onto the host.
+   - `"Running"` means the pod has been bound to a node and all of the containers have been started. At least one container is still running or is in the process of being restarted.
+   - `"Succeeded"` means that all containers in the pod have voluntarily terminated with a container exit code of 0, and the system is not going to restart any of these containers.
+   - `"Unknown"` means that for some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod. Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
 
 - **message** (string)
 
@@ -2451,6 +2720,11 @@ PodStatus represents information about the status of a pod. Status may trail the
 - **qosClass** (string)
 
   The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes
+  
+  Possible enum values:
+   - `"BestEffort"` is the BestEffort qos class.
+   - `"Burstable"` is the Burstable qos class.
+   - `"Guaranteed"` is the Guaranteed qos class.
 
 - **initContainerStatuses** ([]ContainerStatus)
 
@@ -2728,6 +3002,73 @@ PodStatus represents information about the status of a pod. Status may trail the
   - **initContainerStatuses.stopSignal** (string)
 
     StopSignal reports the effective stop signal for this container
+    
+    Possible enum values:
+     - `"SIGABRT"`
+     - `"SIGALRM"`
+     - `"SIGBUS"`
+     - `"SIGCHLD"`
+     - `"SIGCLD"`
+     - `"SIGCONT"`
+     - `"SIGFPE"`
+     - `"SIGHUP"`
+     - `"SIGILL"`
+     - `"SIGINT"`
+     - `"SIGIO"`
+     - `"SIGIOT"`
+     - `"SIGKILL"`
+     - `"SIGPIPE"`
+     - `"SIGPOLL"`
+     - `"SIGPROF"`
+     - `"SIGPWR"`
+     - `"SIGQUIT"`
+     - `"SIGRTMAX"`
+     - `"SIGRTMAX-1"`
+     - `"SIGRTMAX-10"`
+     - `"SIGRTMAX-11"`
+     - `"SIGRTMAX-12"`
+     - `"SIGRTMAX-13"`
+     - `"SIGRTMAX-14"`
+     - `"SIGRTMAX-2"`
+     - `"SIGRTMAX-3"`
+     - `"SIGRTMAX-4"`
+     - `"SIGRTMAX-5"`
+     - `"SIGRTMAX-6"`
+     - `"SIGRTMAX-7"`
+     - `"SIGRTMAX-8"`
+     - `"SIGRTMAX-9"`
+     - `"SIGRTMIN"`
+     - `"SIGRTMIN+1"`
+     - `"SIGRTMIN+10"`
+     - `"SIGRTMIN+11"`
+     - `"SIGRTMIN+12"`
+     - `"SIGRTMIN+13"`
+     - `"SIGRTMIN+14"`
+     - `"SIGRTMIN+15"`
+     - `"SIGRTMIN+2"`
+     - `"SIGRTMIN+3"`
+     - `"SIGRTMIN+4"`
+     - `"SIGRTMIN+5"`
+     - `"SIGRTMIN+6"`
+     - `"SIGRTMIN+7"`
+     - `"SIGRTMIN+8"`
+     - `"SIGRTMIN+9"`
+     - `"SIGSEGV"`
+     - `"SIGSTKFLT"`
+     - `"SIGSTOP"`
+     - `"SIGSYS"`
+     - `"SIGTERM"`
+     - `"SIGTRAP"`
+     - `"SIGTSTP"`
+     - `"SIGTTIN"`
+     - `"SIGTTOU"`
+     - `"SIGURG"`
+     - `"SIGUSR1"`
+     - `"SIGUSR2"`
+     - `"SIGVTALRM"`
+     - `"SIGWINCH"`
+     - `"SIGXCPU"`
+     - `"SIGXFSZ"`
 
   - **initContainerStatuses.user** (ContainerUser)
 
@@ -3060,6 +3401,73 @@ PodStatus represents information about the status of a pod. Status may trail the
   - **containerStatuses.stopSignal** (string)
 
     StopSignal reports the effective stop signal for this container
+    
+    Possible enum values:
+     - `"SIGABRT"`
+     - `"SIGALRM"`
+     - `"SIGBUS"`
+     - `"SIGCHLD"`
+     - `"SIGCLD"`
+     - `"SIGCONT"`
+     - `"SIGFPE"`
+     - `"SIGHUP"`
+     - `"SIGILL"`
+     - `"SIGINT"`
+     - `"SIGIO"`
+     - `"SIGIOT"`
+     - `"SIGKILL"`
+     - `"SIGPIPE"`
+     - `"SIGPOLL"`
+     - `"SIGPROF"`
+     - `"SIGPWR"`
+     - `"SIGQUIT"`
+     - `"SIGRTMAX"`
+     - `"SIGRTMAX-1"`
+     - `"SIGRTMAX-10"`
+     - `"SIGRTMAX-11"`
+     - `"SIGRTMAX-12"`
+     - `"SIGRTMAX-13"`
+     - `"SIGRTMAX-14"`
+     - `"SIGRTMAX-2"`
+     - `"SIGRTMAX-3"`
+     - `"SIGRTMAX-4"`
+     - `"SIGRTMAX-5"`
+     - `"SIGRTMAX-6"`
+     - `"SIGRTMAX-7"`
+     - `"SIGRTMAX-8"`
+     - `"SIGRTMAX-9"`
+     - `"SIGRTMIN"`
+     - `"SIGRTMIN+1"`
+     - `"SIGRTMIN+10"`
+     - `"SIGRTMIN+11"`
+     - `"SIGRTMIN+12"`
+     - `"SIGRTMIN+13"`
+     - `"SIGRTMIN+14"`
+     - `"SIGRTMIN+15"`
+     - `"SIGRTMIN+2"`
+     - `"SIGRTMIN+3"`
+     - `"SIGRTMIN+4"`
+     - `"SIGRTMIN+5"`
+     - `"SIGRTMIN+6"`
+     - `"SIGRTMIN+7"`
+     - `"SIGRTMIN+8"`
+     - `"SIGRTMIN+9"`
+     - `"SIGSEGV"`
+     - `"SIGSTKFLT"`
+     - `"SIGSTOP"`
+     - `"SIGSYS"`
+     - `"SIGTERM"`
+     - `"SIGTRAP"`
+     - `"SIGTSTP"`
+     - `"SIGTTIN"`
+     - `"SIGTTOU"`
+     - `"SIGURG"`
+     - `"SIGUSR1"`
+     - `"SIGUSR2"`
+     - `"SIGVTALRM"`
+     - `"SIGWINCH"`
+     - `"SIGXCPU"`
+     - `"SIGXFSZ"`
 
   - **containerStatuses.user** (ContainerUser)
 
@@ -3392,6 +3800,73 @@ PodStatus represents information about the status of a pod. Status may trail the
   - **ephemeralContainerStatuses.stopSignal** (string)
 
     StopSignal reports the effective stop signal for this container
+    
+    Possible enum values:
+     - `"SIGABRT"`
+     - `"SIGALRM"`
+     - `"SIGBUS"`
+     - `"SIGCHLD"`
+     - `"SIGCLD"`
+     - `"SIGCONT"`
+     - `"SIGFPE"`
+     - `"SIGHUP"`
+     - `"SIGILL"`
+     - `"SIGINT"`
+     - `"SIGIO"`
+     - `"SIGIOT"`
+     - `"SIGKILL"`
+     - `"SIGPIPE"`
+     - `"SIGPOLL"`
+     - `"SIGPROF"`
+     - `"SIGPWR"`
+     - `"SIGQUIT"`
+     - `"SIGRTMAX"`
+     - `"SIGRTMAX-1"`
+     - `"SIGRTMAX-10"`
+     - `"SIGRTMAX-11"`
+     - `"SIGRTMAX-12"`
+     - `"SIGRTMAX-13"`
+     - `"SIGRTMAX-14"`
+     - `"SIGRTMAX-2"`
+     - `"SIGRTMAX-3"`
+     - `"SIGRTMAX-4"`
+     - `"SIGRTMAX-5"`
+     - `"SIGRTMAX-6"`
+     - `"SIGRTMAX-7"`
+     - `"SIGRTMAX-8"`
+     - `"SIGRTMAX-9"`
+     - `"SIGRTMIN"`
+     - `"SIGRTMIN+1"`
+     - `"SIGRTMIN+10"`
+     - `"SIGRTMIN+11"`
+     - `"SIGRTMIN+12"`
+     - `"SIGRTMIN+13"`
+     - `"SIGRTMIN+14"`
+     - `"SIGRTMIN+15"`
+     - `"SIGRTMIN+2"`
+     - `"SIGRTMIN+3"`
+     - `"SIGRTMIN+4"`
+     - `"SIGRTMIN+5"`
+     - `"SIGRTMIN+6"`
+     - `"SIGRTMIN+7"`
+     - `"SIGRTMIN+8"`
+     - `"SIGRTMIN+9"`
+     - `"SIGSEGV"`
+     - `"SIGSTKFLT"`
+     - `"SIGSTOP"`
+     - `"SIGSYS"`
+     - `"SIGTERM"`
+     - `"SIGTRAP"`
+     - `"SIGTSTP"`
+     - `"SIGTTIN"`
+     - `"SIGTTOU"`
+     - `"SIGURG"`
+     - `"SIGUSR1"`
+     - `"SIGUSR2"`
+     - `"SIGVTALRM"`
+     - `"SIGWINCH"`
+     - `"SIGXCPU"`
+     - `"SIGXFSZ"`
 
   - **ephemeralContainerStatuses.user** (ContainerUser)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
@@ -57,6 +57,10 @@ PriorityClass defines mapping from a priority class name to the priority integer
 - **preemptionPolicy** (string)
 
   preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+  
+  Possible enum values:
+   - `"Never"` means that pod never preempts other pods with lower priority.
+   - `"PreemptLowerPriority"` means that pod can preempt other pods with lower priority.
 
 
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/resource-claim-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/resource-claim-v1.md
@@ -338,6 +338,11 @@ ResourceClaimSpec defines what is being requested in a ResourceClaim and how to 
         - **devices.requests.exactly.tolerations.effect** (string)
 
           Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule and NoExecute.
+          
+          
+          Possible enum values:
+           - `"NoExecute"` Evict any already-running pods that do not tolerate the device taint.
+           - `"NoSchedule"` Do not allow new pods to schedule which use a tainted device unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running.
 
         - **devices.requests.exactly.tolerations.key** (string)
 
@@ -346,10 +351,15 @@ ResourceClaimSpec defines what is being requested in a ResourceClaim and how to 
         - **devices.requests.exactly.tolerations.operator** (string)
 
           Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a ResourceClaim can tolerate all taints of a particular category.
+          
+          
+          Possible enum values:
+           - `"Equal"`
+           - `"Exists"`
 
         - **devices.requests.exactly.tolerations.tolerationSeconds** (int64)
 
-          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as \<time when taint was added> + \<toleration seconds>.
+          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as \<time when taint was adedd> + \<toleration seconds>.
 
         - **devices.requests.exactly.tolerations.value** (string)
 
@@ -497,6 +507,11 @@ ResourceClaimSpec defines what is being requested in a ResourceClaim and how to 
         - **devices.requests.firstAvailable.tolerations.effect** (string)
 
           Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule and NoExecute.
+          
+          
+          Possible enum values:
+           - `"NoExecute"` Evict any already-running pods that do not tolerate the device taint.
+           - `"NoSchedule"` Do not allow new pods to schedule which use a tainted device unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running.
 
         - **devices.requests.firstAvailable.tolerations.key** (string)
 
@@ -505,10 +520,15 @@ ResourceClaimSpec defines what is being requested in a ResourceClaim and how to 
         - **devices.requests.firstAvailable.tolerations.operator** (string)
 
           Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a ResourceClaim can tolerate all taints of a particular category.
+          
+          
+          Possible enum values:
+           - `"Equal"`
+           - `"Exists"`
 
         - **devices.requests.firstAvailable.tolerations.tolerationSeconds** (int64)
 
-          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as \<time when taint was added> + \<toleration seconds>.
+          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as \<time when taint was adedd> + \<toleration seconds>.
 
         - **devices.requests.firstAvailable.tolerations.value** (string)
 
@@ -712,6 +732,11 @@ ResourceClaimStatus tracks whether the resource has been allocated and what the 
         - **allocation.devices.results.tolerations.effect** (string)
 
           Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule and NoExecute.
+          
+          
+          Possible enum values:
+           - `"NoExecute"` Evict any already-running pods that do not tolerate the device taint.
+           - `"NoSchedule"` Do not allow new pods to schedule which use a tainted device unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running.
 
         - **allocation.devices.results.tolerations.key** (string)
 
@@ -720,10 +745,15 @@ ResourceClaimStatus tracks whether the resource has been allocated and what the 
         - **allocation.devices.results.tolerations.operator** (string)
 
           Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a ResourceClaim can tolerate all taints of a particular category.
+          
+          
+          Possible enum values:
+           - `"Equal"`
+           - `"Exists"`
 
         - **allocation.devices.results.tolerations.tolerationSeconds** (int64)
 
-          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as \<time when taint was added> + \<toleration seconds>.
+          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as \<time when taint was adedd> + \<toleration seconds>.
 
         - **allocation.devices.results.tolerations.value** (string)
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/resource-slice-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/resource-slice-v1.md
@@ -355,6 +355,11 @@ ResourceSliceSpec contains the information published by the driver in one Resour
     - **devices.taints.effect** (string), required
 
       The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them. Valid effects are NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here.
+      
+      
+      Possible enum values:
+       - `"NoExecute"` Evict any already-running pods that do not tolerate the device taint.
+       - `"NoSchedule"` Do not allow new pods to schedule which use a tainted device unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running.
 
     - **devices.taints.key** (string), required
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
@@ -90,6 +90,10 @@ A StatefulSetSpec is the specification of a StatefulSet.
   - **updateStrategy.type** (string)
 
     Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+    
+    Possible enum values:
+     - `"OnDelete"` triggers the legacy behavior. Version tracking and ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted. When a scale operation is performed with this strategy,specification version indicated by the StatefulSet's currentRevision.
+     - `"RollingUpdate"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.
 
   - **updateStrategy.rollingUpdate** (RollingUpdateStatefulSetStrategy)
 
@@ -112,6 +116,10 @@ A StatefulSetSpec is the specification of a StatefulSet.
 - **podManagementPolicy** (string)
 
   podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+  
+  Possible enum values:
+   - `"OrderedReady"` will create pods in strictly increasing order on scale up and strictly decreasing order on scale down, progressing only when the previous pod is ready or terminated. At most one pod will be changed at any time.
+   - `"Parallel"` will create and delete pods as soon as the stateful set replica count is changed, and will not wait for pods to be ready or complete termination.
 
 - **revisionHistoryLimit** (int32)
 


### PR DESCRIPTION
This PR updates the markdown version of Kubernetes API reference with enum values. The upstream generator change is located at https://github.com/kubernetes-sigs/reference-docs/pull/412