### PR TITLE
[vi] Add Vietnamese translation for kubectl

### DIFF
--- a/content/vi/docs/reference/glossary/kubectl.md
+++ b/content/vi/docs/reference/glossary/kubectl.md
@@ -1,0 +1,22 @@
+---
+title: Kubectl
+id: kubectl
+date: 2018-04-12
+full_link: /docs/reference/kubectl/
+short_description: >
+  Công cụ dòng lệnh giúp giao tiếp với cụm Kubernetes.
+
+aka:
+- kubectl
+tags:
+- tool
+- fundamental
+---
+Công cụ dòng lệnh giúp giao tiếp với {{< glossary_tooltip text="control plane" term_id="control-plane" >}} 
+của cụm Kubernetes thông qua Kubernetes API.
+
+
+<!--more--> 
+
+Bạn có thể sử dụng `kubectl` để tạo, quan sát, cập nhật và xóa
+các đối tượng trong Kubernetes.


### PR DESCRIPTION
### Description
Add Vietnamese translation for [kubectl](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/kubectl.md)

### Issue
None
