### PR TITLE
fix typos in workloads/management.md

### DIFF
--- a/content/en/docs/concepts/workloads/management.md
+++ b/content/en/docs/concepts/workloads/management.md
@@ -132,7 +132,7 @@ NAME           TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)      AGE
 my-nginx-svc   LoadBalancer   10.0.0.208   <pending>     80/TCP       0s
 ```
 
-With the above commands, first you create resources under `examples/application/nginx/` and print
+With the above commands, first you create resources under `docs/concepts/cluster-administration/nginx/` and print
 the resources created with `-o name` output format (print each resource as resource/name).
 Then you `grep` only the Service, and then print it with [`kubectl get`](/docs/reference/kubectl/generated/kubectl_get/).
 
@@ -379,7 +379,7 @@ deployment.apps/my-nginx scaled
 Now you only have one pod managed by the deployment.
 
 ```shell
-kubectl get pods -l app=nginx
+kubectl get pods -l app=my-nginx
 ```
 
 ```none


### PR DESCRIPTION
fix typos in workloads/management.md

1.
I changed from `examples/application/nginx/` to `docs/concepts/cluster-administration/nginx/` because there is "docs/concepts/cluster-administration/nginx/" in previous two `kubectl ...` commands.

2.
I changed from `kubectl get pods -l app=nginx` to `kubectl get pods -l app=my-nginx` because it probably refrers to :

```shell
kubectl create deployment my-nginx --image=nginx:1.14.2
```

and the label is `Labels:           app=my-nginx`

I checked it that way :

```
$ kubectl create deployment my-nginx --image=nginx:1.14.2
deployment.apps/my-nginx created

$ kubectl describe pod my-nginx
Name:             my-nginx-6fcd58f8bc-p5j4c
Namespace:        default
Priority:         0
Service Account:  default
Node:             demo1-worker/172.18.0.2
Start Time:       Sun, 19 Oct 2025 10:14:24 +0200
Labels:           app=my-nginx
                  pod-template-hash=6fcd58f8bc
Annotations:      <none>
Status:           Running
IP:               10.244.2.3
...
```
