### PR TITLE
Include Windows PowerShell instructions for POD_NAME

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
@@ -165,7 +165,7 @@ curl http://localhost:8001/api/v1/namespaces/default/pods/$POD_NAME:8080/proxy/
 {{< note >}}
 If you are using Windows PowerShell, use the following alternative to store the environment variable `POD_NAME`.
 
-```shell
+```powershell
 $POD_NAME = (kubectl get pods -o jsonpath="{.items[0].metadata.name}")
 curl "http://localhost:8001/api/v1/namespaces/default/pods/$($POD_NAME):8080/proxy/"
 ```


### PR DESCRIPTION
**What:** Adding a note to https://kubernetes.io/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/ for users working through the Learn Kubernetes Basics on a windows machine with PowerShell 
**Why** I worked through the Learn Kubernetes Basics and would have thought it would have been helpful to have a note for getting POD_NAME.