### PR TITLE
Clarify Guaranteed QoS requires non-zero resource values

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-qos.md
+++ b/content/en/docs/concepts/workloads/pods/pod-qos.md
@@ -50,6 +50,11 @@ For a Pod to be given a QoS class of `Guaranteed`:
 * Every Container in the Pod must have a CPU limit and a CPU request, both greater than zero.
 * For every Container in the Pod, the CPU limit must equal the CPU request.
 
+{{< note >}}
+Setting CPU or memory requests and limits to zero does not qualify a Pod for the `Guaranteed` QoS class.
+A Pod with zero values for requests and limits is classified as `Burstable`.
+{{< /note >}}
+
 If instead the Pod uses [Pod-level resources](/docs/concepts/configuration/manage-resources-containers/#pod-level-resource-specification):
 
 {{< feature-state feature_gate_name="PodLevelResources" >}}


### PR DESCRIPTION
- Add explicit note that CPU and memory must be non-zero
- Clarify that zero values result in Burstable QoS, not Guaranteed
- Improve wording to combine request/limit requirements

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #