### PR TITLE
Restructuring: Create "Multi-Container Pods" documentation page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -118,7 +118,7 @@ In this example the **Main Application Container** writes raw logs to `/var/log/
 ## Best practices and anti-patterns
 This section summarizes recommended practices when designing multi-container Pods (such as preferring single responsibility per container, using sidecars for supplementary tasks, and keeping interfaces between containers simple). It will also list anti-patterns to avoid, like tightly coupling unrelated services inside a single Pod or using multi-container Pods to work around missing orchestration features.
 
-### Best Practices for Multi-Container Pods
+## Good practice for multi-container Pods
 
 1. **Single Responsibility per Container**:
    - Each container should focus on a specific task (e.g., logging, proxying, or adapting data).

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -133,11 +133,11 @@ In this example, the **Main Application Container** writes raw logs to `/var/log
 The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`.
 Both containers share the `shared-logs` volume for communication.
 
-## Best practices and anti-patterns
+## Good practices and anti-patterns
 
 This section summarizes recommended practices and common anti-patterns when designing multi-container Pods.
 
-### Best practices
+### Good practices
 
 - Single responsibility: give each container a focused role (for example, logging, proxying, or adapting data).
 - Use shared resources judiciously: prefer shared volumes and network namespaces for basic coordination; enforce access control to avoid races.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -1,12 +1,12 @@
 ---
-title: Multi Container Pods
+title: Multi-Container Pods
 content_type: concept
 weight: 60
 ---
 
 <!-- overview -->
 
-This page provides an overview of _multi container_ Pods.
+This page provides an overview of _multi-container_ Pods.
 In Kubernetes, a Pod is the smallest deployable unit and can contain one or more containers.
 While many Pods run a single container, multi-container Pods are a powerful feature for implementing advanced design patterns.
 These patterns leverage the fact that all containers within a single Pod share the same network namespace and can share the same storage volumes.
@@ -21,23 +21,32 @@ This page covers:
 - Multi-container design patterns (sidecar, ambassador, adapter) with practical examples
 - Good practices, and also anti-patterns to avoid
 
+<!-- body -->
 
-<!-- body -->
-<!-- body -->
 ## How containers in a Pod communicate {#inter-container-communication}
-Containers in the same Pod share the same network namespace and can communicate over localhost. They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel. This section explains the common mechanisms for intra-pod communication, trade-offs between them, and simple examples showing when to prefer network-based communication versus file-based coordination.
+
+Containers in the same Pod share the same network namespace and can communicate over localhost.
+They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel.
+This section explains the common mechanisms for intra-pod communication, trade-offs between them,
+and basic examples showing when to prefer network-based communication versus file-based coordination.
 
 ## Resource sharing and container coordination
-Multiple containers in a Pod share resources such as CPU, memory, and the Pod's cgroup limits. Coordination patterns—explicit (for example, a controller container orchestrating lifecycle events) or implicit (for example, one container writing health information to a shared volume)—help containers cooperate without complex orchestration. This section describes how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.
+
+Multiple containers in a Pod share resources such as CPU, memory, and the Pod's cgroup limits.
+Coordination patterns—explicit (for example, a controller container orchestrating lifecycle events)
+or implicit (for example, one container writing health information to a shared volume)—help containers cooperate without complex orchestration.
+This section describes how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.
 
 ## Understanding init containers
 
-An init container runs to completion before a Pod's application containers start. It performs setup tasks such as preparing files, initializing state, or waiting for external services. For details, see the [Init Containers concept page](/docs/concepts/workloads/pods/init-containers/).
-
+An init container runs to completion before a Pod's application containers start.
+It performs setup tasks such as preparing files, initializing state, or waiting for external services.
+For details, see the [Init Containers concept page](/docs/concepts/workloads/pods/init-containers/).
 
 ## Understanding ephemeral containers
 
-Pods often contain a primary application container and auxiliary containers that provide supporting functions such as logging, proxying, or adapting data. Auxiliary containers run alongside or before the app container and use the Pod's shared namespaces and volumes to cooperate while keeping responsibilities separate.
+Pods often contain a primary application container and auxiliary containers that provide supporting functions such as logging, proxying, or adapting data.
+Auxiliary containers run alongside or before the app container and use the Pod's shared namespaces and volumes to cooperate while keeping responsibilities separate.
 
 An ephemeral container is a short-lived auxiliary container added to a running Pod to help with debugging and troubleshooting. Key properties:
 
@@ -46,15 +55,19 @@ An ephemeral container is a short-lived auxiliary container added to a running P
 - are not restarted by the kubelet and do not change Pod scheduling or readiness
 - intended for diagnostics only, not for production behavior
 
-Add ephemeral containers with `kubectl debug` to run a shell, profiling tools, or other diagnostics against the running app container. See the [Ephemeral containers concept page](/docs/concepts/workloads/pods/ephemeral-containers/) for examples and limitations.
-
+Add ephemeral containers with `kubectl debug` to run a shell, profiling tools, or other diagnostics against the running app container.
+See the [Ephemeral containers concept page](/docs/concepts/workloads/pods/ephemeral-containers/) for examples and limitations.
 
 ## Multi-container design patterns
+
 ### Sidecar
+
 See the existing [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) concept page for more details.
 
 ### Ambassador
-An ambassador container proxies connections between containers in the Pod and external services. The ambassador is typically implemented as a sidecar so the application can connect to `localhost` and remain unaware of the external endpoint.
+
+An ambassador container proxies connections between containers in the Pod and external services.
+The ambassador is typically implemented as a sidecar so the application can connect to `localhost` and remain unaware of the external endpoint.
 
 Here’s a minimal sidecar example that reuses the `postgres-proxy` image to forward local port `5432` to an external database:
 
@@ -77,10 +90,13 @@ spec:
     - containerPort: 5432
 ```
 
