### PR TITLE
docs: Remove date field from German glossary entries

### DIFF
--- a/content/de/docs/reference/glossary/addons.md
+++ b/content/de/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Add-ons
 id: addons
-date: 2019-12-15
 full_link: /docs/concepts/cluster-administration/addons/
 short_description: >
   Ressourcen, die die Funktionalität von Kubernetes erweitern.

--- a/content/de/docs/reference/glossary/admission-controller.md
+++ b/content/de/docs/reference/glossary/admission-controller.md
@@ -1,7 +1,6 @@
 ---
 title: Zugangscontroller
 id: admission-controller
-date: 2019-06-28
 full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   Ein Teil Code, das Anfragen an den Kubernetes API Server abfängt, vor der Persistenz eines Objekts.

--- a/content/de/docs/reference/glossary/affinity.md
+++ b/content/de/docs/reference/glossary/affinity.md
@@ -1,7 +1,6 @@
 ---
 title: Affinität
 id: affinity
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
      Regeln, die vom Scheduler verwendet werden, um festzulegen wo Pods platziert werden.

--- a/content/de/docs/reference/glossary/aggregation-layer.md
+++ b/content/de/docs/reference/glossary/aggregation-layer.md
@@ -1,7 +1,6 @@
 ---
 title: Aggregationsschicht
 id: aggregation-layer
-date: 2018-10-08
 full_link: /docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
 short_description: >
   Die Aggregationsschicht erlaubt Ihnen die Installation zusätzlicher Kubernetes-artiger APIs in Ihrem Cluster.

--- a/content/de/docs/reference/glossary/annotation.md
+++ b/content/de/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: Annotation
 id: annotation
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/annotations
 short_description: >
   Ein Key-Value Paar, dass verwendet wird um willkürliche, nicht-identifizierende Metadaten an Objekte zu binden.

--- a/content/de/docs/reference/glossary/api-eviction.md
+++ b/content/de/docs/reference/glossary/api-eviction.md
@@ -1,7 +1,6 @@
 ---
 title: API-initiierte Räumung
 id: api-eviction
-date: 2021-04-27
 full_link: /docs/concepts/scheduling-eviction/api-eviction/
 short_description: >
   API-initiierte Räumung ist der Prozess, durch den Sie die Räumungs API verwenden, um ein Räumungsobjekt zu erstellen, dass eine geordnete Beendung des Pods auslöst.

--- a/content/de/docs/reference/glossary/api-group.md
+++ b/content/de/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: API Gruppe
 id: api-group
-date: 2019-09-02
 full_link: /docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
 short_description: >
   Ein Satz zugehöriger Pfade in der Kubernetes API.

--- a/content/de/docs/reference/glossary/app-container.md
+++ b/content/de/docs/reference/glossary/app-container.md
@@ -1,7 +1,6 @@
 ---
 title: App Container
 id: app-container
-date: 2019-02-12
 full_link:
 short_description: >
   Ein Container, der verwendet wird um einen Teil einer Arbeitslast auszuführen. Vergleiche mit init Container.

--- a/content/de/docs/reference/glossary/application-architect.md
+++ b/content/de/docs/reference/glossary/application-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Anwendungsarchitekt
 id: application-architect
-date: 2018-04-12
 full_link: 
 short_description: >
   Eine Person, die verantwortlich ist für das Highlevel-Design einer Anwendung.

--- a/content/de/docs/reference/glossary/application-developer.md
+++ b/content/de/docs/reference/glossary/application-developer.md
@@ -1,7 +1,6 @@
 ---
 title: Anwendungsentwickler
 id: application-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   Eine Person, die eine Anwendung entwickelt, die in einem Kubernetes Cluster läuft.

--- a/content/de/docs/reference/glossary/applications.md
+++ b/content/de/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: Anwendungen
 id: applications
-date: 2019-05-12
 full_link:
 short_description: >
   Die Schicht, in der verschiedene containerisierte Anwendungen laufen.

