### PR TITLE
docs: modernize static pod guide to use KubeletConfiguration

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -56,27 +56,27 @@ For example, this is how to start a simple web server as a static Pod:
 
 1. Choose a directory, say `/etc/kubernetes/manifests` and place a web server
    Pod definition there, for example `/etc/kubernetes/manifests/static-web.yaml`:
-
-   ```shell
-   # Run this command on the node where kubelet is running
-   mkdir -p /etc/kubernetes/manifests/
-   cat <<EOF >/etc/kubernetes/manifests/static-web.yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: static-web
-     labels:
-       role: myrole
-   spec:
-     containers:
-       - name: web
-         image: nginx
-         ports:
-           - name: web
-             containerPort: 80
-             protocol: TCP
-   EOF
-   ```
+ 
+    ```shell
+    # Run this command on the node where kubelet is running
+    mkdir -p /etc/kubernetes/manifests/
+    cat <<EOF >/etc/kubernetes/manifests/static-web.yaml
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: static-web
+      labels:
+        role: myrole
+    spec:
+      containers:
+        - name: web
+          image: nginx
+          ports:
+            - name: web
+              containerPort: 80
+              protocol: TCP
+    EOF
+    ```
 
 1. Configure the kubelet on that node to set a `staticPodPath` value in the
    [kubelet configuration file](/docs/reference/config-api/kubelet-config.v1beta1/).  
@@ -85,9 +85,9 @@ For example, this is how to start a simple web server as a static Pod:
 
    An alternative and deprecated method is to configure the kubelet on that node
    to look for static Pod manifests locally, using a command line argument.
-   To use the deprecated approach, start the kubelet with the  
+   To use the deprecated approach, start the kubelet with the 
    `--pod-manifest-path=/etc/kubernetes/manifests/` argument.
-      
+   
 1. Restart the kubelet. On Fedora, you would run:
 
    ```shell
@@ -125,11 +125,12 @@ To use this approach:
    ```
 
 1. Configure the kubelet on your selected node to use this web manifest by
-   running it with `--manifest-url=<manifest-url>`.
-   On Fedora, edit `/etc/kubernetes/kubelet` to include this line:
+   updating your kubelet configuration file to include the `staticPodURL` field:
 
-   ```shell
-   KUBELET_ARGS="--cluster-dns=10.254.0.10 --cluster-domain=kube.local --manifest-url=<manifest-url>"
+   ```yaml
+   apiVersion: kubelet.config.k8s.io/v1beta1
+   kind: KubeletConfiguration
+   staticPodURL: "<manifest-url>"
    ```
 
 1. Restart the kubelet. On Fedora, you would run:
@@ -240,7 +241,6 @@ adds/removes Pods as files appear/disappear in this directory.
 ```shell
 # This assumes you are using filesystem-hosted static Pod configuration
 # Run these commands on the node where the container is running
-#
 mv /etc/kubernetes/manifests/static-web.yaml /tmp
 sleep 20
 crictl ps

--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -57,26 +57,26 @@ For example, this is how to start a simple web server as a static Pod:
 1. Choose a directory, say `/etc/kubernetes/manifests` and place a web server
    Pod definition there, for example `/etc/kubernetes/manifests/static-web.yaml`:
  
-    ```shell
-    # Run this command on the node where kubelet is running
-    mkdir -p /etc/kubernetes/manifests/
-    cat <<EOF >/etc/kubernetes/manifests/static-web.yaml
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: static-web
-      labels:
-        role: myrole
-    spec:
-      containers:
-        - name: web
-          image: nginx
-          ports:
-            - name: web
-              containerPort: 80
-              protocol: TCP
-    EOF
-    ```
+   ```shell
+   # Run this command on the node where kubelet is running
+   mkdir -p /etc/kubernetes/manifests/
+   cat <<EOF >/etc/kubernetes/manifests/static-web.yaml
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: static-web
+     labels:
+       role: myrole
+   spec:
+     containers:
+       - name: web
+         image: nginx
+         ports:
+           - name: web
+             containerPort: 80
+             protocol: TCP
+   EOF
+   ```
 
 1. Configure the kubelet on that node to set a `staticPodPath` value in the
    [kubelet configuration file](/docs/reference/config-api/kubelet-config.v1beta1/).  


### PR DESCRIPTION
### Description
This PR addresses #25905 by updating the static pod documentation to favor the modern `KubeletConfiguration` approach over deprecated command-line flags.

### Changes
- Updated the **Filesystem-hosted** section to mark `--pod-manifest-path` as deprecated and point to `staticPodPath`.
- Updated the **Web-hosted** section to replace the Fedora-specific `KUBELET_ARGS` example with a `KubeletConfiguration` YAML block using `staticPodURL`.
- Corrected the step numbering to ensure a logical flow (1. Configure, 2. Restart).

### Why this is needed
The `--pod-manifest-path` and `--manifest-url` flags are deprecated. Moving users toward the declarative configuration file improves security and maintainability.

Fixes #25905

/sig node
/kind documentation
/area contributor-experience