### PR TITLE
Add feature gate GitRepoVolumeDriver

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/GitRepoVolumeDriver.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/GitRepoVolumeDriver.md
@@ -1,0 +1,16 @@
+---
+title: GitRepoVolumeDriver
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.33"
+
+---
+This controls if the `gitRepo` volume plugin is supported or not.
+The `gitRepo` volume plugin is disabled by default starting v1.33 release.
+This provides a way for users to enable it.


### PR DESCRIPTION
We missed a feature gate since v1.33. It is about whether users can use the `gitRepo` volume plugin.