### PR TITLE
Add dynamic redirect for latest Kubernetes API docs

### DIFF
--- a/layouts/shortcodes/api-reference-link.html
+++ b/layouts/shortcodes/api-reference-link.html
@@ -1,0 +1,13 @@
+{{/*
+Shortcode to generate links to the Kubernetes API reference.
+Usage: {{< api-reference-link version="latest" >}}
+       {{< api-reference-link version="v1.33" >}}
+       {{< api-reference-link >}} (defaults to latest)
+*/}}
+{{- $version := .Get "version" | default "latest" -}}
+{{- $baseURL := "/docs/reference/generated/kubernetes-api" -}}
+{{- if eq $version "latest" -}}
+  {{- printf "%s/latest/" $baseURL -}}
+{{- else -}}
+  {{- printf "%s/%s/" $baseURL $version -}}
+{{- end -}}


### PR DESCRIPTION
### Description

This PR adds a dynamic redirect feature for the Kubernetes API documentation. Currently, links to the API reference are version specific (e.g. `/docs/reference/generated/kubernetes-api/v1.30/`). This change allows users to use `/docs/reference/generated/kubernetes-api/latest/` which will automatically redirect to the version defined as `latest` in `hugo.toml`.

Changes included:
- A new script `scripts/generate-api-redirects.sh` that parses `hugo.toml` and updates `static/_redirects`.
- Integration of this script into the `Makefile` build targets.
- A new shortcode `api-reference-link` to easily link to the latest or specific versions in documentation.

This is helpful for external tools, bookmarks, and documentation that wish to always point to the current stable API reference without needing manual updates on every release.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.
-->

Closes: # (No tracking issue, feature enhancement)

Replaces superseded PR #51563 (closed due to CLA email mismatch).
