### PR TITLE
Remove outdated TODO comment from debug-pods documentation

### DIFF
--- a/content/en/docs/tasks/debug/debug-application/debug-pods.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-pods.md
@@ -122,8 +122,6 @@ I0805 10:43:25.129973   46757 schema.go:129] this may be a false alarm, see http
 pods/mypod
 ```
 
-<!-- TODO: Now that #11914 is merged, this advice may need to be updated -->
-
 The next thing to check is whether the pod on the apiserver
 matches the pod you meant to create (e.g. in a yaml file on your local machine).
 For example, run `kubectl get pods/mypod -o yaml > mypod-on-apiserver.yaml` and then

--- a/content/en/docs/tasks/debug/debug-application/debug-pods.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-pods.md
@@ -112,24 +112,25 @@ is nested incorrectly, or a key name is typed incorrectly, and so the key is ign
 For example, if you misspelled `command` as `commnd` then the pod will be created but
 will not use the command line you intended it to use.
 
-The first thing to do is to delete your pod and try creating it again with the `--validate` option.
-For example, run `kubectl apply --validate -f mypod.yaml`.
-If you misspelled `command` as `commnd` then will give an error like this:
+The first thing to do is to delete your pod and try creating it again. 
+For example, run `kubectl apply -f mypod.yaml`.
+Modern versions of Kubernetes (v1.18+) perform server-side validation by default, which will
+catch and report unknown or misspelled fields. If you misspelled `command` as `commnd`, 
+you will get an error like this:
 
 ```shell
-I0805 10:43:25.129850   46757 schema.go:126] unknown field: commnd
-I0805 10:43:25.129973   46757 schema.go:129] this may be a false alarm, see https://github.com/kubernetes/kubernetes/issues/6842
-pods/mypod
+Error from server (BadRequest): error when creating "mypod.yaml": Pod in version "v1" 
+cannot be handled as a Pod: strict decoding error: unknown field "spec.containers[0].commnd"
 ```
 
-The next thing to check is whether the pod on the apiserver
-matches the pod you meant to create (e.g. in a yaml file on your local machine).
-For example, run `kubectl get pods/mypod -o yaml > mypod-on-apiserver.yaml` and then
-manually compare the original pod description, `mypod.yaml` with the one you got
-back from apiserver, `mypod-on-apiserver.yaml`. There will typically be some
-lines on the "apiserver" version that are not on the original version. This is
-expected. However, if there are lines on the original that are not on the apiserver
-version, then this may indicate a problem with your pod spec.
+This validation happens automatically when you apply or create resources. The API server
+will reject manifests that contain unknown fields, preventing configuration errors from
+being silently ignored.
+
+If you want to allow unknown fields (not recommended for debugging), you can use 
+`--validate=ignore`, but this may hide configuration problems. For stricter validation during
+development, use `--validate=strict` (the default) or `--dry-run=server` to test your 
+manifests without actually creating resources.
 
 ### Debugging Replication Controllers
 

--- a/content/en/docs/tasks/debug/debug-application/debug-pods.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-pods.md
@@ -114,7 +114,7 @@ will not use the command line you intended it to use.
 
 The first thing to do is to delete your pod and try creating it again. 
 For example, run `kubectl apply -f mypod.yaml`.
-Modern versions of Kubernetes (v1.18+) perform server-side validation by default, which will
+Kubernetes v1.27 and later perform server-side validation by default, which will
 catch and report unknown or misspelled fields. If you misspelled `command` as `commnd`, 
 you will get an error like this:
 
@@ -128,9 +128,9 @@ will reject manifests that contain unknown fields, preventing configuration erro
 being silently ignored.
 
 If you want to allow unknown fields (not recommended for debugging), you can use 
-`--validate=ignore`, but this may hide configuration problems. For stricter validation during
-development, use `--validate=strict` (the default) or `--dry-run=server` to test your 
-manifests without actually creating resources.
+`--validate=ignore`, but this may hide configuration problems. The default behavior
+is `--validate=true`, which performs server-side validation. You can also use `--dry-run=server` 
+to test your manifests without actually creating resources.
 
 ### Debugging Replication Controllers
 


### PR DESCRIPTION
The TODO comment referencing PR #11914 is no longer relevant. PR kubernetes/kubernetes#11914 was merged in July 2015, over 10 years ago, implementing stricter swagger validation that stops ignoring unknown fields.

The advice in the documentation remains valid and does not need updating, so this change simply removes the obsolete TODO comment.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #