### PR TITLE
Add reference/glossary/affinity.md

### DIFF
--- a/content/pt-br/docs/reference/glossary/affinity.md
+++ b/content/pt-br/docs/reference/glossary/affinity.md
@@ -4,13 +4,13 @@ id: affinity
 date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
-     Regras utilizadas pelo escalonador para determinar onde posicionar os pods
+     Regras utilizadas pelo escalonador para determinar onde alocar os Pods
 aka:
 tags:
 - fundamental
 ---
 
-No Kubernetes, _afinidade_ é um conjunto de regras que fornecem dicas ao escalonador sobre onde posicionar os pods.
+No Kubernetes, _afinidade_ é um conjunto de regras que fornecem dicas ao escalonador sobre onde alocar os Pods.
 
 <!--more-->
 Existem dois tipos de afinidade:
@@ -18,5 +18,5 @@ Existem dois tipos de afinidade:
 * [afinidade entre pods](/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
 
 As regras são definidas usando os {{< glossary_tooltip term_id="label" text="rótulos">}} do Kubernetes,
-e {{< glossary_tooltip term_id="selector" text="seletores">}} especificados nos {{< glossary_tooltip term_id="pod" text="pods" >}}, 
+e {{< glossary_tooltip term_id="selector" text="seletores">}} especificados nos {{< glossary_tooltip term_id="Pod" text="Pods" >}}, 
 e eles podem ser obrigatórios ou preferenciais, dependendo de quão rigorosamente você deseja que o escalonador os aplique.


### PR DESCRIPTION
### Description

Este PR traz a localização da página https://kubernetes.io/docs/reference/glossary/affinity/ para PT-BR.

Caminho da página EN no repositório: `content/en/docs/reference/glossary/affinity.md`
Caminho proposto em PT-BR no repositório: `content/pt-br/docs/reference/glossary/affinity.md`

This PR brings the localization of the page https://kubernetes.io/docs/reference/glossary/affinity/ to PT-BR.

Path of the EN page in the repository: `content/en/docs/reference/glossary/affinity.md`
Proposed path in PT-BR in the repository: `content/pt-br/docs/reference/glossary/affinity.md`

### Issue


Closes: #53155