### PR TITLE
Clarify HPA handling of terminating pods for external metrics

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -152,9 +152,12 @@ metric across all Pods in the HorizontalPodAutoscaler's scale target.
 Before checking the tolerance and deciding on the final values, the control
 plane also considers whether any metrics are missing, and how many Pods
 are [`Ready`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions).
-All Pods with a deletion timestamp set (objects with a deletion timestamp are
-in the process of being shut down / removed) are ignored, and all failed Pods
-are discarded.
+For per-pod resource metrics, all Pods with a deletion timestamp set
+(objects with a deletion timestamp are in the process of being shut
+down / removed) are ignored, and all failed Pods are discarded.
+For external and object metrics, the replica count is based on the
+number of Running and Ready Pods; terminating Pods that are still Ready
+continue to count toward that total.
 
 If a particular Pod is missing metrics, it is set aside for later; Pods
 with missing metrics will be used to adjust the final scaling amount.


### PR DESCRIPTION
## Summary

- Clarify that terminating pods are only ignored for per-pod resource metrics, not for external/object metrics
- For external and object metrics, terminating pods that are still Running and Ready continue to count toward the replica calculation

## Technical basis

The HPA uses two different code paths:

**Per-pod resource metrics** — uses `groupPods()` at [`replica_calculator.go:422`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/podautoscaler/replica_calculator.go#L422), which checks `pod.DeletionTimestamp != nil` and ignores those pods.

**External/object metrics** — uses `getReadyPodsCount()` at [`replica_calculator.go:330`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/podautoscaler/replica_calculator.go#L330), which counts pods by `Phase == Running && IsPodReady(pod)` without checking `DeletionTimestamp`.

This means a pod that is terminating (has a deletion timestamp) but is still Running and Ready will be counted toward the replica total for external metrics, potentially causing the HPA to maintain more replicas than expected.

Fixes #43970

/sig autoscaling