### PR TITLE
Make Service virtual IP scope more explicit

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -689,9 +689,9 @@ Unprefixed names are reserved for end-users.
 
 For a Service of `type: LoadBalancer`, a controller can set `.status.loadBalancer.ingress.ipMode`. 
 The `.status.loadBalancer.ingress.ipMode` specifies how the load-balancer IP behaves. 
-It may be specified only when the `.status.loadBalancer.ingress.ip` field is also specified.
+It may be specified only when the `.status.loadBalancer.ingress[*].ip` field is also specified.
 
-There are two possible values for `.status.loadBalancer.ingress.ipMode`: "VIP" and "Proxy". 
+There are two possible values for `.status.loadBalancer.ingress[*].ipMode`: "VIP" and "Proxy". 
 The default value is "VIP" meaning that traffic is delivered to the node 
 with the destination set to the load-balancer's IP and port. 
 There are two cases when setting this to "Proxy", depending on how the load-balancer 

--- a/content/en/docs/reference/networking/virtual-ips.md
+++ b/content/en/docs/reference/networking/virtual-ips.md
@@ -19,11 +19,15 @@ Each instance of kube-proxy watches the Kubernetes
 for the addition and removal of Service and EndpointSlice
 {{< glossary_tooltip term_id="object" text="objects" >}}. For each Service, kube-proxy
 calls appropriate APIs (depending on the kube-proxy mode) to configure
-the node to capture traffic to the Service's `clusterIP` and `port`,
+the node to capture traffic to the Service's IPs and ports,
 and redirect that traffic to one of the Service's endpoints
 (usually a Pod, but possibly an arbitrary user-provided IP address). A control
 loop ensures that the rules on each node are reliably synchronized with
 the Service and EndpointSlice state as indicated by the API server.
+
+Virtual IPs are created for all of a Service's addresses : `ClusterIPs`,
+`ExternalIPs` and optionally Load Balancer IPs
+(see [Load Balancer IP Mode](/docs/concepts/services-networking/service/#load-balancer-ip-mode)).
 
 {{< figure src="/images/docs/services-iptables-overview.svg" title="Virtual IP mechanism for Services, using iptables mode" class="diagram-medium" >}}
 


### PR DESCRIPTION
### Description

This PR aims at tackling a few ambiguities on how Virtual IPs behave against Service `externalIPs` and LoadBalancer IPs (as reported by the external provider), as I noticed many professional around me that were convinced that any request from a cluster to the external IP of one of the cluster's LB Services would egress the cluster and "come back" as ingress from "outside". (and thus add latency and cloud networking costs)

> [!NOTE]
> I did a first attempt, but I'm very open to iterating with people with a better knowledge of this repo and the underlying topic. Let me know how you would do it differently of if you think this is unnecessary !

### Issue

None that I could find.
I was directed to attempt a PR by the maintainers in [k8s Slack channel #sig-network](https://kubernetes.slack.com/archives/C09QYUH5W/p1761312641556069) so we can discuss its relevance here.

### Relevant Work :
* [KEP-1860 : Kube-proxy IP node binding & ipMode introduction](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding#summary)
* [Cilium Documentation](https://github.com/cilium/cilium/blob/main/Documentation/network/bgp-control-plane/bgp-control-plane-configuration.rst?plain=1#L649-L651)
* kube-proxy Code References : 
    * [ClusterIP](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/iptables/proxier.go#L1033)
    * [ExternalIP](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/iptables/proxier.go#L1055)
    * [LoadBalancer VIPs](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/iptables/proxier.go#L1083)
        * [Source from `status.loadbalancer.ingress.ip` and `ipMode`](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/serviceport.go#L220-L229)