### PR TITLE
[ko] Translate probe glossary

### DIFF
--- a/content/ko/docs/contribute/localization_ko.md
+++ b/content/ko/docs/contribute/localization_ko.md
@@ -414,6 +414,7 @@ postfix | 접미사 |
 prefix | 접두사 |
 PriorityClass | 프라이어리티클래스(PriorityClass) | API 오브젝트인 경우
 Privileged | 특권을 가진(privileged) |
+probe | 프로브(probe) |
 Prometheus | 프로메테우스 |
 proxy | 프록시 |
 proof of concept | 개념 증명 |

--- a/content/ko/docs/reference/glossary/probe.md
+++ b/content/ko/docs/reference/glossary/probe.md
@@ -1,0 +1,18 @@
+---
+title: 프로브(Probe)
+id: probe
+date: 2023-03-21
+full_link: /ko/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+
+short_description: >
+  kubelet이 파드 내 컨테이너에 대해 주기적으로 수행하는 검사.
+
+tags:
+- tool
+---
+{{< glossary_tooltip text="kubelet" term_id="kubelet" >}}이 파드에서 실행 중인 컨테이너에 대해 주기적으로 수행하는 검사로,
+컨테이너의 상태와 정상 동작 여부를 확인하고 컨테이너 라이프사이클에 정보를 제공한다.
+
+<!--more-->
+ 
+자세한 내용은 [컨테이너 프로브](/ko/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)를 참고한다.


### PR DESCRIPTION
### Description

Added Korean translation for `/docs/reference/glossary/probe.md`

### Issue

Closes: #53154
