### PR TITLE
fix(shortcode): ensure preferred language is loaded for `code_sample`

### DIFF
--- a/layouts/shortcodes/code_sample.html
+++ b/layouts/shortcodes/code_sample.html
@@ -11,12 +11,13 @@
 {{/* Read the file relative to the content root. */}}
 {{ with readFile ($.Scratch.Get "filename")}}
 {{ $.Scratch.Set "content" . }}
-{{ end }}
+{{ else }}
 {{/* If not found, try the default language */}}
 {{ $defaultLang := (index (sort site.Languages "Weight") 0).Lang }}
 {{ with readFile (printf "/content/%s/examples/%s" $defaultLang $file) }}
 {{ $.Scratch.Set "content" . }}
 {{ $.Scratch.Set "filename" (printf "/content/%s/examples/%s" $defaultLang $file) }}
+{{ end }}
 {{ end }}
 {{ if not ($.Scratch.Get "content") }}
 {{ errorf "[%s] %q not found in %q" site.Language.Lang $fileDir.File $bundlePath }}


### PR DESCRIPTION
### Description

While reviewing #52439, I noticed that the newly localized code sample `content/pt-br/examples/debug/node-problem-detector-configmap.yaml` is not being loaded by the website, even though it is present in the folder. After some local tests, I realized this is happening because the English version is always being loaded due to a missing `else` clause.

This change ensures that the code branch for loading the English code sample does not run when a sample in the localization loaded for the website is available, using English solely as a fallback when a sample is not available for a given localization.