### PR TITLE
Update Steering members following annual election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -235,9 +235,9 @@ aliases:
   committee-steering: # provide PR approvals for announcements
     - aojea
     - BenTheElder
-    - justaugustus
+    - katcosgrove
     - pacoxu
-    - pohly
+    - ritazh
     - saschagrunert
     - soltysh
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/300.)

Add:

* Kat Cosgrove - @katcosgrove
* Rita Zhang - @ritazh

Now Emeritus:

* Patrick Ohly - @pohly 
* Stephen Augustus - @justaugustus 

Thanks to all of the Emeritus members for your service and welcome to the new Steering Committee members!

/assign @BenTheElder @aojea @saschagrunert 
/cc @kubernetes/steering-committee
/hold