### PR TITLE
Update docs for InPlacePodVerticalScaling GA graduation

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/InPlacePodVerticalScaling.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/InPlacePodVerticalScaling.md
@@ -13,5 +13,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.33"
+    toVersion: "1.34"
+  - stage: stable
+    locked: true
+    defaultValue: true
+    fromVersion: "1.35"
 ---
 Enables in-place Pod vertical scaling.


### PR DESCRIPTION
InPlacePodVerticalScaling is graduating to GA: https://github.com/kubernetes/enhancements/issues/1287

I read through the docs and I think they are up to date -- nothing significant besides the feature stage has changed between 1.34 and 1.35.