### PR TITLE
docs: clarify sidecar usage under initContainers for Jobs

### DIFF
--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -45,6 +45,12 @@ support a container-level `restartPolicy` field.
 
 Here's an example of a Deployment with two containers, one of which is a sidecar:
 
+{{< note >}}
+In this example, the sidecar container is intentionally defined under `initContainers`
+with `restartPolicy: Always`. Kubernetes treats such containers as sidecars that continue
+running for the lifetime of the Pod.
+{{< /note >}}
+
 {{% code_sample language="yaml" file="application/deployment-sidecar.yaml" %}}
 
 ## Sidecar containers and Pod lifecycle
@@ -79,12 +85,6 @@ until their service is no longer required.
 If you define a Job that uses sidecar using Kubernetes-style init containers,
 the sidecar container in each Pod does not prevent the Job from completing after the
 main container has finished.
-
-{{< note >}}
-In this example, the sidecar container is intentionally defined under `initContainers`
-with `restartPolicy: Always`. Kubernetes treats such containers as sidecars that continue
-running for the lifetime of the Pod.
-{{< /note >}}
 
 Here's an example of a Job with two containers, one of which is a sidecar:
 


### PR DESCRIPTION
This PR adds a short clarification near the “Jobs with sidecar containers” example
to explain why the sidecar is defined under initContainers with restartPolicy: Always.

The change is intentionally minimal to reduce confusion for first-time readers,
as suggested in #53814.

Fixes #53814
