### PR TITLE
docs: Remove date field from Spanish glossary entries

### DIFF
--- a/content/es/docs/reference/glossary/addons.md
+++ b/content/es/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Add-ons - (Complementos)
 id: addons
-date: 2023-07-20
 full_link: /es/docs/concepts/cluster-administration/addons/
 short_description: >
   Son recursos que amplían la funcionalidad de Kubernetes.

--- a/content/es/docs/reference/glossary/annotation.md
+++ b/content/es/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: Annotation
 id: annotation
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/annotations
 short_description: >
   Una pareja clave-valor utilizada para añadir metadatos a los objetos.

--- a/content/es/docs/reference/glossary/application-architect.md
+++ b/content/es/docs/reference/glossary/application-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Arquitecto/a de aplicaciones
 id: application-architect
-date: 2019-05-16
 full_link:
 short_description: >
   Una de las personas responsables del diseño a alto nivel de una aplicación.

--- a/content/es/docs/reference/glossary/application-developer.md
+++ b/content/es/docs/reference/glossary/application-developer.md
@@ -1,7 +1,6 @@
 ---
 title: Desarrollador/a de aplicaciones
 id: application-developer
-date: 2019-05-16
 full_link:
 short_description: >
   Una persona que escribe una aplicación que se ejecutará en un clúster de Kubernetes.

--- a/content/es/docs/reference/glossary/applications.md
+++ b/content/es/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: Applications
 id: applications
-date: 2019-08-06
 full_link:
 short_description: >
  Es la capa donde se ejecutan varias aplicaciones en contenedores.

--- a/content/es/docs/reference/glossary/certificate.md
+++ b/content/es/docs/reference/glossary/certificate.md
@@ -1,7 +1,6 @@
 ---
 title: Certificate
 id: certificate
-date: 2019-05-16
 full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
 short_description: >
   Un fichero criptográficamente seguro usado para validar el acceso al clúster de Kubernetes.

--- a/content/es/docs/reference/glossary/cla.md
+++ b/content/es/docs/reference/glossary/cla.md
@@ -1,7 +1,6 @@
 ---
 title: CLA (Contributor License Agreement)
 id: cla
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   Términos bajo los cuales un contribuidor cede la licencia de sus contribuciones a un proyecto de código

--- a/content/es/docs/reference/glossary/cluster.md
+++ b/content/es/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Clúster
 id: cluster
-date: 2018-04-12
 full_link:
 short_description: >
   Un conjunto de máquinas, llamadas nodos, que ejecutan aplicaciones en contenedores administradas por Kubernetes.

--- a/content/es/docs/reference/glossary/configmap.md
+++ b/content/es/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: Configmap
 id: configmap
-date: 2020-07-11
 full_link: /docs/concepts/configuration/configmap/
 short_description: >
   Almacena información no sensible.

--- a/content/es/docs/reference/glossary/container-runtime-interface.md
+++ b/content/es/docs/reference/glossary/container-runtime-interface.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime Interface
 id: container-runtime-interface
-date: 2021-11-24
 full_link: /docs/concepts/architecture/cri
 short_description: >
   El protocolo principal para la comunicación entre el kubelet y el Container Runtime.

--- a/content/es/docs/reference/glossary/container-runtime.md
+++ b/content/es/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime
 id: container-runtime
-date: 2019-06-05
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
   El _Container Runtime_, entorno de ejecución de un contenedor, es el software responsable de ejecutar contenedores.

--- a/content/es/docs/reference/glossary/container.md
+++ b/content/es/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Contenedor
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
 short_description: >
   Una imagen ligera y portátil que contiene un software y todas sus dependencias.

--- a/content/es/docs/reference/glossary/controller.md
+++ b/content/es/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Controlador
 id: controller
-date: 2018-04-12
 full_link: /docs/concepts/architecture/controller/
 short_description: >
   Los controladores son bucles de control que observan el estado del clúster,

--- a/content/es/docs/reference/glossary/deployment.md
+++ b/content/es/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Un objeto API que gestiona una aplicación replicada.

--- a/content/es/docs/reference/glossary/docker.md
+++ b/content/es/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker es una tecnología de software que proporciona virtualización a nivel de sistema operativo, también conocida como contenedores.

--- a/content/es/docs/reference/glossary/etcd.md
+++ b/content/es/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Almacén de datos persistente, consistente y distribuido de clave-valor utilizado

--- a/content/es/docs/reference/glossary/finalizer.md
+++ b/content/es/docs/reference/glossary/finalizer.md
@@ -1,7 +1,6 @@
 ---
 title: Finalizador
 id: finalizer
-date: 2021-07-07
 full_link: /docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
   Un atributo de un namespace que dicta a Kubernetes a esperar hasta que condiciones

