### PR TITLE
Fix syntax for kubectl autoscale command

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -100,7 +100,7 @@ on the algorithm.
 Create the HorizontalPodAutoscaler:
 
 ```shell
-kubectl autoscale deployment php-apache --cpu=50% --min=1 --max=10
+kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
 ```
 
 ```


### PR DESCRIPTION
<html><head></head><body><p>Here’s the <strong>correct syntax</strong> and a <strong>clear explanation</strong> for the <code inline="">kubectl autoscale</code> command you’re using 👇</p>
<hr>
<p>✅ <strong>Correct Command:</strong></p>
<pre><code class="language-bash">kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
</code></pre>
<hr>
<h3>🧩 <strong>Explanation:</strong></h3>
<p>This command creates a <strong>Horizontal Pod Autoscaler (HPA)</strong> for the <code inline="">php-apache</code> deployment.<br>
It automatically adjusts the number of pod replicas based on observed <strong>CPU utilization</strong>.</p>
<h4>🔍 <strong>Breakdown:</strong></h4>

Flag | Description
-- | --
deployment php-apache | Specifies the target Deployment (php-apache) to scale automatically.
--cpu-percent=50 | Sets the target CPU utilization at 50% of the requested CPU for each pod.
--min=1 | Minimum number of pods that the deployment will scale down to (never fewer than 1).
--max=10 | Maximum number of pods the deployment can scale up to.


<hr>
<h3>🧠 <strong>Example Scenario:</strong></h3>
<p>If the average CPU usage across all pods exceeds 50%, Kubernetes will <strong>add more pods</strong> (up to 10) to handle the load.<br>
If CPU usage drops below 50%, it will <strong>reduce pods</strong> (but not below 1) to save resources.</p>
<hr>