### PR TITLE
docs: fix kubectl create configmap env-file example

### DIFF
--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_configmap.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_configmap.md
@@ -46,9 +46,9 @@ kubectl create configmap NAME [--from-file=[key=]source] [--from-literal=key1=va
   kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
   
   # Create a new config map named my-config from the key=value pairs in the file
-  kubectl create configmap my-config --from-file=path/to/bar
+  kubectl create configmap my-config --from-env-file=path/to/bar.env
   
-  # Create a new config map named my-config from an env file
+  # Create a new config map named my-config from env files
   kubectl create configmap my-config --from-env-file=path/to/foo.env --from-env-file=path/to/bar.env
 ```
 


### PR DESCRIPTION
Fixes kubernetes/website#54270.

The `kubectl create configmap` docs had Examples #1 and #4 using identical `--from-file` commands while describing different behavior.

Example #4 is now correctly shown with `--from-env-file=path/to/bar.env`, and the surrounding comment text is adjusted accordingly.