### PR TITLE
nginx ingress controller is retired

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -17,7 +17,7 @@ Unlike other types of controllers which run as part of the `kube-controller-mana
 are not started automatically with a cluster. Use this page to choose the ingress controller implementation 
 that best fits your cluster.
 
-Kubernetes as a project supports and maintains [AWS](https://github.com/kubernetes-sigs/aws-load-balancer-controller#readme), [GCE](https://git.k8s.io/ingress-gce/README.md#readme) ingress controllers. 
+Kubernetes as a project supports and maintains [AWS](https://github.com/kubernetes-sigs/aws-load-balancer-controller#readme) and [GCE](https://git.k8s.io/ingress-gce/README.md#readme) ingress controllers. 
 Note the previously supported [nginx](https://git.k8s.io/ingress-nginx/README.md#readme) ingress controller [is being retired and will receive no more releases, bugfixes, upgrades or security patches after March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). Migration to the [Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/) is recommended. 
 
 


### PR DESCRIPTION
Updated the ingress controllers documentation to note the retirement of the nginx ingress controller and recommend migration to the Gateway API.

### Description

Remove statement Nginx ingress is supported/maintained, instead mention retirement and link to related blog post and Gateway API alternative. 
