### PR TITLE
node: kubeReserved, systemReserved compressible resources

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -181,7 +181,9 @@ specifying `pods` value to the KubeletConfiguration setting `enforceNodeAllocata
 
 Optionally, `kubelet` can be made to enforce `kubeReserved` and
 `systemReserved` by specifying `kube-reserved` & `system-reserved` values in
-the same setting. Note that to enforce `kubeReserved` or `systemReserved`,
+the same setting. Additionally, only compressible resources may be enforced by
+specifying `kube-reserved-compressible` and `system-reserved-compressible`.
+Note that to enforce `kubeReserved` or `systemReserved`,
 `kubeReservedCgroup` or `systemReservedCgroup` needs to be specified
 respectively.
 
@@ -202,10 +204,15 @@ recommendation is to enforce `systemReserved` only if a user has profiled their
 nodes exhaustively to come up with precise estimates and is confident in their
 ability to recover if any process in that group is oom-killed.
 
+Enforcing only compressible resources for `kubeReserved` and `systemReserved`
+is less likely to cause disruption while ensuring that the resource is
+allocated appropriately when there is contention.
+
 * To begin with enforce 'Allocatable' on `pods`.
-* Once adequate monitoring and alerting is in place to track kube system
-  daemons, attempt to enforce `kubeReserved` based on usage heuristics.
-* If absolutely necessary, enforce `systemReserved` over time.
+* Once adequate monitoring and alerting is in place to track kube and system
+  daemons, attempt to enforce compressible resources on `kubeReserved` and `systemReserved`.
+* Attempt to enforce non-compressible `kubeReserved` resources based on usage heuristics.
+* If absolutely necessary, enforce non-compressible `systemReserved` resources over time.
 
 The resource requirements of kube system daemons may grow over time as more and
 more features are added. Over time, kubernetes project will attempt to bring


### PR DESCRIPTION
### Description

Updates the node allocatable documentation to mention `kube-reserved-compressible` and `system-reserved-compressible`. This option was added in 1.32 but has not yet been documented. See also: https://github.com/kubernetes/kubernetes/pull/135638.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #