### PR TITLE
Update feature state for maximum parallel image pulls to stable

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -221,7 +221,7 @@ the kubelet will pull the images in parallel on behalf of the two different Pods
 
 ### Maximum parallel image pulls
 
-{{< feature-state for_k8s_version="v1.32" state="beta" >}}
+{{< feature-state for_k8s_version="v1.35" state="stable" >}}
 
 When `serializeImagePulls` is set to false, the kubelet defaults to no limit on
 the maximum number of images being pulled at the same time. If you would like to


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/issues/3673

- https://github.com/kubernetes/enhancements/pull/5640 was merged
- no k/k update is needed.

