### PR TITLE
Add fa/OWNERS to support Persian (Farsi) localization onboarding

### DIFF
--- a/content/fa/OWNERS
+++ b/content/fa/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the localization project for Farsi (Persian).
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+# Until the Persian localization reviewers/approvers are onboarded,
+# sig-docs-localization leads will review and approve PRs to help the team.
+# Once the team is onboarded, this OWNERS file will be updated.
+reviewers:
+- sig-docs-localization-reviewers
+
+approvers:
+- sig-docs-localization-owners
+
+labels:
+- area/localization
+- language/fa


### PR DESCRIPTION
The SIG Docs Localization Subproject is supporting the initiation of Persian (Farsi) localization,
based on #47142.

The Persian (Farsi) localization team and contributors are actively contributing to the localization effort.
However, since the team is still in the onboarding process, there are currently no official reviewers or approvers.

To facilitate the localization work, I (one of the SIG Docs Localization Subproject Leads) suggests to add a `fa/OWNERS` file so that SIG Docs Localization Leads can officially review and approve PRs for the team.

> **Note:**


```yaml
# Until the Persian localization reviewers/approvers are onboard,
# sig-docs-localization leads will review and approve PRs to help the team.
# Once the team is onboarded, this OWNERS file will be updated.

reviewers:
- sig-docs-localization-reviewers

approvers:
- sig-docs-localization-owners
```


/area localization
/language fa