### PR TITLE
Add caution about non-manifest files in static pod directory

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -66,13 +66,14 @@ which periodically scans the directory and creates/deletes static Pods as YAML/J
 Note that the kubelet will ignore files starting with dots when scanning the specified directory.
 
 {{< caution >}}
-The kubelet processes **all non-hidden files** in the static Pod directory — there is
-no filtering by file extension. For example, if you create a backup of a manifest by
-running `cp kube-apiserver.yaml kube-apiserver.yaml.backup`, the kubelet will read
-**both** files and attempt to create a static Pod from each. When two files define a
-Pod with the same name, the resulting behavior is undefined and can cause the backup's
-outdated spec to silently take effect instead of the current manifest. Always store
-backup files **outside** the static Pod directory (for example, in `/etc/kubernetes/backup/`).
+The kubelet processes **all files not starting with a dot** in the static Pod directory
+— there is no filtering by file extension. For example, if you create a backup of a
+manifest by running `cp kube-apiserver.yaml kube-apiserver.yaml.backup`, the kubelet
+will read **both** files and attempt to create a static Pod from each. When two files
+define a Pod with the same name, the resulting behavior is undefined and can cause the
+backup's outdated spec to silently take effect instead of the current manifest. If you
+do create a backup, store it **outside** the static Pod directory (for example, in
+`/etc/kubernetes/backup/`).
 {{< /caution >}}
 
 For example, this is how to start a simple web server as a static Pod:


### PR DESCRIPTION
## Summary

The kubelet reads **all non-hidden files** from the static pod manifest directory (`staticPodPath`) without filtering by file extension. Backup files such as `kube-apiserver.yaml.backup` are parsed as pod definitions and can silently override the intended manifest when they define a pod with the same name.

This PR adds a `{{< caution >}}` block to the "Filesystem-hosted static Pod manifest" section of the static pod documentation, warning users to store backup files outside the manifest directory.

## Motivation

This was discovered during an encryption at rest deployment across two kubeadm clusters. A backup file left in `/etc/kubernetes/manifests/` silently caused the kube-apiserver to run with an outdated configuration instead of the modified manifest.

See: https://github.com/kubernetes/kubernetes/issues/136962

## Change details

- **File:** `content/en/docs/tasks/configure-pod-container/static-pod.md`
- **What:** Added a `caution` block after the existing note about dot-files being ignored
- **Placement:** Directly below the description of how the kubelet scans the directory, before the example steps

/sig node
/area kubelet
/kind documentation