### PR TITLE
Fix description Gt and Lt in documentation(Line 722 to 723)

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -719,8 +719,8 @@ The following operators can only be used with `nodeAffinity`.
 
 |    Operator    |    Behavior    |
 | :------------: | :-------------: |
-| `Gt` | The field value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
-| `Lt` | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
+| `Gt` | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
+| `Lt` | The field value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
 
 {{<note>}}
 


### PR DESCRIPTION
### Description
Fix description about `Gt` and `Lt` in `content/en/docs/concepts/scheduling-eviction/assign-pod-node.md`. 

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
Issue from #53995 

In content/en/docs/concepts/scheduling-eviction/assign-pod-node.md Line 722 ~ 723,

```
| Gt | The field value would be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
| Lt | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
```

I think each description will be change each other. Gt means Greater than, and Lt means Less than.
So i think it would be change

| `Gt` | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
| `Lt` | The field value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #53995 