### PR TITLE
Update "Connecting Applications with Services"

### DIFF
--- a/content/en/examples/service/networking/curlpod.yaml
+++ b/content/en/examples/service/networking/curlpod.yaml
@@ -22,7 +22,7 @@ spec:
         - sh
         - -c
         - while true; do sleep 1; done
-        image: radial/busyboxplus:curl
+        image: curlimages/curl
         volumeMounts:
         - mountPath: /etc/nginx/ssl
           name: secret-volume

--- a/content/en/examples/service/networking/nginx-default.conf
+++ b/content/en/examples/service/networking/nginx-default.conf
@@ -1,0 +1,17 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server ipv6only=on;
+
+        listen 443 ssl;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        server_name localhost;
+        ssl_certificate /etc/nginx/ssl/tls.crt;
+        ssl_certificate_key /etc/nginx/ssl/tls.key;
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
+}

--- a/content/en/examples/service/networking/nginx-secure-app.yaml
+++ b/content/en/examples/service/networking/nginx-secure-app.yaml
@@ -39,8 +39,8 @@ spec:
         configMap:
           name: nginxconfigmap
       containers:
-      - name: nginxhttps
-        image: bprashanth/nginxhttps:1.0
+      - name: nginx
+        image: nginx
         ports:
         - containerPort: 443
         - containerPort: 80


### PR DESCRIPTION
### Description

#### 1. Replace some unsupported images to official images

`radial/busyboxplus:curl` -> `curlimages/curl` or `busybox` depends on context.
`bprashanth/nginxhttps` -> `nginx`.


#### 2. Decouple from archived example

[The example](https://github.com/kubernetes/examples/tree/master/_archived/https-nginx) is archived and [no longer maintained](https://github.com/kubernetes/examples/issues/567#issuecomment-3397409083). I removed references to archived example by embedding a few files into tutorial directly:

[default.conf](https://github.com/kubernetes/examples/blob/bc9ca4ca32bb28762ef216386934bef20f1f9930/staging/https-nginx/default.conf) into code sample.  
[One-liner Makefile](https://github.com/kubernetes/examples/blob/bc9ca4ca32bb28762ef216386934bef20f1f9930/staging/https-nginx/Makefile#L25) into code snippet.

### Issue

Closes: #33169, #52702