### PR TITLE
[ja] Update Dashboard installation to Helm-based method

### DIFF
--- a/content/ja/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/ja/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -33,16 +33,12 @@ Kubernetes Dashboardは現在、Helmベースのインストールのみをサ�
 {{< /note >}}
 
 ダッシュボードUIはデフォルトではデプロイされていません。デプロイするには、以下のコマンドを実行します:
-```bash
+```shell
 # kubernetes-dashboardリポジトリを追加
 helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
 # "kubernetes-dashboard"という名前のHelm Releaseをkubernetes-dashboardチャートを使用してデプロイ
 helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace kubernetes-dashboard
 ```
-
-{{< note >}}
-Helmチャートの詳細については、[ArtifactHub](https://artifacthub.io/packages/helm/kubernetes-dashboard/kubernetes-dashboard)を参照してください。
-{{< /note >}}
 
 ## ダッシュボードUIへのアクセス
 
@@ -63,9 +59,9 @@ Helmチャートの詳細については、[ArtifactHub](https://artifacthub.io/
 kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
 ```
 
-Kubectlは、ダッシュボードを https://localhost:8443 で利用可能にします。
+kubectlは、ダッシュボードを[https://localhost:8443](https://localhost:8443)で利用可能にします。
 
-UIはコマンドを実行しているマシンから _のみ_ アクセスできます。オプションについては`kubectl proxy --help`を参照してください。
+UIはコマンドを実行しているマシンから _のみ_ アクセスできます。オプションについては`kubectl port-forward --help`を参照してください。
 
 {{< note >}}
 Kubeconfigの認証方法は、外部IDプロバイダーやx509証明書ベースの認証には対応していません。


### PR DESCRIPTION
This PR updates the Japanese documentation for Kubernetes Dashboard to reflect the current installation method using Helm.

**Changes made:**
- Update installation instructions to use Helm instead of `kubectl apply`
- Add note explaining that Kubernetes Dashboard only supports Helm-based installation
- Update port-forward command to use the new service name (`kubernetes-dashboard-kong-proxy`)
- Change access URL from `http://localhost:8001/...` to `https://localhost:8443`
- Add note about kubeconfig authentication limitations
- Add reference to ArtifactHub for Helm chart details

**Why these changes are needed:**
- Kubernetes Dashboard v7.0.0+ dropped support for Manifest-based installation
- Only Helm-based installation is currently supported
- The English documentation has already been updated in #45775
- Japanese documentation needs to be aligned with the current installation method

**References:**
- Kubernetes Dashboard official repository: https://github.com/kubernetes/dashboard#installation

### Issue

This PR addresses the outdated installation instructions in the Japanese documentation.
While there is no specific open issue, this aligns the Japanese docs with the current Dashboard documentation and the already-updated English version (#45775).