### PR TITLE
docs: Remove date field from French glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/addons.md
+++ b/content/fr/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Add-ons
 id: addons
-date: 2019-12-15
 full_link: /docs/concepts/cluster-administration/addons/
 short_description: >
   Ressources qui étendent les fonctionnalités de Kubernetes.

--- a/content/fr/docs/reference/glossary/admission-controller.md
+++ b/content/fr/docs/reference/glossary/admission-controller.md
@@ -1,7 +1,6 @@
 ---
 title: Admission Controller
 id: admission-controller
-date: 2019-06-28
 full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   Un morceau de code qui intercepte les requêtes adressées au serveur API de Kubernetes avant la persistance de l'objet.

--- a/content/fr/docs/reference/glossary/affinity.md
+++ b/content/fr/docs/reference/glossary/affinity.md
@@ -1,7 +1,6 @@
 ---
 title: Affinity
 id: affinity
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
   Règles utilisées par l’ordonnanceur pour déterminer l’emplacement des pods.

--- a/content/fr/docs/reference/glossary/aggregation-layer.md
+++ b/content/fr/docs/reference/glossary/aggregation-layer.md
@@ -1,7 +1,6 @@
 ---
 title: Aggregation Layer
 id: aggregation-layer
-date: 2018-10-08
 full_link: /docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
 short_description: >
   La couche d'agrégation vous permet d'installer des API de type Kubernetes supplémentaires dans votre cluster.

--- a/content/fr/docs/reference/glossary/annotation.md
+++ b/content/fr/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: Annotation
 id: annotation
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/annotations
 short_description: >
   Une paire clé-valeur qui est utilisée pour attacher des métadonnées arbitraires non-identifiantes à des objets.

--- a/content/fr/docs/reference/glossary/api-group.md
+++ b/content/fr/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: Groupe d'API
 id: api-group
-date: 2024-09-12
 full_link: /fr/docs/concepts/overview/kubernetes-api/#groupes-d-api-et-versioning
 short_description: >
   Un ensemble de chemins liés dans l'API Kubernetes.

--- a/content/fr/docs/reference/glossary/app-container.md
+++ b/content/fr/docs/reference/glossary/app-container.md
@@ -1,7 +1,6 @@
 ---
 title: App Container
 id: app-container
-date: 2019-02-12
 full_link:
 short_description: >
   Un conteneur utilisé pour exécuter une partie d'une charge de travail, comparable à un init conteneur.

--- a/content/fr/docs/reference/glossary/application-architect.md
+++ b/content/fr/docs/reference/glossary/application-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Architecte d'Application
 id: application-architect
-date: 2018-04-12
 full_link:
 short_description: >
   Personne responsable de la conception haut niveau d'une application.

--- a/content/fr/docs/reference/glossary/application-developer.md
+++ b/content/fr/docs/reference/glossary/application-developer.md
@@ -1,7 +1,6 @@
 ---
 title: Développeur d'Application
 id: application-developer
-date: 2018-04-12
 full_link:
 short_description: >
   Personne qui écrit une application s'exécutant dans un cluster Kubernetes.

--- a/content/fr/docs/reference/glossary/applications.md
+++ b/content/fr/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: Applications
 id: appplications
-date: 2019-05-12
 full_link:
 short_description: >
   La couche où s'exécutent diverses applications conteneurisées.

--- a/content/fr/docs/reference/glossary/approver.md
+++ b/content/fr/docs/reference/glossary/approver.md
@@ -1,7 +1,6 @@
 ---
 title: Approbateur
 id: approver
-date: 2018-04-12
 full_link:
 short_description: >
   Personne pouvant passer en revue et approuver les contributions au code Kubernetes.

--- a/content/fr/docs/reference/glossary/cadvisor.md
+++ b/content/fr/docs/reference/glossary/cadvisor.md
@@ -1,7 +1,6 @@
 ---
 titre: cAdvisor
 id: cadvisor
-date: 2024-09-12
 full_link: https://github.com/google/cadvisor/
 short_description: >
   Outil qui permet de comprendre l'utilisation des ressources et les caractéristiques de performance des conteneurs

