### PR TITLE
SIG Architecture API Gov. Spotlight: update publication date

### DIFF
--- a/content/en/blog/_posts/2026-02-12-sig-arch-api-spotlight.md
+++ b/content/en/blog/_posts/2026-02-12-sig-arch-api-spotlight.md
@@ -3,7 +3,7 @@ layout: blog
 title: "Spotlight on SIG Architecture: API Governance"
 slug: sig-architecture-api-spotlight
 canonicalUrl: https://www.kubernetes.dev/blog/2026/02/12/sig-architecture-api
-date: 2026-12-31
+date: 2026-02-12
 draft: false
 author: >
   [Frederico Muñoz](https://github.com/fsmunoz) (SAS Institute)"


### PR DESCRIPTION
Removed draft status and update publication date for Feb 12 on already reviewed & merged spotlight (this PR changes headers only, not the content).

Update the slug as per an original suggestion that didn't made it before merge https://github.com/kubernetes/contributor-site/pull/621 

Add canonicalUrl pointing to the contributore-site URL.

A similar PR update was made for the website , which is already merged as well. https://github.com/kubernetes/contributor-site/pull/649