### PR TITLE
[DRAFT - KEP-3085] update reference to PodReadyToStartContainers condition

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -443,6 +443,11 @@ PodConditions:
 * `PodScheduled`: the Pod has been scheduled to a node.
 * `PodReadyToStartContainers`: (beta feature; enabled by [default](#pod-has-network)) the
   Pod sandbox has been successfully created and networking configured.
+  <!--
+  TODO(psaggu) - update references of PodReadyToStartContainers to reflect that
+  this pod status also reflects readiness of volume mounts aka CSI and DRA
+  Device plugins allocate calls too.
+  -->
 * `ContainersReady`: all containers in the Pod are ready.
 * `Initialized`: all [init containers](/docs/concepts/workloads/pods/init-containers/)
   have completed successfully.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Docs updates wrt KEP-3085 - https://github.com/kubernetes/enhancements/issues/4138

(The commit in the PR as of this update, doesn't contain anything.
It will updated later based on the changes in k/k PR https://github.com/kubernetes/kubernetes/pull/134660 is merged.)

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

<!--
### Issue


 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword


Closes: #
-->