### PR TITLE
Add AverageValue example for HPA resource metrics

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -280,6 +280,30 @@ setting the corresponding `target.averageValue` field instead of the `target.ave
         averageValue: 500Mi
 ```
 
+For example, you can configure the HPA to scale based on CPU consumption using absolute values:
+```yaml
+metrics:
+- type: Resource
+  resource:
+    name: cpu
+    target:
+      type: AverageValue
+      averageValue: 100m
+```
+
+With this configuration, the HPA scales based on the actual measured CPU consumption per pod 
+(in millicores), independent of any resource requests configured in the pod specification. 
+If the average CPU usage across all pods is 200m and the target `averageValue` is 100m, 
+the HPA will scale up according to the ratio (200m / 100m = 2.0).
+
+This approach is particularly useful when:
+- Resource requests are not defined in the pod specification
+- You want to scale based on specific absolute resource thresholds rather than percentages
+- You need consistent scaling behavior regardless of how resource requests are configured
+
+There are two other types of metrics, both of which are considered *custom metrics*: pod metrics and
+object metrics...
+
 There are two other types of metrics, both of which are considered *custom metrics*: pod metrics and
 object metrics.  These metrics may have names which are cluster specific, and require a more
 advanced cluster monitoring setup.

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -302,9 +302,6 @@ This approach is particularly useful when:
 - You need consistent scaling behavior regardless of how resource requests are configured
 
 There are two other types of metrics, both of which are considered *custom metrics*: pod metrics and
-object metrics...
-
-There are two other types of metrics, both of which are considered *custom metrics*: pod metrics and
 object metrics.  These metrics may have names which are cluster specific, and require a more
 advanced cluster monitoring setup.
 

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -149,6 +149,31 @@ When a `targetAverageValue` or `targetAverageUtilization` is specified,
 the `currentMetricValue` is computed by taking the average of the given
 metric across all Pods in the HorizontalPodAutoscaler's scale target.
 
+**Example: Scaling based on raw resource values**
+
+You can configure the HPA to scale based on actual resource consumption without depending 
+on resource requests:
+```yaml
+type: Resource
+resource:
+  name: cpu
+  target:
+    type: AverageValue
+    averageValue: 100m
+---
+type: Resource
+resource:
+  name: memory
+  target:
+    type: AverageValue
+    averageValue: 512Mi
+```
+
+With `AverageValue`, the HPA scales based on the actual measured resource consumption per 
+pod, independent of any resource requests configured in the pod specification. For instance, 
+if the average CPU usage across all pods is 200m and the target averageValue is 100m, the 
+HPA will scale up according to the ratio (200m / 100m = 2.0).
+
 Before checking the tolerance and deciding on the final values, the control
 plane also considers whether any metrics are missing, and how many Pods
 are [`Ready`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions).

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -149,31 +149,6 @@ When a `targetAverageValue` or `targetAverageUtilization` is specified,
 the `currentMetricValue` is computed by taking the average of the given
 metric across all Pods in the HorizontalPodAutoscaler's scale target.
 
-**Example: Scaling based on raw resource values**
-
-You can configure the HPA to scale based on actual resource consumption without depending 
-on resource requests:
-```yaml
-type: Resource
-resource:
-  name: cpu
-  target:
-    type: AverageValue
-    averageValue: 100m
----
-type: Resource
-resource:
-  name: memory
-  target:
-    type: AverageValue
-    averageValue: 512Mi
-```
-
-With `AverageValue`, the HPA scales based on the actual measured resource consumption per 
-pod, independent of any resource requests configured in the pod specification. For instance, 
-if the average CPU usage across all pods is 200m and the target averageValue is 100m, the 
-HPA will scale up according to the ratio (200m / 100m = 2.0).
-
 Before checking the tolerance and deciding on the final values, the control
 plane also considers whether any metrics are missing, and how many Pods
 are [`Ready`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions).


### PR DESCRIPTION
### Description

This PR adds a practical example to the HPA documentation demonstrating how to use the `AverageValue` target type for resource-based scaling. 

**Changes:**
- Added YAML configuration examples showing `AverageValue` usage for CPU and memory
- Clarified that `AverageValue` scales based on actual resource consumption rather than resource requests
- Improved documentation clarity by providing a concrete alternative to `Utilization`-based scaling

This enhancement helps users understand when and how to use absolute resource values for autoscaling, particularly useful when resource requests are not defined or when absolute thresholds are preferred.

### Issue

Closes: #53447