### PR TITLE
[ja] Translated docs/reference/glossary/eviction.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/eviction.md
+++ b/content/ja/docs/reference/glossary/eviction.md
@@ -1,0 +1,18 @@
+---
+title: 退避
+id: eviction
+date: 2021-05-08
+full_link: /docs/concepts/scheduling-eviction/
+short_description: >
+    ノード上の1つ以上のPodを終了させるプロセス。
+aka:
+tags:
+- operation
+---
+
+退避はノード上の1つ以上のPodを終了させるプロセスです。
+
+<!--more-->
+退避には2種類あります:
+* [ノードの圧迫による退避](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+* [APIを起点とした退避](/docs/concepts/scheduling-eviction/api-eviction/)


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/eviction.md` into Japanese: `content/ja/docs/reference/glossary/eviction.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?operation=true


### Issue

Closes: #53194 

/area localization
/language ja