-In this example the `ambassador-sidecar` listens on `localhost:5432` inside the Pod and forwards traffic to `external-db.example.com:5432`. Use a production-ready proxy (for example, Envoy, HAProxy, or a managed sidecar) when you need TLS, retries, pooling, or observability.
+In this example, the `ambassador-sidecar` listens on `localhost:5432` inside the Pod and forwards traffic to `external-db.example.com:5432`.
+Use a production-ready proxy (for example, Envoy, HAProxy, or a managed sidecar) when you need TLS, retries, pooling, or observability.
 
 ### Adapter
-An adapter container transforms data between the main container and external systems (for example, log formatting or protocol conversion). The adapter sits alongside the primary application, receives output through a shared volume or localhost, and performs the adaptation before sending data onward.
+
+An adapter container transforms data between the main container and external systems (for example, log formatting or protocol conversion).
+The adapter sits alongside the primary application, receives output through a shared volume or localhost, and performs the adaptation before sending data onward.
 
 Here’s an example of the adapter pattern:
 
@@ -107,17 +123,20 @@ spec:
     emptyDir: {}
 ```
 
-In this example the **Main Application Container** writes raw logs to `/var/log/app/raw.log`. The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`. Both containers share the `shared-logs` volume for communication.
+In this example, the **Main Application Container** writes raw logs to `/var/log/app/raw.log`.
+The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`.
+Both containers share the `shared-logs` volume for communication.
 
 ## Best practices and anti-patterns
+
 This section summarizes recommended practices and common anti-patterns when designing multi-container Pods.
 
 ### Best practices
 
 - Single responsibility: give each container a focused role (for example, logging, proxying, or adapting data).
-- Use shared resources judiciously: prefer shared volumes and network namespaces for simple coordination; enforce access control to avoid races.
+- Use shared resources judiciously: prefer shared volumes and network namespaces for basic coordination; enforce access control to avoid races.
 - Design for resilience: handle restarts gracefully and use readiness and liveness probes where appropriate.
-- Keep interfaces simple: use well-defined protocols (HTTP, gRPC) or shared files for container interaction.
+- Keep interfaces clear: use well-defined protocols (HTTP, gRPC) or shared files for container interaction.
 - Document roles: describe the purpose and interactions of each container in the Pod.
 
 ### Anti-patterns

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -14,6 +14,7 @@ This co-location allows them to collaborate closely while maintaining separation
 
 This page covers:
 
+- Init containers
 - Ephemeral containers
 - Intra-pod communication mechanisms (localhost, shared volumes)
 - Resource sharing and container coordination
@@ -22,6 +23,12 @@ This page covers:
 
 
 <!-- body -->
+## Understanding Init containers
++An init container is a specialized container that runs to completion before the Pod's
++application containers start; it performs setup tasks such as preparing files,
++initializing state, or waiting for external services. For more information, see the
++[Init Containers concept page](/docs/concepts/workloads/pods/init-containers/).
+
 
 ## Understanding ephemeral containers
 See the existing [Ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/) concept page for more details.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -1,6 +1,4 @@
 ---
-reviewers:
-- TBD
 title: Multi Container Pods
 content_type: concept
 weight: 60

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -27,7 +27,7 @@ This page covers:
 See the existing [Ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/) concept page for more details.
 
 
-## Intra-pod communication mechanisms (localhost, shared volumes)
+## How containers in a Pod can communicate {#inter-container-communication}
 Containers in the same Pod share the same network namespace and can communicate over localhost. They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel. This section explains the common mechanisms for intra-pod communication, trade-offs between them, and simple examples showing when to prefer network-based communication versus file-based coordination.
 ## Resource sharing and container coordination
 Multiple containers in a Pod share certain resources such as CPU, memory, and the Pod's cgroup limits. Coordination patterns—explicit (e.g., a controller container orchestrating lifecycle events) or implicit (e.g., one container writing health information to a shared volume)—help containers cooperate without requiring complex orchestration. This section will describe how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -10,7 +10,11 @@ weight: 60
 
 {{< feature-state state="stable" for_k8s_version="v1.25" >}}
 
-This page provides an overview of multi container pods. In Kubernetes, a Pod is the smallest deployable unit and can contain one or more containers. While many Pods run a single container, "multi-container Pods" are a powerful feature for implementing advanced design patterns. These patterns leverage the fact that all containers within a single Pod share the same network namespace (e.g., localhost) and can share the same storage volumes. This co-location allows them to collaborate closely while maintaining separation of concerns.
+This page provides an overview of _multi container_ Pods.
+In Kubernetes, a Pod is the smallest deployable unit and can contain one or more containers.
+While many Pods run a single container, multi-container Pods are a powerful feature for implementing advanced design patterns.
+These patterns leverage the fact that all containers within a single Pod share the same network namespace and can share the same storage volumes.
+This co-location allows them to collaborate closely while maintaining separation of concerns.
 
 This page covers:
 

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -66,10 +66,40 @@ In this example, the **Ambassador Container** (`postgres-proxy`) listens on port
 
 This setup allows the ambassador to handle connection pooling, protocol translation, or observability without modifying the main application.
 
-### Adapter 
-An adapter container transforms data between the main container and external systems (for example, log formatting or protocol conversion). The adapter sits alongside the primary application, receives output through a shared volume or localhost, and performs the adaptation before sending data onward. This section will present typical use cases and a small sketch of how to wire an adapter into your Pod.
+### Adapter
+An adapter container transforms data between the main container and external systems (for example, log formatting or protocol conversion). The adapter sits alongside the primary application, receives output through a shared volume or localhost, and performs the adaptation before sending data onward.
 
+#### Example
+Here’s a simple example of the adapter pattern:
 
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: adapter-pattern-example
+spec:
+  containers:
+  - name: main-app
+    image: custom-logger
+    volumeMounts:
+    - name: shared-logs
+      mountPath: /var/log/app
+  - name: adapter
+    image: log-adapter
+    volumeMounts:
+    - name: shared-logs
+      mountPath: /var/log/app
+    args: ["--input", "/var/log/app/raw.log", "--output", "/var/log/app/processed.log"]
+  volumes:
+  - name: shared-logs
+    emptyDir: {}
+```
+
+In this example:
+- The **Main Application Container** writes raw logs to `/var/log/app/raw.log`.
+- The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`.
+- Both containers share the `shared-logs` volume for communication.
 
 ## Best practices and anti-patterns
 This section summarizes recommended practices when designing multi-container Pods (such as preferring single responsibility per container, using sidecars for supplementary tasks, and keeping interfaces between containers simple). It will also list anti-patterns to avoid, like tightly coupling unrelated services inside a single Pod or using multi-container Pods to work around missing orchestration features.
+

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -77,17 +77,19 @@ kind: Pod
 metadata:
   name: ambassador-sidecar-example
 spec:
+  initContainers:
+  - name: ambassador-sidecar
+    image: postgres-proxy
+    restartPolicy: Always
+    args: ["--target-db", "external-db.example.com:5432"]
+    ports:
+    - containerPort: 5432
   containers:
   - name: main-app
     image: nginx
     env:
     - name: DATABASE_URL
       value: "localhost:5432"
-  - name: ambassador-sidecar
-    image: postgres-proxy
-    args: ["--target-db", "external-db.example.com:5432"]
-    ports:
-    - containerPort: 5432
 ```
 
 In this example, the `ambassador-sidecar` listens on `localhost:5432` inside the Pod and forwards traffic to `external-db.example.com:5432`.
