### PR TITLE
Add guidance on system PriorityClasses for cluster-essential components

### DIFF
--- a/content/en/docs/setup/best-practices/cluster-large.md
+++ b/content/en/docs/setup/best-practices/cluster-large.md
@@ -113,6 +113,10 @@ many nodes, consider the following:
   the case with horizontally-scaled addons, you may also need to raise CPU or memory
   limits slightly.
 
+## Prioritizing cluster-essential components
+
+To ensure cluster-essential components (such as CoreDNS, metrics-server, and other critical add-ons) are scheduled ahead of other workloads and are not preempted by lower-priority pods, run them with a system [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/), such as `system-cluster-critical` or `system-node-critical`.
+
 ## {{% heading "whatsnext" %}}
 
 * `VerticalPodAutoscaler` is a custom resource that you can deploy into your cluster


### PR DESCRIPTION
This PR adds a brief guidance to the "Considerations for large clusters" best practices page 
`(content/en/docs/setup/best-practices/cluster-large.md)`. It recommends running cluster-essential components with a system PriorityClass (system-cluster-critical or system-node-critical) to ensure they are properly prioritized and protected from preemption during resource contention.

Issue
Closes: [#54311](https://github.com/kubernetes/website/issues/54311#issuecomment-3867070447)

