### PR TITLE
[zh-cn]sync kubeadm_init_phase_certs_apiserver-etcd-client kubeadm_init_phase

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase.md
@@ -1,8 +1,3 @@
-<!-- 
-Use this command to invoke single phase of the "init" workflow
--->
-使用此命令可以调用 "init" 工作流程的单个阶段。
-
 <!--
 ### Synopsis
 -->
@@ -22,7 +17,7 @@ kubeadm init phase [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -33,11 +28,14 @@ kubeadm init phase [flags]
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>help for phase</p>
+help for phase</p>
 -->
-<p>phase 操作的帮助命令。</p>
+phase 操作的帮助命令。
+</p>
 </td>
 </tr>
 
@@ -49,7 +47,7 @@ kubeadm init phase [flags]
 -->
 ### 继承于父命令的选择项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -60,11 +58,14 @@ kubeadm init phase [flags]
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
-<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
+[实验] 到 '真实' 主机根文件系统的路径。
+</p>
 </td>
 </tr>
 

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_apiserver-etcd-client.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_apiserver-etcd-client.md
@@ -1,8 +1,3 @@
-<!-- 
-Generate the certificate the apiserver uses to access etcd 
--->
-生成 apiserver 用来访问 etcd 的证书。
-
 <!--
 ### Synopsis
 -->
@@ -11,14 +6,15 @@ Generate the certificate the apiserver uses to access etcd
 <!--
 Generate the certificate the apiserver uses to access etcd, and save them into apiserver-etcd-client.crt and apiserver-etcd-client.key files.
 -->
-生成 apiserver 用于访问 etcd 的证书，并将其保存到 apiserver-etcd-client.crt 和 apiserver-etcd-client.key 文件中。
+生成 apiserver 用于访问 etcd 的证书，并将其保存到 `apiserver-etcd-client.crt`
+和 `apiserver-etcd-client.key` 文件中。
 
 <!--
 If both files already exist, kubeadm skips the generation step and existing files will be used.
 -->
 如果两个文件都已存在，则 kubeadm 将跳过生成步骤，使用现有文件。
 
-```
+```shell
 kubeadm init phase certs apiserver-etcd-client [flags]
 ```
 
@@ -27,7 +23,7 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 -->
 ### 选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -43,11 +39,14 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>The path where to save and store the certificates.</p>
+The path where to save and store the certificates.
 -->
-<p>证书的存储路径。</p>
+证书的存储路径。
+</p>
 </td>
 </tr>
 
@@ -55,11 +54,15 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>Path to a kubeadm configuration file.</p>
+Path to a kubeadm configuration file.
 -->
-<p>kubeadm 配置文件的路径。</p>
+kubeadm 配置文件的路径。
+</p>
 </td>
 </tr>
 
@@ -67,11 +70,15 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <td colspan="2">--dry-run</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>Don't apply any changes; just output what would be done.</p>
+Don't apply any changes; just output what would be done.
 -->
-<p>不做任何更改；只输出将要执行的操作。</p>
+不做任何更改；只输出将要执行的操作。
+</p>
 </td>
 </tr>
 
@@ -79,11 +86,15 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>help for apiserver-etcd-client</p>
+help for apiserver-etcd-client
 -->
-<p>apiserver-etcd-client 操作的帮助命令。</p>
+apiserver-etcd-client 操作的帮助命令。
+</p>
 </td>
 </tr>
 
@@ -94,11 +105,15 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!--
-<p>Choose a specific Kubernetes version for the control plane.</p>
+Choose a specific Kubernetes version for the control plane.
 -->
-<p>为控制平面指定特定的 Kubernetes 版本。</p>
+为控制平面指定特定的 Kubernetes 版本。
+</p>
 </td>
 </tr>
 
@@ -110,7 +125,7 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 -->
 ### 继承于父命令的选项
 
-   <table style="width: 100%; table-layout: fixed;">
+<table style="width: 100%; table-layout: fixed;">
 <colgroup>
 <col span="1" style="width: 10px;" />
 <col span="1" />
@@ -121,11 +136,15 @@ kubeadm init phase certs apiserver-etcd-client [flags]
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td>
+</td>
+<td style="line-height: 130%; word-wrap: break-word;">
+<p>
 <!-- 
-<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+[EXPERIMENTAL] The path to the 'real' host root filesystem.
 -->
-<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
+[实验] 到 '真实' 主机根文件系统的路径。
+</p>
 </td>
 </tr>
 


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_certs_apiserver-etcd-client.md