### PR TITLE
feat(blog): feature blog for watch based routes reconciliation

### DIFF
--- a/content/en/blog/_posts/2025-10-27-watch-based-route-reconciliation-in-ccm.md
+++ b/content/en/blog/_posts/2025-10-27-watch-based-route-reconciliation-in-ccm.md
@@ -9,7 +9,7 @@ author: >
 ---
 
 Up to and including Kubernetes v1.34, the route controller in Cloud Controller Manager (CCM)
-implementations built using the [k8s.io/cloud-provider](k8s.io/cloud-provider) library reconciles
+implementations built using the [k8s.io/cloud-provider](https://github.com/kubernetes/cloud-provider) library reconciles
 routes at a fixed interval. This causes unnecessary API requests to the cloud provider when
 there are no changes to routes. Other controllers implemented through the same library already
 use watch-based mechanisms, leveraging informers to avoid unnecessary API calls. A new feature gate
@@ -18,7 +18,7 @@ is being introduced in v1.35 to allow changing the behavior of the route control
 ## What's new?
 
 The feature gate `CloudControllerManagerWatchBasedRoutesReconciliation` has been
-introduced to [k8s.io/cloud-provider](k8s.io/cloud-provider) in alpha stage by [SIG Cloud Provider](https://github.com/kubernetes/community/blob/master/sig-cloud-provider/README.md).
+introduced to [k8s.io/cloud-provider](https://github.com/kubernetes/cloud-provider) in alpha stage by [SIG Cloud Provider](https://github.com/kubernetes/community/blob/master/sig-cloud-provider/README.md).
 To enable this feature you can use `--feature-gate=CloudControllerManagerWatchBasedRoutesReconciliation=true`
 in the CCM implementation you are using.
 
@@ -36,4 +36,4 @@ changes to their existing route configurations.
 
 ## How can I learn more?
 
-For more details, refer to the [KEP](https://kep.k8s.io/5237).
+For more details, refer to the [KEP-5237](https://kep.k8s.io/5237).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The implementation of [KEP 5237](https://github.com/kubernetes/enhancements/issues/5237) contains a new feature gate. This feature blog shall inform users of cloud controller manager implementations that this feature gate exists and how to enable it.