--- a/content/de/docs/reference/glossary/approver.md
+++ b/content/de/docs/reference/glossary/approver.md
@@ -1,7 +1,6 @@
 ---
 title: Approver
 id: approver
-date: 2018-04-12
 full_link: 
 short_description: >
   Eine Person, die Kubernetes Code Beiträge überprüfen und zulassen kann.

--- a/content/de/docs/reference/glossary/cadvisor.md
+++ b/content/de/docs/reference/glossary/cadvisor.md
@@ -1,7 +1,6 @@
 ---
 title: cAdvisor
 id: cadvisor
-date: 2021-12-09
 full_link: https://github.com/google/cadvisor/
 short_description: >
   Werkzeug, um Ressourcenverbrauch und Performance Charakteristiken von Container besser zu verstehen

--- a/content/de/docs/reference/glossary/certificate.md
+++ b/content/de/docs/reference/glossary/certificate.md
@@ -1,7 +1,6 @@
 ---
 title: Zertifikat
 id: certificate
-date: 2018-04-12
 full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
 short_description: >
   Eine kryptographisch sichere Datei, die verwendet wird um den Zugriff auf das Kubernetes Cluster zu validieren.

--- a/content/de/docs/reference/glossary/cgroup.md
+++ b/content/de/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   Eine Gruppe Linux Prozesse mit optionaler Isolation, Erfassung und Begrenzung der Ressourcen

--- a/content/de/docs/reference/glossary/cidr.md
+++ b/content/de/docs/reference/glossary/cidr.md
@@ -1,7 +1,6 @@
 ---
 title: CIDR
 id: cidr
-date: 2019-11-12
 full_link: 
 short_description: >
   CIDR ist eine Notation, um Blöcke von IP Adressen zu beschreiben und wird viel verwendet in verschiedenen Netzwerkkonfigurationen.

--- a/content/de/docs/reference/glossary/cla.md
+++ b/content/de/docs/reference/glossary/cla.md
@@ -1,7 +1,6 @@
 ---
 title: CLA (Contributor License Agreement)
 id: cla
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   Bedingungen unter denen ein Mitwirkender eine Lizenz an ein Open Source Projekt erteilt für seine Mitwirkungen.

--- a/content/de/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/de/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Controller Manager
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /docs/concepts/architecture/cloud-controller/
 short_description: >
   Control Plane Komponente, die Kubernetes mit Drittanbieter Cloud Provider integriert.

--- a/content/de/docs/reference/glossary/cluster.md
+++ b/content/de/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster
 id: cluster
-date: 2019-06-15
 full_link: 
 short_description: >
    Ein Satz Arbeitermaschinen, genannt Knoten, die containerisierte Anwendungen ausführen. Jedes Cluster hat mindestens einen Arbeiterknoten.

--- a/content/de/docs/reference/glossary/container.md
+++ b/content/de/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Container
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/containers/
 short_description: >
   Ein kleines und portierbares ausführbares Image, dass eine Software und all seine Abhängigkeiten enthält.

--- a/content/de/docs/reference/glossary/control-plane.md
+++ b/content/de/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Control Plane
 id: control-plane
-date: 2019-05-12
 full_link:
 short_description: >
   Die Container Orchestrierungsschicht, die die API und Schnittstellen exponiert, um den Lebenszyklus von Container zu definieren, bereitzustellen, und zu verwalten.

--- a/content/de/docs/reference/glossary/controller.md
+++ b/content/de/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Controller
 id: controller
-date: 2018-04-12
 full_link: /docs/concepts/architecture/controller/
 short_description: >
   Eine Kontrollschleife, die den geteilten Zustand des Clusters über den Apiserver beobachtet, und Änderungen ausführt, um den aktuellen Zustand in Richtung des Wunschzustands zu bewegen.

--- a/content/de/docs/reference/glossary/deployment.md
+++ b/content/de/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Verwaltet eine replizierte Anwendung in Ihrem Cluster.

