### PR TITLE
Document DRA Device Binding Conditions in v1.35

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -812,10 +812,10 @@ from the `status.conditions` field of the ResourceClaim.
 External controllers are responsible for updating these conditions using standard Kubernetes
 condition semantics (`type`, `status`, `reason`, `message`, `lastTransitionTime`).
 
-The scheduler waits up to **600 seconds** for all `bindingConditions` to become `True`.
+The scheduler waits up to **600 seconds** (default) for all `bindingConditions` to become `True`.
 If the timeout is reached or any `bindingFailureConditions` are `True`, the scheduler
 clears the allocation and reschedules the Pod.
-
+This timeout duration is configurable by the user through `KubeSchedulerConfiguration`.
 
 ```yaml
 apiVersion: resource.k8s.io/v1
@@ -857,9 +857,24 @@ the `status.allocation.nodeSelector` field in the ResourceClaim to that node nam
 - The `dra.example.com/is-prepared` binding condition indicates that the device `gpu-1`
 must be prepared (the `is-prepared` condition has a status of `True`) before binding. 
 - If the `gpu-1` device preparation fails (the `preparing-failed` condition has a status of `True`), the scheduler aborts binding.
-- The scheduler waits up to 600 seconds for the device to become ready.
+- The scheduler waits up to 600 seconds (default) for the device to become ready.
 - External controllers can use the node selector in the ResourceClaim to perform
 node-specific setup on the selected node.
+
+An example of configuring this timeout in `KubeSchedulerConfiguration` is given below:
+
+```yaml
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+- schedulerName: default-scheduler
+  pluginConfig:
+  - name: DynamicResources
+    args:
+      apiVersion: kubescheduler.config.k8s.io/v1
+      kind: DynamicResourcesArgs
+      bindingTimeout: 60s
+```
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

k/k development PR:  kubernetes/kubernetes#134905

#### Summary
We have merged an implementation for v1.35 that allows users to configure the timeout period for waiting until devices with DRA Device Binding Conditions become ready, through `KubeSchedulerConfiguration`. By default, the scheduler waits up to **600 seconds** for all required binding conditions to be satisfied before proceeding with binding. If the timeout is reached or any failure conditions are met, the scheduler clears the allocation and reschedules the Pod.
To inform users about this new capability, we will update the documentation for DRA Device Binding Conditions in v1.35 and include instructions on how to configure this timeout.

#### Background: Device Binding Conditions
Device Binding Conditions are used for the scheduler to ensure that resources (such as GPUs or other accelerators) are properly prepared before binding a Pod to a node. For example:

- The `dra.example.com/is-prepared` condition indicates that a device must be prepared before binding.
- If preparation fails (e.g., `preparing-failed` condition is True), the scheduler aborts the binding process.
- External controllers can use the node selector in the ResourceClaim to perform node-specific setup.

By default, the scheduler waits up to **600 seconds** for these conditions to become True. With this new feature, users can customize this timeout in `KubeSchedulerConfiguration` to suit their workloads (e.g., reduce it to 60 seconds).

#### Configuration Example

```yaml
apiVersion: kubescheduler.config.k8s.io/v1
kind: KubeSchedulerConfiguration
profiles:
- schedulerName: default-scheduler
  pluginConfig:
  - name: DynamicResources
    args:
      apiVersion: kubescheduler.config.k8s.io/v1
      kind: DynamicResourcesArgs
      bindingTimeout: 60s
 ```

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

k/enhancement issue: [kubernetes/enhancements#5007](https://github.com/kubernetes/enhancements/issues/5007)

Closes: #