### PR TITLE
Clarify default same-namespace routing behavior for Gateway API

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -118,6 +118,10 @@ processing traffic of backend network endpoints defined in routes.
 See the [Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Gateway)
 reference for a full definition of this API kind.
 
+{{< note >}}
+By default, a Gateway only accepts Routes from the same namespace. Cross-namespace Routes require configuring `allowedRoutes`.
+{{< /note >}}
+
 ### HTTPRoute {#api-kind-httproute}
 
 The HTTPRoute kind specifies routing behavior of HTTP requests from a Gateway listener to backend network


### PR DESCRIPTION
This PR adds a brief Note to the Gateway conceptual page clarifying that
cross-namespace routing requires configuring `allowedRoutes`, as the default
behavior only permits same-namespace Routes.

Fixes #53256
