### PR TITLE
feat: add feature gate CloudControllerManagerWatchBasedRoutesReconciliation

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/CloudControllerManagerWatchBasedRoutesReconciliation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/CloudControllerManagerWatchBasedRoutesReconciliation.md
@@ -1,0 +1,14 @@
+---
+title: CloudControllerManagerWatchBasedRoutesReconciliation
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.35"
+---
+Enables a watch-based route reconciliation mechanism (rather than reconciling at a fixed interval)
+within the cloud-controller-manager library.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The implementation of [KEP 5237](https://github.com/kubernetes/enhancements/issues/5237) contains a new feature gate, which needs to be added to the `command-line-tools-reference`.

Furthermore, the cloud-controller-manager administration document is extended to mention the new feature gate available for users.