### PR TITLE
Fix incorrect StatefulSet updateStrategy path in OnDelete example

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -902,7 +902,7 @@ continue the update process.
 ### OnDelete {#on-delete}
 
 You select this update strategy for a StatefulSet by setting the
-`.spec.template.updateStrategy.type` to `OnDelete`.
+`.spec.updateStrategy.type` to `OnDelete`.
 
 Patch the `web` StatefulSet to use the `OnDelete` update strategy:
 


### PR DESCRIPTION
The documentation used the field `.spec.template.updateStrategy.type` in the
StatefulSet OnDelete update strategy example. This field does not exist for
StatefulSets.

For StatefulSets, the correct field is:

`.spec.updateStrategy.type`

This PR updates the example to use the correct API path.

**What was wrong**
- `.spec.template.updateStrategy.type` (incorrect)

**Fix**
- `.spec.updateStrategy.type` (correct)

**Why**
The StatefulSet API defines `updateStrategy` at the StatefulSet spec level, not
inside the Pod template.

Reference:
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/

