### PR TITLE
Fix incorrect time estimate in Pod failure policy example

### DIFF
--- a/content/en/docs/tasks/job/pod-failure-policy.md
+++ b/content/en/docs/tasks/job/pod-failure-policy.md
@@ -68,8 +68,11 @@ software bug.
      condition. The Job controller adds this condition after all of the Job's Pods
      are terminated.
 
-   For comparison, if the Pod failure policy was disabled it would take 6 retries
-   of the Pod, taking at least 2 minutes.
+   For comparison, if the Pod failure policy were disabled, the Job would
+   retry until reaching the `backoffLimit` (6 failures). Because retries
+   use exponential backoff and, with `parallelism: 2`, failures occur in
+   pairs, the delay between attempts increases with each retry. As a result,
+   this example would take at least 9 minutes before the Job fails.
 
 #### Clean up
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does:**

Corrects an inaccurate time estimate in the Pod failure policy documentation. 
The current documentation states that without a Pod failure policy, retries 
would take "at least 2 minutes", but testing with the exact example 
configuration shows the actual duration is approximately 9 minutes.

This discrepancy is caused by exponential backoff delays between Pod retries, 
which were not accounted for in the original estimate.

**Why this matters:**

Accurate timing information is critical for:
- Setting appropriate Job timeouts
- Capacity planning and resource estimation
- Understanding exponential backoff behavior with parallelism

**Testing:**

Verified using the exact example configuration from the documentation 
(without `podFailurePolicy`):
```yaml
completions: 8
parallelism: 2
backoffLimit: 6
Pod command: sleep 30 && exit 42
```

**Test environment:**
- Kubernetes v1.34.0 (minikube)

**Results:**
- Job start time: 14:11:43
- Job fail time: 14:20:49
- Total duration: **9 minutes 6 seconds**
- Total failed Pods: 8

**Pod failure timeline with backoff delays:**

| Time | Event | Backoff |
|------|-------|---------|
| 14:11:43 | Wave 1: Pods 1-2 created | - |
| 14:12:14 | Wave 1: Pods 1-2 fail (failures: 2) | 20s |
| 14:12:34 | Wave 2: Pods 3-4 created | - |
| 14:13:05 | Wave 2: Pods 3-4 fail (failures: 4) | 80s |
| 14:14:25 | Wave 3: Pods 5-6 created | - |
| 14:14:56 | Wave 3: Pods 5-6 fail (failures: 6) | 320s |
| 14:20:16 | Wave 4: Pods 7-8 created | - |
| 14:20:47 | Wave 4: Pods 7-8 fail (failures: 8) | Job fails |

**Exponential backoff calculation:**

With `parallelism: 2`, pods fail in pairs. The backoff delay is determined by 
the highest failure count:
- After failures 1-2: max(10s, 20s) = 20s
- After failures 3-4: max(40s, 80s) = 80s
- After failures 5-6: max(160s, 320s) = 320s

Total time: (30s × 4 waves) + 20s + 80s + 320s = 540s ≈ 9 minutes