### PR TITLE
docs: Remove date field from Italian glossary entries

### DIFF
--- a/content/it/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/it/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Controller Manager
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /docs/concepts/architecture/cloud-controller/
 short_description: >
   Componente della control plane che integra Kubernetes con cloud providers di terze parti.

--- a/content/it/docs/reference/glossary/cluster.md
+++ b/content/it/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster
 id: cluster
-date: 2019-06-15
 full_link: 
 short_description: >
    Un'insieme di macchine, chiamate nodi, che eseguono container gestiti da Kubernetes. Un cluster ha almeno un Worker Node.

--- a/content/it/docs/reference/glossary/configmap.md
+++ b/content/it/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2022-06-21
 full_link: /it/docs/concepts/configuration/configmap/
 short_description: >
   Un oggetto API usato per memorizzare dati non riservati in coppie chiave-valore. Può essere utilizzato come variabili d'ambiente, argomenti da riga di comanto, o files di configurazione in un volume.

--- a/content/it/docs/reference/glossary/container-runtime.md
+++ b/content/it/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime
 id: container-runtime
-date: 2019-06-05
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
   Il container runtime è il software che è responsabile per l'esecuzione dei container.

--- a/content/it/docs/reference/glossary/container.md
+++ b/content/it/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Container
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
 short_description: >
   Una immagine leggera, portabile ed eseguibile che contiene un software e tutte le sue dipendenze.

--- a/content/it/docs/reference/glossary/control-plane.md
+++ b/content/it/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Control Plane
 id: control-plane
-date: 2019-05-12
 full_link:
 short_description: >
   Lo strato per l'orchestrazione dei container che espone le API e interfaccie per definere, deploy, e gestione del ciclo di vita dei container.

--- a/content/it/docs/reference/glossary/controller.md
+++ b/content/it/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Controller
 id: controller
-date: 2018-04-12
 full_link: /docs/concepts/architecture/controller/
 short_description: >
   Un software che implementa un circuito di controllo che osserva lo stato condiviso del cluster attraverso l'API server e apporta le modifiche necessarie per portate lo stato corrente verso lo stato desiderato.

--- a/content/it/docs/reference/glossary/cri.md
+++ b/content/it/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: Container runtime interface (CRI)
 id: cri
-date: 2019-03-07
 full_link: /docs/concepts/overview/components/#container-runtime
 short_description: >
     Una API per i container runtimes che si integra con la kubelet

--- a/content/it/docs/reference/glossary/daemonset.md
+++ b/content/it/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/daemonset
 short_description: >
   Assicura che una copia di un Pod è attiva su tutti nodi di un cluster.

--- a/content/it/docs/reference/glossary/deployment.md
+++ b/content/it/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Gestisce una applicazione replicata nel tuo cluster.

--- a/content/it/docs/reference/glossary/docker.md
+++ b/content/it/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker è una technologia software che offre una virtualizzazione a livello del sistema operativo nota come container.

--- a/content/it/docs/reference/glossary/etcd.md
+++ b/content/it/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   È un database key-value altamente disponibile che è usato da Kubernetes per salvare tutte le informazioni del cluster.

--- a/content/it/docs/reference/glossary/image.md
+++ b/content/it/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: Image
 id: image
-date: 2022-07-30
 full_link: 
 short_description: >
   Istanza archiviata di un cointainer che contiene un insieme di software e librerie necessarie per eseguire l'applicazione.

--- a/content/it/docs/reference/glossary/job.md
+++ b/content/it/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/jobs-run-to-completion
 short_description: >
   Uno o più lavori (task) che vengono eseguiti fino al loro completamento.

--- a/content/it/docs/reference/glossary/kube-apiserver.md
+++ b/content/it/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: API server
 id: kube-apiserver
-date: 2018-04-12
 full_link: /docs/concepts/architecture/#kube-apiserver
 short_description: >
   Componente della Control plane che serve le Kubernetes API.

--- a/content/it/docs/reference/glossary/kube-controller-manager.md
+++ b/content/it/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   Componente della Control Plane che gestisce i controller.

--- a/content/it/docs/reference/glossary/kube-proxy.md
+++ b/content/it/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` è un proxy eseguito su ogni nodo del cluster.

--- a/content/it/docs/reference/glossary/kube-scheduler.md
+++ b/content/it/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Componente della Control Plane che controlla i pod appena creati che non hanno un nodo assegnato, e dopo averlo identificato glielo assegna.

--- a/content/it/docs/reference/glossary/kubeadm.md
+++ b/content/it/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /docs/reference/setup-tools/kubeadm/
 short_description: >
   Un tool per installare velocemente Kubernetes e avviare un cluster sicuro.

--- a/content/it/docs/reference/glossary/kubelet.md
+++ b/content/it/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/generated/kubelet
 short_description: >
   Un agente che è eseguito su ogni nodo del cluster. Si assicura che i container siano eseguiti in un pod.

--- a/content/it/docs/reference/glossary/label.md
+++ b/content/it/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: Label
 id: label
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   Tags di oggetti con attributi identificativi che sono significativi e pertinenti per gli utenti.

--- a/content/it/docs/reference/glossary/master.md
+++ b/content/it/docs/reference/glossary/master.md
@@ -1,7 +1,6 @@
 ---
 title: Master
 id: master
-date: 2020-04-16
 short_description: >
   Termine vecchio, usato come sinonimo per i nodi che ospitano la control plane.
 

--- a/content/it/docs/reference/glossary/node.md
+++ b/content/it/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: Node
 id: node
-date: 2018-04-12
 full_link: /docs/concepts/architecture/nodes/
 short_description: >
   Un node è una macchina worker in Kubernetes.

--- a/content/it/docs/reference/glossary/pod.md
+++ b/content/it/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/pod-overview/
 short_description: >
   Un Pod rappresenta un gruppo di container nel tuo cluster.

--- a/content/it/docs/reference/glossary/secret.md
+++ b/content/it/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: Secret
 id: secret
-date: 2022-07-30
 full_link:
 short_description: >
   Contiene informazioni sensibili, come passwords, token OAuth, e chiavi ssh.

--- a/content/it/docs/reference/glossary/statefulset.md
+++ b/content/it/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   Gestisce deployment e la scalabilità di un gruppo di Pod, con storage e identificativi persistenti per ogni Pod.

--- a/content/it/docs/reference/glossary/volume.md
+++ b/content/it/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume
 id: volume
-date: 2022-06-21
 full_link: /it/docs/concepts/storage/volumes/
 short_description: >
   Una cartella contenente dati, accessibile dai containers all'interno del pod.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all it/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.