### PR TITLE
Promote the 'HPA configurable tolerance' feature gate to beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/HPAConfigurableTolerance.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/HPAConfigurableTolerance.md
@@ -14,5 +14,5 @@ stages:
     defaultValue: true
     fromVersion: "1.35"
 ---
-Enables setting a [tolerance threshold](/docs/tasks/run-application/horizontal-pod-autoscale.md#tolerance)
+Enables setting a [tolerance threshold](/docs/tasks/run-application/horizontal-pod-autoscale#tolerance)
 for HorizontalPodAutoscaler metrics.


### PR DESCRIPTION
### Description

Update the documentation pertaining to the `HPAConfigurableTolerance` feature gate to reflect its promotion to beta.

See https://github.com/kubernetes/kubernetes/pull/133128 https://github.com/kubernetes/enhancements/pull/5564

### Issue

https://github.com/kubernetes/enhancements/issues/4951