### PR TITLE
[KEP-4639] Graduate image volume enabled by default (beta)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ImageVolume.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ImageVolume.md
@@ -13,6 +13,10 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.33"
+    toVersion: "1.34"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.35"
 ---
 Allow using the [`image`](/docs/concepts/storage/volumes/) volume source in a Pod.
 This volume source lets you mount a container image as a read-only volume.


### PR DESCRIPTION
### Description

Update the feature to become beta again, but now enabled by default.

### Issue

Refers to https://github.com/kubernetes/enhancements/issues/4639