### PR TITLE
Debugging DNS Resolution: Command should use the label "kubernetes.io..." for filtering

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -186,7 +186,7 @@ You can verify that DNS endpoints are exposed by using the `kubectl get endpoint
 command.
 
 ```shell
-kubectl get endpointslice -l k8s.io/service-name=kube-dns --namespace=kube-system
+kubectl get endpointslice -l kubernetes.io/service-name=kube-dns --namespace=kube-system
 ```
 ```
 NAME             ADDRESSTYPE   PORTS   ENDPOINTS                  AGE


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The described command in the pull request did not work on my kubernetes distribution (it was k3s, version 1.34 though). From what I saw the described command/documentation has not changed for a longer time. So I suspect my change is still valid for 1.35. The fixed command works and displays the DNS endpoint:

> 
> ~# kubectl get endpointslice -l kubernetes.io/service-name=kube-dns --namespace=kube-system
> NAME             ADDRESSTYPE   PORTS        ENDPOINTS    AGE
> kube-dns-6gjmr   IPv4          9153,53,53   10.42.0.61   2d8h