### PR TITLE
Enhance describe pod output, align content with other examples

### DIFF
--- a/content/en/examples/pods/security/hello-apparmor-2.yaml
+++ b/content/en/examples/pods/security/hello-apparmor-2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-apparmor-2
+spec:
+  securityContext:
+    appArmorProfile:
+      type: Localhost
+      localhostProfile: k8s-apparmor-example-allow-write
+  containers:
+  - name: hello
+    image: busybox:1.28
+    command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]


### PR DESCRIPTION
### Description
This PR has some smaller changes / fixes for the apparmor tutorial:
* Update the output of `kubectl describe pod`: Remove `container.apparmor.security.beta.kubernetes.io/<container>` annotation, include container status `CreateContainerError` which is actually displayed when using `kubectl get pod` instead of Pending and cleanup duplicate events.
* Typo fix / alter wording a bit
* Replace `kubectl create` with `code_sample file`. Which aligns it with the other security examples like seccomp.

Thanks in advance for reviewing.