### PR TITLE
docs: remove legacy RC reference from HPA diagram

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -52,7 +52,7 @@ graph BT
 
 hpa[HorizontalPodAutoscaler] --> scale[Scale]
 
-subgraph rc[RC / Deployment]
+subgraph rc[Deployment]
     scale
 end
 


### PR DESCRIPTION
This PR updates the Mermaid diagram in the Horizontal Pod Autoscaler concept page. It removes the reference to "RC" (ReplicationController) from the diagram node label, as ReplicationController is a legacy API

Closes: #53755