### PR TITLE
Fix bullet list formatting in VPA documentation

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -105,7 +105,8 @@ The Recommender analyzes both current and historical resource usage data (CPU an
 Based on this analysis, the Recommender calculates three types of recommendations:
 - Target recommendation (optimal resources for typical usage)
 - Lower bound (minimum viable resources)
-- Upper bound (maximum reasonable resources). 
+- Upper bound (maximum reasonable resources).
+
 These recommendations are stored in the VerticalPodAutoscaler resource's `.status.recommendation` field.
 
 


### PR DESCRIPTION
### Description

Fix paragraph formatting in VPA documentation by adding a blank line after the bullet list.

**Page:** en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#how-does-a-verticalpodautoscaler-work

### Issue

Closes: #54050 