### PR TITLE
Document missing PV controller annotations for volume expansion

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1252,6 +1252,29 @@ Used on: PersistentVolumeClaim
 This annotation is added to a PVC that is triggered by a scheduler to be
 dynamically provisioned. Its value is the name of the selected node.
 
+### volume.kubernetes.io/storage-resizer
+
+Type: Annotation
+
+Used on: PersistentVolumeClaim
+
+The expand controller sets this annotation on a PersistentVolumeClaim to record
+the name of the volume plugin or CSI driver that is handling volume expansion.
+For example, when a PVC backed by a CSI volume is resized, the annotation value
+is set to the CSI driver name responsible for the resize operation.
+
+### volume.kubernetes.io/node-expansion-not-required
+
+Type: Annotation
+
+Used on: PersistentVolumeClaim
+
+When this annotation is set to `"true"` on a PersistentVolumeClaim, it indicates
+that node-side volume expansion is not required. The expand controller sets this
+annotation on PersistentVolumeClaims with `ReadWriteMany` access mode after the
+controller-side expansion is complete, because RWX volumes do not need per-node
+filesystem resize operations.
+
 ### volumes.kubernetes.io/controller-managed-attach-detach
 
 Type: Annotation


### PR DESCRIPTION
## Summary
Fixes https://github.com/kubernetes/website/issues/32900

Most storage annotations were already documented, but two used by the volume
expand controller were missing from the labels-annotations-taints reference page:

- **`volume.kubernetes.io/storage-resizer`** — records which volume plugin or CSI driver handles PVC expansion
- **`volume.kubernetes.io/node-expansion-not-required`** — set on ReadWriteMany PVCs to indicate node-side expansion is not needed

## Technical basis
Verified against source code:
- `pkg/volume/util/types/types.go:209` — `VolumeResizerKey = "volume.kubernetes.io/storage-resizer"`
- `pkg/volume/util/types/types.go:29` — `NodeExpansionNotRequired = "volume.kubernetes.io/node-expansion-not-required"`
- `pkg/volume/util/resize_util.go:177-182` — `setResizer()` sets the annotation on PVCs during expansion
- `pkg/volume/util/operationexecutor/node_expander.go:110-113` — checks for the annotation on RWX PVCs to skip node expansion

## Test plan
- [ ] Renders correctly on preview