### PR TITLE
Correct the description of spec.failurePolicy in ValidatingAdmissionPolicy

### DIFF
--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -60,9 +60,9 @@ The following is an example of a ValidatingAdmissionPolicy.
 
 `spec.validations` contains CEL expressions which use the [Common Expression Language (CEL)](https://github.com/google/cel-spec)
 to validate the request. If an expression evaluates to false, the validation action of the respective
-ValidatingAdmissionPolicyBinding is enforces according to the `spec.validationActions` field of the
+ValidatingAdmissionPolicyBinding is handled according to the `spec.validationActions` field of the
 binding. If the evaluation of the expression fails, the validation check is treated according to the
-`spec.failurePolicy` field.
+`spec.failurePolicy` field of the policy.
 
 {{< note >}}
 You can quickly test CEL expressions in [CEL Playground](https://playcel.undistro.io).
@@ -126,7 +126,7 @@ with parameter configuration.
 
 The `spec.paramKind` field of the ValidatingAdmissionPolicy specifies the kind of resources used
 to parameterize this policy. For this example, it is configured by ReplicaLimit custom resources. 
-Note in this example how the CEL expression in the `spec.validations` fields references the parameters
+Note in this example how the CEL expression in the `spec.validations` field references the parameters
 via the CEL params variable, e.g. `params.maxReplicas`. `spec.matchConstraints` specifies what
 resources this policy is designed to validate. Note that the native types such like `ConfigMap` could
 also be used as parameter reference.

--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -59,8 +59,10 @@ The following is an example of a ValidatingAdmissionPolicy.
 {{% code_sample language="yaml" file="validatingadmissionpolicy/basic-example-policy.yaml" %}}
 
 `spec.validations` contains CEL expressions which use the [Common Expression Language (CEL)](https://github.com/google/cel-spec)
-to validate the request. If an expression evaluates to false, the validation check is enforced
-according to the `spec.failurePolicy` field.
+to validate the request. If an expression evaluates to false, the validation action of the respective
+ValidatingAdmissionPolicyBinding is enforces according to the `spec.validationActions` field of the
+binding. If the evaluation of the expression fails, the validation check is treated according to the
+`spec.failurePolicy` field.
 
 {{< note >}}
 You can quickly test CEL expressions in [CEL Playground](https://playcel.undistro.io).
@@ -124,13 +126,10 @@ with parameter configuration.
 
 The `spec.paramKind` field of the ValidatingAdmissionPolicy specifies the kind of resources used
 to parameterize this policy. For this example, it is configured by ReplicaLimit custom resources. 
-Note in this example how the CEL expression references the parameters via the CEL params variable,
-e.g. `params.maxReplicas`. `spec.matchConstraints` specifies what resources this policy is
-designed to validate. Note that the native types such like `ConfigMap` could also be used as
-parameter reference.
-
-The `spec.validations` fields contain CEL expressions. If an expression evaluates to false, the
-validation check is enforced according to the `spec.failurePolicy` field.
+Note in this example how the CEL expression in the `spec.validations` fields references the parameters
+via the CEL params variable, e.g. `params.maxReplicas`. `spec.matchConstraints` specifies what
+resources this policy is designed to validate. Note that the native types such like `ConfigMap` could
+also be used as parameter reference.
 
 The validating admission policy author is responsible for providing the ReplicaLimit parameter CRD.
 


### PR DESCRIPTION
### Description

Correcting the description of the field `spec.failurePolicy` for the ValidatingAdmissionPolicy. The documentation wrongly states that the policy is triggered when the expression evaluates to false but it is only triggered when the evaluation of the expression fails.

Also the statement is repeated word for word into two places. It seems out of place in the section `Parameter resources`. Therefore I removed it there.

See also:
 * [API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#validatingadmissionpolicyspec-v1-admissionregistration-k8s-io): `failurePolicy does not define how validations that evaluate to false are handled.`
* [source code](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go#L76) of the feature