### PR TITLE
Revert docs for promotion of RelaxedServiceNameValidation to beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedServiceNameValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedServiceNameValidation.md
@@ -9,10 +9,6 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.34"
-    toVersion: "1.34"
-  - stage: beta
-    defaultValue: true
-    fromVersion: "1.35"
 
 ---
 


### PR DESCRIPTION
### Description

Revert the promotion of RelaxedServiceNameValidation  to beta (KEP-5311)

### Issue

Related to https://github.com/kubernetes/kubernetes/pull/135426

/hold
(holding since we're still trying to figure out a way forward)
/sig network 