### PR TITLE
[ja] Update content/ja/docs/reference/glossary/volume.md

### DIFF
--- a/content/ja/docs/reference/glossary/volume.md
+++ b/content/ja/docs/reference/glossary/volume.md
@@ -8,7 +8,6 @@ short_description: >
 
 aka:
 tags:
-- core-object
 - fundamental
 ---
  データを格納するディレクトリで、{{< glossary_tooltip text="Pod" term_id="pod" >}}内の{{< glossary_tooltip text="コンテナ" term_id="container" >}}からアクセス可能です。
@@ -17,4 +16,4 @@ tags:
 
 Kubernetesボリュームはボリュームを含んだPodが存在する限り有効です。そのため、ボリュームはPod内で実行されるどのコンテナよりも長く存在し、コンテナが再起動してもボリューム内のデータは維持されます。
 
-詳しくは[ストレージ](/ja/docs/concepts/storage/)をご覧ください。
+詳しくは[ストレージ](/docs/concepts/storage/)をご覧ください。


### PR DESCRIPTION
### Description

Updated Japanese translation: `content/ja/docs/reference/glossary/volume.md`.

- Removed `core-object` tag
- Removed `/ja` from link.

**Website Link**:

- Japanese: https://kubernetes.io/ja/docs/reference/glossary/?core-object=true&fundamental=true#term-volume
- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-volume


### Issue

Closes: #53327 

/area localization
/language ja
