### PR TITLE
[ja] Translate content/ja/docs/concepts/workloads/workload-api/_index.md into Japanese

### DIFF
--- a/content/ja/docs/concepts/workloads/workload-api/_index.md
+++ b/content/ja/docs/concepts/workloads/workload-api/_index.md
@@ -60,6 +60,6 @@ spec:
 
 ## {{% heading "whatsnext" %}}
 
-* PodでWorkloadを[参照する方法](/docs/concepts/workloads/pods/workload-reference/)を確認する。
+* Podで[Workloadを参照する方法](/docs/concepts/workloads/pods/workload-reference/)を確認する。
 * [Podグループポリシー](/docs/concepts/workloads/workload-api/policies/)について学ぶ。
 * [gangスケジューリング](/docs/concepts/scheduling-eviction/gang-scheduling/)アルゴリズムについて読む。


### PR DESCRIPTION
### Description

Translated `content/en/docs/concepts/workloads/workload-api/_index.md` into Japanese: `content/ja/docs/concepts/workloads/workload-api/_index.md`.

**Website Link**:

- English: https://kubernetes.io/docs/concepts/workloads/workload-api/


### Issue

Closes: #53822 

/area localization
/language ja
