### PR TITLE
Update minimum etcd versions to reflect new dependencies

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -20,7 +20,7 @@ Refer to the [etcd documentation](https://etcd.io/docs/) for more context.
 
 Key details include:
 
-* The minimum recommended etcd versions to run in production are `3.4.22+` and `3.5.6+`.
+* The minimum recommended etcd versions to run in production are `3.4.29+` and `3.5.11+`.
 
 * etcd is a leader-based distributed system. Ensure that the leader
   periodically send heartbeats on time to all followers to keep the cluster


### PR DESCRIPTION
Description
Kubernetes 1.31 and later assumes the existence of health check endpoints backported to 3.5.11 (https://github.com/etcd-io/etcd/pull/17039) and 3.4.29 (https://github.com/etcd-io/etcd/pull/17128), so update the minimum versions to reflect this.

This is the equivalent of https://github.com/kubernetes/website/pull/54019 for the 1.31 branch.