### PR TITLE
Fix typos in English documentation

### DIFF
--- a/content/en/blog/_posts/2019-03-15-Kubernetes-setup-using-Ansible-and-Vagrant.md
+++ b/content/en/blog/_posts/2019-03-15-Kubernetes-setup-using-Ansible-and-Vagrant.md
@@ -109,7 +109,7 @@ We will be installing the following packages, and then adding a user named “va
       repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
       state: present
 
-  - name: Install docker and its dependecies
+  - name: Install docker and its dependencies
     apt: 
       name: "{{ packages }}"
       state: present

--- a/content/en/blog/_posts/2019-03-19-kubeedge-k8s-based-edge-intro.md
+++ b/content/en/blog/_posts/2019-03-19-kubeedge-k8s-based-edge-intro.md
@@ -29,7 +29,7 @@ It started with its v0.1 providing the basic edge computing features. Now, with 
   - [SourceCode](https://github.com/kubeedge/kubeedge)
   - [Documentation](https://docs.kubeedge.io)
 
-Based on its roadmap and architecture, KubeEdge tries to support all edge nodes, applications, devices and even the cluster management consistent with the Kuberenetes interface. This will help the edge cloud act exactly like a cloud cluster. This can save a lot of time and cost on the edge cloud development deployment based on KubeEdge.
+Based on its roadmap and architecture, KubeEdge tries to support all edge nodes, applications, devices and even the cluster management consistent with the Kubernetes interface. This will help the edge cloud act exactly like a cloud cluster. This can save a lot of time and cost on the edge cloud development deployment based on KubeEdge.
 
 KubeEdge provides a containerized edge computing platform, which is inherently scalable. As it's modular and optimized, it is lightweight (66MB foot print and ~30MB running memory) and could be deployed on low resource devices. Similarly, the edge node can be of different hardware architecture and with different hardware configurations. For the device connectivity, it can support multiple protocols and it uses a standard MQTT-based communication. This helps in scaling the edge clusters with new nodes and devices efficiently. 
 
@@ -38,7 +38,7 @@ KubeEdge provides a containerized edge computing platform, which is inherently s
 
 By open sourcing both the edge and cloud modules, KubeEdge brings a complete cloud vendor agnostic lightweight heterogeneous edge computing platform. It is now ready to support building a complete Kubernetes ecosystem for edge computing, exploiting most of the existing cloud native projects or software modules. This can enable a mini-cloud at the edge to support demanding use cases like data analytics, video analytics, machine learning and more.
 
-## KubeEdge Architecture: Building Kuberenetes Native Edge computing!
+## KubeEdge Architecture: Building Kubernetes Native Edge computing!
 
 The core architecture tenet for KubeEdge is to build interfaces that are consistent with Kubernetes, be it on the cloud side or edge side. 
 

--- a/content/en/blog/_posts/2023-05-05-memory-qos-cgroups-v2/index.md
+++ b/content/en/blog/_posts/2023-05-05-memory-qos-cgroups-v2/index.md
@@ -201,7 +201,7 @@ If a container has no memory limits specified, `limits.memory` is substituted fo
 container, pod, and node level cgroups.
 {{< /note >}}
 
-### `memory.min` calculations for cgroups heirarchy
+### `memory.min` calculations for cgroups hierarchy
 
 When container memory requests are made, kubelet passes `memory.min` to the back-end 
 CRI runtime (such as containerd or CRI-O) via the `Unified` field in CRI during 

--- a/content/en/blog/_posts/2024-04-17-kubernetes-1.30.md
+++ b/content/en/blog/_posts/2024-04-17-kubernetes-1.30.md
@@ -214,7 +214,7 @@ From the v1.27 release, Kubernetes already included an optimization that sets SE
 contents of volumes, using only constant time. Kubernetes achieves that speed up using a mount
 option. The slower legacy behavior requires the container runtime to recursively walk through the
 whole volumes and apply SELinux labelling individually to each file and directory; this is
-especially noticable for volumes with large amount of files and directories.
+especially noticeable for volumes with large amount of files and directories.
 
 Kubernetes v1.27 graduated this feature as beta, but limited it to ReadWriteOncePod volumes. The
 corresponding feature gate is `SELinuxMountReadWriteOncePod`. It's still enabled by default and

--- a/content/en/blog/_posts/2024-08-13-Kubernetes-v1-31-Release.md
+++ b/content/en/blog/_posts/2024-08-13-Kubernetes-v1-31-Release.md
@@ -246,7 +246,7 @@ See the Kubernetes [deprecation and removal policy](/docs/reference/using-api/de
 
 As Kubernetes continues to evolve and adapt to the changing landscape of container orchestration, the community has decided to move cgroup v1 support into maintenance mode in v1.31.
 This shift aligns with the broader industry's move towards [cgroup v2](/docs/concepts/architecture/cgroups/), offering improved functionality, scalability, and a more consistent interface. 
-Kubernetes maintance mode means that no new features will be added to cgroup v1 support. 
+Kubernetes maintenance mode means that no new features will be added to cgroup v1 support. 
 Critical security fixes will still be provided, however, bug-fixing is now best-effort, meaning major bugs may be fixed if feasible, but some issues might remain unresolved.
 
 It is recommended that you start switching to use cgroup v2 as soon as possible. 

--- a/content/en/blog/_posts/2024-12-11-Kubernetes-v1-32-Release/index.md
+++ b/content/en/blog/_posts/2024-12-11-Kubernetes-v1-32-Release/index.md
@@ -387,7 +387,7 @@ Last but not least a big thanks goes to all the release members - leads and shad
 for the terrific work and outcome achieved during these 14 weeks of release work:
 
 - [SIG Docs](https://github.com/kubernetes/community/tree/master/sig-docs) - for the fundamental support in docs and
-blog reviews and continous collaboration with release Comms and Docs;
+blog reviews and continuous collaboration with release Comms and Docs;
 - [SIG k8s Infra](https://github.com/kubernetes/community/tree/master/sig-k8s-infra) and [SIG
 Testing](https://github.com/kubernetes/community/tree/master/sig-testing) - for the outstanding work in keeping the
 testing framework in check, along with all the infra components necessary;

--- a/content/en/blog/_posts/2025-05-14-Container-Stop-Signals.md
+++ b/content/en/blog/_posts/2025-05-14-Container-Stop-Signals.md
@@ -40,7 +40,7 @@ If a container has a custom stop signal defined in its lifecycle, the container 
 
 ### Version skew
 
-For the feature to work as intended, both the versions of Kubernetes and the container runtime should support container stop signals. The changes to the Kuberentes API and kubelet are available in alpha stage from v1.33, which can be enabled with the `ContainerStopSignals` feature gate. The container runtime implementations for containerd and CRI-O are still a work in progress and will be rolled out soon.
+For the feature to work as intended, both the versions of Kubernetes and the container runtime should support container stop signals. The changes to the Kubernetes API and kubelet are available in alpha stage from v1.33, which can be enabled with the `ContainerStopSignals` feature gate. The container runtime implementations for containerd and CRI-O are still a work in progress and will be rolled out soon.
 
 ### Using container stop signals
 

--- a/content/en/blog/_posts/2025-07-03-devices-failure-handling/index.md
+++ b/content/en/blog/_posts/2025-07-03-devices-failure-handling/index.md
@@ -377,7 +377,7 @@ restart the failed step. The most efficient way to achieve this generally is to
 reuse as many Pods as possible by restarting them in-place, while replacing the
 failed pod to clear up the error from it. Like demonstrated in this picture:
 
-{{< figure src="inplace-pod-restarts.svg" alt="The picture shows 512 pod, most ot them are green and have a recycle sign next to them indicating that they can be reused, and one Pod drawn in red, and a new green replacement Pod next to it indicating that it needs to be replaced." >}}
+{{< figure src="inplace-pod-restarts.svg" alt="The picture shows 512 pod, most of them are green and have a recycle sign next to them indicating that they can be reused, and one Pod drawn in red, and a new green replacement Pod next to it indicating that it needs to be replaced." >}}
 
 It is possible to implement this scenario, but all solutions implementing it are
 fragile due to lack of certain extension points in Kubernetes. Adding these

--- a/content/en/blog/_posts/2025-10-05-gateway-api-1.4/index.md
+++ b/content/en/blog/_posts/2025-10-05-gateway-api-1.4/index.md
@@ -138,7 +138,7 @@ This creates a strong, verifiable link between an implementation's declared capa
 making it easier for implementers to run the correct conformance tests and for users to trust the conformance reports.
 
 This means when the SupportedFeatures field is populated in the GatewayClass status there will be no need for additional
-conformance tests flags like `–suported-features`, or `–exempt` or `–all-features`.
+conformance tests flags like `–supported-features`, or `–exempt` or `–all-features`.
 It's important to note that Mesh features are an exception to this and can be tested for conformance by using
 _Conformance Profiles_, or by manually providing any combination of features related flags until the dedicated resource
 graduates from the experimental channel.

--- a/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -188,10 +188,10 @@ Also, to enable this feature, the scheduler configuration needs to:
 to `true` to make the batching more efficient
 
 Note that whenever:
-1. Exisiting pods use pod affinity constraints that match any of the scheduled pods' labels, the feature may bring no benefit
+1. Existing pods use pod affinity constraints that match any of the scheduled pods' labels, the feature may bring no benefit
 1. Custom plugins are used, they need to implement the Signature extension point
 
-The restrictions and conditions are expected to evolve in furutre releases.
+The restrictions and conditions are expected to evolve in future releases.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -791,7 +791,7 @@ which can be surfaced to running containers using the
 [Downward API](docs/concepts/workloads/pods/downward-api/).
 The labels available as a result of this controller are the
 [topology.kubernetes.io/region](docs/reference/labels-annotations-taints/#topologykubernetesioregion) and
-[topology.kuberentes.io/zone](docs/reference/labels-annotations-taints/#topologykubernetesiozone) labels.
+[topology.kubernetes.io/zone](docs/reference/labels-annotations-taints/#topologykubernetesiozone) labels.
 
 {{<note>}}
 If any mutating admission webhook adds or modifies labels of the `pods/binding` subresource,

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -1151,7 +1151,7 @@ The certificate key is a hex encoded string that is an AES key of size 32 bytes.
 <td>(Members of <code>ImageMeta</code> are embedded into this type.)
    <p>ImageMeta allows to customize the container image used for etcd.
 Passing a custom etcd image tells <code>kubeadm upgrade</code> that this image is user-managed
-and taht its upgrade must be skipped.</p>
+and that its upgrade must be skipped.</p>
 </td>
 </tr>
 <tr><td><code>dataDir</code> <B>[Required]</B><br/>

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -907,7 +907,7 @@ PersistentVolumeStatus is the current status of a persistent volume.
 
 - **lastPhaseTransitionTime** (Time)
 
-  lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions.
+  lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time every time a volume phase transitions.
 
   <a name="Time"></a>
   *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*


### PR DESCRIPTION
### Description

Fix 15 spelling errors across English documentation and blog posts:

- taht → that (kubeadm-config.v1beta3.md)
- noticable → noticeable (kubernetes-1.30.md)
- ot → of (devices-failure-handling)
- everytime → every time (persistent-volume-v1.md)
- continous → continuous (v1-32-Release)
- heirarchy → hierarchy (memory-qos-cgroups-v2)
- kuberentes → kubernetes (admission-controllers.md)
- Exisiting → Existing (scheduler-perf-tuning.md)
- furutre → future (scheduler-perf-tuning.md)
- suported → supported (gateway-api-1.4)
- Kuberentes → Kubernetes (Container-Stop-Signals.md)
- maintance → maintenance (v1-31-Release.md)
- Kuberenetes → Kubernetes (kubeedge-k8s-based-edge-intro.md)
- dependecies → dependencies (Kubernetes-setup-using-Ansible-and-Vagrant.md)

### Issue

None - discovered via automated typo search.

/kind documentation