### PR TITLE
[ja] Translated docs/reference/glossary/duration.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/duration.md
+++ b/content/ja/docs/reference/glossary/duration.md
@@ -1,0 +1,20 @@
+---
+title: 期間(Duration)
+id: duration
+date: 2024-10-05
+full_link:
+short_description: >
+  時間の長さを表す文字列値です。
+tags:
+- fundamental
+---
+時間の長さを表す文字列値です。
+
+<!--more-->
+
+Kubernetesにおける期間のフォーマットは、Goプログラミング言語の[`time.Duration`](https://pkg.go.dev/time#Duration)型に基づいています。
+
+期間を使用するKubernetes APIでは、値は非負整数と時間単位のサフィックスを組み合わせた一連の値として表現されます。複数の時間量を指定でき、期間はそれらの時間量の合計となります。
+有効な時間単位は「ns」、「µs」(または「us」)、「ms」、「s」、「m」、「h」です。
+
+例: `5s`は5秒の期間を表し、`1m30s`は1分30秒の期間を表します。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/duration.md` into Japanese: `content/ja/docs/reference/glossary/duration.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true


### Issue

Closes: #53196 

/area localization
/language ja
