### PR TITLE
[zh-cn] sync with PR 49474

### DIFF
--- a/content/zh-cn/examples/pods/inject/dapi-envars-container.yaml
+++ b/content/zh-cn/examples/pods/inject/dapi-envars-container.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox:1.24
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/content/zh-cn/examples/pods/inject/dapi-envars-pod.yaml
+++ b/content/zh-cn/examples/pods/inject/dapi-envars-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/content/zh-cn/examples/pods/inject/dapi-volume-resources.yaml
+++ b/content/zh-cn/examples/pods/inject/dapi-volume-resources.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: registry.k8s.io/busybox:1.24
+      image: registry.k8s.io/busybox:1.27.2
       command: ["sh", "-c"]
       args:
       - while true; do

--- a/content/zh-cn/examples/pods/inject/dapi-volume.yaml
+++ b/content/zh-cn/examples/pods/inject/dapi-volume.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: ["sh", "-c"]
       args:
       - while true; do

--- a/content/zh-cn/examples/pods/pod-configmap-env-var-valueFrom.yaml
+++ b/content/zh-cn/examples/pods/pod-configmap-env-var-valueFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/echo", "$(SPECIAL_LEVEL_KEY) $(SPECIAL_TYPE_KEY)" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/zh-cn/examples/pods/pod-configmap-envFrom.yaml
+++ b/content/zh-cn/examples/pods/pod-configmap-envFrom.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "env" ]
       envFrom:
       - configMapRef:

--- a/content/zh-cn/examples/pods/pod-configmap-volume-specific-key.yaml
+++ b/content/zh-cn/examples/pods/pod-configmap-volume-specific-key.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh","-c","cat /etc/config/keys" ]
       volumeMounts:
       - name: config-volume

--- a/content/zh-cn/examples/pods/pod-configmap-volume.yaml
+++ b/content/zh-cn/examples/pods/pod-configmap-volume.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "ls /etc/config/" ]
       volumeMounts:
       - name: config-volume

--- a/content/zh-cn/examples/pods/pod-multiple-configmap-env-variable.yaml
+++ b/content/zh-cn/examples/pods/pod-multiple-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: SPECIAL_LEVEL_KEY

--- a/content/zh-cn/examples/pods/pod-single-configmap-env-variable.yaml
+++ b/content/zh-cn/examples/pods/pod-single-configmap-env-variable.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.27.2
       command: [ "/bin/sh", "-c", "env" ]
       env:
         # 定义环境变量

--- a/content/zh-cn/examples/pods/probe/exec-liveness.yaml
+++ b/content/zh-cn/examples/pods/probe/exec-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: registry.k8s.io/busybox
+    image: registry.k8s.io/busybox:1.27.2
     args:
     - /bin/sh
     - -c


### PR DESCRIPTION
sync with PR #49474 .

the file `content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md` has already been synchronized and is up to date .