### PR TITLE
[ja] Translated docs/reference/glossary/api-resource.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/api-resource.md
+++ b/content/ja/docs/reference/glossary/api-resource.md
@@ -7,7 +7,7 @@ short_description: >
   Kubernetes APIサーバー上のエンドポイントを表すKubernetesのエンティティです。
 
 aka:
- - Resource
+ - リソース
 tags:
 - architecture
 ---


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/api-resource.md` into Japanese: `content/ja/docs/reference/glossary/api-resource.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?architecture=true


### Issue

Closes: #53190 

/area localization
/language ja
