### PR TITLE
Fix typos and change `--` symbols to `—` in a "Objects In Kubernetes" page.

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/en/docs/concepts/overview/working-with-objects/_index.md
@@ -28,7 +28,7 @@ entities to represent the state of your cluster. Specifically, they can describe
 * The resources available to those applications
 * The policies around how those applications behave, such as restart policies, upgrades, and fault-tolerance
 
-A Kubernetes object is a "record of intent"--once you create the object, the Kubernetes system
+A Kubernetes object is a "record of intent"—once you create the object, the Kubernetes system
 will constantly work to ensure that the object exists. By creating an object, you're effectively
 telling the Kubernetes system what you want your cluster's workload to look like; this is your
 cluster's *desired state*.
@@ -57,10 +57,10 @@ For example: in Kubernetes, a Deployment is an object that can represent an
 application running on your cluster. When you create the Deployment, you
 might set the Deployment `spec` to specify that you want three replicas of
 the application to be running. The Kubernetes system reads the Deployment
-spec and starts three instances of your desired application--updating
+spec and starts three instances of your desired application—updating
 the status to match your spec. If any of those instances should fail
 (a status change), the Kubernetes system responds to the difference
-between spec and status by making a correction--in this case, starting
+between spec and status by making a correction—in this case, starting
 a replacement instance.
 
 For more information on the object spec, status, and metadata, see the

--- a/content/en/docs/concepts/overview/working-with-objects/storage-version.md
+++ b/content/en/docs/concepts/overview/working-with-objects/storage-version.md
@@ -148,7 +148,7 @@ it can be used as a storage version.
 Multiple storage versions for a single resource can pose problems for cluster
 administrators. A cluster administrator may not remove old versions of an API
 for CRDs which may be unsupported until they are sure that all objects are no
-longer using the storege version associated with it. With a large number of
+longer using the storage version associated with it. With a large number of
 objects and an opaque view into which ones are new and which ones still are
 backed by old storage versions, it makes it difficult to tell when a version can
 be safely removed. If a version is removed prematurely, it can mean being unable


### PR DESCRIPTION
### Description

Fix typos: replace `storege` to `storage`. Change `--` symbols to `—` in a "Objects In Kubernetes" page for a more prettier and consistent look, and remove a mix of both styles.

### Issue

Closes: nothing