### PR TITLE
[KEP-4639]: Update ImageVolume documentation for GA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ImageVolume.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ImageVolume.md
@@ -17,6 +17,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.35"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 Allow using the [`image`](/docs/concepts/storage/volumes/) volume source in a Pod.
 This volume source lets you mount a container image as a read-only volume.

--- a/content/en/docs/tasks/configure-pod-container/image-volumes.md
+++ b/content/en/docs/tasks/configure-pod-container/image-volumes.md
@@ -20,7 +20,6 @@ mount content from OCI registries inside containers.
 - The container runtime needs to support the image volumes feature
 - You need to exec commands in the host
 - You need to be able to exec into pods
-- You need to enable the `ImageVolume` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 
 <!-- steps -->
 


### PR DESCRIPTION
Updates documentation to reflect ImageVolume graduation to GA in v1.36.

Changes:
- Add GA (stable) stage starting from v1.36 to feature gate metadata
- Remove prerequisite about enabling the feature gate (no longer needed for GA)

The feature-state shortcode will automatically update to show GA status.

KEP: https://github.com/kubernetes/enhancements/issues/4639