### PR TITLE
Add automated release page generation using content adapter

### DIFF
--- a/content/en/releases/_content.gotmpl
+++ b/content/en/releases/_content.gotmpl
@@ -1,0 +1,90 @@
+{{/*
+  This content adapter generates release series pages for all languages.
+  Do NOT place a _content.gotmpl in other language directories (e.g., content/ja/releases/).
+  Pages for each language are generated from this single file via .EnableAllLanguages.
+*/}}
+{{ .EnableAllLanguages }}
+
+{{ $eolData := site.Data.releases.eol }}
+{{ $supportedData := site.Data.releases.schedule }}
+
+{{ $now := now }}
+{{ $allReleases := dict }}
+
+{{ range $eolData.branches }}
+  {{ $version := .release }}
+  {{ $releaseInfo := dict
+    "releaseDate" ""
+    "endOfLifeDate" .endOfLifeDate
+    "maintenanceModeStartDate" ""
+    "status" "end-of-life"
+    "latestPatchVersion" .finalPatchRelease
+    "latestReleaseDate" ""
+  }}
+  {{ $allReleases = merge $allReleases (dict $version $releaseInfo) }}
+{{ end }}
+
+{{ range $supportedData.schedules }}
+  {{ $version := .release }}
+
+  {{ $latestPatchVersion := "" }}
+  {{ $latestReleaseDate := "" }}
+  {{ if .previousPatches }}
+    {{ $latestPatchVersion = (index .previousPatches 0).release }}
+    {{ $latestReleaseDate = (index .previousPatches 0).targetDate }}
+  {{ else }}
+    {{ $latestPatchVersion = printf "%s.0" .release }}
+    {{ $latestReleaseDate = .releaseDate }}
+  {{ end }}
+
+  {{ $status := "supported" }}
+  {{ if .maintenanceModeStartDate }}
+    {{ $maintenanceDate := time.AsTime .maintenanceModeStartDate }}
+    {{ if $maintenanceDate.Before $now }}
+      {{ $status = "maintenance" }}
+    {{ end }}
+  {{ end }}
+
+  {{ $releaseInfo := dict 
+    "releaseDate" .releaseDate
+    "endOfLifeDate" .endOfLifeDate
+    "maintenanceModeStartDate" .maintenanceModeStartDate
+    "status" $status
+    "latestPatchVersion" $latestPatchVersion
+    "latestReleaseDate" $latestReleaseDate
+  }}
+  {{ $allReleases = merge $allReleases (dict $version $releaseInfo) }}
+{{ end }}
+
+{{ $latestSupportedVersion := (index $supportedData.schedules 0).release }}
+
+{{ range $version, $info := $allReleases }}
+  {{ $minorVersionPath := $version }}
+  {{ $title := T "kubernetes" }}
+  
+  {{ $parts := split $version "." }}
+  {{ $major := int (index $parts 0) }}
+  {{ $minor := int (index $parts 1) }}
+  {{ $weight := mul -1 (add (mul $major 1000) $minor) }}
+
+  {{ $sectionPage := dict
+    "kind" "section"
+    "type" "docs"
+    "path" $minorVersionPath
+    "layout" "release-series"
+    "title" (printf "%s %s" $title $version)
+    "weight" $weight
+    "params" (dict
+      "minorVersion" $version
+      "status" $info.status
+      "releaseDate" $info.releaseDate
+      "endOfLifeDate" $info.endOfLifeDate
+      "maintenanceModeStartDate" (index $info "maintenanceModeStartDate")
+      "latestPatchVersion" (index $info "latestPatchVersion")
+      "latestReleaseDate" (index $info "latestReleaseDate")
+      "isLatestVersion" (eq $version $latestSupportedVersion)
+      "toc_hide" true
+    )
+  }}
+  {{ $.AddPage $sectionPage }}
+{{ end }}

--- a/content/en/releases/_index.md
+++ b/content/en/releases/_index.md
@@ -26,6 +26,20 @@ More information in the [version skew policy](/releases/version-skew-policy/) do
 
 {{< release-data >}}
 
