### PR TITLE
Fix inaccurate taint and toleration glossary descriptions

### DIFF
--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -3,13 +3,13 @@ title: Taint
 id: taint
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of pods on nodes or node groups.
+  Consisting of three properties: key, value, and effect. Taints prevent the scheduling of pods on nodes or node groups.
 
 aka:
 tags:
 - fundamental
 ---
- A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups.
+ Consisting of three properties: key, value, and effect. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups. The key and effect are required; the value is optional.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -3,14 +3,14 @@ title: Toleration
 id: toleration
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have a matching taint.
+  Consisting of three properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have a matching taint.
 
 aka:
 tags:
 - core-object
 - fundamental
 ---
- A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
+ Consisting of three properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}. All three properties are optional; an empty toleration matches all taints.
 
 <!--more-->
 


### PR DESCRIPTION
## Summary
~~`Fixes #51383`~~

Both glossary entries described taints and tolerations as having "three required
properties: key, value, and effect". This is inaccurate:

- For **taints**, `value` is optional (`+optional` in types.go:4036)
- For **tolerations**, all of `key`, `value`, and `effect` are optional
  (`+optional` in types.go:4076-4092); an empty toleration matches all taints

Additionally, the taint description used the phrase "core object" even though
the `core-object` tag was removed in #45972.

Changes:
- Remove "core object" from the taint description
- Remove "required" from both descriptions
- Add a note clarifying which properties are optional

## Technical basis
- `staging/src/k8s.io/api/core/v1/types.go:4032-4045` — Taint struct: Key and Effect are required, Value is `+optional`
- `staging/src/k8s.io/api/core/v1/types.go:4073-4092` — Toleration struct: Key, Operator, Value, Effect are all `+optional`

## Test plan
- [ ] Renders correctly on preview