### PR TITLE
Fix PersistentVolume Provisioning link in StatefulSet Basics tutorial

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -25,7 +25,7 @@ following Kubernetes concepts:
 * [Pods](/docs/concepts/workloads/pods/)
 * [Cluster DNS](/docs/concepts/services-networking/dns-pod-service/)
 * [Headless Services](/docs/concepts/services-networking/service/#headless-services)
-* [PersistentVolumes](/docs/concepts/storage/dynamic-provisioning.md)
+* [PersistentVolumes](/docs/concepts/storage/dynamic-provisioning/)
 * The [kubectl](/docs/reference/kubectl/kubectl/) command line tool
 
 {{% include "task-tutorial-prereqs.md" %}}

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -25,7 +25,7 @@ following Kubernetes concepts:
 * [Pods](/docs/concepts/workloads/pods/)
 * [Cluster DNS](/docs/concepts/services-networking/dns-pod-service/)
 * [Headless Services](/docs/concepts/services-networking/service/#headless-services)
-* [PersistentVolumes](/docs/concepts/storage/persistent-volumes/)
+* [PersistentVolumes](/docs/concepts/storage/dynamic-provisioning.md)
 * The [kubectl](/docs/reference/kubectl/kubectl/) command line tool
 
 {{% include "task-tutorial-prereqs.md" %}}


### PR DESCRIPTION
## Fixes #53085

+ Replaces the outdated PersistentVolume Provisioning link with the correct Dynamic Volume Provisioning concept page.

