### PR TITLE
docs: clarify authorization and security for kubectl port-forward

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -207,6 +207,14 @@ The support for UDP protocol is tracked in
 [issue 47862](https://github.com/kubernetes/kubernetes/issues/47862).
 {{< /note >}}
 
+## Authorization and security considerations
+
+Access to `kubectl port-forward` is controlled by Kubernetes authorization mechanisms like Role-Based Access Control (RBAC). Authorization is enforced by the Kubernetes API server, not by the `kubectl` client.
+
+To use `kubectl port-forward`, a user must have permission to access the target resource (example, a Pod or Service) and the `portforward` subresource. Typical required permissions include `get` on pods and `create` on `pods/portforward`.
+
+Cluster administrators should carefully restrict these permissions, as port-forwarding can provide direct network access to workloads and may bypass network-level controls.
+
 ## {{% heading "whatsnext" %}}
 
 Learn more about [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands/#port-forward).

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -211,7 +211,7 @@ The support for UDP protocol is tracked in
 
 Access to `kubectl port-forward` is controlled by Kubernetes authorization mechanisms like Role-Based Access Control (RBAC). Authorization is enforced by the Kubernetes API server, not by the `kubectl` client.
 
-To use `kubectl port-forward`, a user must have permission to access the target resource (example, a Pod or Service) and the `portforward` subresource. Typical required permissions include `get` on pods and `create` on `pods/portforward`.
+To use `kubectl port-forward`, a user must have permission to access the target resource (for example, a Pod or Service) and the `portforward` subresource. Typical required permissions include `get` on pods and `create` on `pods/portforward`.
 
 Cluster administrators should carefully restrict these permissions, as port-forwarding can provide direct network access to workloads and may bypass network-level controls.
 

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -211,7 +211,7 @@ The support for UDP protocol is tracked in
 
 Access to `kubectl port-forward` is controlled by Kubernetes authorization mechanisms like {{< glossary_tooltip text="Role-Based Access Control (RBAC)" term_id="rbac" >}}. Authorization is enforced by the Kubernetes API server, not by the `kubectl` client.
 
-To use `kubectl port-forward`, a user must have permission to access the target resource (for example, a Pod or Service) and the `portforward` subresource. Typical required permissions include `get` on pods and `create` on `pods/portforward`.
+To use `kubectl port-forward`, a user must have permission to access the target resource (for example, a Pod or Service) and the `portforward` subresource. Typical required permissions include `get` on `pods` and `create` on `pods/portforward`.
 
 Cluster administrators should carefully restrict these permissions, as port-forwarding can provide direct network access to workloads and may bypass network-level controls.
 

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -209,7 +209,7 @@ The support for UDP protocol is tracked in
 
 ## Authorization and security considerations
 
-Access to `kubectl port-forward` is controlled by Kubernetes authorization mechanisms like Role-Based Access Control (RBAC). Authorization is enforced by the Kubernetes API server, not by the `kubectl` client.
+Access to `kubectl port-forward` is controlled by Kubernetes authorization mechanisms like {{< glossary_tooltip text="Role-Based Access Control (RBAC)" term_id="rbac" >}}. Authorization is enforced by the Kubernetes API server, not by the `kubectl` client.
 
 To use `kubectl port-forward`, a user must have permission to access the target resource (for example, a Pod or Service) and the `portforward` subresource. Typical required permissions include `get` on pods and `create` on `pods/portforward`.
 


### PR DESCRIPTION
### Description

This PR adds a short section to the `port-forward` task documentation
explaining how access to `kubectl port-forward` is authorized in Kubernetes.

It explains:
- Authorization is enforced by the API server (not the `kubectl` client)
- RBAC controls access to port-forwarding
- Typical required permissions include `get` on pods and `create` on `pods/portforward`
- Port-forwarding has security implications for cluster administrators

### Issue

Closes: #51700
