### PR TITLE
[KEP-5440] Update docs wrt MutableSchedulingDirectivesForSuspendedJobs

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -863,6 +863,10 @@ the Job to true; later, when you want to resume it again, update it to false.
 Creating a Job with `.spec.suspend` set to true will create it in the suspended
 state.
 
+In Kubernetes 1.35 or later the `.status.startTime` field is cleared on Job suspension
+when the [MutableSchedulingDirectivesForSuspendedJobs](#mutable-scheduling-directives-for-suspended-jobs)
+feature gate is enabled.
+
 When a Job is resumed from suspension, its `.status.startTime` field will be
 reset to the current time. This means that the `.spec.activeDeadlineSeconds`
 timer will be stopped and reset when a Job is suspended and resumed.
@@ -971,11 +975,20 @@ a custom queue controller has no influence on where the pods of a job will actua
 
 This feature allows updating a Job's scheduling directives before it starts, which gives custom queue
 controllers the ability to influence pod placement while at the same time offloading actual
-pod-to-node assignment to kube-scheduler. This is allowed only for suspended Jobs that have never
-been unsuspended before.
+pod-to-node assignment to kube-scheduler. 
 
 The fields in a Job's pod template that can be updated are node affinity, node selector,
 tolerations, labels, annotations and [scheduling gates](/docs/concepts/scheduling-eviction/pod-scheduling-readiness/).
+
+#### Mutable Scheduling Directives for suspended Jobs
+
+{{< feature-state feature_gate_name="MutableSchedulingDirectivesForSuspendedJobs" >}}
+
+In Kubernetes 1.34 or earlier mutating of Pod's scheduling directives is allowed only for
+suspended Jobs that have never been unsuspended before. In Kubernetes 1.35, this is allowed
+for any suspended Jobs when the `MutableSchedulingDirectivesForSuspendedJobs` feature gate is enabled.
+
+Additionally, this feature gate enables clearing of the `.status.startTime` field on [Job suspension](#suspending-a-job).
 
 ### Mutable Pod resources for suspended Jobs
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MutableSchedulingDirectivesForSuspendedJobs.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MutableSchedulingDirectivesForSuspendedJobs.md
@@ -1,0 +1,15 @@
+---
+title: MutableSchedulingDirectivesForSuspendedJobs 
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.35"
+removed: false
+---
+Enable the ability to patch pod templates for suspended Jobs, in order to change the pod scheduling directives.
+


### PR DESCRIPTION

### Description

This is a follow up to https://github.com/kubernetes/website/pull/52800 to document the semantic changes behind the MutableSchedulingDirectivesForSuspendedJobs feature gate.

### Issue

KEP: https://github.com/kubernetes/enhancements/issues/5440