### PR TITLE
[KEP-4006] Rename erroneous feature gate name - AuthorizePodWebsocketUpgradeCreatePermission

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/AuthorizePodWebsocketUpgradeCreatePermission.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/AuthorizePodWebsocketUpgradeCreatePermission.md
@@ -1,5 +1,5 @@
 ---
-title: AuthorizeWebsocketUpdateCreatePermission
+title: AuthorizePodWebsocketUpgradeCreatePermission
 content_type: feature_gate
 _build:
   list: never


### PR DESCRIPTION
### [KEP-4006] Rename to AuthorizePodWebsocketUpgradeCreatePermission

- Erroneous name: AuthorizeWebsocketUpdateCreatePermission
- Previous erroneous PR: https://github.com/kubernetes/website/pull/52896

[KEP-4006](https://github.com/kubernetes/enhancements/issues/4006)