### PR TITLE
Fix Accessibility Violations: Add Missing Alt Text and ARIA Labels

### DIFF
--- a/layouts/partials/cncf.html
+++ b/layouts/partials/cncf.html
@@ -3,7 +3,7 @@
       <p>{{ T "main_cncf_project" | safeHTML }}</p>
       <picture>
           <source srcset="/images/cncf-logo-dark.svg" media="(prefers-color-scheme: dark)">
-          <img src="/images/cncf-logo-white.svg" class="cncf-img">
+          <img src="/images/cncf-logo-white.svg" class="cncf-img" alt="Cloud Native Computing Foundation logo">
       </picture>
   </div>
 </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -23,8 +23,8 @@
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0 footer-icons">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
-    <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ T .name_key }}">
+    <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ T .name_key }}">
       <i class="{{ .icon }}"></i>
     </a>
   </li>


### PR DESCRIPTION
## Description


This PR fixes 11 accessibility violations on [website homepage](https://kubernetes.io/) identified by the [IBM Equal Access Accessibility Checker](https://github.com/IBMa/equal-access), I developed an automated repair tool [A11YRepair](https://sites.google.com/view/a11yrepair/home) to repair these accessibility bugs:

**Screenshot of Fix Before**
<img width="2560" height="960" alt="image" src="https://github.com/user-attachments/assets/dd43696b-f499-4b37-8c62-9b4868aeda2d" />

**Screenshot of Fix After**
<img width="2560" height="922" alt="image" src="https://github.com/user-attachments/assets/0b1b954b-13e8-4d84-8b45-b8ae6275df05" />

## Issue

### **1) A11Y Issue: 1 image missing alternative text**
<img width="1920" height="800" alt="1" src="https://github.com/user-attachments/assets/89e220b4-eda1-437f-8681-0f8c962b545f" />

```
The image has neither an accessible name nor is marked as decorative or redundant
```

**Why is this important?**
When an image contains important information, providing a text alternative makes the same information accessible through assistive technologies, such as a Braille display. When an image is decorative or redundant, providing correct markup allows assistive technologies to ignore or not repeat the information.

### **2) A11Y Issue: 10 hyperlinks missing accessible names**
<img width="1920" height="800" alt="2" src="https://github.com/user-attachments/assets/627d3bd2-d4a5-4562-9fc7-77b131900b4c" />

```
Hyperlink has no link text, label or image with a text alternative
```

**Why is this important?**
When the purpose of a link is clear users can easily navigate links on the page without having to see the surrounding information for context.

## Changes

### 1. Added Alt Text to CNCF Logo (`layouts/partials/cncf.html`)

- Issue: The CNCF logo image was missing an `alt` attribute, making it inaccessible to screen readers
- Fix: Added descriptive alt text: `alt="Cloud Native Computing Foundation logo"`

### 2. Fixed Footer Icon Links (`layouts/partials/footer.html`)

- Issue: 10 social media icon links in the footer had no accessible names because the template was referencing a non-existent `.name` property
- Root Cause: The data model uses `name_key` (defined in `hugo.toml`) which references translation strings in `i18n/en/en.toml`, but the template was trying to access `.name` directly
- Fix: Updated the template to use Hugo's translation function `{{ T .name_key }}` for both the tooltip title and aria-label attributes

## Testing
Verified using IBM Equal Access Accessibility Checker:

✅ All 11 violations resolved
✅ CNCF logo now has proper alternative text
✅ All footer icon links now have accessible names via aria-label

#### **1) A11Y Issue: 1 image missing alternative text**

**Fix Before:**
<img width="1771" height="483" alt="image" src="https://github.com/user-attachments/assets/a4dd9e2b-d90b-4457-9cbb-6bc64f97e0ef" />

**Fix After:**
<img width="1852" height="457" alt="image" src="https://github.com/user-attachments/assets/dd1dd8a5-d787-4061-a4f3-02f2fa6204a9" />


#### **2) A11Y Issue: 10 hyperlinks missing accessible names**

**Fix Before:**
<img width="2563" height="919" alt="image" src="https://github.com/user-attachments/assets/adef8969-f1d3-417d-a1b2-3088520a5401" />
 `title` and `aria-label` is null

**Fix After:** 
<img width="1950" height="782" alt="image" src="https://github.com/user-attachments/assets/2d8013c7-a981-4cd7-8198-50cadade8b94" />
add description text for these icon elements

## Additional Info
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.