### PR TITLE
Update description of feature gates for KEP-5278 moving to Beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ClearingNominatedNodeNameAfterBinding.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ClearingNominatedNodeNameAfterBinding.md
@@ -10,6 +10,8 @@ stages:
     defaultValue: false
     fromVersion: "1.34"
     toVersion: "1.34"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.35"
 ---
-
 Enable clearing `.status.nominatedNodeName` whenever Pods are bound to nodes.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/NominatedNodeNameForExpectation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/NominatedNodeNameForExpectation.md
@@ -9,10 +9,16 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.34"
+    toVersion: "1.34"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.35"
 
 ---
+When enabled, kube-scheduler uses `.status.nominatedNodeName` to express where a
+Pod is going to be bound. The `.status.nominatedNodeName` field is set when kube-scheduler
+triggers preemption of pods, or anticipates that WaitOnPermit or PreBinding phase will take
+relatively long.
+Other components may read and use `.status.nominatedNodeName`, but should not set it.
 
-When enabled, the kube-scheduler uses `.status.nominatedNodeName` to express where a
-Pod is going to be bound.
-External components can also write to `.status.nominatedNodeName` for a Pod to provide
-a suggested placement.
+When disabled, kube-scheduler will only set `.status.nominatedNodeName` before triggering preemption.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Update description of feature gates: ClearingNominatedNodeNameAfterBinding and NominatedNodeNameForExpectation.

### Issue
Enhancements issue: https://github.com/kubernetes/enhancements/issues/5278
