### PR TITLE
Fix taint and toleration glossary descriptions

### DIFF
--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -4,13 +4,13 @@ id: taint
 date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of pods on nodes or node groups.
+  A property applied to a node or node group that uses three fields: key, value, and effect (key and effect are required). Taints prevent the scheduling of Pods onto that node or node group.
 
 aka:
 tags:
 - fundamental
 ---
- A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups.
+ A property applied to a {{< glossary_tooltip text="node" term_id="node" >}} or node group that uses three fields: key, value, and effect (key and effect are required). Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} onto that node or node group.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -4,14 +4,13 @@ id: toleration
 date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have a matching taint.
+  A property applied to a pod that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have matching taints.
 
 aka:
 tags:
-- core-object
 - fundamental
 ---
- A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
+ A property applied to a {{< glossary_tooltip text="pod" term_id="pod" >}} that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -4,7 +4,7 @@ id: toleration
 date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A property applied to a pod that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have matching taints.
+  A property applied to a Pod that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have matching taints.
 
 aka:
 tags:

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - fundamental
 ---
- A property applied to a {{< glossary_tooltip text="pod" term_id="pod" >}} that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
+ A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
 
 <!--more-->
 


### PR DESCRIPTION
Update taint and toleration glossary entries to accurately reflect their properties:

- Changed from 'core object' to 'property' for both
- Removed 'required' from all fields description
- For taint: Clarified that key and effect are required, value is optional
- For toleration: Updated to mention four fields (key, operator, value, effect)
- Removed 'core-object' tag from toleration
- Fixed capitalization consistency (Pods, nodes)

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #