### PR TITLE
Remove Rodolfo Martinez from the Spanish owners list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -86,13 +86,11 @@ aliases:
     - electrocucaracha
     - krol3
     - raelga
-    - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
     - electrocucaracha
     - jossemarGT
     - krol3
     - raelga
-    - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - perriea
     - rekcah78


### PR DESCRIPTION
### Description

Following the sad news of Rodolfo Martínez’s passing, this update removes him from the list of owners for the Spanish team. This ensures that future assignments and notifications are properly handled and do not go unanswered.

https://github.com/cncf/memorials/blob/main/rodolfo-martinez.md

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #