### PR TITLE
[ja] Update Service documentation and add Virtual IPs reference

### DIFF
--- a/content/ja/docs/concepts/services-networking/service.md
+++ b/content/ja/docs/concepts/services-networking/service.md
@@ -1,58 +1,68 @@
 ---
+reviewers:
+- bprashanth
 title: Service
+api_metadata:
+- apiVersion: "v1"
+  kind: "Service"
 feature:
   title: サービスディスカバリーと負荷分散
   description: >
     Kubernetesでは、なじみのないサービスディスカバリーのメカニズムを使用するためにユーザーがアプリケーションの修正をする必要はありません。KubernetesはPodにそれぞれのIPアドレス割り振りや、Podのセットに対する単一のDNS名を提供したり、それらのPodのセットに対する負荷分散が可能です。
-
+description: >-
+  クラスター内で実行されているアプリケーションを、ワークロードが複数のバックエンドに分割されている場合でも、単一の外向きのエンドポイントの背後に公開します。
 content_type: concept
 weight: 10
 ---
-
 
 <!-- overview -->
 
 {{< glossary_definition term_id="service" length="short" prepend="KubernetesにおけるServiceとは、" >}}
 
-Kubernetesでは、なじみのないサービスディスカバリーのメカニズムを使用するためにユーザーがアプリケーションの修正をする必要はありません。
-KubernetesはPodにそれぞれのIPアドレス割り振りや、Podのセットに対する単一のDNS名を提供したり、それらのPodのセットに対する負荷分散が可能です。
+KubernetesにおけるServiceの主な目的は、なじみのないサービスディスカバリーのメカニズムを使用するためにユーザーが既存のアプリケーションの修正をする必要がないようにすることです。
+クラウドネイティブな世界のために設計されたコードであれ、コンテナ化された古いアプリであれ、Podでコードを実行できます。Serviceを使用することで、そのPodのセットをネットワーク上で利用可能にし、クライアントがそれと対話できるようにします。
 
+{{< glossary_tooltip term_id="deployment" >}}を使用してアプリを実行する場合、そのDeploymentはPodを動的に作成および削除できます。ある瞬間から次の瞬間にかけて、それらのPodのいくつが動作していて健全であるかはわかりません。それらの健全なPodの名前さえわからないかもしれません。
+Kubernetesの{{< glossary_tooltip term_id="pod" text="Pod" >}}は、クラスターの希望する状態に合わせて作成および削除されます。Podは揮発性のリソースです（個々のPodが信頼性が高く耐久性があることを期待すべきではありません）。
 
+各Podは独自のIPアドレスを取得します（Kubernetesはネットワークプラグインがこれを保証することを期待しています）。
+クラスター内の特定のDeploymentについて、ある時点で実行されているPodのセットは、その後の時点でそのアプリケーションを実行しているPodのセットとは異なる場合があります。
+
+これは問題につながります。あるPodのセット（「バックエンド」と呼びます）がクラスター内の他のPodのセット（「フロントエンド」と呼びます）に機能を提供する場合、フロントエンドは接続先のIPアドレスをどのように見つけ、追跡すればよいのでしょうか？
+
+そこで _Service_ の出番です。
 
 <!-- body -->
 
-## Serviceを利用する動機
+## KubernetesにおけるService
 
-Kubernetes {{< glossary_tooltip term_id="pod" text="Pod" >}}はクラスターの状態に合わせて作成され削除されます。Podは揮発的なリソースです。
-{{< glossary_tooltip term_id="deployment" >}}をアプリケーションを稼働させるために使用すると、Podを動的に作成・削除してくれます。
+Kubernetesの一部であるService APIは、ネットワーク上でPodのグループを公開するのに役立つ抽象化です。各Serviceオブジェクトは、論理的なエンドポイントのセット（通常、これらのエンドポイントはPodです）と、それらのPodにアクセスする方法についてのポリシーを定義します。
 
-各Podはそれ自身のIPアドレスを持ちます。しかしDeploymentでは、ある時点において同時に稼働しているPodのセットは、その後のある時点において稼働しているPodのセットとは異なる場合があります。
+例えば、3つのレプリカで実行されているステートレスな画像処理バックエンドを考えてみましょう。これらのレプリカは代替可能です。フロントエンドはどのバックエンドを使用するかを気にしません。バックエンドセットを構成する実際のPodが変更される可能性がありますが、フロントエンドクライアントはそのことを認識する必要はなく、バックエンドのセット自体を追跡する必要もありません。
 
-この仕組みはある問題を引き起こします。もし、あるPodのセット(ここでは"バックエンド"と呼びます)がクラスター内で他のPodのセット(ここでは"フロントエンド"と呼びます)に対して機能を提供する場合、フロントエンドのPodがワークロードにおけるバックエンドを使用するために、バックエンドのPodのIPアドレスを探し出したり、記録し続けるためにはどうすればよいでしょうか?
+Serviceの抽象化により、この分離が可能になります。
 
