### PR TITLE
[zh-cn]sync kubeadm_init_phase_addon_coredns

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_coredns.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_coredns.md
@@ -61,18 +61,16 @@ Don't apply any changes; just output what would be done.
 <p>
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-ControlPlaneKubeletLocalMode=true|false (BETA - default=true)<br/>
-NodeLocalCRISocket=true|false (ALPHA - default=false)<br/>
+ControlPlaneKubeletLocalMode=true|false (default=true)<br/>
+NodeLocalCRISocket=true|false (BETA - default=true)<br/>
 PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
-RootlessControlPlane=true|false (ALPHA - default=false)<br/>
-WaitForAllControlPlaneComponents=true|false (BETA - default=true)
+RootlessControlPlane=true|false (ALPHA - default=false)
 -->
 一组用来描述各种特性门控的键值对（key=value）。选项是：<br/>
-ControlPlaneKubeletLocalMode=true|false（BETA - 默认值=true）<br/>
-NodeLocalCRISocket=true|false（ALPHA - 默认值=false）<br/>
-PublicKeysECDSA=true|false（DEPRECATED - 默认值=false）<br/>
-RootlessControlPlane=true|false（ALPHA - 默认值=false）<br/>
-WaitForAllControlPlaneComponents=true|false（BETA - 默认值=true）
+ControlPlaneKubeletLocalMode=true|false (默认值=true)<br/>
+NodeLocalCRISocket=true|false (BETA - 默认值=true)<br/>
+PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
+RootlessControlPlane=true|false (ALPHA - 默认值=false)
 </p>
 </td>
 </tr>


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_coredns.md