### PR TITLE
mutating-admission-policy.md - Grammar

### DIFF
--- a/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
@@ -13,7 +13,7 @@ content_type: concept
 <!-- due to feature gate history, use manual version specification here -->
 
 This page provides an overview of _MutatingAdmissionPolicies_.
-MutatingAdmissionPolicies allow you change what happens when someone writes a change to the Kubernetes API.
+MutatingAdmissionPolicies allow you to change what happens when someone writes a change to the Kubernetes API.
 If you want to use declarative policies just to prevent a particular kind of change to resources (for example: protecting platform namespaces from deletion),
 [ValidatingAdmissionPolicy](/docs/reference/access-authn-authz/validating-admission-policy/)
 is


### PR DESCRIPTION
### Description
Quick grammar change to [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/)
