### PR TITLE
Clarify 'manual' StorageClass in PersistentVolume tutorial

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
+++ b/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
@@ -99,6 +99,20 @@ read-write by a single Node. It defines the [StorageClass name](/docs/concepts/s
 PersistentVolumeClaim requests to this PersistentVolume.
 
 {{< note >}}
+In this tutorial, the StorageClass name `manual` is used as a label to bind the PersistentVolume 
+and PersistentVolumeClaim together. **You do not need to create an actual StorageClass object** 
+named "manual". 
+
+For static provisioning (manually created PersistentVolumes), the storageClassName acts as a 
+binding label. Both the PersistentVolume and PersistentVolumeClaim must specify the same 
+storageClassName for them to bind together.
+
+This is different from dynamic provisioning, where a StorageClass object must exist and defines 
+how to automatically create volumes. See [StorageClasses](/docs/concepts/storage/storage-classes/) 
+for more information.
+{{< /note >}}
+
+{{< note >}}
 This example uses the `ReadWriteOnce` access mode, for simplicity. For
 production use, the Kubernetes project recommends using the `ReadWriteOncePod`
 access mode instead.


### PR DESCRIPTION
Add detailed explanation that the 'manual' storageClassName is used as a binding label for static provisioning and does not require creating an actual StorageClass object.

This addresses confusion where users encounter 'storageclass.storage.k8s.io manual not found' errors when following the tutorial. The clarification explains the difference between static and dynamic provisioning.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #