### PR TITLE
Drop duplicate web manifest link

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -35,8 +35,6 @@
 
 <meta name="theme-color" content="#326ce5">
 
-<link rel="manifest" href="/manifest.webmanifest">
-
 {{- if .HasShortcode "kubeweekly" -}}
 <link href="https://cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
 <style type="text/css">


### PR DESCRIPTION
We have two lines in the same file similar to:
```html
<link rel="manifest" href="/manifest.webmanifest">
```

Drop one of them.

/area web-development