### PR TITLE
Fix misleading imagePullPolicy: Always description

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -90,21 +90,25 @@ these values have:
 : the image is pulled only if it is not already present locally.
 
 `Always`
-: every time the kubelet launches a container, the kubelet queries the container
-  image registry to resolve the name to an image
-  [digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier).
-  If the kubelet has a container image with that exact digest cached locally, the kubelet uses its
-  cached image; otherwise, the kubelet pulls the image with the resolved digest, and uses that image
-  to launch the container.
+: every time the kubelet launches a container, the kubelet requests the
+  {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
+  to pull the image. The container runtime contacts the registry, resolves
+  the image tag or name to a
+  [digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier),
+  and downloads any layers that are not already cached locally.
+  If all layers are already present, the container runtime uses the cached
+  image without downloading it again. The kubelet itself does not check
+  whether the image is cached locally; it always delegates to the container
+  runtime.
 
 `Never`
 : the kubelet does not try fetching the image. If the image is somehow already present
   locally, the kubelet attempts to start the container; otherwise, startup fails.
   See [pre-pulled images](#pre-pulled-images) for more details.
 
-The caching semantics of the underlying image provider make even
+The caching semantics of the container runtime make even
 `imagePullPolicy: Always` efficient, as long as the registry is reliably accessible.
-Your container runtime can notice that the image layers already exist on the node
+The container runtime can notice that the image layers already exist on the node
 so that they don't need to be downloaded again.
 
 {{< note >}}


### PR DESCRIPTION
## Summary
Fixes https://github.com/kubernetes/website/issues/41805

The `imagePullPolicy: Always` description stated that the kubelet queries the registry to resolve a digest and checks its local cache before pulling. In reality, the kubelet unconditionally requests a pull from the container runtime — it is the container runtime (containerd, CRI-O) that contacts the registry, resolves the digest, and skips re-downloading already-cached layers.

This change:
- Corrects the `Always` definition to accurately describe the kubelet-to-runtime delegation
- Clarifies that the container runtime (not the kubelet) handles digest resolution and layer caching
- Updates the efficiency note to say "container runtime" instead of "underlying image provider"

## Technical basis
Verified against source code:
- `pkg/kubelet/images/image_manager.go:117-119` — `imagePullPrecheck` returns immediately for `PullAlways` without checking image presence
- `pkg/kubelet/images/image_manager.go:240-281` — for `PullAlways`, `imageRef` is empty so the "already present" check is skipped; falls through to `pullImage()` which delegates to the container runtime via CRI

## Test plan
- [ ] Renders correctly on preview