--- a/content/es/docs/reference/glossary/image.md
+++ b/content/es/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: Image
 id: image
-date: 2018-04-12
 full_link:
 short_description: >
   Instantánea de un contenedor que contiene un conjunto de librerías necesarias para ejecutar la aplicación.

--- a/content/es/docs/reference/glossary/ingress.md
+++ b/content/es/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/ingress/
 short_description: >
   Un objeto de la API que administra el acceso externo a los servicios en un clúster, típicamente HTTP.

--- a/content/es/docs/reference/glossary/job.md
+++ b/content/es/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/jobs-run-to-completion
 short_description: >
   Una tarea finita o por lotes que se ejecuta hasta su finalización.

--- a/content/es/docs/reference/glossary/kops.md
+++ b/content/es/docs/reference/glossary/kops.md
@@ -1,7 +1,6 @@
 ---
 title: Kops
 id: kops
-date: 2018-04-12
 full_link: /docs/getting-started-guides/kops/
 short_description: >
 Herramienta de línea de comandos que facilita la creación, destrucción, actualización y mantenimiento de clústeres de Kubernetes en alta disponibilidad para entornos de producción. *NOTA: Oficialmente solo soporta AWS, aunque también ofrece soporte para GCE en beta y WMware vSphere en versión alpha*.

--- a/content/es/docs/reference/glossary/kube-apiserver.md
+++ b/content/es/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: API Server
 id: kube-apiserver
-date: 2020-07-01
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
   Componente del plano de control que expone la API de Kubernetes.

--- a/content/es/docs/reference/glossary/kube-controller-manager.md
+++ b/content/es/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   Componente del plano de control que ejecuta los controladores de Kubernetes.

