### PR TITLE
Update content/ko/docs/contribute/participate/_index.md to match the English version …

### DIFF
--- a/content/ko/docs/contribute/participate/_index.md
+++ b/content/ko/docs/contribute/participate/_index.md
@@ -50,7 +50,7 @@ GitHub 팀과 OWNERS 파일이다.
 
 ### GitHub 팀
 
-GitHub의 SIG Docs [팀]에는 두 분류가 있다.
+GitHub의 SIG Docs [팀](https://github.com/orgs/kubernetes/teams?query=sig-docs)에는 두 분류가 있다.
 
 - 승인자와 리더를 위한 `@sig-docs-{language}-owners`
 - 리뷰어를 위한 `@sig-docs-{language}-reviews`


### PR DESCRIPTION

### Description

## What this PR does

Updates the Korean translation of `content/ko/docs/contribute/participate/_index.md` to match the latest English version.

### Changes
- Added missing hyperlink for the GitHub teams section: `[팀]` → `[팀](https://github.com/orgs/kubernetes/teams?query=sig-docs)`

This change ensures parity with the English version at `content/en/docs/contribute/participate/_index.md`.


/language ko
/area localization

### Issue

Closes: #53262