### PR TITLE
Clarify Opportunistic batching limitations in v1.35 release blog

### DIFF
--- a/content/en/blog/_posts/2025-12-17-kubernetes-v1-35-release/index.md
+++ b/content/en/blog/_posts/2025-12-17-kubernetes-v1-35-release/index.md
@@ -129,9 +129,18 @@ This work was done as part of [KEP #4876](https://kep.k8s.io/4876) led by SIG St
 
 Historically, the Kubernetes scheduler processes pods sequentially with time complexity of `O(num pods × num nodes)`, which can result in redundant computation for compatible pods. This KEP introduces an opportunistic batching mechanism that aims to improve performance by identifying such compatible Pods via `Pod scheduling signature` and batching them together, allowing shared filtering and scoring results across them.
 
-The pod scheduling signature ensures that two pods with the same signature are “the same” from a scheduling perspective. It takes into account not only the pod and node attributes, but also the other pods in the system and global data about the pod placement. This means that any pod with the given signature will get the same scores/feasibility results from any arbitrary set of nodes.
+This optimization is particularly beneficial for batch and ML workloads that create many similar pods with identical scheduling requirements.
 
-The batching mechanism consists of two operations that can be invoked whenever needed - *create* and *nominate*. Create leads to the creation of a new set of batch information from the scheduling results of Pods that have a valid signature. Nominate uses the batching information from create to set the nominated node name from a new Pod whose signature matches the canonical Pod’s signature.
+**How it works:** Pods are assigned a "scheduling signature" based on their pod and node attributes. Pods with identical signatures can reuse scoring results, significantly improving scheduling throughput.
+
+**Important limitations:** Not all pods can be batched. The following pods receive a `nil` signature and fall back to the standard scheduling path:
+
+- Pods using **InterPodAffinity** or **InterPodAntiAffinity** constraints
+- Pods using **PodTopologySpread** constraints (including default spread rules)
+
+These pods depend on the placement of other pods in the cluster, so their optimal node scores cannot be cached and reused.
+
+The batching mechanism consists of two operations that can be invoked whenever needed - *create* and *nominate*. Create leads to the creation of a new set of batch information from the scheduling results of Pods that have a valid signature. Nominate uses the batching information from create to set the nominated node name from a new Pod whose signature matches the canonical Pod's signature.
 
 This work was done as part of [KEP #5598](https://kep.k8s.io/5598) led by SIG Scheduling.
 


### PR DESCRIPTION
## What this PR does

Clarifies the "Opportunistic batching" section in the Kubernetes v1.35 release blog to accurately describe which pods can benefit from this optimization.

## Changes made

1. Added information about when this optimization is most beneficial (batch/ML workloads)
2. Clarified which types of pods can be batched
3. Documented limitations for pods using InterPodAffinity and PodTopologySpread
4. Removed misleading text about considering "other pods in the system"

## Why it's needed

The current text is misleading - it implies that scheduling signatures consider "other pods in the system," but according to KEP #5598, pods that depend on other pods are actually **excluded** from batching and receive a nil signature.

Fixes #53929

/kind documentation
/sig docs
/language en