### PR TITLE
[en] Update tasks/configure-pod-container/resize-pod-resources.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/resize-pod-resources.md
+++ b/content/en/docs/tasks/configure-pod-container/resize-pod-resources.md
@@ -1,5 +1,5 @@
 ---
-title: Resize CPU and Memory Resources assigned to Containers
+title: Resize CPU and Memory Resources assigned to Pods
 content_type: task
 weight: 30
 min-kubernetes-server-version: 1.35
@@ -56,7 +56,7 @@ Pod-level resource resize does not support or require its own restart policy.
 
 ## Limitations
 
-For Kubernetes {{< skew currentVersion >}}, resizing Pod-level resources in-place is subject to all the limitations described for container-level resource resize, which you can find here: (Resize CPU and Memory Resources assigned to Containers: Limitations)[docs/tasks/configure-pod-container/resize-container-resources/#limitations].
+For Kubernetes {{< skew currentVersion >}}, resizing Pod-level resources in-place is subject to all the limitations described for container-level resource resize, which you can find here: [Resize CPU and Memory Resources assigned to Containers: Limitations](/docs/tasks/configure-pod-container/resize-container-resources/#limitations).
 
 Additionally, the following constraint is specific to Pod-level resource resize:
 * Container Requests Validation: A resize is only permitted if the resulting


### PR DESCRIPTION
### Description

This PR proposes the following changes to the page https://kubernetes.io/docs/tasks/configure-pod-container/resize-pod-resources/:

**1. Title change**

Changed the title from:

> Resize CPU and Memory Resources assigned to Containers

to:

> Resize CPU and Memory Resources assigned to Pods

This change was made because the content is about Pod-level resources, and there is already another page (https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/) that correctly addresses container-level resource resizing.

- Pod-level (repo): `content/en/docs/tasks/configure-pod-container/resize-pod-resources.md`
- Container-level (repo): `content/en/docs/tasks/configure-pod-container/resize-container-resources.md`

**2. Fixed inline link in the Limitations section**

`[Resize CPU and Memory Resources assigned to Containers: Limitations](/docs/tasks/configure-pod-container/resize-container-resources/#limitations)`

### Issue

Closes: #53738