### PR TITLE
[en] fix service v1 load balancer source ranges client IP restriction note

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -157,7 +157,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
   *Atomic: will be replaced during a merge*
   
-  If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+  If specified and supported by the platform, traffic through the cloud-provider load balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
 
 - **loadBalancerClass** (string)
 


### PR DESCRIPTION
### Description

Fix wrong sentence structure for service v1 api reference in the description of the field `spec.loadBalancerSourceRanges`.

Closes: #