### PR TITLE
Add docs for ResourcePoolStatusRequest (KEP-5677)

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -6,7 +6,7 @@ title: Dynamic Resource Allocation
 content_type: concept
 weight: 65
 api_metadata:
-- apiVersion: "resource.k8s.io/v1alpha1"
+- apiVersion: "resource.k8s.io/v1alpha3"
   kind: "ResourcePoolStatusRequest"
 - apiVersion: "resource.k8s.io/v1alpha3"
   kind: "DeviceTaintRule"
@@ -879,41 +879,62 @@ are available, allocated, or unavailable across your cluster's DRA resource pool
 To check resource pool status:
 
 1. Create a ResourcePoolStatusRequest specifying the driver name (required) and
-   optionally a pool name filter:
+   optionally a limit on the number of pools returned. You can also limit it to a single pool by specifying a pool name:
 
    ```yaml
-   apiVersion: resource.k8s.io/v1alpha1
+   apiVersion: resource.k8s.io/v1alpha3
    kind: ResourcePoolStatusRequest
    metadata:
      name: check-gpus
    spec:
      driver: example.com/gpu
+     # Optional: filter to a specific pool
+     # poolName: my-pool
+     # Optional: limit number of pools returned (default: 100, max: 1000)
+     # limit: 10
    ```
 
 1. Wait for the controller to process the request:
 
    ```shell
-   kubectl wait --for=condition=Complete rpsr/check-gpus --timeout=30s
+   kubectl wait --for=condition=Complete resourcepoolstatusrequest/check-gpus --timeout=30s
    ```
 
 1. Read the status to see pool availability:
 
    ```shell
-   kubectl get rpsr/check-gpus -o yaml
+   kubectl get resourcepoolstatusrequest/check-gpus -o yaml
    ```
 
-   The status includes information about each pool such as total devices,
-   allocated devices, and available devices.
+   The status includes:
+   - `poolCount`: total number of pools matching the filter (may exceed the number
+     of pools listed if truncated by the limit).
+   - `pools`: a list of pool details, each containing:
+     - `driver` and `poolName`: identify the pool.
+     - `generation`: the latest pool generation observed across ResourceSlices.
+     - `resourceSliceCount`: the number of ResourceSlices making up the pool.
+     - `totalDevices`: total devices in the pool.
+     - `allocatedDevices`: devices currently allocated to claims.
+     - `availableDevices`: devices available for allocation
+       (totalDevices - allocatedDevices - unavailableDevices).
+     - `unavailableDevices`: devices not available due to taints or other conditions.
+     - `nodeName`: the node associated with the pool, if any.
+     - `validationError`: set when the pool's data could not be fully validated
+       (for example, during a generation rollout). When set, device count fields
+       may be unset.
+   - `conditions`: includes `Complete` (success) or `Failed` (error) condition types.
 
 1. Delete the request when done:
 
    ```shell
-   kubectl delete rpsr/check-gpus
+   kubectl delete resourcepoolstatusrequest/check-gpus
    ```
 
 ResourcePoolStatusRequest objects are processed once by a controller in
-kube-controller-manager. To get updated availability data, delete and recreate
-the request.
+kube-controller-manager. The spec is immutable once created, and the entire
+object becomes immutable once the status is populated. To get updated
+availability data, delete and recreate the request. Completed requests are
+automatically cleaned up after 1 hour.
 
 This feature requires explicit RBAC permissions on the ResourcePoolStatusRequest
 resource. No default ClusterRoles include this permission.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DRAResourcePoolStatus.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DRAResourcePoolStatus.md
@@ -10,9 +10,10 @@ stages:
     defaultValue: false
     fromVersion: "1.36"
 ---
-Enables the ResourcePoolStatusRequest API for querying the availability of
-devices in DRA resource pools. When enabled, users can create
-ResourcePoolStatusRequest objects to get a point-in-time snapshot of device
-availability (total, allocated, and available devices) for a specific driver
-and optionally a specific pool. A controller in kube-controller-manager
-processes these requests and populates the status with pool information.
+Enables the ResourcePoolStatusRequest API for querying the
+[availability of devices in DRA resource pools](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resource-pool-status).
+When enabled, users can create ResourcePoolStatusRequest objects to get a
+point-in-time snapshot of device availability (total, allocated, available, and
+unavailable devices) for a specific driver and optionally a specific pool.
+A controller in kube-controller-manager processes these one-time requests and
+populates the status with pool information.


### PR DESCRIPTION
### Description
This PR adds ResourcePoolStatusRequest API introduced in KEP-5677 (DRA Resource Availability Visibility).

This is an alpha feature gated by `DRAResourcePoolStatus` feature gate in kube-apiserver and kube-controller-manager.

### Issue
k/enhancements  https://github.com/kubernetes/enhancements/issues/5677
k/k  https://github.com/kubernetes/kubernetes/pull/137028

/kind documentation
/sig node
/wg device-management

