### PR TITLE
Align pt-br.toml with en.toml for feature_gate_enabled

### DIFF
--- a/i18n/pt-br/pt-br.toml
+++ b/i18n/pt-br/pt-br.toml
@@ -144,7 +144,7 @@ other = "Talvez você estivesse procurando por:"
 other = "Exemplos"
 
 [feature_gate_enabled]
-other = "(habilitado por padrão: {{ .enabled }})"
+other = "(habilitado por padrão)"
 
 [feature_gate_stage_alpha]
 other = "Alfa"


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

In #52635, the `[feature_gate_enabled]` field in `i18n/en/en.toml` was updated.
This PR updates `pt-br.toml` so that its `feature_gate_enabled` field matches the current version in `en.toml`.

Only the `pt-br` file requires changes. 
Other languages are not affected because they do not include a localized value yet for the `[feature_gate_enabled]` field.

### Issue

- ref: #52635