### PR TITLE
KEP-4540: CPU Manager strict-cpu-reservation option graduated to GA

### DIFF
--- a/content/en/docs/concepts/policy/node-resource-managers.md
+++ b/content/en/docs/concepts/policy/node-resource-managers.md
@@ -203,9 +203,9 @@ listed in alphabetical order:
 `full-pcpus-only` (GA, visible by default)
 : Always allocate full physical cores (available since Kubernetes v1.22, GA since Kubernetes v1.33)
 
-`strict-cpu-reservation` (beta, visible by default)
+`strict-cpu-reservation` (GA, visible by default)
 : Prevent all the pods regardless of their Quality of Service class to run on reserved CPUs
-  (available since Kubernetes v1.32)
+  (available since Kubernetes v1.32, GA since Kubernetes v1.35)
 
 `prefer-align-cpus-by-uncorecache` (beta, visible by default)
 : Align CPUs by uncore (Last-Level) cache boundary on a best-effort way

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -155,7 +155,7 @@ The following policy options exist for the static `CPUManager` policy:
 * `distribute-cpus-across-numa` (beta, visible by default) (1.33 or higher)
 * `align-by-socket` (alpha, hidden by default) (1.25 or higher)
 * `distribute-cpus-across-cores` (alpha, hidden by default) (1.31 or higher)
-* `strict-cpu-reservation` (beta, visible by default) (1.32 or higher)
+* `strict-cpu-reservation` (GA, visible by default) (1.35 or higher)
 * `prefer-align-cpus-by-uncorecache` (beta, visible by default) (1.34 or higher)
 
 The `full-pcpus-only` option can be enabled by adding `full-pcpus-only=true` to


### PR DESCRIPTION
### Description
Declare the `strict-cpu-reservation` option is now GA. There are no functional changes or user actions needed, so we just update the relevant versions.

k/k code changes:
* https://github.com/kubernetes/kubernetes/pull/134388

### Issue
Closes: https://github.com/kubernetes/enhancements/issues/4540