### PR TITLE
Document DisableCPUQuotaWithExclusiveCPUs feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableCPUQuotaWithExclusiveCPUs.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableCPUQuotaWithExclusiveCPUs.md
@@ -1,0 +1,18 @@
+---
+title: DisableCPUQuotaWithExclusiveCPUs
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.33"
+---
+
+When the feature gate `DisableCPUQuotaWithExclusiveCPUs` is enabled (the default), then Kubernetes
+does **not** enforce CPU quota for Pods that use the [Guaranteed](/docs/concepts/workloads/pods/pod-qos/#guaranteed)
+{{< glossary_tooltip text="QoS class" term_id="qos-class" >}}.
+
+You can disable the `DisableCPUQuotaWithExclusiveCPUs` feature gate to restore the legacy behavior.


### PR DESCRIPTION
Whilst working on fixups for the v1.34 docs, I noticed we don't document the `DisableCPUQuotaWithExclusiveCPUs` feature gate that was introduced by https://github.com/kubernetes/kubernetes/pull/127525

This PR would document it. The wording is awkward but we can't now change the feature gate name. It will soon (a few minor releases) be removed anyway.

/sig node