### PR TITLE
Revert "Fix description Gt and Lt in documentation"

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -719,8 +719,8 @@ The following operators can only be used with `nodeAffinity`.
 
 |    Operator    |    Behavior    |
 | :------------: | :-------------: |
-| `Gt` | The field value will be parsed as an integer, and that integer is greater than the integer that results from parsing the value of a label named by this selector |
-| `Lt` | The field value will be parsed as an integer, and that integer is less than the integer that results from parsing the value of a label named by this selector |
+| `Gt` | The field value will be parsed as an integer, and the integer that results from parsing the value of a label named by this selector is greater than this integer |
+| `Lt` | The field value will be parsed as an integer, and the integer that results from parsing the value of a label named by this selector is less than this integer |
 
 {{<note>}}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR reverts the changes made in [PR #53996](https://github.com/kubernetes/website/pull/53996).

PR https://github.com/kubernetes/website/pull/53996 was merged with an incorrect interpretation of the semantics for Gt (Greater Than) and Lt (Less Than). These operators follow specific logic in Kubernetes scheduling that was misrepresented in the previous change, so we need to revert it to ensure technical accuracy.

---

### Related Pull Requests
This revert is related to the following PRs that address similar Gt/Lt semantic issues:
https://github.com/kubernetes/website/pull/53952

https://github.com/kubernetes/website/pull/54342

https://github.com/kubernetes/website/pull/54350

https://github.com/kubernetes/website/pull/54351

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #54359 