### PR TITLE
Clarify that OOM cgroup messages may not appear in `kubectl describe …

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -227,6 +227,28 @@ The output includes a record of the Container being killed because of an out-of-
 Warning OOMKilling Memory cgroup out of memory: Kill process 4481 (stress) score 1994 or sacrifice child
 ```
 
+> **Note**
+> The following note clarifies what you are likely to see in real clusters:
+>
+> The example OOM cgroup message shown in the above output (e.g.:
+> `Warning OOMKilling Memory cgroup out of memory: Kill process 4481 (stress) score 1994 or sacrifice child`)
+> may not always appear in the output of `kubectl describe nodes`. This depends on the kubelet logging
+> configuration.
+>
+> Kubernetes reliably surfaces OOM events at the **Pod** level instead. Check:
+>
+> - `kubectl describe pod memory-demo-2 --namespace=mem-example` → Events / Last State (`OOMKilled`, `exitCode: 137`)
+> - or inspect `.status.containerStatuses[].lastState` using:
+>
+>       kubectl get pod memory-demo-2 -o yaml --namespace=mem-example
+>
+> For the raw kernel/kubelet cgroup messages, view the node logs directly:
+>
+> - `sudo journalctl -u kubelet`
+> - `sudo dmesg | grep -i -e memory -e oom`
+>
+```
+
 Delete your Pod:
 
 ```shell


### PR DESCRIPTION
…nodes`

### Description

The current documentation suggests that the OOM cgroup message appears in the output of `kubectl describe nodes`. In practice, this is not always the case may be dependent on the kubelet logging setup.

This change clarifies that:
- The detailed OOM cgroup log line is not reliably surfaced in `kubectl describe nodes`
- Pod level information (`OOMKilled`, exitCode 137) is the reliable place to find OOM events
- Kernel/kubelet logs on the node contain the actual cgroup message

Motivation:
During testing on (Minikube and a GCP managed cluster) environments, the OOM event was consistently visible at the Pod level but the cgroup message was not present in `kubectl describe nodes`, despite appearing in kubelet/journal logs. This clarification helps align user expectations with observed kubelet behavior in different runtime environments.

This PR only updates documentation and does not affect code.

### Issue
N/A
