### PR TITLE
[ja] Update content/ja/docs/concepts/architecture/cloud-controller.md

### DIFF
--- a/content/ja/docs/concepts/architecture/cloud-controller.md
+++ b/content/ja/docs/concepts/architecture/cloud-controller.md
@@ -170,7 +170,7 @@ rules:
 
 * [クラウドコントローラーマネージャーの運用管理](/docs/tasks/administer-cluster/running-cloud-controller/#cloud-controller-manager)はクラウドコントローラーマネージャーの実行と管理を説明しています。
 
-* クラウドコントローラーマネージャーを使用するためにHAコントロールプレーンをアップグレードするには、[Migrate Replicated Control Plane To Use Cloud Controller Manager](/docs/tasks/administer-cluster/controller-manager-leader-migration/)を参照してください。
+* クラウドコントローラーマネージャーを使用するためにHAコントロールプレーンをアップグレードするには、[複製されたコントロールプレーンをクラウドコントローラーマネージャーを使用するために移行する](/docs/tasks/administer-cluster/controller-manager-leader-migration/)を参照してください。
 
 * どのようにあなた自身のクラウドコントローラーマネージャーが実装されるのか、もしくは既存プロジェクトの拡張について知りたいですか？
 


### PR DESCRIPTION
### Description

Update the Japanese translation of the following page to match the latest English version (commit 153543263ca1ed7c99311e5470665a83ecef82fc):

- Japanese: https://kubernetes.io/ja/docs/concepts/architecture/cloud-controller/
- English: https://kubernetes.io/docs/concepts/architecture/cloud-controller/

(update) In addition to updating the document to match the latest English version, this PR also includes adjustments to align with the Japanese localization style guidelines and updates certain phrases to follow the source wording more accurately.

### Issue

Closes: #53381