### PR TITLE
docs: hyphenate open-source in Kubernetes overview

### DIFF
--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -4,7 +4,7 @@ reviewers:
 - mikedanese
 title: "Overview"
 description: >
-  Kubernetes is a portable, extensible, open source platform for managing containerized workloads and services that facilitate both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
+  Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services that facilitate both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
 content_type: concept
 weight: 20
 card:


### PR DESCRIPTION
What changed:
- Hyphenated "open-source" in the Kubernetes overview for grammatical correctness.

Why:
- "Open-source" is used as a compound adjective modifying "platform".
