### PR TITLE
Update resource version comparison guidelines

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -1367,9 +1367,12 @@ changed, or to express data consistency requirements when getting, listing and
 watching resources. Resource versions must be treated as opaque by clients and passed
 unmodified back to the server.
 
-You must not assume resource versions are numeric or collatable. API clients may
-only compare two resource versions for equality (this means that you must not compare
-resource versions for greater-than or less-than relationships).
+Starting with K8s 1.35, it can be assumed that resource versions of all Kubernetes 
+resources and CRDs are comparable. Resource versions are considered monotonically
+increasing integers and can be compared as such. Clients can not make assumptions
+on the size of the resource version and comparisons must be only between a single
+resource. See [KEP-5504](https://github.com/kubernetes/enhancements/issues/5504)
+for more details on how to use this.
 
 ### `resourceVersion` fields in metadata {#resourceversion-in-metadata}
 


### PR DESCRIPTION
Clarify that resource versions in Kubernetes are now comparable as monotonically increasing integers starting from K8s 1.35.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Update resource version documentation for https://github.com/kubernetes/enhancements/issues/5504

### Issue
https://github.com/kubernetes/enhancements/issues/5504
