### PR TITLE
Strengthen and clarify warnings around the kubelet API nodes/proxy permission

### DIFF
--- a/content/en/blog/_posts/2023-04-21-node-log-query-alpha.md
+++ b/content/en/blog/_posts/2023-04-21-node-log-query-alpha.md
@@ -37,9 +37,16 @@ On Linux we assume that service logs are available via journald, and that
 `journalctl` is installed. On Windows we assume that service logs are available
 in the application log provider. Also note that fetching node logs is only
 available if you are authorized to do so (in RBAC, that's **get** and
-**create** access to `nodes/proxy`). The privileges that you need to fetch node
-logs also allow elevation-of-privilege attacks, so be careful about how you
-manage them.
+**create** access to `nodes/proxy`).
+
+{{< warning >}}
+Granting permissions to `nodes/proxy` (even just **get** permission) also authorizes access to powerful kubelet
+APIs that can be used to execute commands in any container running on the node, so be careful about how you manage them.
+See [Kubelet authentication/authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/#get-nodes-proxy-warning)
+for more information.
+{{< /warning >}}
+
+_(this warning message was added to the article in early 2026)_
 
 ## How do I use it?
 

--- a/content/en/docs/concepts/security/api-server-bypass-risks.md
+++ b/content/en/docs/concepts/security/api-server-bypass-risks.md
@@ -64,6 +64,10 @@ distribution in use. Direct access to the API allows for disclosure of informati
 the pods running on a node, the logs from those pods, and execution of commands in
 every container running on the node.
 
+Some of these endpoints support Websocket protocols via HTTP `GET` requests, which are authorized with the **get** verb.
+This means that **get** permission on `nodes/proxy` is not a read-only permission,
+and authorizes access to endpoints which can be used to execute commands in any container running on the node.
+
 When Kubernetes cluster users have RBAC access to `Node` object sub-resources, that access
 serves as authorization to interact with the kubelet API. The exact access depends on
 which sub-resource access has been granted, as detailed in
@@ -84,6 +88,8 @@ The default anonymous access doesn't make this assertion with the control plane.
 - Restrict access to sub-resources of the `nodes` API object using mechanisms such as
   [RBAC](/docs/reference/access-authn-authz/rbac/). Only grant this access when required,
   such as by monitoring services.
+- Avoid granting the `nodes/proxy` catch-all permission, even with just the **get** verb.
+  Instead, grant [granular permissions](/docs/reference/access-authn-authz/kubelet-authn-authz/#fine-grained-authorization).
 - Restrict access to the kubelet port. Only allow specified and trusted IP address
   ranges to access the port.
 - Ensure that [kubelet authentication](/docs/reference/access-authn-authz/kubelet-authn-authz/#kubelet-authentication).

--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -140,10 +140,15 @@ PersistentVolumes, and constrained users should use PersistentVolumeClaims to ac
 
 ### Access to `proxy` subresource of Nodes
 
-Users with access to the proxy sub-resource of node objects have rights to the Kubelet API,
+Users with access to the `nodes/proxy` sub-resource have rights to the Kubelet API,
 which allows for command execution on every pod on the node(s) to which they have rights.
 This access bypasses audit logging and admission control, so care should be taken before
-granting rights to this resource.
+granting any rights to this resource.
+These APIs can be exercised via websocket HTTP `GET` requests, which only requires authorization of the **get** verb.
+This means that **get** permission on `nodes/proxy` is not a read-only permission.
+
+See [Kubelet authentication/authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/#get-nodes-proxy-warning)
+for more information.
 
 ### Escalate verb
 

--- a/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
@@ -31,7 +31,7 @@ To enable X509 client certificate authentication to the kubelet's HTTPS endpoint
 
 To enable API bearer tokens (including service account tokens) to be used to authenticate to the kubelet's HTTPS endpoint:
 
-* ensure the `authentication.k8s.io/v1beta1` API group is enabled in the API server
+* ensure the `authentication.k8s.io/v1` API group is enabled in the API server
 * start the kubelet with the `--authentication-token-webhook` and `--kubeconfig` flags
 * the kubelet calls the `TokenReview` API on the configured API server to determine user information from bearer tokens
 
@@ -47,7 +47,7 @@ There are many possible reasons to subdivide access to the kubelet API:
 
 To subdivide access to the kubelet API, delegate authorization to the API server:
 
-* ensure the `authorization.k8s.io/v1beta1` API group is enabled in the API server
+* ensure the `authorization.k8s.io/v1` API group is enabled in the API server
 * start the kubelet with the `--authorization-mode=Webhook` and the `--kubeconfig` flags
 * the kubelet calls the `SubjectAccessReview` API on the configured API server to determine whether each request is authorized
 
@@ -73,6 +73,16 @@ Kubelet API         | resource | subresource
 /spec/\*            | nodes    | spec
 /checkpoint/\*      | nodes    | checkpoint
 *all others*        | nodes    | proxy
+
+<a name="get-nodes-proxy-warning"></a>
+{{< warning >}}
+`nodes/proxy` permission grants access to all other kubelet APIs.
+This includes APIs that can be used to execute commands in any container running on the node.
+
+Some of these endpoints support Websocket protocols via HTTP `GET` requests, which are authorized with the **get** verb.
+This means that **get** permission on `nodes/proxy` is not a read-only permission,
+and authorizes executing commands in any container running on the node.
+{{< /warning >}}
 
 The namespace and API group attributes are always an empty string, and
 the resource name is always the name of the kubelet's `Node` API object.


### PR DESCRIPTION
### Description

Strengthen and clarify warnings around the `nodes/proxy` catch-all permission to the Kubelet API.

xref discussion in https://github.com/kubernetes/kubernetes/pull/136550#issuecomment-3807789829

Previews:
* https://deploy-preview-54191--kubernetes-io-main-staging.netlify.app/blog/2023/04/21/node-log-query-alpha/#how-does-it-work
* https://deploy-preview-54191--kubernetes-io-main-staging.netlify.app/docs/concepts/security/api-server-bypass-risks/#kubelet-api
  * originally added in https://github.com/kubernetes/website/pull/35908/files#diff-d77b018b9070dd4252fcb1b977c150ef2799eddf891d7c4304825dbc7a0792f6R65-R71
* https://deploy-preview-54191--kubernetes-io-main-staging.netlify.app/docs/reference/access-authn-authz/kubelet-authn-authz/#get-nodes-proxy-warning
* https://deploy-preview-54191--kubernetes-io-main-staging.netlify.app/docs/concepts/security/rbac-good-practices/#access-to-proxy-subresource-of-nodes
  * originally added in https://github.com/kubernetes/website/pull/32812/files#diff-85ec59bc885620464210943d5117a104e39c42734d497f07dc9c76547925b0feR121-R126


/sig node auth security
/cc @enj @micahhausler 