### PR TITLE
Update cgroup-driver fallback removal version to 1.37

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -158,7 +158,7 @@ containerd 1.y and below) do not support the `RuntimeConfig` CRI RPC, and
 may not respond correctly to this query, and thus the Kubelet falls back to using the
 value in its own `--cgroup-driver` flag.
 
-In Kubernetes 1.36, this fallback behavior will be dropped, and older versions
+In Kubernetes 1.37, this fallback behavior will be dropped, and older versions
 of containerd will fail with newer kubelets.
 
 {{< caution >}}


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/136731#issuecomment-3849299026
/hold
until https://github.com/kubernetes/kubernetes/pull/136846 and https://github.com/kubernetes/enhancements/pull/5899 are merged.