### PR TITLE
[pt-br] Standardize terminology for ‘daemon’ in related glossaries

### DIFF
--- a/content/pt-br/docs/reference/glossary/cadvisor.md
+++ b/content/pt-br/docs/reference/glossary/cadvisor.md
@@ -13,6 +13,6 @@ O cAdvisor (Contêiner Advisor) fornece aos usuários de contêineres uma compre
 
 <!--more-->
 
-É um daemon em execução que coleta, agrega, processa e exporta informações sobre contêineres em execução. 
+É um serviço (daemon) em execução que coleta, agrega, processa e exporta informações sobre contêineres em execução. 
 Especificamente, para cada contêiner, ele mantém parâmetros de isolamento de recursos, uso histórico de recursos, histogramas de uso histórico completo de recursos e estatísticas de rede. 
 Esses dados são exportados por contêiner e em toda a máquina.

--- a/content/pt-br/docs/reference/glossary/daemonset.md
+++ b/content/pt-br/docs/reference/glossary/daemonset.md
@@ -15,4 +15,4 @@ tags:
  Garante que uma cópia de um {{< glossary_tooltip text="Pod" term_id="pod" >}} esteja sendo executada em um conjunto de nós em um {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
 <!--more--> 
 
-Usado para instalar daemons do sistema como coletores de log e agentes de monitoramento que normalmente devem ser executados em todos os {{< glossary_tooltip text="nós" term_id="node" >}}.
+Usado para instalar serviços (daemons) do sistema como coletores de log e agentes de monitoramento que normalmente devem ser executados em todos os {{< glossary_tooltip text="nós" term_id="node" >}}.

--- a/content/pt-br/docs/reference/glossary/static-pod.md
+++ b/content/pt-br/docs/reference/glossary/static-pod.md
@@ -4,7 +4,7 @@ id: static-pod
 date: 2021-09-17
 full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
-  Um pod gerenciado diretamente pelo daemon do kubelet em um nó específico.
+  Um pod gerenciado diretamente pelo serviço (daemon) do kubelet em um nó específico.
 
 aka: 
 tags:


### PR DESCRIPTION
### Description
Este pull request propõe um pequeno ajuste de terminologia na documentação em pt-br para manter consistência no uso do termo “daemon”.

Identifiquei que em diferentes arquivos, a tradução e o uso do termo não estavam alinhados com o padrão aplicado em outras partes da documentação, especialmente quando relacionados ao conceito de "serviço".

Os seguintes arquivos foram atualizados para garantir uniformidade terminológica:

- content/pt-br/docs/reference/glossary/cadvisor.md
- content/pt-br/docs/reference/glossary/daemonset.md
- content/pt-br/docs/reference/glossary/static-pod.md

A alteração melhora a coerência interna da documentação e facilita a compreensão dos leitores que seguem a terminologia oficial da tradução pt-br.

### Issue
N/A

Closes: N/A

/release-note-none