### PR TITLE
Document ImageVolume with an image diges

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ImageVolumeWithDigest.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ImageVolumeWithDigest.md
@@ -1,0 +1,14 @@
+---
+title: ImageVolumeWithDigest
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.35"
+---
+For each [`image` volume](/docs/concepts/storage/volumes#image) in a Pod,
+image digest as part of the pod's status.


### PR DESCRIPTION
### Description

Adds a small section under https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/ to document the new [KEP](https://github.com/kubernetes/enhancements/issues/5365) regarding reporting the image volume's digest as part of the pod's status.

### Description

Changes preview:
<img width="1075" height="932" alt="Screenshot From 2025-10-28 10-41-18" src="https://github.com/user-attachments/assets/2f293aab-3655-4fd6-87c2-c57cafab3a09" />


### Issue

KEP: https://github.com/kubernetes/enhancements/issues/5365.