### PR TITLE
Document PodTopologySpread edge cases in Known Limitations

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -635,14 +635,6 @@ section of the enhancement proposal about Pod topology spread constraints.
   You can work around this by using a Node autoscaler that is aware of
   Pod topology spread constraints and is also aware of the overall set of topology
   domains.
-- Node label typos can cause unexpected scheduling behavior. If a node has a typo
-  in its topology label (for example, `zon` instead of `zone`), the scheduler treats
-  that node as not having the topology key at all. This can result in:
-  - Pods failing to schedule with `UnschedulableAndUnresolvable` errors
-  - Uneven pod distribution that appears to violate spread constraints
-
-  Always verify that node labels exactly match the `topologyKey` specified in your
-  spread constraints.
 - Pods that don't match their own labelSelector create "ghost pods". If a pod's
   labels don't match the `labelSelector` in its topology spread constraint, the pod
   won't count itself in spread calculations. This means:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR adds documentation for an important edge case in PodTopologySpread behavior to the "Known limitations" section of the topology spread constraints documentation.

**Ghost pods (pods not matching their own constraint)**
- Documents what happens when a pod's labels don't match its spread constraint's labelSelector
- Explains that such pods don't count themselves in spread calculations, allowing multiple pods to accumulate on the same topology
- Clarifies that the spreading constraint works in an unintended way rather than being ineffective

This edge case was identified while working on the scheduler codebase and was previously only documented in test files. Adding it to
user-facing documentation helps users:
- Understand unexpected scheduling behaviour
- Avoid common misconfigurations
- Debug PodTopologySpread issues more effectively

This PR complements kubernetes/kubernetes#134373, which adds similar documentation to test files.

#### Which issue(s) this PR fixes:

None - this is a documentation improvement based on internal TODO items in the scheduler test code.

#### Does this PR introduce a user-facing change?

```release-note
Document edge case in PodTopologySpread Known Limitations: pods not matching their own constraint selector ("ghost pods").
```

#### Additional documentation:

- Related test documentation PR: https://github.com/kubernetes/kubernetes/pull/134373
- Feedback from @Huang-Wei suggesting website documentation instead of only test comments
