### PR TITLE
docs: Remove date field from Japanese glossary entries

### DIFF
--- a/content/ja/docs/reference/glossary/addons.md
+++ b/content/ja/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Add-ons
 id: addons
-date: 2019-12-15
 full_link: /ja/docs/concepts/cluster-administration/addons/
 short_description: >
   Kubernetesの機能を拡張するリソース。

--- a/content/ja/docs/reference/glossary/admission-controller.md
+++ b/content/ja/docs/reference/glossary/admission-controller.md
@@ -1,7 +1,6 @@
 ---
 title: アドミッションコントローラー
 id: admission-controller
-date: 2019-06-28
 full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   オブジェクトを永続化する前に、Kubernetes APIサーバーへのリクエストをインターセプトするコード。

--- a/content/ja/docs/reference/glossary/affinity.md
+++ b/content/ja/docs/reference/glossary/affinity.md
@@ -1,7 +1,6 @@
 ---
 title: アフィニティ
 id: affinity
-date: 2019-01-11
 full_link: /ja/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
      Podを配置する場所を決定するためにスケジューラーによって使用されるルール

--- a/content/ja/docs/reference/glossary/aggregation-layer.md
+++ b/content/ja/docs/reference/glossary/aggregation-layer.md
@@ -1,7 +1,6 @@
 ---
 title: アグリゲーションレイヤー
 id: aggregation-layer
-date: 2018-10-08
 full_link: /docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
 short_description: >
   アグリゲーションレイヤーを使用すると、追加のKubernetesスタイルのAPIをクラスターにインストールできます。

--- a/content/ja/docs/reference/glossary/annotation.md
+++ b/content/ja/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: アノテーション
 id: annotation
-date: 2018-04-12
 full_link: /ja/docs/concepts/overview/working-with-objects/annotations
 short_description: >
   任意の非識別メタデータをオブジェクトにアタッチするために使用されるキーと値のペア。

--- a/content/ja/docs/reference/glossary/api-eviction.md
+++ b/content/ja/docs/reference/glossary/api-eviction.md
@@ -1,7 +1,6 @@
 ---
 title: APIを起点とした退避
 id: api-eviction
-date: 2021-04-27
 full_link: /ja/docs/concepts/scheduling-eviction/api-eviction/
 short_description: >
   APIを起点とした退避は、Eviction APIを使用してEvictionオブジェクトを作成し、Podの正常終了を起動させるプロセスです。

--- a/content/ja/docs/reference/glossary/api-group.md
+++ b/content/ja/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: APIグループ
 id: api-group
-date: 2019-09-02
 full_link: /ja/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
 short_description: >
   Kubernetes APIの関連するパスのセット。

--- a/content/ja/docs/reference/glossary/api-resource.md
+++ b/content/ja/docs/reference/glossary/api-resource.md
@@ -1,7 +1,6 @@
 ---
 title: APIリソース
 id: api-resource
-date: 2025-02-09
 full_link: /docs/reference/using-api/api-concepts/#standard-api-terminology
 short_description: >
   Kubernetes APIサーバー上のエンドポイントを表すKubernetesのエンティティです。

--- a/content/ja/docs/reference/glossary/app-container.md
+++ b/content/ja/docs/reference/glossary/app-container.md
@@ -1,7 +1,6 @@
 ---
 title: Appコンテナ
 id: app-container
-date: 2019-02-12
 full_link:
 short_description: >
  ワークロードの一部を実行するために使用されるコンテナ。Initコンテナと比較してください。

--- a/content/ja/docs/reference/glossary/application-architect.md
+++ b/content/ja/docs/reference/glossary/application-architect.md
@@ -1,7 +1,6 @@
 ---
 title: アプリケーションアーキテクト
 id: application-architect
-date: 2018-04-12
 full_link: 
 short_description: >
   アプリケーションの高レベルの設計を担当する人。

--- a/content/ja/docs/reference/glossary/application-developer.md
+++ b/content/ja/docs/reference/glossary/application-developer.md
@@ -1,7 +1,6 @@
 ---
 title: アプリケーション開発者
 id: application-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   Kubernetesクラスターで実行されるアプリケーションを作成する人。

--- a/content/ja/docs/reference/glossary/applications.md
+++ b/content/ja/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: アプリケーション
 id: applications
-date: 2019-05-12
 full_link:
 short_description: >
   様々なコンテナ化されたアプリケーションが実行される層。

--- a/content/ja/docs/reference/glossary/approver.md
+++ b/content/ja/docs/reference/glossary/approver.md
@@ -1,7 +1,6 @@
 ---
 title: 承認者
 id: approver
-date: 2018-04-12
 full_link: 
 short_description: >
   Kubernetesコードの貢献をレビュー、および承認できる人。

--- a/content/ja/docs/reference/glossary/cadvisor.md
+++ b/content/ja/docs/reference/glossary/cadvisor.md
@@ -1,7 +1,6 @@
 ---
 title: cAdvisor
 id: cadvisor
-date: 2021-12-09
 full_link: https://github.com/google/cadvisor/
 short_description: >
   コンテナのリソース使用量とパフォーマンス特性を理解するためのツール

--- a/content/ja/docs/reference/glossary/certificate.md
+++ b/content/ja/docs/reference/glossary/certificate.md
@@ -1,7 +1,6 @@
 ---
 title: 証明書
 id: certificate
