### PR TITLE
Fix typo in feature-gates/SizeBasedListCostEstimate.md

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/SizeBasedListCostEstimate.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/SizeBasedListCostEstimate.md
@@ -8,6 +8,6 @@ _build:
 stages:
   - stage: beta
     defaultValue: true
-    fromVersion: "1.24"
+    fromVersion: "1.34"
 ---
 Enables APF to use size of objects for estimating request cost.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR updates the fromVersion for the `SizeBasedListCostEstimate` feature gate.
I believe this feature gate was introduced in Kubernetes 1.34, but the documentation currently lists it as 1.24. This change updates the value to what appears to be the correct version.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: N/A