### PR TITLE
Fix KCSA certification name in Kubestronaut section

### DIFF
--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -152,7 +152,7 @@ menu:
     <div class="call-to-action" id="cta-kubestronaut">
       <div class="cta-text">
         <h2>Kubestronaut Program: Elevate Your Kubernetes Expertise</h2>
-        <p> The CNCF's Kubestronaut Program celebrates and recognizes exceptional community leaders who have demonstrated a profound commitment to mastering Kubernetes. This prestigious initiative highlights individuals who have consistently invested in their ongoing education and achieved the highest levels of proficiency. To earn the esteemed title of Kubestronaut, individuals must successfully obtain and maintain all five CNCF Kubernetes certifications: Certified Kubernetes Administrator (CKA), Certified Kubernetes Application Developer (CKAD), Certified Kubernetes Security Specialist (CKS), Kubernetes and Cloud Native Associate (KCNA), and Kubernetes and Cloud Security Associate (KCSA). </p>
+        <p> The CNCF's Kubestronaut Program celebrates and recognizes exceptional community leaders who have demonstrated a profound commitment to mastering Kubernetes. This prestigious initiative highlights individuals who have consistently invested in their ongoing education and achieved the highest levels of proficiency. To earn the esteemed title of Kubestronaut, individuals must successfully obtain and maintain all five CNCF Kubernetes certifications: Certified Kubernetes Administrator (CKA), Certified Kubernetes Application Developer (CKAD), Certified Kubernetes Security Specialist (CKS), Kubernetes and Cloud Native Associate (KCNA), and Kubernetes and Cloud Native Security Associate (KCSA). </p>
       </div>
       <div class="cta-img-container">
         <div class="logo-certification cta-image" id="logo-kubestronaut">


### PR DESCRIPTION
## Summary
- Fix typo in Kubestronaut section: "Kubernetes and Cloud Security Associate (KCSA)" → "Kubernetes and Cloud Native Security Associate (KCSA)"
- The word "Native" was missing from the KCSA certification name
- This matches the official certification name used in the Get Kubernetes Certified section of the same page

## Details
In the Kubestronaut Program section (line 155), the KCSA certification was incorrectly listed as "Kubernetes and Cloud Security Associate" instead of "Kubernetes and Cloud Native Security Associate".

The correct name is used in the certification section (line 109) of the same file.