### PR TITLE
[ja] Translated content/ja/docs/reference/glossary/manifest.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/manifest.md
+++ b/content/ja/docs/reference/glossary/manifest.md
@@ -1,5 +1,5 @@
 ---
-title: Manifest
+title: マニフェスト
 id: manifest
 date: 2019-06-28
 short_description: >


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/manifest.md` into Japanese: `content/ja/docs/reference/glossary/manifest.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-manifest


### Issue

Closes: #53339 

/area localization
/language ja
