### PR TITLE
Anchors to a description of a feature gate in a list of feature gates.

### DIFF
--- a/layouts/shortcodes/feature-gate-list.html
+++ b/layouts/shortcodes/feature-gate-list.html
@@ -9,7 +9,7 @@
 <!-- Sort Feature gate pages list -->
 {{- $sortedFeatureGates := sort ($featureDataFiles.Resources.ByType "page") -}}
 
-<ul class="feature-gate-list">
+<dl class="feature-gate-list">
   {{- range $featureGateFile := $sortedFeatureGates -}}
 
     <!-- Extract the feature gate name from the "Title" parameter in file -->
@@ -48,13 +48,14 @@
 
     {{- if $shouldDisplayThisFeatureGate -}}
       {{- with $featureGateFile.Content -}}
-      <li>
+      <dt id="{{ $featureGateName }}"><code class="feature-gate-name">{{ $featureGateName }}</code></dt>
+      <dd>
         {{- $hasParagraphWrapper := (hasPrefix ( . | markdownify ) "<p>") -}}
         {{- if not $hasParagraphWrapper }}<p>{{ end -}}
-          <code class="feature-gate-name">{{ $featureGateName }}</code>: {{ . | markdownify -}}
+           {{ . | markdownify -}}
         {{- if not $hasParagraphWrapper }}</p>{{ end -}}
-      </li>
+      </dd>
       {{- end -}}
     {{- end -}}
   {{- end -}}
-</ul>
+</dl>


### PR DESCRIPTION
This PR proposes an updated version of the [feature gate list formatting](https://deploy-preview-52619--kubernetes-io-main-staging.netlify.app/docs/reference/command-line-tools-reference/feature-gates/#feature-gates) to make it look similar to Definition Lists[^1] in Markdown. Along with the list update, anchors have been added so that other articles can link to the description of the corresponding feature gate rather than just the feature gate page.

> <dl>
>   <dt>First Term</dt>
>   <dd>This is the definition of the first term.</dd>
>   <dt>Second Term</dt>
>   <dd>This is one definition of the second term. </dd>
> </dl>

[^1]: <https://www.markdownguide.org/extended-syntax/#definition-lists>
