### PR TITLE
Fix broken link to static CPU management policy in Pod QoS documentation

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-qos.md
+++ b/content/en/docs/concepts/workloads/pods/pod-qos.md
@@ -39,7 +39,7 @@ to face eviction. They are guaranteed not to be killed until they exceed their l
 or there are no lower-priority Pods that can be preempted from the Node. They may
 not acquire resources beyond their specified limits. These Pods can also make
 use of exclusive CPUs using the
-[`static`](/docs/tasks/administer-cluster/cpu-management-policies/#static-policy) CPU management policy.
+[`static`](/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-configuration) CPU management policy.
 
 #### Criteria
 


### PR DESCRIPTION
### Description

Fixed a broken link in the Pod Quality of Service documentation.

The link to the static CPU management policy was pointing to an incorrect anchor (`#static-policy`),
which does not exist on the target page.
Updated it to the correct anchor (`#static-policy-configuration`).

### Issue

Closes: #53372 