@@ -106,18 +108,20 @@ kind: Pod
 metadata:
   name: adapter-pattern-example
 spec:
+  initContainers:
+  - name: adapter
+    image: log-adapter
+    restartPolicy: Always
+    volumeMounts:
+    - name: shared-logs
+      mountPath: /var/log/app
+    args: ["--input", "/var/log/app/raw.log", "--output", "/var/log/app/processed.log"]
   containers:
   - name: main-app
     image: custom-logger
     volumeMounts:
     - name: shared-logs
       mountPath: /var/log/app
-  - name: adapter
-    image: log-adapter
-    volumeMounts:
-    - name: shared-logs
-      mountPath: /var/log/app
-    args: ["--input", "/var/log/app/raw.log", "--output", "/var/log/app/processed.log"]
   volumes:
   - name: shared-logs
     emptyDir: {}

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -22,7 +22,7 @@ This page covers:
 - Intra-pod communication mechanisms (localhost, shared volumes)
 - Resource sharing and container coordination
 - Multi-container design patterns (sidecar, ambassador, adapter) with practical examples
-- Best practices and anti-patterns
+- Good practices, and also anti-patterns to avoid
 
 
 <!-- body -->

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -103,3 +103,36 @@ In this example:
 ## Best practices and anti-patterns
 This section summarizes recommended practices when designing multi-container Pods (such as preferring single responsibility per container, using sidecars for supplementary tasks, and keeping interfaces between containers simple). It will also list anti-patterns to avoid, like tightly coupling unrelated services inside a single Pod or using multi-container Pods to work around missing orchestration features.
 
+### Best Practices for Multi-Container Pods
+
+1. **Single Responsibility per Container**:
+   - Each container should focus on a specific task (e.g., logging, proxying, or adapting data).
+   - Avoid overloading a single container with multiple responsibilities.
+
+2. **Use Shared Resources Judiciously**:
+   - Leverage shared volumes and network namespaces for communication between containers.
+   - Ensure proper access control to avoid race conditions or data corruption.
+
+3. **Design for Resilience**:
+   - Handle container restarts gracefully.
+   - Use readiness and liveness probes to monitor container health.
+
+4. **Keep Interfaces Simple**:
+   - Use well-defined communication protocols (e.g., HTTP, gRPC) or shared files for interaction between containers.
+
+5. **Document Container Roles**:
+   - Clearly document the purpose and interactions of each container in the Pod.
+
+### Anti-Patterns to Avoid
+
+1. **Tightly Coupled Containers**:
+   - Avoid making containers overly dependent on each other. Each container should be replaceable without affecting the others.
+
+2. **Overloading a Pod**:
+   - Don’t cram unrelated services into a single Pod. Use separate Pods for unrelated workloads.
+
+3. **Using Multi-Container Pods as a Workaround**:
+   - Don’t use multi-container Pods to compensate for missing orchestration features. Use Kubernetes-native solutions like Deployments, Services, or ConfigMaps.
+
+4. **Ignoring Resource Limits**:
+   - Always define resource requests and limits for each container to prevent resource contention.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -6,8 +6,6 @@ weight: 60
 
 <!-- overview -->
 
