### PR TITLE
Tweak v1.35 kuberc docs

### DIFF
--- a/content/en/docs/reference/kubectl/kuberc.md
+++ b/content/en/docs/reference/kubectl/kuberc.md
@@ -254,10 +254,11 @@ one of the following conditions is met:
 1. Full path resolution is performed on the `command` and the `name` field is an
    exact match.
 
-With regard to "full path resolution" mentioned above, it is important to note
-that neither symlinks nor shell globs are resolved. For example, consider an
-allowlist entry with the `name` `/usr/local/bin/my-binary`, where
-`/usr/local/bin/my-binary` is a symlink to `/this/is/a/target`. If `command`
+With regard to _full path resolution_ mentioned earlier in this page,
+neither symlinks nor shell globs are resolved.
+
+For example, consider an allowlist entry with the `name` `/usr/local/bin/my-binary`,
+where `/usr/local/bin/my-binary` is a symlink to `/this/is/a/target`. If `command`
 specified in the kubeconfig is `/this/is/a/target`, it will not be allowed. In
 order to make that work, you would need to add `/this/is/a/target` to the
 allowlist explicitly. On the other hand, if the kubeconfig has the `command` as
@@ -343,3 +344,5 @@ or disable the feature gate:
 ```shell
 export KUBECTL_KUBERC=false
 ```
+
+This might be useful for troubleshooting whether your `kuberc` is causing a problem.


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/website/pull/52877

- Upgrade the note about credential plugins and the allowlist to a [caution](https://kubernetes.io/docs/contribute/style/style-guide/#caution).
- Mention the Windows path to kuberc; we may be part of the Linux Foundation, but Windows is still a thing.
- Other tidying to the same page.