### PR TITLE
Only redirect to current API docs on current site

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,14 +1,16 @@
 {{- $latest := or .Site.Params.latest (errorf "missing .Site.Params.latest") -}}
-
 ###############################################
 # set server-side redirects in this file      #
 # see https://www.netlify.com/docs/redirects/ #
 # test at https://play.netlify.com/redirects  #
 ###############################################
 
+{{/* Omit "latest" redirect for old versions of the docs */}}
+{{- if not ( index .Site.Params "deprecated" ) -}}
 # Dynamic latest API redirect - automatically points to current latest version
 /docs/reference/generated/kubernetes-api/latest/     /docs/reference/generated/kubernetes-api/{{ $latest }}/ 307
 /docs/reference/generated/kubernetes-api/latest/*   /docs/reference/generated/kubernetes-api/{{ $latest }}/:splat 307
+{{- end -}}
 
 # Include all existing static redirects
 {{- $staticRedirects := readFile "static/_redirects.base" -}}


### PR DESCRIPTION
Rather than have every older documentation site serve a redirect to the current single-page API reference, just do it for https://kubernetes.io/

Here's a [preview](https://deploy-preview-53145--kubernetes-io-main-staging.netlify.app/docs/reference/generated/kubernetes-api/latest/).

Examples:

- https://k8s.io/docs/reference/generated/kubernetes-api/latest/ redirects to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/
- https://kubernetes.io/docs/reference/generated/kubernetes-api/latest/ redirects to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/
- https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/latest/ is a 404 (and will stay as a 404)
- https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/latest/ will be a 404 once we start to serve that site

/area web-development

Follow-up tweak to PR https://github.com/kubernetes/website/pull/52591

@Caesarsage FYI