### PR TITLE
fix typos in configure-pod-container

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -65,8 +65,8 @@ kubectl create namespace cpu-example
 
 ## Specify a CPU request and a CPU limit
 
-To specify a CPU request for a container, include the `resources:requests` field
-in the Container resource manifest. To specify a CPU limit, include `resources:limits`.
+To specify a CPU request for a container, include the `resources.requests.cpu` field
+in the container’s resource manifest. To specify a CPU limit, include `resources.limits.cpu`.
 
 In this exercise, you create a Pod that has one container. The container has a request
 of 0.5 CPU and a limit of 1 CPU. Here is the configuration file for the Pod:

--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -62,8 +62,8 @@ kubectl create namespace mem-example
 
 ## Specify a memory request and a memory limit
 
-To specify a memory request for a Container, include the `resources:requests` field
-in the Container's resource manifest. To specify a memory limit, include `resources:limits`.
+To specify a memory request for a container, include the `resources.requests.memory` field
+in the container’s resource manifest. To specify a memory limit, include `resources.limits.memory`.
 
 In this exercise, you create a Pod that has one Container. The Container has a memory
 request of 100 MiB and a memory limit of 200 MiB. Here's the configuration file

--- a/content/en/docs/tasks/configure-pod-container/assign-pod-level-resources.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pod-level-resources.md
@@ -223,13 +223,13 @@ kubectl apply -f https://k8s.io/examples/pods/resource/pod-level-resources.yaml 
 Verify that the Pod Container is running:
 
 ```shell
-kubectl get pod-resources-demo --namespace=pod-resources-example
+kubectl get pod pod-resources-demo --namespace=pod-resources-example
 ```
 
 View detailed information about the Pod:
 
 ```shell
-kubectl get pod memory-demo --output=yaml --namespace=pod-resources-example
+kubectl get pod pod-resources-demo --output=yaml --namespace=pod-resources-example
 ```
 
 The output shows that one container in the Pod has a memory request of 50 MiB and a
@@ -239,24 +239,27 @@ cores. The Pod itself has a memory request of 100 MiB and a CPU request of
 
 ```yaml
 ...
-containers:
-  name: pod-resources-demo-ctr-1
-  resources:
-      requests:
-        cpu: 500m
-        memory: 50Mi
+  containers:
+  -
+    name: pod-resources-demo-ctr-1
+    resources:
       limits:
         cpu: 500m
         memory: 100Mi
-  ...
-  name: pod-resources-demo-ctr-2
-  resources: {}  
-resources:
-  limits:
-      cpu: 1
+      requests:
+        cpu: 500m
+        memory: 50Mi
+...
+  -
+    name: pod-resources-demo-ctr-2
+    resources: {}  
+...      
+  resources:
+    limits:
+      cpu: "1"
       memory: 200Mi
     requests:
-      cpu: 1
+      cpu: "1"
       memory: 100Mi
 ...
 ```

--- a/content/en/docs/tasks/configure-pod-container/extended-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/extended-resource.md
@@ -29,8 +29,8 @@ That will configure one of your Nodes to advertise a dongle resource.
 
 ## Assign an extended resource to a Pod
 
-To request an extended resource, include the `resources:requests` field in your
-Container manifest. Extended resources are fully qualified with any domain outside of
+To request an extended resource, include the `resources.requests.<resource_name>` field
+in the container manifest.
 `*.kubernetes.io/`. Valid extended resource names have the form `example.com/foo` where
 `example.com` is replaced with your organization's domain and `foo` is a
 descriptive resource name.


### PR DESCRIPTION
fix typos in configure-pod-container

1. 
fix yaml paths,
from `resources:requests` to `resources.requests`,
from `resources:limits` to `resources.limits`,
the same as on the page https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/#create-a-pod-with-cpu-requests-and-limits-at-pod-level

2.
fix `kubectl get ...` commands

3.
fix `kubectl get ... -o yaml` output

full output:
```
$ kubectl get pod pod-resources-demo --output=yaml --namespace=pod-resources-example
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"pod-resources-demo","namespace":"pod-resources-example"},"spec":{"containers":[{"image":"nginx","name":"pod-resources-demo-ctr-1","resources":{"limits":{"cpu":"0.5","memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}},{"command":["sleep","inf"],"image":"fedora","name":"pod-resources-demo-ctr-2"}],"resources":{"limits":{"cpu":"1","memory":"200Mi"},"requests":{"cpu":"1","memory":"100Mi"}}}}
  creationTimestamp: "2025-10-18T16:46:35Z"
  generation: 1
  name: pod-resources-demo
  namespace: pod-resources-example
  resourceVersion: "1546341"
  uid: d1b459bd-264c-4e9b-ad9a-1bdefb475d85
spec:
  containers:
  - image: nginx
    imagePullPolicy: Always
    name: pod-resources-demo-ctr-1
    resources:
      limits:
        cpu: 500m
        memory: 100Mi
      requests:
        cpu: 500m
        memory: 50Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-4bqlc
      readOnly: true
  - command:
    - sleep
    - inf
    image: fedora
    imagePullPolicy: Always
    name: pod-resources-demo-ctr-2
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-4bqlc
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: demo1-worker
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  resources:
    limits:
      cpu: "1"
      memory: 200Mi
    requests:
      cpu: "1"
      memory: 100Mi
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
...
```