### PR TITLE
[ja] Translate content/ja/docs/concepts/scheduling-eviction/gang-scheduling.md into Japanese

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/gang-scheduling.md
+++ b/content/ja/docs/concepts/scheduling-eviction/gang-scheduling.md
@@ -15,7 +15,7 @@ Gangスケジューリングは、Podのグループを「全か無か」の原�
 
 <!-- body -->
 
-## 動作の仕組み {##how-it-works}
+## 動作の仕組み {#how-it-works}
 
 `GangScheduling`プラグインが有効な場合、スケジューラーは[Workload](/docs/concepts/workloads/workload-api/)内の`gang` [Podグループポリシー](/docs/concepts/workloads/workload-api/policies/)に属するPodのライフサイクルを変更します。
 このプロセスは、各Podグループとそのレプリカキーごとに独立して実行されます:


### PR DESCRIPTION
### Description

Translated `content/en/docs/concepts/scheduling-eviction/gang-scheduling.md` into Japanese: `content/ja/docs/concepts/scheduling-eviction/gang-scheduling.md`.

**Website Link**:

- English: https://kubernetes.io/docs/concepts/scheduling-eviction/gang-scheduling/


### Issue

Closes: #53824

/area localization
/language ja
