### PR TITLE
docs: Remove date field from Indonesian glossary entries

### DIFF
--- a/content/id/docs/reference/glossary/annotation.md
+++ b/content/id/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: Anotasi
 id: annotation
-date: 2018-04-12
 full_link: /id/docs/concepts/overview/working-with-objects/annotations
 short_description: >
   Suatu pasangan kunci-nilai (_key-value_) yang digunakan untuk melampirkan metadata nonidentifikasi arbitrer ke objek.

--- a/content/id/docs/reference/glossary/api-group.md
+++ b/content/id/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: Grup API
 id: api-group
-date: 2019-09-02
 full_link: /id/docs/concepts/overview/kubernetes-api/#api-groups
 short_description: >
   Sekumpulan _path_ terkait pada API Kubernetes.

--- a/content/id/docs/reference/glossary/applications.md
+++ b/content/id/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: Aplikasi
 id: applications
-date: 2019-05-12
 full_link:
 short_description: >
   Lapisan (_layer_) tempat menjalankan berbagai aplikasi dalam Container.

--- a/content/id/docs/reference/glossary/cgroup.md
+++ b/content/id/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   Suatu grup proses Linux dengan isolasi, penghitungan, dan pembatasan sumber daya opsional.

--- a/content/id/docs/reference/glossary/cluster-operator.md
+++ b/content/id/docs/reference/glossary/cluster-operator.md
@@ -1,7 +1,6 @@
 ---
 title: Operator Klaster
 id: cluster-operator
-date: 2018-04-12
 full_link: 
 short_description: >
   Seseorang yang mengonfigurasi, mengontrol, dan memonitor klaster.

--- a/content/id/docs/reference/glossary/cluster.md
+++ b/content/id/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Klaster
 id: cluster
-date: 2019-06-15
 full_link: 
 short_description: >
   Sekumpulan mesin pekerja, yang dikenal sebagai Node, yang menjalankan aplikasi dalam Container. Setiap klaster setidaknya mempunyai satu Node pekerja.

--- a/content/id/docs/reference/glossary/configmap.md
+++ b/content/id/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2018-04-12
 full_link: /docs/concepts/configuration/configmap/
 short_description: >
   Sebuah objek API yang digunakan untuk menyimpan data nonkonfidensial sebagai pasangan kunci-nilai (_key-value_). Pod dapat menggunakan ConfigMap sebagai variabel lingkungan, argumen baris perintah (_command-line_), atau berkas konfigurasi dalam sebuah _volume_.

--- a/content/id/docs/reference/glossary/container-env-variables.md
+++ b/content/id/docs/reference/glossary/container-env-variables.md
@@ -1,7 +1,6 @@
 ---
 title: Variabel Lingkungan Container
 id: container-env-variables
-date: 2019-06-24
 full_link: /docs/concepts/containers/container-environment-variables/
 short_description: >
   Variabel lingkungan Container merupakan pasangan nama=nilai yang dapat digunakan untuk menyediakan informasi penting bagi Container yang dijalankan pada Pod.

--- a/content/id/docs/reference/glossary/container-runtime.md
+++ b/content/id/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Runtime Container
 id: container-runtime
-date: 2019-06-05
 full_link: /id/docs/setup/production-environment/container-runtimes
 short_description: >
  _Runtime_ Container adalah perangkat lunak yang bertanggung jawab untuk menjalankan Container.

--- a/content/id/docs/reference/glossary/container.md
+++ b/content/id/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Container
 id: container
-date: 2019-06-24
 full_link: /id/docs/concepts/overview/what-is-kubernetes/#mengapa-kontainer
 short_description: >
   Sebuah _image_ yang ringan dan dapat dijalankan yang mengandung perangkat lunak and segala dependensi yang dibutuhkan.

--- a/content/id/docs/reference/glossary/contributor.md
+++ b/content/id/docs/reference/glossary/contributor.md
@@ -1,7 +1,6 @@
 ---
 title: Contributor
 id: contributor
-date: 2018-04-12
 full_link: 
 short_description: >
   Seseorang yang menyumbangkan kode, dokumentasi, atau waktu mereka untuk membantu proyek atau komunitas Kubernetes.

--- a/content/id/docs/reference/glossary/control-plane.md
+++ b/content/id/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Control Plane
 id: control-plane
-date: 2019-05-12
 full_link:
 short_description: >
   Merupakan lapisan orkestrasi Container yang mengekspos API dan antarmuka untuk mendefinisikan, menggelar, dan mengelola siklus hidup suatu Container.

--- a/content/id/docs/reference/glossary/controller.md
+++ b/content/id/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Pengontrol
 id: controller
-date: 2018-04-12
 full_link: /id/docs/concepts/architecture/controller/
 short_description: >
   Kontrol tertutup yang mengawasi kondisi bersama dari klaster melalui apiserver dan membuat perubahan yang mencoba untuk membawa kondisi saat ini ke kondisi yang diinginkan.

--- a/content/id/docs/reference/glossary/cri.md
+++ b/content/id/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: Antarmuka Runtime Container
 id: cri
-date: 2019-03-07
 full_link: /id/docs/concepts/overview/components/#container-runtime
 short_description: >
   Sebuah API untuk mengintegrasikan _runtime_ Container dengan kubelet.

--- a/content/id/docs/reference/glossary/customresourcedefinition.md
+++ b/content/id/docs/reference/glossary/customresourcedefinition.md
@@ -1,7 +1,6 @@
 ---
 title: CustomResourceDefinition (CRD)
 id: CustomResourceDefinition
-date: 2018-04-12
 full_link: /docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 short_description: >
   Kode khusus yang mendefinisikan sebuah sumber daya untuk ditambahkan ke server API Kubernetes-mu tanpa membangun server khusus tersendiri.

--- a/content/id/docs/reference/glossary/daemonset.md
+++ b/content/id/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /id/docs/concepts/workloads/controllers/daemonset
 short_description: >
   Memastikan salinan Pod dijalankan pada sekumpulan Node dalam satu klaster.

--- a/content/id/docs/reference/glossary/data-plane.md
+++ b/content/id/docs/reference/glossary/data-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Data Plane
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   Lapisan yang menyediakan kapasitas seperti CPU, memori, jaringan, dan penyimpanan sehingga Container dapat dijalankan dan terhubung ke suatu jaringan.

--- a/content/id/docs/reference/glossary/deployment.md
+++ b/content/id/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /id/docs/concepts/workloads/controllers/deployment/
 short_description: >
   Mengelola aplikasi yang direplikasi di dalam klastermu.

--- a/content/id/docs/reference/glossary/device-plugin.md
+++ b/content/id/docs/reference/glossary/device-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: Pugasan Peranti
 id: device-plugin
-date: 2019-02-02
 full_link: /id/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   Ekstensi perangkat lunak untuk memungkinkan Pod mengakses peranti yang membutuhkan inisialisasi atau penyiapan khusus.

--- a/content/id/docs/reference/glossary/disruption.md
+++ b/content/id/docs/reference/glossary/disruption.md
@@ -1,7 +1,6 @@
 ---
 title: Disrupsi
 id: disruption
-date: 2019-09-10
 full_link: /id/docs/concepts/workloads/pods/disruptions/
 short_description: >
   Peristiwa yang menyebabkan hilangnya Pod

--- a/content/id/docs/reference/glossary/docker.md
+++ b/content/id/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker merupakan suatu teknologi perangkat lunak yang menyediakan virtualisasi pada level sistem operasi yang juga dikenal sebagai Container.

--- a/content/id/docs/reference/glossary/ephemeral-container.md
+++ b/content/id/docs/reference/glossary/ephemeral-container.md
@@ -1,7 +1,6 @@
 ---
 title: Container Sementara
 id: ephemeral-container
-date: 2019-08-26
 full_link: /id/docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
   Jenis tipe Container yang dapat kamu jalankan sementara di dalam sebuah Pod.

--- a/content/id/docs/reference/glossary/etcd.md
+++ b/content/id/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2019-04-21
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Penyimpanan <i>key value</i> konsisten yang digunakan sebagai penyimpanan data klaster Kubernetes.

--- a/content/id/docs/reference/glossary/extensions.md
+++ b/content/id/docs/reference/glossary/extensions.md
@@ -1,7 +1,6 @@
 ---
 title: Ekstensi
 id: Extensions
-date: 2019-02-01
 full_link: /id/docs/concepts/extend-kubernetes/extend-cluster/#perluasan
 short_description: >
   Ekstensi adalah komponen perangkat lunak yang memperluas dan terintegrasi secara mendalam dengan Kubernetes untuk mendukung perangkat keras baru.

--- a/content/id/docs/reference/glossary/image.md
+++ b/content/id/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: Image
 id: image
-date: 2019-04-24
 full_link: 
 short_description: >
   Instans yang disimpan dari sebuah Container yang memuat seperangkat perangkat lunak yang dibutuhkan untuk menjalankan sebuah aplikasi.

