### PR TITLE
Fix inconsistent profile names in scheduler configuration documentation

### DIFF
--- a/content/en/docs/concepts/security/hardening-guide/scheduler.md
+++ b/content/en/docs/concepts/security/hardening-guide/scheduler.md
@@ -81,10 +81,10 @@ profiles:
         - name: "*"               # Disables all permit plugins
       # - name: "TaintToleration" # Disable specific permit plugin
 ```
-This creates a scheduler profile ` my-custom-scheduler`.
+This creates a scheduler profile ` my-scheduler`.
 Whenever the `.spec` of a Pod does not have a value for `.spec.schedulerName`, the kube-scheduler runs for that Pod, 
 using its main configuration, and default plugins.
-If you define a Pod with `.spec.schedulerName` set to `my-custom-scheduler`, the kube-scheduler runs but with a custom configuration; in that custom configuration,
+If you define a Pod with `.spec.schedulerName` set to `my-scheduler`, the kube-scheduler runs but with a custom configuration; in that custom configuration,
 the  `queueSort`, `filter` and `permit` extension points are disabled.
 If you use this KubeSchedulerConfiguration, and don't run any custom scheduler, 
 and you then define a Pod with  `.spec.schedulerName` set to `nonexistent-scheduler` 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
Fixed inconsistent profile names in [scheduler configuration documentation](https://kubernetes.io/docs/concepts/security/hardening-guide/scheduler/#key-considerations).

The documentation used multiple different names to refer to the same scheduler profile example (`my-shceduler` and `my-custom-scheduler`) .
All references have been standardized to `my-scheduler` for consistency.



### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: https://github.com/kubernetes/website/issues/53440