### PR TITLE
[ja] Translated docs/reference/glossary/init-container.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/init-container.md
+++ b/content/ja/docs/reference/glossary/init-container.md
@@ -4,17 +4,17 @@ id: init-container
 date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/init-containers/
 short_description: >
-  アプリケーションコンテナの前に実行される1つ以上の初期化コンテナです。
+  アプリケーションコンテナの起動前に実行が完了している必要がある、1つ以上の初期化コンテナです。
 aka: 
 tags:
 - fundamental
 ---
-アプリケーションコンテナの前に実行される1つ以上の初期化{{< glossary_tooltip text="コンテナ" term_id="container" >}}です。
+アプリケーションコンテナの起動前に実行が完了している必要がある、1つ以上の初期化{{< glossary_tooltip text="コンテナ" term_id="container" >}}です。
 
 <!--more--> 
 
-初期化(Init)コンテナは通常のアプリケーションコンテナと似ていますが、1つの違いがあります。
-アプリケーションコンテナが開始される前に、Initコンテナが完了する必要があります。
+初期化(Init)コンテナは通常のアプリケーションコンテナと似ていますが、違いが1つあります。
+それは、アプリケーションコンテナが開始される前に、Initコンテナが完了していなければならない点です。
 Initコンテナは順番に実行され、各Initコンテナが完了してから次のInitコンテナが開始されます。
 
 {{< glossary_tooltip text="サイドカーコンテナ" term_id="sidecar-container" >}}とは異なり、InitコンテナはPod起動後に実行され続けることはありません。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/init-container.md` into Japanese: `content/ja/docs/reference/glossary/init-container.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true


### Issue

Closes: #

/area localization
/language ja