--- a/content/id/docs/reference/glossary/ingress.md
+++ b/content/id/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2019-04-21
 full_link: /docs/concepts/services-networking/ingress/
 short_description: >
   Sebuah obyek API yang mengatur akses eksternal terhadap *Service* yang ada di dalam klaster, biasanya dalam bentuk *request* HTTP.

--- a/content/id/docs/reference/glossary/init-container.md
+++ b/content/id/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: Container Inisialisasi
 id: init-container
-date: 2018-04-12
 full_link: 
 short_description: >
   Satu atau beberapa Container inisialisasi yang harus berjalan hingga selesai sebelum Container aplikasi apapun dijalankan.

--- a/content/id/docs/reference/glossary/job.md
+++ b/content/id/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/job/
 short_description: >
   Tugas terbatas atau bertumpuk (_batch_) yang berjalan sampai selesai.

--- a/content/id/docs/reference/glossary/kube-apiserver.md
+++ b/content/id/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: kube-apiserver
 id: kube-apiserver
-date: 2019-04-21
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
   Komponen _control plane_ yang mengekspos API Kubernetes. Merupakan _front-end_ dari _control plane_ Kubernetes.

--- a/content/id/docs/reference/glossary/kube-controller-manager.md
+++ b/content/id/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2019-04-21
 full_link: /docs/reference/generated/kube-controller-manager/
 short_description: >
   Komponen _control plane_ yang menjalankan pengontrol.

