### PR TITLE
Shortcode add highlight options

### DIFF
--- a/layouts/shortcodes/code_sample.html
+++ b/layouts/shortcodes/code_sample.html
@@ -1,5 +1,6 @@
 {{ $p := .Page }}
 {{ $file := .Get "file" }}
+{{ $opts := .Get "options" | default "" }}
 {{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }}
 {{ $fileDir := path.Split $file }}
 {{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
@@ -34,7 +35,7 @@
     {{- end -}}
     </div>
     <div class="includecode" id="{{ $file | anchorize }}">
-    {{- highlight . $codelang "" -}}
+       {{- highlight . $codelang $opts -}}
     </div>
 </div>
 {{- end -}}


### PR DESCRIPTION
### Description
Adds an options parameter to the code_sample shortcode and forwards it to Hugo’s highlight function. This enables linenos, hl_lines, and other highlight features when including external files without changing existing calls.

follow-up PR will demonstrate usage #52837

**Before:**
```
{{% code_sample file="pods/resource/cpu-request-limit.yaml" %}}
```

**After:**
```
{{% code_sample file="pods/resource/cpu-request-limit.yaml" options="hl_lines=10-14" %}}
```
Preview

### old:
<img width="734" height="673" alt="image" src="https://github.com/user-attachments/assets/8a3248b0-480b-49b5-9852-687577b068eb" />

### new:
<img width="800" height="667" alt="image" src="https://github.com/user-attachments/assets/80beaa4a-a2a7-4bf5-9ccb-222acfe79c5e" />

Closes: #