### PR TITLE
Remove deprecated flag --cpu-percent & set correct flag --cpu=50% in HPA walkthrough

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -100,7 +100,7 @@ on the algorithm.
 Create the HorizontalPodAutoscaler:
 
 ```shell
-kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
+kubectl autoscale deployment php-apache --cpu=50% --min=1 --max=10
 ```
 
 ```


### PR DESCRIPTION
Flag --cpu-percent has been deprecated, Use --cpu with percentage or resource quantity format (e.g., '70%' for utilization or '500m' for milliCPU).

Use `cpu=50%` so it matches the rest of the walkthrough.