### PR TITLE
[ko] Update source-ip doc in tutorial

### DIFF
--- a/content/ko/docs/tutorials/services/source-ip.md
+++ b/content/ko/docs/tutorials/services/source-ip.md
@@ -26,7 +26,7 @@ weight: 40
 페이지로 연결한다.
 {{< /comment >}}
 
-[NAT]https://ko.wikipedia.org/wiki/%EB%84%A4%ED%8A%B8%EC%9B%8C%ED%81%AC_%EC%A3%BC%EC%86%8C_%EB%B3%80%ED%99%98)
+[NAT](https://ko.wikipedia.org/wiki/%EB%84%A4%ED%8A%B8%EC%9B%8C%ED%81%AC_%EC%A3%BC%EC%86%8C_%EB%B3%80%ED%99%98)
 : 네트워크 주소 변환
 
 [소스 NAT](https://ko.wikipedia.org/wiki/%EB%84%A4%ED%8A%B8%EC%9B%8C%ED%81%AC_%EC%A3%BC%EC%86%8C_%EB%B3%80%ED%99%98#SNAT)
@@ -59,7 +59,6 @@ kubectl create deployment source-ip-app --image=registry.k8s.io/echoserver:1.10
 ```
 deployment.apps/source-ip-app created
 ```
-
 
 
 ## {{% heading "objectives" %}}


### PR DESCRIPTION
### Description

Update the doc with the following details:
1. Wikipedia link from English to Korean per comment guide
2. Translate a note which is not in Korean doc
3. sync empty lines with English doc
4. Deleting "/ko" part for K8s doc links per new rendering functionality


### Issue


Closes: #53875