### PR TITLE
Fix duplicated word in DaemonSet self-healing description

### DIFF
--- a/content/en/docs/concepts/architecture/self-healing.md
+++ b/content/en/docs/concepts/architecture/self-healing.md
@@ -22,7 +22,7 @@ It automatically replaces failed containers, reschedules workloads when nodes be
 - **Container-level restarts:** If a container inside a Pod fails, Kubernetes restarts it based on the [`restartPolicy`](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy).
 
 - **Replica replacement:** If a Pod in a [Deployment](/docs/concepts/workloads/controllers/deployment/) or [StatefulSet](/docs/concepts/workloads/controllers/statefulset/) fails, Kubernetes creates a replacement Pod to maintain the specified number of replicas.
-  If a Pod fails that is part of a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) fails, the control plane
+  If a Pod that is part of a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) fails, the control plane
   creates a replacement Pod to run on the same node.
   
 - **Persistent storage recovery:** If a node is running a Pod with a PersistentVolume (PV) attached, and the node fails, Kubernetes can reattach the volume to a new Pod on a different node.


### PR DESCRIPTION
This commit fixes a minor typo in the self-healing documentation.

In the paragraph describing replica replacement behavior, the sentence:

“If a Pod fails that is part of a DaemonSet fails …”

contained a duplicated “fails” and incorrect word order.

The corrected sentence now reads:

“If a Pod that is part of a DaemonSet fails, the control plane creates a replacement Pod to run on the same node.”

This improves readability and maintains consistency with the surrounding documentation.