### PR TITLE
[en] Link Pod Resource Resize docs in related Container docs

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/resize-container-resources.md
+++ b/content/en/docs/tasks/configure-pod-container/resize-container-resources.md
@@ -16,7 +16,7 @@ assigned to a container *without recreating the Pod*.
 Traditionally, changing a Pod's resource requirements necessitated deleting the existing Pod
 and creating a replacement, often managed by a [workload controller](/docs/concepts/workloads/controllers/).
 In-place Pod Resize allows changing the CPU/memory allocation of container(s) within a running Pod
-while potentially avoiding application disruption.
+while potentially avoiding application disruption. The process for resizing Pod resources is covered in [Resize CPU and Memory Resources assigned to Pods](/docs/tasks/configure-pod-container/resize-pod-resources).
 
 **Key Concepts:**
 


### PR DESCRIPTION
### Description

Added a "back-reference" to the process for resizing Pod resources inside the Container docs, mirroring the other document. Follows discussions in https://github.com/kubernetes/website/pull/53741#issuecomment-3764390930

### Issue

Didn't create one, as it's a follow up to the linked PR discussion.