### PR TITLE
[ja] Translated docs/reference/glossary/pod-priority.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/pod-priority.md
+++ b/content/ja/docs/reference/glossary/pod-priority.md
@@ -1,0 +1,18 @@
+---
+title: Podの優先度
+id: pod-priority
+date: 2019-01-31
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+short_description: >
+  Podの優先度は、他のPodと比較したPodの重要度を示します。
+
+aka:
+tags:
+- operation
+---
+Podの優先度は、他のPodと比較した{{< glossary_tooltip term_id="pod" >}}の重要度を示します。
+
+<!--more-->
+
+[Podの優先度](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority)により、Podのスケジューリング優先度を他のPodよりも高くまたは低く設定できます。
+これは本番環境のクラスターワークロードにとって重要な機能です。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/pod-priority.md` into Japanese: `content/ja/docs/reference/glossary/pod-priority.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?operation=true


### Issue

Closes: #53192 

/area localization
/language ja
