### PR TITLE
[ja] Update content/ja/docs/reference/glossary/kubelet.md

### DIFF
--- a/content/ja/docs/reference/glossary/kubelet.md
+++ b/content/ja/docs/reference/glossary/kubelet.md
@@ -2,16 +2,18 @@
 title: Kubelet
 id: kubelet
 date: 2018-04-12
-full_link: /docs/reference/generated/kubelet
+full_link: /docs/reference/command-line-tools-reference/kubelet
 short_description: >
-  クラスター内の各ノードで実行されるエージェントです。各コンテナがPodで実行されていることを保証します。
+  クラスター内の各ノードで実行されるエージェント。コンテナがPod内で実行されていることを保証します。
 
-aka: 
+aka:
 tags:
 - fundamental
-- core-object
 ---
- クラスター内の各{{< glossary_tooltip text="ノード" term_id="node" >}}で実行されるエージェントです。各{{< glossary_tooltip text="コンテナ" term_id="container" >}}が{{< glossary_tooltip text="Pod" term_id="pod" >}}で実行されていることを保証します。
+ クラスター内の各{{< glossary_tooltip text="ノード" term_id="node" >}}上で実行されるエージェント。
+ {{< glossary_tooltip text="コンテナ" term_id="container" >}}が{{< glossary_tooltip text="Pod" term_id="pod" >}}内で実行されていることを保証します。
 
 <!--more-->
-kubeletは、さまざまなメカニズムを通じて提供されるPodSpecのセットを取得し、それらのPodSpecに記述されているコンテナが正常に実行されている状態を保証します。kubeletは、Kubernetesが作成したものではないコンテナは管理しません。
+
+[kubelet](/docs/reference/command-line-tools-reference/kubelet/)は、さまざまなメカニズムを通じて提供される一連のPodSpecを受け取り、そのPodSpecに記述されたコンテナが実行され、正常であることを保証します。
+kubeletは、Kubernetesによって作成されていないコンテナを管理しません。


### PR DESCRIPTION
### Description

Updated Japanese translation: `content/ja/docs/reference/glossary/kubelet.md`.

**Website Link**:

- Japanese: https://kubernetes.io/ja/docs/reference/glossary/?fundamental=true&core-object=true#term-kubelet
- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-kubelet


### Issue

Closes: #53711 

/area localization
/language ja
