### PR TITLE
[ja] Translate content/ja/docs/concepts/workloads/workload-api/policies.md into Japanese

### DIFF
--- a/content/ja/docs/concepts/workloads/workload-api/policies.md
+++ b/content/ja/docs/concepts/workloads/workload-api/policies.md
@@ -37,7 +37,7 @@ policy:
 
 これは、すべてのワーカーが同時に実行されなければ処理が進まない[Job](/docs/concepts/workloads/controllers/job/)や、その他のバッチ処理に使用できます。
 
-`gang`ポリシーには`minCount`パラメータが必要です:
+`gang`ポリシーには`minCount`パラメーターが必要です:
 
 ```yaml
 policy:


### PR DESCRIPTION
### Description

Translated `content/en/docs/concepts/workloads/workload-api/policies.md` into Japanese: `content/ja/docs/concepts/workloads/workload-api/policies.md`.

**Website Link**:

- English: https://kubernetes.io/docs/concepts/workloads/workload-api/policies/


### Issue

Closes: #53821

/area localization
/language ja
