### PR TITLE
Fix kubeweekly section bug

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -420,6 +420,19 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
         }
       }
 
+        section.section-feature#kubeweekly {
+        background-color: $dark-bg-color-2;
+        color: $dark-text-color-1;
+
+        .kubeweekly-inner form p {
+          color: $white; 
+        }
+
+        a.kubeweekly-signup, a.kubeweekly-signup:hover {
+          color: $white; 
+        }
+      }
+
       .search-bar {
         background-color: #d3d3d3;
         color: #ffffff;


### PR DESCRIPTION
Description
Fixes dark mode text visibility issue in the KubeWeekly newsletter signup section on the homepage. The text was displaying in black on the dark background making it unreadable for users browsing with dark mode enabled.

Changes:
Added dark mode styles for .section-feature#kubeweekly

Issue
Closes: [#53121](https://github.com/kubernetes/website/issues/53121)