### PR TITLE
update the broken link

### DIFF
--- a/content/en/docs/concepts/services-networking/_index.md
+++ b/content/en/docs/concepts/services-networking/_index.md
@@ -72,7 +72,7 @@ corresponding functionality is provided by external components, some
 of which are optional:
 
 * Pod network namespace setup is handled by system-level software implementing the
-  [Container Runtime Interface](/docs/concepts/architecture/cri.md).
+  [Container Runtime Interface](/docs/concepts/containers/cri/).
 
 * The pod network itself is managed by a
   [pod network implementation](/docs/concepts/cluster-administration/addons/#networking-and-network-policy).


### PR DESCRIPTION

## Summary
- Fix the Container Runtime Interface reference in `services-networking` docs to use the correct `/docs/concepts/containers/cri/` link.

```74:76:content/en/docs/concepts/services-networking/_index.md
* Pod network namespace setup is handled by system-level software implementing the
  [Container Runtime Interface](/docs/concepts/containers/cri/).
```

## Testing
- not run (docs-only change)