### PR TITLE
Docs/clarify names 8802

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -47,7 +47,7 @@ as defined in [RFC 1123](https://tools.ietf.org/html/rfc1123).
 This means the name must:
 
 - contain no more than 253 characters
-- contain only lowercase alphanumeric characters, **hyphens ('-')**, or **periods('.')**
+- contain only lowercase alphanumeric characters or hyphens ('-')
 - start with an alphanumeric character
 - end with an alphanumeric character
 


### PR DESCRIPTION
This PR addresses Issue #8802 by improving clarity in the "DNS Subdomain Names" list.

**Action Taken:**
Updated Line 36 in names.md to explicitly name the special characters.

- **Before:** `- contain only lowercase alphanumeric characters, '-' or '.'`
- **After:** `- contain only lowercase alphanumeric characters, hyphens ('-'), or periods ('.')`

Closes #8802