### PR TITLE
[en] Mark HonorPVReclaimPolicy feature gate as removed

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/HonorPVReclaimPolicy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/HonorPVReclaimPolicy.md
@@ -18,6 +18,9 @@ stages:
     defaultValue: true
     locked: true
     fromVersion: "1.33"
+    toVersion: "1.35"
+
+removed: true
 ---
 Honor persistent volume reclaim policy when it is `Delete` irrespective of PV-PVC deletion ordering.
 For more details, check the


### PR DESCRIPTION
Mark the HonorPVReclaimPolicy feature gate as removed in v1.36.

This feature gate was locked and enabled since v1.33 and is being removed in v1.36.

**Changes:**
- Added `toVersion: "1.35"` to the stable stage (last version where the feature gate is available)
- Added `removed: true` flag to mark the feature gate as removed

**Related PR:**
- kubernetes/kubernetes#135335