### PR TITLE
docs: clarify components tracked for local ephemeral storage monitoring

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -343,6 +343,17 @@ configuring the requests and/or limits of ephemeral storage for a container,
 please check the [local ephemeral storage](/docs/concepts/storage/ephemeral-storage/)
 page.
 
+### Resource monitoring for local ephemeral storage
+
+The kubelet can measure how much local ephemeral storage is being used. It 
+does this as long as you have enabled local ephemeral storage capacity isolation.
+
+Kubernetes tracks the amount of ephemeral storage a Pod uses from the following:
+* Writing to the container's writable layer (rootfs), container images, or both.
+* Writing to local `emptyDir` volumes.
+* The Pod's own logs (usually stored under `/var/log/pods`).
+* System files managed by Kubernetes that are mapped into the Pod, such as `/etc/hosts`.
+
 ## Extended resources
 
 Extended resources are fully-qualified resource names outside the


### PR DESCRIPTION
### Description
This PR addresses #51114 by explicitly documenting the components that the kubelet tracks for local ephemeral storage monitoring and eviction. 

Based on the technical gap identified in the issue, I have added a section clarifying that the following are included in storage limit enforcement:
* Container writable layers (rootfs)
* `emptyDir` volumes
* Pod logs
* Internal metadata (such as `/etc/hosts`)

This information helps users understand why a Pod might be evicted even if they haven't explicitly requested large volumes.

### Related Issue
Fixes #51114

/sig docs
/sig node
/kind feature