### PR TITLE
[ja] Translated content/ja/docs/reference/glossary/wg.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/wg.md
+++ b/content/ja/docs/reference/glossary/wg.md
@@ -1,5 +1,5 @@
 ---
-title: WG (working group)
+title: WG(ワーキンググループ)
 id: wg
 date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/wg.md` into Japanese: `content/ja/docs/reference/glossary/wg.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?community=true#term-wg


### Issue

Closes: #53329 

/area localization
/language ja
