### PR TITLE
[uk] sync with PR 47743

### DIFF
--- a/content/uk/docs/reference/glossary/kube-apiserver.md
+++ b/content/uk/docs/reference/glossary/kube-apiserver.md
@@ -3,7 +3,7 @@
 title: API-сервер
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/architecture/#kube-apiserver
 # short_description: >
 #  Control plane component that serves the Kubernetes API.
 short_description: >


### PR DESCRIPTION
the last commit of content/uk/docs/reference/glossary/kube-apiserver.md 2020-03-31 

sync with PR #47743 ( 2024-08-31 )
and this change overrides the previous update from PR #23241 ( 2020-08-20 )