### PR TITLE
Make sure announcements are not printed

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1541,12 +1541,6 @@ body.td-documentation {
   text-decoration: none !important;
 }
 
-@media print {
-  /* Do not print announcements */
-  #announcement {
-    display: none;
-  }
-}
 
 /* Announcements */
 
@@ -1660,6 +1654,17 @@ html.no-js body div#announcement {
 
 @media (min-width: 768px) {
   #announcement + .header-hero {
+    display: none;
+  }
+}
+
+@media print {
+  /* Do not print announcements */
+  #announcement {
+    display: none;
+  }
+
+  #announcement.display-announcement {
     display: none;
   }
 }


### PR DESCRIPTION
### Description

Announcements are included in printed pages due to outdated css selector:

<details>
<summary>Image</summary>

<img width="832" height="442" alt="2025-11-05-200747_832x442_scrot" src="https://github.com/user-attachments/assets/b812a367-3f93-4946-8683-c3479dcc0a8f" />

</details>