### PR TITLE
fix: currentVersion skew in feature flag docs

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/index.md
@@ -41,7 +41,7 @@ Use `<component> -h` to list available feature gates for a specific component.
 For detailed instructions on configuring feature gates in your cluster, see
 [Configure Feature Gates](/docs/tasks/administer-cluster/configure-feature-gates/).
 
-## Feature gates in Kubernetes {{% skew currentVersion %}} {#list-of-gates}
+## Feature gates in Kubernetes v{{% skew currentVersion %}} {#list-of-gates}
 
 The following tables are a summary of the feature gates that you can set on
 different Kubernetes components.

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/index.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/index.md
@@ -72,7 +72,7 @@ Use `<component> -h` to list available feature gates for a specific component.
 For detailed instructions on configuring feature gates in your cluster, see
 [Configure Feature Gates](/docs/tasks/administer-cluster/configure-feature-gates/).
 
-## Feature gates in Kubernetes {{% skew currentVersion %}} {#list-of-gates}
+## Feature gates in Kubernetes {{< skew current version >}} {#list-of-gates}
 -->
 每个 Kubernetes 组件只支持与其自身功能相关的特性门控。
 使用 `<component> -h` 可以列出特定组件支持的所有特性门控。
@@ -80,7 +80,7 @@ For detailed instructions on configuring feature gates in your cluster, see
 如需了解在集群中配置特性门控的详细步骤，
 参阅[配置特性门控](/zh-cn/docs/tasks/administer-cluster/configure-feature-gates/)。
 
-## Kubernetes {{% skew currentVersion %}} 中的特性门控   {#list-of-gates}
+## Kubernetes {{< skew current version >}} 中的特性门控   {#list-of-gates}
 
 <!--
 Each Kubernetes component lets you enable or disable a set of feature gates that
@@ -116,9 +116,9 @@ For detailed instructions on configuring feature gates in your cluster, see
 有关在集群中配置特性门控的详细说明，请参阅[配置特性门控](/zh-cn/docs/tasks/administer-cluster/configure-feature-gates/)。
 
 <!--
-## Feature gates in Kubernetes {{% skew currentVersion %}} {#list-of-gates}
+## Feature gates in Kubernetes {{< skew current version >}} {#list-of-gates}
 -->
-## Kubernetes {{% skew currentVersion %}} 中的特性门控    {#list-of-gates}
+## Kubernetes {{< skew current version >}} 中的特性门控    {#list-of-gates}
 
 <!--
 The following tables are a summary of the feature gates that you can set on


### PR DESCRIPTION
### Description

Fixes docs to use the proper skew shortcode based on [this doc](https://github.com/kubernetes/website/blob/5c39fa2f9790195b47c514a9193a212abe419f37/layouts/shortcodes/skew.html#L103). Also updates to the [markdown notation](https://gohugo.io/content-management/shortcodes/#markdown-notation) which ensures they properly render on the table of contents/sidebar.

### Issue

No open issues, but I noticed something was off based on [this page](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) showing `HAHAHUGOSHORTCODE3093s0HBHB` ([placeholder shortcode](https://github.com/gohugoio/hugo/blob/b3ea2a5fab48615ffc0acd44264171360ddaa33d/hugolib/shortcode.go#L193)).