### PR TITLE
Clarify that storageClassName in PV tutorial is a matching label

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
+++ b/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
@@ -99,6 +99,15 @@ read-write by a single Node. It defines the [StorageClass name](/docs/concepts/s
 PersistentVolumeClaim requests to this PersistentVolume.
 
 {{< note >}}
+The `storageClassName: manual` field is a label used to match a PersistentVolume
+with a PersistentVolumeClaim. It does not reference a StorageClass object — you
+do not need to create a StorageClass named `manual`. The PV and PVC bind when
+their `storageClassName` values match and the PV satisfies the claim's size and
+access mode requirements. Make sure to create the PersistentVolume before the
+PersistentVolumeClaim so that binding can succeed.
+{{< /note >}}
+
+{{< note >}}
 This example uses the `ReadWriteOnce` access mode, for simplicity. For
 production use, the Kubernetes project recommends using the `ReadWriteOncePod`
 access mode instead.

--- a/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
+++ b/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
@@ -99,15 +99,18 @@ read-write by a single Node. It defines the [StorageClass name](/docs/concepts/s
 PersistentVolumeClaim requests to this PersistentVolume.
 
 {{< note >}}
-The `storageClassName: manual` field is a label used to match a PersistentVolume
-with a PersistentVolumeClaim. It does not reference a StorageClass object — you
-do not need to create a StorageClass named `manual`. The PV and PVC bind when
-their `storageClassName` values match and the PV satisfies the claim's size and
-access mode requirements. Make sure to create the PersistentVolume before the
-PersistentVolumeClaim so that binding can succeed.
-{{< /note >}}
+For the purposes of this task, the `storageClassName: manual` field is used to
+match a PersistentVolume with a PersistentVolumeClaim.
 
-{{< note >}}
+It does not reference a StorageClass object — and you do not need to create a StorageClass named `manual`.
+The PV and PVC bind when their `storageClassName` values match and the PV satisfies
+the claim's size and access mode requirements.
+Make sure to create the PersistentVolume before the PersistentVolumeClaim, so that binding can succeed.
+
+Outside of a learning context, you should use a `storageClassName` matching a real StorageClass.
+
+---
+
 This example uses the `ReadWriteOnce` access mode, for simplicity. For
 production use, the Kubernetes project recommends using the `ReadWriteOncePod`
 access mode instead.


### PR DESCRIPTION
## Summary
Fixes https://github.com/kubernetes/website/issues/30912

Users following the PersistentVolume tutorial see `storageClassName: manual` and assume a StorageClass object named "manual" must exist, leading to confusion when they see "storageclass 'manual' not found" errors (typically caused by creating the PVC before the PV).

This change adds a note explaining that:
- `storageClassName` is a label used to match PVs with PVCs, not a reference to a StorageClass object
- No StorageClass object named "manual" needs to be created
- The PV must be created before the PVC for binding to succeed

## Test plan
- [ ] Renders correctly on preview