### PR TITLE
Set output of shell command correct

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1751,8 +1751,8 @@ kubectl get shirts.stable.example.com --field-selector spec.color=green,spec.siz
 Should output:
 
 ```
-NAME       COLOR  SIZE
-example2   blue   M
+NAME       COLOR   SIZE
+example3   green   M
 ```
 
 ### Subresources


### PR DESCRIPTION
The output of `kubectl get shirts.stable.example.com --field-selector spec.color=green,spec.size=M` is:
```
NAME       COLOR   SIZE
example3   green   M
```