### PR TITLE
Docs: Clarify health check endpoint behaviors and add probe reference

### DIFF
--- a/content/en/docs/reference/using-api/health-checks.md
+++ b/content/en/docs/reference/using-api/health-checks.md
@@ -20,6 +20,12 @@ The `livez` endpoint can be used with the `--livez-grace-period` [flag](/docs/re
 For a graceful shutdown you can specify the `--shutdown-delay-duration` [flag](/docs/reference/command-line-tools-reference/kube-apiserver) with the `/readyz` endpoint.
 Machines that check the `healthz`/`livez`/`readyz` of the API server should rely on the HTTP status code.
 A status code `200` indicates the API server is `healthy`/`live`/`ready`, depending on the called endpoint.
+
+These endpoints align with how Kubernetes [HTTP probes](/docs/concepts/configuration/liveness-readiness-startup-probes/) function:
+
+* **livez**: Use this to determine if the API server should be restarted. If `/livez` returns a failure status code (such as 500), the API server is likely in a non-recoverable state, such as a deadlock, and requires a restart.
+* **readyz**: Use this to determine if the API server is ready to accept traffic. If `/readyz` returns a failure status code, it indicates the server is still initializing or temporarily unable to serve requests (for example, waiting for etcd to be available), and traffic should be routed away from it.
+
 The more verbose options shown below are intended to be used by human operators to debug their cluster or understand the state of the API server.
 
 The following examples will show how you can interact with the health API endpoints.


### PR DESCRIPTION
### Description
This PR clarifies the semantic definitions of the `/livez` and `/readyz` endpoints as requested in #53657. It explicitly defines when an operator should restart a process versus routing traffic away and adds a cross-reference link to the standard Kubernetes HTTP probes conceptual page.

### Related Issue
Fixes #53657

### Types of changes
- [x] Documentation improvement (non-breaking change)

### Checklist
- [x] The title of this PR is descriptive and follows the Kubernetes contribution guidelines.
- [x] I have updated the documentation accordingly.