### PR TITLE
docs: fix singular pronoun for container

### DIFF
--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -43,7 +43,7 @@ can easily manage a canary deployment for your system.
 Kubernetes provides you with:
 
 * **Service discovery and load balancing**
-  Kubernetes can expose a container using a DNS name or their own IP address.
+  Kubernetes can expose a container using a DNS name or its own IP address.
   If traffic to a container is high, Kubernetes is able to load balance and distribute
   the network traffic so that the deployment is stable.
 * **Storage orchestration**


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR fixes a singular/plural pronoun mismatch in the "Kubernetes Service Discovery and Load balancing" documentation. In the Kubernetes website repository, this specific file is located at `content/en/docs/concepts/overview/_index.md`

**Change:**
- Updated "their own IP address" to "its own IP address" when referring to a singular container.

