### PR TITLE
[fr] add outdated content title and message

### DIFF
--- a/i18n/fr/fr.toml
+++ b/i18n/fr/fr.toml
@@ -178,3 +178,8 @@ other = """<p>Certains éléments sur cette page font référence à des produit
 [release_date_before]
 other = "(publiée: "
 
+[outdated_content_title]
+other = "Les informations contenues dans ce document peuvent être obsolètes"
+
+[outdated_content_message]
+other = "Ce document a une date de mise à jour antérieure à celle de l'original, les informations qu'il contient peuvent donc être obsolètes. Si vous comprenez l'anglais, consultez la version anglaise pour obtenir les informations les plus récentes :  "


### PR DESCRIPTION
This PR adds the missing French translations for the outdated_content_title and outdated_content_message i18n keys.

On the French Kubernetes website page : https://kubernetes.io/fr/docs/tutorials/kubernetes-basics/  the outdated content notice was still displayed in English because these keys were not defined in i18n/fr/fr.toml