### PR TITLE
Remove duplicate Kui description

### DIFF
--- a/content/en/docs/reference/tools/_index.md
+++ b/content/en/docs/reference/tools/_index.md
@@ -63,7 +63,7 @@ Use Kompose to:
 
 ## Kui
 
-[`Kui`](https://github.com/kubernetes-sigs/kui) is a GUI tool that takes your normal `kubectl` command line requests and responds with graphics. 
+[`Kui`](https://github.com/kubernetes-sigs/kui) is a GUI tool that takes your normal `kubectl` command line requests and responds with graphics.
 Instead of ASCII tables, Kui provides a GUI rendering with tables that you can sort.
 
 Kui lets you:


### PR DESCRIPTION
### Description
Remove duplicate description of Kui in the tools documentation. The first two sentences were saying essentially the same thing about Kui responding to kubectl commands with graphics.

### Issue
Closes: #54307