--- a/content/fr/docs/reference/glossary/certificate.md
+++ b/content/fr/docs/reference/glossary/certificate.md
@@ -1,7 +1,6 @@
 ---
 title: Certificat
 id: certificate
-date: 2018-04-12
 full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
 short_description: >
   Fichier cryptograhpiquement sécurisé utilisé pour valider l'accès au cluster Kubernetes.

--- a/content/fr/docs/reference/glossary/cgroup.md
+++ b/content/fr/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   Un groupe de processus Linux avec des options d'isolation, de suivi, et de limites des ressources.

--- a/content/fr/docs/reference/glossary/cla.md
+++ b/content/fr/docs/reference/glossary/cla.md
@@ -1,7 +1,6 @@
 ---
 title: CLA (Contributor License Agreement)
 id: cla
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   Conditions en vertu desquelles un contributeur accorde une licence à un projet open source pour ses contributions.

--- a/content/fr/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/fr/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Controller Manager
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/running-cloud-controller/
 short_description: >
   Le Cloud Controller Manager est une fonctionnalité alpha de la version 1.8. Dans les prochaines versions, il deviendra le moyen privilégié pour l'intégration de Kubernetes à n'importe quel cloud.

--- a/content/fr/docs/reference/glossary/cloud-provider.md
+++ b/content/fr/docs/reference/glossary/cloud-provider.md
@@ -1,7 +1,6 @@
 ---
 title: Fournisseur de Cloud
 id: cloud-provider
-date: 2018-04-12
 full_link: /docs/concepts/cluster-administration/cloud-providers
 short_description: >
   Le fournisseur de cloud est une entreprise offrant une plateforme de cloud computing, pouvant faire fonctionner des clusters Kubernetes.

--- a/content/fr/docs/reference/glossary/cluster-architect.md
+++ b/content/fr/docs/reference/glossary/cluster-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Architecte de Cluster
 id: cluster-architect
-date: 2018-04-12
 full_link:
 short_description: >
   Personne qui conçoit une infrastructure impliquant un ou plusieurs clusters Kubernetes.

--- a/content/fr/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/fr/docs/reference/glossary/cluster-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: Infrastructure de Cluster
 id: cluster-infrastructure
-date: 2019-05-12
 full_link:
 short_description: >
  La couche d'infrastructure fournit et maintient, entre autres, les machines virtuelles, les réseaux ainsi que les groupes de sécurité.

--- a/content/fr/docs/reference/glossary/cluster-operations.md
+++ b/content/fr/docs/reference/glossary/cluster-operations.md
@@ -1,7 +1,6 @@
 ---
 title: Opérations sur le Cluster
 id: cluster-operations
-date: 2019-05-12
 full_link:
 short_description: >
  Activités telles que la mise à niveau des clusters, la mise en œuvre de la sécurité, du stockage, de l'Ingress, du réseau, de la consignation et de la surveillance, et autres opérations nécessaires pour gérer un cluster Kubernetes.

--- a/content/fr/docs/reference/glossary/cluster-operator.md
+++ b/content/fr/docs/reference/glossary/cluster-operator.md
@@ -1,7 +1,6 @@
 ---
 title: Opérateur de Cluster
 id: cluster-operator
-date: 2018-04-12
 full_link:
 short_description: >
   Une personne qui configure, contrôle et surveille les clusters.

--- a/content/fr/docs/reference/glossary/cluster.md
+++ b/content/fr/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster
 id: cluster
-date: 2018-04-12
 full_link:
 short_description: >
   Un ensemble de machines, appelées des "nœuds", qui exécutent des applications conteneurisées gérées par Kubernetes.

--- a/content/fr/docs/reference/glossary/cncf.md
+++ b/content/fr/docs/reference/glossary/cncf.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Native Computing Foundation (CNCF)
 id: cncf
-date: 2019-05-26
 full_link: https://cncf.io/
 short_description: >
   Cloud Native Computing Foundation

--- a/content/fr/docs/reference/glossary/cni.md
+++ b/content/fr/docs/reference/glossary/cni.md
@@ -1,7 +1,6 @@
 ---
 title: Interface réseau de conteneurs (CNI)
 id: cni
-date: 2018-05-25
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 short_description: >
     Les plugins de l'interface réseau de conteneurs (CNI, de l'anglais Container Network Interface), sont un type de plugin réseau conforme à la spécification appc/CNI.

--- a/content/fr/docs/reference/glossary/code-contributor.md
+++ b/content/fr/docs/reference/glossary/code-contributor.md
@@ -1,7 +1,6 @@
 ---
 title: Contributeur de Code
 id: code-contributor
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
 short_description: >
   Personne qui développe et contribue au code open source de Kubernetes.

--- a/content/fr/docs/reference/glossary/configmap.md
+++ b/content/fr/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-pod-configmap/
 short_description: >
   Un objet API utilisé pour stocker des données non confidentielles dans des paires clé-valeur. Peut être utilisé comme variable d'environnement, argument de ligne de commande ou fichier de configuration dans un volume.

--- a/content/fr/docs/reference/glossary/container-env-variables.md
+++ b/content/fr/docs/reference/glossary/container-env-variables.md
@@ -1,7 +1,6 @@
 ---
 title: Variables d'Environnement de Conteneur
 id: container-env-variables
-date: 2018-04-12
 full_link: /docs/concepts/containers/container-environment-variables/
 short_description: >
   Les variables d'environnement de conteneur sont des paires nom=valeur qui fournissent des informations utiles aux conteneurs fonctionnant au sein d'un Pod.

--- a/content/fr/docs/reference/glossary/container-lifecycle-hooks.md
+++ b/content/fr/docs/reference/glossary/container-lifecycle-hooks.md
@@ -1,7 +1,6 @@
 ---
 title: Container Lifecycle Hooks
 id: container-lifecycle-hooks
-date: 2018-10-08
 full_link: /docs/concepts/containers/container-lifecycle-hooks/
 short_description: >
   Les hooks (ou déclencheurs) du cycle de vie exposent les événements du cycle de vie de la gestion du conteneur et permettent à l'utilisateur d'exécuter le code lorsque les événements se produisent.

--- a/content/fr/docs/reference/glossary/container-runtime-interface.md
+++ b/content/fr/docs/reference/glossary/container-runtime-interface.md
@@ -1,7 +1,6 @@
 ---
 title: Interface du Runtime de Conteneur
 id: container-runtime-interface
-date: 2024-09-12
 full_link: /fr/docs/concepts/architecture/cri
 short_description: >
   Le protocole principal pour la communication entre le kubelet et le Runtime de Conteneur.

--- a/content/fr/docs/reference/glossary/container-runtime.md
+++ b/content/fr/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime
 id: container-runtime
-date: 2019-06-05
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
  L'environnement d'exécution de conteneurs est le logiciel responsable de l'exécution des conteneurs.

--- a/content/fr/docs/reference/glossary/container.md
+++ b/content/fr/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Container
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
 short_description: >
   Une image exécutable légère et portable qui contient le logiciel et toutes ses dépendances.

--- a/content/fr/docs/reference/glossary/containerd.md
+++ b/content/fr/docs/reference/glossary/containerd.md
@@ -1,7 +1,6 @@
 ---
 title: containerd
 id: containerd
-date: 2019-05-14
 full_link: https://containerd.io/docs/
 short_description: >
   Un environnement d'exécution des conteneurs qui met l'accent sur la simplicité, la robustesse et la portabilité.

--- a/content/fr/docs/reference/glossary/contributor.md
+++ b/content/fr/docs/reference/glossary/contributor.md
@@ -1,7 +1,6 @@
 ---
 title: Contributeur
 id: contributor
-date: 2018-04-12
 full_link:
 short_description: >
   Quelqu'un qui code, documente ou donne de son temps autrement, pour aider le projet ou la communauté Kubernetes.

--- a/content/fr/docs/reference/glossary/control-plane.md
+++ b/content/fr/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Plan de Contrôle
 id: control-plane
-date: 2019-05-12
 full_link:
 short_description: >
   Couche d'orchestration des conteneurs exposant l'API et les interfaces pour définir, déployer et gérer le cycle de vie des conteneurs.

--- a/content/fr/docs/reference/glossary/controller.md
+++ b/content/fr/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Contrôleur
 id: controller
-date: 2018-04-12
 full_link: /docs/admin/kube-controller-manager/
 short_description: >
   Boucle de contrôle surveillant l'état partagé du cluster à travers l'apiserver et effectuant des changements en essayant de déplacer l'état actuel vers l'état désiré.

--- a/content/fr/docs/reference/glossary/cri-o.md
+++ b/content/fr/docs/reference/glossary/cri-o.md
@@ -1,7 +1,6 @@
 ---
 title: CRI-O
 id: cri-o
-date: 2019-05-14
 full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   Un runtime (environnement d'exécution) de conteneur, léger et spécifiquement conçu pour Kubernetes.

--- a/content/fr/docs/reference/glossary/cri.md
+++ b/content/fr/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime Interface (CRI)
 id: cri
-date: 2019-03-07
 full_link: https://kubernetes.io/docs/concepts/overview/components/#container-runtime
 short_description: >
     Une API pour les runtimes de conteneurs à intégrer avec kubelet

--- a/content/fr/docs/reference/glossary/cronjob.md
+++ b/content/fr/docs/reference/glossary/cronjob.md
@@ -1,7 +1,6 @@
 ---
 title: CronJob
 id: cronjob
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/cron-jobs/
 short_description: >
   Gère une [Tâche](/docs/concepts/workloads/controllers/jobs-run-to-completion/) qui s'exécute périodiquement.

--- a/content/fr/docs/reference/glossary/csi.md
+++ b/content/fr/docs/reference/glossary/csi.md
@@ -1,7 +1,6 @@
 ---
 title: Interface de Stockage de Conteneurs (CSI)
 id: csi
-date: 2018-06-25
 full_link: /docs/concepts/storage/volumes/#csi
 short_description: >
     L'Interface de Stockage de Conteneurs (CSI, de l'anglais Container Storage Interface) définit une interface normalisée pour exposer les systèmes de stockage aux conteneurs.

--- a/content/fr/docs/reference/glossary/customresourcedefinition.md
+++ b/content/fr/docs/reference/glossary/customresourcedefinition.md
@@ -1,7 +1,6 @@
 ---
 title: CustomResourceDefinition
 id: CustomResourceDefinition
-date: 2018-04-12
 full_link: /docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
 short_description: >
   Définition d'une ressource personnalisée qui est ajoutée au serveur d'API Kubernetes sans construire un serveur personnalisé complet.

--- a/content/fr/docs/reference/glossary/daemonset.md
+++ b/content/fr/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/daemonset
 short_description: >
   S'assure qu'une copie d'un Pod s'exécute sur un ensemble de nœuds d'un cluster.

--- a/content/fr/docs/reference/glossary/data-plane.md
+++ b/content/fr/docs/reference/glossary/data-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Plan de Données
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   Couche fournissant des capacités comme le CPU, la mémoire, le réseau et le stockage afin que les conteneurs puissent fonctionner et se connecter à un réseau.

--- a/content/fr/docs/reference/glossary/deployment.md
+++ b/content/fr/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Déploiement
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Objet API gérant une application répliquée.

--- a/content/fr/docs/reference/glossary/developer.md
+++ b/content/fr/docs/reference/glossary/developer.md
@@ -1,7 +1,6 @@
 ---
 title: Développeur (désambiguïsation)
 id: developer
-date: 2018-04-12
 full_link:
 short_description: >
   Peut faire référence à un Développeur d'Application, Contributeur de Code ou à un Développeur de Plate-forme.

--- a/content/fr/docs/reference/glossary/device-plugin.md
+++ b/content/fr/docs/reference/glossary/device-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: Plugin de Périphérique
 id: device-plugin
-date: 2019-02-02
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   Les Plugins de Périphériques sont des conteneurs fonctionnant dans Kubernetes, donnant accès à une ressource spécifique d'un fournisseur.

--- a/content/fr/docs/reference/glossary/docker.md
+++ b/content/fr/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker est un logiciel fournissant une virtualisation au niveau du système d'exploitation, également connue sous le nom de conteneurs.

--- a/content/fr/docs/reference/glossary/downstream.md
+++ b/content/fr/docs/reference/glossary/downstream.md
@@ -1,7 +1,6 @@
 ---
 title: Downstream (désambiguïsation)
 id: downstream
-date: 2018-04-12
 full_link:
 short_description: >
   Peut se référer soit au code de l'écosystème Kubernetes dépendant de la base de code Kubernetes, soit à un répertoire forké.

--- a/content/fr/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/fr/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,7 +1,6 @@
 ---
 title: Provisionnement Dynamique de Volume
 id: dynamicvolumeprovisioning
-date: 2018-04-12
 full_link: /docs/concepts/storage/dynamic-provisioning
 short_description: >
   Permet aux utilisateurs de demander la création automatique de Volumes de stockage.

--- a/content/fr/docs/reference/glossary/etcd.md
+++ b/content/fr/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Base de données clé-valeur consistante et hautement disponible utilisée comme mémoire de sauvegarde pour toutes les données du cluster.

--- a/content/fr/docs/reference/glossary/extensions.md
+++ b/content/fr/docs/reference/glossary/extensions.md
@@ -1,7 +1,6 @@
 ---
 title: Extensions
 id: Extensions
-date: 2019-02-01
 full_link: /docs/concepts/extend-kubernetes/extend-cluster/#extensions
 short_description: >
   Les extensions sont des composants logiciels qui s'intègrent profondément à Kubernetes afin de supporter de nouveaux types de matériel informatique.

--- a/content/fr/docs/reference/glossary/finalizer.md
+++ b/content/fr/docs/reference/glossary/finalizer.md
@@ -1,7 +1,6 @@
 ---
 title: Finalizer
 id: finalizer
-date: 2024-09-02
 full_link: /docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
   Une clé du namespace qui indique à Kubernetes d'attendre que certaines conditions soient remplies

--- a/content/fr/docs/reference/glossary/garbage-collection.md
+++ b/content/fr/docs/reference/glossary/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 title: Garbage Collection
 id: garbage-collection
-date: 2024-09-02
 full_link: /docs/concepts/architecture/garbage-collection/
 short_description: >
   Le Garbage collection est un terme générique désignant les différents mécanismes utilisés par Kubernetes pour nettoyer les ressources du cluster.

--- a/content/fr/docs/reference/glossary/helm-chart.md
+++ b/content/fr/docs/reference/glossary/helm-chart.md
@@ -1,7 +1,6 @@
 ---
 title: Chart Helm
 id: helm-chart
-date: 2018-04-12
 full_link: https://github.com/kubernetes/helm/blob/master/docs/charts.md
 short_description: >
   Un ensemble de ressources Kubernetes préconfigurées qui peuvent être gérées avec l'outil Helm.

--- a/content/fr/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/fr/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,7 +1,6 @@
 ---
 title: Horizontal Pod Autoscaler
 id: horizontal-pod-autoscaler
-date: 2018-04-12
 full_link: /docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/
 short_description: >
   Objet qui met automatiquement à l’échelle le nombre de répliques de pods en fonction de la consommation ciblée de ressources ou d’objectifs de métriques personnalisées.

--- a/content/fr/docs/reference/glossary/image.md
+++ b/content/fr/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: Image
 id: image
-date: 2018-04-12
 full_link:
 short_description: >
   Instance stockée d'un conteneur qui contient un ensemble de logiciels nécessaires à l'exécution d'une application.

--- a/content/fr/docs/reference/glossary/ingress.md
+++ b/content/fr/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/ingress/
 short_description: >
   Un objet API qui gère l'accès externe aux services d'un cluster, typiquement HTTP.

--- a/content/fr/docs/reference/glossary/init-container.md
+++ b/content/fr/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: Init Container
 id: init-container
-date: 2018-04-12
 full_link:
 short_description: >
   Un ou plusieurs conteneurs d'initialisation qui doivent être exécutés jusqu'à la fin, avant l'exécution de tout conteneur d'application.

--- a/content/fr/docs/reference/glossary/istio.md
+++ b/content/fr/docs/reference/glossary/istio.md
@@ -1,7 +1,6 @@
 ---
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   Une plate-forme ouverte (non spécifique à Kubernetes) qui fournit un moyen uniforme d'intégrer des microservices, de gérer des flux de trafic, d'appliquer des règles et d'agréger des données télémétriques.

--- a/content/fr/docs/reference/glossary/job.md
+++ b/content/fr/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/job/
 short_description: >
   Une tâche finie ou par lots qui s’exécute jusqu’à sa terminaison.

--- a/content/fr/docs/reference/glossary/kube-apiserver.md
+++ b/content/fr/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: kube-apiserver
 id: kube-apiserver
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
   Composant sur le master qui expose l'API Kubernetes. Il s'agit du front-end pour le plan de contrôle Kubernetes.

--- a/content/fr/docs/reference/glossary/kube-controller-manager.md
+++ b/content/fr/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-controller-manager/
 short_description: >
   Composant du master qui exécute les contrôleurs.

--- a/content/fr/docs/reference/glossary/kube-proxy.md
+++ b/content/fr/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` est un proxy réseau qui s'exécute sur chaque nœud du cluster.

--- a/content/fr/docs/reference/glossary/kube-scheduler.md
+++ b/content/fr/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Composant sur le master qui surveille les pods nouvellement créés qui ne sont pas assignés à un nœud et sélectionne un nœud sur lequel ils vont s'exécuter.

--- a/content/fr/docs/reference/glossary/kubelet.md
+++ b/content/fr/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/generated/kubelet
 short_description: >
   Un agent qui s'exécute sur chaque nœud du cluster. Il s'assure que les conteneurs fonctionnent dans un pod.

--- a/content/fr/docs/reference/glossary/kubernetes-api.md
+++ b/content/fr/docs/reference/glossary/kubernetes-api.md
@@ -1,7 +1,6 @@
 ---
 title: API Kubernetes
 id: kubernetes-api
-date: 2024-09-12
 full_link: /fr/docs/concepts/overview/kubernetes-api/
 short_description: >
   L'application qui offre les fonctionnalités de Kubernetes via une interface RESTful et stocke l'état du cluster.

--- a/content/fr/docs/reference/glossary/name.md
+++ b/content/fr/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: Name
 id: name
-date: 2024-09-02
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   Un texte fourni par le client qui fait référence à un objet dans une URL de ressource, comme `/api/v1/pods/some-name`.

--- a/content/fr/docs/reference/glossary/namespace.md
+++ b/content/fr/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/namespaces
 short_description: >
   Une abstraction utilisée par Kubernetes pour permettre l’isolation de groupes de ressources au sein d’un même cluster.

--- a/content/fr/docs/reference/glossary/node.md
+++ b/content/fr/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 titre: Node
 id: node
-date: 2024-09-12
 full_link: /fr/docs/concepts/architecture/nodes/
 short_description: >
   Un nœud est une machine de travail dans Kubernetes.

--- a/content/fr/docs/reference/glossary/pod.md
+++ b/content/fr/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /fr/docs/concepts/workloads/pods/pod-overview/
 short_description: >
   Le plus petit et le plus simple des objets Kubernetes. Un Pod est un ensemble de conteneurs fonctionnant sur votre cluster.

--- a/content/fr/docs/reference/glossary/quantity.md
+++ b/content/fr/docs/reference/glossary/quantity.md
@@ -1,7 +1,6 @@
 ---
 title: Quantity
 id: quantity
-date: 2018-08-07
 full_link:
 short_description: >
   Une représentation en nombres entiers de petits et grands nombres utilisant des suffixes SI.

--- a/content/fr/docs/reference/glossary/rbac.md
+++ b/content/fr/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 titre: RBAC (Contrôle d'accès basé sur les rôles)
 id: rbac
-date: 2024-09-12
 full_link: /docs/reference/access-authn-authz/rbac/
 short_description: >
   Gère les décisions d'autorisation, permettant aux administrateurs de configurer dynamiquement les politiques d'accès via l'API Kubernetes.

--- a/content/fr/docs/reference/glossary/replica-set.md
+++ b/content/fr/docs/reference/glossary/replica-set.md
@@ -1,7 +1,6 @@
 ---
 title: ReplicaSet
 id: replica-set
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/replicaset/
 short_description: >
   Un ReplicaSet garantit qu’un nombre spécifié de répliques de Pods sont en cours d’exécution à tout moment.

--- a/content/fr/docs/reference/glossary/replica.md
+++ b/content/fr/docs/reference/glossary/replica.md
@@ -1,7 +1,6 @@
 ---
 title: Replica
 id: replica
-date: 2024-09-12
 full_link: 
 short_description: >
   Les replicas sont des copies de pods, assurant la disponibilité, la scalabilité et la tolérance aux pannes en maintenant des instances identiques.

--- a/content/fr/docs/reference/glossary/reviewer.md
+++ b/content/fr/docs/reference/glossary/reviewer.md
@@ -1,7 +1,6 @@
 ---
 title: Reviewer
 id: reviewer
-date: 2018-04-12
 full_link: 
 short_description: >
   Une personne qui examine la qualité et l'exactitude du code sur une partie du projet.

--- a/content/fr/docs/reference/glossary/selector.md
+++ b/content/fr/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: Selector
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Permet aux utilisateurs de filtrer une liste de ressources en fonction de labels.

--- a/content/fr/docs/reference/glossary/service-account.md
+++ b/content/fr/docs/reference/glossary/service-account.md
@@ -1,7 +1,6 @@
 ---
 title: ServiceAccount
 id: service-account
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   Fournit une identité aux processus s’exécutant dans un Pod.

--- a/content/fr/docs/reference/glossary/service.md
+++ b/content/fr/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2018-04-12
 full_link: /fr/docs/concepts/services-networking/service/
 short_description: >
   Un moyen d'exposer une application s'exécutant sur un ensemble de pods en tant que service réseau.

--- a/content/fr/docs/reference/glossary/statefulset.md
+++ b/content/fr/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /fr/docs/concepts/workloads/controllers/statefulset/
 short_description: >
   Gère le déploiement et la mise à l'échelle d'un ensemble de Pods, avec un stockage durable et des identifiants persistants pour chaque Pod.

--- a/content/fr/docs/reference/glossary/taint.md
+++ b/content/fr/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: Taint
 id: taint
-date: 2019-01-11
 full_link: /docs/concepts/configuration/taint-and-toleration/
 short_description: >
   Un objet de base composé de trois caractéristiques requises : clé, valeur et effet. Les marquages empêchent l'ordonnancement des pods sur les nœuds ou les groupes de nœuds.

--- a/content/fr/docs/reference/glossary/toleration.md
+++ b/content/fr/docs/reference/glossary/toleration.md
@@ -1,7 +1,6 @@
 ---
 title: Toleration
 id: toleration
-date: 2019-01-11
 full_link: /docs/concepts/configuration/taint-and-toleration/
 short_description: >
   Un objet de base composé de trois caractéristiques requises : clé, valeur et effet. Les tolérances permettent d'ordonnancer les pods sur les nœuds ou les groupes de nœuds qui ont un marquage compatible.

--- a/content/fr/docs/reference/glossary/uid.md
+++ b/content/fr/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   Chaîne de caractères générée par les systèmes Kubernetes pour identifier de manière unique les objets.

--- a/content/fr/docs/reference/glossary/volume.md
+++ b/content/fr/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume
 id: volume
-date: 2018-04-12
 full_link: /fr/docs/concepts/storage/volumes/
 short_description: >
   Un répertoire contenant des données, accessible aux conteneurs d'un pod.

--- a/content/fr/docs/reference/glossary/workload.md
+++ b/content/fr/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: Workload
 id: workload
-date: 2019-02-13
 full_link: /fr/docs/concepts/workloads/
 short_description: >
    Une charge de travail (workload) est une application exécutée sur Kubernetes.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all fr/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.