### PR TITLE
KEP-5311 - Promote RelaxedServiceNameValidation to beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedServiceNameValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedServiceNameValidation.md
@@ -9,6 +9,7 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.34"
+    toVersion: "1.34"
   - stage: beta
     defaultValue: true
     fromVersion: "1.35"


### PR DESCRIPTION
### Description

KEP-5311 - Promote RelaxedServiceNameValidation to beta
### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Related to https://github.com/kubernetes/kubernetes/pull/134493