### PR TITLE
fix typo in tasks/configure-pod-container/image-volumes.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/image-volumes.md
+++ b/content/en/docs/tasks/configure-pod-container/image-volumes.md
@@ -26,7 +26,7 @@ mount content from OCI registries inside containers.
 
 ## Run a Pod that uses an image volume {#create-pod}
 
-An image volume for a pod is enabled by setting the `volumes.[*].image` field of `.spec`
+An image volume for a pod is enabled by setting the `volumes[*].image` field of `.spec`
 to a valid reference and consuming it in the `volumeMounts` of the container. For example:
 
 {{% code_sample file="pods/image-volumes.yaml" %}}
@@ -40,7 +40,7 @@ to a valid reference and consuming it in the `volumeMounts` of the container. Fo
 1. Attach to the container:
 
    ```shell
-   kubectl attach -it image-volume bash
+   kubectl exec image-volume -it -- bash
    ```
 
 1. Check the content of a file in the volume:
@@ -85,7 +85,7 @@ from Kubernetes v1.33 when using the image volume feature.
 1. Attach to the container:
 
    ```shell
-   kubectl attach -it image-volume bash
+   kubectl exec image-volume -it -- bash
    ```
 
 1. Check the content of the file from the `dir` sub path in the volume:


### PR DESCRIPTION
## fix incorrect yaml-path
from `volumes.[*].image` to `volumes[*].image`

---

## fix incorrect kubectl command

from:
```
kubectl attach -it image-volume bash
```
to:
```
kubectl exec image-volume -it -- bash
```

### validation:

```
$ kubectl apply -f https://k8s.io/examples/pods/image-volumes-subpath.yaml
pod/image-volume created

$ kubectl attach -it image-volume bash
error: the server doesn't have a resource type "image-volume"

$ kubectl attach -it image-volume -c shell
error: Unable to use a TTY - container shell did not allocate one
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.

$ kubectl exec pod/image-volume -it -- bash
root@image-volume:/#
```
