### PR TITLE
Fix: kuberc schema link

### DIFF
--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -55,7 +55,7 @@ In this example, the following settings were used:
 With this alias, running `kubectl getn pods` will default JSON output. However,
 if you execute `kubectl getn pods -oyaml`, the output will be in YAML format.
 
-Full `kuberc` schema is available [here](/docs/reference/config-api/kubelet-config.v1beta1/).
+Full `kuberc` schema is available [here](/docs/reference/config-api/kuberc.v1beta1/).
 
 ### prependArgs
 


### PR DESCRIPTION
I believe the link should be pointing to the `kuberc` schema, rather than `kubelet-config` schema.