### PR TITLE
[pt] Sync front matter for docs landing page

### DIFF
--- a/content/pt-br/docs/home/_index.md
+++ b/content/pt-br/docs/home/_index.md
@@ -3,9 +3,8 @@ approvers:
 - chenopis
 title: Kubernetes 
 noedit: true
-cid: docsHome
 layout: docsportal_home
-class: gridPage gridPageHome
+body_class: docs-portal
 linkTitle: "Documentação"
 main_menu: true
 weight: 10


### PR DESCRIPTION
Update the front matter for (Brazilian) Portuguese; especially relevant given that https://github.com/kubernetes/website/pull/53029 has merged.

/area web-development
/area localization
/language pt