### PR TITLE
[pt-br] Update concepts/cluster-administration/system-metrics.md

### DIFF
--- a/content/pt-br/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/pt-br/docs/concepts/cluster-administration/system-metrics.md
@@ -138,7 +138,7 @@ O kube-scheduler identifica as requisições de [recursos e limites](/docs/conce
 - o nome do recurso (por exemplo, `cpu`)
 - a unidade do recurso, se conhecida (por exemplo, `cores`)
 
-Uma vez que o pod alcança um estado de conclusão (sua `restartPolicy` está como `Never` ou `OnFailure` e está na fase de `Succeeded` ou `Failed`, ou foi deletado e todos os contêineres têm um estado de terminado), a série não é mais relatada já que o scheduler agora está livre para agendar a execução de outros pods. As duas métricas são chamadas de `kube_pod_resource_request` e `kube_pod_resource_limit`.
+Uma vez que o pod alcança um estado de conclusão (sua `restartPolicy` está como `Never` ou `OnFailure` e está na fase `Succeeded` ou `Failed`, ou foi deletado e todos os contêineres têm um estado de terminado), a série não é mais relatada já que o scheduler agora está livre para agendar a execução de outros pods. As duas métricas são chamadas de `kube_pod_resource_request` e `kube_pod_resource_limit`.
 
 As métricas são expostas no endpoint HTTP `/metrics/resources`. Elas requerem
 autorização para o endpoint `/metrics/resources`, geralmente concedida por uma


### PR DESCRIPTION
### Description

Este PR traz a atualização da página https://kubernetes.io/pt-br/docs/concepts/cluster-administration/system-metrics/ em **PT-BR** para sync com a versão EN.

- Caminho da página EN no repositório: `content/en/docs/concepts/cluster-administration/system-metrics.md`
- Caminho da página PT-BR no repositório: `content/pt-br/docs/concepts/cluster-administration/system-metrics.md`

---

This PR brings the update of the page https://kubernetes.io/pt-br/docs/concepts/cluster-administration/system-metrics/ in **PT-BR** to sync with the EN version.

- Path of the EN page in the repository: `content/en/docs/concepts/cluster-administration/system-metrics.md`
- Path of the PT-BR page in the repository: `content/pt-br/docs/concepts/cluster-administration/system-metrics.md`

### Issue

Closes: #52454