### PR TITLE
Document request body contents sent to CRD conversion webhooks, in more detail

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -877,32 +877,32 @@ The API server processes conversion requests in the following general order:
 3. After receiving the converted object from the webhook, the API server validates the converted object according to the target version's schema.
 4. The validated object is then stored or returned to the client.
 
-{{< warning >}}
-**Validation may not occur before conversion:** The API server does not guarantee that objects are validated against their schema before being sent to conversion webhooks. This is particularly relevant for [server-side apply](/docs/reference/using-api/server-side-apply/) operations where field pruning can occur, potentially resulting in objects that do not fully conform to their schema being sent to conversion webhooks.
+{{< caution >}}
+**Validation might not occur before conversion:** The API server does not guarantee that objects are validated against their schema before being sent to conversion webhooks. This is particularly relevant for [server-side apply](/docs/reference/using-api/server-side-apply/) operations where field pruning can occur, potentially resulting in objects that do not fully conform to their schema being sent to conversion webhooks.
 
 Conversion webhooks should be designed to handle objects that may be partial, empty, or not yet validated. Do not assume that objects received by conversion webhooks have already passed validation.
-{{< /warning >}}
+{{< /caution >}}
 
 #### Request object contract
 
-The objects in the `request.objects` array sent to conversion webhooks represent the current state of the custom resources as they exist in storage or as they are being processed. These objects:
+The items in the `request.objects` array sent to conversion webhooks each represent the current state of a custom resource as it exists in storage or is being processed. These items:
 
 * May contain all fields from the stored version of the resource
 * May be partial or empty, especially during server-side apply operations where field pruning occurs before conversion
-* May not have been validated against their schema before being sent to the conversion webhook
+* Might not have been validated against their schema before being sent to the conversion webhook
 * Will have their `apiVersion` field set to the source version
 * Include all metadata fields (name, namespace, uid, labels, annotations, etc.)
 
 Conversion webhooks must:
 
-* Handle all objects in the `request.objects` array, regardless of their completeness or validity
-* Convert objects based on the version specified in each object's `apiVersion` field to the version specified in `request.desiredAPIVersion`
+* Handle all items in the `request.objects` array, regardless of their completeness or validity
+* Convert items based on the version specified in each item's `apiVersion` field to the version specified in `request.desiredAPIVersion`
 * Preserve all metadata fields (`metadata.name`, `metadata.namespace`, `metadata.uid`) without modification
-* Return converted objects in the same order as they were received
+* Return converted items in the same order as they were received
 * Not rely on schema validation having occurred before conversion
 * Be idempotent and able to handle the same conversion request multiple times
 
-The API server will validate the converted objects returned by the webhook against the target version's schema after receiving the conversion response. If validation fails after conversion, the request will be rejected.
+After the HTTP callout to the webhook has finished and the response is available to the API server, the API server validates the returned resource data against the target version's schema. If validation fails after conversion, the API server reports an error to the client and treats the request as having failed.
 
 ### Response
 


### PR DESCRIPTION
…re detail

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR adds documentation clarifying the order of operations that the API server follows when converting CRDs between versions, and the contract and expectations for request objects sent to conversion webhooks.

The new documentation section "Order of operations and request object expectations" explains:

1. **Order of operations**: The sequence of steps the API server follows when processing conversion requests (request receipt → conversion webhook → validation → storage/response)

2. **Validation timing**: A warning block highlighting that the API server does not guarantee objects are validated against their schema before being sent to conversion webhooks. This is particularly relevant for server-side apply operations where field pruning can occur, potentially resulting in objects that do not fully conform to their schema being sent to conversion webhooks.

3. **Request object contract**: Detailed information about:
   - Objects may be partial or empty, especially during server-side apply operations
   - Objects may not have been validated before being sent to the conversion webhook
   - Requirements that conversion webhooks must follow (handle all objects regardless of completeness, preserve metadata, be idempotent, etc.)
   - Validation occurs after conversion, not before

This documentation addresses a common misunderstanding where developers assumed validation always occurs before conversion webhooks are called. The clarification helps developers implement more robust conversion webhooks that can handle partial or invalid objects gracefully.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #48055 


