### PR TITLE
Clarify which errors trigger webhook failurePolicy

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -994,11 +994,22 @@ in an object could already exist in the user-provided object, but it is essentia
 
 ### Failure policy
 
-`failurePolicy` defines how unrecognized errors and timeout errors from the admission webhook
-are handled. Allowed values are `Ignore` or `Fail`.
+`failurePolicy` defines how errors encountered while _calling_ the admission webhook are handled.
+Allowed values are `Ignore` or `Fail`.
 
 * `Ignore` means that an error calling the webhook is ignored and the API request is allowed to continue.
 * `Fail` means that an error calling the webhook causes the admission to fail and the API request to be rejected.
+
+The failure policy applies to the following types of errors:
+
+* Network errors, timeouts, or connection failures when contacting the webhook.
+* The webhook returns a non-2xx HTTP response or a malformed response.
+* The API server fails to serialize the admission request or create a REST client for the webhook.
+* For mutating webhooks: the response contains an undecodable or unsupported patch type.
+
+The failure policy does **not** apply when the webhook is reached successfully and explicitly
+rejects the request (by returning `allowed: false`). An explicit rejection always denies the
+API request, regardless of the `failurePolicy` setting.
 
 Here is a mutating webhook configured to reject an API request if errors are encountered calling the admission webhook:
 

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -1005,11 +1005,13 @@ The failure policy applies to the following types of errors:
 * Network errors, timeouts, or connection failures when contacting the webhook.
 * The webhook returns a non-2xx HTTP response or a malformed response.
 * The API server fails to serialize the admission request or create a REST client for the webhook.
-* For mutating webhooks: the response contains an undecodable or unsupported patch type.
+* (Only for mutating webhooks) the response contains an undecodable or unsupported patch type.
 
-The failure policy does **not** apply when the webhook is reached successfully and explicitly
-rejects the request (by returning `allowed: false`). An explicit rejection always denies the
-API request, regardless of the `failurePolicy` setting.
+If a write to the Kubernetes API is rejected via an admission callout, this
+is a _rejection_ but Kubernetes does not consider it as a failure.
+The Kubernetes API server does **not** apply a failure policy when the webhook is reached successfully, and the webhook implementation
+has explicitly rejected the request (by specifying `allowed: false` in the response).
+A explicit rejection, correctly transmitted, always denies the API request, regardless of the `failurePolicy` setting.
 
 Here is a mutating webhook configured to reject an API request if errors are encountered calling the admission webhook:
 

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -1004,14 +1004,14 @@ The failure policy applies to the following types of errors:
 
 * Network errors, timeouts, or connection failures when contacting the webhook.
 * The webhook returns a non-2xx HTTP response or a malformed response.
-* The API server fails to serialize the admission request or create a REST client for the webhook.
+* The API server fails to serialize the admission request or create an internal HTTP client for the webhook.
 * (Only for mutating webhooks) the response contains an undecodable or unsupported patch type.
 
 If a write to the Kubernetes API is rejected via an admission callout, this
 is a _rejection_ but Kubernetes does not consider it as a failure.
 The Kubernetes API server does **not** apply a failure policy when the webhook is reached successfully, and the webhook implementation
 has explicitly rejected the request (by specifying `allowed: false` in the response).
-A explicit rejection, correctly transmitted, always denies the API request, regardless of the `failurePolicy` setting.
+An explicit rejection, correctly transmitted, always denies the API request, regardless of the `failurePolicy` setting.
 
 Here is a mutating webhook configured to reject an API request if errors are encountered calling the admission webhook:
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/kubernetes/website/issues/33039

- Replaces vague "unrecognized errors" phrasing with a specific list of error types that trigger the failure policy
- Clarifies that explicit webhook rejections (`allowed: false`) always deny the request regardless of `failurePolicy`

## Technical basis
Verified against source code:
- `webhook/error.go` — `ErrCallingWebhook` (transport errors, subject to failurePolicy) vs `ErrWebhookRejection` (explicit denial, always rejects)
- `validating/dispatcher.go:170-193` — switch on error type; only `ErrCallingWebhook` checks `ignoreClientCallFailures`
- `mutating/dispatcher.go` — same pattern

## Test plan
- [x] `hugo` build succeeds with no errors (verified locally)
- [ ] Renders correctly on preview