### PR TITLE
Kubernetes v1.35 restart all containers blog publish (Jan 5, 2026)

### DIFF
--- a/content/en/blog/_posts/2026-01-05-restart-all-containers.md
+++ b/content/en/blog/_posts/2026-01-05-restart-all-containers.md
@@ -2,7 +2,6 @@
 layout: blog
 title: "Kubernetes v1.35: New level of efficiency with in-place Pod restart"
 date: 2026-01-05T10:30:00-08:00
-
 slug: kubernetes-v1-35-restart-all-containers
 author: >
   [Yuan Wang](https://github.com/yuanwang04)


### PR DESCRIPTION
Schedule: https://github.com/kubernetes/website/pull/52895
Schedule date: Jan 05, 2026