### PR TITLE
mark feature gates CSIMigrationPortworx and InTreePluginPortworxUnregister as removed

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/CSIMigrationPortworx.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/CSIMigrationPortworx.md
@@ -21,6 +21,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.33"
+    toVersion: "1.35"
+
+removed: true
 ---
 Enables shims and translation logic to route volume operations
 from the Portworx in-tree plugin to Portworx CSI plugin.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/InTreePluginPortworxUnregister.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/InTreePluginPortworxUnregister.md
@@ -9,6 +9,9 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.23"
+    toVersion: "1.35"
+
+removed: true
 ---
 Stops registering the Portworx in-tree plugin in kubelet
 and volume controllers.


### PR DESCRIPTION
/hold
until https://github.com/kubernetes/kubernetes/pull/135322 is merged.