### PR TITLE
Change navbar-lang-selector behavior

### DIFF
--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -8,6 +8,11 @@
   }
 }
 
+// Hidden in dropdowns, visible when cloned into the mobile push menu
+.dropdown-menu .lang-pushmenu-only {
+  display: none;
+}
+
 /* Gutter for sidebar splitter */
 .gutter {
   background-color: #eee;

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -465,6 +465,9 @@ other = "This article is more than one year old. Older articles may contain outd
 [page_deprecated]
 other = "(stale page)"
 
+[page_not_available_in_language]
+other = "This page is not available in {{ .Language }}"
+
 [parentoptions_heading]
 other = "Parent Options Inherited"
 

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,10 +1,39 @@
-{{/* Link directly to documentation etc., if possible. */}}
-{{ $langPage := cond (gt (len .Translations) 0) . .Site.Home }}
+<!-- TODO: This file overrides the language selector behavior.
+     The motivation for this improvement is addressed upstream in Docsy 0.13.0
+     (google/docsy#2303).
+     When upgrading to Docsy 0.13.0, this file should be revisited and,
+     if possible, simplified to align with the default upstream configuration.
+     See: https://github.com/google/docsy/pull/2303
+     Related PR: https://github.com/kubernetes/website/pull/53804 -->
+{{ $currentLang := .Language.Lang }}
+{{ $translationMap := dict }}
+{{ range .Translations }}
+  {{ $translationMap = merge $translationMap (dict .Language.Lang .) }}
+{{ end }}
+{{ $homeMap := dict }}
+{{ range .Site.Home.Translations }}
+  {{ $homeMap = merge $homeMap (dict .Language.Lang .) }}
+{{ end }}
 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	{{ $langPage.Language.LanguageName }}
+	{{ .Language.LanguageName }}
 </a>
 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
-	{{ range $langPage.Translations }}
-	<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+	{{ range site.Languages }}
+		{{ if ne .Lang $currentLang }}
+			{{ with index $translationMap .Lang }}
+				<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+			{{ end }}
+		{{ end }}
+	{{ end }}
+	{{ range site.Languages }}
+		{{ if and (ne .Lang $currentLang) (not (index $translationMap .Lang)) }}
+			<span class="dropdown-item-text text-muted" title="{{ T "page_not_available_in_language" (dict "Language" .LanguageName) }}">
+				{{ .LanguageName }}
+				{{ with index $homeMap .Lang }}
+					<a href="{{ .RelPermalink }}" class="ml-1" data-auto-burger-exclude><i class="fas fa-home fa-xs"></i></a>
+					<a class="dropdown-item lang-pushmenu-only text-muted" href="{{ .RelPermalink }}">{{ .Language.LanguageName }} <i class="fas fa-home fa-xs text-primary"></i></a>
+				{{ end }}
+			</span>
+		{{ end }}
 	{{ end }}
 </div>


### PR DESCRIPTION
### Description

The current `navbar-lang-selector` behavior lists all languages in the dropdown even when no translations are available for the current page. When a user selects a language, they are redirected to that language's home page instead of a translated version of the current page.
This misleads users into thinking translations exist for the page, and they only discover it's a fallback behavior after being redirected to the home page.

#### Proposed changes in this PR:

- Available languages (with translations for the current page) are listed first with default formatting
- Remaining languages (available on other pages but not the current one) are listed afterward, greyed out, with a home icon that links to the site's landing page in the corresponding language

Repo files: 

- `/layouts/partials/navbar-lang-selector.html`
- `/assets/scss/_k8s_sidebar-tree.scss`
- `/i18n/en/en.toml`

#### Example pages with current behavior:

- https://kubernetes.io/docs/tasks/debug/debug-cluster/topology/ (EN only at this time)
- https://kubernetes.io/docs/reference/kubectl/ (currently lists only languages that have a localized version of the page)

### Issue

Closes: #53803