### PR TITLE
[en] fix invalid description for avg300 PSI metric

### DIFF
--- a/content/en/docs/reference/instrumentation/understand-psi-metrics.md
+++ b/content/en/docs/reference/instrumentation/understand-psi-metrics.md
@@ -37,7 +37,7 @@ Pressure Stall Information (PSI) metrics are provided for three resources: CPU, 
 *   **`some`**: This value indicates that some tasks (one or more) are stalled on a resource. For example, if some tasks are waiting for I/O, this metric will increase. This can be an early indicator of resource contention.
 *   **`full`**: This value indicates that *all* non-idle tasks are stalled on a resource simultaneously. This signifies a more severe resource shortage, where the entire system is unable to make progress.
 
-Each pressure type provides four metrics: `avg10`, `avg60`, `avg300`, and `total`. The `avg` values represent the percentage of wall-clock time that tasks were stalled over 10-second, 60-second, and 3-minute moving averages. The `total` value is a cumulative counter in microseconds showing the total time tasks have been stalled.
+Each pressure type provides four metrics: `avg10`, `avg60`, `avg300`, and `total`. The `avg` values represent the percentage of wall-clock time that tasks were stalled over 10-second, 60-second, and 5-minute moving averages. The `total` value is a cumulative counter in microseconds showing the total time tasks have been stalled.
 
 ## Example Scenarios
 


### PR DESCRIPTION
**Description**

Tiny PR to fix the incorrect description for avg300. It doesn’t represent 3 minutes but 300 seconds (5 minutes).