### PR TITLE
KEP-2570: Add documentation for MemoryQoS with cgroups v2 for 1.36

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -53,11 +53,9 @@ container that over allocates memory may not be immediately killed. This means
 its `memory` limit, but if it does, it may get killed.
 
 {{< note >}}
-There is an alpha feature `MemoryQoS` which attempts to add more preemptive
-limit enforcement for memory (as opposed to reactive enforcement by the OOM
-killer). However, this effort is
-[stalled](https://github.com/kubernetes/enhancements/tree/a47155b340/keps/sig-node/2570-memory-qos#latest-update-stalled)
-due to a potential livelock situation a memory hungry can cause.
+There is an alpha feature `MemoryQoS` which adds preemptive memory throttling
+and optional memory reservation on Linux nodes using cgroup v2. For details, see
+[Memory QoS with cgroup v2](/docs/concepts/workloads/pods/pod-qos/#memory-qos-with-cgroup-v2).
 {{< /note >}}
 
 {{< note >}}

--- a/content/en/docs/concepts/workloads/pods/pod-qos.md
+++ b/content/en/docs/concepts/workloads/pods/pod-qos.md
@@ -97,14 +97,51 @@ Containers in a Pod can request other resources (not CPU or memory) and still be
 
 {{< feature-state feature_gate_name="MemoryQoS" >}}
 
-Memory QoS uses the memory controller of cgroup v2 to guarantee memory resources in Kubernetes.
-Memory requests and limits of containers in pod are used to set specific interfaces `memory.min`
-and `memory.high` provided by the memory controller. When `memory.min` is set to memory requests,
-memory resources are reserved and never reclaimed by the kernel; this is how Memory QoS ensures
-memory availability for Kubernetes pods. And if memory limits are set in the container,
-this means that the system needs to limit container memory usage; Memory QoS uses `memory.high`
-to throttle workload approaching its memory limit, ensuring that the system is not overwhelmed
-by instantaneous memory allocation.
+Memory QoS uses the memory controller of cgroup v2 to guarantee memory resources in Kubernetes. When enabled, the kubelet can set `memory.high` to throttle workloads
+approaching their memory limits, and can optionally reserve memory via `memory.min` or `memory.low`.
+
+### Memory throttling
+
+For Burstable pods, the kubelet sets `memory.high` to throttle memory allocation before the workload hits its hard limit (`memory.max`). The throttling threshold is calculated as:
+
+```
+memory.high=floor[(requests.memory + memory throttling factor * (limits.memory or node allocatable memory - requests.memory))/pageSize] * pageSize
+```
+
+where default value of memory throttling factor is set to 0.9.
+For example, a container with a
+256 MiB request and a 1 GiB limit gets `memory.high` set to roughly 947 MiB.
+If a Burstable container has no memory limit, node allocatable memory is used in
+place of the limit.
+
+Guaranteed pods do not get `memory.high` set because their requests equal their
+limits, which means there is no overcommitment.
+
+BestEffort pods do not get `memory.high` calculated since they have no requests or limits.
+
+### Configuring Memory QoS
+
+Memory reservation is controlled via the kubelet configuration field `memoryReservationPolicy`:
+
+- `None` (default): the kubelet does not set `memory.min` or `memory.low` for containers and pods,
+  ensuring no hard memory is locked by the kernel. This is the default to maintain node stability.
+- `TieredReservation`: the kubelet sets tiered memory protection based on the pod's QoS class:
+  - Guaranteed pods (hard reservation): `memory.min` is set to memory requests, memory resources are reserved and never reclaimed by the kernel.
+  - Burstable pods (soft reservation): `memory.low` is set to memory requests, the kernel preferentially retains this memory but may reclaim it under extreme pressure.
+  - BestEffort pods: no memory protection is set.
+
+
+
+
+### System Requirements
+
+Memory QoS requires:
+- Linux with cgroup v2
+- Kernel 5.9 or higher is recommended
+because `memory.high` throttling on older kernels can trigger a known
+[livelock bug](https://lore.kernel.org/all/20200710012662.GA29679@chep.ntu.edu.tw/).
+If the `MemoryQoS` feature gate is enabled on an older kernel, the kubelet logs
+a warning at startup.
 
 Memory QoS relies on QoS class to determine which settings to apply; however, these are different
 mechanisms that both provide controls over quality of service.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MemoryQoS.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MemoryQoS.md
@@ -11,4 +11,8 @@ stages:
     fromVersion: "1.22"
 ---
 Enable memory protection and usage throttle on pod / container using
-cgroup v2 memory controller.
+cgroup v2 memory controller. This feature allows kubelet to set `memory.high`
+for throttling and configure tiered memory protection, when `memoryReservationPolicy` kubelet
+configuration is set to `TieredReservation`, `memory.min` / `memory.low` for memory protection are enabled.
+Requires cgroup v2; kubelet warns on kernels older
+than 5.9 because `memory.high` throttling can trigger a livelock bug.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This is a placeholder PR for the documentation of MemoryQoS v1.36, which is targeting Alpha v3 for the 1.36 release.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

k/e KEP: https://github.com/kubernetes/enhancements/pull/5879
k/e issue: https://github.com/kubernetes/enhancements/issues/2570

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #