### PR TITLE
Update blog approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,14 +2,12 @@ aliases:
   sig-docs-blog-owners: # Approvers for blog content
     - lmktfy
     - graz-dev
-    - mrbobbytables
     - natalisucks
     - nate-double-u
   sig-docs-blog-reviewers: # Reviewers for blog content
     - Gauravpadam
     - graz-dev
     - lmktfy
-    - mrbobbytables
     - natalisucks
     - nate-double-u
   sig-docs-website-owners: # Admins for overall website


### PR DESCRIPTION
Remove @mrbobbytables from our local copy of @kubernetes/sig-docs-blog-owners; we have other folks happy to help here.

@mrbobbytables if you would LGTM this one, I'd appreciate it, just so we have on record that you're happy to step away.

Also see https://github.com/kubernetes/org/pull/6067

For the record, I consider this emeritus status, albeit without tracking in the YAML data. Feel free to rejoin the team!