### PR TITLE
docs: Consolidate October 2025 patches with November 2025

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,9 +7,10 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2025-10-10"
+    cherryPickDeadline: "2025-11-07"
+    note: "October 2025 patches consolidated with November"
     release: 1.34.2
-    targetDate: "2025-10-14"
+    targetDate: "2025-11-11"
   previousPatches:
   - cherryPickDeadline: "2025-09-05"
     release: 1.34.1
@@ -21,9 +22,10 @@ schedules:
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2025-10-10"
+    cherryPickDeadline: "2025-11-07"
+    note: "October 2025 patches consolidated with November"
     release: 1.33.6
-    targetDate: "2025-10-14"
+    targetDate: "2025-11-11"
   previousPatches:
   - cherryPickDeadline: "2025-09-05"
     release: 1.33.5
@@ -45,9 +47,10 @@ schedules:
 - endOfLifeDate: "2026-02-28"
   maintenanceModeStartDate: "2025-12-28"
   next:
-    cherryPickDeadline: "2025-10-10"
+    cherryPickDeadline: "2025-11-07"
+    note: "October 2025 patches consolidated with November"
     release: 1.32.10
-    targetDate: "2025-10-14"
+    targetDate: "2025-11-11"
   previousPatches:
   - cherryPickDeadline: "2025-09-05"
     release: 1.32.9
@@ -83,9 +86,10 @@ schedules:
 - endOfLifeDate: "2025-10-28"
   maintenanceModeStartDate: "2025-08-28"
   next:
-    cherryPickDeadline: "2025-10-10"
+    cherryPickDeadline: "2025-11-07"
+    note: "Final patch release to honor EOL. October 2025 patches consolidated with November"
     release: 1.31.14
-    targetDate: "2025-10-14"
+    targetDate: "2025-11-11"
   previousPatches:
   - cherryPickDeadline: "2025-09-05"
     release: 1.31.13
@@ -131,8 +135,6 @@ schedules:
   release: "1.31"
   releaseDate: "2024-08-13"
 upcoming_releases:
-- cherryPickDeadline: "2025-10-10"
-  targetDate: "2025-10-14"
 - cherryPickDeadline: "2025-11-07"
   targetDate: "2025-11-11"
 - cherryPickDeadline: "2025-12-05"


### PR DESCRIPTION
October 2025 patch releases are being consolidated with November 2025 releases, as announced in the [relevant mailing lists
](https://groups.google.com/a/kubernetes.io/g/dev/c/g6TibFkr80U/m/RfH9w0TpAAAJ).

This PR manually updates the release schedule to:
Remove October 2025 from the upcoming monthly releases table, update all active branches (1.34, 1.33, 1.32, 1.31) to use November dates, noting that 1.31.14 will be the final patch release to honor its EOL date (Oct 28, 2025).

/assign @xmudrii 
cc @kubernetes/release-engineering