### PR TITLE
Fix broken link in workloads/pods/_index.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -245,7 +245,7 @@ have some limitations:
 The above update rules apply to regular pod updates, but other pod fields can be updated through _subresources_.
 
 - **Resize:** The `resize` subresource allows container resources (`spec.containers[*].resources`) to be updated.
-  See [Resize Container Resources](#resize-container-resources) for more details.
+  See [Resize Container Resources](/docs/tasks/configure-pod-container/resize-container-resources/) for more details.
 - **Ephemeral Containers:** The `ephemeralContainers` subresource allows
   {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}}
   to be added to a Pod.


### PR DESCRIPTION
'Resize Container Resources' links to an anchor '#resize-container-resources', which doesn't exist on this page. If a reader clicks on the link to learn more about resizing container resources, nothing happens.

Updating the link to point to a page about resizing container resources.