### PR TITLE
Remove outdated FIXME comment in blog submission guide

### DIFF
--- a/content/en/docs/contribute/blog/submission.md
+++ b/content/en/docs/contribute/blog/submission.md
@@ -23,7 +23,6 @@ As an author, you have three different routes towards publication.
 The approach the Kubernetes project recommends is: pitch your article by contacting the blog team. You can do that via Kubernetes Slack ([#sig-docs-blog](https://kubernetes.slack.com/archives/CJDHVD54J)).
 For articles that you want to publish to the contributor blog only, you can also pitch directly
 to [SIG ContribEx comms](https://kubernetes.slack.com/archives/C03KT3SUJ20).
-<!-- FIXME: or using this [form] -->
 
 Unless there's a problem with your submission, the blog team / SIG ContribEx will pair you up with:
 


### PR DESCRIPTION
The FIXME comment about a submission form was left during the March 2025 restructuring of the blog contribution documentation. The current recommended process is to pitch articles via Kubernetes Slack (#sig-docs-blog or SIG ContribEx comms), not through a form.

This change removes the obsolete FIXME comment to clean up the documentation and align with the current submission process.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #