### PR TITLE
[ja] Translated content/ja/docs/reference/glossary/managed-service.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/managed-service.md
+++ b/content/ja/docs/reference/glossary/managed-service.md
@@ -1,0 +1,17 @@
+---
+title: マネージドサービス
+id: managed-service
+date: 2018-04-12
+full_link: 
+short_description: >
+  サードパーティのプロバイダーによって保守されるソフトウェアの提供形態です。
+
+aka: 
+tags:
+- extension
+---
+サードパーティのプロバイダーによって保守されるソフトウェアの提供形態です。
+
+<!--more--> 
+
+マネージドサービスの例としては、AWS EC2、Azure SQL Database、GCP Pub/Subなどがありますが、アプリケーションで使用できるあらゆるソフトウェアの提供形態が該当します。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/managed-service.md` into Japanese: `content/ja/docs/reference/glossary/managed-service.md`.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?extension=true#term-managed-service


### Issue

Closes: #53342

/area localization
/language ja