-date: 2018-04-12
 full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
 short_description: >
   Kubernetesクラスターへのアクセスを検証するために使用される暗号化されたセキュアなファイル。

--- a/content/ja/docs/reference/glossary/cgroup.md
+++ b/content/ja/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   リソースの分離、使用状況の監視、制限を行うLinuxプロセスのグループ。

--- a/content/ja/docs/reference/glossary/cidr.md
+++ b/content/ja/docs/reference/glossary/cidr.md
@@ -1,7 +1,6 @@
 ---
 title: CIDR
 id: cidr
-date: 2019-11-12
 full_link: 
 short_description: >
   CIDRは、IPアドレスの範囲を記述するための表記法であり、さまざまなネットワークを構成するために使用されています。

--- a/content/ja/docs/reference/glossary/cla.md
+++ b/content/ja/docs/reference/glossary/cla.md
@@ -1,7 +1,6 @@
 ---
 title: CLA (Contributor License Agreement)
 id: cla
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   コントリビューターが行った貢献について、オープンソースプロジェクトが利用することを許諾する同意契約。

--- a/content/ja/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/ja/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: クラウドコントローラーマネージャー
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /ja/docs/concepts/architecture/cloud-controller/
 short_description: >
   サードパーティクラウドプロバイダーにKubernetesを結合するコントロールプレーンコンポーネント

--- a/content/ja/docs/reference/glossary/cloud-provider.md
+++ b/content/ja/docs/reference/glossary/cloud-provider.md
@@ -1,7 +1,6 @@
 ---
 title: クラウドプロバイダー
 id: cloud-provider
-date: 2018-04-12
 short_description: >
   クラウドコンピューティングプラットフォームを提供する組織。
 

--- a/content/ja/docs/reference/glossary/cluster-architect.md
+++ b/content/ja/docs/reference/glossary/cluster-architect.md
@@ -1,7 +1,6 @@
 ---
 title: クラスターアーキテクト
 id: cluster-architect
-date: 2018-04-12
 full_link: 
 short_description: >
   一つ以上のKubernetesクラスターで構成されるインフラストラクチャーを設計する人。

--- a/content/ja/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/ja/docs/reference/glossary/cluster-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: クラスターインフラストラクチャ
 id: cluster-infrastructure
-date: 2019-05-12
 full_link:
 short_description: >
  インフラストラクチャレイヤーは、VM、ネットワーキング、セキュリティグループなどを提供および運用します。

--- a/content/ja/docs/reference/glossary/cluster-operations.md
+++ b/content/ja/docs/reference/glossary/cluster-operations.md
@@ -1,7 +1,6 @@
 ---
 title: クラスター管理
 id: cluster-operations
-date: 2019-05-12
 full_link:
 short_description: >
  Kubernetesクラスターの管理に関連する作業です。

--- a/content/ja/docs/reference/glossary/cluster-operator.md
+++ b/content/ja/docs/reference/glossary/cluster-operator.md
@@ -1,7 +1,6 @@
 ---
 title: クラスター管理者
 id: cluster-operator
-date: 2018-04-12
 full_link: 
 short_description: >
   クラスターを設定、管理そして、監視する人

--- a/content/ja/docs/reference/glossary/cluster.md
+++ b/content/ja/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: クラスター
 id: cluster
-date: 2019-06-15
 full_link: 
 short_description: >
 

--- a/content/ja/docs/reference/glossary/cncf.md
+++ b/content/ja/docs/reference/glossary/cncf.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Native Computing Foundation (CNCF)
 id: cncf
-date: 2019-05-26
 full_link: https://cncf.io/
 short_description: >
   Cloud Native Computing Foundation

--- a/content/ja/docs/reference/glossary/cni.md
+++ b/content/ja/docs/reference/glossary/cni.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナネットワークインターフェース(CNI)
 id: cni
-date: 2018-05-25
 full_link: /ja/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 short_description: >
     コンテナネットワークインターフェース(CNI)プラグインは、appc/CNI仕様に準拠したネットワークプラグインの一種です。

--- a/content/ja/docs/reference/glossary/code-contributor.md
+++ b/content/ja/docs/reference/glossary/code-contributor.md
@@ -1,7 +1,6 @@
 ---
 title: コードコントリビューター
 id: code-contributor
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
 short_description: >
   Kubernetesのオープンソースのコードベースを開発し、貢献する人。

--- a/content/ja/docs/reference/glossary/configmap.md
+++ b/content/ja/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2018-04-12
 full_link: /ja/docs/concepts/configuration/configmap/
 short_description: >
   機密性のないデータをキーと値のペアで保存するために使用されるAPIオブジェクトです。環境変数、コマンドライン引数、またはボリューム内の設定ファイルとして使用できます。

--- a/content/ja/docs/reference/glossary/container-env-variables.md
+++ b/content/ja/docs/reference/glossary/container-env-variables.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナ環境変数
 id: container-env-variables
-date: 2018-04-12
 full_link: /ja/docs/concepts/containers/container-environment/
 short_description: >
   コンテナ環境変数は、Pod内で実行されているコンテナに関する有用な情報を提供する`name=value`のペアです。

--- a/content/ja/docs/reference/glossary/container-lifecycle-hooks.md
+++ b/content/ja/docs/reference/glossary/container-lifecycle-hooks.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナライフサイクルフック
 id: container-lifecycle-hooks
-date: 2018-10-08
 full_link: /ja/docs/concepts/containers/container-lifecycle-hooks/
 short_description: >
   ライフサイクルフックは、コンテナ管理のライフサイクルにおけるイベントを公開し、イベントが発生したときにユーザーがコードを実行できるようにします。

--- a/content/ja/docs/reference/glossary/container-runtime.md
+++ b/content/ja/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナランタイム
 id: container-runtime
-date: 2019-06-05
 full_link: /ja/docs/setup/production-environment/container-runtimes
 short_description: >
  コンテナランタイムは、コンテナの実行を担当するソフトウェアです。

--- a/content/ja/docs/reference/glossary/container.md
+++ b/content/ja/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナ
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/containers/
 short_description: >
   ソフトウェアとそのすべての依存関係を含む、軽量でポータブルな実行可能イメージです。

--- a/content/ja/docs/reference/glossary/containerd.md
+++ b/content/ja/docs/reference/glossary/containerd.md
@@ -1,7 +1,6 @@
 ---
 title: containerd
 id: containerd
-date: 2019-05-14
 full_link: https://containerd.io/docs/
 short_description: >
   シンプルさ、堅牢性、移植性を重視したコンテナランタイムです。

--- a/content/ja/docs/reference/glossary/contributor.md
+++ b/content/ja/docs/reference/glossary/contributor.md
@@ -1,7 +1,6 @@
 ---
 title: コントリビューター
 id: contributor
-date: 2018-04-12
 full_link: 
 short_description: >
   Kubernetesプロジェクトやコミュニティのために、コード、ドキュメント、またはその他の作業に自身の時間を使って貢献している人々

--- a/content/ja/docs/reference/glossary/control-plane.md
+++ b/content/ja/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: コントロールプレーン
 id: control-plane
-date: 2019-05-12
 full_link:
 short_description: >
   コンテナのライフサイクルを定義、展開、管理するためのAPIとインターフェースを公開するコンテナオーケストレーションレイヤーです。

--- a/content/ja/docs/reference/glossary/controller.md
+++ b/content/ja/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Controller
 id: controller
-date: 2018-04-12
 full_link: /ja/docs/concepts/architecture/controller/
 short_description: >
   クラスターの状態をAPIサーバーから取得、見張る制御ループで、現在の状態を望ましい状態に移行するように更新します。

--- a/content/ja/docs/reference/glossary/cri-o.md
+++ b/content/ja/docs/reference/glossary/cri-o.md
@@ -1,7 +1,6 @@
 ---
 title: CRI-O
 id: cri-o
-date: 2019-05-14
 full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   Kubernetesに特化した軽量コンテナランタイム

--- a/content/ja/docs/reference/glossary/cri.md
+++ b/content/ja/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナランタイムインターフェース(CRI)
 id: cri
-date: 2021-11-24
 full_link: /docs/concepts/architecture/cri
 short_description: >
   kubeletとローカルコンテナランタイム間の通信のためのプロトコルです。

--- a/content/ja/docs/reference/glossary/cronjob.md
+++ b/content/ja/docs/reference/glossary/cronjob.md
@@ -1,7 +1,6 @@
 ---
 title: CronJob
 id: cronjob
-date: 2018-04-12
 full_link: /ja/docs/concepts/workloads/controllers/cron-jobs/
 short_description: >
   定期的なスケジュールで繰り返し実行されるタスク(Job)

--- a/content/ja/docs/reference/glossary/csi.md
+++ b/content/ja/docs/reference/glossary/csi.md
@@ -1,7 +1,6 @@
 ---
 title: コンテナストレージインターフェース(CSI)
 id: csi
-date: 2018-06-25
 full_link: /docs/concepts/storage/volumes/#csi
 short_description: >
     コンテナストレージインターフェース(CSI)はストレージシステムをコンテナに公開するための標準インターフェースを定義します。

--- a/content/ja/docs/reference/glossary/customresourcedefinition.md
+++ b/content/ja/docs/reference/glossary/customresourcedefinition.md
@@ -1,7 +1,6 @@
 ---
 title: カスタムリソース定義(Custom Resource Definitions)
 id: CustomResourceDefinition
-date: 2018-04-12
 full_link: /docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 short_description: >
   拡張APIサーバーを構築することなく、Kubernetes APIサーバーに追加するリソースを定義するカスタムコードです。

--- a/content/ja/docs/reference/glossary/daemonset.md
+++ b/content/ja/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/daemonset
 short_description: >
   Podのコピーがクラスター内の一連のNodeに渡って実行されることを保証します。

--- a/content/ja/docs/reference/glossary/data-plane.md
+++ b/content/ja/docs/reference/glossary/data-plane.md
@@ -1,7 +1,6 @@
 ---
 title: データプレーン
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   コンテナを実行し、ネットワークに接続できるように、CPU、メモリ、ネットワーク、ストレージなどのキャパシティを提供するレイヤーです。

--- a/content/ja/docs/reference/glossary/deployment.md
+++ b/content/ja/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /ja/docs/concepts/workloads/controllers/deployment/
 short_description: >
   クラスター上の複製されたアプリケーションを管理します。

--- a/content/ja/docs/reference/glossary/device-plugin.md
+++ b/content/ja/docs/reference/glossary/device-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: デバイスプラグイン
 id: device-plugin
-date: 2019-02-02
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   ベンダー固有の初期化やセットアップを必要とするデバイスにPodがアクセスできるようにするためのソフトウェア拡張機能

--- a/content/ja/docs/reference/glossary/docker.md
+++ b/content/ja/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Dockerは、コンテナとして知られる、オペレーティングシステムレベルでの仮想化を提供するソフトウェア技術です。

--- a/content/ja/docs/reference/glossary/dockershim.md
+++ b/content/ja/docs/reference/glossary/dockershim.md
@@ -1,7 +1,6 @@
 ---
 title: Dockershim
 id: dockershim
-date: 2022-04-15
 full_link: /ja/dockershim
 short_description: >
    Kubernetesバージョン1.23およびそれ以前のバージョンに存在するコンポーネントです。DockershimによりKubernetesシステムのコンポーネントがDocker Engineと通信できるようになります。

--- a/content/ja/docs/reference/glossary/drain.md
+++ b/content/ja/docs/reference/glossary/drain.md
@@ -1,7 +1,6 @@
 ---
 title: Drain
 id: drain
-date: 2024-12-27
 full_link:
 short_description: >
   メンテナンスや削除に備え、Podをノードから安全に退避します。

--- a/content/ja/docs/reference/glossary/duration.md
+++ b/content/ja/docs/reference/glossary/duration.md
@@ -1,7 +1,6 @@
 ---
 title: 期間(Duration)
 id: duration
-date: 2024-10-05
 full_link:
 short_description: >
   時間の長さを表す文字列値です。

--- a/content/ja/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/ja/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,7 +1,6 @@
 ---
 title: ボリュームの動的プロビジョニング
 id: dynamicvolumeprovisioning
-date: 2018-04-12
 full_link: /ja/docs/concepts/storage/dynamic-provisioning
 short_description: >
  ユーザーがストレージボリュームの自動作成をリクエストできるようにします。

--- a/content/ja/docs/reference/glossary/endpoint.md
+++ b/content/ja/docs/reference/glossary/endpoint.md
@@ -1,7 +1,6 @@
 ---
 title: エンドポイント（Endpoints）
 id: endpoints
-date: 2020-04-23
 full_link: 
 short_description: >
   エンドポイントは、サービスのセレクターに一致するPodのIPアドレスを記録する責任があります。

--- a/content/ja/docs/reference/glossary/etcd.md
+++ b/content/ja/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   一貫性、高可用性を持ったキーバリューストアで、Kubernetesの全てのクラスター情報の保存場所として利用されています。

--- a/content/ja/docs/reference/glossary/eviction.md
+++ b/content/ja/docs/reference/glossary/eviction.md
@@ -1,7 +1,6 @@
 ---
 title: 退避
 id: eviction
-date: 2021-05-08
 full_link: /docs/concepts/scheduling-eviction/
 short_description: >
     ノード上の1つ以上のPodを終了させるプロセス。

--- a/content/ja/docs/reference/glossary/feature-gates.md
+++ b/content/ja/docs/reference/glossary/feature-gates.md
@@ -1,7 +1,6 @@
 ---
 title: フィーチャーゲート(Feature gate)
 id: feature-gate
-date: 2023-01-12
 full_link: /ja/docs/reference/command-line-tools-reference/feature-gates/
 short_description: >
   特定のKubernetes機能を有効にするかどうかを制御する方法。

--- a/content/ja/docs/reference/glossary/finalizer.md
+++ b/content/ja/docs/reference/glossary/finalizer.md
@@ -1,7 +1,6 @@
 ---
 title: ファイナライザー
 id: finalizer
-date: 2021-07-07
 full_link: /ja/docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
   削除対象としてマークされたオブジェクトを完全に削除する前に、特定の条件が満たされるまでKubernetesを待機させるための名前空間付きのキーです。

--- a/content/ja/docs/reference/glossary/flexvolume.md
+++ b/content/ja/docs/reference/glossary/flexvolume.md
@@ -1,7 +1,6 @@
 ---
 title: FlexVolume
 id: flexvolume
-date: 2018-06-25
 full_link: /ja/docs/concepts/storage/volumes/#flexvolume
 short_description: >
     FlexVolumeは、ツリー外のボリュームプラグインを作成するための非推奨なインターフェースです。{{< glossary_tooltip text="コンテナストレージインターフェース(CSI)" term_id="csi" >}}は、FlexVolumeのいくつかの問題に対処する新しいインターフェースです。

--- a/content/ja/docs/reference/glossary/garbage-collection.md
+++ b/content/ja/docs/reference/glossary/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 title: ガベージコレクション
 id: garbage-collection
-date: 2021-07-07
 full_link: /ja/docs/concepts/architecture/garbage-collection/
 short_description: >
   Kubernetesがクラスターリソースをクリーンアップするために使用するさまざまなメカニズムの総称です。

--- a/content/ja/docs/reference/glossary/gateway.md
+++ b/content/ja/docs/reference/glossary/gateway.md
@@ -1,7 +1,6 @@
 ---
 title: Gateway API
 id: gateway-api
-date: 2023-10-19
 full_link: /docs/concepts/services-networking/gateway/
 short_description: >
   Kubernetesでサービスネットワークをモデル化するために使用されるAPI。

--- a/content/ja/docs/reference/glossary/helm-chart.md
+++ b/content/ja/docs/reference/glossary/helm-chart.md
@@ -1,7 +1,6 @@
 ---
 title: Helmチャート
 id: helm-chart
-date: 2018-04-12
 full_link: https://helm.sh/docs/topics/charts/
 short_description: >
   Helmツールで管理できる、事前構成されたKubernetesリソースのパッケージ。

--- a/content/ja/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/ja/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,7 +1,6 @@
 ---
 title: Horizontal Pod Autoscaler
 id: horizontal-pod-autoscaler
-date: 2018-04-12
 full_link: /ja/docs/tasks/run-application/horizontal-pod-autoscale/
 short_description: >
   水平Pod自動スケーラーは、ターゲットCPU使用率またはカスタムメトリクスターゲットに基づいて、Podのレプリカ数をスケーリングするAPIリソースです。

--- a/content/ja/docs/reference/glossary/host-aliases.md
+++ b/content/ja/docs/reference/glossary/host-aliases.md
@@ -1,7 +1,6 @@
 ---
 title: HostAliases
 id: HostAliases
-date: 2019-01-31
 full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
 short_description: >
   HostAliasesは、Podのhostsファイルに注入されるIPアドレスとホスト名の間のマッピングです。

--- a/content/ja/docs/reference/glossary/image.md
+++ b/content/ja/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: イメージ
 id: image
-date: 2018-04-12
 full_link:
 short_description: >
   アプリケーションの実行に必要なソフトウェアのセットを持つ、保存されたコンテナの実体です。

--- a/content/ja/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/ja/docs/reference/glossary/immutable-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: イミュータブルインフラストラクチャ
 id: immutable-infrastructure
-date: 2024-03-25
 full_link:
 short_description: >
   イミュータブルインフラストラクチャはデプロイ後に変更できないコンピューターインフラストラクチャ(仮想マシン、コンテナ、ネットワークアプライアンス)を指します。

--- a/content/ja/docs/reference/glossary/ingress.md
+++ b/content/ja/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /ja/docs/concepts/services-networking/ingress/
 short_description: >
   クラスター内のServiceに対する外部からのアクセス(主にHTTP)を管理するAPIオブジェクトです。

--- a/content/ja/docs/reference/glossary/init-container.md
+++ b/content/ja/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: Initコンテナ
 id: init-container
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/init-containers/
 short_description: >
   アプリケーションコンテナの起動前に実行が完了している必要がある、1つ以上の初期化コンテナです。

--- a/content/ja/docs/reference/glossary/istio.md
+++ b/content/ja/docs/reference/glossary/istio.md
@@ -1,7 +1,6 @@
 ---
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   Istioは、マイクロサービスの統合やトラフィックフローの管理、ポリシーの適用、そしてテレメトリーデータの集約を行うための一様な方法を提供するオープンソースのプラットフォームです(Kubernetesに特化したものではありません)。

--- a/content/ja/docs/reference/glossary/job.md
+++ b/content/ja/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/job/
 short_description: >
   完了まで実行される有限またはバッチのタスク。

--- a/content/ja/docs/reference/glossary/jwt.md
+++ b/content/ja/docs/reference/glossary/jwt.md
@@ -1,7 +1,6 @@
 ---
 title: JSON Web Token (JWT)
 id: jwt
-date: 2023-01-17
 full_link: https://www.rfc-editor.org/rfc/rfc7519
 short_description: >
   2つの通信主体間で送受信されるクレームを表現する手段。

--- a/content/ja/docs/reference/glossary/kops.md
+++ b/content/ja/docs/reference/glossary/kops.md
@@ -1,7 +1,6 @@
 ---
 title: kOps(Kubernetes Operations)
 id: kops
-date: 2018-04-12
 full_link: /docs/setup/production-environment/kops/
 short_description: >
   kOpsは、プロダクショングレードの高可用性のあるKubernetesクラスターの作成、破棄、アップグレード、メンテナンスを支援するだけでなく、それに必要なクラウドインフラストラクチャのプロビジョニングも行います。

--- a/content/ja/docs/reference/glossary/kube-apiserver.md
+++ b/content/ja/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: APIサーバー
 id: kube-apiserver
-date: 2018-04-12
 full_link: /ja/docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Kubernetes APIを提供するコントロールプレーンのコンポーネントです。

--- a/content/ja/docs/reference/glossary/kube-controller-manager.md
+++ b/content/ja/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   コントロールプレーン上で動作するコンポーネントで、複数のコントローラープロセスを実行します。

--- a/content/ja/docs/reference/glossary/kube-proxy.md
+++ b/content/ja/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy`はクラスター内の各Nodeで動作しているネットワークプロキシです。

--- a/content/ja/docs/reference/glossary/kube-scheduler.md
+++ b/content/ja/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   コントロールプレーン上で動作するコンポーネントで、新しく作られたPodにノードが割り当てられているか監視し、割り当てられていなかった場合にそのPodを実行するノードを選択します。

--- a/content/ja/docs/reference/glossary/kubeadm.md
+++ b/content/ja/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /ja/docs/reference/setup-tools/kubeadm/
 short_description: >
   Kubernetesを迅速にインストールし、安全なクラスターをセットアップするためのツール。

--- a/content/ja/docs/reference/glossary/kubectl.md
+++ b/content/ja/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /ja/docs/reference/kubectl/
 short_description: >
   Kubernetesクラスターと通信するためのコマンドラインツールです。

--- a/content/ja/docs/reference/glossary/kubelet.md
+++ b/content/ja/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kubelet
 short_description: >
   クラスター内の各ノードで実行されるエージェント。コンテナがPod内で実行されていることを保証します。

--- a/content/ja/docs/reference/glossary/label.md
+++ b/content/ja/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: ラベル
 id: label
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   ユーザーにとって意味があり関連性のある識別属性を、オブジェクトにタグ付けするものです。

--- a/content/ja/docs/reference/glossary/limitrange.md
+++ b/content/ja/docs/reference/glossary/limitrange.md
@@ -1,7 +1,6 @@
 ---
 title: LimitRange
 id: limitrange
-date: 2019-04-15
 full_link:  /ja/docs/concepts/policy/limit-range/
 short_description: >
   各Namespace内のコンテナまたはPodごとのリソース消費量を制限するための制約を提供します。

--- a/content/ja/docs/reference/glossary/managed-service.md
+++ b/content/ja/docs/reference/glossary/managed-service.md
@@ -1,7 +1,6 @@
 ---
 title: マネージドサービス
 id: managed-service
-date: 2018-04-12
 full_link: 
 short_description: >
   サードパーティのプロバイダーによって保守されるソフトウェアの提供形態です。

--- a/content/ja/docs/reference/glossary/manifest.md
+++ b/content/ja/docs/reference/glossary/manifest.md
@@ -1,7 +1,6 @@
 ---
 title: マニフェスト
 id: manifest
-date: 2019-06-28
 short_description: >
   1つ以上のKubernetes APIオブジェクトをシリアライズした仕様です。
 

--- a/content/ja/docs/reference/glossary/member.md
+++ b/content/ja/docs/reference/glossary/member.md
@@ -1,7 +1,6 @@
 ---
 title: メンバー
 id: member
-date: 2018-04-12
 full_link: 
 short_description: >
   K8sコミュニティの継続的かつアクティブなコントリビューター

--- a/content/ja/docs/reference/glossary/minikube.md
+++ b/content/ja/docs/reference/glossary/minikube.md
@@ -1,7 +1,6 @@
 ---
 title: Minikube
 id: minikube
-date: 2018-04-12
 full_link: /ja/docs/tasks/tools/#minikube
 short_description: >
   ローカルでKubernetesを実行するためのツールです。

--- a/content/ja/docs/reference/glossary/mirror-pod.md
+++ b/content/ja/docs/reference/glossary/mirror-pod.md
@@ -1,7 +1,6 @@
 ---
 title: ミラーPod
 id: mirror-pod
-date: 2019-08-06
 short_description: >
   kubelet上のstatic Podを追跡するAPIサーバー内のオブジェクトです。
 

--- a/content/ja/docs/reference/glossary/name.md
+++ b/content/ja/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: 名前(Name)
 id: name
-date: 2018-04-12
 full_link: /ja/docs/concepts/overview/working-with-objects/names
 short_description: >
   クライアントから提供され、リソースURL内のオブジェクトを参照する文字列です。例えば`/api/v1/pods/何らかの名前`のようになります。

--- a/content/ja/docs/reference/glossary/namespace.md
+++ b/content/ja/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2018-04-12
 full_link: /ja/docs/concepts/overview/working-with-objects/namespaces
 short_description: >
   同一の物理クラスター上で複数の仮想クラスターをサポートするために使われる抽象概念です。

--- a/content/ja/docs/reference/glossary/network-policy.md
+++ b/content/ja/docs/reference/glossary/network-policy.md
@@ -1,7 +1,6 @@
 ---
 title: ネットワークポリシー
 id: network-policy
-date: 2018-04-12
 full_link: /ja/docs/concepts/services-networking/network-policies/
 short_description: >
   一連のPodがPod同士やその他のネットワークエンドポイントとどのように通信することを許可されるかを定める規定。

--- a/content/ja/docs/reference/glossary/node-pressure-eviction.md
+++ b/content/ja/docs/reference/glossary/node-pressure-eviction.md
@@ -1,7 +1,6 @@
 ---
 title: ノード圧迫による退避
 id: node-pressure-eviction
-date: 2021-05-13
 full_link: /ja/docs/concepts/scheduling-eviction/node-pressure-eviction/
 short_description: >
   ノード圧迫による退避は、kubeletがノード上のリソースを回収するためにPodを積極的に失敗させるプロセスです。

--- a/content/ja/docs/reference/glossary/node.md
+++ b/content/ja/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: ノード
 id: node
-date: 2018-04-12
 full_link: /ja/docs/concepts/architecture/nodes/
 short_description: >
   ノードはKubernetesのワーカーマシンです。

--- a/content/ja/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/ja/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: 永続ボリューム要求
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/
 short_description: >
   コンテナ内でボリュームとしてマウントするためにPersistentVolume内で定義されたストレージリソースを要求します。

--- a/content/ja/docs/reference/glossary/persistent-volume.md
+++ b/content/ja/docs/reference/glossary/persistent-volume.md
@@ -1,7 +1,6 @@
 ---
 title: 永続ボリューム
 id: persistent-volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/
 short_description: >
  クラスター内のストレージの一部を表すAPIオブジェクトです。通常利用可能で、個々のPodのライフサイクルの先にあるプラグイン形式のリソースです。

--- a/content/ja/docs/reference/glossary/platform-developer.md
+++ b/content/ja/docs/reference/glossary/platform-developer.md
@@ -1,7 +1,6 @@
 ---
 title: プラットフォーム開発者
 id: platform-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   自身のプロジェクトの要件に合わせ、Kubernetesプラットフォームをカスタマイズする人

--- a/content/ja/docs/reference/glossary/pod-lifecycle.md
+++ b/content/ja/docs/reference/glossary/pod-lifecycle.md
@@ -1,7 +1,6 @@
 ---
 title: Podのライフサイクル
 id: pod-lifecycle
-date: 2019-02-17
 full-link: /ja/docs/concepts/workloads/pods/pod-lifecycle/
 related:
  - pod

--- a/content/ja/docs/reference/glossary/pod-priority.md
+++ b/content/ja/docs/reference/glossary/pod-priority.md
@@ -1,7 +1,6 @@
 ---
 title: Podの優先度
 id: pod-priority
-date: 2019-01-31
 full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
 short_description: >
   Podの優先度は、他のPodと比較したPodの重要度を示します。

--- a/content/ja/docs/reference/glossary/pod.md
+++ b/content/ja/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /ja/docs/concepts/workloads/pods/
 short_description: >
   一番小さく一番シンプルな Kubernetes のオブジェクト。Pod とはクラスターで動作しているいくつかのコンテナのまとまりです。

--- a/content/ja/docs/reference/glossary/priority-class.md
+++ b/content/ja/docs/reference/glossary/priority-class.md
@@ -1,7 +1,6 @@
 ---
 title: PriorityClass
 id: priority-class
-date: 2024-03-19
 full_link: /ja/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
 short_description: >
   クラス名からPodが持つべきスケジューリングの優先度への対応付け。

--- a/content/ja/docs/reference/glossary/probe.md
+++ b/content/ja/docs/reference/glossary/probe.md
@@ -1,7 +1,6 @@
 ---
 title: Probe
 id: probe
-date: 2023-03-21
 full_link: /ja/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 short_description: >

--- a/content/ja/docs/reference/glossary/rbac.md
+++ b/content/ja/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: RBAC (Role-Based Access Control)
 id: rbac
-date: 2018-04-12
 full_link: /ja/docs/reference/access-authn-authz/rbac/
 short_description: >
   管理者がKubernetes APIを通じてアクセスポリシーを動的に設定できるようにし、認可の判断を管理します。

--- a/content/ja/docs/reference/glossary/replica-set.md
+++ b/content/ja/docs/reference/glossary/replica-set.md
@@ -1,7 +1,6 @@
 ---
 title: ReplicaSet
 id: replica-set
-date: 2018-04-12
 full_link: /ja/docs/concepts/workloads/controllers/replicaset/
 short_description: >
   ReplicaSetは、指定された数のPodレプリカが一度に動作するように保証します。

--- a/content/ja/docs/reference/glossary/replica.md
+++ b/content/ja/docs/reference/glossary/replica.md
@@ -1,7 +1,6 @@
 ---
 title: Replica
 id: replica
-date: 2023-06-11
 full_link: 
 short_description: >
   ReplicaはPodのコピーであり、同一インスタンスを維持することで、可用性、スケーラビリティ、耐障害性を保証します。

--- a/content/ja/docs/reference/glossary/secret.md
+++ b/content/ja/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: Secret
 id: secret
-date: 2018-04-12
 full_link: /ja/docs/concepts/configuration/secret/
 short_description: >
   パスワードやOAuthトークン、SSHキーのような機密の情報を保持します。

--- a/content/ja/docs/reference/glossary/security-context.md
+++ b/content/ja/docs/reference/glossary/security-context.md
@@ -1,7 +1,6 @@
 ---
 title: Security Context
 id: security-context
-date: 2018-04-12
 full_link: /ja/docs/tasks/configure-pod-container/security-context/
 short_description: >
   `securityContext`フィールドは、Podまたはコンテナの権限とアクセス制御の設定を定義します。

--- a/content/ja/docs/reference/glossary/selector.md
+++ b/content/ja/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: セレクター
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   セレクターを利用すると、ユーザーはラベルに基づいてリソースのリストをフィルタリングできます。

--- a/content/ja/docs/reference/glossary/service-account.md
+++ b/content/ja/docs/reference/glossary/service-account.md
@@ -1,7 +1,6 @@
 ---
 title: サービスアカウント
 id: service-account
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   Pod内で動作するプロセスのアイデンティティを提供します。

--- a/content/ja/docs/reference/glossary/service-catalog.md
+++ b/content/ja/docs/reference/glossary/service-catalog.md
@@ -1,7 +1,6 @@
 ---
 title: サービスカタログ
 id: service-catalog
-date: 2018-04-12
 full_link: 
 short_description: >
  Kubernetesクラスターで稼働するアプリケーションが、クラウドプロバイダーによって提供されるデータストアサービスのように、外部のマネージドソフトウェアを容易に使えるようにするための古い拡張APIです。

--- a/content/ja/docs/reference/glossary/service.md
+++ b/content/ja/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2018-04-12
 full_link: /ja/docs/concepts/services-networking/service/
 short_description: >
   Podの集合で実行されているアプリケーションをネットワークサービスとして公開する方法。

--- a/content/ja/docs/reference/glossary/sidecar-container.md
+++ b/content/ja/docs/reference/glossary/sidecar-container.md
@@ -1,7 +1,6 @@
 ---
 title: サイドカーコンテナ
 id: sidecar-container
-date: 2018-04-12
 full_link: /ja/docs/concepts/workloads/pods/sidecar-containers/
 short_description: >
   Podのライフサイクル全体を通して実行を続ける補助コンテナ。

--- a/content/ja/docs/reference/glossary/sig.md
+++ b/content/ja/docs/reference/glossary/sig.md
@@ -1,7 +1,6 @@
 ---
 title: SIG (special interest group)
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
 short_description: >
   大規模なKubernetesオープンソースプロジェクトにおいて、開発中の部分または側面を集合的に管理するコミュニティのメンバー

--- a/content/ja/docs/reference/glossary/statefulset.md
+++ b/content/ja/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /ja/docs/concepts/workloads/controllers/statefulset/
 short_description: >
   StatefulSetはPodのデプロイとスケーリングを管理し、永続化ストレージと各Podの永続的な識別子を備えています。

--- a/content/ja/docs/reference/glossary/static-pod.md
+++ b/content/ja/docs/reference/glossary/static-pod.md
@@ -1,7 +1,6 @@
 ---
 title: Static Pod
 id: static-pod
-date: 2019-02-12
 full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
   特定のノード上でkubeletデーモンによって直接管理されるPodです。

--- a/content/ja/docs/reference/glossary/storage-class.md
+++ b/content/ja/docs/reference/glossary/storage-class.md
@@ -1,7 +1,6 @@
 ---
 title: StorageClass
 id: storageclass
-date: 2018-04-12
 full_link: /docs/concepts/storage/storage-classes
 short_description: >
   StorageClassは管理者が利用可能なさまざまなストレージタイプを記述する方法を提供します。

--- a/content/ja/docs/reference/glossary/taint.md
+++ b/content/ja/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: Taint
 id: taint
-date: 2019-01-11
 full_link: /ja/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   key、value、effectの3つの必須属性からなり、Podが特定のノードやノードグループにスケジューリングされることを防ぎます。

--- a/content/ja/docs/reference/glossary/toleration.md
+++ b/content/ja/docs/reference/glossary/toleration.md
@@ -1,7 +1,6 @@
 ---
 title: Toleration
 id: toleration
-date: 2019-01-11
 full_link: /ja/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   key、value、effectの3つの必須属性からなるコアオブジェクトです。

--- a/content/ja/docs/reference/glossary/uid.md
+++ b/content/ja/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   オブジェクトを一意に識別するためのKubernetesが生成する文字列です。

--- a/content/ja/docs/reference/glossary/upstream.md
+++ b/content/ja/docs/reference/glossary/upstream.md
@@ -1,7 +1,6 @@
 ---
 title: アップストリーム(曖昧さ回避)
 id: upstream
-date: 2018-04-12
 full_link: 
 short_description: >
   Kubernetesのコア、またはリポジトリのフォーク元となるソースリポジトリのいずれかを指す場合があります。

--- a/content/ja/docs/reference/glossary/userns.md
+++ b/content/ja/docs/reference/glossary/userns.md
@@ -1,7 +1,6 @@
 ---
 title: ユーザー名前空間
 id: userns
-date: 2021-07-13
 full_link: https://man7.org/linux/man-pages/man7/user_namespaces.7.html
 short_description: >
   非特権ユーザーに対して管理者権限をエミュレートするLinuxカーネルの機能。

--- a/content/ja/docs/reference/glossary/volume.md
+++ b/content/ja/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: ボリューム
 id: volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/volumes/
 short_description: >
   データを格納するディレクトリで、Pod内のコンテナからアクセス可能です。

--- a/content/ja/docs/reference/glossary/watch.md
+++ b/content/ja/docs/reference/glossary/watch.md
@@ -1,7 +1,6 @@
 ---
 title: Watch
 id: watch
-date: 2024-07-02
 full_link: /docs/reference/using-api/api-concepts/#api-verbs
 short_description: >
   Kubernetes内のオブジェクトへの変更をストリームとして追跡するために使用される動詞です。

--- a/content/ja/docs/reference/glossary/wg.md
+++ b/content/ja/docs/reference/glossary/wg.md
@@ -1,7 +1,6 @@
 ---
 title: WG(ワーキンググループ)
 id: wg
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
 short_description: >
   委員会、{{< glossary_tooltip text="SIG" term_id="sig" >}}、またはSIG横断の取り組みにおいて、短期的、限定的、または独立したプロジェクトの議論や実装を促進します。

--- a/content/ja/docs/reference/glossary/workload.md
+++ b/content/ja/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: ワークロード
 id: workload
-date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
    ワークロードとは、Kubernetes上で実行中のアプリケーションです。


### PR DESCRIPTION
Remove obsolete date fields from all Japanese (ja/) glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296. Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #