### PR TITLE
Change defaultValue of WatchListClient to true on v1.35

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/WatchListClient.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/WatchListClient.md
@@ -9,6 +9,7 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.30"
+    toVersion: "1.34"
   - stage: beta
     defaultValue: true
     fromVersion: "1.35"


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR updates the information on WatchListClient feature gate, mentioning the default value change introduced on Kubernetes v1.35.

For more details, see https://github.com/kubernetes/kubernetes/pull/134180

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
