### PR TITLE
The size of the button on the main page of the Documentation portal has been normalized for narrow screens

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -387,7 +387,7 @@ body.glossary {
       display: flex;
       padding: 0 30px 0 0;
       .card-content{
-        width: fit-content;
+        width: 100%;
         display: flex;
         flex-direction: column;
         margin: 0;


### PR DESCRIPTION
This minor style improvement to the Documentation portal's main page significantly improves formatting on narrow screens, see Before/After examples.

| Before | After |
| --- | --- |
| <img width="575" height="1514" alt="Monosnap Image 2025-11-01 21-05-43" src="https://github.com/user-attachments/assets/c594f00d-74fb-4c4f-9324-9194f7553f2c" /> |  <img width="575" height="1514" alt="Monosnap Image 2025-11-01 21-15-32" src="https://github.com/user-attachments/assets/53302529-2eb8-4924-9d6d-08cbc02d6899" /> |
