### PR TITLE
Add example manifests for HorizontalPodAutoscaler

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -265,13 +265,18 @@ When you create a HorizontalPodAutoscaler API object, make sure the name specifi
 More details about the API object can be found at
 [HorizontalPodAutoscaler Object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#horizontalpodautoscaler-v2-autoscaling).
 
-### Example manifests for different API versions
+### Differences between v1 and v2 APIs
 
-Below are example HorizontalPodAutoscaler manifests using different API versions.
+The `autoscaling/v1` and `autoscaling/v2` APIs represent different versions of the **same underlying HorizontalPodAutoscaler object**. You can read and write a HorizontalPodAutoscaler using either API version, and Kubernetes will preserve fields that are not directly represented in the older version as annotations.
 
-#### autoscaling/v1 (CPU utilization only)
+The main practical difference is in how scaling metrics are expressed:
+- `autoscaling/v1` supports only CPU utilization
+- `autoscaling/v2` supports multiple resource, custom, and external metrics
 
-```yaml
+{{< tabs name="hpa-api-versions" >}}
+{{% tab name="autoscaling/v1" %}}
+
+{{< highlight yaml >}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -284,15 +289,13 @@ spec:
     kind: Deployment
     name: my-app
   targetCPUUtilizationPercentage: 80
-```
+{{< /highlight >}}
 
-This version supports scaling only based on CPU utilization.
+{{% /tab %}}
 
----
+{{% tab name="autoscaling/v2" %}}
 
-#### autoscaling/v2 (Multiple metrics)
-
-```yaml
+{{< highlight yaml >}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -317,9 +320,10 @@ spec:
       target:
         type: AverageValue
         averageValue: 500Mi
-```
+{{< /highlight >}}
 
-This version supports CPU, memory, and custom or external metrics.
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Stability of workload scale {#flapping}
 

--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -265,6 +265,62 @@ When you create a HorizontalPodAutoscaler API object, make sure the name specifi
 More details about the API object can be found at
 [HorizontalPodAutoscaler Object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#horizontalpodautoscaler-v2-autoscaling).
 
+### Example manifests for different API versions
+
+Below are example HorizontalPodAutoscaler manifests using different API versions.
+
+#### autoscaling/v1 (CPU utilization only)
+
+```yaml
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-hpa-v1
+spec:
+  minReplicas: 2
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  targetCPUUtilizationPercentage: 80
+```
+
+This version supports scaling only based on CPU utilization.
+
+---
+
+#### autoscaling/v2 (Multiple metrics)
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-hpa-v2
+spec:
+  minReplicas: 2
+  maxReplicas: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: AverageValue
+        averageValue: 500Mi
+```
+
+This version supports CPU, memory, and custom or external metrics.
+
 ## Stability of workload scale {#flapping}
 
 When managing the scale of a group of replicas using the HorizontalPodAutoscaler,


### PR DESCRIPTION
Fixes #54108

While reading this page as a learner, I found it difficult to connect the detailed explanation of HPA metrics and API versions with what a minimal HorizontalPodAutoscaler manifest actually looks like in each version.

The page explains behavior and metrics well, but it does not show a simple, generic comparison between autoscaling/v1 and autoscaling/v2. Existing examples are either tied to the walkthrough or focus on v2, which makes it harder to understand how fields map between versions and what changed structurally.

This PR adds a short section under **API object** that:

- Shows minimal example manifests for autoscaling/v1 and autoscaling/v2 side by side (using tabs)
- Explains that these are two API views over the same underlying HorizontalPodAutoscaler object, and can be round-tripped
- Highlights the practical difference in how metrics are expressed (single CPU field in v1 vs the `metrics` array in v2)

The goal is to make the API discussion more concrete at the point where the object itself is introduced, and to help readers reason about version differences without modifying existing tutorial or metrics content.
