### PR TITLE
Update self-healing.md to include Deployment in controllers

### DIFF
--- a/content/en/docs/concepts/architecture/self-healing.md
+++ b/content/en/docs/concepts/architecture/self-healing.md
@@ -33,7 +33,7 @@ Here are some of the key components that provide Kubernetes self-healing:
 
 - **[kubelet](/docs/concepts/architecture/#kubelet):** Ensures that containers are running, and restarts those that fail.
 
-- **[Deployment(via ReplicaSet)](docs/concepts/workloads/controllers/deployment/), ReplicaSet, StatefulSet and DaemonSet controller:** Maintains the desired number of Pod replicas.
+- **Deployment (via ReplicaSet), ReplicaSet, StatefulSet and DaemonSet controllers:** Maintain the desired number of Pod replicas.
 
 - **PersistentVolume controller:** Manages volume attachment and detachment for stateful workloads.
 


### PR DESCRIPTION
### Description

It is important to include the most widely used Kubernetes Resource(deployment) along with the other resources which are already mentioned in the document. It gives confidence to the new users and does not raise the concern if "deployment" is an exception.