### PR TITLE
[ja] Translated content/ja/docs/reference/glossary/static-pod.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/static-pod.md
+++ b/content/ja/docs/reference/glossary/static-pod.md
@@ -1,0 +1,18 @@
+---
+title: Static Pod
+id: static-pod
+date: 2019-02-12
+full_link: /docs/tasks/configure-pod-container/static-pod/
+short_description: >
+  特定のノード上でkubeletデーモンによって直接管理されるPodです。
+
+aka: 
+tags:
+- fundamental
+---
+
+{{< glossary_tooltip text="APIサーバー" term_id="kube-apiserver" >}}の監視なしに、特定のノード上で{{< glossary_tooltip text="kubelet" term_id="kubelet" >}}デーモンによって直接管理される{{< glossary_tooltip text="Pod" term_id="pod" >}}です。
+
+<!--more-->
+
+Static Podは{{< glossary_tooltip text="エフェメラルコンテナ" term_id="ephemeral-container" >}}をサポートしていません。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/static-pod.md` into Japanese: `content/ja/docs/reference/glossary/static-pod.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-static-pod


### Issue

Closes: #53336

/area localization
/language ja
