### PR TITLE
format yaml in concepts/storage/projected-volumes.md

### DIFF
--- a/content/en/examples/pods/storage/projected-podcertificate.yaml
+++ b/content/en/examples/pods/storage/projected-podcertificate.yaml
@@ -18,7 +18,7 @@ spec:
   volumes:
   - name: my-x509-credentials
     projected:
-      defaultMode: 420
+      defaultMode: 0644
       sources:
       - podCertificate:
           keyType: ED25519

--- a/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
+++ b/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
@@ -18,19 +18,19 @@ spec:
       - secret:
           name: mysecret
           items:
-            - key: username
-              path: my-group/my-username
+          - key: username
+            path: my-group/my-username
       - downwardAPI:
           items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "cpu_limit"
-              resourceFieldRef:
-                containerName: container-test
-                resource: limits.cpu
+          - path: "labels"
+            fieldRef:
+              fieldPath: metadata.labels
+          - path: "cpu_limit"
+            resourceFieldRef:
+              containerName: container-test
+              resource: limits.cpu
       - configMap:
           name: myconfigmap
           items:
-            - key: config
-              path: my-group/my-config
+          - key: config
+            path: my-group/my-config

--- a/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
+++ b/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
@@ -18,11 +18,11 @@ spec:
       - secret:
           name: mysecret
           items:
-            - key: username
-              path: my-group/my-username
+          - key: username
+            path: my-group/my-username
       - secret:
           name: mysecret2
           items:
-            - key: password
-              path: my-group/my-password
-              mode: 511
+          - key: password
+            path: my-group/my-password
+            mode: 0777


### PR DESCRIPTION
### file mode - change from decimal to octal

0777 (octal) == 511 (decimal)
0644 (octal) == 420 (decimal)

both forms are valid but as far as I know humans use octal for file permissions :) or am I wrong ?

### format yaml indentation in lists

these files are part of the https://kubernetes.io/docs/concepts/storage/projected-volumes/ document.
and in most places there is no additional indentation for list items.

moreover, kubectl also formats yaml with no additional indentation.

so this:
```
  volumes:
  - name: all-in-one
    projected:
      sources:
      - secret:
          name: mysecret
          items:
            - key: username
              path: my-group/my-username
```
kubectl formats like this:
```
  volumes:
  - name: all-in-one
    projected:
      sources:
      - secret:
          name: mysecret
          items:
          - key: username
            path: my-group/my-username
```

---

```
$ kubectl apply -f content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml --dry-run=client -o yaml

apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"volume-test","namespace":"default"},"spec":{"containers":[{"command":["sleep","3600"],"image":"busybox:1.28","name":"container-test","volumeMounts":[{"mountPath":"/projected-volume","name":"all-in-one","readOnly":true}]}],"volumes":[{"name":"all-in-one","projected":{"sources":[{"secret":{"items":[{"key":"username","path":"my-group/my-username"}],"name":"mysecret"}},{"downwardAPI":{"items":[{"fieldRef":{"fieldPath":"metadata.labels"},"path":"labels"},{"path":"cpu_limit","resourceFieldRef":{"containerName":"container-test","resource":"limits.cpu"}}]}},{"configMap":{"items":[{"key":"config","path":"my-group/my-config"}],"name":"myconfigmap"}}]}}]}}
  name: volume-test
  namespace: default
spec:
  containers:
  - command:
    - sleep
    - "3600"
    image: busybox:1.28
    name: container-test
    volumeMounts:
    - mountPath: /projected-volume
      name: all-in-one
      readOnly: true
  volumes:
  - name: all-in-one
    projected:
      sources:
      - secret:
          items:
          - key: username
            path: my-group/my-username
          name: mysecret
      - downwardAPI:
          items:
          - fieldRef:
              fieldPath: metadata.labels
            path: labels
          - path: cpu_limit
            resourceFieldRef:
              containerName: container-test
              resource: limits.cpu
      - configMap:
          items:
          - key: config
            path: my-group/my-config
          name: myconfigmap
```
