### PR TITLE
Describe Cluster Shutdown and Restart in docs

### DIFF
--- a/content/en/docs/concepts/cluster-administration/node-shutdown.md
+++ b/content/en/docs/concepts/cluster-administration/node-shutdown.md
@@ -315,3 +315,5 @@ Learn more about the following:
 
 - Blog: [Non-Graceful Node Shutdown](/blog/2023/08/16/kubernetes-1-28-non-graceful-node-shutdown-ga/).
 - Cluster Architecture: [Nodes](/docs/concepts/architecture/nodes/).
+
+For how to shutdown a cluster see [Shutting Down and Restarting Clusters](/docs/task/administer-cluster/cluster-shutdown-and-restart/).

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -41,41 +41,50 @@ You can shut down your cluster in a graceful manner by gracefully shutting down 
 ### (Optional) Checking for certificate expiration
 
 If you are shutting the cluster down for an extended period, identify the date on which certificates will expire.
-```
-$ openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -enddate
+
+```bash
+openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -enddate
 ```
 
-Output
-```
+Example output:
+
+```bash
 notAfter=Mar  3 09:18:19 2026 GMT
 ``` 
 
 To ensure that the cluster can restart gracefully after this shut down, plan to restart it on or before the specified date. 
+Note that various certificates may have different expiration dates.
 
 ### Making nodes unschedulable
+
 Make all nodes in the cluster unschedulable using kubectl cordon
 
-```
-$ kubectl cordon node1 node2 node3
+```bash
+kubectl cordon node1 node2 node3
 ```
 
 ### Terminating pods in the nodes
+
 Evict all the pods using `kubectl drain`
 
 While `kubectl drain` should basically be enough due to it capable of internally making the specified nodes unschedulable before pod eviction, larger clusters may need to make sure all nodes are properly cordoned first before draining. You can check the nodes' schedulability using kubectl get nodes
-```
-$ kubectl drain --ignore-daemonsets node1 node2 node3
+
+```bash
+kubectl drain --ignore-daemonsets node1 node2 node3
 ```
 
 ### Shutting down nodes in the cluster
+
 Shut down all of the nodes in the cluster. You can do this in ways that best fit your cluster; such as through your cloud provider's web console, or a script, or playbook. 
 
-- Example
-```
-[user@node1 ~]# systemctl poweroff
+Example:
+
+```bash
+systemctl poweroff
 ```
 
 ### Shutting down cluster dependencies
+
 After all nodes have successfully shut down, shut down any other cluster dependencies that are no longer needed, such as external storages. Consult your vendor's documentation to see if some resources are okay to shut down, suspend, or delete.
 
 ## Restarting Clusters
@@ -85,27 +94,30 @@ This section describes the process you need to restart the cluster after being g
 If the cluster fails to recover, you restore the cluster to its previous state using the [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#restoring-an-etcd-cluster).
 
 ### Powering on cluster dependencies
+
 Power on any cluster dependencies you need for your cluster, such as external storages.
 
 ### Powering on cluster machines
+
 Start all cluster machines (i.e. your nodes). Use the method best-fit for your cluster to turn on the machines, like using the cloud provider's web console. 
 
 Allow a few minutes for the cluster's control plane nodes and worker nodes to become `Ready`. Verify that all nodes are `Ready`. 
 
-```
-$ kubectl get nodes
+```bash
+kubectl get nodes
 ```
 
 ### Making your nodes schedulable again
+
 Once the nodes are `Ready`, mark all the nodes in the cluster schedulable using kubectl uncordon
 
-```
-$ kubectl uncordon node1 node2 node3
+```bash
+kubectl uncordon node1 node2 node3
 ```
 
 Wait until all pods are back in operation. Verify that the pods are `Running`
 
-```
+```bash
 kubectl get pods --all-namespaces
 ```
 

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -1,5 +1,4 @@
 ---
-reviewers:
 title: Shutting Down and Restarting Clusters
 content_type: task
 weight: 55
@@ -27,16 +26,7 @@ Meanwhile, the steps you perform for restarting are:
 
 ## {{% heading "prerequisites" %}}
 
