### PR TITLE
[zh-cn]sync kubeadm_init_phase_certs_etcd-{peer,healthcheck-client}

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_etcd-healthcheck-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_etcd-healthcheck-client.md
@@ -1,8 +1,3 @@
-<!-- 
-Generate the certificate for liveness probes to healthcheck etcd 
--->
-生成用于 etcd 健康检查的活跃性探针的证书。
-
 <!--
 ### Synopsis
 -->
@@ -11,14 +6,15 @@ Generate the certificate for liveness probes to healthcheck etcd
 <!--
 Generate the certificate for liveness probes to healthcheck etcd, and save them into etcd/healthcheck-client.crt and etcd/healthcheck-client.key files
 -->
-生成用于 etcd 健康检查的活跃性探针的证书，并将其保存到 etcd/healthcheck-client.crt 和 etcd/healthcheck-client.key 文件中。
+生成用于 etcd 健康检查的活跃性探针的证书，并将其保存到 `etcd/healthcheck-client.crt`
+和 `etcd/healthcheck-client.key` 文件中。
 
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-```
+```shell
 kubeadm init phase certs etcd-healthcheck-client [flags]
 ```
 
@@ -27,7 +23,7 @@ kubeadm init phase certs etcd-healthcheck-client [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -44,10 +40,12 @@ kubeadm init phase certs etcd-healthcheck-client [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>The path where to save and store the certificates.</p>
+The path where to save and store the certificates.
 -->
-<p>证书存储的路径。</p>
+证书存储的路径。
+</p>
 </td>
 </tr>
 
@@ -55,11 +53,14 @@ kubeadm init phase certs etcd-healthcheck-client [flags]
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>Path to a kubeadm configuration file.</p>
+Path to a kubeadm configuration file.
 -->
-<p>kubeadm 配置文件的路径。</p>
+kubeadm 配置文件的路径。
+</p>
 </td>
 </tr>
 
@@ -67,11 +68,12 @@ kubeadm init phase certs etcd-healthcheck-client [flags]
 <td colspan="2">--dry-run</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Don't apply any changes; just output what would be done.
 -->
-<p>
 不做任何更改；只输出将要执行的操作。
 </p>
 </td>
@@ -81,11 +83,14 @@ Don't apply any changes; just output what would be done.
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>help for etcd-healthcheck-client</p>
+help for etcd-healthcheck-client
 -->
-<p>etcd-healthcheck-client 操作的帮助命令。</p>
+etcd-healthcheck-client 操作的帮助命令。
+</p>
 </td>
 </tr>
 
@@ -99,10 +104,12 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>Choose a specific Kubernetes version for the control plane.</p>
+Choose a specific Kubernetes version for the control plane.
 -->
-<p>为控制平面选择特定的 Kubernetes 版本。</p>
+为控制平面选择特定的 Kubernetes 版本。
+</p>
 </td>
 </tr>
 
@@ -114,7 +121,7 @@ Don't apply any changes; just output what would be done.
 -->
 ### 继承于父命令的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -126,10 +133,12 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
-<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
+[实验] 到 '真实' 主机根文件系统的路径。
+</p>
 </td>
 </tr>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_etcd-peer.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_etcd-peer.md
@@ -1,9 +1,4 @@
 <!-- 
-Generate the certificate for etcd nodes to communicate with each other 
--->
-生成 etcd 节点相互通信的证书。
-
-<!-- 
 ### Synopsis
 -->
 ### 概要
@@ -11,19 +6,20 @@ Generate the certificate for etcd nodes to communicate with each other
 <!--
 Generate the certificate for etcd nodes to communicate with each other, and save them into etcd/peer.crt and etcd/peer.key files.
 -->
-生成 etcd 节点相互通信的证书，并将其保存到 etcd/peer.crt 和 etcd/peer.key 文件中。
+生成 etcd 节点相互通信的证书，并将其保存到 `etcd/peer.crt` 和
+`etcd/peer.key` 文件中。
 
 <!--
 Default SANs are localhost, 127.0.0.1, 127.0.0.1, ::1
 -->
-默认 SAN 为 localhost、127.0.0.1、127.0.0.1、:: 1
+默认 SAN 为 localhost、127.0.0.1、127.0.0.1、::1
 
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-```
+```shell
 kubeadm init phase certs etcd-peer [flags]
 ```
 
@@ -32,7 +28,7 @@ kubeadm init phase certs etcd-peer [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -49,10 +45,12 @@ kubeadm init phase certs etcd-peer [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>The path where to save and store the certificates.</p>  
+The path where to save and store the certificates.
 -->
-<p>保存和存储证书的路径。</p>
+保存和存储证书的路径。
+</p>
 </td>
 </tr>
 
@@ -61,10 +59,12 @@ kubeadm init phase certs etcd-peer [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>Path to a kubeadm configuration file.</p>
+Path to a kubeadm configuration file.
 -->
-<p>kubeadm 配置文件的路径。</p>
+kubeadm 配置文件的路径。
+</p>
 </td>
 </tr>
 
@@ -73,10 +73,10 @@ kubeadm init phase certs etcd-peer [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
 Don't apply any changes; just output what would be done.
 -->
-<p>
 不做任何更改；只输出将要执行的操作。
 </p>
 </td>
@@ -87,10 +87,12 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>help for etcd-peer</p> 
+help for etcd-peer
 -->
-<p>etcd-peer 操作的帮助命令。</p>
+etcd-peer 操作的帮助命令。
+</p>
 </td>
 </tr>
 
@@ -104,10 +106,12 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>Choose a specific Kubernetes version for the control plane.</p>  
+Choose a specific Kubernetes version for the control plane.
 -->
-<p>为控制平面指定特定的 Kubernetes 版本。</p>
+为控制平面指定特定的 Kubernetes 版本。
+</p>
 </td>
 </tr>
 
@@ -119,7 +123,7 @@ Don't apply any changes; just output what would be done.
 -->
 ### 继承于父命令的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -131,10 +135,12 @@ Don't apply any changes; just output what would be done.
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
-<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
+[实验] 到 '真实' 主机根文件系统的路径。
+</p>
 </td>
 </tr>
 


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_etcd-healthcheck-client.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_etcd-peer.md