### PR TITLE
Update stale declarative validation introduction

### DIFF
--- a/content/en/docs/reference/using-api/declarative-validation.md
+++ b/content/en/docs/reference/using-api/declarative-validation.md
@@ -21,16 +21,9 @@ optimized Go code for API validation.
 While primarily a feature impacting Kubernetes contributors and potentially developers of [extension API servers](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/), cluster administrators should understand its behavior, especially during its rollout phases.
 
 
+Declarative validation is being rolled out gradually to replace legacy hand-written validation code. It allows developers to define validation rules directly alongside API type definitions using special tags (e.g., `+k8s:minimum=0`).
 
-Declarative validation is being rolled out gradually to replace legacy hand-written validation code.
-In Kubernetes {{< skew currentVersion >}}, declarative validation is enabled for a growing number of APIs, including:
-
-* [ReplicationController](/docs/concepts/workloads/controllers/replicationcontroller/)
-* `EndpointSlice`
-* `ResourceSlice`
-* `DeviceClass`
-
-As adoption continues, more native Kubernetes types will utilize this mechanism to ensure API consistency and reduce development overhead.
+This mechanism is designed to ensure API consistency and reduce development overhead by centralizing validation logic. As the feature matures, an increasing number of Kubernetes APIs are adopting this approach.
 
 
 *   `DeclarativeValidation`: (Beta, Default: `true`) When enabled, the API server runs *both* the new declarative validation and the old hand-written validation for migrated types/fields. The results are compared internally.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR updates the introduction of the [Declarative API Validation](https://kubernetes.io/docs/reference/using-api/declarative-validation/) page to address stale information.

Changes:
- Removes the stale note describing `ReplicationController` as a "test bed" for the feature.
- Replaces the specific list of APIs with a broader explanation of the mechanism and its benefits.
- Updates the text to reflect that the feature is maturing and being adopted by an increasing number of native types, preventing the documentation from becoming stale in future releases.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #53932 