### PR TITLE
[ja] Translate content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md

### DIFF
--- a/content/ja/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/ja/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -194,6 +194,8 @@ kubectl delete deployment kube-dns-autoscaler --namespace=kube-system
 
 マニフェストファイルが削除されると、Addon Managerはkube-dns-autoscaler Deploymentを削除します。
 
+
+
 <!-- discussion -->
 
 ## DNS水平オートスケールの仕組みを理解する {#understanding-how-dns-horizontal-autoscaling-works}


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds a Japanese translation for [content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md](cci:7://file:///Users/pratikmahalle/code/k8s-website/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md:0:0-0:0).

### Which issue(s) this PR fixes

Fixes #53610

### Does this PR introduce a user-facing change?

None

/area localization
/language ja