### PR TITLE
Mark CSIServiceAccountTokenSecrets feature gate as GA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/CSIServiceAccountTokenSecrets.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/CSIServiceAccountTokenSecrets.md
@@ -9,6 +9,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.35"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 Enables CSI drivers to opt-in for receiving service account tokens from kubelet
 through the dedicated secrets field in NodePublishVolumeRequest instead of the volume_context field.


### PR DESCRIPTION
Doc update for KEP 5538 GA: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/5538-csi-sa-tokens-secrets-field/README.md
KEP issue: https://github.com/kubernetes/enhancements/issues/5538

/sig auth storage
/assign @msau42 @xing-yang