### PR TITLE
Fix Hidden table of content after scrolling down and unscrollable toc

### DIFF
--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -55,6 +55,7 @@
   & > .td-sidebar-nav__section {
     padding-top: .5rem;
     padding-left: 1.5rem;
+    padding-bottom: 1rem;
   }
 }
 
@@ -79,7 +80,7 @@
   @include media-breakpoint-up(md) {
     @supports (position: sticky) {
       position: sticky;
-      top: 8.5rem;
+      top: 10rem;
       align-self: flex-start;
       height: fit-content;
       // min-height: 200px;
@@ -87,21 +88,23 @@
       overflow: visible;
       z-index: 10;
       padding: 0;
+      padding-left: 1.5rem;
       padding-bottom: 1rem;
       margin: 0;
 
       @media only screen and (min-width: 1075px) {
-        top: 6.5rem;
+        top: 8rem;
         // max-height: calc(100vh - 8rem); // REQUIRED for sticky to work
       }
 
       // Make the TableOfContents scrollable within the sticky container
       #TableOfContents {
         height: auto;
-        max-height: calc(100vh - 20rem); // Allows scrolling if content is too long
+        max-height: calc(100vh - 12rem);
         overflow-y: auto;
-        padding-bottom: 0;
-        margin-bottom: 0;
+        padding-top: 1.5rem;
+        padding-bottom: 1rem;
+        margin: 0;
       }
     }
   }

--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -73,3 +73,36 @@
     display: none;
   }
 }
+
+// Make the entire TOC area sticky and maximize space until footer
+.td-toc {
+  @include media-breakpoint-up(md) {
+    @supports (position: sticky) {
+      position: sticky;
+      top: 8.5rem;
+      align-self: flex-start;
+      height: fit-content;
+      // min-height: 200px;
+      // max-height: calc(100vh - 10rem); // REQUIRED for sticky to work
+      overflow: visible;
+      z-index: 10;
+      padding: 0;
+      padding-bottom: 1rem;
+      margin: 0;
+
+      @media only screen and (min-width: 1075px) {
+        top: 6.5rem;
+        // max-height: calc(100vh - 8rem); // REQUIRED for sticky to work
+      }
+
+      // Make the TableOfContents scrollable within the sticky container
+      #TableOfContents {
+        height: auto;
+        max-height: calc(100vh - 20rem); // Allows scrolling if content is too long
+        overflow-y: auto;
+        padding-bottom: 0;
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -102,6 +102,7 @@
         height: auto;
         max-height: calc(100vh - 12rem);
         overflow-y: auto;
+        overscroll-behavior: contain;
         padding-top: 1.5rem;
         padding-bottom: 1rem;
         margin: 0;

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="{{ "css/case-studies.css" | relURL }}">
 {{- end}}
 {{- if (eq .Section "case-studies") }}
-  {{ $caseStudiesCSS := resources.Get "scss/case_studies.scss" | css.Sass | resources.Copy "/css/case-studies.css" }}
+  {{ $caseStudiesCSS := resources.Get "scss/case_studies.scss" | resources.ToCSS | resources.Copy "/css/case-studies.css" }}
   {{ if $inServerMode }}
     <link rel="stylesheet" href="{{ $caseStudiesCSS.RelPermalink }}">
   {{ else }}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Fix the table of contents so that it does not hide after scrolling it down.

Result:
<img width="1904" height="1100" alt="image" src="https://github.com/user-attachments/assets/fb26eaa2-a491-4b3e-91dc-bb2556505433" />


<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

#52648 

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #