### PR TITLE
Fix broken CRI link in services-networking documentation

### DIFF
--- a/content/en/docs/concepts/services-networking/_index.md
+++ b/content/en/docs/concepts/services-networking/_index.md
@@ -72,7 +72,7 @@ corresponding functionality is provided by external components, some
 of which are optional:
 
 * Pod network namespace setup is handled by system-level software implementing the
-  [Container Runtime Interface](/docs/concepts/architecture/cri.md).
+  [Container Runtime Interface](/docs/concepts/containers/cri/).
 
 * The pod network itself is managed by a
   [pod network implementation](/docs/concepts/cluster-administration/addons/#networking-and-network-policy).


### PR DESCRIPTION
This PR fixes the broken Container Runtime Interface link in the services-networking documentation.

Changes:
- Update CRI link from /docs/concepts/architecture/cri.md to /docs/concepts/containers/cri/
- English documentation only

Other language versions will be updated by their respective localization teams after this PR is merged.

Fixes #53090