### PR TITLE
Remove outdated TODO comment from ephemeral volumes blog post

### DIFF
--- a/content/en/blog/_posts/2020-09-01-generic-ephemeral-volumes.md
+++ b/content/en/blog/_posts/2020-09-01-generic-ephemeral-volumes.md
@@ -142,7 +142,6 @@ driver](https://github.com/kubernetes-csi/external-provisioner/blob/master/READM
 the `external-provisioner` must be told to publish capacity
 information that it then retrieves from the CSI driver through the normal
 `GetCapacity` call.
-<!-- TODO: update the link with a revision once https://github.com/kubernetes-csi/external-provisioner/pull/450 is merged -->
 
 When the Kubernetes scheduler needs to choose a node for a Pod with an
 unbound volume that uses late binding and the CSI driver deployment


### PR DESCRIPTION
The TODO comment referencing PR kubernetes-csi/external-provisioner#450 is no longer relevant. That PR was merged on August 18, 2020, over 5 years ago.

This change simply removes the obsolete TODO comment.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #