### PR TITLE
Revise the rendering of feature state

### DIFF
--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -174,7 +174,10 @@ other = "Error"
 other = "Examples"
 
 [feature_gate_enabled]
-other = "(enabled by default: {{ .enabled }})"
+other = "(enabled by default)"
+
+[feature_gate_disabled]
+other = "(disabled by default)"
 
 [feature_gate_stage_alpha]
 other = "Alpha"

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -34,7 +34,12 @@
 
             <div class="feature-state-notice feature-{{ .stage }}" title="{{ printf "%s %s" (T "feature_state_feature_gate_tooltip") $feature_gate_name }}">
               <span class="feature-state-name">{{ T "feature_state" }}</span> 
-              <code>{{ T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code> {{ T "feature_gate_enabled" (dict "enabled" .defaultValue) }}
+              <code>{{ T "feature_state_kubernetes_label" }} v{{ .fromVersion }} [{{ .stage }}]</code>
+              {{- if eq .defaultValue true -}}
+                {{ T "feature_gate_enabled" }}
+              {{- else -}}
+                {{ T "feature_gate_disabled" }}
+              {{- end -}}
             </div>
 
             {{- $featureGateFound = true -}}


### PR DESCRIPTION
This PR changes the logic for rendering feature state.
Currently, a feature state is rendered as "enabled by default: true" or "enabled by default: false". A more user-friendly way to render it should be "enabled by default" or "disabled by default". This saves users some brain cells when reading the feature state.
