### PR TITLE
Publish blog article "Announcing the Checkpoint/Restore Working Group" (Jan 21)

### DIFF
--- a/content/en/blog/_posts/2026-01-21-announcing-checkpoint-restore-wg.md
+++ b/content/en/blog/_posts/2026-01-21-announcing-checkpoint-restore-wg.md
@@ -1,7 +1,7 @@
 ---
 title: "Announcing the Checkpoint/Restore Working Group"
-date: 2026-XX-XX
-draft: true
+date: 2026-01-21T10:00:00-08:00
+canonicalUrl: https://www.kubernetes.dev/blog/2026/01/21/introducing-checkpoint-restore-wg/
 slug: introducing-checkpoint-restore-wg
 author: >
   [Radostin Stoyanov](https://github.com/rst0git),


### PR DESCRIPTION
As a follow-up to the comment in https://github.com/kubernetes/website/pull/53611#pullrequestreview-3647939281, this pull request sets the publication date and removes the `draft: true` line.

[Preview](https://deploy-preview-54015--kubernetes-io-main-staging.netlify.app/blog/2026/01/21/introducing-checkpoint-restore-wg/)

/area blog