### PR TITLE
Added Schedule for v1.35

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,6 +4,15 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 schedules:
+- endOfLifeDate: "2027-02-28"
+  maintenanceModeStartDate: "2026-12-28"
+  next:
+    release: 1.35.1
+    cherryPickDeadline: "2026-01-09"
+    targetDate: "2026-01-13"
+  previousPatches: []
+  release: "1.35"
+  releaseDate: "2025-12-17"
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:


### PR DESCRIPTION
This PR adds 1.35 to the releases schedule for the 1.35.0 release.

/milestone 1.35
cc: @dipesh-rawat @drewhagen @katcosgrove @kubernetes/release-managers

It is the same as PR https://github.com/kubernetes/website/pull/53649 but targets _main_.