### PR TITLE
Fix reversed logic in Taint/Toleration numeric operator descriptions

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -183,8 +183,8 @@ In addition to `Equal` and `Exists`, you can use numeric comparison operators
 (`Gt` and `Lt`) to match taints with integer values. This is useful for threshold-based
 scheduling, such as matching nodes by reliability level or SLA tier.
 
-* `Gt` matches when the toleration value is greater than the taint value.
-* `Lt` matches when the toleration value is less than the taint value.
+* `Gt` matches when the taint value is greater than the toleration value.
+* `Lt` matches when the taint value is less than the toleration value.
 
 For numeric operators, both the toleration and taint values must be valid integers.
 If either value cannot be parsed as an integer, the toleration does not match.
@@ -228,7 +228,7 @@ When using numeric comparison operators:
 * If a value cannot be parsed as an integer, the toleration does not match.
 * Numeric operators work with all taint effects: `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
 * For `PreferNoSchedule` with numeric operators: if a pod's toleration doesn't satisfy the numeric comparison
-  (e.g., toleration value < taint value when using `Gt`), the scheduler gives the node a lower priority
+  (e.g., taint value < toleration value when using `Gt`), the scheduler gives the node a lower priority
   but may still schedule there if no better options exist.
 {{< /note >}}
 


### PR DESCRIPTION
**What this PR does**:
This PR corrects the descriptions for the `Gt` and `Lt` numeric comparison operators in the Taints and Tolerations documentation.

Currently, the documentation defines the operators with the subject and object reversed (stating `Toleration > Taint`), which contradicts the mathematical example provided immediately after it.

**Specific fixes:**
1.  **Operator Definition:**
    * *Current (Wrong):* "Gt matches when the **toleration value** is greater than the **taint value**."
    * *Corrected:* "Gt matches when the **taint value** is greater than the **toleration value**." (and similarly for `Lt`).
2.  **PreferNoSchedule Logic:**
    * *Current (Wrong):* States that failure occurs when "toleration value < taint value" (for Gt). This describes a success condition.
    * *Corrected:* States that failure occurs when "taint value < toleration value".

The existing example in the docs (`taint=950`, `toleration=900`, `op=Gt`) correctly identifies a match because `950 > 900`. This confirms that the prose definition was reversed and my change aligns the text with the example and actual scheduler behavior.