### PR TITLE
add minikube verification to docs

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -39,7 +39,7 @@ See [Install tools](/docs/tasks/tools/#kubectl) for installation instructions.
 minikube start
 ```
 
-## Check the status of minikube cluster
+## Check the status of the minikube cluster
 
 Verify the status of the minikube cluster to ensure all the components are in a running state.
 


### PR DESCRIPTION
### Description

Adding minikube verification step by running minikube status, to verify the current running kubernetes components that were started.

This will be also be helpful to check if the kubectl command fails to connect to API Server.