### PR TITLE
docs: fix broken flannel link for windows worker nodes

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -155,7 +155,6 @@ plane nodes must be prepared to support the CNI plugin running on Windows worker
 {{% thirdparty-content %}}
 
 Only a few CNI plugins currently support Windows. Below you can find individual setup instructions for them:
-* [Flannel](https://sigs.k8s.io/sig-windows-tools/guides/flannel.md)
 * [Calico](https://docs.tigera.io/calico/latest/getting-started/kubernetes/windows-calico/)
 
 ### Install kubectl for Windows (optional) {#install-kubectl}


### PR DESCRIPTION
What this PR does / why we need it: This PR fixes a 404 link in the "Adding Windows worker nodes" task page. The previous link to the Flannel guide in the sig-windows-tools repository was broken due to a repository refactor. I have updated it to point to the current HostProcess Flannel manifests and documentation.