### PR TITLE
Fix: update cluster-level PSS(issue #52661)

### DIFF
--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,25 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        admission-control-config-file: /etc/config/pod-security-admission.yaml
+      extraVolumes:
+      - name: pod-security-admission
+        hostPath: /etc/config/pod-security-admission.yaml    # Inside container path
+        mountPath: /etc/config/pod-security-admission.yaml   # Where API server reads it
+        readOnly: true
+        pathType: File
+  extraMounts:
+  - hostPath: ./pod-security-admission.yaml    # Your local file in website folder
+    containerPath: /etc/config/pod-security-admission.yaml   # Maps to container path
+    readOnly: true

--- a/pod-security-admission.yaml
+++ b/pod-security-admission.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: "baseline"
+      enforce-version: "latest"
+      audit: "restricted"
+      audit-version: "latest"
+      warn: "restricted"
+      warn-version: "latest"


### PR DESCRIPTION
Requirement/Issue:
Users following the Kubernetes tutorial "Apply Pod Security Standards at the Cluster Level" ([issue #52661](vscode-file://vscode-app/c:/Users/KRISHNA/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) were experiencing cluster creation failures when trying to create a kind cluster with Pod Security Admission configuration. The error indicated that the control plane failed to start due to connection issues (dial tcp 172.18.0.2:6443: connect: connection refused).
Fix Done:
I created two simplified configuration files in the website repository root 

[pod-security-admission.yaml]- Contains the Pod Security Admission configuration:
Sets baseline enforcement mode
Sets restricted audit and warn modes
Uses latest versions for all policies

[kind-config.yaml]- Contains the kind cluster configuration:

Properly configures the API server to use the pod security admission file
Uses simpler, more reliable volume mounting (maps local file directly to container path)
Eliminates the need for users to create temporary directories
Works consistently across different operating systems