-{{< feature-state state="stable" for_k8s_version="v1.25" >}}
-
 This page provides an overview of _multi container_ Pods.
 In Kubernetes, a Pod is the smallest deployable unit and can contain one or more containers.
 While many Pods run a single container, multi-container Pods are a powerful feature for implementing advanced design patterns.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -37,7 +37,9 @@ Coordination patterns—explicit (for example, a controller container orchestrat
 or implicit (for example, one container writing health information to a shared volume)—help containers cooperate without complex orchestration.
 This section describes how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.
 
-## Understanding init containers
+## Types of container
+
+### Init containers
 
 An init container runs to completion before a Pod's application containers start.
 It performs setup tasks such as preparing files, initializing state, or waiting for external services.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -1,0 +1,44 @@
+---
+reviewers:
+- TBD
+title: Multi Container Pods
+content_type: concept
+weight: 60
+---
+
+<!-- overview -->
+
+{{< feature-state state="stable" for_k8s_version="v1.25" >}}
+
+This page provides an overview of multi container pods. In Kubernetes, a Pod is the smallest deployable unit and can contain one or more containers. While many Pods run a single container, "multi-container Pods" are a powerful feature for implementing advanced design patterns. These patterns leverage the fact that all containers within a single Pod share the same network namespace (e.g., localhost) and can share the same storage volumes. This co-location allows them to collaborate closely while maintaining separation of concerns.
+
+This page covers:
+
+- Ephemeral containers
+- Intra-pod communication mechanisms (localhost, shared volumes)
+- Resource sharing and container coordination
+- Multi-container design patterns (sidecar, ambassador, adapter) with practical examples
+- Best practices and anti-patterns
+
+
+<!-- body -->
+
+## Understanding ephemeral containers
+See the existing [Ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/) concept page for more details.
+
+
+## Intra-pod communication mechanisms (localhost, shared volumes)
+Containers in the same Pod share the same network namespace and can communicate over localhost. They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel. This section explains the common mechanisms for intra-pod communication, trade-offs between them, and simple examples showing when to prefer network-based communication versus file-based coordination.
+## Resource sharing and container coordination
+Multiple containers in a Pod share certain resources such as CPU, memory, and the Pod's cgroup limits. Coordination patterns—explicit (e.g., a controller container orchestrating lifecycle events) or implicit (e.g., one container writing health information to a shared volume)—help containers cooperate without requiring complex orchestration. This section will describe how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.
+
+## Multi-container design patterns
+### Sidecar
+See the existing [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) concept page for more details.
+
+### Ambassador
+An ambassador container proxies connections between the other containers in the Pod and external services. This pattern is useful when you need to adapt or translate protocols, implement connection pooling, or provide observability without changing the main application container. The draft will include a short example showing how an ambassador can forward traffic and the considerations for lifecycle and failure modes.
+### Adapter 
+An adapter container transforms data between the main container and external systems (for example, log formatting or protocol conversion). The adapter sits alongside the primary application, receives output through a shared volume or localhost, and performs the adaptation before sending data onward. This section will present typical use cases and a small sketch of how to wire an adapter into your Pod.
+## Best practices and anti-patterns
+This section summarizes recommended practices when designing multi-container Pods (such as preferring single responsibility per container, using sidecars for supplementary tasks, and keeping interfaces between containers simple). It will also list anti-patterns to avoid, like tightly coupling unrelated services inside a single Pod or using multi-container Pods to work around missing orchestration features.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -69,8 +69,7 @@ This setup allows the ambassador to handle connection pooling, protocol translat
 ### Adapter
 An adapter container transforms data between the main container and external systems (for example, log formatting or protocol conversion). The adapter sits alongside the primary application, receives output through a shared volume or localhost, and performs the adaptation before sending data onward.
 
-#### Example
-Here’s a simple example of the adapter pattern:
+Here’s an example of the adapter pattern:
 
 ```yaml
 apiVersion: v1
@@ -95,10 +94,7 @@ spec:
     emptyDir: {}
 ```
 
-In this example:
-- The **Main Application Container** writes raw logs to `/var/log/app/raw.log`.
-- The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`.
-- Both containers share the `shared-logs` volume for communication.
+In this example the **Main Application Container** writes raw logs to `/var/log/app/raw.log`. The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`. Both containers share the `shared-logs` volume for communication.
 
 ## Best practices and anti-patterns
 This section summarizes recommended practices when designing multi-container Pods (such as preferring single responsibility per container, using sidecars for supplementary tasks, and keeping interfaces between containers simple). It will also list anti-patterns to avoid, like tightly coupling unrelated services inside a single Pod or using multi-container Pods to work around missing orchestration features.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -23,6 +23,13 @@ This page covers:
 
 
 <!-- body -->
+
+## How containers in a Pod can communicate {#inter-container-communication}
+Containers in the same Pod share the same network namespace and can communicate over localhost. They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel. This section explains the common mechanisms for intra-pod communication, trade-offs between them, and simple examples showing when to prefer network-based communication versus file-based coordination.
+
+## Resource sharing and container coordination
+Multiple containers in a Pod share certain resources such as CPU, memory, and the Pod's cgroup limits. Coordination patterns—explicit (e.g., a controller container orchestrating lifecycle events) or implicit (e.g., one container writing health information to a shared volume)—help containers cooperate without requiring complex orchestration. This section will describe how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.
+
 ## Understanding Init containers
 +An init container is a specialized container that runs to completion before the Pod's
 +application containers start; it performs setup tasks such as preparing files,
@@ -31,13 +38,18 @@ This page covers:
 
 
 ## Understanding ephemeral containers
-See the existing [Ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/) concept page for more details.
 
+Pods commonly contain a primary application container plus one or more auxiliary containers that provide supporting functionality — for example, logging, proxying, adapting data formats, or performing initialization. These "other" containers run alongside or before the app container and use the Pod's shared network namespace and volumes to cooperate while keeping responsibilities separate.
 
-## How containers in a Pod can communicate {#inter-container-communication}
-Containers in the same Pod share the same network namespace and can communicate over localhost. They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel. This section explains the common mechanisms for intra-pod communication, trade-offs between them, and simple examples showing when to prefer network-based communication versus file-based coordination.
-## Resource sharing and container coordination
-Multiple containers in a Pod share certain resources such as CPU, memory, and the Pod's cgroup limits. Coordination patterns—explicit (e.g., a controller container orchestrating lifecycle events) or implicit (e.g., one container writing health information to a shared volume)—help containers cooperate without requiring complex orchestration. This section will describe how resource limits and requests affect multi-container Pods, techniques for coordination, and common pitfalls to avoid.
+An ephemeral container is a special, short-lived auxiliary container that you add to a *running* Pod to help with debugging and troubleshooting. Unlike sidecars or init containers, ephemeral containers:
+
+- Are not part of the Pod's original spec and are created only for inspection or debugging tasks;
+- Share the target Pod's namespaces and volumes so they can inspect processes, network state, and files;
+- Are not restarted by the kubelet and do not affect Pod scheduling, lifecycle, or readiness;
+- Should not be used to provide production behavior — they are strictly for diagnostics.
+
+You typically add an ephemeral container with `kubectl debug` to run a shell, profiling tools, or other diagnostics tools against the running app container. For usage details, examples, and limitations, see the [Ephemeral containers concept page](/docs/concepts/workloads/pods/ephemeral-containers/).
+
 
 ## Multi-container design patterns
 ### Sidecar

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -102,7 +102,12 @@ spec:
 ```
 
 In this example, the `ambassador-sidecar` listens on `localhost:5432` inside the Pod and forwards traffic to `external-db.example.com:5432`.
-Use a production-ready proxy (for example, Envoy, HAProxy, or a managed sidecar) when you need TLS, retries, pooling, or observability.
+
+Use a production-ready proxy when you need TLS, retries, pooling, or observability. Options include:
+
+- [Envoy](https://www.envoyproxy.io/)
+- [HAProxy](https://www.haproxy.org/)
+- A managed sidecar provided by your service mesh
 
 ### Adapter
 

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -63,8 +63,15 @@ See the [Ephemeral containers concept page](/docs/concepts/workloads/pods/epheme
 ## Multi-container design patterns
 
 ### Sidecar
+The Sidecar pattern involves running a helper container alongside your main application container within the same Pod. This pattern is commonly used for tasks like logging agents, service proxies, or configuration managers that need to share the same network namespace and storage volumes as the application.
 
-See the existing [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) concept page for more details.
+In Kubernetes, you can implement this pattern in two ways:
+
+- Standard Sidecars: Helper containers defined in the spec.containers list. These start and stop alongside the main application.
+
+- Native Sidecar Containers: A specific type of init container configured with restartPolicy: Always. Unlike regular init containers, native sidecars continue running after the Pod has started and provide better lifecycle guarantees for long-lived helper processes.
+
+For a deep dive into the native implementation, see the dedicated [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) documentation concept page for more details.
 
 ### Ambassador
 

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -9,7 +9,7 @@ weight: 60
 This page provides an overview of _multi-container_ Pods.
 In Kubernetes, a Pod is the smallest deployable unit and can contain one or more containers.
 While many Pods run a single container, multi-container Pods are a powerful feature for implementing advanced design patterns.
-These patterns leverage the fact that all containers within a single Pod share the same network namespace and can share the same storage volumes.
+These patterns leverage the fact that all containers within a single Pod typically share the same network namespace and can share the same storage volumes.
 This co-location allows them to collaborate closely while maintaining separation of concerns.
 
 This page covers:
@@ -25,7 +25,7 @@ This page covers:
 
 ## How containers in a Pod communicate {#inter-container-communication}
 
-Containers in the same Pod share the same network namespace and can communicate over localhost.
+Containers in the same Pod typically share the same network namespace and can communicate over localhost.
 They can also share storage volumes mounted into the Pod, which allows files and directories to be used as a communication channel.
 This section explains the common mechanisms for intra-pod communication, trade-offs between them,
 and basic examples showing when to prefer network-based communication versus file-based coordination.
@@ -69,7 +69,7 @@ In Kubernetes, you can implement this pattern in two ways:
 
 - Native Sidecar Containers: Init containers in `.spec.initContainers` with `restartPolicy: Always`. Unlike regular init containers, native sidecars continue running after the Pod has started, and Kubernetes manages their lifecycle specially to provide better guarantees for long-lived helper processes.
 
-Kubernetes-native sidecar, plus app container
+- Kubernetes-native sidecar, plus app container
 : You define each sidecar in the Pod template within `.spec.initContainers`, and you specifically also set `restartPolicy: Always`. The app container is defined as normal. Unlike actual [init containers](#init-containers), sidecar containers continue running after the main app container has started.
 
 For a deep dive into the native implementation, see the dedicated [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) documentation concept page for more details.
@@ -79,7 +79,7 @@ For a deep dive into the native implementation, see the dedicated [Sidecar conta
 An ambassador container proxies connections between containers in the Pod and external services.
 The ambassador is typically implemented as a sidecar so the application can connect to `localhost` and remain unaware of the external endpoint.
 
-Here’s a minimal sidecar example that reuses the `postgres-proxy` image to forward local port `5432` to an external database:
+Here’s a minimal sidecar example that forwards local port `5432` to an external database:
 
 ```yaml
 apiVersion: v1
@@ -89,14 +89,14 @@ metadata:
 spec:
   initContainers:
   - name: ambassador-sidecar
-    image: postgres-proxy
+    image: quay.io/prometheus/busybox:latest
     restartPolicy: Always
     args: ["--target-db", "external-db.example.com:5432"]
     ports:
     - containerPort: 5432
   containers:
   - name: main-app
-    image: nginx
+    image: quay.io/centos/centos:stream9
     env:
     - name: DATABASE_URL
       value: "localhost:5432"
@@ -121,7 +121,7 @@ metadata:
 spec:
   initContainers:
   - name: adapter
-    image: log-adapter
+    image: quay.io/fluent/fluent-bit:3.0
     restartPolicy: Always
     volumeMounts:
     - name: shared-logs
@@ -129,7 +129,7 @@ spec:
     args: ["--input", "/var/log/app/raw.log", "--output", "-"]
   containers:
   - name: main-app
-    image: custom-logger
+    image: quay.io/centos/centos:stream9
     volumeMounts:
     - name: shared-logs
       mountPath: /var/log/app
@@ -150,13 +150,11 @@ This section summarizes recommended practices and common anti-patterns when desi
 
 - Single responsibility: give each container a focused role (for example, logging, proxying, or adapting data).
 - Use shared resources judiciously: prefer shared volumes and network namespaces for basic coordination; enforce access control to avoid races.
-- Design for resilience: handle restarts gracefully and use readiness and liveness probes where appropriate.
-- Keep interfaces clear: use well-defined protocols (HTTP, gRPC) or shared files for container interaction.
+- Design for resilience: handle restarts gracefully and use [probes](/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) where appropriate.
 - Document roles: describe the purpose and interactions of each container in the Pod.
 
 ### Anti-patterns
 
-- Tightly coupled containers: avoid strong dependencies that make containers hard to replace.
 - Overloading a Pod: do not put unrelated services in the same Pod; prefer separate Pods for unrelated workloads.
 - Using Pods as a workaround: avoid using multi-container Pods to work around missing orchestration features; use Deployments, Services, or ConfigMaps instead.
-- Ignoring resource limits: always set resource requests and limits to prevent contention.
+- Ignoring resource limits: sidecars should have a memory limit and a CPU request; the app container or the overall Pod should also have an appropriate CPU request and memory limit.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -126,7 +126,7 @@ spec:
     volumeMounts:
     - name: shared-logs
       mountPath: /var/log/app
-    args: ["--input", "/var/log/app/raw.log", "--output", "/var/log/app/processed.log"]
+    args: ["--input", "/var/log/app/raw.log", "--output", "-"]
   containers:
   - name: main-app
     image: custom-logger

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -67,10 +67,9 @@ The Sidecar pattern involves running a helper container alongside your main appl
 
 In Kubernetes, you can implement this pattern in two ways:
 
-- Native Sidecar Containers: Init containers in `.spec.initContainers` with `restartPolicy: Always`. Unlike regular init containers, native sidecars continue running after the Pod has started, and Kubernetes manages their lifecycle specially to provide better guarantees for long-lived helper processes.
+- Native sidecar containers: You define each sidecar in `.spec.initContainers` with `restartPolicy: Always`. The app container is defined as normal in `.spec.containers`. Unlike regular init containers, native sidecars continue running after the main app container has started, and Kubernetes manages their lifecycle specially to provide better guarantees for long-lived helper processes.
 
-- Kubernetes-native sidecar, plus app container
-: You define each sidecar in the Pod template within `.spec.initContainers`, and you specifically also set `restartPolicy: Always`. The app container is defined as normal. Unlike actual [init containers](#init-containers), sidecar containers continue running after the main app container has started.
+- Multiple application containers: The app container and its helper container(s) are both defined in the `.spec.containers` list. Kubernetes does not manage the sidecar lifecycle specially, so this approach is **not** recommended.
 
 For a deep dive into the native implementation, see the dedicated [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) documentation concept page for more details.
 

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -69,7 +69,8 @@ In Kubernetes, you can implement this pattern in two ways:
 
 - Standard Sidecars: Helper containers defined in the spec.containers list. These start and stop alongside the main application.
 
-- Native Sidecar Containers: A specific type of init container configured with restartPolicy: Always. Unlike regular init containers, native sidecars continue running after the Pod has started and provide better lifecycle guarantees for long-lived helper processes.
+Kubernetes-native sidecar, plus app container
+: You define each sidecar in the Pod template within `.spec.initContainers`, and you specifically also set `restartPolicy: Always`. The app container is defined as normal. Unlike actual [init containers](#init-containers), sidecar containers continue running after the main app container has started.
 
 For a deep dive into the native implementation, see the dedicated [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/) documentation concept page for more details.
 

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -67,7 +67,7 @@ The Sidecar pattern involves running a helper container alongside your main appl
 
 In Kubernetes, you can implement this pattern in two ways:
 
-- Standard Sidecars: Helper containers defined in the spec.containers list. These start and stop alongside the main application.
+- Native Sidecar Containers: Init containers in `.spec.initContainers` with `restartPolicy: Always`. Unlike regular init containers, native sidecars continue running after the Pod has started, and Kubernetes manages their lifecycle specially to provide better guarantees for long-lived helper processes.
 
 Kubernetes-native sidecar, plus app container
 : You define each sidecar in the Pod template within `.spec.initContainers`, and you specifically also set `restartPolicy: Always`. The app container is defined as normal. Unlike actual [init containers](#init-containers), sidecar containers continue running after the main app container has started.

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -104,11 +104,7 @@ spec:
 
 In this example, the `ambassador-sidecar` listens on `localhost:5432` inside the Pod and forwards traffic to `external-db.example.com:5432`.
 
-Use a production-ready proxy when you need TLS, retries, pooling, or observability. Options include:
-
-- [Envoy](https://www.envoyproxy.io/)
-- [HAProxy](https://www.haproxy.org/)
-- A managed sidecar provided by your service mesh
+Use a production-ready proxy when you need TLS, retries, or observability.
 
 ### Adapter
 

--- a/content/en/docs/concepts/workloads/pods/multi-container-pods.md
+++ b/content/en/docs/concepts/workloads/pods/multi-container-pods.md
@@ -138,8 +138,8 @@ spec:
     emptyDir: {}
 ```
 
-In this example, the **Main Application Container** writes raw logs to `/var/log/app/raw.log`.
-The **Adapter Container** reads the raw logs, transforms them into a standard format, and writes the processed logs to `/var/log/app/processed.log`.
+In this example, the *main application container* writes raw logs to `/var/log/app/raw.log`.
+The *adapter container* reads the raw logs, transforms them into a standard format, and writes the processed logs to stdout.
 Both containers share the `shared-logs` volume for communication.
 
 ## Good practices and anti-patterns


### PR DESCRIPTION
### Description

Added the following sections:

- Intra-pod communication mechanisms (localhost, shared volumes)
- Resource sharing and container coordination
- Ambassador pattern
- Adapter pattern
- Best practices and anti-patterns

### Issue

Closes: [#51422](https://github.com/kubernetes/website/issues/51422)