--- a/content/es/docs/reference/glossary/kube-proxy.md
+++ b/content/es/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` es un componente de red que se ejecuta en cada nodo del clúster.

--- a/content/es/docs/reference/glossary/kube-scheduler.md
+++ b/content/es/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Componente del plano de control que está pendiente de los pods que no tienen

--- a/content/es/docs/reference/glossary/kubeadm.md
+++ b/content/es/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /docs/admin/kubeadm/
 short_description: >
   Utilidad para instalar Kubernetes con rapidez y configurar un clúster seguro.

--- a/content/es/docs/reference/glossary/kubectl.md
+++ b/content/es/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /docs/user-guide/kubectl-overview/
 short_description: >
   Herramienta de línea de comandos para comunicarse con un servidor ejecutando la API de Kubernetes.

--- a/content/es/docs/reference/glossary/kubelet.md
+++ b/content/es/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/generated/kubelet
 short_description: >
   Agente que se ejecuta en cada nodo de un clúster. Se asegura de que los contenedores estén corriendo en un pod.

--- a/content/es/docs/reference/glossary/label.md
+++ b/content/es/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: Label
 id: label
-date: 2019-10-26
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   Metadatos en forma de clave-valor que permite añadir a los objetos atributos que sean relevantes para los usuarios para identificarlos.

--- a/content/es/docs/reference/glossary/limitrange.md
+++ b/content/es/docs/reference/glossary/limitrange.md
@@ -1,7 +1,6 @@
 ---
 title: LimitRange
 id: limitrange
-date: 2019-04-15
 full_link: /docs/concepts/policy/limit-range/
 short_description: >
   Proporciona restricciones para limitar el consumo de recursos por Contenedores o Pods en un espacio de nombres

--- a/content/es/docs/reference/glossary/minikube.md
+++ b/content/es/docs/reference/glossary/minikube.md
@@ -1,7 +1,6 @@
 ---
 title: Minikube
 id: minikube
-date: 2018-04-12
 full_link: /docs/getting-started-guides/minikube/
 short_description: >
   Herramienta para ejecutar Kubernetes de forma local.

--- a/content/es/docs/reference/glossary/name.md
+++ b/content/es/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: Nombre
 id: name
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   Una cadena de caracteres proporcionada por el cliente que identifica un objeto en la URL de un recurso, como por ejemplo, `/api/v1/pods/nombre-del-objeto`.

--- a/content/es/docs/reference/glossary/namespace.md
+++ b/content/es/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2018-04-12
 full_link: /es/docs/concepts/overview/working-with-objects/namespaces/
 short_description: >
   Abstracción utilizada por Kubernetes para soportar múltiples clústeres virtuales en el mismo clúster físico.

--- a/content/es/docs/reference/glossary/node.md
+++ b/content/es/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: Node
 id: node
-date: 2018-04-12
 full_link: /docs/concepts/architecture/nodes/
 short_description: >
   Un Node, nodo en castellano, es una de las máquinas del clúster de Kubernetes.

--- a/content/es/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/es/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: Persistent Volume Claim
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   Reserva el recurso de almacenamiento definido en un PersistentVolume para poderlo montar como un volúmen en un contenedor.

--- a/content/es/docs/reference/glossary/pod-priority.md
+++ b/content/es/docs/reference/glossary/pod-priority.md
@@ -1,7 +1,6 @@
 ---
 title: Pod Priority
 id: pod-priority
-date: 2019-01-31
 full_link: /docs/concepts/configuration/pod-priority-preemption/#pod-priority
 short_description: >
   Pod Priority indica la importancia de un {{< glossary_tooltip text="Pod" term_id="pod" >}} con relación a otros {{< glossary_tooltip text="Pods" term_id="pod" >}}.

--- a/content/es/docs/reference/glossary/pod.md
+++ b/content/es/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2018-05-16
 full_link: /docs/concepts/workloads/pods/pod-overview/
 short_description: >
   El objeto más pequeño y simple de Kubernetes. Un Pod es la unidad mínima de computación en Kubernetes y representa uno o más contenedores ejecutándose en el clúster.

--- a/content/es/docs/reference/glossary/replica-set.md
+++ b/content/es/docs/reference/glossary/replica-set.md
@@ -1,7 +1,6 @@
 ---
 title: ReplicaSet
 id: replica-set
-date: 2018-05-16
 full_link: /docs/concepts/workloads/controllers/replicaset/
 short_description: >
   El ReplicaSet es la nueva generación del ReplicationController.

--- a/content/es/docs/reference/glossary/rkt.md
+++ b/content/es/docs/reference/glossary/rkt.md
@@ -1,7 +1,6 @@
 ---
 title: rkt
 id: rkt
-date: 2019-05-16
 full_link: https://coreos.com/rkt/
 short_description: >
   Un motor de contenedores basado en el estándar y centrado en la seguridad.

--- a/content/es/docs/reference/glossary/secret.md
+++ b/content/es/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: Secret
 id: secret
-date: 2019-05-16
 full_link: /docs/concepts/configuration/secret/
 short_description: >
   Almacena información sensible, como contraseñas, tokens OAuth o claves ssh.

--- a/content/es/docs/reference/glossary/selector.md
+++ b/content/es/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: Selector
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Permite a los usuarios filtrar recursos por {{< glossary_tooltip text="Labels" term_id="label" >}}.

--- a/content/es/docs/reference/glossary/service.md
+++ b/content/es/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   Un Service, servicio en castellano, es el objeto de la API de Kubernetes que describe cómo se accede a las aplicaciones, tal como un conjunto de Pods, y que puede describir puertos y balanceadores de carga.

--- a/content/es/docs/reference/glossary/sig.md
+++ b/content/es/docs/reference/glossary/sig.md
@@ -1,7 +1,6 @@
 ---
 title: SIG (special interest group)
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
 short_description: >
   Grupo de miembros de la comunidad que gestionan una pieza o parte del proyecto Kubernetes de forma colectiva.

--- a/content/es/docs/reference/glossary/statefulset.md
+++ b/content/es/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   Gestiona el despliegue y escalado de un conjunto de Pods,

--- a/content/es/docs/reference/glossary/sysctl.md
+++ b/content/es/docs/reference/glossary/sysctl.md
@@ -1,7 +1,6 @@
 ---
 title: sysctl
 id: sysctl
-date: 2019-02-12
 full_link: /docs/tasks/administer-cluster/sysctl-cluster/
 short_description: >
   Una interfaz para obtener y asignar valores a parámetros del núcleo Unix activo.

--- a/content/es/docs/reference/glossary/uid.md
+++ b/content/es/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   Una cadena de caracteres generada por Kubernetes para identificar objetos de forma única.

--- a/content/es/docs/reference/glossary/volume.md
+++ b/content/es/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume
 id: volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/volumes/
 short_description: >
   Un directorio que contiene datos y que es accesible desde los contenedores corriendo en un pod.

--- a/content/es/docs/reference/glossary/wg.md
+++ b/content/es/docs/reference/glossary/wg.md
@@ -1,7 +1,6 @@
 ---
 title: WG (working group)
 id: wg
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
 short_description: >
   Facilita la discusión y/o la implementación de un proyecto que sea efímero, corto o desacoplado para un comité, {{< glossary_tooltip text="SIG" term_id="sig" >}}, o esfuerzo SIG cruzado.

--- a/content/es/docs/reference/glossary/workload.md
+++ b/content/es/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: Workload
 id: workloads
-date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
    Un Workload es una aplicación que se ejecuta en Kubernetes.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all es/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.