### PR TITLE
Fix link in workload aware scheduling blog post

### DIFF
--- a/content/en/blog/_posts/2025-12-29-gang-scheduling.md
+++ b/content/en/blog/_posts/2025-12-29-gang-scheduling.md
@@ -130,7 +130,7 @@ disables the batching mechanism for those Pods to ensure correctness.
 Note that you may need to review your `kube-scheduler` configuration
 to ensure it is not implicitly disabling batching for your workloads.
 
-See the [docs](/docs/concepts/scheduling-eviction/gang-scheduling/) for more details about restrictions.
+See the [docs](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/#enabling-opportunistic-batching) for more details about restrictions.
 
 ## The north star vision
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Fixes a link in workload aware scheduling blog post, pointing to a proper opportunistic batching site.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #