### PR TITLE
Remove noexec description from image volume

### DIFF
--- a/content/en/blog/_posts/2025-04-29-image-volume-beta/index.md
+++ b/content/en/blog/_posts/2025-04-29-image-volume-beta/index.md
@@ -25,7 +25,7 @@ The major change for the beta graduation of Image Volumes is the support for
 [`subPathExpr`](/docs/concepts/storage/volumes/#using-subpath-expanded-environment) mounts
 for containers via `spec.containers[*].volumeMounts.[subPath,subPathExpr]`. This
 allows end-users to mount a certain subdirectory of an image volume, which is
-still mounted as readonly (`noexec`). This means that non-existing
+still mounted as readonly (`ro`). This means that non-existing
 subdirectories cannot be mounted by default. As for other `subPath` and
 `subPathExpr` values, Kubernetes will ensure that there are no absolute path or
 relative path components part of the specified sub path. Container runtimes are

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -607,8 +607,7 @@ The types of objects that may be mounted by this volume are defined by the
 container runtime implementation on a host machine. At a minimum, they must include
 all valid types supported by the container image field. The OCI object gets
 mounted in a single directory (`spec.containers[*].volumeMounts[*].mountPath`)
-and will be mounted read-only. On Linux, the container runtime typically also mounts the
-volume with file execution blocked (`noexec`).
+and will be mounted read-only.
 
 Besides that:
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This removes outdated description about noexec.
This aligns with https://github.com/kubernetes/enhancements/pull/5354
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

https://kep.k8s.io/4639
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #