### PR TITLE
Fix incorrect kubectl attach commands in image volume documentation

### DIFF
--- a/content/en/blog/_posts/2025-04-29-image-volume-beta/index.md
+++ b/content/en/blog/_posts/2025-04-29-image-volume-beta/index.md
@@ -75,7 +75,7 @@ kubectl apply -f image-volumes-subpath.yaml
 Now you can attach to the container:
 
 ```shell
-kubectl attach -it image-volume bash
+kubectl exec image-volume -it -- bash
 ```
 
 And check the content of the file from the `dir` sub path in the volume:


### PR DESCRIPTION
### Description

This PR fixes incorrect `kubectl attach` commands in the image volume documentation. 

The original commands used `kubectl exec image-volume -it -- bash`, which:
1. Includes an invalid `bash` argument (kubectl attach doesn't accept command arguments)
2. Cannot provide interactive shell access when the container's main process is `sleep infinity`

All instances have been replaced with `kubectl exec -it image-volume -- bash`, which correctly:
- Starts a new bash process inside the container
- Provides proper interactive terminal access
- Follows Kubernetes best practices for container interaction

## Related PR

This PR is related to but independent from #52931.

While #52931 fixed the incorrect `kubectl attach` commands in the task documentation (`content/en/docs/tasks/configure-pod-container/image-volumes.md`), this PR addresses the same issue in the blog post (`content/en/blog/_posts/2025-04-29-image-volume-beta/index.md`).

Both files contained the same incorrect command pattern, but they are separate documents that need individual fixes.

**Files modified:**
- `content/en/blog/_posts/2025-04-29-image-volume-beta/index.md` (1 occurrence)

### Issue

#53623 