### PR TITLE
Add actual priority value for system component

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -46,6 +46,7 @@ Keep reading for more information about these steps.
 Kubernetes already ships with two PriorityClasses:
 `system-cluster-critical` and `system-node-critical`.
 These are common classes and are used to [ensure that critical components are always scheduled first](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
+Their priority values are 2000000000 for `system-cluster-critical` and 2000001000 for `system-node-critical`.
 {{< /note >}}
 
 ## PriorityClass

--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -42,13 +42,6 @@ To use priority and preemption:
 
 Keep reading for more information about these steps.
 
-{{< note >}}
-Kubernetes already ships with two PriorityClasses:
-`system-cluster-critical` and `system-node-critical`.
-These are common classes and are used to [ensure that critical components are always scheduled first](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
-Their priority values are 2000000000 for `system-cluster-critical` and 2000001000 for `system-node-critical`.
-{{< /note >}}
-
 ## PriorityClass
 
 A PriorityClass is a non-namespaced object that defines a mapping from a
@@ -65,6 +58,13 @@ to 1 billion. This means that the range of values for a PriorityClass object is
 from -2147483648 to 1000000000 inclusive. Larger numbers are reserved for
 built-in PriorityClasses that represent critical system Pods. A cluster
 admin should create one PriorityClass object for each such mapping that they want.
+
+{{< note >}}
+Kubernetes already ships with two PriorityClasses:
+`system-cluster-critical` and `system-node-critical`.
+These are common classes and are used to [ensure that critical components are always scheduled first](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
+For Kubernetes v{{< skew currentVersion >}} their priority values are 2000000000 for `system-cluster-critical` and 2000001000 for `system-node-critical`.
+{{< /note >}}
 
 PriorityClass also has two optional fields: `globalDefault` and `description`.
 The `globalDefault` field indicates that the value of this PriorityClass should


### PR DESCRIPTION
### Description
Add the actual priority values for the built-in PriorityClasses (system-node-critical: 2000001000, system-cluster-critical: 2000000000) to the Pod Priority and Preemption page.

### Issue
Closes: #54107 