### PR TITLE
Reorganize autoscaling docs

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling.md
+++ b/content/en/docs/concepts/workloads/autoscaling.md
@@ -3,7 +3,7 @@ title: Autoscaling Workloads
 description: >-
   With autoscaling, you can automatically update your workloads in one way or another. This allows your cluster to react to changes in resource demand more elastically and efficiently.
 content_type: concept
-weight: 40
+weight: 50
 ---
 
 <!-- overview -->
@@ -42,7 +42,7 @@ object that manages a set of Pods (for example a
 
 ### Scaling workloads horizontally
 
-In Kubernetes, you can automatically scale a workload horizontally using a _HorizontalPodAutoscaler_ (HPA).
+In Kubernetes, you can automatically scale a workload horizontally using a [HorizontalPodAutoscaler](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) (HPA).
 
 It is implemented as a Kubernetes API resource and a {{< glossary_tooltip text="controller" term_id="controller" >}}
 and periodically adjusts the number of {{< glossary_tooltip text="replicas" term_id="replica" >}}
@@ -54,9 +54,8 @@ There is a [walkthrough tutorial](/docs/tasks/run-application/horizontal-pod-aut
 
 {{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
-You can automatically scale a workload vertically using a _VerticalPodAutoscaler_ (VPA).
-Unlike the HPA, the VPA doesn't come with Kubernetes by default, but is a separate project
-that can be found [on GitHub](https://github.com/kubernetes/autoscaler/tree/9f87b78df0f1d6e142234bb32e8acbd71295585a/vertical-pod-autoscaler).
+You can automatically scale a workload vertically using a [VerticalPodAutoscaler](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) (VPA).
+Unlike the HPA, the VPA doesn't come with Kubernetes by default, but is a an add-on that you or a cluster administrator may need to deploy before you can use it.
 
 Once installed, it allows you to create {{< glossary_tooltip text="CustomResourceDefinitions" term_id="customresourcedefinition" >}}
 (CRDs) for your workloads which define _how_ and _when_ to scale the resources of the managed replicas.
@@ -65,17 +64,6 @@ Once installed, it allows you to create {{< glossary_tooltip text="CustomResourc
 You will need to have the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
 installed to your cluster for the VPA to work.
 {{< /note >}}
-
-At the moment, the VPA can operate in four different modes:
-
-{{< table caption="Different modes of the VPA" >}}
-Mode | Description
-:----|:-----------
-`Auto` | Currently `Recreate`. This might change to in-place updates in the future.
-`Recreate` | The VPA assigns resource requests on pod creation as well as updates them on existing pods by evicting them when the requested resources differ significantly from the new recommendation
-`Initial` | The VPA only assigns resource requests on pod creation and never changes them later.
-`Off` | The VPA does not automatically change the resource requirements of the pods. The recommendations are calculated and can be inspected in the VPA object.
-{{< /table >}}
 
 #### In-place pod vertical scaling
 

--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -8,7 +8,7 @@ feature:
   description: >
     Scale your application up and down with a simple command, with a UI, or automatically based on CPU usage.
 content_type: concept
-weight: 90
+weight: 60
 math: true
 ---
 
@@ -664,6 +664,7 @@ guidelines, which cover this exact use case.
 If you configure autoscaling in your cluster, you may also want to consider using
 [node autoscaling](/docs/concepts/cluster-administration/node-autoscaling/)
 to ensure you are running the right number of nodes.
+You can also read more about [_vertical_ Pod autoscaling](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/).
 
 For more information on HorizontalPodAutoscaler:
 

--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -8,7 +8,7 @@ feature:
   description: >
     Automatically adjust resource requests and limits based on actual usage patterns.
 content_type: concept
-weight: 90
+weight: 70
 math: true
 ---
 
@@ -248,4 +248,4 @@ For example, if the `max` field in a Container LimitRange resource is exceeded, 
 If you configure autoscaling in your cluster, you may also want to consider using
 [node autoscaling](/docs/concepts/cluster-administration/node-autoscaling/)
 to ensure you are running the right number of nodes.
-You can also read more about [_horizontal_ Pod autoscaling](/docs/tasks/run-application/horizontal-pod-autoscale/).
+You can also read more about [_horizontal_ Pod autoscaling](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/).

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -637,7 +637,7 @@ The output is similar to this:
 deployment.apps/nginx-deployment scaled
 ```
 
-Assuming [horizontal Pod autoscaling](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) is enabled
+Assuming [horizontal Pod autoscaling](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) is enabled
 in your cluster, you can set up an autoscaler for your Deployment and choose the minimum and maximum number of
 Pods you want to run based on the CPU utilization of your existing Pods.
 
@@ -1135,7 +1135,7 @@ deployment --replicas=X`, and then you update that Deployment based on a manifes
 (for example: by running `kubectl apply -f deployment.yaml`),
 then applying that manifest overwrites the manual scaling that you previously did.
 
-If a [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/) (or any
+If a [HorizontalPodAutoscaler](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) (or any
 similar API for horizontal scaling) is managing scaling for a Deployment, don't set `.spec.replicas`.
 
 Instead, allow the Kubernetes

--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -561,7 +561,7 @@ based on a manifest (for example: by running `kubectl apply -f
 statefulset.yaml`), then applying that manifest overwrites the manual scaling
 that you previously did.
 
-If a [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/)
+If a [HorizontalPodAutoscaler](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)
 (or any similar API for horizontal scaling) is managing scaling for a
 Statefulset, don't set `.spec.replicas`. Instead, allow the Kubernetes
 {{<glossary_tooltip text="control plane" term_id="control-plane" >}} to manage

--- a/content/en/docs/concepts/workloads/management.md
+++ b/content/en/docs/concepts/workloads/management.md
@@ -403,7 +403,7 @@ Now your nginx replicas will be scaled up and down as needed, automatically.
 
 For more information, please see [kubectl scale](/docs/reference/kubectl/generated/kubectl_scale/),
 [kubectl autoscale](/docs/reference/kubectl/generated/kubectl_autoscale/) and
-[horizontal pod autoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/) document.
+[horizontal pod autoscaler](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) document.
 
 ## In-place updates of resources
 

--- a/content/en/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/en/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -2,7 +2,7 @@
 title: Horizontal Pod Autoscaler
 id: horizontal-pod-autoscaler
 date: 2018-04-12
-full_link: /docs/tasks/run-application/horizontal-pod-autoscale/
+full_link: docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/
 short_description: >
   Object that automatically scales the number of pod replicas based on targeted resource utilization or custom metric targets.
 

--- a/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -15,8 +15,8 @@ including metrics for CPU and memory.  If you deploy the Metrics API into your c
 the Kubernetes API can then query for this information, and you can use Kubernetes' access control
 mechanisms to manage permissions to do so.
 
-The [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/)  (HPA) and
-[VerticalPodAutoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#readme) (VPA)
+The [HorizontalPodAutoscaler](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)  (HPA) and
+[VerticalPodAutoscaler](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) (VPA)
 use data from the metrics API to adjust workload replicas and resources to meet customer demand.
 
 You can also view the resource metrics using the

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -12,7 +12,7 @@ min-kubernetes-server-version: 1.23
 
 <!-- overview -->
 
-A [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/)
+A [HorizontalPodAutoscaler](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)
 (HPA for short)
 automatically updates a workload resource (such as
 a {{< glossary_tooltip text="Deployment" term_id="deployment" >}} or
@@ -93,7 +93,7 @@ The Deployment then updates the ReplicaSet - this is part of how all Deployments
 and then the ReplicaSet either adds or removes Pods based on the change to its `.spec`.
 
 Since each pod requests 200 milli-cores by `kubectl run`, this means an average CPU usage of 100 milli-cores.
-See [Algorithm details](/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) for more details
+See [Algorithm details](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/#algorithm-details) for more details
 on the algorithm.
 
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.md
@@ -59,7 +59,7 @@ _Scaling is accomplished by changing the number of replicas in a Deployment._
 
 Scaling out a Deployment will ensure new Pods are created and scheduled to Nodes
 with available resources. Scaling will increase the number of Pods to the new desired
-state. Kubernetes also supports [autoscaling](/docs/tasks/run-application/horizontal-pod-autoscale/)
+state. Kubernetes also supports [autoscaling](/docs/concepts/workloads/autoscaling/)
 of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also
 possible, and it will terminate all Pods of the specified Deployment.
 

--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -317,7 +317,7 @@
 /id/docs/tasks/tools/install-minikube/     https://minikube.sigs.k8s.io/docs/start/ 302
 /docs/tasks/troubleshoot/debug-init-containers/     /docs/tasks/debug/debug-application/debug-init-containers/ 301
 /docs/tasks/web-ui-dashboard/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
-
+/docs/tasks/run-application/horizontal-pod-autoscale/ /docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/ 301
 /docs/tasks/debug-application-cluster/troubleshooting/     /docs/tasks/debug/ 301
 /docs/tasks/debug-application-cluster/     /docs/tasks/debug/ 301
 /docs/tasks/debug-application-cluster/debug-init-containers/     /docs/tasks/debug/debug-application/debug-init-containers/ 301
@@ -381,7 +381,9 @@
 
 /docs/whatisk8s/     /docs/concepts/overview/what-is-kubernetes/ 301
 /events/     /docs/community     301
-/horizontal-pod-autoscaler/     /docs/tasks/run-application/horizontal-pod-autoscale/ 301
+/horizontal-pod-autoscaler/     /docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/ 301
+
+
 /kubernetes/     /docs/ 301
 /kubernetes-bootcamp/*     /docs/tutorials/kubernetes-basics/ 301
 /kubernetes/third_party/swagger-ui/     /docs/reference/ 301


### PR DESCRIPTION
- move HPA into workload autoscaling section

[preview](https://deploy-preview-53353--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/autoscaling/)

Helps with issue https://github.com/kubernetes/website/issues/4493

/sig autoscaling
/language en
/label refactor