### PR TITLE
Fix link to configuring swap memory on Kubernetes nodes

### DIFF
--- a/content/en/docs/concepts/cluster-administration/swap-memory-management.md
+++ b/content/en/docs/concepts/cluster-administration/swap-memory-management.md
@@ -388,7 +388,7 @@ Containers configured in this manner will not have access to swap memory.
 ## {{% heading "whatsnext" %}}
 
 - To learn about managing swap on Linux nodes, read
-  [configuring swap memory on Kubernetes nodes](/docs/tutorials/configuration/provision-swap-memory/).
+  [configuring swap memory on Kubernetes nodes](/docs/tutorials/cluster-management/provision-swap-memory/).
 - You can check out a [blog post about Kubernetes and swap](/blog/2025/03/25/swap-linux-improvements/)
 - For background information, please see the original KEP, [KEP-2400](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap),
 and its [design](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

The link <https://kubernetes.io/docs/tutorials/configuration/provision-swap-memory/> returns 404. The correct link is probably <https://kubernetes.io/docs/tutorials/cluster-management/provision-swap-memory/>

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

