### PR TITLE
Update German translation: use lowercase for pronouns in _index.html

### DIFF
--- a/content/de/_index.html
+++ b/content/de/_index.html
@@ -21,14 +21,14 @@ Kubernetes basiert auf denselben Prinzipien, die es Google ermöglichen, Milliar
 {{% blocks/feature image="blocks" %}}
 #### Mitwachsend
 
-Unabhängig davon, ob Du lokal testest oder ein globales Unternehmen betreibst: Die Flexibilität von Kubernetes wächst mit Dir, um Deine Anwendungen konsistent und einfach bereitzustellen - Unabhängig von der Komplexität Deiner Anforderungen.
+Unabhängig davon, ob du lokal testest oder ein globales Unternehmen betreibst: Die Flexibilität von Kubernetes wächst mit dir, um deine Anwendungen konsistent und einfach bereitzustellen - Unabhängig von der Komplexität deiner Anforderungen.
 
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="suitcase" %}}
 #### Überall Lauffähig
 
-Kubernetes ist Open Source und bietet Dir die Freiheit, die Infrastruktur vor Ort, Hybrid oder Public Cloud zu nutzen. So kannst Du Workloads mühelos dorthin verschieben, wo es Dir wichtig ist.
+Kubernetes ist Open Source und bietet dir die Freiheit, die Infrastruktur vor Ort, Hybrid oder Public Cloud zu nutzen. So kannst du Workloads mühelos dorthin verschieben, wo es dir wichtig ist.
 
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
Hello!

I fixed the capitalization of German pronouns (Du -> du,Dir->dir,Deine->deine) on the index page to match modern German grammar and style.