### PR TITLE
Clarify that Guaranteed QoS requires resource values greater than zero

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-qos.md
+++ b/content/en/docs/concepts/workloads/pods/pod-qos.md
@@ -45,9 +45,9 @@ use of exclusive CPUs using the
 
 For a Pod to be given a QoS class of `Guaranteed`:
 
-* Every Container in the Pod must have a memory limit and a memory request.
+* Every Container in the Pod must have a memory limit and a memory request, both greater than zero.
 * For every Container in the Pod, the memory limit must equal the memory request.
-* Every Container in the Pod must have a CPU limit and a CPU request.
+* Every Container in the Pod must have a CPU limit and a CPU request, both greater than zero.
 * For every Container in the Pod, the CPU limit must equal the CPU request.
 
 If instead the Pod uses [Pod-level resources](/docs/concepts/configuration/manage-resources-containers/#pod-level-resource-specification):


### PR DESCRIPTION
## Summary
Fixes https://github.com/kubernetes/website/issues/54306

The Guaranteed QoS criteria stated that requests must equal limits for CPU and
memory, but did not mention that the values must also be greater than zero.
Setting `cpu: 0` (or `memory: 0`) with matching request and limit does not
result in Guaranteed QoS — the pod is classified as Burstable instead.

## Technical basis
Verified against source code:
- `pkg/apis/core/helper/qos/qos.go:136` — `if quantity.Cmp(zeroQuantity) == 1` — only quantities strictly greater than zero are tracked
- `pkg/apis/core/helper/qos/qos.go:148` — `isGuaranteed = false` if both CPU and memory limits (>0) are not found for a container
- `pkg/apis/core/helper/qos/qos.go:46` — `zeroQuantity = resource.MustParse("0")`

## Test plan
- [ ] Renders correctly on preview