### PR TITLE
[zh] align translations of "Set up DRA"

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/assign-resources/allocate-devices-dra.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/assign-resources/allocate-devices-dra.md
@@ -58,8 +58,8 @@ Pods, and place the Pods on nodes that can access those devices.
   drivers. For more information, see
   [Set Up DRA in a Cluster](/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster).
 -->
-* 请确保集群管理员已设置好 DRA，挂接了设备并安装了驱动程序。
-  详情请参见[在集群中设置 DRA](/zh-cn/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster)。
+* 请确保集群管理员已安装好 DRA，挂接了设备并安装了驱动程序。
+  详情请参见[在集群中安装 DRA](/zh-cn/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster)。
 
 <!-- steps -->
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster.md
@@ -1,5 +1,5 @@
 ---
-title: "在集群中设置 DRA"
+title: "在集群中安装 DRA"
 content_type: task
 min-kubernetes-server-version: v1.34
 weight: 10


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

As comment https://github.com/kubernetes/website/pull/52703#issuecomment-3431548889 of previous PR mentioned,
"Set up DRA" is not accurated and should be translated as "安装 DRA". This PR align the translation in several Chinese docs.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #