### PR TITLE
Add etcd version skew table

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -60,8 +60,6 @@ The following table lists the supported etcd versions for each supported Kuberne
 | 1.34 | 3.6 |
 | 1.33 | 3.5 |
 
-
-
 When upgrading your cluster, you must ensure that your etcd version remains compatible with your Kubernetes API server. For detailed instructions on how to upgrade etcd safely, refer to the official etcd upgrade documentation.
 
 ### kubelet

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -60,7 +60,7 @@ The following table lists the supported etcd versions for each supported Kuberne
 | 1.34 | 3.6 |
 | 1.33 | 3.5 |
 
-When upgrading your cluster, you must ensure that your etcd version remains compatible with your Kubernetes API server. For detailed instructions on how to upgrade etcd safely, refer to the official etcd upgrade documentation.
+When upgrading your cluster, you must ensure that your etcd version remains compatible with your Kubernetes API server. For detailed instructions on how to upgrade etcd safely, refer to [the official etcd upgrade documentation](https://etcd.io/docs/v3.6/upgrades/).
 
 ### kubelet
 

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -50,6 +50,20 @@ Example:
 * newest `kube-apiserver` is at **{{< skew currentVersion >}}**
 * other `kube-apiserver` instances are supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 
+### etcd
+
+The following table lists the supported etcd versions for each supported Kubernetes version.
+
+| Kubernetes Version | Supported etcd Version |
+| :--- | :--- |
+| 1.35 | 3.6 |
+| 1.34 | 3.6 |
+| 1.33 | 3.5 |
+
+
+
+When upgrading your cluster, you must ensure that your etcd version remains compatible with your Kubernetes API server. For detailed instructions on how to upgrade etcd safely, refer to the official etcd upgrade documentation.
+
 ### kubelet
 
 * `kubelet` must not be newer than `kube-apiserver`.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR adds a new section to the Version Skew Policy document detailing the compatibility between Kubernetes API server versions and etcd versions, as requested in the linked issue #53355 

* Added a table showing the supported etcd versions for Kubernetes 1.33, 1.34, and 1.35.
| Kubernetes Version | Supported etcd Version |
| :--- | :--- |
| 1.35 | 3.6 |
| 1.34 | 3.6 |
| 1.33 | 3.5 |

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #53355 