### PR TITLE
KEP-4622: node: topology manager max-allowable-numa-nodes is GA

### DIFF
--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -253,12 +253,11 @@ You can enable this option by adding `prefer-closest-numa-nodes=true` to the Top
 By default (without this option), the Topology Manager aligns resources on either a single NUMA node or,
 in the case where more than one NUMA node is required, using the minimum number of NUMA nodes.
 
-### `max-allowable-numa-nodes` (beta) {#policy-option-max-allowable-numa-nodes}
+### `max-allowable-numa-nodes` {#policy-option-max-allowable-numa-nodes}
 
-The `max-allowable-numa-nodes` option is beta since Kubernetes 1.31. In Kubernetes {{< skew currentVersion >}},
-this policy option is visible by default provided that the `TopologyManagerPolicyOptions` and
-`TopologyManagerPolicyBetaOptions` [feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
-are enabled.
+The `max-allowable-numa-nodes` option is GA since Kubernetes 1.35. In Kubernetes {{< skew currentVersion >}},
+this policy option is visible by default provided that the `TopologyManagerPolicyOptions`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled.
 
 The time to admit a pod is tied to the number of NUMA nodes on the physical machine.
 By default, Kubernetes does not run a kubelet with the Topology Manager enabled, on any (Kubernetes) node where


### PR DESCRIPTION
### Description
Docs updates for KEP-4622

### Issue
https://github.com/kubernetes/enhancements/issues/4622

Implementation PR (GA): https://github.com/kubernetes/kubernetes/pull/134614

Closes: N/A