### PR TITLE
Add docs for CSI driver opt-in for serviceaccount tokens via secrets field beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/CSIServiceAccountTokenSecrets.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/CSIServiceAccountTokenSecrets.md
@@ -1,0 +1,14 @@
+---
+title: CSIServiceAccountTokenSecrets
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.35"
+---
+Enables CSI drivers to opt-in for receiving service account tokens from kubelet
+through the dedicated secrets field in NodePublishVolumeRequest instead of the volume_context field.


### PR DESCRIPTION
Doc update for KEP 5538: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/5538-csi-sa-tokens-secrets-field/README.md
KEP issue: https://github.com/kubernetes/enhancements/issues/5538