### PR TITLE
Adding mirror of Steering election result 2025 blog post

### DIFF
--- a/content/en/blog/_posts/2025-11-08-steering-committee-results-2025.md
+++ b/content/en/blog/_posts/2025-11-08-steering-committee-results-2025.md
@@ -2,8 +2,8 @@
 layout: blog
 title: "Announcing the 2025 Steering Committee Election Results"
 slug: steering-committee-results-2025
-canonicalUrl: https://www.kubernetes.dev/blog/2025/11/08/steering-committee-results-2025
-date: 2025-11-08T15:10:00-05:00
+canonicalUrl: https://www.kubernetes.dev/blog/2025/11/09/steering-committee-results-2025
+date: 2025-11-09T15:10:00-05:00
 author: >
   Arujjwal Negi
 ---


### PR DESCRIPTION
Adding mirror of election blog post; merge only after reconciling with any updates that happen before https://github.com/kubernetes/contributor-site/pull/594 is merged.