### PR TITLE
docs: Use install command for kubectl binary on macOS

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -94,17 +94,10 @@ The following methods exist for installing kubectl on macOS:
    Download the same version of the binary and checksum.
    {{< /note >}}
 
-1. Make the kubectl binary executable.
+1. Install kubectl to a file location on your system `PATH`:
 
    ```bash
-   chmod +x ./kubectl
-   ```
-
-1. Move the kubectl binary to a file location on your system `PATH`.
-
-   ```bash
-   sudo mv ./kubectl /usr/local/bin/kubectl
-   sudo chown root: /usr/local/bin/kubectl
+   sudo install -o root -m 0755 ./kubectl /usr/local/bin/kubectl
    ```
 
    {{< note >}}
@@ -244,17 +237,10 @@ See [kuberc](/docs/reference/kubectl/kuberc) for more information.
    Download the same version of the binary and checksum.
    {{< /note >}}
 
-1. Make kubectl-convert binary executable
+1. Install kubectl-convert to a file location on your system `PATH`:
 
    ```bash
-   chmod +x ./kubectl-convert
-   ```
-
-1. Move the kubectl-convert binary to a file location on your system `PATH`.
-
-   ```bash
-   sudo mv ./kubectl-convert /usr/local/bin/kubectl-convert
-   sudo chown root: /usr/local/bin/kubectl-convert
+   sudo install -o root -m 0755 ./kubectl-convert /usr/local/bin/kubectl-convert
    ```
 
    {{< note >}}


### PR DESCRIPTION
## What this PR does / why we need it

This PR updates the kubectl installation documentation for macOS to use the `install` command instead of separate `chmod`, `mv`, and `chown` commands.

### Before (3 commands, 2 steps):
```bash
chmod +x ./kubectl
sudo mv ./kubectl /usr/local/bin/kubectl
sudo chown root: /usr/local/bin/kubectl
```

### After (1 command, 1 step):
```bash
sudo install -o root -m 0755 ./kubectl /usr/local/bin/kubectl
```

The `install` command is cleaner because it:
- Sets executable permissions (`-m 0755`)
- Sets ownership (`-o root`)
- Copies the file to destination

All in a single, explicit command.

## Which issue(s) this PR fixes

Fixes https://github.com/kubernetes/website/issues/53518 (partial - macOS page only)

## Special notes for your reviewer

- This PR only updates the macOS installation page as a starting point
- The same pattern exists in ~35 other files (as noted in the issue)
- If this approach is approved, similar updates can be made to other installation docs

/kind documentation