### PR TITLE
Modernize API reference docs: remove GOPATH workflow and outdated `api-index.md` file

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
@@ -157,7 +157,8 @@ static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/js/scroll
 The generated API reference files (HTML version) are copied to `<web-base>/static/docs/reference/generated/kubernetes-api/{{< param "version" >}}/`. This directory contains the standalone HTML API documentation. 
 
 {{< note >}}
-Note: The Markdown version of the API reference located at `<web-base>/content/en/docs/reference/kubernetes-api/` is generated separately using the [gen-resourcesdocs](https://github.com/kubernetes-sigs/reference-docs/tree/master/gen-resourcesdocs) generator.
+The Markdown version of the API reference located at `<web-base>/content/en/docs/reference/kubernetes-api/`
+is generated separately using the [gen-resourcesdocs](https://github.com/kubernetes-sigs/reference-docs/tree/master/gen-resourcesdocs) generator.
 {{< /note >}}
 
 ## Locally test the API reference


### PR DESCRIPTION


<!--
 Hello!
This pull request updates the Kubernetes API reference documentation contributor guide to modernize and simplify instructions, removing outdated `$GOPATH` references and clarifying repository setup and environment variable usage. It also revises the section on API reference versioning to better explain the location and generation of reference files.

**Repository setup and environment variables:**
* Replaces `go get` with `git clone` for acquiring the `reference-docs` repository and updates instructions to use generic `<your-path-to>` paths instead of `$GOPATH` for all repositories, reflecting current Go best practices.
* Updates environment variable examples to use `<your-path-to>` instead of `$GOPATH`, making it clearer for users not working inside a GOPATH workspace.

**API reference location and versioning:**
* Removes the manual instructions for updating the API reference index pages and instead provides a clearer explanation of where the generated API reference files are located, including a note about the Markdown version and its separate generation process.
 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR addresses the following changes:

- since the generator now only produces the Markdown reference files directly under `content/en/docs/reference/kubernetes-api/`. This PR removes the outdated section in the contributor guide that referenced the now-unused `api-index.md` file.
- update API reference generation documentation
- replace deprecated GOPATH-based setup with modern git clone approach
-  clarify API reference file locations and distinguish HTML vs Markdown versions
-  add note about `gen-resourcesdocs` for Markdown API reference generation
-  update repository setup instructions to use direct paths instead of GOPATH
-  simplify git clone commands by removing GOPATH references




