### PR TITLE
[pt-br] Add reference/glossary/init-container.md

### DIFF
--- a/content/pt-br/docs/reference/glossary/init-container.md
+++ b/content/pt-br/docs/reference/glossary/init-container.md
@@ -1,0 +1,20 @@
+---
+title: Contêiner de inicialização
+id: init-container
+date: 2018-04-12
+full_link: /docs/concepts/workloads/pods/init-containers/
+short_description: >
+  Um ou mais contêineres de inicialização que devem ser executados até a conclusão antes que qualquer contêiner de aplicação seja executado.
+aka: 
+tags:
+- fundamental
+---
+ Um ou mais {{< glossary_tooltip text="contêineres" term_id="container" >}} de inicialização que devem ser executados até a conclusão antes que qualquer contêiner de aplicação seja executado.
+
+<!--more--> 
+
+Contêineres de inicialização (init) são como contêineres de aplicação regulares, com uma diferença: contêineres de inicialização devem ser executados até a conclusão antes que qualquer contêiner de aplicação possa iniciar. Contêineres de inicialização são executados em série: cada contêiner de inicialização deve ser executado até a conclusão antes que o próximo contêiner de inicialização comece.
+
+Diferentemente dos {{< glossary_tooltip text="contêineres sidecar" term_id="sidecar-container" >}}, contêineres de inicialização não permanecem em execução após a inicialização do Pod.
+
+Para mais informações, leia [contêineres de inicialização](/docs/concepts/workloads/pods/init-containers/).


### PR DESCRIPTION
### Description

Adicionar **init-container** ao Glossário em PT-BR:

- Link da página no site: https://kubernetes.io/pt-br/docs/reference/glossary/
- Caminho da página EN no repositório: `content/en/docs/reference/glossary/init-container.md`
- Caminho PT-BR proposto no repositório: `content/pt-br/docs/reference/glossary/init-container.md`

Adicionar suporte ao tooltip em PT-BR via shortcode:

`{{< glossary_tooltip text="contêineres de inicialização" term_id="init-container" >}}`

/cc @stormqueen1990 @edsoncelio

---

Add **init-container** to the Glossary in PT-BR:

- Link to the page on the site: https://kubernetes.io/pt-br/docs/reference/glossary/
- Path to the EN page in the repository: `content/en/docs/reference/glossary/init-container.md`
- Proposed PT-BR path in the repository: `content/pt-br/docs/reference/glossary/init-container.md`

Add tooltip support in PT-BR via shortcode:

`{{< glossary_tooltip text="contêineres de inicialização" term_id="init-container" >}}`

### Issue

Closes: #53558