### PR TITLE
Add clarifying comments to sidecar container YAML examples

### DIFF
--- a/content/en/examples/application/deployment-sidecar.yaml
+++ b/content/en/examples/application/deployment-sidecar.yaml
@@ -24,6 +24,7 @@ spec:
       initContainers:
         - name: logshipper
           image: alpine:latest
+          # Setting restartPolicy: Always makes this a sidecar container.
           restartPolicy: Always
           command: ['sh', '-c', 'tail -F /opt/logs.txt']
           volumeMounts:

--- a/content/en/examples/application/job/job-sidecar.yaml
+++ b/content/en/examples/application/job/job-sidecar.yaml
@@ -15,6 +15,7 @@ spec:
       initContainers:
         - name: logshipper
           image: alpine:latest
+          # Setting restartPolicy: Always makes this a sidecar container.
           restartPolicy: Always
           command: ['sh', '-c', 'tail -F /opt/logs.txt']
           volumeMounts:


### PR DESCRIPTION
## Summary

- Add a YAML comment (`# Setting restartPolicy: Always makes this a sidecar container.`) next to `restartPolicy: Always` in both sidecar container examples
- Clarifies that the `restartPolicy` field is what distinguishes a sidecar container from a regular init container

The page already has a `{{< note >}}` block explaining this, but users who jump straight to the YAML examples may miss it. A comment in the YAML itself makes the distinction immediately visible.

Fixes #53390