### PR TITLE
Correct misleading way to determine whether Pods are terminating

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -408,9 +408,9 @@ Kubernetes {{< skew currentVersion >}} supports the following scopes:
 | [`BestEffort`](#quota-scope-best-effort) | Match pods that have best effort quality of service. |
 | [`CrossNamespacePodAffinity`](#cross-namespace-pod-affinity-scope) | Match pods that have cross-namespace pod [(anti)affinity terms](/docs/concepts/scheduling-eviction/assign-pod-node). |
 | [`NotBestEffort`](#quota-scope-non-best-effort) | Match pods that do not have best effort quality of service. |
-| [`NotTerminating`](#quota-scope-non-terminating) | Match pods where `.spec.activeDeadlineSeconds` is `nil` |
+| [`NotTerminating`](#quota-scope-non-terminating) | Match pods where `.metadata.deletionGracePeriodSeconds` is **not** set |
 | [`PriorityClass`](#resource-quota-per-priorityclass) | Match pods that references the specified [priority class](/docs/concepts/scheduling-eviction/pod-priority-preemption). |
-| [`Terminating`](#quota-scope-terminating) | Match pods where `.spec.activeDeadlineSeconds` >= `0` |
+| [`Terminating`](#quota-scope-terminating) | Match pods where `.metadata.deletionGracePeriodSeconds` has a value set |
 | [`VolumeAttributesClass`](#quota-scope-volume-attributes-class) | Match PersistentVolumeClaims that reference the specified [volume attributes class](/docs/concepts/storage/volume-attributes-classes). |
 
 ResourceQuotas with a scope set can also have a optional `scopeSelector` field. You define one or more _match expressions_


### PR DESCRIPTION
To find out if a Pod is terminating, you check `.metadata.deletionGracePeriodSeconds`. Update the ResourceQuota docs to make that clear.

Deleted Pods don't count; once the grace period has expired, either the grace period is zero or the Pod no longer exists (and therefore do not contribute to resource quota).

/language en

Submitting this as a draft.
I think the existing documentation correctly documents how Kubernetes behaves, but I also think that that behavior is wrong. See https://github.com/kubernetes/kubernetes/issues/135411