### PR TITLE
[ja] Sync front matter for docs landing page

### DIFF
--- a/content/ja/docs/home/_index.md
+++ b/content/ja/docs/home/_index.md
@@ -1,10 +1,8 @@
 ---
-approvers:
 title: Kubernetesドキュメント
 noedit: true
-cid: docsHome
 layout: docsportal_home
-class: gridPage gridPageHome
+body_class: docs-portal
 linkTitle: "ドキュメント"
 main_menu: true
 weight: 10


### PR DESCRIPTION
Update the front matter for Japanese; especially relevant given that https://github.com/kubernetes/website/pull/53029 has merged.

/area web-development
/area localization
/language ja