### PR TITLE
Update link to case study guidelines

### DIFF
--- a/content/en/docs/contribute/new-content/case-studies.md
+++ b/content/en/docs/contribute/new-content/case-studies.md
@@ -21,6 +21,6 @@ Case studies require extensive review before they're approved.
 Have a look at the source for the
 [existing case studies](https://github.com/kubernetes/website/tree/main/content/en/case-studies).
 
-Refer to the [case study guidelines](https://github.com/cncf/foundation/blob/master/case-study-guidelines.md)
+Refer to the [case study guidelines](https://github.com/cncf/foundation/blob/main/policies-guidance/case-study-guidelines.md)
 and submit your request as outlined in the guidelines.
 


### PR DESCRIPTION
The existing link for the "case study guidelines" was broken (404 error).

* **Current (broken) link:** `https://github.com/cncf/foundation/blob/main/case-study-guidelines.md`
* **Updated (working) link:** `https://github.com/cncf/foundation/blob/main/policies-guidance/case-study-guidelines.md`