### PR TITLE
Make announcement bg darker and navbar bg semi-transparent

### DIFF
--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -1,5 +1,11 @@
+// Ensure background is dark enough for the navbar text to have sufficient contrast
+#announcement {
+  filter: brightness(0.8);
+}
+
 .td-navbar {
-  background: transparent !important;
+  // Set bg transparency so that it works for both light and dark backgrounds
+  background-color: rgba(0, 0, 0, 0.1);
   position: fixed !important;
   transition: 0.3s;
   width: 100%;


### PR DESCRIPTION
- Fixes #54234
- Applies a filter to the `#announcement` so that the background color is a bit darker.
- Sets the navbar to be a little bit less transparent
- The above two tweaks make the navbar text readable
- Longer-term fix is to upgrade Docsy. It has improved navbar styling and reliable light/dark mode support

**Preview**: https://deploy-preview-54235--kubernetes-io-main-staging.netlify.app/

### Screenshots

Before:

<img width="823" height="588" alt="image" src="https://github.com/user-attachments/assets/114f3c58-5d94-40dd-b662-c76cd1981b08" />

After:

<img width="826" height="593" alt="image" src="https://github.com/user-attachments/assets/b08a78d9-306b-4af6-b3c3-c339a9936af0" />

Same solution applied to the standard hero:

<img width="823" height="588" alt="image" src="https://github.com/user-attachments/assets/abc5f38b-0caa-439f-85bf-f639fe60f335" />

/cc @nate-double-u 