-ここで _Service_ について説明します。
+ServiceによってターゲットとされるPodのセットは、通常、定義した{{< glossary_tooltip text="セレクター" term_id="selector" >}}によって決定されます。
+Serviceエンドポイントを定義する他の方法については、[セレクターなしのService](#services-without-selectors)を参照してください。
 
-## Serviceリソース {#service-resource}
+ワークロードがHTTPを話す場合、Webトラフィックがそのワークロードに到達する方法を制御するために[Ingress](/ja/docs/concepts/services-networking/ingress/)を使用することを選択するかもしれません。
+IngressはServiceタイプではありませんが、クラスターのエントリーポイントとして機能します。Ingressを使用すると、ルーティングルールを単一のリソースに統合できるため、クラスター内で別々に実行されているワークロードの複数のコンポーネントを単一のリスナーの背後に公開できます。
 
-Kubernetesにおいて、ServiceはPodの論理的なセットや、そのPodのセットにアクセスするためのポリシーを定義します(このパターンはよくマイクロサービスと呼ばることがあります)。
-ServiceによってターゲットとされたPodのセットは、たいてい {{< glossary_tooltip text="セレクター" term_id="selector" >}}によって定義されます。
-その他の方法について知りたい場合は[セレクターなしのService](#services-without-selectors)を参照してください。
+Kubernetes用の[Gateway](https://gateway-api.sigs.k8s.io/#what-is-the-gateway-api) APIは、IngressとServiceを超えた追加機能を提供します。Gatewayをクラスターに追加できます（これは{{< glossary_tooltip term_id="CustomResourceDefinition" text="CustomResourceDefinitions" >}}を使用して実装された拡張APIのファミリーです）。そして、これらを使用して、クラスター内で実行されているネットワークサービスへのアクセスを構成できます。
 
-例えば、3つのレプリカが稼働しているステートレスな画像処理用のバックエンドを考えます。これらのレプリカは代替可能です。&mdash; フロントエンドはバックエンドが何であろうと気にしません。バックエンドのセットを構成する実際のPodのセットが変更された際、フロントエンドクライアントはその変更を気にしたり、バックエンドのPodのセットの情報を記録しておく必要はありません。
+### クラウドネイティブなサービスディスカバリー
 
-Serviceによる抽象化は、クライアントからバックエンドのPodの管理する責務を分離することを可能にします。
+アプリケーションでサービスディスカバリーにKubernetes APIを使用できる場合、一致するEndpointSlicesについて{{< glossary_tooltip text="APIサーバー" term_id="kube-apiserver" >}}にクエリを実行できます。Kubernetesは、Service内のPodのセットが変更されるたびに、ServiceのEndpointSlicesを更新します。
 
-### クラウドネイティブのサービスディスカバリー
+非ネイティブなアプリケーションのために、KubernetesはアプリケーションとバックエンドPodの間にネットワークポートまたはロードバランサーを配置する方法を提供します。
 
-アプリケーション内でサービスディスカバリーのためにKubernetes APIが使える場合、ユーザーはエンドポイントを{{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}に問い合わせることができ、またService内のPodのセットが変更された時はいつでも更新されたエンドポイントの情報を取得できます。
-
-非ネイティブなアプリケーションのために、KubernetesはアプリケーションとバックエンドPodの間で、ネットワークポートやロードバランサーを配置する方法を提供します。
+いずれにせよ、ワークロードはこれらの[サービスディスカバリー](#discovering-services)メカニズムを使用して、接続したいターゲットを見つけることができます。
 
 ## Serviceの定義
 
-KubernetesのServiceはPodと同様にRESTのオブジェクトです。他のRESTオブジェクトと同様に、ユーザーはServiceの新しいインスタンスを作成するためにAPIサーバーに対してServiceの定義を`POST`できます。Serviceオブジェクトの名前は、有効な[DNSラベル名](/ja/docs/concepts/overview/working-with-objects/names#dns-label-names)である必要があります。
+Serviceは{{< glossary_tooltip text="オブジェクト" term_id="object" >}}です（PodやConfigMapがオブジェクトであるのと同じです）。Kubernetes APIを使用して、Service定義を作成、表示、または変更できます。通常、`kubectl`などのツールを使用して、それらのAPI呼び出しを行います。
 
-例えば、TCPで9376番ポートで待ち受けていて、`app=Myapp`というラベルをもつPodのセットがあるとします。
+例えば、それぞれがTCPポート9376でリッスンし、`app.kubernetes.io/name=MyApp`というラベルが付けられたPodのセットがあるとします。そのTCPリスナーを公開するためのServiceを定義できます。
 
 ```yaml
 apiVersion: v1
@@ -61,41 +71,82 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 9376
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
 ```
 
-この定義では、"my-service"という名前のついた新しいServiceオブジェクトを作成します。これは`app=Myapp`ラベルのついた各Pod上でTCPの9376番ポートをターゲットとします。
+このマニフェストを適用すると、デフォルトのClusterIP [Serviceタイプ](#publishing-services-service-types)で「my-service」という名前の新しいServiceが作成されます。このServiceは、`app.kubernetes.io/name: MyApp`ラベルを持つ任意のPodのTCPポート9376をターゲットにします。
 
-Kubernetesは、このServiceに対してIPアドレス("clusterIP"とも呼ばれます)を割り当てます。これはServiceのプロキシによって使用されます(下記の[仮想IPとServiceプロキシ](#virtual-ips-and-service-proxies)を参照ください)。
+KubernetesはこのServiceにIPアドレス（_クラスターIP_）を割り当てます。これは仮想IPアドレスメカニズムによって使用されます。そのメカニズムの詳細については、[仮想IPとサービスプロキシ](/ja/docs/reference/networking/virtual-ips/)を読んでください。
 
-Serviceセレクターのコントローラーはセレクターに一致するPodを継続的にスキャンし、“my-service”という名前のEndpointsオブジェクトに対して変更をPOSTします。
+そのServiceのコントローラーは、そのセレクターに一致するPodを継続的にスキャンし、ServiceのEndpointSlicesのセットに必要な更新を行います。
+
+Serviceオブジェクトの名前は、有効な[RFC 1035ラベル名](/ja/docs/concepts/overview/working-with-objects/names#rfc-1035-label-names)である必要があります。
 
 {{< note >}}
-Serviceは`port`から`targetPort`へのマッピングを行います。デフォルトでは、利便性のために`targetPort`フィールドは`port`フィールドと同じ値で設定されます。
+Serviceは、任意の受信`port`を`targetPort`にマッピングできます。デフォルトでは、利便性のために、`targetPort`は`port`フィールドと同じ値に設定されます。
 {{< /note >}}
 
-Pod内のポートの定義は名前を設定でき、Serviceの`targetPort`属性にてその名前を参照できます。これは単一の設定名をもつService内で、複数の種類のPodが混合していたとしても有効で、異なるポート番号を介することによって利用可能な、同一のネットワークプロトコルを利用します。
-この仕組みはServiceをデプロイしたり、設定を追加する場合に多くの点でフレキシブルです。例えば、バックエンドソフトウェアにおいて、次のバージョンでPodが公開するポート番号を変更するときに、クライアントの変更なしに行えます。
+### Serviceオブジェクトの命名要件の緩和
 
-ServiceのデフォルトプロトコルはTCPです。また、他の[サポートされているプロトコル](#protocol-support)も利用可能です。
+{{< feature-state feature_gate_name="RelaxedServiceNameValidation" >}}
 
-多くのServiceが、1つ以上のポートを公開する必要があるように、Kubernetesは1つのServiceオブジェクトに対して複数のポートの定義をサポートしています。
-各ポート定義は同一の`protocol`または異なる値を設定できます。
+`RelaxedServiceNameValidation`フィーチャーゲートにより、Serviceオブジェクト名を数字で始めることができます。このフィーチャーゲートが有効になっている場合、Serviceオブジェクト名は有効な[RFC 1123ラベル名](/ja/docs/concepts/overview/working-with-objects/names/#dns-label-names)である必要があります。
+
+### ポート定義 {#field-spec-ports}
+
+Pod内のポート定義には名前があり、Serviceの`targetPort`属性でこれらの名前を参照できます。例えば、次のようにServiceの`targetPort`をPodのポートにバインドできます。
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: proxy
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 80
+        name: http-web-svc
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app.kubernetes.io/name: proxy
+  ports:
+  - name: name-of-service-port
+    protocol: TCP
+    port: 80
+    targetPort: http-web-svc
+```
+
+これは、単一の構成名を使用するService内にPodが混在しており、異なるポート番号を介して同じネットワークプロトコルが利用可能な場合でも機能します。これにより、Serviceのデプロイと進化に多くの柔軟性がもたらされます。例えば、クライアントを壊すことなく、バックエンドソフトウェアの次のバージョンでPodが公開するポート番号を変更できます。
+
+Serviceのデフォルトプロトコルは[TCP](/ja/docs/reference/networking/service-protocols/#protocol-tcp)です。他の[サポートされているプロトコル](/ja/docs/reference/networking/service-protocols/)も使用できます。
+
+多くのServiceは複数のポートを公開する必要があるため、Kubernetesは単一のServiceに対する[複数のポート定義](#multi-port-services)をサポートしています。各ポート定義は、同じ`protocol`を持つことも、異なるプロトコルを持つこともできます。
 
 ### セレクターなしのService {#services-without-selectors}
 
-Serviceは多くの場合、KubernetesのPodに対するアクセスを抽象化しますが、他の種類のバックエンドも抽象化できます。
+Serviceは、セレクターのおかげでKubernetes Podへのアクセスを抽象化するのが最も一般的ですが、対応する{{< glossary_tooltip term_id="endpoint-slice" text="EndpointSlices" >}}オブジェクトのセットとともにセレクターなしで使用される場合、Serviceはクラスター外で実行されるものを含む他の種類のバックエンドを抽象化できます。
+
 例えば:
 
-* プロダクション環境で外部のデータベースクラスターを利用したいが、テスト環境では、自身のクラスターが持つデータベースを利用したい場合
-* Serviceを、異なる{{< glossary_tooltip term_id="namespace" >}}のServiceや他のクラスターのServiceに向ける場合
-* ワークロードをKubernetesに移行するとき、アプリケーションに対する処理をしながら、バックエンドの一部をKubernetesで実行する場合
+* 本番環境では外部のデータベースクラスターを使用したいが、テスト環境では独自のデータベースを使用する場合。
+* 別の{{< glossary_tooltip term_id="namespace" >}}または別のクラスターにあるServiceにServiceを向けたい場合。
+* ワークロードをKubernetesに移行している場合。アプローチを評価している間、バックエンドの一部のみをKubernetesで実行します。
 
-このような場合において、ユーザーはPodセレクター*なしで*Serviceを定義できます。
+これらのシナリオのいずれでも、Podに一致するセレクターを指定_せずに_Serviceを定義できます。例えば:
 
 ```yaml
 apiVersion: v1
@@ -104,135 +155,114 @@ metadata:
   name: my-service
 spec:
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 9376
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 9376
 ```
 
-このServiceはセレクターがないため、対応するEndpointsオブジェクトは自動的に作成されません。
-ユーザーはEndpointsオブジェクトを手動で追加することにより、向き先のネットワークアドレスとポートを手動でマッピングできます。
+このServiceにはセレクターがないため、対応するEndpointSliceオブジェクトは自動的に作成されません。EndpointSliceオブジェクトを手動で追加することで、Serviceを実行中のネットワークアドレスとポートにマッピングできます。例えば:
 
 ```yaml
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
-  name: my-service
-subsets:
+  name: my-service-1 # 慣例により、EndpointSliceの名前のプレフィックスとしてServiceの名前を使用します
+  labels:
+    # "kubernetes.io/service-name"ラベルを設定する必要があります。
+    # その値をServiceの名前と一致するように設定します
+    kubernetes.io/service-name: my-service
+addressType: IPv4
+ports:
+  - name: http # 上記で定義されたサービスポートの名前と一致する必要があります
+    appProtocol: http
+    protocol: TCP
+    port: 9376
+endpoints:
   - addresses:
-      - ip: 192.0.2.42
-    ports:
-      - port: 9376
+      - "10.4.5.6"
+  - addresses:
+      - "10.1.2.3"
 ```
 
-Endpointsオブジェクトの名前は、有効な[DNSサブドメイン名](/ja/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)である必要があります。
+#### カスタムEndpointSlices
+
+Service用の[EndpointSlice](#endpointslices)オブジェクトを作成する場合、EndpointSliceには任意の名前を使用できます。名前空間内の各EndpointSliceには一意の名前が必要です。EndpointSliceをServiceにリンクするには、そのEndpointSliceに`kubernetes.io/service-name` {{< glossary_tooltip text="ラベル" term_id="label" >}}を設定します。
 
 {{< note >}}
-Endpointsのipは、loopback (127.0.0.0/8 for IPv4, ::1/128 for IPv6), や
-link-local (169.254.0.0/16 and 224.0.0.0/24 for IPv4, fe80::/64 for IPv6)に設定することができません。
+エンドポイントIPは、ループバック（IPv4の場合は127.0.0.0/8、IPv6の場合は::1/128）、またはリンクローカル（IPv4の場合は169.254.0.0/16および224.0.0.0/24、IPv6の場合はfe80::/64）であっては_なりません_。
 
-{{< glossary_tooltip term_id="kube-proxy" >}}が仮想IPを最終的な到達先に設定することをサポートしていないため、Endpointsのipアドレスは他のKubernetes ServiceのClusterIPにすることができません。
+エンドポイントIPアドレスは、他のKubernetes ServiceのクラスターIPにすることはできません。これは、{{< glossary_tooltip term_id="kube-proxy" >}}が宛先として仮想IPをサポートしていないためです。
 {{< /note >}}
 
-セレクターなしのServiceへのアクセスは、セレクターをもっているServiceと同じようにふるまいます。上記の例では、トラフィックはYAMLファイル内で`192.0.2.42:9376` (TCP)で定義された単一のエンドポイントにルーティングされます。
+自分で、または独自のコードで作成するEndpointSliceの場合、ラベル[`endpointslice.kubernetes.io/managed-by`](/ja/docs/reference/labels-annotations-taints/#endpointslicekubernetesiomanaged-by)に使用する値も選択する必要があります。EndpointSlicesを管理するための独自のコントローラーコードを作成する場合は、`"my-domain.example/name-of-controller"`のような値を使用することを検討してください。サードパーティのツールを使用している場合は、ツールの名前をすべて小文字で使用し、スペースやその他の句読点をダッシュ（`-`）に変更してください。
+`kubectl`などのツールを直接使用してEndpointSlicesを管理する場合は、`"staff"`や`"cluster-admins"`など、この手動管理を説明する名前を使用してください。Kubernetes独自のコントロールプレーンによって管理されるEndpointSlicesを識別する予約値`"controller"`の使用は避けてください。
 
-ExternalName Serviceはセレクターの代わりにDNS名を使用する特殊なケースのServiceです。さらなる情報は、このドキュメントの後で紹介する[ExternalName](#externalname)を参照ください。
+#### セレクターなしでServiceにアクセスする {#service-no-selector-access}
 
-### エンドポイントスライス
+セレクターなしでServiceにアクセスすることは、セレクターがある場合と同じように機能します。セレクターなしのServiceの[例](#services-without-selectors)では、トラフィックはEndpointSliceマニフェストで定義された2つのエンドポイントのいずれか（ポート9376の10.1.2.3または10.4.5.6へのTCP接続）にルーティングされます。
 
-{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+{{< note >}}
+Kubernetes APIサーバーは、Podにマッピングされていないエンドポイントへのプロキシを許可しません。Serviceにセレクターがない場合、`kubectl port-forward service/<service-name> forwardedPort:servicePort`などのアクションは、この制約のために失敗します。これにより、Kubernetes APIサーバーが、呼び出し元がアクセスを許可されていないエンドポイントへのプロキシとして使用されるのを防ぎます。
+{{< /note >}}
 
-エンドポイントスライスは、Endpointsに対してよりスケーラブルな代替手段を提供できるAPIリソースです。概念的にはEndpointsに非常に似ていますが、エンドポイントスライスを使用すると、ネットワークエンドポイントを複数のリソースに分割できます。デフォルトでは、エンドポイントスライスは、100個のエンドポイントに到達すると「いっぱいである」と見なされ、その時点で追加のエンドポイントスライスが作成され、追加のエンドポイントが保存されます。
+`ExternalName` Serviceは、セレクターを持たず、代わりにDNS名を使用するServiceの特殊なケースです。詳細については、[ExternalName](#externalname)セクションを参照してください。
 
-エンドポイントスライスは、[エンドポイントスライスのドキュメント](/ja/docs/concepts/services-networking/endpoint-slices/)にて詳しく説明されている追加の属性と機能を提供します。
+### EndpointSlices
+
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
+
+[EndpointSlices](/ja/docs/concepts/services-networking/endpoint-slices/)は、Serviceのバッキングネットワークエンドポイントのサブセット（_スライス_）を表すオブジェクトです。
+
+Kubernetesクラスターは、各EndpointSliceが表すエンドポイントの数を追跡します。Serviceのエンドポイントが多すぎてしきい値に達した場合、Kubernetesは別の空のEndpointSliceを追加し、そこに新しいエンドポイント情報を保存します。
+デフォルトでは、既存のEndpointSlicesがすべて少なくとも100個のエンドポイントを含むと、Kubernetesは新しいEndpointSliceを作成します。Kubernetesは、追加のエンドポイントを追加する必要があるまで、新しいEndpointSliceを作成しません。
+
+このAPIの詳細については、[EndpointSlices](/ja/docs/concepts/services-networking/endpoint-slices/)を参照してください。
+
+### Endpoints (非推奨) {#endpoints}
+
+{{< feature-state for_k8s_version="v1.33" state="deprecated" >}}
+
+EndpointSlice APIは、古い[Endpoints](/ja/docs/reference/kubernetes-api/service-resources/endpoints-v1/) APIの進化形です。非推奨のEndpoints APIには、EndpointSliceと比較していくつかの問題があります。
+
+  - デュアルスタッククラスターをサポートしていません。
+  - [trafficDistribution](/ja/docs/concepts/services-networking/service/#traffic-distribution)などの新しい機能をサポートするために必要な情報が含まれていません。
+  - 単一のオブジェクトに収まらないほど長い場合、エンドポイントのリストを切り捨てます。
+
+このため、すべてのクライアントはEndpointsではなくEndpointSlice APIを使用することをお勧めします。
+
+#### 容量超過のエンドポイント
+
+Kubernetesは、単一のEndpointsオブジェクトに収まるエンドポイントの数を制限します。Serviceのバッキングエンドポイントが1000を超えると、KubernetesはEndpointsオブジェクトのデータを切り捨てます。Serviceは複数のEndpointSliceにリンクできるため、1000個のバッキングエンドポイント制限はレガシーEndpoints APIにのみ影響します。
+
+その場合、Kubernetesは最大1000個の可能なバックエンドエンドポイントを選択してEndpointsオブジェクトに保存し、Endpointsに{{< glossary_tooltip text="アノテーション" term_id="annotation" >}} [`endpoints.kubernetes.io/over-capacity: truncated`](/ja/docs/reference/labels-annotations-taints/#endpoints-kubernetes-io-over-capacity)を設定します。コントロールプレーンは、バックエンドPodの数が1000を下回ると、そのアノテーションを削除します。
+
+トラフィックは依然としてバックエンドに送信されますが、レガシーEndpoints APIに依存するロードバランシングメカニズムは、利用可能なバッキングエンドポイントの最大1000個にのみトラフィックを送信します。
+
+同じAPI制限により、Endpointsを手動で更新して1000を超えるエンドポイントを持つことはできません。
 
 ### アプリケーションプロトコル
 
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
+{{< feature-state for_k8s_version="v1.20" state="stable" >}}
 
-`AppProtocol`フィールドによってServiceの各ポートに対して特定のアプリケーションプロトコルを指定することができます。
-この値は、対応するEndpointsオブジェクトとEndpointSliceオブジェクトに反映されます。
-## 仮想IPとサービスプロキシ {#virtual-ips-and-service-proxies}
+`appProtocol`フィールドは、各Serviceポートにアプリケーションプロトコルを指定する方法を提供します。これは、実装が理解できるプロトコルに対してより豊かな動作を提供するためのヒントとして使用されます。
+このフィールドの値は、対応するEndpointsおよびEndpointSliceオブジェクトによってミラーリングされます。
 
-Kubernetesクラスターの各Nodeは`kube-proxy`を稼働させています。`kube-proxy`は[`ExternalName`](#externalname)タイプ以外の`Service`用に仮想IPを実装する責務があります。
+このフィールドは標準のKubernetesラベル構文に従います。有効な値は次のいずれかです。
 
-### なぜ、DNSラウンドロビンを使わないのでしょうか。
+* [IANA標準サービス名](https://www.iana.org/assignments/service-names)。
 
-ここで湧き上がる質問として、なぜKubernetesは内部のトラフィックをバックエンドへ転送するためにプロキシに頼るのでしょうか。
-他のアプローチはどうなのでしょうか。例えば、複数のAバリュー(もしくはIPv6用にAAAAバリューなど)をもつDNSレコードを設定し、ラウンドロビン方式で名前を解決することは可能でしょうか。
+* `mycompany.com/my-custom-protocol`などの実装定義のプレフィックス付き名前。
 
-Serviceにおいてプロキシを使う理由はいくつかあります。
+* Kubernetes定義のプレフィックス付き名前:
 
-* DNSの実装がレコードのTTLをうまく扱わず、期限が切れた後も名前解決の結果をキャッシュするという長い歴史がある。
-* いくつかのアプリケーションではDNSルックアップを1度だけ行い、その結果を無期限にキャッシュする。
-* アプリケーションとライブラリーが適切なDNS名の再解決を行ったとしても、DNSレコード上の0もしくは低い値のTTLがDNSに負荷をかけることがあり、管理が難しい。
+| プロトコル | 説明 |
+|----------|-------------|
+| `kubernetes.io/h2c` | [RFC 7540](https://www.rfc-editor.org/rfc/rfc7540)で説明されているクリアテキスト上のHTTP/2 |
+| `kubernetes.io/ws`  | [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455)で説明されているクリアテキスト上のWebSocket |
+| `kubernetes.io/wss` | [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455)で説明されているTLS上のWebSocket |
 
-### user-spaceプロキシモード {#proxy-mode-userspace}
-
-このモードでは、kube-proxyはServiceやEndpointsオブジェクトの追加・削除をチェックするために、Kubernetes Masterを監視します。
-各Serviceは、ローカルのNode上でポート(ランダムに選ばれたもの)を公開します。この"プロキシポート"に対するどのようなリクエストも、そのServiceのバックエンドPodのどれか1つにプロキシされます(Endpointsを介して通知されたPodに対して)。
-kube-proxyは、どのバックエンドPodを使うかを決める際にServiceの`SessionAffinity`項目の設定を考慮に入れます。
-
-最後に、user-spaceプロキシはServiceの`clusterIP`(仮想IP)と`port`に対するトラフィックをキャプチャするiptablesルールをインストールします。
-そのルールは、トラフィックをバックエンドPodにプロキシするためのプロキシポートにリダイレクトします。
-
-デフォルトでは、user-spaceモードにおけるkube-proxyはラウンドロビンアルゴリズムによってバックエンドPodを選択します。
-
-![user-spaceプロキシのService概要ダイアグラム](/images/docs/services-userspace-overview.svg)
-
-### `iptables`プロキシモード {#proxy-mode-iptables}
-
-このモードでは、kube-proxyはServiceやEndpointsオブジェクトの追加・削除のチェックのためにKubernetesコントロールプレーンを監視します。
-各Serviceでは、そのServiceの`clusterIP`と`port`に対するトラフィックをキャプチャするiptablesルールをインストールし、そのトラフィックをServiceのあるバックエンドのセットに対してリダイレクトします。
-各Endpointsオブジェクトは、バックエンドのPodを選択するiptablesルールをインストールします。
-
-デフォルトでは、iptablesモードにおけるkube-proxyはバックエンドPodをランダムで選択します。
-
-トラフィックのハンドリングのためにiptablesを使用すると、システムのオーバーヘッドが少なくなります。これは、トラフィックがLinuxのnetfilterによってuser-spaceとkernel-spaceを切り替える必要がないためです。
-このアプローチは、オーバーヘッドが少ないことに加えて、より信頼できる方法でもあります。
-
-kube-proxyがiptablesモードで稼働し、最初に選択されたPodが応答しない場合、そのコネクションは失敗します。
-これはuser-spaceモードでの挙動と異なります: user-spaceモードにおいては、kube-proxyは最初のPodに対するコネクションが失敗したら、自動的に他のバックエンドPodに対して再接続を試みます。
-
-iptablesモードのkube-proxyが正常なバックエンドPodのみをリダイレクト対象とするために、Podの[ReadinessProbe](/ja/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)を使用してバックエンドPodが正常に動作しているか確認できます。これは、ユーザーがkube-proxyを介して、コネクションに失敗したPodに対してトラフィックをリダイレクトするのを除外することを意味します。
-
-![iptablesプロキシのService概要ダイアグラム](/images/docs/services-iptables-overview.svg)
-
-### IPVSプロキシモード {#proxy-mode-ipvs}
-
-{{< feature-state for_k8s_version="v1.11" state="stable" >}}
-
-`ipvs`モードにおいて、kube-proxyはServiceとEndpointsオブジェクトを監視し、IPVSルールを作成するために`netlink`インターフェースを呼び出し、定期的にKubernetesのServiceとEndpointsとIPVSルールを同期させます。
-このコントロールループはIPVSのステータスが理想的な状態になることを保証します。
-Serviceにアクセスするとき、IPVSはトラフィックをバックエンドのPodに向けます。
-
-IPVSプロキシモードはiptablesモードと同様に、netfilterのフック関数に基づいています。ただし、基礎となるデータ構造としてハッシュテーブルを使っているのと、kernel-spaceで動作します。
-これは、IPVSモードにおけるkube-proxyはiptablesモードに比べてより低いレイテンシーでトラフィックをリダイレクトし、プロキシのルールを同期する際にはよりパフォーマンスがよいことを意味します。
-他のプロキシモードと比較して、IPVSモードはより高いネットワークトラフィックのスループットをサポートしています。
-
-IPVSはバックエンドPodに対するトラフィックのバランシングのために多くのオプションを下記のとおりに提供します。
-
-* `rr`: ラウンドロビン
-* `lc`: 最低コネクション数(オープンされているコネクション数がもっとも小さいもの)
-* `dh`: 送信先IPによって割り当てられたハッシュ値をもとに割り当てる(Destination Hashing)
-* `sh`: 送信元IPによって割り当てられたハッシュ値をもとに割り当てる(Source Hashing)
-* `sed`: 見込み遅延が最小なもの
-* `nq`: キューなしスケジューリング
-
-{{< note >}}
-IPVSモードでkube-proxyを稼働させるためには、kube-proxyを稼働させる前にNode上でIPVSを有効にしなければなりません。
-
-kube-proxyはIPVSモードで起動する場合、IPVSカーネルモジュールが利用可能かどうかを確認します。
-もしIPVSカーネルモジュールが見つからなかった場合、kube-proxyはiptablesモードで稼働するようにフォールバックされます。
-{{< /note >}}
-
-![IPVSプロキシのService概要ダイアグラム](/images/docs/services-ipvs-overview.svg)
-
-このダイアグラムのプロキシモデルにおいて、ServiceのIP:Portに対するトラフィックは、クライアントがKubernetesのServiceやPodについて何も知ることなく適切にバックエンドにプロキシされています。
-
-特定のクライアントからのコネクションが、毎回同一のPodにリダイレクトされるようにするためには、`service.spec.sessionAffinity`に"ClientIP"を設定することにより、クライアントのIPアドレスに基づいたSessionAffinityを選択することができます(デフォルトは"None")。
-また、`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds`を適切に設定することにより、セッションのタイムアウト時間を設定できます(デフォルトではこの値は18,000で、3時間となります)。
-
-## 複数のポートを公開するService
+### 複数のポートを公開するService {#multi-port-services}
 
 いくつかのServiceにおいて、ユーザーは1つ以上のポートを公開する必要があります。Kubernetesは、Serviceオブジェクト上で複数のポートを定義するように設定できます。
 Serviceで複数のポートを使用するとき、どのポートかを明確にするために、複数のポート全てに対して名前をつける必要があります。
@@ -245,142 +275,82 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 9376
-  - name: https
-    protocol: TCP
-    port: 443
-    targetPort: 9377
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 9376
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 9377
 ```
 
 {{< note >}}
-KubernetesのPod名と同様に、ポート名は小文字の英数字と`-`のみ含める必要があります。また、ポート名の最初と最後の文字は英数字である必要があります。
+一般的なKubernetesの{{< glossary_tooltip term_id="name" text="名前">}}と同様に、ポート名は小文字の英数字と`-`のみを含める必要があります。また、ポート名の最初と最後の文字は英数字である必要があります。
 
-例えば、`123-abc`や`web`という名前は有効で、`123_abc`や`-web`は無効です。
+例えば、`123-abc`や`web`という名前は有効ですが、`123_abc`や`-web`は無効です。
 {{< /note >}}
 
-## ユーザー所有のIPアドレスを選択する
+## Serviceタイプ {#publishing-services-service-types}
 
-`Service`を作成するリクエストの一部として、ユーザー所有のclusterIPアドレスを指定することができます。
-これを行うためには`.spec.clusterIP`フィールドにセットします。
-使用例として、もしすでに再利用したいDNSエントリーが存在していた場合や、特定のIPアドレスを設定されたレガシーなシステムや、IPの再設定が難しい場合です。
+アプリケーションのいくつかの部分（例えば、フロントエンドなど）において、クラスターの外部からアクセス可能な外部IPアドレス上にServiceを公開したい場合があります。
 
-ユーザーが指定したIPアドレスは、そのAPIサーバーのために設定されている`service-cluster-ip-range`というCIDRレンジ内の有効なIPv4またはIPv6アドレスである必要があります。
-もし無効なclusterIPアドレスの値を設定してServiceを作成した場合、問題があることを示すためにAPIサーバーはHTTPステータスコード422を返します。
+KubernetesのServiceタイプを使用すると、必要なServiceの種類を指定できます。
 
-## サービスディスカバリー
+利用可能な`type`の値とその振る舞いは以下の通りです:
 
-Kubernetesは、Serviceオブジェクトを見つけ出すために2つの主要なモードをサポートしています。 - それは環境変数とDNSです。
+[`ClusterIP`](#type-clusterip)
+: クラスター内部のIPでServiceを公開します。この値を選択すると、Serviceはクラスター内部からのみ到達可能になります。これは、Serviceの`type`を明示的に指定しない場合に使用されるデフォルトです。
+  [Ingress](/ja/docs/concepts/services-networking/ingress/)または[Gateway](https://gateway-api.sigs.k8s.io/)を使用して、Serviceをパブリックインターネットに公開できます。
 
-### 環境変数
+[`NodePort`](#type-nodeport)
+: 各NodeのIPにて、静的なポート（`NodePort`）上でServiceを公開します。ノードポートを利用可能にするために、Kubernetesは`type: ClusterIP`のServiceを要求したかのように、クラスターIPアドレスを設定します。
 
-PodがNode上で稼働するとき、kubeletはアクティブな各Serviceに対して、環境変数のセットを追加します。
-これは[Docker links互換性](https://docs.docker.com/userguide/dockerlinks/)のある変数(
-[makeLinkVariables関数](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/pkg/kubelet/envvars/envvars.go#L72)を確認してください)や、より簡単な`{SVCNAME}_SERVICE_HOST`や、`{SVCNAME}_SERVICE_PORT`変数をサポートします。この変数名で使われるService名は大文字に変換され、`-`は`_`に変換されます。
+[`LoadBalancer`](#loadbalancer)
+: 外部のロードバランサーを使用して、Serviceを外部に公開します。Kubernetesは直接ロードバランシングコンポーネントを提供しません。ユーザーが提供するか、Kubernetesクラスターをクラウドプロバイダーと統合することができます。
 
-例えば、TCPポート6379番を公開していて、さらにclusterIPが10.0.0.11に割り当てられている`redis-master`というServiceは、下記のような環境変数を生成します。
+[`ExternalName`](#externalname)
+: Serviceを`externalName`フィールドの内容（例えば、ホスト名`api.foo.bar.example`）にマッピングします。マッピングは、クラスターのDNSサーバーがその外部ホスト名の値を持つ`CNAME`レコードを返すように構成します。
+  いかなる種類のプロキシも設定されません。
 
-```shell
-REDIS_MASTER_SERVICE_HOST=10.0.0.11
-REDIS_MASTER_SERVICE_PORT=6379
-REDIS_MASTER_PORT=tcp://10.0.0.11:6379
-REDIS_MASTER_PORT_6379_TCP=tcp://10.0.0.11:6379
-REDIS_MASTER_PORT_6379_TCP_PROTO=tcp
-REDIS_MASTER_PORT_6379_TCP_PORT=6379
-REDIS_MASTER_PORT_6379_TCP_ADDR=10.0.0.11
-```
+Service APIの`type`フィールドは、ネストされた機能として設計されています。各レベルは前のレベルに追加されます。ただし、このネストされた設計には例外があります。[ロードバランサーの`NodePort`割り当てを無効にする](/ja/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation)ことで、`LoadBalancer` Serviceを定義できます。
 
-{{< note >}}
-Serviceにアクセスする必要のあるPodがあり、クライアントであるそのPodに対して環境変数を使ってポートとclusterIPを公開する場合、クライアントのPodが存在する*前に* Serviceを作成しなくてはなりません。
-そうでない場合、クライアントのPodはそれらの環境変数を作成しません。
+### `type: ClusterIP` {#type-clusterip}
 
-ServiceのclusterIPを発見するためにDNSのみを使う場合、このような問題を心配する必要はありません。
-{{< /note >}}
+このデフォルトのServiceタイプは、クラスターがその目的のために予約したIPアドレスのプールからIPアドレスを割り当てます。
 
-### DNS
+Serviceの他のいくつかのタイプは、基盤として`ClusterIP`タイプの上に構築されています。
 
-ユーザーは[アドオン](/ja/docs/concepts/cluster-administration/addons/)を使ってKubernetesクラスターにDNS Serviceをセットアップできます(常にセットアップすべきです)。
+`.spec.clusterIP`が`"None"`に設定されたServiceを定義すると、KubernetesはIPアドレスを割り当てません。詳細については、[Headless Service](#headless-services)を参照してください。
 
-CoreDNSなどのクラスター対応のDNSサーバーは新しいServiceや、各Service用のDNSレコードのセットのためにKubernetes APIを常に監視します。
-もしクラスターを通してDNSが有効になっている場合、全てのPodはDNS名によって自動的にServiceに対する名前解決をするようにできるはずです。
+#### 独自のIPアドレスを選択する
 
-例えば、Kubernetesの`my-ns`というNamespace内で`my-service`というServiceがある場合、KubernetesコントロールプレーンとDNS Serviceが協調して動作し、`my-service.my-ns`というDNSレコードを作成します。
-`my-ns`というNamespace内のPodは`my-service`という名前で簡単に名前解決できるはずです(`my-service.my-ns`でも動作します)。
+`Service`作成リクエストの一部として、独自のクラスターIPアドレスを指定できます。これを行うには、`.spec.clusterIP`フィールドを設定します。例えば、再利用したい既存のDNSエントリがある場合や、特定のIPアドレス用に構成されており再構成が難しいレガシーシステムがある場合などです。
 
-他のNamespace内でのPodは`my-service.my-ns`といった形で指定しなくてはなりません。これらのDNS名は、そのServiceのclusterIPに名前解決されます。
+選択するIPアドレスは、APIサーバー用に構成された`service-cluster-ip-range` CIDR範囲内の有効なIPv4またはIPv6アドレスである必要があります。
+無効な`clusterIP`アドレス値でServiceを作成しようとすると、APIサーバーは問題があることを示すために422 HTTPステータスコードを返します。
 
-Kubernetesは名前付きのポートに対するDNS SRV(Service)レコードもサポートしています。もし`my-service.my-ns`というServiceが`http`という名前のTCPポートを持っていた場合、IPアドレスと同様に、`http`のポート番号を探すために`_http._tcp.my-service.my-ns`というDNS SRVクエリを実行できます。
+2つの異なるServiceが同じIPアドレスを使用しようとするリスクと影響をKubernetesがどのように軽減するかについては、[衝突の回避](/ja/docs/reference/networking/virtual-ips/#avoiding-collisions)を参照してください。
 
-KubernetesのDNSサーバーは`ExternalName` Serviceにアクセスする唯一の方法です。
-[DNS Pods と Service](/ja/docs/concepts/services-networking/dns-pod-service/)にて`ExternalName`による名前解決に関するさらなる情報を確認できます。
+### `type: NodePort` {#type-nodeport}
 
-## Headless Service {#headless-service}
+`type`フィールドを`NodePort`に設定すると、Kubernetesコントロールプレーンは`--service-node-port-range`フラグで指定された範囲（デフォルト: 30000-32767）からポートを割り当てます。
+各ノードは、そのポート（すべてのノードで同じポート番号）をServiceにプロキシします。
+Serviceは、割り当てられたポートを`.spec.ports[*].nodePort`フィールドで報告します。
 
-場合によっては、負荷分散と単一のService IPは不要です。このケースにおいて、clusterIP(`.spec.clusterIP`)の値を`"None"`に設定することにより、"Headless"とよばれるServiceを作成できます。
+NodePortを使用すると、独自のロードバランシングソリューションをセットアップしたり、Kubernetesによって完全にサポートされていない環境を構成したり、1つ以上のノードのIPアドレスを直接公開したりする自由が得られます。
 
-ユーザーは、Kubernetesの実装と紐づくことなく、他のサービスディスカバリーのメカニズムと連携するためにHeadless Serviceを使用できます。
-例えば、ユーザーはこのAPI上でカスタム{{< glossary_tooltip term_id="operator-pattern" text="オペレーター" >}}を実装することができます。
+ノードポートServiceの場合、Kubernetesはさらにポート（Serviceのプロトコルに合わせてTCP、UDP、またはSCTP）を割り当てます。クラスター内のすべてのノードは、その割り当てられたポートでリッスンし、そのServiceに関連付けられた準備完了のエンドポイントの1つにトラフィックを転送するように構成されます。適切なプロトコル（例: TCP）と適切なポート（そのServiceに割り当てられたもの）を使用して任意のノードに接続することで、クラスターの外部から`type: NodePort` Serviceにアクセスできます。
 
-この`Service`においては、clusterIPは割り当てられず、kube-proxyはこのServiceをハンドリングしないのと、プラットフォームによって行われるはずの
-ロードバランシングやプロキシとしての処理は行われません。DNSがどのように自動で設定されるかは、定義されたServiceが定義されたラベルセレクターを持っているかどうかに依存します。
+#### 独自のポートを選択する {#nodeport-custom-port}
 
-### ラベルセレクターの利用
+特定のポート番号が必要な場合は、`nodePort`フィールドに値を指定できます。コントロールプレーンは、そのポートを割り当てるか、APIトランザクションが失敗したことを報告します。
+これは、ポートの衝突の可能性を自分で処理する必要があることを意味します。
+また、NodePortの使用用に構成された範囲内の有効なポート番号を使用する必要があります。
 
-ラベルセレクターを定義したHeadless Serviceにおいて、EndpointsコントローラーはAPIにおいて`Endpoints`レコードを作成し、`Service`のバックエンドにある`Pod`へのIPを直接指し示すためにDNS設定を修正します。
-
-### ラベルセレクターなしの場合
-
-ラベルセレクターを定義しないHeadless Serviceにおいては、Endpointsコントローラーは`Endpoints`レコードを作成しません。
-しかしDNSのシステムは下記の2つ両方を探索し、設定します。
-
-* [`ExternalName`](#externalname)タイプのServiceに対するCNAMEレコード
-* 他の全てのServiceタイプを含む、Service名を共有している全ての`Endpoints`レコード
-
-## Serviceの公開 (Serviceのタイプ) {#publishing-services-service-types}
-
-ユーザーのアプリケーションのいくつかの部分において(例えば、frontendsなど)、ユーザーのクラスターの外部にあるIPアドレス上でServiceを公開したい場合があります。
-
-Kubernetesの`ServiceTypes`によって、ユーザーがどのような種類のServiceを使いたいかを指定することが可能です。
-デフォルトでは`ClusterIP`となります。
-
-`Type`項目の値と、そのふるまいは以下のようになります。
-
-* `ClusterIP`: クラスター内部のIPでServiceを公開する。このタイプではServiceはクラスター内部からのみ疎通性があります。このタイプはデフォルトの`ServiceType`です。
-* [`NodePort`](#nodeport): 各NodeのIPにて、静的なポート(`NodePort`)上でServiceを公開します。その`NodePort` のServiceが転送する先の`ClusterIP` Serviceが自動的に作成されます。`<NodeIP>:<NodePort>`にアクセスすることによって`NodePort` Serviceにアクセスできるようになります。
-* [`LoadBalancer`](#loadbalancer): クラウドプロバイダーのロードバランサーを使用して、Serviceを外部に公開します。クラスター外部にあるロードバランサーが転送する先の`NodePort`と`ClusterIP` Serviceは自動的に作成されます。
-* [`ExternalName`](#externalname): `CNAME`レコードを返すことにより、`externalName`フィールドに指定したコンテンツ(例: `foo.bar.example.com`)とServiceを紐づけます。しかし、いかなる種類のプロキシも設定されません。
-  {{< note >}}
-  `ExternalName`タイプのServiceを利用するためには、kube-dnsのバージョン1.7かCoreDNSのバージョン0.0.8以上が必要となります。
-  {{< /note >}}
-
-また、Serviceを公開するために[Ingress](/ja/docs/concepts/services-networking/ingress/)も利用可能です。IngressはServiceのタイプではありませんが、クラスターに対するエントリーポイントとして動作します。
-Ingressは同一のIPアドレスにおいて、複数のServiceを公開するように、ユーザーの設定した転送ルールを1つのリソースにまとめることができます。
-
-### NodePort タイプ {#nodeport}
-
-もし`type`フィールドの値を`NodePort`に設定すると、Kubernetesコントロールプレーンは`--service-node-port-range`フラグによって指定されたレンジのポート(デフォルト: 30000-32767)を割り当てます。
-各Nodeはそのポート(各Nodeで同じポート番号)への通信をServiceに転送します。
-作成したServiceは、`.spec.ports[*].nodePort`フィールド内に割り当てられたポートを記述します。
-
-もしポートへの通信を転送する特定のIPを指定したい場合、特定のIPブロックをkube-proxyの`--nodeport-address`フラグで指定できます。これはKubernetes v1.10からサポートされています。
-このフラグは、コンマ区切りのIPブロックのリスト(例: 10.0.0./8, 192.0.2.0/25)を使用し、kube-proxyがこのNodeに対してローカルとみなすべきIPアドレスの範囲を指定します。
-
-例えば、`--nodeport-addresses=127.0.0.0/8`というフラグによってkube-proxyを起動した時、kube-proxyはNodePort Serviceのためにループバックインターフェースのみ選択します。`--nodeport-addresses`のデフォルト値は空のリストになります。これはkube-proxyがNodePort Serviceに対して全てのネットワークインターフェースを利用可能とするべきということを意味します(これは以前のKubernetesのバージョンとの互換性があります)。
-
-もしポート番号を指定したい場合、`nodePort`フィールドに値を指定できます。コントロールプレーンは指定したポートを割り当てるか、APIトランザクションが失敗したことを知らせるかのどちらかになります。
-これは、ユーザーが自分自身で、ポート番号の衝突に関して気をつける必要があることを意味します。
-また、ユーザーは有効なポート番号を指定する必要があり、NodePortの使用において、設定された範囲のポートを指定する必要があります。
-
-NodePortの使用は、Kubernetesによって完全にサポートされていないようなユーザー独自の負荷分散を設定をするための有効な方法や、1つ以上のNodeのIPを直接公開するための方法となりえます。
-
-注意点として、このServiceは`<NodeIP>:spec.ports[*].nodePort`と、`.spec.clusterIP:spec.ports[*].port`として疎通可能です。
-(もしkube-proxyにおいて`--nodeport-addressses`が設定された場合、<NodeIP>はフィルターされたNodeIPとなります。)
-
-例えば:
+以下は、NodePort値（この例では30007）を指定する`type: NodePort`のServiceのマニフェスト例です。
 
 ```yaml
 apiVersion: v1
@@ -390,20 +360,44 @@ metadata:
 spec:
   type: NodePort
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
-      # デフォルトでは利便性のため、 `targetPort` は `port` と同じ値にセットされます。
     - port: 80
+      # デフォルトでは利便性のため、 `targetPort` は `port` と同じ値にセットされます。
       targetPort: 80
       # 省略可能なフィールド
       # デフォルトでは利便性のため、Kubernetesコントロールプレーンはある範囲から1つポートを割り当てます(デフォルト値の範囲:30000-32767)
       nodePort: 30007
 ```
 
-### LoadBalancer タイプ {#loadbalancer}
+#### 衝突を避けるためにNodeport範囲を予約する {#avoid-nodeport-collisions}
 
-外部のロードバランサーをサポートするクラウドプロバイダー上で、`type`フィールドに`LoadBalancer`を設定すると、Service用にロードバランサーがプロビジョニングされます。
-実際のロードバランサーの作成は非同期で行われ、プロビジョンされたバランサーの情報は、Serviceの`.status.loadBalancer`フィールドに記述されます。
+NodePort Serviceへのポート割り当てのポリシーは、自動割り当てと手動割り当ての両方のシナリオに適用されます。ユーザーが特定のポートを使用するNodePort Serviceを作成しようとすると、ターゲットポートがすでに割り当てられている別のポートと競合する可能性があります。
+
+この問題を回避するために、NodePort Serviceのポート範囲は2つの帯域に分割されています。
+動的ポート割り当てはデフォルトで上位帯域を使用し、上位帯域が使い果たされると下位帯域を使用する場合があります。ユーザーは、ポート衝突のリスクが低い下位帯域から割り当てることができます。
+
+#### `type: NodePort` ServiceのカスタムIPアドレス構成 {#service-nodeport-custom-listen-address}
+
+クラスター内のノードを設定して、ノードポートServiceの提供に特定のIPアドレスを使用するようにできます。各ノードが複数のネットワーク（例: アプリケーショントラフィック用のネットワークと、ノードとコントロールプレーン間のトラフィック用の別のネットワーク）に接続されている場合に、これを行うことができます。
+
+ポートをプロキシする特定のIPアドレスを指定したい場合は、kube-proxyの`--nodeport-addresses`フラグ、または[kube-proxy構成ファイル](/ja/docs/reference/config-api/kube-proxy-config.v1alpha1/)の同等の`nodePortAddresses`フィールドを特定のIPブロックに設定できます。
+
+このフラグは、コンマ区切りのIPブロックのリスト（例: `10.0.0.0/8`, `192.0.2.0/25`）を使用して、kube-proxyがこのノードに対してローカルと見なすべきIPアドレスの範囲を指定します。
+
+例えば、`--nodeport-addresses=127.0.0.0/8`フラグを使用してkube-proxyを起動すると、kube-proxyはNodePort Service用にループバックインターフェースのみを選択します。
+`--nodeport-addresses`のデフォルトは空のリストです。
+これは、kube-proxyがNodePortのすべての利用可能なネットワークインターフェースを考慮すべきであることを意味します。（これは以前のKubernetesリリースとも互換性があります。）
+
+{{< note >}}
+このServiceは、`<NodeIP>:spec.ports[*].nodePort`および`.spec.clusterIP:spec.ports[*].port`として表示されます。
+kube-proxyの`--nodeport-addresses`フラグまたはkube-proxy構成ファイルの同等のフィールドが設定されている場合、`<NodeIP>`はフィルタリングされたノードIPアドレス（またはIPアドレス）になります。
+{{< /note >}}
+
+### `type: LoadBalancer` {#loadbalancer}
+
+外部ロードバランサーをサポートするクラウドプロバイダーでは、`type`フィールドを`LoadBalancer`に設定すると、Service用のロードバランサーがプロビジョニングされます。
+ロードバランサーの実際の作成は非同期に行われ、プロビジョニングされたバランサーに関する情報はServiceの`.status.loadBalancer`フィールドに公開されます。
 例えば:
 
 ```yaml
@@ -413,11 +407,11 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 9376
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
   clusterIP: 10.0.171.239
   type: LoadBalancer
 status:
@@ -426,370 +420,186 @@ status:
     - ip: 192.0.2.127
 ```
 
-外部のロードバランサーからのトラフィックはバックエンドのPodに直接転送されます。クラウドプロバイダーはどのようにそのリクエストをバランシングするかを決めます。
+外部ロードバランサーからのトラフィックは、バックエンドPodに直接向けられます。クラウドプロバイダーは、負荷分散の方法を決定します。
 
-LoadBalancerタイプのサービスで複数のポートが定義されている場合、すべてのポートが同じプロトコルである必要があり、さらにそのプロトコルは`TCP`、`UDP`、`SCTP`のいずれかである必要があります。
+`type: LoadBalancer`のServiceを実装するために、Kubernetesは通常、`type: NodePort`のServiceを要求するのと同等の変更を行うことから始めます。次に、cloud-controller-managerコンポーネントは、割り当てられたノードポートにトラフィックを転送するように外部ロードバランサーを構成します。
 
-いくつかのクラウドプロバイダーにおいて、`loadBalancerIP`の設定をすることができます。このようなケースでは、そのロードバランサーはユーザーが指定した`loadBalancerIP`に対してロードバランサーを作成します。
-もし`loadBalancerIP`フィールドの値が指定されていない場合、そのロードバランサーはエフェメラルなIPアドレスに対して作成されます。もしユーザーが`loadBalancerIP`を指定したが、使っているクラウドプロバイダーがその機能をサポートしていない場合、その`loadBalancerIP`フィールドに設定された値は無視されます。
+クラウドプロバイダーの実装がこれをサポートしている場合は、ノードポートの割り当てを[省略](#load-balancer-nodeport-allocation)するようにロードバランシングされたServiceを構成できます。
 
-{{< note >}}
-もしSCTPを使っている場合、`LoadBalancer` タイプのServiceに関する[使用上の警告](#caveat-sctp-loadbalancer-service-type)を参照してください。
-{{< /note >}}
+一部のクラウドプロバイダーでは、`loadBalancerIP`を指定できます。その場合、ロードバランサーはユーザー指定の`loadBalancerIP`で作成されます。`loadBalancerIP`フィールドが指定されていない場合、ロードバランサーはエフェメラルIPアドレスでセットアップされます。`loadBalancerIP`を指定したが、クラウドプロバイダーがその機能をサポートしていない場合、設定した`loadbalancerIP`フィールドは無視されます。
 
 {{< note >}}
+Serviceの`.spec.loadBalancerIP`フィールドはKubernetes v1.24で非推奨になりました。
 
-**Azure** において、もしユーザーが指定する`loadBalancerIP`を使用したい場合、最初に静的なパブリックIPアドレスのリソースを作成する必要があります。
-このパブリックIPアドレスのリソースは、クラスター内で自動的に作成された他のリソースと同じグループに作られるべきです。
-例: `MC_myResourceGroup_myAKSCluster_eastus`
+このフィールドは仕様が不十分であり、その意味は実装によって異なります。
+また、デュアルスタックネットワークもサポートできません。このフィールドは、将来のAPIバージョンで削除される可能性があります。
 
-割り当てられたIPアドレスをloadBalancerIPとして指定してください。クラウドプロバイダーの設定ファイルにおいてsecurityGroupNameを更新したことを確認してください。
-`CreatingLoadBalancerFailed`というパーミッションの問題に対するトラブルシューティングの情報は、[Azure Kubernetes Service(AKS)のロードバランサーで静的IPアドレスを使用する](https://docs.microsoft.com/en-us/azure/aks/static-ip) や、[高度なネットワークを使用したAKSクラスターでのCreatingLoadBalancerFailed](https://github.com/Azure/AKS/issues/357)を参照してください。
+（プロバイダー固有の）アノテーションを介してServiceのロードバランサーIPアドレスを指定することをサポートするプロバイダーと統合している場合は、その方法に切り替える必要があります。
+
+Kubernetesとのロードバランサー統合のコードを作成している場合は、このフィールドの使用を避けてください。
+Serviceではなく[Gateway](https://gateway-api.sigs.k8s.io/)と統合するか、同等の詳細を指定する独自の（プロバイダー固有の）アノテーションをServiceに定義できます。
 {{< /note >}}
 
-#### 内部のロードバランサー
-複雑な環境において、同一の(仮想)ネットワークアドレスブロック内のServiceからのトラフィックを転送する必要がでてきます。
+#### ロードバランサートラフィックへのノードの活性の影響
 
-Split-HorizonなDNS環境において、ユーザーは2つのServiceを外部と内部の両方からのトラフィックをエンドポイントに転送させる必要がでてきます。
+ロードバランサーのヘルスチェックは、最新のアプリケーションにとって重要です。これらは、ロードバランサーがトラフィックをディスパッチするサーバー（仮想マシン、またはIPアドレス）を決定するために使用されます。Kubernetes APIは、Kubernetes管理のロードバランサーに対してヘルスチェックをどのように実装するかを定義していません。代わりに、動作を決定するのはクラウドプロバイダー（および統合コードを実装する人々）です。ロードバランサーのヘルスチェックは、Serviceの`externalTrafficPolicy`フィールドをサポートするコンテキスト内で広く使用されています。
 
-ユーザーは、Serviceに対して下記のアノテーションを1つ追加することでこれを実現できます。
-追加するアノテーションは、ユーザーが使っているクラウドプロバイダーに依存しています。
+#### 混合プロトコルタイプのロードバランサー
+
+{{< feature-state feature_gate_name="MixedProtocolLBService" >}}
+
+デフォルトでは、LoadBalancerタイプのServiceの場合、複数のポートが定義されていると、すべてのポートが同じプロトコルである必要があり、そのプロトコルはクラウドプロバイダーによってサポートされているものである必要があります。
+
+フィーチャーゲート`MixedProtocolLBService`（v1.24以降のkube-apiserverではデフォルトで有効）を使用すると、複数のポートが定義されている場合に、LoadBalancerタイプのServiceに異なるプロトコルを使用できます。
+
+{{< note >}}
+ロードバランシングされたServiceに使用できるプロトコルのセットは、クラウドプロバイダーによって定義されます。Kubernetes APIが強制するもの以上の制限を課す場合があります。
+{{< /note >}}
+
+#### ロードバランサーのNodePort割り当てを無効にする {#load-balancer-nodeport-allocation}
+
+{{< feature-state for_k8s_version="v1.24" state="stable" >}}
+
+フィールド`spec.allocateLoadBalancerNodePorts`を`false`に設定することで、`type: LoadBalancer`のServiceのノードポート割り当てをオプションで無効にできます。これは、ノードポートを使用するのではなく、Podに直接トラフィックをルーティングするロードバランサー実装にのみ使用する必要があります。デフォルトでは、`spec.allocateLoadBalancerNodePorts`は`true`であり、タイプLoadBalancerのServiceは引き続きノードポートを割り当てます。既存のServiceで`spec.allocateLoadBalancerNodePorts`が`false`に設定されている場合、割り当てられたノードポートは自動的に割り当て解除**されません**。それらのノードポートを割り当て解除するには、すべてのServiceポートの`nodePorts`エントリを明示的に削除する必要があります。
+
+#### ロードバランサー実装のクラスを指定する {#load-balancer-class}
+
+{{< feature-state for_k8s_version="v1.24" state="stable" >}}
+
+`type`が`LoadBalancer`に設定されているServiceの場合、`.spec.loadBalancerClass`フィールドを使用すると、クラウドプロバイダーのデフォルト以外のロードバランサー実装を使用できます。
+
+デフォルトでは、`.spec.loadBalancerClass`は設定されておらず、`LoadBalancer`タイプのServiceは、クラスターが`--cloud-provider`コンポーネントフラグを使用してクラウドプロバイダーで構成されている場合、クラウドプロバイダーのデフォルトのロードバランサー実装を使用します。
+
+`.spec.loadBalancerClass`を指定すると、指定されたクラスに一致するロードバランサー実装がServiceを監視していると想定されます。
+デフォルトのロードバランサー実装（例えば、クラウドプロバイダーによって提供されるもの）は、このフィールドが設定されているServiceを無視します。
+`spec.loadBalancerClass`は、タイプ`LoadBalancer`のServiceにのみ設定できます。
+一度設定すると変更できません。
+`spec.loadBalancerClass`の値は、"`internal-vip`"や"`example.com/internal-vip`"などのオプションのプレフィックスを持つラベルスタイルの識別子である必要があります。
+プレフィックスのない名前はエンドユーザー用に予約されています。
+
+#### ロードバランサーIPアドレスモード {#load-balancer-ip-mode}
+
+{{< feature-state feature_gate_name="LoadBalancerIPMode" >}}
+
+`type: LoadBalancer`のServiceの場合、コントローラーは`.status.loadBalancer.ingress.ipMode`を設定できます。
+`.status.loadBalancer.ingress.ipMode`は、ロードバランサーIPの動作を指定します。
+これは、`.status.loadBalancer.ingress.ip`フィールドも指定されている場合にのみ指定できます。
+
+`.status.loadBalancer.ingress.ipMode`には、「VIP」と「Proxy」の2つの可能な値があります。
+デフォルト値は「VIP」で、トラフィックがロードバランサーのIPとポートに設定された宛先でノードに配信されることを意味します。
+これを「Proxy」に設定する場合、クラウドプロバイダーからのロードバランサーがトラフィックをどのように配信するかに応じて、2つのケースがあります。
+
+- トラフィックがノードに配信されてからPodにDNATされる場合、宛先はノードのIPとノードポートに設定されます。
+- トラフィックがPodに直接配信される場合、宛先はPodのIPとポートに設定されます。
+
+Serviceの実装は、この情報を使用してトラフィックルーティングを調整できます。
+
+#### 内部ロードバランサー
+
+混合環境では、同じ（仮想）ネットワークアドレスブロック内のServiceからのトラフィックをルーティングする必要がある場合があります。
+
+スプリットホライズンDNS環境では、外部トラフィックと内部トラフィックの両方をエンドポイントにルーティングするために2つのServiceが必要になります。
+
+内部ロードバランサーを設定するには、使用しているクラウドサービスプロバイダーに応じて、次のアノテーションのいずれかをServiceに追加します。
 
 {{< tabs name="service_tabs" >}}
 {{% tab name="Default" %}}
 タブを選択してください。
 {{% /tab %}}
+
 {{% tab name="GCP" %}}
 
 ```yaml
-[...]
 metadata:
-    name: my-service
-    annotations:
-        networking.gke.io/load-balancer-type: "Internal"
-[...]
+  name: my-service
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
 ```
-
 {{% /tab %}}
 {{% tab name="AWS" %}}
 
 ```yaml
-[...]
 metadata:
-    name: my-service
-    annotations:
-        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-[...]
+  name: my-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
 ```
 
 {{% /tab %}}
 {{% tab name="Azure" %}}
 
 ```yaml
-[...]
 metadata:
-    name: my-service
-    annotations:
-        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-[...]
+  name: my-service
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 ```
 
 {{% /tab %}}
 {{% tab name="IBM Cloud" %}}
 
 ```yaml
-[...]
 metadata:
-    name: my-service
-    annotations:
-        service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
-[...]
+  name: my-service
+  annotations:
+    service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
 ```
 
 {{% /tab %}}
 {{% tab name="OpenStack" %}}
 
 ```yaml
-[...]
 metadata:
-    name: my-service
-    annotations:
-        service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
-[...]
+  name: my-service
+  annotations:
+    service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
 ```
 
 {{% /tab %}}
 {{% tab name="Baidu Cloud" %}}
 
 ```yaml
-[...]
 metadata:
-    name: my-service
-    annotations:
-        service.beta.kubernetes.io/cce-load-balancer-internal-vpc: "true"
-[...]
+  name: my-service
+  annotations:
+    service.beta.kubernetes.io/cce-load-balancer-internal-vpc: "true"
 ```
 
 {{% /tab %}}
 {{% tab name="Tencent Cloud" %}}
 
 ```yaml
-[...]
 metadata:
   annotations:
     service.kubernetes.io/qcloud-loadbalancer-internal-subnetid: subnet-xxxxx
-[...]
 ```
 
 {{% /tab %}}
+{{% tab name="Alibaba Cloud" %}}
+
+```yaml
+metadata:
+  annotations:
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-address-type: "intranet"
+```
+
+{{% /tab %}}
+{{% tab name="OCI" %}}
+
+```yaml
+metadata:
+  name: my-service
+  annotations:
+    service.beta.kubernetes.io/oci-load-balancer-internal: true
+```
+{{% /tab %}}
 {{< /tabs >}}
 
+### `type: ExternalName` {#externalname}
 
-#### AWSにおけるTLSのサポート {#ssl-support-on-aws}
+ExternalNameタイプのServiceは、`my-service`や`cassandra`のような一般的なセレクターではなく、DNS名にServiceをマッピングします。`spec.externalName`パラメータでこれらのServiceを指定します。
 
-AWS上で稼働しているクラスターにおいて、部分的なTLS/SSLのサポートをするには、`LoadBalancer` Serviceに対して3つのアノテーションを追加できます。
-
-```yaml
-metadata:
-  name: my-service
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
-```
-
-1つ目は、使用する証明書のARNです。これはIAMにアップロードされたサードパーティーが発行した証明書か、AWS Certificate Managerで作成された証明書になります。
-
-```yaml
-metadata:
-  name: my-service
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: (https|http|ssl|tcp)
-```
-
-2つ目のアノテーションはPodが利用するプロトコルを指定するものです。HTTPSとSSLの場合、ELBはそのPodが証明書を使って暗号化されたコネクションを介して自分自身のPodを認証すると推測します。
-
-HTTPとHTTPSでは、レイヤー7でのプロキシを選択します。ELBはユーザーとのコネクションを切断し、リクエストを転送するときにリクエストヘッダーをパースして、`X-Forwarded-For`ヘッダーにユーザーのIPを追加します(Podは接続相手のELBのIPアドレスのみ確認可能です)。
-
-TCPとSSLでは、レイヤー4でのプロキシを選択します。ELBはヘッダーの値を変更せずにトラフィックを転送します。
-
-いくつかのポートがセキュアに保護され、他のポートではセキュアでないような混合した環境において、下記のようにアノテーションを使うことができます。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-        service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443,8443"
-```
-
-上記の例では、もしServiceが`80`、`443`、`8443`と3つのポートを含んでいる場合、`443`と`8443`はSSL証明書を使いますが、`80`では単純にHTTPでのプロキシとなります。
-
-Kubernetes v1.9以降のバージョンからは、Serviceのリスナー用にHTTPSやSSLと[事前定義されたAWS SSLポリシー](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html)を使用できます。
-どのポリシーが使用できるかを確認するために、`aws`コマンドラインツールを使用できます。
-
-```bash
-aws elb describe-load-balancer-policies --query 'PolicyDescriptions[].PolicyName'
-```
-
-ユーザーは"`service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy`"というアノテーションを使用することにより、複数のポリシーの中からどれか1つを指定できます。
-例えば:
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
-```
-
-#### AWS上でのPROXYプロトコルのサポート
-
-AWS上で稼働するクラスターで[PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)のサポートを有効にするために、下記のServiceのアノテーションを使用できます。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-```
-
-Kubernetesバージョン1.3.0からは、このアノテーションを使用するとELBによってプロキシされた全てのポートが対象になり、そしてそれ以外の場合は構成されません。
-
-#### AWS上でのELBのアクセスログ
-
-AWS上でのELB Service用のアクセスログを管理するためにはいくつかのアノテーションが使用できます。
-
-`service.beta.kubernetes.io/aws-load-balancer-access-log-enabled`というアノテーションはアクセスログを有効にするかを設定できます。
-
-`service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval`というアノテーションはアクセスログをパブリッシュするためのインターバル(分)を設定できます。
-ユーザーはそのインターバルで5分もしくは60分で設定できます。
-
-`service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name`というアノテーションはロードバランサーのアクセスログが保存されるAmazon S3のバケット名を設定できます。
-
-`service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix`というアノテーションはユーザーが作成したAmazon S3バケットの論理的な階層を指定します。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
-        # ロードバランサーのアクセスログが有効かどうか。
-        service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
-        # アクセスログをパブリッシュするためのインターバル(分)。ユーザーはそのインターバルで5分もしくは60分で設定できます。
-        service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "my-bucket"
-        # ロードバランサーのアクセスログが保存されるAmazon S3のバケット名。
-        service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "my-bucket-prefix/prod"
-        # ユーザーが作成したAmazon S3バケットの論理的な階層。例えば: `my-bucket-prefix/prod`
-```
-
-#### AWSでの接続の中断
-
-古いタイプのELBでの接続の中断は、`service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled`というアノテーションを`"true"`に設定することで管理できます。
-`service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout`というアノテーションで、インスタンスを登録解除するまえに既存の接続をオープンにし続けるための最大時間(秒)を指定できます。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-        service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "60"
-```
-
-#### 他のELBアノテーション
-
-古いタイプのELBを管理するためのアノテーションは他にもあり、下記で紹介します。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-        # ロードバランサーによってクローズされる前にアイドル状態(コネクションでデータは送信されない)になれる秒数
-
-        service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-        # ゾーンを跨いだロードバランシングが有効かどうか
-
-        service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "environment=prod,owner=devops"
-        # ELBにおいて追加タグとして保存されるキー・バリューのペアのコンマ区切りのリスト
-
-        service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: ""
-        # バックエンドへのトラフィックが正常になったと判断するために必要なヘルスチェックの連続成功数
-        # デフォルトでは2 この値は2から10の間で設定可能
-
-        service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "3"
-        # バックエンドへのトラフィックが異常になったと判断するために必要なヘルスチェックの連続失敗数
-        # デフォルトでは6 この値は2から10の間で設定可能
-
-        service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "20"
-        # 各インスタンスのヘルスチェックのおよそのインターバル(秒)
-        # デフォルトでは10 この値は5から300の間で設定可能
-
-        service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "5"
-        # ヘルスチェックが失敗したと判断されるレスポンスタイムのリミット(秒)
-        # この値はservice.beta.kubernetes.io/aws-load-balancer-healthcheck-intervalの値以下である必要があります。
-        # デフォルトでは5 この値は2から60の間で設定可能
-
-        service.beta.kubernetes.io/aws-load-balancer-security-groups: "sg-53fae93f"
-        # ELBが作成される際に追加されるセキュリティグループのリスト
-        # service.beta.kubernetes.io/aws-load-balancer-extra-security-groupsアノテーションと異なり
-        # 元々ELBに付与されていたセキュリティグループを置き換えることになります。
-
-        service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: "sg-53fae93f,sg-42efd82e"
-        # ELBに追加される予定のセキュリティーグループのリスト
-
-        service.beta.kubernetes.io/aws-load-balancer-target-node-labels: "ingress-gw,gw-name=public-api"
-        # ロードバランサーがターゲットノードを指定する際に利用するキーバリューのペアのコンマ区切りリストです。
-```
-
-#### AWSでのNetwork Load Balancerのサポート {#aws-nlb-support}
-
-{{< feature-state for_k8s_version="v1.15" state="beta" >}}
-
-AWSでNetwork Load Balancerを使用するには、値を`nlb`に設定してアノテーション`service.beta.kubernetes.io/aws-load-balancer-type`を付与します。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-```
-
-{{< note >}}
-NLBは特定のインスタンスクラスでのみ稼働します。サポートされているインスタンスタイプを確認するためには、ELBに関する[AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html#register-deregister-targets)を参照してください。
-{{< /note >}}
-
-古いタイプのElastic Load Balancersとは異なり、Network Load Balancers (NLBs)はクライアントのIPアドレスをNodeに転送します。
-もしServiceの`.spec.externalTrafficPolicy`の値が`Cluster`に設定されていた場合、クライアントのIPアドレスは末端のPodに伝播しません。
-
-`.spec.externalTrafficPolicy`を`Local`に設定することにより、クライアントIPアドレスは末端のPodに伝播します。しかし、これにより、トラフィックの分配が不均等になります。
-特定のLoadBalancer Serviceに紐づいたPodがないNodeでは、自動的に割り当てられた`.spec.healthCheckNodePort`に対するNLBのターゲットグループのヘルスチェックが失敗し、トラフィックを全く受信しません。
-
-均等なトラフィックの分配を実現するために、DaemonSetの使用や、同一のNodeに配備しないように[Podのanti-affinity](/ja/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)を設定します。
-
-また、[内部のロードバランサー](/ja/docs/concepts/services-networking/service/#internal-load-balancer)のアノテーションとNLB Serviceを使用できます。
-
-NLBの背後にあるインスタンスに対してクライアントのトラフィックを転送するために、Nodeのセキュリティーグループは下記のようなIPルールに従って変更されます。
-
-| Rule | Protocol | Port(s) | IpRange(s) | IpRange Description |
-|------|----------|---------|------------|---------------------|
-| ヘルスチェック | TCP | NodePort(s) (`.spec.healthCheckNodePort` for `.spec.externalTrafficPolicy = Local`) | VPC CIDR | kubernetes.io/rule/nlb/health=\<loadBalancerName\> |
-| クライアントのトラフィック | TCP | NodePort(s) | `.spec.loadBalancerSourceRanges` (デフォルト: `0.0.0.0/0`) | kubernetes.io/rule/nlb/client=\<loadBalancerName\> |
-| MTUによるサービスディスカバリー | ICMP | 3,4 | `.spec.loadBalancerSourceRanges` (デフォルト: `0.0.0.0/0`) | kubernetes.io/rule/nlb/mtu=\<loadBalancerName\> |
-
-どのクライアントIPがNLBにアクセス可能かを制限するためには、`loadBalancerSourceRanges`を指定してください。
-
-```yaml
-spec:
-  loadBalancerSourceRanges:
-  - "143.231.0.0/16"
-```
-
-{{< note >}}
-もし`.spec.loadBalancerSourceRanges`が設定されていない場合、KubernetesはNodeのセキュリティーグループに対して`0.0.0.0/0`からのトラフィックを許可します。
-もしNodeがパブリックなIPアドレスを持っていた場合、NLBでないトラフィックも修正されたセキュリティーグループ内の全てのインスタンスにアクセス可能になってしまうので注意が必要です。
-
-{{< /note >}}
-
-#### Tencent Kubernetes Engine(TKE)におけるその他のCLBアノテーション
-
-以下に示すように、TKEでCloud Load Balancerを管理するためのその他のアノテーションがあります。
-
-```yaml
-    metadata:
-      name: my-service
-      annotations:
-        # 指定したノードでロードバランサーをバインドします
-        service.kubernetes.io/qcloud-loadbalancer-backends-label: key in (value1, value2)
-
-        # 既存のロードバランサーのID
-        service.kubernetes.io/tke-existed-lbid: lb-6swtxxxx
-
-        # ロードバランサー(LB)のカスタムパラメーターは、LBタイプの変更をまだサポートしていません
-        service.kubernetes.io/service.extensiveParameters: ""
-
-        # LBリスナーのカスタムパラメーター
-        service.kubernetes.io/service.listenerParameters: ""
-
-        # ロードバランサーのタイプを指定します
-        # 有効な値: classic(Classic Cloud Load Balancer)またはapplication(Application Cloud Load Balancer)
-        service.kubernetes.io/loadbalance-type: xxxxx
-
-        # パブリックネットワーク帯域幅の課金方法を指定します
-        # 有効な値: TRAFFIC_POSTPAID_BY_HOUR(bill-by-traffic)およびBANDWIDTH_POSTPAID_BY_HOUR(bill-by-bandwidth)
-        service.kubernetes.io/qcloud-loadbalancer-internet-charge-type: xxxxxx
-
-        # 帯域幅の値を指定します(値の範囲:[1-2000] Mbps)。
-        service.kubernetes.io/qcloud-loadbalancer-internet-max-bandwidth-out: "10"
-
-        # この注釈が設定されている場合、ロードバランサーはポッドが実行されているノードのみを登録します
-        # そうでない場合、すべてのノードが登録されます
-        service.kubernetes.io/local-svc-only-bind-node-with-pod: true
-```
-
-### ExternalName タイプ {#externalname}
-
-ExternalNameタイプのServiceは、ServiceをDNS名とマッピングし、`my-service`や`cassandra`というような従来のラベルセレクターとはマッピングしません。
-ユーザーはこれらのServiceにおいて`spec.externalName`フィールドの値を指定します。
-
-このServiceの定義では、例えば`prod`というNamespace内の`my-service`というServiceを`my.database.example.com`にマッピングします。
+例えば、このService定義は、`prod`名前空間内の`my-service` Serviceを`my.database.example.com`にマッピングします。
 
 ```yaml
 apiVersion: v1
@@ -803,34 +613,153 @@ spec:
 ```
 
 {{< note >}}
-ExternalNameはIpv4のアドレスの文字列のみ受け付けますが、IPアドレスではなく、数字で構成されるDNS名として受け入れます。
-IPv4アドレスに似ているExternalNamesはCoreDNSもしくはIngress-Nginxによって名前解決されず、これはExternalNameは正規のDNS名を指定することを目的としているためです。
-IPアドレスをハードコードする場合、[Headless Service](#headless-service)の使用を検討してください。
+`type: ExternalName`のServiceはIPv4アドレス文字列を受け入れますが、その文字列をIPアドレスとしてではなく、数字で構成されるDNS名として扱います（ただし、インターネットではDNSでそのような名前は許可されていません）。
+IPv4アドレスに似た外部名を持つServiceは、DNSサーバーによって解決されません。
+
+Serviceを特定のIPアドレスに直接マッピングしたい場合は、[Headless Service](#headless-services)の使用を検討してください。
 {{< /note >}}
 
-`my-service.prod.svc.cluster.local`というホストをルックアップするとき、クラスターのDNS Serviceは`my.database.example.com`という値をもつ`CNAME`レコードを返します。
-`my-service`へのアクセスは、他のServiceと同じ方法ですが、再接続する際はプロキシや転送を介して行うよりも、DNSレベルで行われることが決定的に異なる点となります。
-後にユーザーが使用しているデータベースをクラスター内に移行することになった場合は、Podを起動させ、適切なラベルセレクターやEndpointsを追加し、Serviceの`type`を変更します。
+ホスト`my-service.prod.svc.cluster.local`を検索すると、クラスターDNS Serviceは値`my.database.example.com`を持つ`CNAME`レコードを返します。
+`my-service`へのアクセスは他のServiceと同じように機能しますが、リダイレクトがプロキシや転送ではなくDNSレベルで行われるという重要な違いがあります。
+後でデータベースをクラスター内に移動することにした場合は、そのPodを開始し、適切なセレクターまたはエンドポイントを追加し、Serviceの`type`を変更できます。
 
-{{< warning >}}
-HTTPやHTTPSなどの一般的なプロトコルでExternalNameを使用する際に問題が発生する場合があります。ExternalNameを使用する場合、クラスター内のクライアントが使用するホスト名は、ExternalNameが参照する名前とは異なります。
+{{< caution >}}
+HTTPやHTTPSなどの一般的なプロトコルでExternalNameを使用すると、問題が発生する場合があります。
+ExternalNameを使用する場合、クラスター内のクライアントが使用するホスト名は、ExternalNameが参照する名前とは異なります。
 
-ホスト名を使用するプロトコルの場合、この違いによりエラーまたは予期しない応答が発生する場合があります。HTTPリクエストがオリジンサーバーが認識しない`Host:`ヘッダーを持っていたなら、TLSサーバーはクライアントが接続したホスト名に一致する証明書を提供できません。
-{{< /warning >}}
+ホスト名を使用するプロトコルの場合、この違いによりエラーや予期しない応答が発生する可能性があります。
+HTTPリクエストには、オリジンサーバーが認識しない`Host:`ヘッダーが含まれます。
+TLSサーバーは、クライアントが接続したホスト名に一致する証明書を提供できません。
+{{< /caution >}}
+
+## Headless Service {#headless-services}
+
+ロードバランシングや単一のService IPが必要ない場合があります。
+この場合、クラスターIPアドレス（`.spec.clusterIP`）に`"None"`を明示的に指定することで、_Headless Service_と呼ばれるものを作成できます。
+
+Headless Serviceを使用すると、Kubernetesの実装に縛られることなく、他のサービスディスカバリーメカニズムと連携できます。
+
+Headless Serviceの場合、クラスターIPは割り当てられず、kube-proxyはこれらのServiceを処理しません。また、プラットフォームによってロードバランシングやプロキシは行われません。
+
+Headless Serviceを使用すると、クライアントは好みのPodに直接接続できます。HeadlessであるServiceは、[仮想IPアドレスとプロキシ](/ja/docs/reference/networking/virtual-ips/)を使用してルートとパケット転送を構成しません。代わりに、Headless Serviceは、クラスターの[DNSサービス](/ja/docs/concepts/services-networking/dns-pod-service/)を通じて提供される内部DNSレコードを介して、個々のPodのエンドポイントIPアドレスを報告します。
+Headless Serviceを定義するには、`.spec.type`をClusterIP（これは`type`のデフォルトでもあります）に設定し、さらに`.spec.clusterIP`をNoneに設定したServiceを作成します。
+
+文字列値Noneは特殊なケースであり、`.spec.clusterIP`フィールドを設定しないままにするのと同じではありません。
+
+DNSが自動的に構成される方法は、Serviceにセレクターが定義されているかどうかによって異なります。
+
+### セレクターあり
+
+セレクターを定義するHeadless Serviceの場合、エンドポイントコントローラーはKubernetes APIにEndpointSlicesを作成し、ServiceをバックアップするPodを直接指すAまたはAAAAレコード（IPv4またはIPv6アドレス）を返すようにDNS構成を変更します。
+
+### セレクターなし
+
+セレクターを定義しないHeadless Serviceの場合、コントロールプレーンはEndpointSliceオブジェクトを作成しません。ただし、DNSシステムは以下を探して構成します。
+
+* [`type: ExternalName`](#externalname) ServiceのDNS CNAMEレコード。
+* `ExternalName`以外のすべてのServiceタイプの、Serviceの準備完了エンドポイントのすべてのIPアドレスのDNS A / AAAAレコード。
+  * IPv4エンドポイントの場合、DNSシステムはAレコードを作成します。
+  * IPv6エンドポイントの場合、DNSシステムはAAAAレコードを作成します。
+
+セレクターなしでHeadless Serviceを定義する場合、`port`は`targetPort`と一致する必要があります。
+
+## サービスの検出 {#discovering-services}
+
+クラスター内で実行されているクライアントの場合、KubernetesはServiceを見つけるための2つの主要なモード（環境変数とDNS）をサポートしています。
+
+### 環境変数
+
+PodがNode上で実行されると、kubeletはアクティブな各Serviceに一連の環境変数を追加します。`{SVCNAME}_SERVICE_HOST`および`{SVCNAME}_SERVICE_PORT`変数を追加します。ここで、Service名は大文字になり、ダッシュはアンダースコアに変換されます。
+
+例えば、TCPポート6379を公開し、クラスターIPアドレス10.0.0.11が割り当てられた`redis-primary`というServiceは、次の環境変数を生成します。
+
+```shell
+REDIS_PRIMARY_SERVICE_HOST=10.0.0.11
+REDIS_PRIMARY_SERVICE_PORT=6379
+REDIS_PRIMARY_PORT=tcp://10.0.0.11:6379
+REDIS_PRIMARY_PORT_6379_TCP=tcp://10.0.0.11:6379
+REDIS_PRIMARY_PORT_6379_TCP_PROTO=tcp
+REDIS_PRIMARY_PORT_6379_TCP_PORT=6379
+REDIS_PRIMARY_PORT_6379_TCP_ADDR=10.0.0.11
+```
 
 {{< note >}}
-このセクションは、[Alen Komljen](https://akomljen.com/)による[Kubernetes Tips - Part1](https://akomljen.com/kubernetes-tips-part-1/)というブログポストを参考にしています。
+Serviceにアクセスする必要があるPodがあり、環境変数メソッドを使用してポートとクラスターIPをクライアントPodに公開している場合、クライアントPodが存在する*前に*Serviceを作成する必要があります。
+そうしないと、それらのクライアントPodには環境変数が設定されません。
 
+DNSのみを使用してServiceのクラスターIPを検出する場合、この順序の問題について心配する必要はありません。
 {{< /note >}}
 
-### External IPs
+Kubernetesは、Docker Engineの「_[レガシーコンテナリンク](https://docs.docker.com/network/links/)_」機能と互換性のある変数もサポートおよび提供しています。
+Kubernetesでこれがどのように実装されているかを確認するには、[`makeLinkVariables`](https://github.com/kubernetes/kubernetes/blob/dd2d12f6dc0e654c15d5db57a5f9f6ba61192726/pkg/kubelet/envvars/envvars.go#L72)を読むことができます。
 
-もし1つ以上のクラスターNodeに転送するexternalIPが複数ある場合、Kubernetes Serviceは`externalIPs`に指定したIPで公開されます。
-そのexternalIP(到達先のIPとして扱われます)のServiceのポートからトラフィックがクラスターに入って来る場合、ServiceのEndpointsのどれか1つに対して転送されます。
-`externalIPs`はKubernetesによって管理されず、それを管理する責任はクラスターの管理者にあります。
+### DNS
 
-Serviceのspecにおいて、`externalIPs`は他のどの`ServiceTypes`と併用して設定できます。
-下記の例では、"`my-service`"は"`198.51.100.32:80`" (`externalIP:port`)のクライアントからアクセス可能です。
+[アドオン](/ja/docs/concepts/cluster-administration/addons/)を使用して、Kubernetesクラスター用のDNSサービスをセットアップできます（そして、ほぼ常にそうすべきです）。
+
+CoreDNSなどのクラスター対応DNSサーバーは、新しいServiceについてKubernetes APIを監視し、それぞれに一連のDNSレコードを作成します。クラスター全体でDNSが有効になっている場合、すべてのPodはDNS名によってServiceを自動的に解決できるはずです。
+
+例えば、Kubernetes名前空間`my-ns`に`my-service`というServiceがある場合、コントロールプレーンとDNSサービスが連携して`my-service.my-ns`のDNSレコードを作成します。`my-ns`名前空間内のPodは、`my-service`の名前検索を行うことでServiceを見つけることができるはずです（`my-service.my-ns`も機能します）。
+
+他の名前空間のPodは、名前を`my-service.my-ns`として修飾する必要があります。これらの名前は、Serviceに割り当てられたクラスターIPに解決されます。
+
+Kubernetesは、名前付きポートのDNS SRV（Service）レコードもサポートしています。`my-service.my-ns` Serviceにプロトコルが`TCP`に設定された`http`という名前のポートがある場合、`_http._tcp.my-service.my-ns`のDNS SRVクエリを実行して、`http`のポート番号とIPアドレスを検出できます。
+
+Kubernetes DNSサーバーは、`ExternalName` Serviceにアクセスする唯一の方法です。
+`ExternalName`解決の詳細については、[ServiceとPodのDNS](/ja/docs/concepts/services-networking/dns-pod-service/)を参照してください。
+
+<!-- preserve existing hyperlinks -->
+<a id="shortcomings" />
+<a id="the-gory-details-of-virtual-ips" />
+<a id="proxy-modes" />
+<a id="proxy-mode-userspace" />
+<a id="proxy-mode-iptables" />
+<a id="proxy-mode-ipvs" />
+<a id="ips-and-vips" />
+
+## 仮想IPアドレスメカニズム
+
+[仮想IPとサービスプロキシ](/ja/docs/reference/networking/virtual-ips/)を読むと、Kubernetesが仮想IPアドレスを使用してServiceを公開するために提供するメカニズムが説明されています。
+
+### トラフィックポリシー
+
+`.spec.internalTrafficPolicy`および`.spec.externalTrafficPolicy`フィールドを設定して、Kubernetesが健全な（「準備完了」）バックエンドにトラフィックをルーティングする方法を制御できます。
+
+詳細については、[トラフィックポリシー](/ja/docs/reference/networking/virtual-ips/#traffic-policies)を参照してください。
+
+### トラフィック分散 {#traffic-distribution}
+
+{{< feature-state feature_gate_name="ServiceTrafficDistribution" >}}
+
+`.spec.trafficDistribution`フィールドは、Kubernetes Service内のトラフィックルーティングに影響を与える別の方法を提供します。トラフィックポリシーは厳密な意味的保証に焦点を当てていますが、トラフィック分散を使用すると、_好み_（トポロジー的に近いエンドポイントへのルーティングなど）を表現できます。これにより、パフォーマンス、コスト、または信頼性を最適化できます。Kubernetes {{< skew currentVersion >}}では、次のフィールド値がサポートされています。
+
+`PreferClose`
+: クライアントと同じゾーンにあるエンドポイントへのトラフィックルーティングを優先することを示します。
+
+{{< feature-state feature_gate_name="PreferSameTrafficDistribution" >}}
+
+Kubernetes {{< skew currentVersion >}}では、2つの追加の値が利用可能です（`PreferSameTrafficDistribution` [フィーチャーゲート](/ja/docs/reference/command-line-tools-reference/feature-gates/)が無効になっていない限り）:
+
+`PreferSameZone`
+: これは`PreferClose`のエイリアスであり、意図されたセマンティクスについてより明確です。
+
+`PreferSameNode`
+: クライアントと同じノードにあるエンドポイントへのトラフィックルーティングを優先することを示します。
+
+フィールドが設定されていない場合、実装はデフォルトのルーティング戦略を適用します。
+
+詳細については、[トラフィック分散](/ja/docs/reference/networking/virtual-ips/#traffic-distribution)を参照してください。
+
+### セッションのスティッキネス {#session-stickiness}
+
+特定のクライアントからの接続が毎回同じPodに渡されるようにしたい場合は、クライアントのIPアドレスに基づいてセッションアフィニティを構成できます。詳細については、[セッションアフィニティ](/ja/docs/reference/networking/virtual-ips/#session-affinity)を参照してください。
+
+## External IPs
+
+1つ以上のクラスターノードにルーティングする外部IPがある場合、Kubernetes Serviceはそれらの`externalIPs`で公開できます。ネットワークトラフィックがクラスターに到着し、外部IP（宛先IPとして）とポートがそのServiceと一致すると、Kubernetesが構成したルールとルートにより、トラフィックがそのServiceのエンドポイントの1つにルーティングされることが保証されます。
+
+Serviceを定義するとき、任意の[Serviceタイプ](#publishing-services-service-types)に対して`externalIPs`を指定できます。
+以下の例では、`"my-service"`という名前のServiceは、クライアントがTCPを使用して`"198.51.100.32:80"`（`.spec.externalIPs[]`と`.spec.ports[].port`から計算）でアクセスできます。
 
 ```yaml
 apiVersion: v1
@@ -839,162 +768,36 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 9376
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 49152
   externalIPs:
-  - 80.11.12.10
+    - 198.51.100.32
 ```
 
-## Serviceの欠点
-
-仮想IP用にuserspaceモードのプロキシを使用すると、小規模もしくは中規模のスケールでうまく稼働できますが、1000以上のServiceがあるようなとても大きなクラスターではうまくスケールしません。
-これについては、[Serviceのデザインプロポーザル](https://github.com/kubernetes/kubernetes/issues/1107)にてさらなる詳細を確認できます。
-
-userspaceモードのプロキシの使用は、Serviceにアクセスするパケットの送信元IPアドレスが不明瞭になります。
-これは、いくつかの種類のネットワークフィルタリング(ファイアウォールによるフィルタリング)を不可能にします。
-iptablesプロキシモードはクラスター内の送信元IPを不明瞭にはしませんが、依然としてロードバランサーやNodePortへ疎通するクライアントに影響があります。
-
-`Type`フィールドはネストされた機能としてデザインされています。 - 各レベルの値は前のレベルに対して追加します。
-これは全てのクラウドプロバイダーにおいて厳密に要求されていません(例: Google Compute Engineは`LoadBalancer`を動作させるために`NodePort`を割り当てる必要はありませんが、AWSではその必要があります)が、現在のAPIでは要求しています。
-
-## 仮想IPの実装について {#the-gory-details-of-virtual-ips}
-
-これより前の情報は、ただServiceを使いたいという多くのユーザーにとっては有益かもしれません。しかし、その裏側では多くのことが行われており、理解する価値があります。
-
-### 衝突の回避
-
-Kubernetesの主要な哲学のうちの一つは、ユーザーは、ユーザー自身のアクションによるミスでないものによって、ユーザーのアクションが失敗するような状況に晒されるべきでないことです。
-Serviceリソースの設計において、これはユーザーの指定したポートが衝突する可能性がある場合はそのポートのServiceを作らないことを意味します。これは障害を分離することとなります。
-
-Serviceのポート番号を選択できるようにするために、我々はどの2つのServiceでもポートが衝突しないことを保証します。
-Kubernetesは各Serviceに、それ自身のIPアドレスを割り当てることで実現しています。
-
-各Serviceが固有のIPを割り当てられるのを保証するために、内部のアロケーターは、Serviceを作成する前に、etcd内のグローバルの割り当てマップをアトミックに更新します。
-そのマップオブジェクトはServiceのIPアドレスの割り当てのためにレジストリー内に存在しなくてはならず、そうでない場合は、Serviceの作成時にIPアドレスが割り当てられなかったことを示すエラーメッセージが表示されます。
-
-コントロールプレーンにおいて、バックグラウンドのコントローラーはそのマップを作成する責務があります(インメモリーのロックが使われていた古いバージョンのKubernetesからのマイグレーションをサポートすることも必要です)。
-また、Kubernetesは(例えば、管理者の介入によって)無効な割り当てがされているかをチェックすることと、現時点でどのServiceにも使用されていない割り当て済みIPアドレスのクリーンアップのためにコントローラーを使用します。
-
-### ServiceのIPアドレス {#ips-and-vips}
-
-実際に固定された向き先であるPodのIPアドレスとは異なり、ServiceのIPは実際には単一のホストによって応答されません。
-その代わり、kube-proxyは必要な時に透過的にリダイレクトされる*仮想*IPアドレスを定義するため、iptables(Linuxのパケット処理ロジック)を使用します。
-クライアントがVIPに接続する時、そのトラフィックは自動的に適切なEndpointsに転送されます。
-Service用の環境変数とDNSは、Serviceの仮想IPアドレス(とポート)の面において、自動的に生成されます。
-
-kube-proxyは3つの微妙に異なった動作をするプロキシモード&mdash; userspace、iptablesとIPVS &mdash; をサポートしています。
-
-#### Userspace
-
-例として、上記で記述されている画像処理のアプリケーションを考えます。
-バックエンドのServiceが作成されたとき、KubernetesのMasterは仮想IPを割り当てます。例えば10.0.0.1などです。
-そのServiceのポートが1234で、そのServiceはクラスター内の全てのkube-proxyインスタンスによって監視されていると仮定します。
-kube-proxyが新しいServiceを見つけた時、kube-proxyは新しいランダムポートをオープンし、その仮想IPアドレスの新しいポートにリダイレクトするようにiptablesを更新し、そのポート上で新しい接続を待ち受けを開始します。
-
-クライアントがServiceの仮想IPアドレスに接続したとき、iptablesルールが有効になり、そのパケットをプロキシ自身のポートにリダイレクトします。
-その"Service プロキシ"はバックエンドPodの対象を選択し、クライアントのトラフィックをバックエンドPodに転送します。
-
-これはServiceのオーナーは、衝突のリスクなしに、求めるどのようなポートも選択できることを意味します。
-クライアントは単純にそのIPとポートに対して接続すればよく、実際にどのPodにアクセスしているかを意識しません。
-
-#### iptables
-
-また画像処理のアプリケーションについて考えます。バックエンドServiceが作成された時、そのKubernetesコントロールプレーンは仮想IPアドレスを割り当てます。例えば10.0.0.1などです。
-Serviceのポートが1234で、そのServiceがクラスター内のすべてのkube-proxyインスタンスによって監視されていると仮定します。
-kube-proxyが新しいServiceを見つけた時、kube-proxyは仮想IPから各Serviceのルールにリダイレクトされるような、iptablesルールのセットをインストールします。
-Service毎のルールは、トラフィックをバックエンドにリダイレクト(Destination NATを使用)しているEndpoints毎のルールに対してリンクしています。
-
-クライアントがServiceの仮想IPアドレスに対して接続しているとき、そのiptablesルールが有効になります。
-バックエンドのPodが選択され(SessionAffinityに基づくか、もしくはランダムで選択される)、パケットはバックエンドにリダイレクトされます。
-userspaceモードのプロキシとは異なり、パケットは決してuserspaceにコピーされず、kube-proxyは仮想IPのために稼働される必要はなく、またNodeでは変更されていないクライアントIPからトラフィックがきます。
-
-このように同じ基本的なフローは、NodePortまたはLoadBalancerを介してトラフィックがきた場合に、実行され、ただクライアントIPは変更されます。
-
-#### IPVS
-
-iptablesの処理は、大規模なクラスターの場合劇的に遅くなります。例としてはServiceが10,000ほどある場合です。
-IPVSは負荷分散のために設計され、カーネル内のハッシュテーブルに基づいています。そのためIPVSベースのkube-proxyによって、多数のServiceがある場合でも一貫して高パフォーマンスを実現できます。
-次第に、IPVSベースのkube-proxyは負荷分散のアルゴリズムはさらに洗練されています(最小接続数、位置ベース、重み付け、永続性など)。
+{{< note >}}
+Kubernetesは`externalIPs`の割り当てを管理しません。これらはクラスター管理者の責任です。
+{{< /note >}}
 
 ## APIオブジェクト
 
-ServiceはKubernetesのREST APIにおいてトップレベルのリソースです。ユーザーはそのAPIオブジェクトに関して、[Service API object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#service-v1-core)でさらなる情報を確認できます。
-
-## サポートされているプロトコル {#protocol-support}
-
-### TCP
-
-ユーザーはどの種類のServiceにおいてもTCPを利用できます。これはデフォルトのネットワークプロトコルです。
-
-### UDP
-
-ユーザーは多くのServiceにおいてUDPを利用できます。 type=LoadBalancerのServiceにおいては、UDPのサポートはこの機能を提供しているクラウドプロバイダーに依存しています。
-
-### HTTP
-
-もしクラウドプロバイダーがサポートしている場合、ServiceのEndpointsに転送される外部のHTTP/HTTPSでのリバースプロキシをセットアップするために、LoadBalancerモードでServiceを作成可能です。
-
-{{< note >}}
-ユーザーはまた、HTTP/HTTPS Serviceを公開するために、Serviceの代わりに{{< glossary_tooltip term_id="ingress" >}}を利用することもできます。
-{{< /note >}}
-
-### PROXY プロトコル
-
-もしクラウドプロバイダーがサポートしている場合、Kubernetesクラスターの外部のロードバランサーを設定するためにLoadBalancerモードでServiceを利用できます。これは[PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)がついた接続を転送します。
-
-ロードバランサーは、最初の一連のオクテットを送信します。
-下記のような例となります。
-
-```
-PROXY TCP4 192.0.2.202 10.0.42.7 12345 7\r\n
-```
-
-クライアントからのデータのあとに追加されます。
-
-### SCTP
-
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
-
-KubernetesはService、Endpoints、EndpointSlice、NetworkPolicyとPodの定義において`protocol`フィールドの値でSCTPをサポートしています。ベータ版の機能のため、この機能はデフォルトで有効になっています。SCTPをクラスターレベルで無効にするには、クラスター管理者はAPI Serverにおいて`SCTPSupport` [フィーチャーゲート](/ja/docs/reference/command-line-tools-reference/feature-gates/)を`--feature-gates=SCTPSupport=false,…`と設定して無効にする必要があります。
-
-そのフィーチャーゲートが有効になった時、ユーザーはService、Endpoints、EndpointSlice、NetworkPolicy、またはPodの`protocol`フィールドに`SCTP`を設定できます。
-Kubernetesは、TCP接続と同様に、SCTPアソシエーションに応じてネットワークをセットアップします。
-
-#### 警告 {#caveat-sctp-overview}
-
-##### マルチホームSCTPアソシエーションのサポート {#caveat-sctp-multihomed}
-
-{{< warning >}}
-マルチホームSCTPアソシエーションのサポートは、複数のインターフェースとPodのIPアドレスの割り当てをサポートできるCNIプラグインを要求します。
-
-マルチホームSCTPアソシエーションにおけるNATは、対応するカーネルモジュール内で特別なロジックを要求します。
-{{< /warning >}}
-
-##### type=LoadBalancer Service について {#caveat-sctp-loadbalancer-service-type}
-
-{{< warning >}}
-クラウドプロバイダーのロードバランサーの実装がプロトコルとしてSCTPをサポートしている場合は、`type` がLoadBalancerで` protocol`がSCTPの場合でのみサービスを作成できます。
-そうでない場合、Serviceの作成要求はリジェクトされます。現時点でのクラウドのロードバランサーのプロバイダー(Azure、AWS、CloudStack、GCE、OpenStack)は全てSCTPのサポートをしていません。
-{{< /warning >}}
-
-##### Windows {#caveat-sctp-windows-os}
-
-{{< warning >}}
-SCTPはWindowsベースのNodeではサポートされていません。
-{{< /warning >}}
-
-##### Userspace kube-proxy {#caveat-sctp-kube-proxy-userspace}
-
-{{< warning >}}
-kube-proxyはuserspaceモードにおいてSCTPアソシエーションの管理をサポートしません。
-{{< /warning >}}
+Serviceは、Kubernetes REST APIのトップレベルリソースです。[Service APIオブジェクト](/ja/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#service-v1-core)の詳細を確認できます。
 
 ## {{% heading "whatsnext" %}}
 
-* [Connecting Applications with Services](/ja/docs/concepts/services-networking/connect-applications-service/)を参照してください。
-* [Ingress](/ja/docs/concepts/services-networking/ingress/)を参照してください。
-* [EndpointSlices](/ja/docs/concepts/services-networking/endpoint-slices/)を参照してください。
+ServiceとそれらがKubernetesにどのように適合するかについて詳しく学びましょう:
+
+* [Serviceを使用したアプリケーションの接続](/ja/docs/tutorials/services/connect-applications-service/)チュートリアルに従ってください。
+* [Ingress](/ja/docs/concepts/services-networking/ingress/)について読んでください。これは、クラスターの外部からクラスター内のServiceへのHTTPおよびHTTPSルートを公開します。
+* [Gateway](/ja/docs/concepts/services-networking/gateway/)について読んでください。これは、Ingressよりも柔軟性を提供するKubernetesの拡張機能です。
+
+その他のコンテキストについては、以下をお読みください:
+
+* [仮想IPとサービスプロキシ](/ja/docs/reference/networking/virtual-ips/)
+* [EndpointSlices](/ja/docs/concepts/services-networking/endpoint-slices/)
+* [Service APIリファレンス](/ja/docs/reference/kubernetes-api/service-resources/service-v1/)
+* [EndpointSlice APIリファレンス](/ja/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/)
+* [Endpoint APIリファレンス (レガシー)](/ja/docs/reference/kubernetes-api/service-resources/endpoints-v1/)

--- a/content/ja/docs/reference/networking/virtual-ips.md
+++ b/content/ja/docs/reference/networking/virtual-ips.md
@@ -1,0 +1,149 @@
+---
+title: 仮想IPとサービスプロキシ
+content_type: reference
+weight: 50
+---
+
+<!-- overview -->
+
+Kubernetesクラスターの各Nodeは`kube-proxy`を稼働させています。`kube-proxy`は[`ExternalName`](/ja/docs/concepts/services-networking/service/#externalname)タイプ以外の`Service`用に仮想IPを実装する責務があります。
+
+### なぜ、DNSラウンドロビンを使わないのでしょうか。
+
+ここで湧き上がる質問として、なぜKubernetesは内部のトラフィックをバックエンドへ転送するためにプロキシに頼るのでしょうか。
+他のアプローチはどうなのでしょうか。例えば、複数のAバリュー(もしくはIPv6用にAAAAバリューなど)をもつDNSレコードを設定し、ラウンドロビン方式で名前を解決することは可能でしょうか。
+
+Serviceにおいてプロキシを使う理由はいくつかあります。
+
+* DNSの実装がレコードのTTLをうまく扱わず、期限が切れた後も名前解決の結果をキャッシュするという長い歴史がある。
+* いくつかのアプリケーションではDNSルックアップを1度だけ行い、その結果を無期限にキャッシュする。
+* アプリケーションとライブラリーが適切なDNS名の再解決を行ったとしても、DNSレコード上の0もしくは低い値のTTLがDNSに負荷をかけることがあり、管理が難しい。
+
+<!-- body -->
+
+## プロキシモード {#proxy-modes}
+
+### user-spaceプロキシモード {#proxy-mode-userspace}
+
+このモードでは、kube-proxyはServiceやEndpointsオブジェクトの追加・削除をチェックするために、Kubernetes Masterを監視します。
+各Serviceは、ローカルのNode上でポート(ランダムに選ばれたもの)を公開します。この"プロキシポート"に対するどのようなリクエストも、そのServiceのバックエンドPodのどれか1つにプロキシされます(Endpointsを介して通知されたPodに対して)。
+kube-proxyは、どのバックエンドPodを使うかを決める際にServiceの`SessionAffinity`項目の設定を考慮に入れます。
+
+最後に、user-spaceプロキシはServiceの`clusterIP`(仮想IP)と`port`に対するトラフィックをキャプチャするiptablesルールをインストールします。
+そのルールは、トラフィックをバックエンドPodにプロキシするためのプロキシポートにリダイレクトします。
+
+デフォルトでは、user-spaceモードにおけるkube-proxyはラウンドロビンアルゴリズムによってバックエンドPodを選択します。
+
+![user-spaceプロキシのService概要ダイアグラム](/images/docs/services-userspace-overview.svg)
+
+### `iptables`プロキシモード {#proxy-mode-iptables}
+
+このモードでは、kube-proxyはServiceやEndpointsオブジェクトの追加・削除のチェックのためにKubernetesコントロールプレーンを監視します。
+各Serviceでは、そのServiceの`clusterIP`と`port`に対するトラフィックをキャプチャするiptablesルールをインストールし、そのトラフィックをServiceのあるバックエンドのセットに対してリダイレクトします。
+各Endpointsオブジェクトは、バックエンドのPodを選択するiptablesルールをインストールします。
+
+デフォルトでは、iptablesモードにおけるkube-proxyはバックエンドPodをランダムで選択します。
+
+トラフィックのハンドリングのためにiptablesを使用すると、システムのオーバーヘッドが少なくなります。これは、トラフィックがLinuxのnetfilterによってuser-spaceとkernel-spaceを切り替える必要がないためです。
+このアプローチは、オーバーヘッドが少ないことに加えて、より信頼できる方法でもあります。
+
+kube-proxyがiptablesモードで稼働し、最初に選択されたPodが応答しない場合、そのコネクションは失敗します。
+これはuser-spaceモードでの挙動と異なります: user-spaceモードにおいては、kube-proxyは最初のPodに対するコネクションが失敗したら、自動的に他のバックエンドPodに対して再接続を試みます。
+
+iptablesモードのkube-proxyが正常なバックエンドPodのみをリダイレクト対象とするために、Podの[ReadinessProbe](/ja/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)を使用してバックエンドPodが正常に動作しているか確認できます。これは、ユーザーがkube-proxyを介して、コネクションに失敗したPodに対してトラフィックをリダイレクトするのを除外することを意味します。
+
+![iptablesプロキシのService概要ダイアグラム](/images/docs/services-iptables-overview.svg)
+
+### IPVSプロキシモード {#proxy-mode-ipvs}
+
+{{< feature-state for_k8s_version="v1.11" state="stable" >}}
+
+`ipvs`モードにおいて、kube-proxyはServiceとEndpointsオブジェクトを監視し、IPVSルールを作成するために`netlink`インターフェースを呼び出し、定期的にKubernetesのServiceとEndpointsとIPVSルールを同期させます。
+このコントロールループはIPVSのステータスが理想的な状態になることを保証します。
+Serviceにアクセスするとき、IPVSはトラフィックをバックエンドのPodに向けます。
+
+IPVSプロキシモードはiptablesモードと同様に、netfilterのフック関数に基づいています。ただし、基礎となるデータ構造としてハッシュテーブルを使っているのと、kernel-spaceで動作します。
+これは、IPVSモードにおけるkube-proxyはiptablesモードに比べてより低いレイテンシーでトラフィックをリダイレクトし、プロキシのルールを同期する際にはよりパフォーマンスがよいことを意味します。
+他のプロキシモードと比較して、IPVSモードはより高いネットワークトラフィックのスループットをサポートしています。
+
+IPVSはバックエンドPodに対するトラフィックのバランシングのために多くのオプションを下記のとおりに提供します。
+
+* `rr`: ラウンドロビン
+* `lc`: 最低コネクション数(オープンされているコネクション数がもっとも小さいもの)
+* `dh`: 送信先IPによって割り当てられたハッシュ値をもとに割り当てる(Destination Hashing)
+* `sh`: 送信元IPによって割り当てられたハッシュ値をもとに割り当てる(Source Hashing)
+* `sed`: 見込み遅延が最小なもの
+* `nq`: キューなしスケジューリング
+
+{{< note >}}
+IPVSモードでkube-proxyを稼働させるためには、kube-proxyを稼働させる前にNode上でIPVSを有効にしなければなりません。
+
+kube-proxyはIPVSモードで起動する場合、IPVSカーネルモジュールが利用可能かどうかを確認します。
+もしIPVSカーネルモジュールが見つからなかった場合、kube-proxyはiptablesモードで稼働するようにフォールバックされます。
+{{< /note >}}
+
+![IPVSプロキシのService概要ダイアグラム](/images/docs/services-ipvs-overview.svg)
+
+このダイアグラムのプロキシモデルにおいて、ServiceのIP:Portに対するトラフィックは、クライアントがKubernetesのServiceやPodについて何も知ることなく適切にバックエンドにプロキシされています。
+
+特定のクライアントからのコネクションが、毎回同一のPodにリダイレクトされるようにするためには、`service.spec.sessionAffinity`に"ClientIP"を設定することにより、クライアントのIPアドレスに基づいたSessionAffinityを選択することができます(デフォルトは"None")。
+また、`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds`を適切に設定することにより、セッションのタイムアウト時間を設定できます(デフォルトではこの値は18,000で、3時間となります)。
+
+## 仮想IPの実装について {#the-gory-details-of-virtual-ips}
+
+これより前の情報は、ただServiceを使いたいという多くのユーザーにとっては有益かもしれません。しかし、その裏側では多くのことが行われており、理解する価値があります。
+
+### 衝突の回避
+
+Kubernetesの主要な哲学のうちの一つは、ユーザーは、ユーザー自身のアクションによるミスでないものによって、ユーザーのアクションが失敗するような状況に晒されるべきでないことです。
+Serviceリソースの設計において、これはユーザーの指定したポートが衝突する可能性がある場合はそのポートのServiceを作らないことを意味します。これは障害を分離することとなります。
+
+Serviceのポート番号を選択できるようにするために、我々はどの2つのServiceでもポートが衝突しないことを保証します。
+Kubernetesは各Serviceに、それ自身のIPアドレスを割り当てることで実現しています。
+
+各Serviceが固有のIPを割り当てられるのを保証するために、内部のアロケーターは、Serviceを作成する前に、etcd内のグローバルの割り当てマップをアトミックに更新します。
+そのマップオブジェクトはServiceのIPアドレスの割り当てのためにレジストリー内に存在しなくてはならず、そうでない場合は、Serviceの作成時にIPアドレスが割り当てられなかったことを示すエラーメッセージが表示されます。
+
+コントロールプレーンにおいて、バックグラウンドのコントローラーはそのマップを作成する責務があります(インメモリーのロックが使われていた古いバージョンのKubernetesからのマイグレーションをサポートすることも必要です)。
+また、Kubernetesは(例えば、管理者の介入によって)無効な割り当てがされているかをチェックすることと、現時点でどのServiceにも使用されていない割り当て済みIPアドレスのクリーンアップのためにコントローラーを使用します。
+
+### ServiceのIPアドレス {#ips-and-vips}
+
+実際に固定された向き先であるPodのIPアドレスとは異なり、ServiceのIPは実際には単一のホストによって応答されません。
+その代わり、kube-proxyは必要な時に透過的にリダイレクトされる*仮想*IPアドレスを定義するため、iptables(Linuxのパケット処理ロジック)を使用します。
+クライアントがVIPに接続する時、そのトラフィックは自動的に適切なEndpointsに転送されます。
+Service用の環境変数とDNSは、Serviceの仮想IPアドレス(とポート)の面において、自動的に生成されます。
+
+kube-proxyは3つの微妙に異なった動作をするプロキシモード&mdash; userspace、iptablesとIPVS &mdash; をサポートしています。
+
+#### Userspace
+
+例として、上記で記述されている画像処理のアプリケーションを考えます。
+バックエンドのServiceが作成されたとき、KubernetesのMasterは仮想IPを割り当てます。例えば10.0.0.1などです。
+そのServiceのポートが1234で、そのServiceはクラスター内の全てのkube-proxyインスタンスによって監視されていると仮定します。
+kube-proxyが新しいServiceを見つけた時、kube-proxyは新しいランダムポートをオープンし、その仮想IPアドレスの新しいポートにリダイレクトするようにiptablesを更新し、そのポート上で新しい接続を待ち受けを開始します。
+
+クライアントがServiceの仮想IPアドレスに接続したとき、iptablesルールが有効になり、そのパケットをプロキシ自身のポートにリダイレクトします。
+その"Service プロキシ"はバックエンドPodの対象を選択し、クライアントのトラフィックをバックエンドPodに転送します。
+
+これはServiceのオーナーは、衝突のリスクなしに、求めるどのようなポートも選択できることを意味します。
+クライアントは単純にそのIPとポートに対して接続すればよく、実際にどのPodにアクセスしているかを意識しません。
+
+#### iptables
+
+また画像処理のアプリケーションについて考えます。バックエンドServiceが作成された時、そのKubernetesコントロールプレーンは仮想IPアドレスを割り当てます。例えば10.0.0.1などです。
+Serviceのポートが1234で、そのServiceがクラスター内のすべてのkube-proxyインスタンスによって監視されていると仮定します。
+kube-proxyが新しいServiceを見つけた時、kube-proxyは仮想IPから各Serviceのルールにリダイレクトされるような、iptablesルールのセットをインストールします。
+Service毎のルールは、トラフィックをバックエンドにリダイレクト(Destination NATを使用)しているEndpoints毎のルールに対してリンクしています。
+
+クライアントがServiceの仮想IPアドレスに対して接続しているとき、そのiptablesルールが有効になります。
+バックエンドのPodが選択され(SessionAffinityに基づくか、もしくはランダムで選択される)、パケットはバックエンドにリダイレクトされます。
+userspaceモードのプロキシとは異なり、パケットは決してuserspaceにコピーされず、kube-proxyは仮想IPのために稼働される必要はなく、またNodeでは変更されていないクライアントIPからトラフィックがきます。
+
+このように同じ基本的なフローは、NodePortまたはLoadBalancerを介してトラフィックがきた場合に、実行され、ただクライアントIPは変更されます。
+
+#### IPVS
+
+iptablesの処理は、大規模なクラスターの場合劇的に遅くなります。例としてはServiceが10,000ほどある場合です。
+IPVSは負荷分散のために設計され、カーネル内のハッシュテーブルに基づいています。そのためIPVSベースのkube-proxyによって、多数のServiceがある場合でも一貫して高パフォーマンスを実現できます。
+次第に、IPVSベースのkube-proxyは負荷分散のアルゴリズムはさらに洗練されています(最小接続数、位置ベース、重み付け、永続性など)。


### PR DESCRIPTION
### Description

This pull request updates the Japanese documentation for **Services and Networking** and introduces a new reference page for **Virtual IPs**.

The update aligns the Japanese localization with the upstream English documentation, incorporating large structural updates, content rewrites, and terminology improvements.

#### What this PR changes
- Updates `content/ja/docs/concepts/services-networking/service.md` with the latest upstream content  
  - Synchronizes explanations of proxy modes (userspace, iptables, IPVS)  
  - Updates diagrams, descriptions, and conceptual flow  
  - Ensures accuracy of networking terminology in Japanese  
- Adds a new reference document:  
  - `content/ja/docs/reference/networking/virtual-ips.md`  
  - Provides a complete explanation of Kubernetes virtual IPs, allocation mechanisms, implementation details, and proxying models  
- Fixes outdated phrasing, removes obsolete sections, and restructures content to match upstream  
- Maintains glossary consistency and preserves shortcode elements such as `feature-state` and `glossary_tooltip`

#### Why this change is needed
Keeping localized documentation synchronized with upstream is essential for:
- Ensuring Japanese users receive accurate, up-to-date Kubernetes information  
- Improving documentation reliability for new contributors and learners  
- Maintaining compatibility with current API behavior and networking implementation  
- Reducing technical debt in the localization by removing legacy references

This update brings the Service documentation in line with the current Kubernetes reference model and improves translation quality and conceptual consistency.

### Issue

Closes: #53415

Signed-off-by: Paulo Sergio Romao Junior [opauloromao@gmail.com](mailto:opauloromao@gmail.com)

