### PR TITLE
docs: clarify mutation ordering for MutatingAdmissionPolicy

### DIFF
--- a/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
@@ -237,7 +237,7 @@ may differ from what would exist if all mutations were applied to a single in-me
 
 ### Single mutation vs. multiple mutations
 
-A single mutation expression can evaluate to multiple `JSON Patch  operations, that are applied
+A single mutation expression can evaluate to multiple `JSON Patch`  operations, that are applied
 in sequence to the same resource representation within the API server. For example:
 
 ```cel

--- a/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
@@ -227,41 +227,43 @@ Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 When a MutatingAdmissionPolicy defines multiple mutations, each mutation is applied
 independently to the object. Between mutations, the following occurs:
 
-- The object is serialized to JSON and then parsed back
+- The object may be serialized and deserialized
 - Built-in defaulting is applied
-- Empty fields (fields with `omitempty` that are absent or null) may be removed
+- Empty fields (fields defined as `omitempty`, and that are absent or null) may be removed
 
-Because of this behavior, a mutation must not assume that fields added by a previous
+Because of this behavior, a mutation **must not** assume that fields added by a previous
 mutation will still exist when it runs. The intermediate state after each mutation
 may differ from what would exist if all mutations were applied to a single in-memory object.
 
 ### Single mutation vs. multiple mutations
 
-A single mutation expression can contain multiple JSONPatch operations that are applied
-in sequence to the same in-memory object. For example:
+A single mutation expression can evaluate to multiple `JSON Patch  operations, that are applied
+in sequence to the same resource representation within the API server. For example:
 
 ```cel
 [
-  JSONPatch{op: "add", path: "/spec/labels", value: Object.spec.labels{"app": "myapp"}},
+  JSONPatch{op: "add", path: "/spec/labels", value: Object.spec.labels{"workload-name": "MyApp"}},
   JSONPatch{op: "add", path: "/spec/labels/owner", value: "team-a"}
 ]
 ```
 
-These two operations are applied to the same object, so the second operation can safely
+These two operations are applied to the **same** object, without other admission control
+mechanisms being able
+to see an intermediate state, so the second operation can safely
 depend on the result of the first.
 
 In contrast, each expression in the `spec.mutations` list results in a separate mutation
-that is applied independently. The intermediate object is serialized and deserialized
+that is applied independently. The intermediate representation of the resource is serialized and deserialized
 between mutations, which can cause fields to be lost.
 
-### Best practices
+### Good practices {#ordering-good-practice}
 
-- **Group dependent operations**: If multiple JSONPatch operations depend on each other,
+- **Group dependent operations**: If multiple JSON Patch operations depend on each other,
   define them in a single CEL expression so they operate on the same in-memory object.
 
-- **Prefer ApplyConfiguration for list fields**: When mutating optional list fields,
-  ApplyConfiguration-style mutations use server-side apply merge strategy, which is
-  safer for list manipulation than independent JSONPatch operations.
+- **Prefer `ApplyConfiguration` for list fields**: When mutating optional list fields,
+  `ApplyConfiguration` mutations use a [server-side apply](/docs/reference/using-api/server-side-apply/) patch strategy, which is
+  safer for list manipulation than independent `JSONPatch` operations.
 
 ## API kinds exempt from mutating admission
 


### PR DESCRIPTION
### Description

This PR documents mutation ordering behavior for `MutatingAdmissionPolicy`. It explains that when multiple mutations are defined, each mutation is applied independently and the object may be serialized, defaulted, and normalized between mutations. As a result, intermediate object state (for example, empty list fields removed due to `omitempty`) is not guaranteed to persist across mutations.

The documentation also clarifies the difference between multiple JSONPatch operations within a single mutation versus multiple JSONPatch mutations, and provides best-practice guidance for writing dependent mutations.

### Issue
Closes: kubernetes/website#49641  
Related: kubernetes/kubernetes#129309