### PR TITLE
docs: small clarification in contribute overview

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -12,6 +12,7 @@ card:
 ---
 
 <!-- overview -->
+Kubernetes documentation is maintained collaboratively by the community through GitHub pull requests.
 
 There are lots of ways to contribute to Kubernetes. You can work on designs for new features,
 you can document the code we already have, you can [write for our blogs](/docs/contribute/blog/).


### PR DESCRIPTION
This PR adds a small clarifying sentence to the contribute overview.

Opening this PR to complete contributor onboarding (CLA signing).
Happy to close if not needed.