### PR TITLE
Add January/February 2026 patch releases to schedule

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,7 +7,12 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-02-06"
+    cherryPickDeadline: "2026-03-06"
+    release: 1.35.2
+    targetDate: "2026-03-10"
+  previousPatches:
+  - cherryPickDeadline: "2026-02-06"
+    note: January 2026 patches consolidated with February
     release: 1.35.1
     targetDate: "2026-02-10"
   release: "1.35"
@@ -15,10 +20,14 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2026-02-06"
+    cherryPickDeadline: "2026-03-06"
+    release: 1.34.5
+    targetDate: "2026-03-10"
+  previousPatches:
+  - cherryPickDeadline: "2026-02-06"
+    note: January 2026 patches consolidated with February
     release: 1.34.4
     targetDate: "2026-02-10"
-  previousPatches:
   - cherryPickDeadline: "2025-12-05"
     release: 1.34.3
     targetDate: "2025-12-09"
@@ -36,10 +45,14 @@ schedules:
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2026-02-06"
+    cherryPickDeadline: "2026-03-06"
+    release: 1.33.9
+    targetDate: "2026-03-10"
+  previousPatches:
+  - cherryPickDeadline: "2026-02-06"
+    note: January 2026 patches consolidated with February
     release: 1.33.8
     targetDate: "2026-02-10"
-  previousPatches:
   - cherryPickDeadline: "2025-12-05"
     release: 1.33.7
     targetDate: "2025-12-09"
@@ -67,10 +80,14 @@ schedules:
 - endOfLifeDate: "2026-02-28"
   maintenanceModeStartDate: "2025-12-28"
   next:
-    cherryPickDeadline: "2026-02-06"
+    cherryPickDeadline: "2026-03-06"
+    release: 1.32.13
+    targetDate: "2026-03-10"
+  previousPatches:
+  - cherryPickDeadline: "2026-02-06"
+    note: January 2026 patches consolidated with February
     release: 1.32.12
     targetDate: "2026-02-10"
-  previousPatches:
   - cherryPickDeadline: "2025-12-05"
     release: 1.32.11
     targetDate: "2025-12-09"
@@ -110,9 +127,9 @@ schedules:
   release: "1.32"
   releaseDate: "2024-12-11"
 upcoming_releases:
-- cherryPickDeadline: "2026-02-06"
-  targetDate: "2026-02-10"
-- cherryPickDeadline: "2026-02-06"
-  targetDate: "2026-02-10"
 - cherryPickDeadline: "2026-03-06"
   targetDate: "2026-03-10"
+- cherryPickDeadline: "2026-04-10"
+  targetDate: "2026-04-14"
+- cherryPickDeadline: "2026-05-08"
+  targetDate: "2026-05-12"


### PR DESCRIPTION
This PR adds January/February 2026 patch releases to the schedule as released. We consolidated January and February patch releases into February, an appropriate note has been added.

cc @kubernetes/release-engineering 