### PR TITLE
Tweak authentication advice about command line arguments

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -1127,10 +1127,6 @@ extra:
   - profile
 ```
 
-{{< note >}}
-Prior to Kubernetes 1.11.3 (and 1.10.7, 1.9.11), the `extra` key could only contain characters that
-were [legal in HTTP header labels](https://tools.ietf.org/html/rfc7230#section-3.2.6).
-{{< /note >}}
 
 #### Client certificate {#reverse-proxy-client-certificate}
 


### PR DESCRIPTION
PR https://github.com/kubernetes/website/pull/52907 added a page about user impersonation that ~will go live when v1.35 is released~ is now live.

Build on that to:
- make it clear that the _authenticating reverse proxy_ mode is separate from _user impersonation_
- help readers find the command line options that are relevant to authentication

[Original](https://k8s.io/docs/reference/access-authn-authz/authentication/) / [preview](https://deploy-preview-53397--kubernetes-io-main-staging.netlify.app/docs/reference/access-authn-authz/authentication/).

Based on PR https://github.com/kubernetes/website/pull/50364 but not directly derived from it.

/language en
/sig auth