### PR TITLE
Misc updates to endpoint-related annotation/label docs

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -749,13 +749,13 @@ There are two possible values:
 
 Type: Annotation
 
-Used on: StatefulSet
+Used on: Service
 
-This annotation on a Service denotes if the Endpoints controller should go ahead and create
-Endpoints for unready Pods. Endpoints of these Services retain their DNS records and continue
-receiving traffic for the Service from the moment the kubelet starts all containers in the pod
-and marks it _Running_, til the kubelet stops all containers and deletes the pod from
-the API server.
+This annotation was formerly used to indicate that the Endpoints controller
+should create Endpoints for unready Pods. Since Kubernetes 1.11, the preferred
+API for this feature has been the `.publishNotReadyAddresses` field on the
+{{< glossary_tooltip term_id="service" >}}. This annotation has no effect in
+Kubernetes {{< skew currentVersion >}}.
 
 ### autoscaling.alpha.kubernetes.io/behavior (deprecated) {#autoscaling-alpha-kubernetes-io-behavior}
 
@@ -1230,10 +1230,14 @@ Type: Label
 
 Example: `service.kubernetes.io/headless: ""`
 
-Used on: Endpoints
+Used on: EndpointSlice, Endpoints
 
-The control plane adds this label to an Endpoints object when the owning Service is headless.
-To learn more, read [Headless Services](/docs/concepts/services-networking/service/#headless-services).
+The {{< glossary_tooltip term_id="control-plane" text="control plane" >}} adds
+this {{< glossary_tooltip term_id="label" text="label" >}} to EndpointSlice and
+Endpoints objects when the owning {{< glossary_tooltip term_id="service" >}} is
+headless (as a hint to the service proxy that it can ignore these endpoints). To
+learn more, read [Headless
+Services](/docs/concepts/services-networking/service/#headless-services).
 
 ### service.kubernetes.io/topology-aware-hints (deprecated) {#servicekubernetesiotopology-aware-hints}
 
@@ -1241,19 +1245,9 @@ Example: `service.kubernetes.io/topology-aware-hints: "Auto"`
 
 Used on: Service
 
-This annotation was used for enabling _topology aware hints_ on Services. Topology aware
-hints have since been renamed: the concept is now called
-[topology aware routing](/docs/concepts/services-networking/topology-aware-routing/).
-Setting the annotation to `Auto`, on a Service, configured the Kubernetes control plane to
-add topology hints on EndpointSlices associated with that Service. You can also explicitly
-set the annotation to `Disabled`.
-
-If you are running a version of Kubernetes older than {{< skew currentVersion >}},
-check the documentation for that Kubernetes version to see how topology aware routing
-works in that release.
-
-There are no other valid values for this annotation. If you don't want topology aware hints
-for a Service, don't add this annotation.
+This is a deprecated alias for the
+[`service.kubernetes.io/topology-mode`](#service-kubernetes-io-topology-mode)
+annotation, which has the same functionality.
 
 ### service.kubernetes.io/topology-mode
 
@@ -1578,11 +1572,11 @@ a separate change could have been made since the last manually triggered rollout
 If you manually set this annotation on a Pod, nothing happens. The restarting side effect comes from
 how workload management and Pod templating works.
 
-### endpoints.kubernetes.io/over-capacity
+### endpoints.kubernetes.io/over-capacity (deprecated) {#endpoints-kubernetes-io-over-capacity}
 
 Type: Annotation
 
-Example: `endpoints.kubernetes.io/over-capacity:truncated`
+Example: `endpoints.kubernetes.io/over-capacity: truncated`
 
 Used on: Endpoints
 
@@ -1594,7 +1588,14 @@ has been truncated to 1000.
 
 If the number of backend endpoints falls below 1000, the control plane removes this annotation.
 
-### endpoints.kubernetes.io/last-change-trigger-time
+{{< note >}}
+The [Endpoints](/docs/reference/kubernetes-api/service-resources/endpoints-v1/)
+API is deprecated in favor of
+[EndpointSlice](/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/).
+A Service can have multiple EndpointSlice objects. As a result, EndpointSlices do not require truncation.
+{{< /note >}}
+
+### endpoints.kubernetes.io/last-change-trigger-time (deprecated) {#endpoints-kubernetes-io-last-change-trigger-time}
 
 Type: Annotation
 
@@ -1606,6 +1607,12 @@ This annotation set to an [Endpoints](/docs/concepts/services-networking/service
 represents the timestamp (The timestamp is stored in RFC 3339 date-time string format. For example, '2018-10-22T19:32:52.1Z'). This is timestamp
 of the last change in some Pod or Service object, that triggered the change to the Endpoints object.
 
+{{< note >}}
+The [Endpoints](/docs/reference/kubernetes-api/service-resources/endpoints-v1/)
+API is deprecated in favor of
+[EndpointSlice](/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/).
+{{< /note >}}
+
 ### control-plane.alpha.kubernetes.io/leader (deprecated) {#control-plane-alpha-kubernetes-io-leader}
 
 Type: Annotation
@@ -1614,9 +1621,10 @@ Example: `control-plane.alpha.kubernetes.io/leader={"holderIdentity":"controller
 
 Used on: Endpoints
 
-The {{< glossary_tooltip text="control plane" term_id="control-plane" >}} previously set annotation on
-an [Endpoints](/docs/concepts/services-networking/service/#endpoints) object. This annotation provided
-the following detail:
+The {{< glossary_tooltip text="control plane" term_id="control-plane" >}} previously used
+an [Endpoints](/docs/concepts/services-networking/service/#endpoints) object to
+coordinate leader assignment for the Kubernetes control plane. This Endpoints
+object included an annotation with the following detail:
 
 - Who is the current leader.
 - The time when the current leadership was acquired.


### PR DESCRIPTION
This came out of https://github.com/kubernetes/kubernetes/pull/134623 where we noticed that the `service.kubernetes.io/headless` label was documented as only applying to Endpoints (rather than both Endpoints and EndpointSlices), but while I was updating that I decided to search for all references to "endpoints" and ended up fixing a few other things:

- The `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation was mistakenly listed as applying to `StatefulSet` rather than `Service`, and while it did mention that it was deprecated, it failed to mention its replacement, or the fact that we completely dropped support for the annotation in 1.24.
- `service.kubernetes.io/headless` is now documented as applying to both Endpoints and EndpointSlices, and I added a bit about why it's there (to make it clearer that it's not expected to be useful to you unless you're writing a service proxy).
- Removed the docs for `service.kubernetes.io/topology-aware-hints` and just noted that it's a deprecated alias for `service.kubernetes.io/topology-mode`.
- Marked `endpoints.kubernetes.io/over-capacity` and `endpoints.kubernetes.io/last-change-trigger-time` as deprecated and added the same deprecation note as `endpoints.kubernetes.io/managed-by` has (plus a bit of extra text on `over-capacity` pointing out that EndpointSlice doesn't have the problem that necessitated this annotation on Endpoints).
- Clarified the docs on `control-plane.alpha.kubernetes.io/leader` which weren't very clear on why Endpoints were involved at all.

I waffled back and forth on marking `endpointslice.kubernetes.io/skip-mirror` deprecated and ended up not, since the mirroring controller itself is not deprecated.