--- a/content/de/docs/reference/glossary/docker.md
+++ b/content/de/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker ist eine Software Technologie, die Virtualisierung auf Betriebssystemebene (auch bekannt als Container) bereitstellt.

--- a/content/de/docs/reference/glossary/etcd.md
+++ b/content/de/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Konsistenter und hochverfügbarer Key-Value Speicher, der als Backupspeicher von Kubernetes für alle Clusterdaten verwendet wird.

--- a/content/de/docs/reference/glossary/kube-apiserver.md
+++ b/content/de/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: kube-apiserver
 id: kube-apiserver
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
   Komponente auf der Control Plane, die die Kubernetes-API verfügbar macht. Es ist das Frontend für die Kubernetes-Steuerebene.

--- a/content/de/docs/reference/glossary/kube-controller-manager.md
+++ b/content/de/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-controller-manager/
 short_description: >
   Komponente auf der Control Plane, auf der Controller ausgeführt werden.

--- a/content/de/docs/reference/glossary/kube-scheduler.md
+++ b/content/de/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Komponente auf der Control Plane, die neu erstellte Pods überwacht, denen kein Knoten zugewiesen ist. Sie wählt den Knoten aus, auf dem sie ausgeführt werden sollen.

--- a/content/de/docs/reference/glossary/kubeadm.md
+++ b/content/de/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /docs/reference/setup-tools/kubeadm/
 short_description: >
   Ein Werkzeug um schnell Kubernetes zu installieren und ein sicheres Cluster zu erstellen.

--- a/content/de/docs/reference/glossary/kubelet.md
+++ b/content/de/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/generated/kubelet
 short_description: >
   Ein Agent, der auf jedem Knoten im Cluster ausgeführt wird. Er stellt sicher, dass Container in einem Pod ausgeführt werden.

--- a/content/de/docs/reference/glossary/label.md
+++ b/content/de/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: Label
 id: label
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   Kennzeichnet Objekte mit identifizierenden Attributen, die sinnvoll und relevant für die Nutzer sind.

--- a/content/de/docs/reference/glossary/master.md
+++ b/content/de/docs/reference/glossary/master.md
@@ -1,7 +1,6 @@
 ---
 title: Master
 id: master
-date: 2020-04-16
 short_description: >
   Veralteter Begriff, verwendet als Synonym für die Knoten auf denen die Control Plane läuft. 
 

--- a/content/de/docs/reference/glossary/node.md
+++ b/content/de/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: Knoten
 id: node
-date: 2018-04-12
 full_link: /docs/concepts/architecture/nodes/
 short_description: >
   Ein Knoten ist eine Arbietermaschine in Kubernetes.

--- a/content/de/docs/reference/glossary/object.md
+++ b/content/de/docs/reference/glossary/object.md
@@ -1,7 +1,6 @@
 ---
 title: Objekt
 id: object
-date: 2020-10-12
 full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
 short_description: >
    Eine Einheit im Kubernetessystem, die ein Teil des Zustands Ihres Clusters darstellt.

--- a/content/de/docs/reference/glossary/pod.md
+++ b/content/de/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/
 short_description: >
   Ein Pod stellt ein Satz laufender Container in Ihrem Cluster dar.

--- a/content/de/docs/reference/glossary/selector.md
+++ b/content/de/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: Selector
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Eralubt Benutzer das Filtern einer Liste Ressourcen basierend auf Label.

--- a/content/de/docs/reference/glossary/service.md
+++ b/content/de/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   Eine Methode um Anwendungen, die auf einem Satz Pods laufen, als Netzwerkdienst freizugeben.

--- a/content/de/docs/reference/glossary/statefulset.md
+++ b/content/de/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   Ein StatefulSet verwaltet die Bereitstellung und die Skalierung eines Satzes Pods, mit langlebigem Speicher und persistenter Identifzierung für jeden Pod.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all de/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.