### PR TITLE
Fix endpointslices API group in RBAC documentation

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -297,7 +297,10 @@ metadata:
 # the rules below will be added to the "monitoring" ClusterRole.
 rules:
 - apiGroups: [""]
-  resources: ["services", "endpointslices", "pods"]
+  resources: ["services", "pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
   verbs: ["get", "list", "watch"]
 ```
 

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -290,10 +290,10 @@ ClusterRole labeled `rbac.example.com/aggregate-to-monitoring: true`.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: monitoring-endpoints
+  name: monitoring-endpointslices
   labels:
     rbac.example.com/aggregate-to-monitoring: "true"
-# When you create the "monitoring-endpoints" ClusterRole,
+# When you create the "monitoring-endpointslices" ClusterRole,
 # the rules below will be added to the "monitoring" ClusterRole.
 rules:
 - apiGroups: [""]


### PR DESCRIPTION
### Description

Fixed the `endpointslices` resource API group in the RBAC documentation.

The `endpointslices` resource was incorrectly shown in the core API group 
(`apiGroups: [""]`) along with `services` and `pods` in the "Aggregated 
ClusterRoles" example. EndpointSlices actually belong to the 
`discovery.k8s.io` API group.

This PR corrects the example by splitting the rules into two separate entries:
- Core API group (`apiGroups: [""]`) for `services` and `pods`
- Discovery API group (`apiGroups: ["discovery.k8s.io"]`) for `endpointslices`

This ensures the documentation provides accurate and working RBAC examples.

### Issue

Closes: #53857
