### PR TITLE
[pt-br] Fix typo: correct ‘accesso’ → ‘acesso’ in PT-BR docs

### DIFF
--- a/content/pt-br/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
+++ b/content/pt-br/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
@@ -123,7 +123,7 @@ No arquivo `$HOME/.kube/config`, caminhos relativos são armazenados de forma re
 ## {{% heading "whatsnext" %}}
 
 
-* [Configurar Accesso para Multiplos Clusters](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+* [Configurar Acesso para Multiplos Clusters](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 * [`kubectl config`](/docs/reference/generated/kubectl/kubectl-commands#config)
 
 

--- a/content/pt-br/docs/concepts/configuration/secret.md
+++ b/content/pt-br/docs/concepts/configuration/secret.md
@@ -78,7 +78,7 @@ está rodando no mesmo cluster Kubernetes, você pode utilizar uma
 e seus tokens para identificar seu cliente.
 - existem ferramentas fornecidas por terceiros que você pode rodar, no seu
 cluster ou externamente, que providenciam gerenciamento de Secrets. Por exemplo,
-um serviço que Pods accessam via HTTPS, que revelam um Secret se o cliente
+um serviço que Pods acessam via HTTPS, que revelam um Secret se o cliente
 autenticar-se corretamente (por exemplo, utilizando um token de ServiceAccount).
 - para autenticação, você pode implementar um serviço de assinatura de
 certificados X.509 personalizado, e utilizar
@@ -999,7 +999,7 @@ para mais informações sobre como referenciar service accounts em Pods.
 ### Secrets de configuração do Docker
 
 Você pode utilizar um dos tipos abaixo para criar um Secret que armazena
-credenciais para accesso a um registro de contêineres para busca de imagens:
+credenciais para acesso a um registro de contêineres para busca de imagens:
 
 - `kubernetes.io/dockercfg`
 - `kubernetes.io/dockerconfigjson`

--- a/content/pt-br/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/pt-br/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -167,7 +167,7 @@ kubeadm join --token abcdef.1234567890abcdef --discovery-token-unsafe-skip-ca-ve
 
 - Se um mau ator conseguir roubar um token de inicialização através de algum tipo
   de vulnerabilidade, este mau ator conseguirá utilizar o token (juntamente com
-  accesso a nível de rede) para personificar um nó da camada de gerenciamento
+  acesso a nível de rede) para personificar um nó da camada de gerenciamento
   perante os outros nós de processamento. Esta contrapartida pode ou não ser
   aceitável no seu ambiente.
 

--- a/content/pt-br/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/pt-br/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -240,7 +240,7 @@ Você pode realizar a montagem de 2 volumes no seu contêiner nginx:
 
 <!-- discussion -->
 
-## Controle de accesso
+## Controle de acesso
 
 Armazenamento configurado com um `group ID` (GID) possibilita a escrita somente pelos 
 Pods usando a mesma GID. GIDs incompatíveis ou perdidos causam erros de negação 


### PR DESCRIPTION
### Description
This PR fixes a typo in the PT-BR documentation, correcting ‘accesso’ to ‘acesso

### Files changed:

content/pt-br/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
content/pt-br/docs/concepts/configuration/secret.md
content/pt-br/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
content/pt-br/docs/reference/setup-tools/kubeadm/kubeadm-join.md

### Issue
N/A

Closes: N/A

/release-note-none