### PR TITLE
Updated KubeCon event links for 2026

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -54,10 +54,10 @@ To download Kubernetes, visit the [download](/releases/download/) section.
 <h2>Attend upcoming KubeCon + CloudNativeCon events</h2>
   <!-- TODO: change this to a shortcode that auto-updates from a schedule -->
   <div>
-    <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" class="desktopKCButton"><strong>North America</strong> (Atlanta, Nov 10-13)</a>
+    <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Amsterdam, Mar 23-26, 2026)</a>
   </div>
   <div>
-    <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Amsterdam, Mar 23-26, 2026)</a>
+    <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/" class="desktopKCButton"><strong>North America</strong> (Salt Lake City, Nov 9-12, 2026)</a>
   </div>
 {{< /blocks/section >}}
 


### PR DESCRIPTION
The homepage (content/en/_index.md) contained an outdated event reference under the “Upcoming Events” section:
North America (Atlanta, Nov 10-13)

The event date has passed so I removed  and updated to the upcoming KubeCon + CloudNativeCon