-You must have an existing cluster. This page is about shutting down and restarting clusters from Kubernetes
-{{< skew currentVersionAddMinor -1 >}} to Kubernetes {{< skew currentVersion >}}. You must also have access to the cluster as a user with the cluster admin role.
-
-## Backup your cluster
-
-If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster didn't work as intended.
-
-## Shut Down Clusters
-
-You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will allow you to gracefully restart the cluster for later use. While [node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
+You must have an existing cluster. This page is about shutting down and restarting clusters. You must also have access to the cluster as a user with the cluster admin role.
 
 ### (Optional) Checking for certificate expiration
 
@@ -54,6 +44,19 @@ notAfter=Mar  3 09:18:19 2026 GMT
 
 To ensure that the cluster can restart gracefully after this shut down, plan to restart it on or before the specified date. 
 Note that various certificates may have different expiration dates.
+
+## Backup your cluster
+
+If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster didn't work as intended.
+
+{{< note >}}
+- This procedure terminates workloads normally to prevent data crush, but if necessary, back up the workloads. Check the backup method for each workload.
+- Cluster shutdown will be executed by the cluster administrator, but workload backups must be executed by each user. The cluster administrator should establish management rule for cluster shutdown, such as notifying users in advance.
+{{< /note >}}
+
+## Shut Down Clusters
+
+You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will allow you to gracefully restart the cluster for later use. While [node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
 
 ### Making nodes unschedulable
 
@@ -78,6 +81,8 @@ kubectl drain --ignore-daemonsets node1 node2 node3
 Shut down all of the nodes in the cluster. You can do this in ways that best fit your cluster; such as through your cloud provider's web console, or a script, or playbook. 
 
 Example:
+
+Run the following command on all nodes.
 
 ```bash
 systemctl poweroff
@@ -123,4 +128,4 @@ kubectl get pods --all-namespaces
 
 ### Caveats
 
-Pre-shutdown pod scheduling may not be preserved after restart. Making the nodes schedulable again happens sequentially. Kube-scheduler will only schedule the pods to `Ready` and `Schedulable` nodes polled at an instance. In case there are many nodes that need to be made schedulable again, the pod scheduling may end up imbalanced in favor of the first nodes that become schedulable at that instance.
+Pre-shutdown pod scheduling might not be preserved after restart. Making the nodes schedulable again happens sequentially. Kube-scheduler will only schedule the pods to `Ready` and `Schedulable` nodes polled at an instance. In case there are many nodes that need to be made schedulable again, the pod scheduling might end up imbalanced in favor of the first nodes that become schedulable at that instance.

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -8,7 +8,7 @@ weight: 55
 
 This page outlines the steps required to safely shut down and restart Kubernetes clusters.
 
-As cluster administrators, you may need to suspend your running cluster and restart it for later use. There are different reasons why you may need to perform this shutdown, such as cluster maintenance or saving on operation/resource costs.
+As cluster administrators, you may need to suspend your running cluster and restart it at a later time. There are different reasons why you may need to perform this shutdown, such as cluster maintenance or saving on operation/resource costs.
 
 At a high level, the steps you perform for shutting down are:
 - Back up the cluster
@@ -19,7 +19,7 @@ At a high level, the steps you perform for shutting down are:
 
 Meanwhile, the steps you perform for restarting are:
 - Start external dependencies
-- Power on your nodes and waiting until they are Ready
+- Power on your nodes and wait until they are Ready
 - Mark the nodes as schedulable again
 
 <!-- body -->
@@ -47,16 +47,16 @@ Note that various certificates may have different expiration dates.
 
 ## Backup your cluster
 
-If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster didn't work as intended.
+If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster does not work.
 
 {{< note >}}
-- This procedure terminates workloads normally to prevent data crush, but if necessary, back up the workloads. Check the backup method for each workload.
-- Cluster shutdown will be executed by the cluster administrator, but workload backups must be executed by each user. The cluster administrator should establish management rule for cluster shutdown, such as notifying users in advance.
+- This procedure terminates workloads normally to prevent data corruption, but if necessary, back up the workloads. Check the backup method for each workload.
+- Cluster shutdown will be executed by the cluster administrator, but workload backups must be executed by each user. The cluster administrator should establish management process for cluster shutdown, such as notifying users in advance.
 {{< /note >}}
 
 ## Shut Down Clusters
 
-You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will allow you to gracefully restart the cluster for later use. While [node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
+You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will allow you to gracefully restart the cluster for later use. While [node shutdown](/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
 
 ### Making nodes unschedulable
 
@@ -96,7 +96,7 @@ After all nodes have successfully shut down, shut down any other cluster depende
 
 This section describes the process you need to restart the cluster after being gracefully shutdown.
 
-If the cluster fails to recover, you restore the cluster to its previous state using the [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#restoring-an-etcd-cluster).
+If the cluster fails to recover, restore the cluster to its previous state using the [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#restoring-an-etcd-cluster).
 
 ### Powering on cluster dependencies
 
@@ -106,7 +106,7 @@ Power on any cluster dependencies you need for your cluster, such as external st
 
 Start all cluster machines (i.e. your nodes). Use the method best-fit for your cluster to turn on the machines, like using the cloud provider's web console. 
 
-Allow a few minutes for the cluster's control plane nodes and worker nodes to become `Ready`. Verify that all nodes are `Ready`. 
+Allow a few minutes for the cluster's control plane nodes and worker nodes to become `Ready`. Control plane components (kube-apiserver, etcd) may take longer. Verify that all nodes are `Ready`. 
 
 ```bash
 kubectl get nodes

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -1,0 +1,114 @@
+---
+reviewers:
+title: Shutting Down and Restarting Clusters
+content_type: task
+weight: 55
+---
+
+<!-- overview -->
+
+This page outlines the steps required to safely shut down and restart Kubernetes clusters.
+
+As cluster administrators, you may need to suspend your running cluster and restart it for later use. There are different reasons why you may need to perform this shutdown, such as cluster maintenance or saving on operation/resource costs.
+
+At a high level, the steps you perform for shutting down are:
+- Back up the cluster
+- Cordon the nodes (mark as unschedulable)
+- Drain pods from nodes
+- Shut down nodes
+- Shut down any dependencies of your cluster
+
+Meanwhile, the steps you perform for restarting are:
+- Start external dependencies
+- Power on your nodes and waiting until they are Ready
+- Mark the nodes as schedulable again
+
+<!-- body -->
+
+## {{% heading "prerequisites" %}}
+
+You must have an existing cluster. This page is about shutting down and restarting clusters from Kubernetes
+{{< skew currentVersionAddMinor -1 >}} to Kubernetes {{< skew currentVersion >}}. You must also have access to the cluster as a user with the cluster admin role.
+
+## Backup your cluster
+
+If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster didn't work as intended.
+
+## Shut Down Clusters
+
+You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will allow you to gracefully restart the cluster for later use. While [node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
+
+### (Optional) Checking for certificate expiration
+
+If you are shutting the cluster down for an extended period, identify the date on which certificates will expire.
+```
+$ openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -enddate
+```
+
+Output
+```
+notAfter=Mar  3 09:18:19 2026 GMT
+``` 
+
+To ensure that the cluster can restart gracefully after this shut down, plan to restart it on or before the specified date. 
+
+### Making nodes unschedulable
+Make all nodes in the cluster unschedulable using kubectl cordon
+
+```
+$ kubectl cordon node1 node2 node3
+```
+
+### Terminating pods in the nodes
+Evict all the pods using `kubectl drain`
+
+While `kubectl drain` should basically be enough due to it capable of internally making the specified nodes unschedulable before pod eviction, larger clusters may need to make sure all nodes are properly cordoned first before draining. You can check the nodes' schedulability using kubectl get nodes
+```
+$ kubectl drain --ignore-daemonsets node1 node2 node3
+```
+
+### Shutting down nodes in the cluster
+Shut down all of the nodes in the cluster. You can do this in ways that best fit your cluster; such as through your cloud provider's web console, or a script, or playbook. 
+
+- Example
+```
+[user@node1 ~]# systemctl poweroff
+```
+
+### Shutting down cluster dependencies
+After all nodes have successfully shut down, shut down any other cluster dependencies that are no longer needed, such as external storages. Consult your vendor's documentation to see if some resources are okay to shut down, suspend, or delete.
+
+## Restarting Clusters
+
+This section describes the process you need to restart the cluster after being gracefully shutdown.
+
+If the cluster fails to recover, you restore the cluster to its previous state using the [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#restoring-an-etcd-cluster).
+
+### Powering on cluster dependencies
+Power on any cluster dependencies you need for your cluster, such as external storages.
+
+### Powering on cluster machines
+Start all cluster machines (i.e. your nodes). Use the method best-fit for your cluster to turn on the machines, like using the cloud provider's web console. 
+
+Allow a few minutes for the cluster's control plane nodes and worker nodes to become `Ready`. Verify that all nodes are `Ready`. 
+
+```
+$ kubectl get nodes
+```
+
+### Making your nodes schedulable again
+Once the nodes are `Ready`, mark all the nodes in the cluster schedulable using kubectl uncordon
+
+```
+$ kubectl uncordon node1 node2 node3
+```
+
+Wait until all pods are back in operation. Verify that the pods are `Running`
+
+```
+kubectl get pods --all-namespaces
+```
+
+### Caveats
+
+Pre-shutdown pod scheduling may not be preserved after restart. Making the nodes schedulable again happens sequentially. Kube-scheduler will only schedule the pods to `Ready` and `Schedulable` nodes polled at an instance. In case there are many nodes that need to be made schedulable again, the pod scheduling may end up imbalanced in favor of the first nodes that become schedulable at that instance.

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -26,7 +26,9 @@ Meanwhile, the steps you perform for restarting are:
 
 ## {{% heading "prerequisites" %}}
 
-You must have an existing cluster. This page is about shutting down and restarting clusters. You must also have access to the cluster as a user with the cluster admin role.
+- You must have an existing cluster. This page is about shutting down and restarting clusters. You must also have access to the cluster as a user with the cluster admin role.
+- You can't use the node autoscaler to perform this procedure. Disable the node autoscaler.
+- In this procedure, you will shut down the nodes in order to shut down the cluster. Some server management systems are configured to delete servers (VMs) that no longer respond to liveness checks. In such cases, the VMs may be deleted automatically, so you should not perform this procedure.
 
 ### (Optional) Check for certificate expiration {#check-certificate-expiration}
 

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -28,7 +28,7 @@ Meanwhile, the steps you perform for restarting are:
 
 You must have an existing cluster. This page is about shutting down and restarting clusters. You must also have access to the cluster as a user with the cluster admin role.
 
-### (Optional) Checking for certificate expiration
+### (Optional) Check for certificate expiration {#check-certificate-expiration}
 
 If you are shutting the cluster down for an extended period, identify the date on which certificates will expire.
 
@@ -51,16 +51,23 @@ If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/
 
 {{< note >}}
 - This procedure terminates workloads normally to prevent data corruption, but if necessary, back up the workloads. Check the backup method for each workload.
-- Cluster shutdown will be executed by the cluster administrator, but workload backups must be executed by each user. The cluster administrator should establish management process for cluster shutdown, such as notifying users in advance.
+- Cluster shutdown will be executed by the cluster administrator, but workload backups may needed be executed by the people responsible for each individual workload.
+  As a cluster administrator, you should establish management processes for cluster shutdown, such as notifying users in advance.
 {{< /note >}}
 
-## Shut Down Clusters
+See below for details about the etcd that is external to the cluster.
 
-You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will allow you to gracefully restart the cluster for later use. While [node shutdown](/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
+- [External etcd topology](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/ha-topology/#external-etcd-topology)
+- [External etcd nodes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/#external-etcd-nodes)
+- [Set up a High Availability etcd Cluster with kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)
 
-### Making nodes unschedulable
+## Shut down the nodes in your cluster {#node-shutdown}
 
-Make all nodes in the cluster unschedulable using kubectl cordon
+You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will typically allow you to gracefully restart the cluster for later use. While [node shutdown](/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
+
+### Mark worker nodes unschedulable
+
+Make all nodes in the cluster unschedulable using `kubectl cordon`
 
 ```bash
 kubectl cordon node1 node2 node3
@@ -70,7 +77,7 @@ kubectl cordon node1 node2 node3
 
 Evict all the pods using `kubectl drain`
 
-While `kubectl drain` should basically be enough due to it capable of internally making the specified nodes unschedulable before pod eviction, larger clusters may need to make sure all nodes are properly cordoned first before draining. You can check the nodes' schedulability using kubectl get nodes
+While `kubectl drain` should basically be enough due to it capable of internally making the specified nodes unschedulable before pod eviction, larger clusters may need to make sure all nodes are properly cordoned first before draining. You can check the nodes' schedulability using `kubectl get nodes`
 
 ```bash
 kubectl drain --ignore-daemonsets node1 node2 node3
@@ -85,6 +92,7 @@ Example:
 Run the following command on all nodes.
 
 ```bash
+# Run this on each node (not on your own PC)
 systemctl poweroff
 ```
 
@@ -92,7 +100,7 @@ systemctl poweroff
 
 After all nodes have successfully shut down, shut down any other cluster dependencies that are no longer needed, such as external storages. Consult your vendor's documentation to see if some resources are okay to shut down, suspend, or delete.
 
-## Restarting Clusters
+## Restart the cluster
 
 This section describes the process you need to restart the cluster after being gracefully shutdown.
 
@@ -112,12 +120,20 @@ Allow a few minutes for the cluster's control plane nodes and worker nodes to be
 kubectl get nodes
 ```
 
-### Making your nodes schedulable again
+### Making control plane nodes schedulable
 
-Once the nodes are `Ready`, mark all the nodes in the cluster schedulable using kubectl uncordon
+Once the control plane nodes are `Ready`, mark all control plane nodes in the cluster schedulable using `kubectl uncordon`
 
 ```bash
-kubectl uncordon node1 node2 node3
+kubectl uncordon control-plane-node1 control-plane-node2 control-plane-node3
+```
+
+### Making worker nodes schedulable
+
+Once the worker nodes are `Ready`, mark all worker nodes in the cluster schedulable using `kubectl uncordon`
+
+```bash
+kubectl uncordon worker-node1 worker-node2 worker-node3
 ```
 
 Wait until all pods are back in operation. Verify that the pods are `Running`
@@ -125,6 +141,9 @@ Wait until all pods are back in operation. Verify that the pods are `Running`
 ```bash
 kubectl get pods --all-namespaces
 ```
+
+This is the simplest verification method.
+In a real production situation, additional procedures and verifications may be required depending on your system environment.
 
 ### Caveats
 

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -10,24 +10,12 @@ This page outlines the steps required to safely shut down and restart Kubernetes
 
 As cluster administrators, you may need to suspend your running cluster and restart it at a later time. There are different reasons why you may need to perform this shutdown, such as cluster maintenance or saving on operation/resource costs.
 
-At a high level, the steps you perform for shutting down are:
-- Back up the cluster
-- Cordon the nodes (mark as unschedulable)
-- Drain pods from nodes
-- Shut down nodes
-- Shut down any dependencies of your cluster
-
-Meanwhile, the steps you perform for restarting are:
-- Start external dependencies
-- Power on your nodes and wait until they are Ready
-- Mark the nodes as schedulable again
-
 <!-- body -->
 
 ## {{% heading "prerequisites" %}}
 
 - You must have an existing cluster. This page is about shutting down and restarting clusters. You must also have access to the cluster as a user with the cluster admin role.
-- You can't use the node autoscaler to perform this procedure. Disable the node autoscaler.
+- This procedure does not apply to environments using a node autoscaler.
 - In this procedure, you will shut down the nodes in order to shut down the cluster. Some server management systems are configured to delete servers (VMs) that no longer respond to liveness checks. In such cases, the VMs may be deleted automatically, so you should not perform this procedure.
 
 ### (Optional) Check for certificate expiration {#check-certificate-expiration}
@@ -47,7 +35,7 @@ notAfter=Mar  3 09:18:19 2026 GMT
 To ensure that the cluster can restart gracefully after this shut down, plan to restart it on or before the specified date. 
 Note that various certificates may have different expiration dates.
 
-## Backup your cluster
+## (Optional) Backup an etcd cluster
 
 If your Kubernetes cluster uses etcd as its backing store, make sure to create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster does not work.
 
@@ -59,24 +47,27 @@ If your Kubernetes cluster uses etcd as its backing store, make sure to create a
 
 ## Shut down the nodes in your cluster {#node-shutdown}
 
-You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will typically allow you to gracefully restart the cluster for later use. While [node shutdown](/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart.
+You can shut down your cluster in a graceful manner by gracefully shutting down its nodes. This will typically allow you to gracefully restart the cluster for later use. While [node shutdown](/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown) allows you to safely evict the pods of the node to another available node, cluster shutdowns do not need evicted pods to be rescheduled anywhere else until the cluster is restarted. Thus, this procedure suppresses any pod rescheduling from the nodes being shutdown until cluster restart. The procedure involves first shutting down the worker nodes, and then shutting down the control plane.
 
 ### Mark worker nodes unschedulable
 
 Make all nodes in the cluster unschedulable using `kubectl cordon`
 
 ```bash
-kubectl cordon node1 node2 node3
+kubectl cordon --selector='!node-role.kubernetes.io/control-plane'
+kubectl cordon --selector='node-role.kubernetes.io/control-plane'
 ```
 
 ### Terminating pods in the nodes
 
 Evict all the pods using `kubectl drain`
 
-While `kubectl drain` should basically be enough due to it capable of internally making the specified nodes unschedulable before pod eviction, larger clusters may need to make sure all nodes are properly cordoned first before draining. You can check the nodes' schedulability using `kubectl get nodes`
+While `kubectl drain` should basically be enough due to it capable of internally making the specified nodes unschedulable before pod eviction, larger clusters may need to make sure all nodes are properly cordoned first before draining. You can check the nodes' schedulability using `kubectl get nodes`.
+First, drain the worker nodes, then drain the control plane nodes.
 
 ```bash
-kubectl drain --ignore-daemonsets node1 node2 node3
+kubectl drain --ignore-daemonsets --selector='!node-role.kubernetes.io/control-plane'
+kubectl drain --ignore-daemonsets --selector='node-role.kubernetes.io/control-plane'
 ```
 
 ### Shutting down nodes in the cluster
@@ -108,12 +99,14 @@ Power on any cluster dependencies you need for your cluster, such as external st
 
 ### Powering on cluster machines
 
-Start all cluster machines (i.e. your nodes). Use the method best-fit for your cluster to turn on the machines, like using the cloud provider's web console. 
+First, start the machines for all control plane nodes in the cluster. Use the method best-fit for your cluster to turn on the machines, like using the cloud provider's web console. 
+Allow a few minutes for the cluster's control plane nodes to become `Ready`. Control plane components (kube-apiserver, etcd) may take longer. Verify that all nodes are `Ready`. 
 
-Allow a few minutes for the cluster's control plane nodes and worker nodes to become `Ready`. Control plane components (kube-apiserver, etcd) may take longer. Verify that all nodes are `Ready`. 
+Next, start the machines for all worker nodes in the cluster and verify that they are in the "Ready" state.
 
 ```bash
-kubectl get nodes
+kubectl get nodes --selector='node-role.kubernetes.io/control-plane'
+kubectl get nodes --selector='!node-role.kubernetes.io/control-plane'
 ```
 
 ### Making control plane nodes schedulable
@@ -121,7 +114,7 @@ kubectl get nodes
 Once the control plane nodes are `Ready`, mark all control plane nodes in the cluster schedulable using `kubectl uncordon`
 
 ```bash
-kubectl uncordon control-plane-node1 control-plane-node2 control-plane-node3
+kubectl uncordon --selector='node-role.kubernetes.io/control-plane'
 ```
 
 ### Making worker nodes schedulable
@@ -129,7 +122,7 @@ kubectl uncordon control-plane-node1 control-plane-node2 control-plane-node3
 Once the worker nodes are `Ready`, mark all worker nodes in the cluster schedulable using `kubectl uncordon`
 
 ```bash
-kubectl uncordon worker-node1 worker-node2 worker-node3
+kubectl uncordon --selector='!node-role.kubernetes.io/control-plane'
 ```
 
 Wait until all pods are back in operation. Verify that the pods are `Running`

--- a/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-shutdown-and-restart.md
@@ -49,19 +49,13 @@ Note that various certificates may have different expiration dates.
 
 ## Backup your cluster
 
-If the cluster has etcd, create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster does not work.
+If your Kubernetes cluster uses etcd as its backing store, make sure to create an [etcd backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster). This backup may be useful in restoring the cluster if restarting the cluster does not work.
 
 {{< note >}}
 - This procedure terminates workloads normally to prevent data corruption, but if necessary, back up the workloads. Check the backup method for each workload.
 - Cluster shutdown will be executed by the cluster administrator, but workload backups may needed be executed by the people responsible for each individual workload.
   As a cluster administrator, you should establish management processes for cluster shutdown, such as notifying users in advance.
 {{< /note >}}
-
-See below for details about the etcd that is external to the cluster.
-
-- [External etcd topology](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/ha-topology/#external-etcd-topology)
-- [External etcd nodes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/#external-etcd-nodes)
-- [Set up a High Availability etcd Cluster with kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)
 
 ## Shut down the nodes in your cluster {#node-shutdown}
 


### PR DESCRIPTION
### Description

The addition of a Cluster Graceful Shutdown and Graceful Restart procedure in the documentation/website.

### Issue

As stated in Issue #49723 , the current K8s documentation does not provide a community-standard approach for cluster shutdown.

Because the procedure is not officially defined or finalized yet anywhere else, any corrections and suggestions to improve this procedure is welcome.

### Additional Information

This PR is a continuation of #50025.
The author of #50025 has left the company and is no longer able to update the PR, so it has been moved to this PR.

I tried to import the commit log of #50025 into this PR, but the old author became CLA error.
Therefore, I committed the latest fix of #50025 and then committed the last review comment for #50025.

Closes: #49723