### PR TITLE
Shortcode highlight options options usage

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -71,7 +71,7 @@ in the Container resource manifest. To specify a CPU limit, include `resources:l
 In this exercise, you create a Pod that has one container. The container has a request
 of 0.5 CPU and a limit of 1 CPU. Here is the configuration file for the Pod:
 
-{{% code_sample file="pods/resource/cpu-request-limit.yaml" %}}
+{{% code_sample file="pods/resource/cpu-request-limit.yaml" options="hl_lines=10-14" %}}
 
 The `args` section of the configuration file provides arguments for the container when it starts.
 The `-cpus "2"` argument tells the Container to attempt to use 2 CPUs.
@@ -163,7 +163,7 @@ the capacity of any Node in your cluster. Here is the configuration file for a P
 that has one Container. The Container requests 100 CPU, which is likely to exceed the
 capacity of any Node in your cluster.
 
-{{% code_sample file="pods/resource/cpu-request-limit-2.yaml" %}}
+{{% code_sample file="pods/resource/cpu-request-limit-2.yaml" options="hl_lines=10-14" %}}
 
 Create the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -69,7 +69,7 @@ In this exercise, you create a Pod that has one Container. The Container has a m
 request of 100 MiB and a memory limit of 200 MiB. Here's the configuration file
 for the Pod:
 
-{{% code_sample file="pods/resource/memory-request-limit.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit.yaml" options="hl_lines=10-14" %}}
 
 The `args` section in the configuration file provides arguments for the Container when it starts.
 The `"--vm-bytes", "150M"` arguments tell the Container to attempt to allocate 150 MiB of memory.
@@ -139,7 +139,7 @@ In this exercise, you create a Pod that attempts to allocate more memory than it
 Here is the configuration file for a Pod that has one Container with a
 memory request of 50 MiB and a memory limit of 100 MiB:
 
-{{% code_sample file="pods/resource/memory-request-limit-2.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit-2.yaml" options="hl_lines=10-14" %}}
 
 In the `args` section of the configuration file, you can see that the Container
 will attempt to allocate 250 MiB of memory, which is well above the 100 MiB limit.
@@ -248,7 +248,7 @@ capacity of any Node in your cluster. Here is the configuration file for a Pod t
 Container with a request for 1000 GiB of memory, which likely exceeds the capacity
 of any Node in your cluster.
 
-{{% code_sample file="pods/resource/memory-request-limit-3.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit-3.yaml" options="hl_lines=10-14" %}}
 
 Create the Pod:
 


### PR DESCRIPTION
## Description

This PR depends on #52795, which adds the `options` parameter support to the `code_sample` shortcode.

Demonstrates the use of the new `options` parameter in the `code_sample` shortcode by adding line highlighting to relevant code examples in the documentation.

This PR updates code samples in the following files to use the new highlight options:
- `content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md` - highlights resource limit lines
## Examples of Changes

**Before:**
```
{{% code_sample file="pods/resource/cpu-request-limit.yaml" %}}
```

**After:**
```
{{% code_sample file="pods/resource/cpu-request-limit.yaml" options="hl_lines=10-14" %}}
```
Preview

### old:
<img width="734" height="673" alt="image" src="https://github.com/user-attachments/assets/8a3248b0-480b-49b5-9852-687577b068eb" />

### new:
<img width="800" height="667" alt="image" src="https://github.com/user-attachments/assets/80beaa4a-a2a7-4bf5-9ccb-222acfe79c5e" />