### PR TITLE
docs: clarify dropping Linux capabilities using drop

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -468,11 +468,11 @@ exit
 
 With [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html),
 you can grant certain privileges to a process without granting all the privileges
-of the root user. To add or remove Linux capabilities for a Container, include the
+of the root user. To add or drop Linux capabilities for a Container, include the
 `capabilities` field in the `securityContext` section of the Container manifest.
 
 First, see what happens when you don't include a `capabilities` field.
-Here is configuration file that does not add or remove any Container capabilities:
+Here is configuration file that does not add or drop any Container capabilities:
 
 {{% code_sample file="pods/security/security-context-3.yaml" %}}
 


### PR DESCRIPTION
Description
This PR clarifies the documentation for Linux capabilities by explicitly stating
that capabilities can be removed using the drop field in the
securityContext.capabilities configuration.

The change improves clarity for readers by making the add/drop mechanism
explicit without altering behavior or examples.

issues: #53177