### PR TITLE
KEP-5593: Configure the max CrashLoopBackOff delay beta docs

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -397,7 +397,7 @@ different maximum delays.
 
 {{< feature-state feature_gate_name="KubeletCrashLoopBackOffMax" >}}
 
-With the alpha feature gate `KubeletCrashLoopBackOffMax` enabled, you can
+With the feature gate `KubeletCrashLoopBackOffMax` enabled, you can
 reconfigure the maximum delay between container start retries from the default
 of 300s (5 minutes). This configuration is set per node using kubelet
 configuration. In your [kubelet

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletCrashLoopBackOffMax.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletCrashLoopBackOffMax.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.32"
+    toVersion: "1.34"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.35"
 ---
 Enables support for configurable per-node backoff maximums for restarting
 containers in the `CrashLoopBackOff` state.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Docs changes for [KEP-5593](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5593-configure-the-max-crashloopbackoff-delay) graduation to beta.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

kubernetes/enhancements: https://github.com/kubernetes/enhancements/issues/5593
kubernetes/kubernetes PRs:
