### PR TITLE
[ko] Standardize English notation and capitalization in localization …

### DIFF
--- a/content/ko/docs/contribute/localization_ko.md
+++ b/content/ko/docs/contribute/localization_ko.md
@@ -268,19 +268,19 @@ PR을 생성하여 개선된 용어를 제안한다.
 
 English | 한글 | 비고
 --- | --- | ---
-Access | 접근 |
+access | 접근 |
 Active | Active | 잡의 상태
-Active Job | 액티브 잡 |
-Addons | 애드온 |
+active job | 액티브 잡 |
+addons | 애드온 |
 admission controller | 어드미션 컨트롤러 |
-Age | 기간 |
-Allocation | 할당량 |
+age | 기간 |
+allocation | 할당량 |
 alphanumeric | 영숫자 |
-Annotation | 어노테이션 |
+annotation | 어노테이션 |
 APIService | API서비스(APIService) | API 오브젝트인 경우
-App | 앱 |
-Appendix | 부록 |
-Application | 애플리케이션 |
+app | 앱 |
+appendix | 부록 |
+application | 애플리케이션 |
 Args | Args | 약어의 형태이므로 한글화하지 않고 영문 표기
 array | 배열 |
 autoscaler | 오토스케일러 |
@@ -289,31 +289,31 @@ bare pod | 베어(bare) 파드 |
 beta | 베타 |
 Binding | 바인딩(Binding) | API 오브젝트인 경우
 boilerplate | 상용구 |
-Boot | 부트 |
-Bootstrap | 부트스트랩 |
-Build | 빌드 |
-Cache | 캐시 |
+boot | 부트 |
+bootstrap | 부트스트랩 |
+build | 빌드 |
+cache | 캐시 |
 Calico | 캘리코(Calico) |
 canary | 카나리(canary) | 릴리스 방식에 관련한 용어인 경우에 한함
 cascading | 캐스케이딩(cascading) |
 CertificateSigningRequest | CertificateSigningRequest | API 오브젝트인 경우
 character set | 캐릭터 셋 |
-Charts | 차트 |
+charts | 차트 |
 checkpoint | 체크포인트 |
 Cilium | 실리움(Cilium) |
 CLI | CLI |
-Cluster | 클러스터 |
+cluster | 클러스터 |
 ClusterRole | 클러스터롤(ClusterRole) | API 오브젝트인 경우
 ClusterRoleBinding | 클러스터롤바인딩(ClusterRoleBinding) | API 오브젝트인 경우
-Command Line Tool | 커맨드라인 툴 |
-Component | 컴포넌트 |
+command line tool | 커맨드라인 툴 |
+component | 컴포넌트 |
 ComponentStatus | 컴포넌트스테이터스(ComponentStatus) | API 오브젝트인 경우
 ConfigMap | 컨피그맵(ConfigMap) | API 오브젝트인 경우
 configuration | 구성, 설정 |
-Connection | 연결 |
+connection | 연결 |
 containerized | 컨테이너화 된 |
-Context | 컨텍스트  |
-Control Plane | 컨트롤 플레인 |
+context | 컨텍스트 |
+control plane | 컨트롤 플레인 |
 controller | 컨트롤러 |
 ControllerRevision | 컨트롤러리비전(ControllerRevision) | API 오브젝트인 경우
 cron job | 크론 잡 |
@@ -323,21 +323,21 @@ CSINode | CSI노드(CSINode) | API 오브젝트인 경우
 custom metrics | 사용자 정의 메트릭 |
 custom resource | 사용자 정의 리소스 |
 CustomResourceDefinition | 커스텀리소스데피니션(CustomResourceDefinition) | API 오브젝트인 경우
-Daemon | 데몬 |
+daemon | 데몬 |
 DaemonSet | 데몬셋(DaemonSet) | API 오브젝트인 경우
-Dashboard | 대시보드 |
-Data Plane | 데이터 플레인 |
+dashboard | 대시보드 |
+data plane | 데이터 플레인 |
 Deployment | 디플로이먼트(Deployment) | API 오브젝트인 경우
 deprecated | 사용 중단(deprecated) |
 descriptor | 디스크립터, 식별자 |
-Desired number of pods | 의도한 파드의 수 |
-Desired State | 의도한 상태 |
+desired number of pods | 의도한 파드의 수 |
+desired state | 의도한 상태 |
 disruption | 중단(disruption) |
 distros | 배포판 |
 Docker | 도커 |
 Dockerfile | Dockerfile |
 Docker Swarm | Docker Swarm |
-Downward API | 다운워드(Downward) API |
+downward API | 다운워드(Downward) API |
 draining | 드레이닝(draining) |
 egress | 이그레스, 송신(egress) |
 endpoint | 엔드포인트 |
@@ -347,11 +347,11 @@ entry point | 진입점 |
 Event | 이벤트(Event) | API 오브젝트인 경우
 evict | 축출하다 |
 eviction | 축출 |
-Exec | Exec |
+exec | exec |
 expose | 노출시키다 |
 extension | 익스텐션(extension) |
 Failed | Failed | 파드의 상태에 한함
-Federation | 페더레이션 |
+federation | 페더레이션 |
 field | 필드 |
 finalizer | 파이널라이저(finalizer) |
 Flannel | 플란넬(Flannel) |
@@ -361,21 +361,21 @@ hash | 해시 |
 headless | 헤드리스 |
 health check | 헬스 체크 |
 Heapster | 힙스터(Heapster) |
-Heartbeat | 하트비트 |
+heartbeat | 하트비트 |
 Homebrew | Homebrew |
 hook | 훅(hook) |
 Horizontal Pod Autoscaler | Horizontal Pod Autoscaler | 예외적으로 API 오브젝트에 대해 외래어 표기법 적용하지 않고 원문 그대로 표기
 hosted zone | 호스팅 영역 |
 hostname | 호스트네임 |
-Huge page | Huge page |
-Hypervisor | 하이퍼바이저 |
+huge page | huge page |
+hypervisor | 하이퍼바이저 |
 idempotent | 멱등성 |
-Image | 이미지 |
-Image Pull Secrets | 이미지 풀(Pull) 시크릿 |
+image | 이미지 |
+image pull secrets | 이미지 풀(Pull) 시크릿 |
 Ingress | 인그레스(Ingress) | API 오브젝트인 경우
 IngressClass | 인그레스클래스(IngressClass) | API 오브젝트인 경우
-Init Container | 초기화 컨테이너 |
-Instance group | 인스턴스 그룹 |
+init container | 초기화 컨테이너 |
+instance group | 인스턴스 그룹 |
 introspection | 인트로스펙션(introspection) |
 Istio | 이스티오(Istio) |
 Job | 잡(Job) | API 오브젝트인 경우
@@ -391,17 +391,17 @@ limit | 한도(limit) | 리소스의 개수나 용량을 한정하기 위한 수
 Linux | 리눅스 |
 load | 부하 |
 LocalSubjectAccessReview | 로컬서브젝트액세스리뷰(LocalSubjectAccessReview) | API 오브젝트인 경우
-Log | 로그 |
+log | 로그 |
 loopback | 루프백(loopback) |
 Lost | Lost | 클레임의 상태에 한함
-Machine | 머신 |
+machine | 머신 |
 manifest | 매니페스트 |
-Master | 마스터 |
+master | 마스터 |
 metadata | 메타데이터 |
 metric | 메트릭 |
 masquerading | 마스커레이딩 |
 Minikube | Minikube |
-Mirror pod | 미러 파드(mirror pod) |
+mirror pod | 미러 파드(mirror pod) |
 monitoring | 모니터링 |
 multihomed | 멀티홈드(multihomed) |
 MutatingWebhookConfiguration | MutatingWebhookConfiguration | API 오브젝트인 경우
@@ -411,11 +411,11 @@ netfilter | 넷필터(netfilter) |
 NetworkPolicy | 네트워크폴리시(NetworkPolicy) | API 오브젝트인 경우
 Node | 노드(Node) | API 오브젝트인 경우
 node lease | 노드 리스(lease)
-Object | 오브젝트 |
+object | 오브젝트 |
 observability | 가시성(observability) |
-Operator | 오퍼레이터 | [쿠버네티스의 소프트웨어 익스텐션](/docs/concepts/extend-kubernetes/operator/)을 의미하는 경우
-Orchestrate | 오케스트레이션하다 |
-Output | 출력 |
+operator | 오퍼레이터 | [쿠버네티스의 소프트웨어 익스텐션](/docs/concepts/extend-kubernetes/operator/)을 의미하는 경우
+orchestrate | 오케스트레이션하다 |
+output | 출력 |
 parameter | 파라미터 |
 patch | 패치 |
 payload | 페이로드(payload) |
@@ -425,7 +425,7 @@ PersistentVolumeClaim | 퍼시스턴트볼륨클레임(PersistentVolumeClaim) | 
 pipeline | 파이프라인 |
 placeholder pod | 플레이스홀더(placeholder) 파드 |
 Pod | 파드 | API 오브젝트인 경우에도 표현의 간결함을 위해 한영병기를 하지 않음
-Pod Preset | 파드 프리셋 |
+pod preset | 파드 프리셋 |
 PodAntiAffinity | 파드안티어피니티(PodAntiAffinity) |
 PodDisruptionBudget | PodDisruptionBudget | API 오브젝트인 경우
 PodSecurityPolicy | 파드시큐리티폴리시(PodSecurityPolicy) | API 오브젝트인 경우
@@ -433,23 +433,23 @@ PodTemplate | 파드템플릿(PodTemplate) | API 오브젝트인 경우
 postfix | 접미사 |
 prefix | 접두사 |
 PriorityClass | 프라이어리티클래스(PriorityClass) | API 오브젝트인 경우
-Privileged | 특권을 가진(privileged) |
+privileged | 특권을 가진(privileged) |
 probe | 프로브(probe) |
 Prometheus | 프로메테우스 |
 proxy | 프록시 |
 proof of concept | 개념 증명 |
-Pull Request | 풀 리퀘스트 |
-Pull Secret Credentials | 풀(Pull) 시크릿 자격증명 |
-QoS Class | QoS 클래스 |
-Quota | 쿼터 |
+pull request | 풀 리퀘스트 |
+pull secret credentials | 풀(Pull) 시크릿 자격증명 |
+QoS class | QoS 클래스 |
+quota | 쿼터 |
 readiness gate | 준비성 게이트(readiness gate) |
 readiness probe | 준비성 프로브(readiness probe) |
 Ready | Ready |
-Reclaim Policy | 반환 정책 |
+reclaim policy | 반환 정책 |
 redirect | 리다이렉트(redirect) |
 redirection | 리다이렉션 |
-Registry | 레지스트리 |
-Release | 릴리스 |
+registry | 레지스트리 |
+release | 릴리스 |
 ReplicaSet | 레플리카셋(ReplicaSet) | API 오브젝트인 경우
 replicas | 레플리카 |
 ReplicationController | 레플리케이션컨트롤러(ReplicationController) | API 오브젝트인 경우
@@ -468,60 +468,60 @@ Romana | 로마나(Romana) |
 Running | Running | 파드의 상태에 한함
 runtime | 런타임 |
 RuntimeClass | 런타임클래스(RuntimeClass) | API 오브젝트인 경우
-Scale | 스케일 |
+scale | 스케일 |
 Secret | 시크릿(Secret) | API 오브젝트인 경우
 segment | 세그먼트 |
-Selector | 셀렉터 |
-Self-healing | 자가 치유 |
+selector | 셀렉터 |
+self-healing | 자가 치유 |
 SelfSubjectAccessReview | 셀프서브젝트액세스리뷰(SelfSubjectAccessReview) | API 오브젝트인 경우
 SelfSubjectRulesReview | SelfSubjectRulesReview | API 오브젝트이지만 용어를 구성하는 단어 중 복수형 Rules를 '룰스'로 외래어 표기하는 경우 한국어 독자에게 다소 생경할 수 있어 예외적으로 영문 용어를 사용함
 Service | 서비스 | API 오브젝트인 경우에도 표현의 간결함을 위해 한영병기를 하지 않음
 ServiceAccount | 서비스어카운트(ServiceAccount) | API 오브젝트인 경우
 service discovery | 서비스 디스커버리 |
 service mesh | 서비스 메시 |
-Session | 세션 |
-Session Affinity | 세션 어피니티(Affinity) |
-Setting | 세팅 |
-Shell | 셸 |
+session | 세션 |
+session affinity | 세션 어피니티(session affinity) |
+setting | 세팅 |
+shell | 셸 |
 sidecar | 사이드카(sidecar) |
-Sign In | 로그인 |
-Sign Out | 로그아웃 |
+sign in | 로그인 |
+sign out | 로그아웃 |
 skew | 차이(skew) |
 snippet | 스니펫(snippet) |
 spec | 명세, 스펙, 사양 |
 specification | 명세 |
 StatefulSet | 스테이트풀셋(StatefulSet) | API 오브젝트인 경우
 stateless | 스테이트리스 |
-Static pod | 스태틱(static) 파드 |
+static pod | 스태틱(static) 파드 |
 StorageClass | 스토리지클래스(StorageClass) | API 오브젝트인 경우
 SubjectAccessReview | 서브젝트액세스리뷰(SubjectAccessReview) | API 오브젝트인 경우
-Sub-Object | 서브-오브젝트 |
+sub-object | 서브-오브젝트 |
 support | 지원 |
-Surge | 증가율 | 롤링업데이트 전략에 한함
-System | 시스템 |
+surge | 증가율 | 롤링업데이트 전략에 한함
+system | 시스템 |
 taint | 테인트(taint) |
-Task | 태스크 |
+task | 태스크 |
 telepresence | 텔레프레즌스(telepresence) |
 Terminated | Terminated | 파드의 상태에 한함
 TokenReview | 토큰리뷰(TokenReview) | API 오브젝트인 경우
 tolerations | 톨러레이션(toleration) |
-Topology spread constraints | 토폴로지 분배 제약 조건 |
-Tools  | 도구 |
+topology spread constraints | 토폴로지 분배 제약 조건 |
+tools | 도구 |
 traffic | 트래픽 |
-Type | 타입 |
-ubuntu | 우분투 |
+type | 타입 |
+Ubuntu | 우분투 |
 use case | 유스케이스 |
 userspace | 유저스페이스(userspace) |
-Utilization | 사용량, 사용률 |
+utilization | 사용량, 사용률 |
 ValidatingWebhookConfiguration | ValidatingWebhookConfiguration | API 오브젝트인 경우
 verbosity | 로그 상세 레벨(verbosity) |
 virtualization | 가상화 |
-Volume | 볼륨 |
+volume | 볼륨 |
 VolumeAttachment | 볼륨어태치먼트(VolumeAttachment) | API 오브젝트인 경우
 Waiting | Waiting | 파드의 상태에 한함
-Walkthrough | 연습 |
+walkthrough | 연습 |
 Weave-net | 위브넷(Weave Net) | Weaveworks 사의 솔루션 공식 명칭은 'Weave Net'이므로 한영병기 시 공식 명칭 사용
 Windows | 윈도우 |
-Worker | 워커 | 노드의 형태에 한함
-Workload | 워크로드 |
+worker | 워커 | 노드의 형태에 한함
+workload | 워크로드 |
 YAML | YAML |


### PR DESCRIPTION
### Description

This PR standardizes capitalization of general terminology in the localization glossary (`content/ko/docs/contribute/localization_ko.md`) by converting them to lowercase (for example, `Session Affinity` -> `session affinity`) for consistency.

This change is part of the follow-up work discussed in #53156.

### Issue

Closes: #54406 