### PR TITLE
Fix broken link in 'Gateway API' page

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -252,7 +252,7 @@ Gateway API is the successor to the [Ingress](/docs/concepts/services-networking
 However, it does not include the Ingress kind. As a result, a one-time conversion from your existing
 Ingress resources to Gateway API resources is necessary.
 
-Refer to the [ingress migration](https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/#migrating-from-ingress)
+Refer to the [ingress migration](https://gateway-api.sigs.k8s.io/guides/getting-started/migrating-from-ingress)
 guide for details on migrating Ingress resources to Gateway API resources.
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
The existing link for the "Ingress migration guide" was broken (404 error).

* **Current (broken) link:** `https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/#migrating-from-ingress`
* **Updated (working) link:** `https://gateway-api.sigs.k8s.io/guides/getting-started/migrating-from-ingress`