### PR TITLE
improve gateway resource example

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -95,19 +95,24 @@ that can be used for processing traffic, i.e. filtering, balancing, splitting, e
 such as a Service. For example, a Gateway may represent a cloud load balancer or an in-cluster proxy
 server that is configured to accept HTTP traffic.
 
-A minimal Gateway resource example:
+A typical Gateway resource example:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: example-gateway
+  namespace: example-namespace
 spec:
   gatewayClassName: example-class
   listeners:
   - name: http
     protocol: HTTP
     port: 80
+    hostname: "www.example.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
 ```
 
 In this example, an instance of traffic handling infrastructure is programmed to listen for HTTP
@@ -126,7 +131,7 @@ IP or the backing EndpointSlices of the Service. An HTTPRoute represents configu
 underlying Gateway implementation. For example, defining a new HTTPRoute may result in configuring additional
 traffic routes in a cloud load balancer or in-cluster proxy server.
 
-A minimal HTTPRoute example:
+A typical HTTPRoute example:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -166,7 +171,7 @@ traffic routes in a cloud load balancer or in-cluster proxy server.
 Gateways supporting GRPCRoute are required to support HTTP/2 without an initial upgrade from HTTP/1,
 so gRPC traffic is guaranteed to flow properly.
 
-A minimal GRPCRoute example:
+A typical GRPCRoute example:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
The documentation for most other resources provides typical, workable YAML examples. These can often, with some minor amendments, be used directly in ones own cluster.

This PR aims to make the YAML example for the gateway resource into one that is equally useful, rather than merely minimal. This gives readers a better understanding of how it should be structured.

I have validated the YAML:

```shell
k apply -f gateway.yaml --dry-run=client
gateway.gateway.networking.k8s.io/example-gateway created (dry run)
```