### PR TITLE
Make update-schedule workflow resilient to transient failures

### DIFF
--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml && break
-            echo "schedule-builder failed, retrying ($i/3)..."
+            echo "schedule-builder failed, retrying ($i/3)..." >&2
             sleep 20
           done
 


### PR DESCRIPTION
The update-schedule workflow intermittently fails due to transient upstream
errors when running schedule-builder, which can prevent release data from
being updated on the website.

Closes: #50781.
