### PR TITLE
layouts: replace role="alert" with role="note"

### DIFF
--- a/layouts/shortcodes/caution.html
+++ b/layouts/shortcodes/caution.html
@@ -1,7 +1,7 @@
 <!-- adapted from Docsy alert shortcode -->
 {{- $_hugo_config := `{ "version": 1 }` -}}
 {{- $color := "caution" -}}
-<div class="alert alert-{{- $color -}}" role="alert">
+<div class="alert alert-{{- $color -}}" role="note">
 {{- with ( T "caution" ) -}}<h4 class="alert-heading">{{- . | safeHTML -}}</h4>{{- end -}}
 {{- if eq .Page.File.Ext "md" -}}
     {{- .Inner | markdownify -}}

--- a/layouts/shortcodes/dockershim-removal.html
+++ b/layouts/shortcodes/dockershim-removal.html
@@ -1,3 +1,3 @@
-<div class="alert alert-secondary callout note" role="alert">
+<div class="alert alert-secondary callout note" role="note">
   <strong>{{ T "note" | safeHTML }}</strong> {{ T "dockershim_message" | safeHTML }}
 </div>

--- a/layouts/shortcodes/legacy-repos-deprecation.html
+++ b/layouts/shortcodes/legacy-repos-deprecation.html
@@ -1,3 +1,3 @@
-<div class="alert alert-secondary callout note" role="alert">
+<div class="alert alert-secondary callout note" role="note">
   <strong>{{ T "note" | safeHTML }}</strong> {{ T "legacy_repos_message" | markdownify }}
 </div>

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -5,7 +5,7 @@
 </figure>
 <!-- Hide content and error if JS is disabled. -->
 <noscript>
-  <div class="alert alert-secondary callout" role="alert">
+  <div class="alert alert-secondary callout" role="note">
     <em class="javascript-required">{{ T "javascript_required" | markdownify }}</em>
   </div>
 </noscript>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,7 +1,7 @@
 <!-- adapted from Docsy alert shortcode -->
 {{- $_hugo_config := `{ "version": 1 }` -}}
 {{ $color := "info" }}
-<div class="alert alert-{{- $color -}}" role="alert">
+<div class="alert alert-{{- $color -}}" role="note">
 {{- with ( T "note" ) -}}<h4 class="alert-heading">{{- . | safeHTML -}}</h4>{{- end -}}
 {{- if eq .Page.File.Ext "md" -}}
     {{- .Inner | markdownify -}}

--- a/layouts/shortcodes/release-binaries.html
+++ b/layouts/shortcodes/release-binaries.html
@@ -58,7 +58,7 @@
         {{ $releaseBinarySection = replace $releaseBinarySection "<current-version>" $currentVersion }}
         {{ $releaseBinarySection | markdownify }}
     </p>
-    <div class="alert alert-info note callout" role="alert">
+    <div class="alert alert-info note callout" role="note">
         <strong>{{ T "note" }}</strong>
         {{ $releaseBinarySectionNote := T "release_binary_section_note" }}
         {{ $releaseBinarySectionNote = replace $releaseBinarySectionNote "<current-changelog-url>" (replace $currentVersion "v" "") }}

--- a/layouts/shortcodes/thirdparty-content.html
+++ b/layouts/shortcodes/thirdparty-content.html
@@ -1,6 +1,6 @@
 {{- $single := .Get "single" | default "false" -}}
 {{- $vendor_message := .Get "vendor" | default "false" -}}
-<div class="alert alert-secondary callout third-party-content" role="alert">
+<div class="alert alert-secondary callout third-party-content" role="note">
 {{- if not (eq $single "true" ) -}}
   <strong>{{ T "note" | safeHTML }}</strong>&puncsp;
   {{- if (eq $vendor_message "true" ) -}}

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,7 +1,7 @@
 <!-- adapted from Docsy alert shortcode -->
 {{- $_hugo_config := `{ "version": 1 }` -}}
 {{- $color := "danger" -}}
-<div class="alert alert-{{- $color -}}" role="alert">
+<div class="alert alert-{{- $color -}}" role="note">
 {{- with ( T "warning" ) -}}<h4 class="alert-heading">{{- . | safeHTML -}}</h4>{{- end -}}
 {{- if eq .Page.File.Ext "md" -}}
     {{- .Inner | markdownify -}}


### PR DESCRIPTION
The "alert" role is meant for shortlived content, usually for interactive apps. The "note" role, on the other hand, is meant for content that has no suitable semantic element otherwise and is supposed to hint the user on ancillary information.

See:
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/note_role

split up per https://github.com/kubernetes/website/pull/54363#issuecomment-3890061463