### PR TITLE
Update PVC claim name in pv-duplicate.yaml

### DIFF
--- a/content/en/examples/pods/storage/pv-duplicate.yaml
+++ b/content/en/examples/pods/storage/pv-duplicate.yaml
@@ -19,4 +19,4 @@ spec:
   volumes:
     - name: config
       persistentVolumeClaim:
-        claimName: task-pv-storage
+        claimName: task-pv-claim


### PR DESCRIPTION
the example is using pv name instead of pvc name under `persistentVolumeClaim`

https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#mounting-the-same-persistentvolume-in-two-places