### PR TITLE
[KEP-4006] Docs for AuthorizeWebsocketUpgradeCreatePermission (Beta)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/AuthorizeWebsocketUpdateCreatePermission.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/AuthorizeWebsocketUpdateCreatePermission.md
@@ -17,8 +17,8 @@ creation using a WebSocket.
 The connection upgrade request occurs for each of the following subresources: `pods/exec`,
 `pods/attach`, and `pods/portforward`. This feature gate fixes a security gap caused by
 the protocol transition: while SPDY requests utilize HTTP `POST` (naturally aligning with
-the **create** RBAC verb), the WebSocket protocol requires an HTTP `GET` request for the
-handshake. To correct this defect, a synthetic RBAC check is now applied to ensure
+the **create** RBAC permission), the WebSocket protocol requires an HTTP `GET` request for
+the handshake. To correct this defect, a synthetic RBAC check is now applied to ensure
 WebSocket upgrades strictly enforce the **create** permission, matching the existing
 SPDY security model.
 


### PR DESCRIPTION
### [KEP-4006] Docs for AuthorizeWebsocketUpgradeCreatePermission

* Docs for new `AuthorizeWebsocketUpgradeCreatePermission` feature gate, which is Beta and on by default.

* KEP PR for v1.35: https://github.com/kubernetes/enhancements/pull/5524
* PR for v1.35: https://github.com/kubernetes/kubernetes/pull/134577

[KEP-4006](https://github.com/kubernetes/enhancements/issues/4006)

