### PR TITLE
[vi] Add Vietnamese translation for glossary cluster-operator

### DIFF
--- a/content/vi/docs/reference/glossary/cluster-operator.md
+++ b/content/vi/docs/reference/glossary/cluster-operator.md
@@ -1,0 +1,21 @@
+---
+title: Người vận hành Cluster
+id: cluster-operator
+date: 2018-04-12
+full_link: 
+short_description: >
+  Người cấu hình, kiểm soát và giám sát các cluster.
+
+aka: 
+tags:
+- user-type
+---
+ Người cấu hình, kiểm soát và giám sát các cluster.
+
+<!--more--> 
+
+Trách nhiệm chính của họ là duy trì cluster hoạt động ổn định, có thể bao gồm các hoạt động bảo trì định kỳ hoặc nâng cấp.<br>
+
+{{< note >}}
+Người vận hành cluster khác với [Operator pattern](/vi/docs/concepts/extend-kubernetes/operator/) - mẫu thiết kế mở rộng Kubernetes API.
+{{< /note >}}


### PR DESCRIPTION
## Description

- Add Vietnamese translation for cluster-operator
- Link: https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/cluster-operator.md

## Issue

NONE

Closes: #