### PR TITLE
Update "data/releases/schedule.yaml" for Dec 2025 patches

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,15 +7,17 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    release: 1.35.1
     cherryPickDeadline: "2026-01-09"
+    release: 1.35.1
     targetDate: "2026-01-13"
-  previousPatches: []
   release: "1.35"
   releaseDate: "2025-12-17"
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
-  next: {}
+  next:
+    cherryPickDeadline: "2026-01-09"
+    release: 1.34.4
+    targetDate: "2026-01-13"
   previousPatches:
   - cherryPickDeadline: "2025-12-05"
     release: 1.34.3
@@ -34,10 +36,13 @@ schedules:
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2025-12-05"
+    cherryPickDeadline: "2026-01-09"
+    release: 1.33.8
+    targetDate: "2026-01-13"
+  previousPatches:
+  - cherryPickDeadline: "2025-12-05"
     release: 1.33.7
     targetDate: "2025-12-09"
-  previousPatches:
   - cherryPickDeadline: "2025-11-07"
     note: October 2025 patches consolidated with November
     release: 1.33.6
@@ -62,10 +67,13 @@ schedules:
 - endOfLifeDate: "2026-02-28"
   maintenanceModeStartDate: "2025-12-28"
   next:
-    cherryPickDeadline: "2025-12-05"
+    cherryPickDeadline: "2026-01-09"
+    release: 1.32.12
+    targetDate: "2026-01-13"
+  previousPatches:
+  - cherryPickDeadline: "2025-12-05"
     release: 1.32.11
     targetDate: "2025-12-09"
-  previousPatches:
   - cherryPickDeadline: "2025-11-07"
     note: October 2025 patches consolidated with November
     release: 1.32.10
@@ -102,9 +110,9 @@ schedules:
   release: "1.32"
   releaseDate: "2024-12-11"
 upcoming_releases:
-- cherryPickDeadline: "2025-12-05"
-  targetDate: "2025-12-09"
 - cherryPickDeadline: "2026-01-09"
   targetDate: "2026-01-13"
 - cherryPickDeadline: "2026-02-06"
   targetDate: "2026-02-10"
+- cherryPickDeadline: "2026-03-06"
+  targetDate: "2026-03-10"


### PR DESCRIPTION
Closes : #53692

Changes made:

Moved 1.34.3 from next → previousPatches
Updated next for 1.34 to be empty (next: {}) to indicate no upcoming patch is currently scheduled
