### PR TITLE
fix typo in debug-init-containers.md

### DIFF
--- a/content/en/docs/tasks/debug/debug-application/debug-init-containers.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-init-containers.md
@@ -92,11 +92,11 @@ You can also access the Init Container statuses programmatically by reading the
 
 
 ```shell
-kubectl get pod nginx --template '{{.status.initContainerStatuses}}'
+kubectl get pod <pod-name> --template '{{.status.initContainerStatuses}}'
 ```
 
 
-This command will return the same information as above in raw JSON.
+This command will return the same information as above, formatted using a [Go template](https://pkg.go.dev/text/template).
 
 ## Accessing logs from Init Containers
 


### PR DESCRIPTION
1. fix inconsistency - the entire document has commands with `<pod-name>` in examples. the line with `nginx` seems to be out of context because there is nothing about nginx before in the text.
2. command "kubectl get pod <pod-name> --template ..." does not generate raw JSON. the output is generated in a format defined in a golang template ( passed as a parameter ).