### PR TITLE
KEP-3015: Update PreferSameTrafficDistribution to GA

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -992,31 +992,26 @@ See [Traffic Policies](/docs/reference/networking/virtual-ips/#traffic-policies)
 ### Traffic distribution
 
 {{< feature-state feature_gate_name="ServiceTrafficDistribution" >}}
+{{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
 
 The `.spec.trafficDistribution` field provides another way to influence traffic
 routing within a Kubernetes Service. While traffic policies focus on strict
 semantic guarantees, traffic distribution allows you to express _preferences_
 (such as routing to topologically closer endpoints). This can help optimize for
 performance, cost, or reliability. In Kubernetes {{< skew currentVersion >}}, the
-following field value is supported: 
-
-`PreferClose`
-: Indicates a preference for routing traffic to endpoints that are in the same
-  zone as the client.
-
-{{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
-
-In Kubernetes {{< skew currentVersion >}}, two additional values are
-available (unless the `PreferSameTrafficDistribution` [feature
-gate](/docs/reference/command-line-tools-reference/feature-gates/) is
-disabled):
+following values are supported:
 
 `PreferSameZone`
-: This is an alias for `PreferClose` that is clearer about the intended semantics.
+: Indicates a preference for routing traffic to endpoints that are in the same
+  zone as the client.
 
 `PreferSameNode`
 : Indicates a preference for routing traffic to endpoints that are on the same
   node as the client.
+
+`PreferClose` (deprecated)
+: This is an older alias for `PreferSameZone` that is less clear about
+  the semantics.
 
 If the field is not set, the implementation will apply its default routing strategy.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/PreferSameTrafficDistribution.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/PreferSameTrafficDistribution.md
@@ -14,6 +14,11 @@ stages:
 - stage: beta
   defaultValue: true
   fromVersion: "1.34"
+  toVersion: "1.34"
+- stage: stable
+  defaultValue: true
+  locked: true
+  fromVersion: "1.35"
 ---
 Allows usage of the values `PreferSameZone` and `PreferSameNode` in
 the Service [`trafficDistribution`](/docs/reference/networking/virtual-ips/#traffic-distribution)

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -704,45 +704,36 @@ pool.
 ## Traffic Distribution
 
 {{< feature-state feature_gate_name="ServiceTrafficDistribution" >}}
+{{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
 
 The `spec.trafficDistribution` field within a Kubernetes Service allows you to
 express preferences for how traffic should be routed to Service endpoints.
 
-`PreferClose`
+`PreferSameZone`
 : This prioritizes sending traffic to endpoints in the same zone as the client.
   The EndpointSlice controller updates EndpointSlices with `hints` to
   communicate this preference, which kube-proxy then uses for routing decisions.
   If a client's zone does not have any available endpoints, traffic will be
   routed cluster-wide for that client.
 
-{{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
-
-In Kubernetes {{< skew currentVersion >}}, two additional values are
-available (unless the `PreferSameTrafficDistribution` [feature
-gate](/docs/reference/command-line-tools-reference/feature-gates/) is
-disabled):
-
-`PreferSameZone`
-: This means the same thing as `PreferClose`, but is more explicit. (Originally,
-  the intention was that `PreferClose` might later include functionality other
-  than just "prefer same zone", but this is no longer planned. In the future,
-  `PreferSameZone` will be the recommended value to use for this functionality,
-  and `PreferClose` will be considered a deprecated alias for it.)
-
 `PreferSameNode`
 : This prioritizes sending traffic to endpoints on the same node as the client.
-  As with `PreferClose`/`PreferSameZone`, the EndpointSlice controller updates
+  As with `PreferSameZone`, the EndpointSlice controller updates
   EndpointSlices with `hints` indicating that a slice should be used for a
   particular node. If a client's node does not have any available endpoints,
   then the service proxy will fall back to "same zone" behavior, or cluster-wide
   if there are no same-zone endpoints either.
+
+`PreferClose` (deprecated)
+: This is an older alias for `PreferSameZone` that is less clear about
+  the semantics.
 
 In the absence of any value for `trafficDistribution`, the default strategy is
 to distribute traffic evenly to all endpoints in the cluster.
 
 ### Comparison with `service.kubernetes.io/topology-mode: Auto`
 
-The `trafficDistribution` field with `PreferClose`/`PreferSameZone`, and the older "Topology-Aware
+The `trafficDistribution` field with `PreferSameZone`, and the older "Topology-Aware
 Routing" feature using the `service.kubernetes.io/topology-mode: Auto`
 annotation both aim to prioritize same-zone traffic. However, there is a key
 difference in their approaches:
@@ -754,7 +745,7 @@ difference in their approaches:
   for small numbers of endpoints), sacrificing some predictability in favor of
   potentially better load balancing.
 
-* `trafficDistribution: PreferClose` aims to be simpler and more predictable:
+* `trafficDistribution: PreferSameZone` aims to be simpler and more predictable:
   "If there are endpoints in the zone, they will receive all traffic for that
   zone, if there are no endpoints in a zone, the traffic will be distributed to
   other zones". This approach offers more predictability, but it means that you


### PR DESCRIPTION
KEP: https://github.com/kubernetes/enhancements/issues/3015

The interesting docs change here is that `trafficDistribution: PreferClose` is now deprecated and the preferred way of saying it is `trafficDistribution: PreferSameZone`.

I didn't bother mentioning that maybe you'd want to use `PreferClose` if you needed to supported older releases but maybe I should have? (`trafficDistribution: PreferClose` was enabled-by-default as of 1.31, while `trafficDistribution: PreferSameZone` was enabled-by-default as of 1.34, so there are three releases where you could use `PreferClose` but not `PreferSameZone`.)

I also removed the rationale section about why PreferClose got deprecated since it seems increasingly less relevant in the future?

/assign @aojea @thockin