### PR TITLE
Fix misleading wording: clarify that a Service targets Pods, not individual containers

### DIFF
--- a/content/en/docs/concepts/containers/container-environment.md
+++ b/content/en/docs/concepts/containers/container-environment.md
@@ -42,7 +42,7 @@ as are any environment variables specified statically in the container image.
 A list of all services that were running when a Container was created is available to that Container as environment variables.
 This list is limited to services within the same namespace as the new Container's Pod and Kubernetes control plane services.
 
-For a service named *foo* that exposes a Pod running a Container named *bar*,
+For a service named *foo* that exposes a set of Pods, each running a container named *bar*,
 the following variables are defined:
 
 ```shell
@@ -51,7 +51,7 @@ FOO_SERVICE_PORT=<the port the service is running on>
 ```
 
 Services have dedicated IP addresses and are available to the Container via DNS,
-if [DNS add-on](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/) is enabled. 
+if [DNS addon](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/) is enabled. 
 
 
 


### PR DESCRIPTION
The Service example in the Container Environment documentation incorrectly states:

“For a service named foo that maps to a Container named bar…”

This phrasing is technically inaccurate, as Kubernetes Services do not map directly to containers. Services target Pods selected by labels, and those Pods may run one or more containers.

This commit updates the example to use terminology consistent with Kubernetes concepts and controller behavior. The corrected sentence reads:

“For a Service named foo that exposes a Pod running a container named bar…”

This revision improves accuracy while keeping the example simple and understandable for readers.