### PR TITLE
docs: clarify PostStart hook concurrency and blocking behavior

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -35,8 +35,8 @@ No parameters are passed to the handler.
 
 {{< note >}}
 While the hook runs concurrently with the container process,
-it is **blocking** for the container's status;
-the container will not transition to a `Running` state until the hook handler completes successfully.
+it can delay container status updates;
+the container may not transition to `Running` until the hook completes.
 {{< /note >}}
 
 `PreStop`


### PR DESCRIPTION
### Why is this change needed?
1. The current documentation for the `PostStart` hook uses the word "unspecified" regarding its execution timing relative to the container `ENTRYPOINT`. Users have found this confusing (see #54327). 
2. The Static Pod documentation references deprecated command-line flags (--pod-manifest-path) which do not reflect current best practices.

### What does this PR do? 
This PR clarifies technical behavior and modernizes documentation:
- Container Hooks: It explicitly states that the PostStart hook runs concurrently with the ENTRYPOINT.
- Timing: It explains the practical result: the hook may run before, during, or after the main process starts.
- Lifecycle: It clarifies that despite being concurrent, the hook is blocking for the container's status transition to Running.
- Modernization: It updates the Static Pod guide to use KubeletConfiguration (YAML) instead of deprecated command-line flags.

Closes #54327