### PR TITLE
Changed max pod size on Windows nodes

### DIFF
--- a/content/en/docs/concepts/services-networking/windows-networking.md
+++ b/content/en/docs/concepts/services-networking/windows-networking.md
@@ -139,7 +139,7 @@ The following networking functionality is _not_ supported on Windows nodes:
 
 * Host networking mode
 * Local NodePort access from the node itself (works for other nodes or external clients)
-* More than 64 backend pods (or unique destination addresses) for a single Service
+* More than 1024 backend pods (or unique destination addresses) for a single Service
 * IPv6 communication between Windows pods connected to overlay networks
 * Local Traffic Policy in non-DSR mode
 * Outbound communication using the ICMP protocol via the `win-overlay`, `win-bridge`, or using the Azure-CNI plugin.


### PR DESCRIPTION
### Description
Updated the backend pod limit for a single Service on Windows nodes in the documentation. 
The limit has been increased from 64 to 1024 due to fixes in Windows Server, and this change reflects that update.

This update applies to documentation in the following languages:
- English
- ~Korean~
- ~Chinese~

### Issue
Closes: kubernetes/kubernetes#135518