--- a/content/id/docs/reference/glossary/kube-proxy.md
+++ b/content/id/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` merupakan proksi jaringan yang berjalan pada setiap node di dalam klaster.

--- a/content/id/docs/reference/glossary/kube-scheduler.md
+++ b/content/id/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2019-04-21
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Komponen _control plane_ yang bertugas mengamati Pod baru yang belum ditempatkan di node manapun dan kemudian memilihkan node di mana Pod baru tersebut akan dijalankan.

--- a/content/id/docs/reference/glossary/kubectl.md
+++ b/content/id/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /docs/user-guide/kubectl-overview/
 short_description: >
   Sebuah utilitas baris perintah untuk berkomunikasi dengan suatu server API Kubernetes.

--- a/content/id/docs/reference/glossary/kubelet.md
+++ b/content/id/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2019-04-21
 full_link: /docs/reference/generated/kubelet
 short_description: >
   Agen yang dijalankan pada setiap node di klaster yang bertugas untuk memastikan kontainer dijalankan di dalam Pod.

--- a/content/id/docs/reference/glossary/managed-service.md
+++ b/content/id/docs/reference/glossary/managed-service.md
@@ -1,7 +1,6 @@
 ---
 title: Layanan Terkelola
 id: managed-service
-date: 2018-04-12
 full_link: 
 short_description: >
   Sebuah perangkat lunak yang dikelola oleh penyedia layanan pihak ketiga.

--- a/content/id/docs/reference/glossary/name.md
+++ b/content/id/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: Name
 id: name
-date: 2019-05-15
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   String yang dihasilkan oleh klien yang mengacu pada sebuah objek dalam suatu URL resource, seperti `/api/v1/pods/some-name`.

--- a/content/id/docs/reference/glossary/namespace.md
+++ b/content/id/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2018-04-12
 full_link: /id/docs/concepts/overview/working-with-objects/namespaces
 short_description: >
   Sebuah abstraksi yang digunakan oleh Kubernetes untuk mendukung multipel klaster virtual pada klaster fisik yang sama.

--- a/content/id/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/id/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: Persistent Volume Claim
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /id/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   Mengklaim sumber daya penyimpanan yang didefinisikan di dalam suatu PersistentVolume, sehingga PersistentVolume tersebut dapat dipasang (_mounted_) sebagai sebuah _volume_ pada suatu Container.

--- a/content/id/docs/reference/glossary/persistent-volume.md
+++ b/content/id/docs/reference/glossary/persistent-volume.md
@@ -1,7 +1,6 @@
 ---
 title: Persistent Volume
 id: persistent-volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/
 short_description: >
   Sebuat objek API yang merepresentasikan bagian penyimpanan pada klaster. Tersedia sebagai sumber daya umum yang dapat dipasang (_pluggable_) yang tetap bertahan bahkan di luar siklus hidup suatu Pod.

--- a/content/id/docs/reference/glossary/platform-developer.md
+++ b/content/id/docs/reference/glossary/platform-developer.md
@@ -1,7 +1,6 @@
 ---
 title: Platform Developer
 id: platform-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   Seseorang yang menyesuaikan platform Kubernetes agar sesuai dengan kebutuhan proyek mereka.

--- a/content/id/docs/reference/glossary/pod.md
+++ b/content/id/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2019-06-24
 full_link: /docs/concepts/workloads/pods/pod-overview/
 short_description: >
   Unit Kubernetes yang paling sederhana dan kecil. Sebuah Pod merepresentasikan sebuah set kontainer yang dijalankan pada klaster kamu.

--- a/content/id/docs/reference/glossary/qos-class.md
+++ b/content/id/docs/reference/glossary/qos-class.md
@@ -1,7 +1,6 @@
 ---
 title: Kelas QoS
 id: qos-class
-date: 2019-04-15
 full_link: /id/docs/concepts/workloads/pods/pod-qos/#kelas-kualitas-layanan
 short_description: >
   Kelas QoS (Kelas Kualitas Layanan) menyediakan cara bagi Kubernetes untuk mengklasifikasikan Pod dalam klaster ke dalam beberapa kelas dan membuat keputusan tentang penjadwalan dan pengusiran.

--- a/content/id/docs/reference/glossary/quantity.md
+++ b/content/id/docs/reference/glossary/quantity.md
@@ -1,7 +1,6 @@
 ---
 title: Kuantitas
 id: quantity
-date: 2018-08-07
 full_link:
 short_description: >
   Representasi bilangan bulat dari bilangan kecil atau besar menggunakan sufiks SI.

--- a/content/id/docs/reference/glossary/rbac.md
+++ b/content/id/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: Kontrol Akses Berbasis Rol
 id: rbac
-date: 2018-04-12
 full_link: /id/docs/reference/access-authn-authz/rbac/
 short_description: >
   Mengelola keputusan otorisasi, memungkinkan admin untuk mengonfigurasi kebijakan akses secara dinamis melalui API Kubernetes.

--- a/content/id/docs/reference/glossary/service-broker.md
+++ b/content/id/docs/reference/glossary/service-broker.md
@@ -1,7 +1,6 @@
 ---
 title: Makelar Servis
 id: service-broker
-date: 2018-04-12
 full_link: 
 short_description: >
   Sebuah _endpoint_ untuk kumpulan servis terlola yang ditawarkan dan dikelola

--- a/content/id/docs/reference/glossary/service-catalog.md
+++ b/content/id/docs/reference/glossary/service-catalog.md
@@ -1,7 +1,6 @@
 ---
 title: Katalog Servis
 id: service-catalog
-date: 2018-04-12
 full_link: 
 short_description: >
   Sebuah ekstensi API yang memungkinkan aplikasi berjalan pada klaster Kubernetes untuk

--- a/content/id/docs/reference/glossary/service.md
+++ b/content/id/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2020-04-05
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   Sebuah Cara untuk mengekspos aplikasi yang berjalan pada sebuah kumpulan Pod sebagai layanan jaringan.

--- a/content/id/docs/reference/glossary/statefulset.md
+++ b/content/id/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2019-10-05
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   Melakukan proses manajemen deployment dan _scaling_ dari sebuah set Pod, *serta menjamin mekanisme _ordering_ dan keunikan* dari Pod ini.

--- a/content/id/docs/reference/glossary/taint.md
+++ b/content/id/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: Taint
 id: taint
-date: 2019-01-11
 full_link: /id/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   Objek inti yang terdiri dari tiga properti yang diperlukan: _key_(kunci), _value_(nilai), dan _effect_(efek). Taint mencegah penjadwalan Pod pada Node atau grup Node.

--- a/content/id/docs/reference/glossary/toleration.md
+++ b/content/id/docs/reference/glossary/toleration.md
@@ -1,7 +1,6 @@
 ---
 title: Toleransi (Toleration)
 id: toleration
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   Objek inti yang terdiri dari tiga properti yang diperlukan: _key_(kunci), _value_(nilai), dan _effect_(efek). Toleransi memungkinkan penjadwalan Pod pada Node atau grup dari Node yang memiliki taint yang cocok.

--- a/content/id/docs/reference/glossary/uid.md
+++ b/content/id/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2019-05-15
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   String yang dihasilkan oleh sistem Kubernetes untuk mengidentifikasi objek secara unik.

--- a/content/id/docs/reference/glossary/volume.md
+++ b/content/id/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume
 id: volume
-date: 2019-04-24
 full_link: /docs/concepts/storage/volumes/
 short_description: >
   Sebuah direktori yang mengandung data, dapat diakses o;eh kontainer-kontainer di dalam pod.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all id/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.