### PR TITLE
Fix internal links on ES documentation

### DIFF
--- a/content/es/docs/tasks/tools/included/install-kubectl-macos.md
+++ b/content/es/docs/tasks/tools/included/install-kubectl-macos.md
@@ -18,9 +18,9 @@ El uso de la última versión de kubectl ayuda a evitar problemas imprevistos.
 
 Existen los siguientes métodos para instalar kubectl en macOS:
 
-- [Instalar el binario de kubectl con curl en macOS](#install-kubectl-binary-with-curl-on-macos)
-- [Instalar con Homebrew en macOS](#install-with-homebrew-on-macos)
-- [Instalar con Macports en macOS](#install-with-macports-on-macos)
+- [Instalar el binario de kubectl con curl en macOS](#instalar-el-binario-de-kubectl-con-curl-en-macos)
+- [Instalar con Homebrew en macOS](#instalar-con-homebrew-en-macos)
+- [Instalar con Macports en macOS](#instalar-con-macports-en-macos)
 
 ### Instalar el binario de kubectl con curl en macOS
 


### PR DESCRIPTION
Fix the internal links on Spanish documentation with correct anchor to binary, homebrew, macports methods.