### PR TITLE
Add time_offset shortcode for timestamps in docs

### DIFF
--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -11,6 +11,61 @@ Read more about shortcodes in the [Hugo documentation](https://gohugo.io/content
 
 <!-- body -->
 
+## Date and time offset {#date-time-offset}
+
+You can use the `{{</* date_time_offset */>}}` shortcode to render a timestamp 
+or a date that's offset from the current time by a specific amount. Use this
+shortcode to create evergreen timestamps for items like `expiration` fields in
+code samples. 
+
+This shortcode supports the following optional arguments:
+
+*   `layout`: the layout of the rendered timestamp. The following values are
+    supported:
+    *   `timestamp`: an absolute UTC timestamp, such as
+        `{{< date_time_offset >}}`. This is the default layout.
+    *   `dateLong`: a human-readable date, such as
+        `{{< date_time_offset layout="dateLong" >}}`.
+*   `years`: the number of years to offset the date by. Specify an integer
+    value. For example, `{{</* date_time_offset years="3" */>}}` results in
+    `{{< date_time_offset years="3" >}}`.
+*   `months`: the number of months to offset the date by. Specify an integer
+    value. For example, `{{</* date_time_offset months="1" */>}}` results in
+    `{{< date_time_offset months="1" >}}`.
+*   `days`: the number of days to offset the date by. Specify an integer
+    value. For example, `{{</* date_time_offset days="5" */>}}` results in
+    `{{< date_time_offset days="5" >}}`.
+
+The following examples demonstrate this shortcode:
+
+*   Default output:
+
+    ```none
+    {{</* date_time_offset */>}}
+    ```
+    The output is `{{< date_time_offset >}}`.
+
+*   `layout` argument:
+
+    ```none
+    {{</* date_time_offset layout="dateLong" */>}}
+    ```
+    The output is `{{< date_time_offset layout="dateLong" >}}`.
+
+*   `months` argument:
+
+    ```none
+    {{</* date_time_offset months="5" */>}}
+    ```
+    The output is `{{< date_time_offset months="5" >}}`.
+
+*   Multiple arguments:
+
+    ```none
+    {{</* date_time_offset months="5" layout="dateLong" days="3" */>}}
+    ```
+    The output is `{{< date_time_offset months="5" layout="dateLong" days="3" >}}`.
+
 ## Feature state
 
 In a Markdown page (`.md` file) on this site, you can add a shortcode to

--- a/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -93,7 +93,7 @@ stringData:
   token-secret: f395accd246ae52d
 
   # Expiration. Optional.
-  expiration: 2017-03-10T03:22:11Z
+  expiration: {{< date_time_offset years=3 >}}
 
   # Allowed usages.
   usage-bootstrap-authentication: "true"

--- a/layouts/shortcodes/date_time_offset.html
+++ b/layouts/shortcodes/date_time_offset.html
@@ -1,0 +1,26 @@
+<!-- Map of supported layouts and corresponding formats. To construct a new
+  layout, see https://gohugo.io/functions/time/format/#layout-string 
+-->
+{{- $supportedLayouts := dict 
+  "timestamp" "2006-01-02T15:04:05Z"
+  "dateLong" "January 02, 2006" 
+-}}
+<!-- Make the RFC3339 timestamp the default layout -->
+{{- $layout := default "timestamp" (.Get "layout") -}}
+{{- $timeFormat := $supportedLayouts.timestamp -}}
+<!-- Get user-specified parameters for offset, or set default values. -->
+{{- $offsetYears := default 0 (.Get "years") -}}
+{{- $offsetMonths := default 0 (.Get "months") -}}
+{{- $offsetDays := default 0 (.Get "days") -}}
+<!-- Return an array of the keys in the supported layouts field, for errors. -->
+{{- $keys := slice -}}
+{{- range $k, $v := $supportedLayouts -}}
+  {{- $keys = $keys | append $k }}
+{{- end -}}
+<!-- If the user-specified layout isn't supported, warn them. -->
+{{- if not (index $supportedLayouts $layout) -}}
+  {{warnf "%s isn't a supported layout. Use one of these values: %q. Using the default \"timestamp\" layout." $layout $keys }}
+{{- else -}}
+  {{- $timeFormat = index $supportedLayouts $layout -}}
+{{- end -}}
+{{- time.Now.AddDate (int $offsetYears) (int $offsetMonths) (int $offsetDays) | time.Format $timeFormat -}}

--- a/layouts/shortcodes/date_time_offset.html
+++ b/layouts/shortcodes/date_time_offset.html
@@ -19,7 +19,7 @@
 {{- end -}}
 <!-- If the user-specified layout isn't supported, warn them. -->
 {{- if not (index $supportedLayouts $layout) -}}
-  {{warnf "%s isn't a supported layout. Use one of these values: %q. Using the default \"timestamp\" layout." $layout $keys }}
+  {{ errorf "%s isn't a supported date_time_offset layout. Use one of these values: %q." $layout $keys }}
 {{- else -}}
   {{- $timeFormat = index $supportedLayouts $layout -}}
 {{- end -}}


### PR DESCRIPTION
Fixes #52709

- Add a `time_offset` shortcode that renders an absolute UTC timestamp in the format `YYYY-MM-DDTHH:mm:ssZ`, offset by a specific number of years (default is `5`). 
- Add an entry to the shortcodes section of the contributor guidance with examples.

## Reviewer discussion

- I decided not to use the latest release timestamp because if someone's on the docs for latestVersion-5, they might still see a date in the past. `time.Now` seems to be fresher always. Is that okay?
- I added an optional param for a number of years. There's no way to use it to render the _current time_ or to render a different format (like specific timezones).
    - Is the default of `5` years too much?
    - Is customization even necessary? 
- I haven't yet updated other timestamps in the docs, since I want us to settle on the setup first.

/sig docs
/hold
/cc @lmktfy 
