### PR TITLE
docs: mention /flagz for feature gate verification

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-feature-gates.md
+++ b/content/en/docs/tasks/administer-cluster/configure-feature-gates.md
@@ -232,11 +232,6 @@ runtime debugging information for core components.
 For more information, see the
 [z-pages documentation](/docs/reference/instrumentation/zpages/).
 
-{{< note >}}
-The `/flagz` endpoint is intended for manual inspection only. It is not machine-parseable,
-has no stability guarantees, and may change between Kubernetes releases.
-{{< /note >}}
-
 ## Understanding component-specific requirements
 
 Some examples of component-specific feature gates:


### PR DESCRIPTION
### Description

This PR updates the *Enable or Disable Feature Gates* documentation to mention the
`/flagz` debugging endpoint as an additional way to verify feature gate configuration.
It adds a short section explaining that `/flagz` exposes the command-line flags used
to start a component and links to the Kubernetes z-pages documentation for details.

### Issue

Closes: #53580