### PR TITLE
[ko] Sync front matter for docs landing page

### DIFF
--- a/content/ko/docs/home/_index.md
+++ b/content/ko/docs/home/_index.md
@@ -3,9 +3,8 @@
 # - chenopis
 title: 쿠버네티스 문서
 noedit: true
-cid: docsHome
 layout: docsportal_home
-class: gridPage gridPageHome
+body_class: docs-portal
 linkTitle: "문서"
 main_menu: true
 weight: 10


### PR DESCRIPTION
Update the front matter for Korean; especially relevant given that https://github.com/kubernetes/website/pull/53029 has merged.

/area web-development
/area localization
/language ko