### PR TITLE
Revise presentation of feature-state shortcode

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -19,13 +19,18 @@ div.feature-state-notice {
   }
   > .feature-state-name {
     display: inline-block;
+    text-transform: uppercase;
     font-size: 0.95em;
     font-weight: bold;
     color: #000;
     background-color: $feature;
   }
 
-  code {
+  &.feature-stable-but-disabled {
+    font-weight: bold;
+  }
+
+  .feature-state-details {
     color: #000;
     font-size: 1em;
     font-family: inherit; // don't treat as actual code

--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -11,11 +11,6 @@
 }
 
 div.feature-state-notice {
-  background-color: $feature;
-  border-radius: 0.75rem;
-  padding: 1rem;
-  margin-bottom: 1em;
-
   font-size: 1.2em;
 
   > .feature-state-name::before {
@@ -36,9 +31,15 @@ div.feature-state-notice {
     font-family: inherit; // don't treat as actual code
     background-color: $feature;
   }
+}
 
-  margin-right: 2em;
-  max-width: 80%;
+div.feature-state-notice, div.feature-state-notice + div.feature-stable.stable-in-latest-release {
+  background-color: $feature;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1em;
+
+  margin-right: 2.5rem;
 }
 
 div.api-reference-header-note {

--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -11,12 +11,6 @@
 }
 
 div.feature-state-notice {
-  background-color: $feature;
-  color: #000;
-  border-radius: 0.75rem;
-  padding: 1rem;
-  margin-bottom: 1em;
-
   font-size: 1.2em;
 
   > .feature-state-name::before {
@@ -37,9 +31,15 @@ div.feature-state-notice {
     font-family: inherit; // don't treat as actual code
     background-color: $feature;
   }
+}
 
-  margin-right: 2em;
-  max-width: 80%;
+div.feature-state-notice, div.feature-state-notice + div.feature-stable.stable-in-latest-release {
+  background-color: $feature;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1em;
+
+  margin-right: 2.5rem;
 }
 
 div.api-reference-header-note {

--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -19,13 +19,37 @@ div.feature-state-notice {
   }
   > .feature-state-name {
     display: inline-block;
+
+    text-transform: capitalize;
     font-size: 0.95em;
     font-weight: bold;
     color: #000;
     background-color: $feature;
   }
 
-  code {
+  span.feature-state-stage {
+    display: inline-block;
+    padding-left: 0.2em;
+    padding-right: 0.2em;
+    border-radius: 0.2em;
+    font-weight: bold;
+    color: $feature;
+    background-color: $primary;
+  }
+
+  /* Less emphasis on features that are stable */
+  &.feature-stable span.feature-state-stage {
+    font-weight: inherit;
+    color: inherit;
+    background-color: transparent;
+    padding: 0;
+  }
+
+  &.feature-stable-but-disabled {
+    font-weight: bold;
+  }
+
+  .feature-state-details {
     color: #000;
     font-size: 1em;
     font-family: inherit; // don't treat as actual code
@@ -33,7 +57,18 @@ div.feature-state-notice {
   }
 }
 
-div.feature-state-notice, div.feature-state-notice + div.feature-stable.stable-in-latest-release {
+div.feature-state-notice + div > details {
+  max-width: 80%;
+}
+
+/* Dotted line under opened <details> elements for feature state */
+div.feature-state-notice + div > details[open] > *:last-child {
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+  border-bottom: 1px dotted $primary;
+}
+
+div.feature-state-notice {
   background-color: $feature;
   border-radius: 0.75rem;
   padding: 1rem;

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -195,6 +195,12 @@ other = "(enabled by default)"
 [feature_gate_disabled]
 other = "(disabled by default)"
 
+[feature_gate_stable_graduated]
+other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release."
+
+[feature_gate_stable_locked]
+other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release. You can no longer disable or opt out of this server."
+
 [feature_gate_stage_alpha]
 other = "Alpha"
 

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -189,17 +189,41 @@ other = "Error"
 [examples_heading]
 other = "Examples"
 
+# Used with feature_gate_stage_* and then with either feature_gate_enabled or feature_gate_disabled
+# This localization string is for determining the punctuation and other details (including word order).
+[feature_gate_details]
+other = "({{ .stage }}; {{ .enabled_or_disabled }})"
+
+[feature_gate_details_locked]
+other = "({{ .stage }})"
+
+[feature_gate_details_unknown]
+other = "({{ .stage }})"
+
 [feature_gate_enabled]
-other = "(enabled by default)"
+other = "enabled by default"
 
 [feature_gate_disabled]
-other = "(disabled by default)"
+other = "disabled by default"
+
+[feature_gate_more_details]
+other = "More information about this feature"
+
+[feature_gate_more_information_how_to_enable]
+other = """<p>To use this feature, you (or a cluster administrator) will need to enable the <a href="/docs/reference/command-line-tools-reference/feature-gates/#{{ .feature_gate_name }}"><tt>{{ .feature_gate_name }}</tt></a> feature gate for all relevant components in your cluster.</p>
+<p>See <a href="/docs/tasks/administer-cluster/configure-feature-gates/">Enable Or Disable Feature Gates</a> for more information.</p>"""
 
 [feature_gate_stable_graduated]
 other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release."
 
+[feature_gate_stable_graduated_disabled]
+other = "This stable feature gate is disabled by default. You can no longer enable this feature gate to opt in to the associated behavior."
+
 [feature_gate_stable_locked]
-other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release. You can no longer disable or opt out of this server."
+other = """This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release. You can no longer disable or opt out of this feature or behavior (it is locked); if you explicitly set a value for the associated feature gate <tt>{{ .featureGateName }}</tt>, Kubernetes ignores it but does not report any error."""
+
+[feature_gate_stable_removed]
+other = """This is a stable feature in Kubernetes, and has been since the {{ .stableVersion }} release. You can no longer toggle this feature (the associated <a href="/docs/reference/command-line-tools-reference/feature-gates-removed/">feature gate</a> has been removed)."""
 
 [feature_gate_stage_alpha]
 other = "Alpha"
@@ -208,7 +232,7 @@ other = "Alpha"
 other = "Beta"
 
 [feature_gate_stage_stable]
-other = "GA"
+other = "Generally Available"
 
 [feature_gate_stage_deprecated]
 other = "Deprecated"
@@ -235,7 +259,7 @@ other = "To"
 other = "Until"
 
 [feature_state]
-other = "FEATURE STATE:"
+other = "Feature state:"
 
 [feature_state_kubernetes_label]
 other = "Kubernetes"

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -198,6 +198,12 @@ other = "(enabled by default)"
 [feature_gate_disabled]
 other = "(disabled by default)"
 
+[feature_gate_stable_graduated]
+other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release."
+
+[feature_gate_stable_locked]
+other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release. You can no longer disable or opt out of this server."
+
 [feature_gate_stage_alpha]
 other = "Alpha"
 

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -192,17 +192,47 @@ other = "Error"
 [examples_heading]
 other = "Examples"
 
+# Used with feature_gate_stage_* and then with either feature_gate_enabled or feature_gate_disabled
+# This localization string is for determining the punctuation and other details (including word order).
+## Localizers: you can put marks such as « and » around the .stage (if useful)
+[feature_gate_details]
+other = """<span class="feature-state-stage">{{ .stage }}</span> since {{ .kubernetes }} v{{ .version }}; {{ .enabled_or_disabled }}"""
+
+## Localizers: you can put marks such as « and » around the .stage (if useful)
+[feature_gate_details_partial]
+other = """<span class="feature-state-stage">{{ .stage }}</span> since {{ .kubernetes }} v{{ .version }}"""
+
 [feature_gate_enabled]
-other = "(enabled by default)"
+other = "enabled by default"
 
 [feature_gate_disabled]
-other = "(disabled by default)"
+other = "disabled by default"
+
+[feature_gate_more_details]
+other = "More information about this feature"
+
+[feature_gate_more_information_how_to_enable]
+other = """<p>To use this feature, you (or a cluster administrator) will need to enable the <a href="/docs/reference/command-line-tools-reference/feature-gates/#{{ .feature_gate_name }}"><tt>{{ .feature_gate_name }}</tt></a> feature gate for all relevant components in your cluster.</p>
+<p>See <a href="/docs/tasks/administer-cluster/configure-feature-gates/">Enable Or Disable Feature Gates</a> for more information.</p>"""
 
 [feature_gate_stable_graduated]
-other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release."
+other = "This is a stable feature in {{ .kubernetes }}, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release."
+
+[feature_gate_stable_graduated_disabled]
+other = "This stable feature gate is disabled by default. You can no longer enable this feature gate to opt in to the associated behavior."
 
 [feature_gate_stable_locked]
-other = "This is a stable feature in Kubernetes, and has been since version {{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release. You can no longer disable or opt out of this server."
+other = """This is a stable feature in {{ .kubernetes }}, and has been since version v{{ .stableVersion }}. It was first available in the v{{ .firstReleaseWithThisFeature }} release. You can no longer disable or opt out of this feature or behavior (it is locked); if you explicitly set a value for the associated feature gate <tt>{{ .featureGateName }}</tt>, {{ .kubernetes }} ignores it but does not report any error."""
+
+[feature_gate_removed_after_ga]
+other = """This is a stable feature in {{ .kubernetes }}, and has been since the {{ .stableVersion }} release. You can no longer toggle this feature (the associated <a href="/docs/reference/command-line-tools-reference/feature-gates-removed/">feature gate</a> has been removed)."""
+
+[feature_gate_removed_before_ga_final_version_clear]
+other = """{{ .kubernetes }} no longer includes this feature / behavior. The last release of {{ .kubernetes }} that recognized the <tt>{{ .featureGateName }}</tt> feature gate was {{ .toVersion }}. You can no longer toggle that setting."""
+
+# Used when we somehow don't know when the feature gate was removed.
+[feature_gate_removed_before_ga_final_version_unclear]
+other = """{{ .kubernetes }} no longer includes this feature / behavior. You can no longer toggle that setting."""
 
 [feature_gate_stage_alpha]
 other = "Alpha"
@@ -211,7 +241,7 @@ other = "Alpha"
 other = "Beta"
 
 [feature_gate_stage_stable]
-other = "GA"
+other = "Stable"
 
 [feature_gate_stage_deprecated]
 other = "Deprecated"
@@ -238,7 +268,7 @@ other = "To"
 other = "Until"
 
 [feature_state]
-other = "FEATURE STATE:"
+other = "Feature state:"
 
 [feature_state_kubernetes_label]
 other = "Kubernetes"

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -1,5 +1,23 @@
-{{/* for features that haven't been removed, show an info box */}}
-{{/* for features that have been removed, show a simple paragraph explaining that the feature is stable */}}
+{{/*
+This shortcode displays feature state information for Kubernetes feature gates.
+
+Parameters:
+  - feature_gate_name: Used to automatically look up the state and version information.
+
+  - state: The feature state (alpha, beta, deprecated, stable) for manual specification
+  - for_k8s_version: The Kubernetes version for manual specification.
+
+The shortcode renders differently depending on:
+  - Feature maturity stage
+  - Whether the feature is enabled/disabled by default
+  - When the feature was introduced and stabilized
+  - Instructions for enabling disabled features
+  - Information about locked/removed feature gates
+
+Sometimes you get an info box about the feature gate, sometimes you get an info box
+and then a paragraph, and sometimes you just get the paragraph.
+*/}}
+
 {{ $valid_states := "alpha, beta, deprecated, stable" }}
 {{ $state := .Get "state" }}
 {{ $for_k8s_version := .Get "for_k8s_version" | default (.Page.Param "version") }}
@@ -8,32 +26,53 @@
 {{ $feature_gate_name := .Get "feature_gate_name" }}
 {{ $firstReleaseWithThisFeature := false }}
 {{ $stableInLatestRelease := false }}
+{{ $featureGateStage := "unknown feature gate stage" }}
 
+{{/* Manual mode */}}
 {{ if not $feature_gate_name }}
+  {{/* Validate the state parameter */}}
   {{ if not $is_valid }}
     {{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
   {{- else -}}
-    {{- /* Display feature state notice */ -}}
+    {{/* Select the correct localized string for the state */}}
+    {{- if eq $state "deprecated" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_deprecated" ) }}
+    {{- end -}}
+    {{- if eq $state "alpha" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_alpha" ) }}
+    {{- end -}}
+    {{- if eq $state "beta" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_beta" ) }}
+    {{- end -}}
+    {{- if eq $state "stable" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_stable" ) }}
+    {{- end -}}
+
+    {{/* Feature state info box (manual mode) */}}
     <div class="feature-state-notice feature-{{ $state }}">
       <span class="feature-state-name">{{ T "feature_state" }}</span>
-      <code>{{ T "feature_state_kubernetes_label" }} {{ $for_k8s_version }} [{{ $state }}]</code>
+      <span class="feature-state-details">
+       {{ T "feature_state_kubernetes_label" }} {{ $for_k8s_version }} {{ T "feature_gate_details_unknown" (dict "stage" $featureGateStage ) }}
+      </span>
     </div>
   {{ end }}
+{{/* Automatic mode (look up from feature-gate files in content/??/docs/reference/command-line-tools-reference/feature-gates) */}}
 {{ else }}
-  <!-- When 'feature_gate_name' is specified, extract status of the feature gate -->
-
   {{- $featureGateDescriptionFilesPath := "/docs/reference/command-line-tools-reference/feature-gates" -}}
 
+  {{/* Treat the version data from the English site as canonical */}}
   {{- with index (where .Site.Sites "Language.Lang" "eq" "en") 0 -}}
     {{- with .GetPage $featureGateDescriptionFilesPath -}}
 
       {{- $sortedFeatureGates := sort (.Resources.ByType "page") -}}
       {{- $featureGateFound := false -}}
 
+      {{/* Loop through all feature gate files to find the matching one */}}
       {{- range $featureGateFile := $sortedFeatureGates -}}
         {{- $featureGateNameFromFile := $featureGateFile.Params.Title -}}
 
         {{- if eq $featureGateNameFromFile $feature_gate_name -}}
+          {{/* A match; extract relevant data */}}
           {{- $featureGateWasRemoved := $featureGateFile.Params.removed -}}
           {{- $earliestStage := (index $featureGateFile.Params.stages 0) -}}
           {{- with $earliestStage -}}
@@ -41,34 +80,90 @@
           {{- end -}}
           {{- $currentStage := index $featureGateFile.Params.stages (sub (len $featureGateFile.Params.stages) 1) -}}
           {{- with $currentStage -}}
+            {{/* Whether the feature gate is locked to true */}}
+            {{ $locked := (or false .locked ) }}
+
+            {{/* Whether this feature is GA (aka stable) in the latest release */}}
             {{- if and (eq .stage "stable") (eq (printf "v%s" .fromVersion) $latestVersion) -}}
               {{ $stableInLatestRelease = true }}
             {{- end -}}
-            {{- if and (eq .stage "stable") ($featureGateWasRemoved) -}}
+
+            {{/* Handle removed feature gates */}}
+            {{- if and (eq .stage "stable") ($featureGateWasRemoved) .defaultValue -}}
             <div class="feature-state-locked feature-state-removed feature-{{ .stage }}">
-              <p><em>{{ T "feature_gate_stable_locked" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em></p>
+              <p><em>{{ T "feature_gate_stable_removed" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion "featureGateName" $feature_gate_name ) | safeHTML }}</em></p>
             </div>
+
+            {{/* Handle active feature gates */}}
             {{- else -}}
-            <div class="feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
-              <span class="feature-state-name">{{ T "feature_state" }}</span> 
-              <code>{{ T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
+              {{/* Determine if feature is enabled or disabled by default */}}
+              {{ $featureGateEnabledOrDisabled := "unknown" -}}
               {{- if eq .defaultValue true -}}
-                {{ T "feature_gate_enabled" }}
+                {{ $featureGateEnabledOrDisabled = (T "feature_gate_enabled" ) }}
               {{- else -}}
-                {{ T "feature_gate_disabled" }}
+                {{ $featureGateEnabledOrDisabled = (T "feature_gate_disabled" ) }}
+              {{- end -}}
+
+              {{/* Determine the feature gate stage */}}
+              {{- if eq .stage "deprecated" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_deprecated" ) }}
+              {{- end -}}
+              {{- if eq .stage "alpha" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_alpha" ) }}
+              {{- end -}}
+              {{- if eq .stage "beta" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_beta" ) }}
+              {{- end -}}
+              {{- if eq .stage "stable" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_stable" ) }}
+              {{- end -}}
+              
+              {{/* Feature gate info box (automatic mode) */}}
+            <div class="feature-state-notice feature-{{ .stage }}{{ if and (eq .stage "stable") (not .defaultValue) }}feature-stable-but-disabled{{ end }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
+              <span class="feature-state-name">{{ T "feature_state" }}</span> 
+              <span class="feature-state-details">{{ T "feature_state_kubernetes_label" }} v{{ .fromVersion }} 
+               {{ if $locked -}}            
+                 {{/* For locked features, show different details format */}}
+                 {{ T "feature_gate_details_locked" (dict "stage" $featureGateStage "enabled_or_disabled" $featureGateEnabledOrDisabled ) }}
+               {{ else -}}
+                 {{/* For features progressing towards enabled & locked, show stage and enabled/disabled status */}}
+                 {{ T "feature_gate_details" (dict "stage" $featureGateStage "enabled_or_disabled" $featureGateEnabledOrDisabled ) }}
+               {{ end -}}
+              </span>
+            </div>
+            
+            {{/* Additional details section (expandable using HTML details element) */}}
+            <div class="feature-{{ .stage }}{{ if $stableInLatestRelease }} stable-in-latest-release{{end}}">
+              {{/* For stable features */}}
+              {{ if and (eq .stage "stable") -}}
+              <details>
+              <summary>{{ T "feature_gate_more_details" }}</summary>
+              <p><em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em>
+              {{/* Special message for feature that are both stable ann disabled by default */}}
+              {{ if not .defaultValue -}}
+                <em>{{ T "feature_gate_stable_graduated_disabled" }}</em></p>
+              {{ end -}}
+              </details>
+
+              {{/* Other feature gates are disabled by default, and get a notice about enabling it */}}
+              {{ else -}}
+                {{ if not .defaultValue -}}
+                {{/* Signpost to guidance on how to enable the feature gate */}}
+                <details>
+                <summary>{{ T "feature_gate_more_details" }}</summary>
+                {{ T "feature_gate_more_information_how_to_enable" (dict "feature_gate_name" $feature_gate_name ) | safeHTML }}
+                </p>
+                </details>
+                {{ end -}}
               {{- end -}}
             </div>
-              {{- if and (eq .stage "stable") -}}
-              <div class="feature-{{ .stage }}{{ if $stableInLatestRelease }} stable-in-latest-release{{end}}">
-              <p><em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em></p>
-              </div>
-              {{- end -}}
             {{- end -}}
             {{- $featureGateFound = true -}}
           {{- end -}}
         {{- end -}}
       {{- end -}}
 
+      {{/* If feature gate not found (in automatic mode), report an error */}}
       {{- if not $featureGateFound -}}
         {{- errorf "Invalid feature gate: '%s' is not recognized or lacks a matching description file in '%s'" $feature_gate_name (print "en" $featureGateDescriptionFilesPath) -}}
       {{- end -}}

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -1,8 +1,13 @@
+{{/* for features that haven't been removed, show an info box */}}
+{{/* for features that have been removed, show a simple paragraph explaining that the feature is stable */}}
 {{ $valid_states := "alpha, beta, deprecated, stable" }}
 {{ $state := .Get "state" }}
 {{ $for_k8s_version := .Get "for_k8s_version" | default (.Page.Param "version") }}
 {{ $is_valid := strings.Contains $valid_states $state }}
+{{ $latestVersion := site.Params.latest }}
 {{ $feature_gate_name := .Get "feature_gate_name" }}
+{{ $firstReleaseWithThisFeature := false }}
+{{ $stableInLatestRelease := false }}
 
 {{ if not $feature_gate_name }}
   {{ if not $is_valid }}
@@ -29,9 +34,21 @@
         {{- $featureGateNameFromFile := $featureGateFile.Params.Title -}}
 
         {{- if eq $featureGateNameFromFile $feature_gate_name -}}
+          {{- $featureGateWasRemoved := $featureGateFile.Params.removed -}}
+          {{- $earliestStage := (index $featureGateFile.Params.stages 0) -}}
+          {{- with $earliestStage -}}
+            {{ $firstReleaseWithThisFeature = .fromVersion -}}
+          {{- end -}}
           {{- $currentStage := index $featureGateFile.Params.stages (sub (len $featureGateFile.Params.stages) 1) -}}
           {{- with $currentStage -}}
-
+            {{- if and (eq .stage "stable") (eq (printf "v%s" .fromVersion) $latestVersion) -}}
+              {{ $stableInLatestRelease = true }}
+            {{- end -}}
+            {{- if and (eq .stage "stable") ($featureGateWasRemoved) -}}
+            <div class="feature-state-locked feature-state-removed feature-{{ .stage }}">
+              <p><em>{{ T "feature_gate_stable_locked" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em></p>
+            </div>
+            {{- else -}}
             <div class="feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
               <span class="feature-state-name">{{ T "feature_state" }}</span> 
               <code>{{ T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
@@ -41,7 +58,12 @@
                 {{ T "feature_gate_disabled" }}
               {{- end -}}
             </div>
-
+              {{- if and (eq .stage "stable") -}}
+              <div class="feature-{{ .stage }}{{ if $stableInLatestRelease }} stable-in-latest-release{{end}}">
+              <p><em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em></p>
+              </div>
+              {{- end -}}
+            {{- end -}}
             {{- $featureGateFound = true -}}
           {{- end -}}
         {{- end -}}

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -1,5 +1,23 @@
-{{/* for features that haven't been removed, show an info box */}}
-{{/* for features that have been removed, show a simple paragraph explaining that the feature is stable */}}
+{{/*
+This shortcode displays feature state information for Kubernetes feature gates.
+
+Parameters:
+  - feature_gate_name: Used to automatically look up the state and version information.
+
+  - state: The feature state (alpha, beta, deprecated, stable) for manual specification
+  - for_k8s_version: The Kubernetes version for manual specification.
+
+The shortcode renders differently depending on:
+  - Feature maturity stage
+  - Whether the feature is enabled/disabled by default
+  - When the feature was introduced and stabilized
+  - Instructions for enabling disabled features
+  - Information about locked/removed feature gates
+
+Sometimes you get an info box about the feature gate, sometimes you get an info box
+and then a paragraph, and sometimes you just get the paragraph.
+*/}}
+
 {{ $valid_states := "alpha, beta, deprecated, stable" }}
 {{ $state := .Get "state" }}
 {{ $for_k8s_version := .Get "for_k8s_version" | default (.Page.Param "version") }}
@@ -8,32 +26,53 @@
 {{ $feature_gate_name := .Get "feature_gate_name" }}
 {{ $firstReleaseWithThisFeature := false }}
 {{ $stableInLatestRelease := false }}
+{{ $featureGateStage := "unknown feature gate stage" }}
 
+{{/* Manual mode */}}
 {{ if not $feature_gate_name }}
+  {{/* Validate the state parameter */}}
   {{ if not $is_valid }}
     {{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
   {{- else -}}
-    {{- /* Display feature state notice */ -}}
+    {{/* Select the correct localized string for the state */}}
+    {{- if eq $state "deprecated" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_deprecated" ) }}
+    {{- end -}}
+    {{- if eq $state "alpha" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_alpha" ) }}
+    {{- end -}}
+    {{- if eq $state "beta" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_beta" ) }}
+    {{- end -}}
+    {{- if eq $state "stable" -}}
+      {{ $featureGateStage = (T "feature_gate_stage_stable" ) }}
+    {{- end -}}
+
+    {{/* Feature state info box (manual mode) */}}
     <div class="feature-state-notice feature-{{ $state }}">
       <span class="feature-state-name">{{ T "feature_state" }}</span>
-      <code>{{ T "feature_state_kubernetes_label" }} {{ $for_k8s_version }} [{{ $state }}]</code>
+      <span class="feature-state-details">
+      {{ T "feature_gate_details_partial" (dict "stage" (T (printf "feature_gate_stage_%s" $state)) "kubernetes" (T "feature_state_kubernetes_label") "version" (trim $for_k8s_version "v")) | safeHTML }}
+      </span>
     </div>
   {{ end }}
+{{/* Automatic mode (look up from feature-gate files in content/??/docs/reference/command-line-tools-reference/feature-gates) */}}
 {{ else }}
-  <!-- When 'feature_gate_name' is specified, extract status of the feature gate -->
-
   {{- $featureGateDescriptionFilesPath := "/docs/reference/command-line-tools-reference/feature-gates" -}}
 
+  {{/* Treat the version data from the English site as canonical */}}
   {{- with index (where .Site.Sites "Language.Lang" "eq" "en") 0 -}}
     {{- with .GetPage $featureGateDescriptionFilesPath -}}
 
       {{- $sortedFeatureGates := sort (.Resources.ByType "page") -}}
       {{- $featureGateFound := false -}}
 
+      {{/* Loop through all feature gate files to find the matching one */}}
       {{- range $featureGateFile := $sortedFeatureGates -}}
         {{- $featureGateNameFromFile := $featureGateFile.Params.Title -}}
 
         {{- if eq $featureGateNameFromFile $feature_gate_name -}}
+          {{/* A match; extract relevant data */}}
           {{- $featureGateWasRemoved := $featureGateFile.Params.removed -}}
           {{- $earliestStage := (index $featureGateFile.Params.stages 0) -}}
           {{- with $earliestStage -}}
@@ -41,34 +80,105 @@
           {{- end -}}
           {{- $currentStage := index $featureGateFile.Params.stages (sub (len $featureGateFile.Params.stages) 1) -}}
           {{- with $currentStage -}}
+            {{/* Whether the feature gate is locked to true */}}
+            {{ $locked := (or false .locked ) }}
+
+            {{/* Whether this feature is GA (aka stable) in the latest release */}}
             {{- if and (eq .stage "stable") (eq (printf "v%s" .fromVersion) $latestVersion) -}}
               {{ $stableInLatestRelease = true }}
             {{- end -}}
-            {{- if and (eq .stage "stable") ($featureGateWasRemoved) -}}
+
+            {{/* Handle removed feature gates */}}
+            {{- if $featureGateWasRemoved -}}
+              {{- if eq .stage "stable" -}}
             <div class="feature-state-locked feature-state-removed feature-{{ .stage }}">
-              <p><em>{{ T "feature_gate_stable_locked" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em></p>
+              <p><em>{{ T "feature_gate_removed_after_ga" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion "featureGateName" $feature_gate_name "kubernetes" (T "feature_state_kubernetes_label")) | safeHTML }}</em></p>
             </div>
-            {{- else -}}
-            <div class="feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
-              <span class="feature-state-name">{{ T "feature_state" }}</span> 
-              <code>{{ T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
-              {{- if eq .defaultValue true -}}
-                {{ T "feature_gate_enabled" }}
               {{- else -}}
-                {{ T "feature_gate_disabled" }}
+            <div class="feature-state-locked feature-state-removed">
+              {{- if isset . "toVersion" -}}
+              <p><em>{{ T "feature_gate_removed_before_ga_final_version_clear" (dict "featureGateName" $feature_gate_name "fromVersion" .fromVersion "toVersion" .toVersion ) | safeHTML }}</em></p>
+              {{- else -}}
+              {{- warnf "Removed feature gate %s doesn't seem to have a toVersion set for its final stage" $feature_gate_name -}}
+              <p><em>{{ T "feature_gate_removed_before_ga_final_version_unclear" (dict "featureGateName" $feature_gate_name "fromVersion" .fromVersion ) | safeHTML }}</em></p>
               {{- end -}}
             </div>
-              {{- if and (eq .stage "stable") -}}
-              <div class="feature-{{ .stage }}{{ if $stableInLatestRelease }} stable-in-latest-release{{end}}">
-              <p><em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em></p>
-              </div>
               {{- end -}}
+
+            {{/* Handle active feature gates */}}
+            {{- else -}}
+              {{/* Determine if feature is enabled or disabled by default */}}
+              {{ $featureGateEnabledOrDisabled := "unknown" -}}
+              {{- if eq .defaultValue true -}}
+                {{ $featureGateEnabledOrDisabled = (T "feature_gate_enabled" ) }}
+              {{- else -}}
+                {{ $featureGateEnabledOrDisabled = (T "feature_gate_disabled" ) }}
+              {{- end -}}
+
+              {{/* Determine the feature gate stage */}}
+              {{- if eq .stage "deprecated" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_deprecated" ) }}
+              {{- end -}}
+              {{- if eq .stage "alpha" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_alpha" ) }}
+              {{- end -}}
+              {{- if eq .stage "beta" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_beta" ) }}
+              {{- end -}}
+              {{- if eq .stage "stable" -}}
+                {{ $featureGateStage = (T "feature_gate_stage_stable" ) }}
+              {{- end -}}
+
+              {{/* Feature gate info box (automatic mode) */}}
+            <div class="feature-state-notice feature-{{ .stage }}{{ if and (eq .stage "stable") (not .defaultValue) }} feature-stable-but-disabled{{ end }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
+              <span class="feature-state-name">{{ T "feature_state" }}</span>
+              <span class="feature-state-details">
+               {{ if $locked -}}
+                 {{ T "feature_gate_details_partial" (dict "enabled_or_disabled" $featureGateEnabledOrDisabled "stage" (T (printf "feature_gate_stage_%s" .stage)) "kubernetes" (T "feature_state_kubernetes_label") "version" .fromVersion) | safeHTML }}
+               {{ else -}}
+                 {{/* Otherwise, show stage and enabled/disabled status */}}
+                 {{ T "feature_gate_details" (dict "enabled_or_disabled" $featureGateEnabledOrDisabled "stage" (T (printf "feature_gate_stage_%s" .stage)) "kubernetes" (T "feature_state_kubernetes_label") "version" .fromVersion) | safeHTML }}
+               {{ end -}}
+              </span>
+            </div>
+            
+            {{/* Additional details section (expandable using HTML details element) */}}
+            <div class="feature-{{ .stage }}{{ if $stableInLatestRelease }} stable-in-latest-release{{end}}">
+              {{/* For stable features */}}
+              {{ if and (eq .stage "stable") -}}
+              <details>
+              <summary>{{ T "feature_gate_more_details" }}</summary>
+              <p>
+              {{- if $locked -}}            
+                {{ T "feature_gate_stable_locked" (dict "featureGateName" $feature_gate_name "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "kubernetes" (T "feature_state_kubernetes_label") "stableVersion" .fromVersion) | safeHTML }}</p>
+              {{- else -}}
+                <em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em>
+                {{/* Special message for feature that are both stable and disabled by default */}}
+                {{- if not .defaultValue -}}
+                <em>{{ T "feature_gate_stable_graduated_disabled" }}</em>
+                {{ end -}}
+              {{ end -}}</p>
+              </details>
+
+              {{/* Other feature gates are disabled by default, and get a notice about enabling it */}}
+              {{ else -}}
+                {{ if not .defaultValue -}}
+                {{/* Signpost to guidance on how to enable the feature gate */}}
+                <details>
+                <summary>{{ T "feature_gate_more_details" }}</summary>
+                {{ T "feature_gate_more_information_how_to_enable" (dict "feature_gate_name" $feature_gate_name ) | safeHTML }}
+         
+                </details>
+                {{ end -}}
+              {{- end -}}
+            </div>
             {{- end -}}
             {{- $featureGateFound = true -}}
           {{- end -}}
         {{- end -}}
       {{- end -}}
 
+      {{/* If feature gate not found (in automatic mode), report an error */}}
       {{- if not $featureGateFound -}}
         {{- errorf "Invalid feature gate: '%s' is not recognized or lacks a matching description file in '%s'" $feature_gate_name (print "en" $featureGateDescriptionFilesPath) -}}
       {{- end -}}


### PR DESCRIPTION
1. Handle removed features differently. When a feature has graduated to stable and has since been removed, don't show the info box that we use for feature gates that Kubernetes still recognizes. Instead, show a simple paragraph explaining the situation.
   The idea I have is to use the metadata we already have (including `locked` and `removed`) to decide what text to show to readers.
1. Highlight alpha and beta features more prominently.
1. For feature gates that haven't been removed, show the info box **and** some optional explanatory text, wrapped in a `<details>` element.

For previews, see https://github.com/kubernetes/website/pull/52632#issuecomment-3369232954