### PR TITLE
Fix broken anchor link in v1.35 release blog post

### DIFF
--- a/content/en/blog/_posts/2025-12-17-kubernetes-v1-35-release/index.md
+++ b/content/en/blog/_posts/2025-12-17-kubernetes-v1-35-release/index.md
@@ -14,7 +14,7 @@ Similar to previous releases, the release of Kubernetes v1.35 introduces new sta
 
 This release consists of 60 enhancements, including 17 stable, 19 beta, and 22 alpha features.
 
-There are also some [deprecations and removals](#deprecations-and-removals) in this release; make sure to read about those.
+There are also some [deprecations and removals](#deprecations-removals-and-community-updates) in this release; make sure to read about those.
 
 ## Release theme and logo
 


### PR DESCRIPTION
### Description

Fixed a broken anchor link in the Kubernetes v1.35 release blog post.
The link `#deprecations-and-removals` has been corrected to `#deprecations-removals-and-community-updates` to match the actual heading ID on the page.

### Issue

Closes: #53842