+## End-of-Life Releases
+
+Older Kubernetes releases that are no longer maintained are listed below.
+
+<details>
+  <summary>End-of-life releases</summary>
+  {{< note >}}
+  These releases are no longer supported and do not receive security updates or bug fixes.
+  If you are running one of these releases, the Kubernetes project strongly recommends upgrading to a [supported version](#release-history).
+  {{< /note >}}
+  
+  {{< eol-releases >}}
+</details>
+
 ## Upcoming Release
 
 Check out the [schedule](https://github.com/kubernetes/sig-release/tree/master/releases/release-{{< skew nextMinorVersion >}})

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -258,6 +258,9 @@ of Katacoda.</p>
 2023</b>. You are seeing this notice because this particular page has not yet been updated
 following that shutdown.</p>"""
 
+[kubernetes]
+other = "Kubernetes"
+
 [latest_release]
 other = "Latest Release:"
 
@@ -477,6 +480,9 @@ other = "Before you begin"
 [previous_patches]
 other = "Patch Releases:"
 
+[release_actively_supported]
+other = "Actively Supported"
+
 # The following text is displayed when JavaScript isn't available.
 [release_binary_alternate_links]
 other  = """You can find links to download Kubernetes components (and their checksums) in the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files.
@@ -566,11 +572,33 @@ other = "2006-01-02"
 [release_date_format_month]
 other = "January 2006"
 
+[release_details]
+other = "View release details"
+
 [release_cherry_pick_deadline]
 other = "Cherry Pick Deadline"
 
+[release_download_page]
+other = "Download Kubernetes {{ .minor_version }}"
+
+[release_end_of_life]
+other = "End Of Life"
+
 [release_end_of_life_date]
 other = "End Of Life Date"
+
+[release_end_of_life_details_past]
+other = """This release has reached End of Life on {{ .release_eol_date }}.
+Kubernetes {{ .minor_version }} is no longer receiving security updates or bug fixes. Upgrade to a [supported version](/releases/)."""
+
+[release_latest_patch]
+other = "Latest patch release"
+
+[release_links]
+other = "Related Links"
+
+[release_maintenance_details_past]
+other = "This release entered maintenance mode on {{ .maintenance_mode_start_date }}. Only critical security fixes are accepted. The End of Life date for Kubernetes {{ .minor_version }} is {{ .release_eol_date }}. Please plan to upgrade to a [newer version](/releases/)."
 
 # Also see release_maintenance_and_end_of_life_details_past
 [release_maintenance_and_end_of_life_details_current]
@@ -582,6 +610,15 @@ other = "Kubernetes {{ .minor_version }} enters maintenance mode on {{ .maintena
 other = """ℹ️ **Kubernetes {{ .minor_version }} entered maintenance mode on {{ .maintenance_mode_start_date }}**.
 
 The End of Life date for Kubernetes {{ .minor_version }} is {{ .release_eol_date }}."""
+
+[release_maintenance_mode]
+other = "Maintenance Mode"
+
+[release_maintenance_mode_start_date]
+other = "Maintenance Mode Start Date"
+
+[release_released_on]
+other = "Released on {{ .date }}"
 
 [release_full_details_initial_text]
 other = "Complete"
@@ -608,6 +645,12 @@ other = "Note"
 
 [release_schedule]
 other = "Schedule"
+
+[release_series_page_intro]
+other = "This page provides an overview of the Kubernetes {{ .minor_version }} release series."
+
+[release_status]
+other = "Release Status"
 
 [release_target_date]
 other = "Target Date"

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -1,0 +1,89 @@
+{{ define "main" }}
+<article class="td-content">
+  {{ if eq .Params.status "end-of-life" }}
+  <div class="pageinfo pageinfo-warning">
+    <p>
+      {{ T "release_end_of_life_details_past"
+        (dict
+          "minor_version" .Params.minorVersion
+          "release_eol_date" .Params.endOfLifeDate
+        ) | markdownify
+      }}
+    </p>
+  </div>
+  {{ else if eq .Params.status "maintenance" }}
+  <div class="pageinfo pageinfo-info">
+    <p>
+      {{ T "release_maintenance_details_past"
+        (dict
+          "minor_version" .Params.minorVersion
+          "maintenance_mode_start_date" .Params.maintenanceModeStartDate
+          "release_eol_date" .Params.endOfLifeDate
+        ) | markdownify
+      }}
+    </p>
+  </div>
+  {{ end }}
+
+  <h1>{{ .Title }}</h1>
+
+  <p>
+    {{ T "release_series_page_intro"
+      (dict "minor_version" .Params.minorVersion) | markdownify
+    }}
+  </p>
+
+  <dl>
+    <dt>{{ T "release_status" }}</dt>
+    <dd>
+      {{ if eq .Params.status "supported" }}
+      <span class="badge badge-success">{{ T "release_actively_supported" }}</span>
+      {{ else if eq .Params.status "maintenance" }}
+      <span class="badge badge-warning">{{ T "release_maintenance_mode" }}</span>
+      {{ else }}
+      <span class="badge badge-danger">{{ T "release_end_of_life" }}</span>
+      {{ end }}
+    </dd>
+
+    <dt>{{ T "release_latest_patch" }}</dt>
+    <dd>
+      {{ .Params.latestPatchVersion }}
+      {{ with .Params.latestReleaseDate }}
+        ({{ T "release_released_on" (dict "date" .) }})
+      {{ end }}
+    </dd>
+
+    {{ with .Params.maintenanceModeStartDate }}
+    <dt>{{ T "release_maintenance_mode_start_date" }}</dt>
+    <dd>{{ . }}</dd>
+    {{ end }}
+
+    {{ with .Params.endOfLifeDate }}
+    <dt>{{ T "release_end_of_life_date" }}</dt>
+    <dd>{{ . }}</dd>
+    {{ end }}
+  </dl>
+
+  <h2>{{ T "release_links" }}</h2>
+  {{ if .Params.status | in (slice "supported" "maintenance") }}
+  <ul>
+    <li>
+      {{ if .Params.isLatestVersion }}
+      <a href="/releases/download/">
+        {{ T "release_download_page"
+          (dict "minor_version" .Params.minorVersion) | markdownify
+        }}
+      </a>
+      {{ else }}
+      {{ $versionPath := replace .Params.minorVersion "." "-" }}
+      <a href="https://v{{ $versionPath }}.docs.kubernetes.io/releases/download/">
+        {{ T "release_download_page"
+          (dict "minor_version" .Params.minorVersion) | markdownify
+        }}
+      </a>
+      {{ end }}
+    </li>
+  </ul>
+  {{ end }}
+</article>
+{{ end }}

--- a/layouts/shortcodes/eol-releases.html
+++ b/layouts/shortcodes/eol-releases.html
@@ -12,7 +12,7 @@
             {{ range $eolRelease := .Site.Data.releases.eol.branches }}
             <tr>
                 <td>
-                    {{ $eolRelease.release }}
+                    <a href="/releases/{{ $eolRelease.release }}/">{{ $eolRelease.release }}</a>
                 </td>
                 <td>
                     {{ $eolRelease.finalPatchRelease }}

--- a/layouts/shortcodes/release-data.html
+++ b/layouts/shortcodes/release-data.html
@@ -38,7 +38,9 @@
 <a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">{{ T "release_schedule" }}</a> {{ T "conjunction_1" }}
 <a hreflang="en" href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">{{ T "release_changelog" }}</a>
 </p>
-
+<p>
+    <a href="{{ relLangURL (printf "/releases/%s/" $dataVersion) }}/">{{ T "release_details" }}</a>
+</p>
 </div>
 
 {{ end }}


### PR DESCRIPTION
## What this PR does

Add dynamically generated release series pages (e.g., `/releases/1.35/`) using Hugo Content Adapters. Each page is generated from the existing `data/releases/` YAML data and shows release status, release-related dates and relevant links based on lifecycle status (supported / maintenance / end-of-life).

[Releases deploy preview](https://deploy-preview-54041--kubernetes-io-main-staging.netlify.app/releases/)
[v1.35 deploy preview](https://deploy-preview-54041--kubernetes-io-main-staging.netlify.app/releases/1.35/)

Fixes #46426

/kind feature
/area release-eng
/sig release