### PR TITLE
[ko] Fix typos in training page

### DIFF
--- a/content/ko/training/_index.html
+++ b/content/ko/training/_index.html
@@ -45,7 +45,7 @@ menu:
         <h5>
           <b>쿠버네티스 소개 <br> &nbsp;</b>
         </h5>
-        <p>쿠버네티스를 배우고 싶습니까? 컨테이너화된 애플리케이션의 관리를 위한 이 강력한 시스템에 대해 심도있는 입문 교육을 받으세요.</p>
+        <p>쿠버네티스를 배우고 싶습니까? 컨테이너화된 애플리케이션의 관리를 위한 이 강력한 시스템에 대해 심도 있는 입문 교육을 받으세요.</p>
         <br>
         <a href="https://www.edx.org/course/introduction-to-kubernetes" target="_blank" class="button">강좌로 이동하기</a>
       </center>
@@ -65,7 +65,7 @@ menu:
         <h5>
           <b>리눅스 소개</b>
         </h5>
-        <p>리눅스를 배운 적이 없습니까? 새로 다시 배우기를 원하시나요? 주요 리눅스 배포판에 걸쳐서 그래픽 인터페이스와 커멘드 라인을 모두 사용할 수 있는 유용한 실무 지식을 개발하세요.</p>
+        <p>리눅스를 배운 적이 없습니까? 새로 다시 배우기를 원하시나요? 주요 리눅스 배포판에 걸쳐서 그래픽 인터페이스와 커맨드 라인을 모두 사용할 수 있는 유용한 실무 지식을 개발하세요.</p>
         <br>
         <a href="https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">강좌로 이동하기</a>
       </center>
@@ -110,7 +110,7 @@ menu:
           <h5>
             <b>공인 쿠버네티스 관리자(Certified Kubernetes Administrator, CKA)</b>
           </h5>
-          <p>공인 쿠버네티스 관리자(CKA) 프로그램은 CKA가 쿠버네티스 관리자 직무을 수행할 수 있는 기술, 지식과 역량을 갖추고 있음을 보장합니다.</p>
+          <p>공인 쿠버네티스 관리자(CKA) 프로그램은 CKA가 쿠버네티스 관리자 직무를 수행할 수 있는 기술, 지식과 역량을 갖추고 있음을 보장합니다.</p>
           <p>공인 쿠버네티스 관리자는 기본 설치를 수행하고 프로덕션 등급의 쿠버네티스 클러스터를 구성하고 관리하는 능력을 보여줍니다.</p>
           <br>
           <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">인증으로 이동하기</a>


### PR DESCRIPTION
### Description

This PR fixes typos in the Korean translation of training documentation.

Changes:
- 심도있는 → 심도 있는 (띄어쓰기)
- 커멘드 → 커맨드 (외래어 표기법 준수)
- 직무을 → 직무를 (조사 오타)