### PR TITLE
docs: Remove date field from Korean glossary entries

### DIFF
--- a/content/ko/docs/reference/glossary/addons.md
+++ b/content/ko/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: 애드온 (원문, Add-ons)
 id: addons
-date: 2019-12-15
 full_link: /ko/docs/concepts/cluster-administration/addons/
 short_description: >
   쿠버네티스의 기능을 확장하는 리소스.

--- a/content/ko/docs/reference/glossary/admission-controller.md
+++ b/content/ko/docs/reference/glossary/admission-controller.md
@@ -1,7 +1,6 @@
 ---
 title: 어드미션 컨트롤러 (원문, Admission Controller)
 id: admission-controller
-date: 2019-06-28
 full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   쿠버네티스 API 서버에서 요청을 처리하여 오브젝트가 지속되기 전에 그 요청을 가로채는 코드 조각.

--- a/content/ko/docs/reference/glossary/affinity.md
+++ b/content/ko/docs/reference/glossary/affinity.md
@@ -1,7 +1,6 @@
 ---
 title: 어피니티 (원문, Affinity)
 id: affinity
-date: 2019-01-11
 full_link: /ko/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
   파드를 배치할 위치를 결정하기 위해 스케줄러에서 사용하는 규칙

--- a/content/ko/docs/reference/glossary/aggregation-layer.md
+++ b/content/ko/docs/reference/glossary/aggregation-layer.md
@@ -1,7 +1,6 @@
 ---
 title: 애그리게이션 레이어 (원문, Aggregation Layer)
 id: aggregation-layer
-date: 2018-10-08
 full_link: /ko/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
 short_description: >
   애그리게이션 레이어를 이용하면 사용자가 추가로 쿠버네티스 형식의 API를 클러스터에 설치할 수 있다.

--- a/content/ko/docs/reference/glossary/annotation.md
+++ b/content/ko/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: 어노테이션 (원문, Annotation)
 id: annotation
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/working-with-objects/annotations
 short_description: >
   임의의 식별되지 않는 메타데이터를 오브젝트에 첨부할 때 이용하는 키-밸류 쌍.

--- a/content/ko/docs/reference/glossary/api-eviction.md
+++ b/content/ko/docs/reference/glossary/api-eviction.md
@@ -1,7 +1,6 @@
 ---
 title: API를 이용한 축출 (원문, API-initiated eviction)
 id: api-eviction
-date: 2021-04-27
 full_link: /ko/docs/concepts/scheduling-eviction/api-eviction/
 short_description: >
   API를 이용한 축출은 축출 API를 사용하여 파드의 정상 종료를 트리거하는

--- a/content/ko/docs/reference/glossary/api-group.md
+++ b/content/ko/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: API 그룹 (원문, API Group)
 id: api-group
-date: 2019-09-02
 full_link: /ko/docs/concepts/overview/kubernetes-api/#api-그룹과-버전-규칙
 short_description: >
   쿠버네티스 API의 연관된 경로들의 집합.

--- a/content/ko/docs/reference/glossary/app-container.md
+++ b/content/ko/docs/reference/glossary/app-container.md
@@ -1,7 +1,6 @@
 ---
 title: 앱 컨테이너 (원문, App Container)
 id: app-container
-date: 2019-02-12
 full_link:
 short_description: >
   워크로드의 일부를 실행하는데 사용되는 컨테이너. 초기화 컨테이너와 비교된다.

--- a/content/ko/docs/reference/glossary/applications.md
+++ b/content/ko/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: 애플리케이션 (원문, Applications)
 id: applications
-date: 2019-05-12
 full_link:
 short_description: >
   컨테이너화된 다양한 애플리케이션들이 실행되는 레이어.

--- a/content/ko/docs/reference/glossary/approver.md
+++ b/content/ko/docs/reference/glossary/approver.md
@@ -1,7 +1,6 @@
 ---
 title: 승인자 (원문, Approver)
 id: approver
-date: 2018-04-12
 full_link: 
 short_description: >
   쿠버네티스 코드 컨트리뷰션을 리뷰하고 승인할 수 있는 사람.

--- a/content/ko/docs/reference/glossary/certificate.md
+++ b/content/ko/docs/reference/glossary/certificate.md
@@ -1,7 +1,6 @@
 ---
 title: 인증서 (원문, Certificate)
 id: certificate
-date: 2018-04-12
 full_link: /ko/docs/tasks/tls/managing-tls-in-a-cluster/
 short_description: >
   암호화된 안전한 파일로 쿠버네티스 클러스터 접근 검증에 사용한다.

--- a/content/ko/docs/reference/glossary/cgroup.md
+++ b/content/ko/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   선택적으로 리소스를 격리, 관리, 제한하는 리눅스 프로세스의 그룹.

--- a/content/ko/docs/reference/glossary/cidr.md
+++ b/content/ko/docs/reference/glossary/cidr.md
@@ -1,7 +1,6 @@
 ---
 title: CIDR
 id: cidr
-date: 2019-11-12
 full_link:
 short_description: >
   CIDR은 IP 주소 블록을 설명하는 표기법으로 다양한 네트워킹 구성에서 많이 사용한다.

--- a/content/ko/docs/reference/glossary/cla.md
+++ b/content/ko/docs/reference/glossary/cla.md
@@ -1,7 +1,6 @@
 ---
 title: CLA(컨트리뷰터 사용권 계약) (원문, CLA (Contributor License Agreement))
 id: cla
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   컨트리뷰터가 기여한 것에 대한 사용권을 오픈 소스 프로젝트에 허락하는 계약 조건.

--- a/content/ko/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/ko/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: 클라우드 컨트롤 매니저 (원문, Cloud Controller Manager)
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /ko/docs/concepts/architecture/cloud-controller/
 short_description: >
   쿠버네티스를 타사 클라우드 공급자와 통합하는 컨트롤 플레인 컴포넌트.

--- a/content/ko/docs/reference/glossary/cloud-provider.md
+++ b/content/ko/docs/reference/glossary/cloud-provider.md
@@ -1,7 +1,6 @@
 ---
 title: 클라우드 공급자 (원문, Cloud Provider)
 id: cloud-provider
-date: 2018-04-12
 short_description: >
   클라우드 컴퓨팅 플랫폼을 제공하는 조직.
 

--- a/content/ko/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/ko/docs/reference/glossary/cluster-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: 클러스터 인프라스트럭처 (원문, Cluster Infrastructure)
 id: cluster-infrastructure
-date: 2019-05-12
 full_link:
 short_description: >
  인프라스트럭처 계층은 VM, 네트워킹, 보안 그룹 등을 제공하고 유지한다.

--- a/content/ko/docs/reference/glossary/cluster-operations.md
+++ b/content/ko/docs/reference/glossary/cluster-operations.md
@@ -1,7 +1,6 @@
 ---
 title: 클러스터 운영 (원문, Cluster Operations)
 id: cluster-operations
-date: 2019-05-12
 full_link:
 short_description: >
  쿠버네티스 클러스터 관리에 관련된 작업.

--- a/content/ko/docs/reference/glossary/cluster-operator.md
+++ b/content/ko/docs/reference/glossary/cluster-operator.md
@@ -1,7 +1,6 @@
 ---
 title: 클러스터 운영자 (원문, Cluster Operator)
 id: cluster-operator
-date: 2018-04-12
 full_link: 
 short_description: >
   클러스터를 구성, 제어 및 모니터링하는 사람.

--- a/content/ko/docs/reference/glossary/cluster.md
+++ b/content/ko/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: 클러스터 (원문, Cluster)
 id: cluster
-date: 2019-06-15
 full_link:
 short_description: >
    컨테이너화된 애플리케이션을 실행하는 노드라고 하는 워커 머신의 집합. 모든 클러스터는 최소 한 개의 워커 노드를 가진다.

--- a/content/ko/docs/reference/glossary/cncf.md
+++ b/content/ko/docs/reference/glossary/cncf.md
@@ -1,7 +1,6 @@
 ---
 title: 클라우드 네이티브 컴퓨팅 재단(CNCF) (원문, Cloud Native Computing Foundation (CNCF))
 id: cncf
-date: 2019-05-26
 full_link: https://cncf.io/
 short_description: >
   클라우드 네이티브 컴퓨팅 재단

--- a/content/ko/docs/reference/glossary/cni.md
+++ b/content/ko/docs/reference/glossary/cni.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 네트워크 인터페이스(CNI) (원문, Container network interface (CNI))
 id: cni
-date: 2018-05-25
 full_link: /ko/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 short_description: >
     컨테이너 네트워크 인터페이스(CNI) 플러그인은 appc/CNI 스팩을 따르는 네트워크 플러그인의 일종이다.

--- a/content/ko/docs/reference/glossary/code-contributor.md
+++ b/content/ko/docs/reference/glossary/code-contributor.md
@@ -1,7 +1,6 @@
 ---
 title: 코드 컨트리뷰터 (원문, Code Contributor)
 id: code-contributor
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
 short_description: >
   쿠버네티스 오픈소스 코드베이스에 코드를 개발하고 기여하는 사람.

--- a/content/ko/docs/reference/glossary/configmap.md
+++ b/content/ko/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: 컨피그맵 (원문, ConfigMap)
 id: configmap
-date: 2018-04-12
 full_link: /ko/docs/concepts/configuration/configmap/
 short_description: >
   키-값 쌍으로 기밀이 아닌 데이터를 저장하는 데 사용하는 API 오브젝트이다. 볼륨에서 환경 변수, 커맨드-라인 인수 또는 구성 파일로 사용될 수 있다.

--- a/content/ko/docs/reference/glossary/container-env-variables.md
+++ b/content/ko/docs/reference/glossary/container-env-variables.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 환경 변수 (원문, Container Environment Variables)
 id: container-env-variables
-date: 2018-04-12
 full_link: /ko/docs/concepts/containers/container-environment/
 short_description: >
   컨테이너 환경 변수는 파드에서 동작 중인 컨테이너에 유용한 정보를 제공하기 위한 이름=값 쌍이다.

--- a/content/ko/docs/reference/glossary/container-lifecycle-hooks.md
+++ b/content/ko/docs/reference/glossary/container-lifecycle-hooks.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 라이프사이클 훅 (원문, Container Lifecycle Hooks)
 id: container-lifecycle-hooks
-date: 2018-10-08
 full_link: /ko/docs/concepts/containers/container-lifecycle-hooks/
 short_description: >
   라이프사이클 훅은 컨테이너 관리 라이프사이클에 이벤트를 노출하고 이벤트가 발생할 때 사용자가 코드를 실행할 수 있도록 한다.

--- a/content/ko/docs/reference/glossary/container-runtime-interface.md
+++ b/content/ko/docs/reference/glossary/container-runtime-interface.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 런타임 인터페이스 (원문, Container Runtime Interface)
 id: container-runtime-interface
-date: 2022-01-10
 full_link: /ko/docs/concepts/architecture/cri/
 short_description: >
   Kubelet과 컨테이너 런타임 사이의 통신을 위한 주요 프로토콜이다.

--- a/content/ko/docs/reference/glossary/container-runtime.md
+++ b/content/ko/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 런타임 (원문, Container Runtime)
 id: container-runtime
-date: 2019-06-05
 full_link: /ko/docs/setup/production-environment/container-runtimes/
 short_description: >
  컨테이너 런타임은 컨테이너 실행을 담당하는 소프트웨어이다.

--- a/content/ko/docs/reference/glossary/container.md
+++ b/content/ko/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 (원문, Container)
 id: container
-date: 2018-04-12
 full_link: /ko/docs/concepts/containers/
 short_description: >
   소프트웨어와 그것에 종속된 모든 것을 포함한 가볍고 휴대성이 높은 실행 가능 이미지.

--- a/content/ko/docs/reference/glossary/contributor.md
+++ b/content/ko/docs/reference/glossary/contributor.md
@@ -1,7 +1,6 @@
 ---
 title: 컨트리뷰터 (원문, Contributor)
 id: contributor
-date: 2018-04-12
 full_link:
 short_description: >
   쿠버네티스 프로젝트 또는 커뮤니티를 돕기 위해 코드, 문서 또는 시간을 기부하는 사람.

--- a/content/ko/docs/reference/glossary/control-plane.md
+++ b/content/ko/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: 컨트롤 플레인 (원문, Control Plane)
 id: control-plane
-date: 2019-05-12
 full_link:
 short_description: >
   컨테이너의 라이프사이클을 정의, 배포, 관리하기 위한 API와 인터페이스들을 노출하는 컨테이너 오케스트레이션 레이어.

--- a/content/ko/docs/reference/glossary/controller.md
+++ b/content/ko/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: 컨트롤러 (원문, Controller)
 id: controller
-date: 2018-04-12
 full_link: /ko/docs/concepts/architecture/controller/
 short_description: >
   API 서버를 통해 클러스터의 공유된 상태를 감시하고, 현재 상태를 원하는 상태로 이행시키는 컨트롤 루프.

--- a/content/ko/docs/reference/glossary/cri.md
+++ b/content/ko/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 런타임 인터페이스(CRI) (원문, Container Runtime Interface (CRI))
 id: cri
-date: 2019-03-07
 full_link: /ko/docs/concepts/overview/components/#컨테이너-런타임
 short_description: >
   Kubelet과 컨테이너 런타임을 통합시키기 위한 API

--- a/content/ko/docs/reference/glossary/cronjob.md
+++ b/content/ko/docs/reference/glossary/cronjob.md
@@ -1,7 +1,6 @@
 ---
 title: 크론잡 (원문, CronJob)
 id: cronjob
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/controllers/cron-jobs/
 short_description: >
   정기적인 일정으로 실행되는 반복 작업(잡).

--- a/content/ko/docs/reference/glossary/csi.md
+++ b/content/ko/docs/reference/glossary/csi.md
@@ -1,7 +1,6 @@
 ---
 title: 컨테이너 스토리지 인터페이스(CSI) (원문, Container Storage Interface (CSI))
 id: csi
-date: 2018-06-25
 full_link: /ko/docs/concepts/storage/volumes/#csi
 short_description: >
     컨테이너 스토리지 인터페이스(CSI)는 컨테이너에 스토리지 시스템을 노출하는 표준 인터페이스를 정의한다.

--- a/content/ko/docs/reference/glossary/customresourcedefinition.md
+++ b/content/ko/docs/reference/glossary/customresourcedefinition.md
@@ -1,7 +1,6 @@
 ---
 title: 커스텀 리소스 데피니션 (원문, CustomResourceDefinition)
 id: CustomResourceDefinition
-date: 2018-04-12
 full_link: /docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 short_description: >
   사용자 정의 서버를 완전히 새로 구축할 필요가 없도록 쿠버네티스 API 서버에 추가할 리소스를 정의하는 사용자 정의 코드.

--- a/content/ko/docs/reference/glossary/daemonset.md
+++ b/content/ko/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: 데몬셋 (원문, DaemonSet)
 id: daemonset
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/controllers/daemonset
 short_description: >
   파드의 복제본을 클러스터 노드 집합에서 동작하게 한다.

--- a/content/ko/docs/reference/glossary/data-plane.md
+++ b/content/ko/docs/reference/glossary/data-plane.md
@@ -1,7 +1,6 @@
 ---
 title: 데이터 플레인 (원문, Data Plane)
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   컨테이너가 실행되고 네트워크에 연결될 수 있게 CPU, 메모리, 네트워크, 스토리지와 같은 능력을 제공하는 레이어.

--- a/content/ko/docs/reference/glossary/deployment.md
+++ b/content/ko/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: 디플로이먼트 (원문, Deployment)
 id: deployment
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/controllers/deployment/
 short_description: >
   클러스터에서 복제된 애플리케이션을 관리한다.

--- a/content/ko/docs/reference/glossary/developer.md
+++ b/content/ko/docs/reference/glossary/developer.md
@@ -1,7 +1,6 @@
 ---
 title: 개발자(의미 명확화) (원문, Developer (disambiguation))
 id: developer
-date: 2018-04-12
 full_link: 
 short_description: >
   애플리케이션 개발자, 코드 컨트리뷰터, 또는 플랫폼 개발자를 가리킨다.

--- a/content/ko/docs/reference/glossary/device-plugin.md
+++ b/content/ko/docs/reference/glossary/device-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: 장치 플러그인 (원문, Device Plugin)
 id: device-plugin
-date: 2019-02-02
 full_link: /ko/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   파드가 공급자별 초기화 또는 설정이 필요한 장치에 접근할 수 있도록 하는 소프트웨어 확장

--- a/content/ko/docs/reference/glossary/disruption.md
+++ b/content/ko/docs/reference/glossary/disruption.md
@@ -1,7 +1,6 @@
 ---
 title: 중단 (원문, Disruption)
 id: disruption
-date: 2019-09-10
 full_link: /ko/docs/concepts/workloads/pods/disruptions/
 short_description: >
   파드의 서비스 중단으로 이어지는 이벤트

--- a/content/ko/docs/reference/glossary/docker.md
+++ b/content/ko/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: 도커 (원문, Docker)
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker는 운영 시스템 수준의 가상화를 제공하는 소프트웨어 기술이며, 컨테이너로도 알려져 있다.

--- a/content/ko/docs/reference/glossary/dockershim.md
+++ b/content/ko/docs/reference/glossary/dockershim.md
@@ -1,7 +1,6 @@
 ---
 title: 도커심 (원문, Dockershim)
 id: dockershim
-date: 2022-04-15
 full_link: /dockershim
 short_description: >
    쿠버네티스 1.23 이하의 버전에서 쿠버네티스 시스템 구성 요소가 도커 엔진과 통신할 수 있게 해주는 컴포넌트

--- a/content/ko/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/ko/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,7 +1,6 @@
 ---
 title: 동적 볼륨 프로비저닝 (원문, Dynamic Volume Provisioning)
 id: dynamicvolumeprovisioning
-date: 2018-04-12
 full_link: /ko/docs/concepts/storage/dynamic-provisioning
 short_description: >
   사용자가 스토리지 볼륨의 자동 생성을 요청할 수 있게 해준다.

--- a/content/ko/docs/reference/glossary/endpoint.md
+++ b/content/ko/docs/reference/glossary/endpoint.md
@@ -1,7 +1,6 @@
 ---
 title: 엔드포인트 (원문, Endpoints)
 id: endpoints
-date: 2020-04-23
 full_link: 
 short_description: >
   엔드포인트는 서비스(Service) 셀렉터에 매치되는 파드의 IP 주소를 추적한다.

--- a/content/ko/docs/reference/glossary/ephemeral-container.md
+++ b/content/ko/docs/reference/glossary/ephemeral-container.md
@@ -1,7 +1,6 @@
 ---
 title: 임시 컨테이너 (원문, Ephemeral Container)
 id: ephemeral-container
-date: 2019-08-26
 full_link: /ko/docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
   파드 내에 임시적으로 실행할 수 있는 컨테이너 타입

--- a/content/ko/docs/reference/glossary/etcd.md
+++ b/content/ko/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   모든 클러스터 데이터를 담는 쿠버네티스 뒷단의 저장소로 사용되는 일관성·고가용성 키-값 저장소.

--- a/content/ko/docs/reference/glossary/event.md
+++ b/content/ko/docs/reference/glossary/event.md
@@ -1,7 +1,6 @@
 ---
 title: 이벤트 (원문, Event)
 id: event
-date: 2022-01-16
 full_link: /docs/reference/kubernetes-api/cluster-resources/event-v1/
 short_description: >
    클러스터 어딘가에서 발생한 이벤트에 대한 보고서이다. 일반적으로 시스템의 상태 변화를 나타낸다.

--- a/content/ko/docs/reference/glossary/eviction.md
+++ b/content/ko/docs/reference/glossary/eviction.md
@@ -1,7 +1,6 @@
 ---
 title: 축출 (원문, Eviction)
 id: eviction
-date: 2021-05-08
 full_link: /ko/docs/concepts/scheduling-eviction/
 short_description: >
     노드에 있는 한 개 이상의 파드를 중단하는 프로세스이다.

--- a/content/ko/docs/reference/glossary/extensions.md
+++ b/content/ko/docs/reference/glossary/extensions.md
@@ -1,7 +1,6 @@
 ---
 title: 익스텐션 (원문, Extensions)
 id: Extensions
-date: 2019-02-01
 full_link: /ko/docs/concepts/extend-kubernetes/#익스텐션
 short_description: >
   익스텐션은 새로운 종류의 하드웨어를 지원하기 위해 쿠버네티스를 확장하고

--- a/content/ko/docs/reference/glossary/finalizer.md
+++ b/content/ko/docs/reference/glossary/finalizer.md
@@ -1,7 +1,6 @@
 ---
 title: 파이널라이저 (원문, Finalizer)
 id: finalizer
-date: 2021-07-07
 full_link: /ko/docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
   쿠버네티스가 오브젝트를 완전히 삭제하기 이전, 삭제 표시를 위해

--- a/content/ko/docs/reference/glossary/garbage-collection.md
+++ b/content/ko/docs/reference/glossary/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 title: 가비지 수집 (원문, Garbage Collection)
 id: garbage-collection
-date: 2022-01-14
 full_link: /ko/docs/concepts/architecture/garbage-collection/
 short_description: >
   쿠버네티스가 클러스터 자원을 정리하기 위해 사용하는

--- a/content/ko/docs/reference/glossary/helm-chart.md
+++ b/content/ko/docs/reference/glossary/helm-chart.md
@@ -1,7 +1,6 @@
 ---
 title: 헬름 차트 (원문, Helm Chart)
 id: helm-chart
-date: 2018-04-12
 full_link: https://helm.sh/ko/docs/topics/charts/
 short_description: >
   헬름(Helm) 도구를 통해 관리할 수 있는 사전 구성된 쿠버네티스 리소스 패키지

--- a/content/ko/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/ko/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,7 +1,6 @@
 ---
 title: Horizontal Pod Autoscaler
 id: horizontal-pod-autoscaler
-date: 2018-04-12
 full_link: /ko/docs/tasks/run-application/horizontal-pod-autoscale/
 short_description: >
   CPU 사용률 또는 사용자 정의 메트릭을 기반으로 파드의 레플리카 수를 자동으로 조절하는 API 리소스이다.

--- a/content/ko/docs/reference/glossary/host-aliases.md
+++ b/content/ko/docs/reference/glossary/host-aliases.md
@@ -1,7 +1,6 @@
 ---
 title: 호스트에일리어스 (원문, HostAliases)
 id: HostAliases
-date: 2019-01-31
 full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
 short_description: >
   호스트에일리어스는 파드의 hosts 파일에 주입될 IP 주소와 호스트네임간의 매핑이다. 

--- a/content/ko/docs/reference/glossary/image.md
+++ b/content/ko/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: 이미지 (원문, Image)
 id: image
-date: 2018-04-12
 full_link: 
 short_description: >
   컨테이너의 저장된 인스턴스이며, 애플리케이션 구동에 필요한 소프트웨어 집합을 가지고 있다.

--- a/content/ko/docs/reference/glossary/ingress.md
+++ b/content/ko/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: 인그레스 (원문, Ingress)
 id: ingress
-date: 2018-04-12
 full_link: /ko/docs/concepts/services-networking/ingress/
 short_description: >
   클러스터 내의 서비스에 대한 외부 접근을 관리하는 API 오브젝트이며, 일반적으로 HTTP를 관리함.

--- a/content/ko/docs/reference/glossary/init-container.md
+++ b/content/ko/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: 초기화 컨테이너 (원문, Init Container)
 id: init-container
-date: 2018-04-12
 full_link:
 short_description: >
   앱 컨테이너가 동작하기 전에 완료되기 위해 실행되는 하나 이상의 초기화 컨테이너.

--- a/content/ko/docs/reference/glossary/istio.md
+++ b/content/ko/docs/reference/glossary/istio.md
@@ -1,7 +1,6 @@
 ---
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   마이크로서비스의 통합을 위한 통일된 방법을 제공하는 오픈 플랫폼(쿠버네티스에 특정적이지 않음)이며, 트래픽 흐름을 관리하고, 정책을 시행하고, 텔레메트리 데이터를 모은다.

--- a/content/ko/docs/reference/glossary/job.md
+++ b/content/ko/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: 잡 (원문, Job)
 id: job
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/controllers/job/
 short_description: >
   완료를 목표로 실행되는 유한 또는 배치 작업.

--- a/content/ko/docs/reference/glossary/kube-apiserver.md
+++ b/content/ko/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: API 서버 (원문, API server)
 id: kube-apiserver
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/components/#kube-apiserver
 short_description: >
   쿠버네티스 API를 제공하는 컨트롤 플레인 컴포넌트.

--- a/content/ko/docs/reference/glossary/kube-controller-manager.md
+++ b/content/ko/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   컨트롤러 프로세스를 실행하는 컨트롤 플레인 컴포넌트.

--- a/content/ko/docs/reference/glossary/kube-proxy.md
+++ b/content/ko/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /ko/docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy`는 클러스터의 각 노드에서 실행되는 네트워크 프록시이다.

--- a/content/ko/docs/reference/glossary/kube-scheduler.md
+++ b/content/ko/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-scheduler/
 short_description: >
   노드가 배정되지 않은 새로 생성된 파드를 감지하고, 실행할 노드를 선택하는 컨트롤 플레인 컴포넌트.

--- a/content/ko/docs/reference/glossary/kubectl.md
+++ b/content/ko/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /docs/user-guide/kubectl-overview/
 short_description: >
   쿠버네티스 클러스터와 통신하기 위한 커맨드라인 툴.

--- a/content/ko/docs/reference/glossary/kubelet.md
+++ b/content/ko/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/generated/kubelet
 short_description: >
   클러스터의 각 노드에서 실행되는 에이전트. Kubelet은 파드에서 컨테이너가 확실하게 동작하도록 관리한다.

--- a/content/ko/docs/reference/glossary/kubernetes-api.md
+++ b/content/ko/docs/reference/glossary/kubernetes-api.md
@@ -1,7 +1,6 @@
 ---
 title: 쿠버네티스 API (원문, Kubernetes API)
 id: kubernetes-api
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/kubernetes-api/
 short_description: >
   RESTful 인터페이스를 통해서 쿠버네티스 기능을 제공하고 클러스터의 상태를 저장하는 애플리케이션.

--- a/content/ko/docs/reference/glossary/label.md
+++ b/content/ko/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: 레이블 (원문, Label)
 id: label
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/working-with-objects/labels
 short_description: >
   사용자에게 의미 있고 관련성 높은 특징으로 식별할 수 있도록 오브젝트에 태그를 붙인다.

--- a/content/ko/docs/reference/glossary/limitrange.md
+++ b/content/ko/docs/reference/glossary/limitrange.md
@@ -1,7 +1,6 @@
 ---
 title: 범위 제한 (원문, LimitRange)
 id: limitrange
-date: 2019-04-15
 full_link: /ko/docs/concepts/policy/limit-range/
 short_description: >
   네임스페이스 내에 컨테이너나 파드당 리소스 소비를 한정하는 제약 조건을 제공한다.

--- a/content/ko/docs/reference/glossary/logging.md
+++ b/content/ko/docs/reference/glossary/logging.md
@@ -1,7 +1,6 @@
 ---
 title: 로깅 (원문, Logging)
 id: logging
-date: 2019-04-04
 full_link: /ko/docs/concepts/cluster-administration/logging/
 short_description: >
   로그는 클러스터나 애플리케이션에 의해 로깅된 이벤트의 목록이다.

--- a/content/ko/docs/reference/glossary/managed-service.md
+++ b/content/ko/docs/reference/glossary/managed-service.md
@@ -1,7 +1,6 @@
 ---
 title: 매니지드 서비스 (원문, Managed Service)
 id: managed-service
-date: 2018-04-12
 full_link:
 short_description: >
   타사 공급자가 유지보수하는 소프트웨어.

--- a/content/ko/docs/reference/glossary/manifest.md
+++ b/content/ko/docs/reference/glossary/manifest.md
@@ -1,7 +1,6 @@
 ---
 title: 매니페스트 (원문, Manifest)
 id: manifest
-date: 2019-06-28
 short_description: >
   하나 이상의 쿠버네티스 API 오브젝트를 직렬화한 명세(specification).
 

--- a/content/ko/docs/reference/glossary/member.md
+++ b/content/ko/docs/reference/glossary/member.md
@@ -1,7 +1,6 @@
 ---
 title: 멤버 (원문, Member)
 id: member
-date: 2018-04-12
 full_link: 
 short_description: >
   K8s 커뮤니티에서 지속적으로 활동하는 컨트리뷰터.

--- a/content/ko/docs/reference/glossary/minikube.md
+++ b/content/ko/docs/reference/glossary/minikube.md
@@ -1,7 +1,6 @@
 ---
 title: Minikube
 id: minikube
-date: 2018-04-12
 full_link: /ko/docs/tasks/tools/#minikube
 short_description: >
   로컬에서 쿠버네티스를 실행하기 위한 도구.

--- a/content/ko/docs/reference/glossary/mirror-pod.md
+++ b/content/ko/docs/reference/glossary/mirror-pod.md
@@ -1,7 +1,6 @@
 ---
 title: 미러 파드 (원문, Mirror Pod)
 id: mirror-pod
-date: 2019-08-06
 short_description: >
   Kubelet의 스태틱 파드(Static Pod)를 추적하는 API 서버 내부의 오브젝트.
 

--- a/content/ko/docs/reference/glossary/name.md
+++ b/content/ko/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: 이름 (원문, Name)
 id: name
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/working-with-objects/names
 short_description: >
   `/api/v1/pods/some-name`과 같이, 리소스 URL에서 오브젝트를 가리키는 클라이언트 제공 문자열.

--- a/content/ko/docs/reference/glossary/namespace.md
+++ b/content/ko/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: 네임스페이스 (원문, Namespace)
 id: namespace
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/working-with-objects/namespaces/
 short_description: >
   쿠버네티스에서, 하나의 클러스터 내에서 리소스 그룹의 격리를 지원하기 위해 사용하는 추상화.

--- a/content/ko/docs/reference/glossary/network-policy.md
+++ b/content/ko/docs/reference/glossary/network-policy.md
@@ -1,7 +1,6 @@
 ---
 title: 네트워크 폴리시 (원문, Network Policy)
 id: network-policy
-date: 2018-04-12
 full_link: /ko/docs/concepts/services-networking/network-policies/
 short_description: >
   파드 그룹들이 서로에 대한 그리고 다른 네트워크 엔드포인트에 대한 통신이 어떻게 허용되는지에 대한 명세이다.

--- a/content/ko/docs/reference/glossary/node-pressure-eviction.md
+++ b/content/ko/docs/reference/glossary/node-pressure-eviction.md
@@ -1,7 +1,6 @@
 ---
 title: 노드-압박 축출 (원문, Node-pressure eviction)
 id: node-pressure-eviction
-date: 2021-05-13
 full_link: /ko/docs/concepts/scheduling-eviction/node-pressure-eviction/
 short_description: >
   노드-압박 축출은 kubelet이 노드의 자원을 회수하기 위해 

--- a/content/ko/docs/reference/glossary/node.md
+++ b/content/ko/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: 노드 (원문, Node)
 id: node
-date: 2018-04-12
 full_link: /ko/docs/concepts/architecture/nodes/
 short_description: >
   노드는 쿠버네티스의 작업 장비(worker machine)이다.

--- a/content/ko/docs/reference/glossary/object.md
+++ b/content/ko/docs/reference/glossary/object.md
@@ -1,7 +1,6 @@
 ---
 title: 오브젝트 (원문, Object)
 id: object
-date: 2020-01-12
 full_link: https://kubernetes.io/ko/docs/concepts/overview/working-with-objects/kubernetes-objects/#kubernetes-objects
 short_description: >
    클러스터 상태의 일부를 나타내는 쿠버네티스 시스템의 엔티티이다.

--- a/content/ko/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/ko/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: 퍼시스턴트 볼륨 클레임 (원문, Persistent Volume Claim)
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /ko/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   컨테이너의 볼륨으로 마운트될 수 있도록 퍼시스턴트볼륨(PersistentVolume)에 정의된 스토리지 리소스를 요청한다.

--- a/content/ko/docs/reference/glossary/persistent-volume.md
+++ b/content/ko/docs/reference/glossary/persistent-volume.md
@@ -1,7 +1,6 @@
 ---
 title: 퍼시스턴트 볼륨 (원문, Persistent Volume)
 id: persistent-volume
-date: 2018-04-12
 full_link: /ko/docs/concepts/storage/persistent-volumes/
 short_description: >
   클러스터의 스토리지를 구성하는 API 오브젝트이다. 보통은 개별 파드보다 수명이 긴 플러그 가능한 형태의 리소스로 제공한다.

--- a/content/ko/docs/reference/glossary/pod-disruption.md
+++ b/content/ko/docs/reference/glossary/pod-disruption.md
@@ -2,7 +2,6 @@
 id: pod-disruption
 title: 파드 중단 (원문, Pod Disruption)
 full_link: /ko/docs/concepts/workloads/pods/disruptions/
-date: 2021-05-12
 short_description: >
   노드에 있는 파드가 자발적 또는 비자발적으로 종료되는 절차
 

--- a/content/ko/docs/reference/glossary/pod-lifecycle.md
+++ b/content/ko/docs/reference/glossary/pod-lifecycle.md
@@ -1,7 +1,6 @@
 ---
 title: 파드 라이프사이클 (원문, Pod Lifecycle)
 id: pod-lifecycle
-date: 2019-02-17
 full-link: /ko/docs/concepts/workloads/pods/pod-lifecycle/
 related:
  - pod

--- a/content/ko/docs/reference/glossary/pod-priority.md
+++ b/content/ko/docs/reference/glossary/pod-priority.md
@@ -1,7 +1,6 @@
 ---
 title: 파드 프라이어리티 (원문, Pod Priority)
 id: pod-priority
-date: 2019-01-31
 full_link: /ko/docs/concepts/scheduling-eviction/pod-priority-preemption/#파드-우선순위
 short_description: >
   파드 프라이어리티는 다른 파드에 대한 상대적인 중요도를 나타낸다.

--- a/content/ko/docs/reference/glossary/pod-security-policy.md
+++ b/content/ko/docs/reference/glossary/pod-security-policy.md
@@ -1,7 +1,6 @@
 ---
 title: 파드 시큐리티 폴리시 (원문, Pod Security Policy)
 id: pod-security-policy
-date: 2018-04-12
 full_link: /ko/docs/concepts/security/pod-security-policy/
 short_description: >
   파드 생성과 업데이트에 대한 세밀한 인가를 활성화한다.

--- a/content/ko/docs/reference/glossary/pod.md
+++ b/content/ko/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: 파드 (원문, Pod)
 id: pod
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/pods/
 short_description: >
   파드는 클러스터에서 실행 중인 컨테이너의 집합을 나타낸다.

--- a/content/ko/docs/reference/glossary/preemption.md
+++ b/content/ko/docs/reference/glossary/preemption.md
@@ -1,7 +1,6 @@
 ---
 title: 선점 (원문, Preemption)
 id: preemption
-date: 2019-01-31
 full_link: /ko/docs/concepts/scheduling-eviction/pod-priority-preemption/#선점
 short_description: >
   쿠버네티스에서 선점(preemption)은 노드에서 낮은 우선 순위를 가지는 파드를 축출함으로써 보류 중인 파드가 적절한 노드를 찾을 수 있도록 한다.

--- a/content/ko/docs/reference/glossary/probe.md
+++ b/content/ko/docs/reference/glossary/probe.md
@@ -1,7 +1,6 @@
 ---
 title: 프로브 (원문, Probe)
 id: probe
-date: 2023-03-21
 full_link: /ko/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 short_description: >

--- a/content/ko/docs/reference/glossary/proxy.md
+++ b/content/ko/docs/reference/glossary/proxy.md
@@ -1,7 +1,6 @@
 ---
 title: 프록시 (원문, Proxy)
 id: proxy
-date: 2019-09-10
 short_description: >
   클라이언트와 서버 간의 중개자 역할을 하는 애플리케이션
 

--- a/content/ko/docs/reference/glossary/qos-class.md
+++ b/content/ko/docs/reference/glossary/qos-class.md
@@ -1,7 +1,6 @@
 ---
 title: QoS 클래스 (원문, QoS Class)
 id: qos-class
-date: 2019-04-15
 full_link:
 short_description: >
   QoS 클래스(서비스 품질 클래스)는 쿠버네티스가 클러스터 안의 파드들을 여러 클래스로 구분하고, 스케줄링과 축출(eviction)에 대한 결정을 내리는 방법을 제공한다.

--- a/content/ko/docs/reference/glossary/quantity.md
+++ b/content/ko/docs/reference/glossary/quantity.md
@@ -1,7 +1,6 @@
 ---
 title: 수량 (원문, Quantity)
 id: quantity
-date: 2018-08-07
 full_link:
 short_description: >
   SI 접미사를 사용하는 작거나 큰 숫자의 정수(whole-number) 표현.

--- a/content/ko/docs/reference/glossary/rbac.md
+++ b/content/ko/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: RBAC(역할 기반 액세스 제어) (원문, RBAC (Role-Based Access Control))
 id: rbac
-date: 2018-04-12
 full_link: /docs/reference/access-authn-authz/rbac/
 short_description: >
   인가 결정을 관리하며, 운영자가 쿠버네티스 API를 통해서 동적으로 액세스 정책을 설정하게 한다.

--- a/content/ko/docs/reference/glossary/replica-set.md
+++ b/content/ko/docs/reference/glossary/replica-set.md
@@ -1,7 +1,6 @@
 ---
 title: 레플리카셋 (원문, ReplicaSet)
 id: replica-set
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/controllers/replicaset/
 short_description: >
   레플리카셋은 지정된 수의 파드 레플리카가 동시에 실행이 되도록 보장한다

--- a/content/ko/docs/reference/glossary/replication-controller.md
+++ b/content/ko/docs/reference/glossary/replication-controller.md
@@ -1,7 +1,6 @@
 ---
 title: 레플리케이션컨트롤러 (원문, ReplicationController)
 id: replication-controller
-date: 2018-04-12
 full_link: 
 short_description: >
   (사용 중단된) 복제된 애플리케이션을 관리하는 API 오브젝트

--- a/content/ko/docs/reference/glossary/resource-quota.md
+++ b/content/ko/docs/reference/glossary/resource-quota.md
@@ -1,7 +1,6 @@
 ---
 title: 리소스 쿼터 (원문, ResourceQuota)
 id: resource-quota
-date: 2018-04-12
 full_link: /ko/docs/concepts/policy/resource-quotas/
 short_description: >
   네임스페이스당 전체 리소스 소비를 제한하는 제약을 제공한다.

--- a/content/ko/docs/reference/glossary/reviewer.md
+++ b/content/ko/docs/reference/glossary/reviewer.md
@@ -1,7 +1,6 @@
 ---
 title: 리뷰어 (원문, Reviewer)
 id: reviewer
-date: 2018-04-12
 full_link:
 short_description: >
   프로젝트 일부에 대한 코드를 품질과 정확성 관점에서 검토하는 사람.

--- a/content/ko/docs/reference/glossary/secret.md
+++ b/content/ko/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: 시크릿 (원문, Secret)
 id: secret
-date: 2018-04-12
 full_link: /ko/docs/concepts/configuration/secret/
 short_description: >
   비밀번호, OAuth 토큰 및 SSH 키와 같은 민감한 정보를 저장한다.

--- a/content/ko/docs/reference/glossary/selector.md
+++ b/content/ko/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: 셀렉터 (원문, Selector)
 id: selector
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/working-with-objects/labels/
 short_description: >
   사용자가 레이블에 따라서 리소스 리스트를 필터할 수 있게 한다.

--- a/content/ko/docs/reference/glossary/service-account.md
+++ b/content/ko/docs/reference/glossary/service-account.md
@@ -1,7 +1,6 @@
 ---
 title: 서비스어카운트 (원문, ServiceAccount)
 id: service-account
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   파드에서 실행 중인 프로세스를 위한 신원(identity)을 제공한다.

--- a/content/ko/docs/reference/glossary/service-catalog.md
+++ b/content/ko/docs/reference/glossary/service-catalog.md
@@ -1,7 +1,6 @@
 ---
 title: 서비스 카탈로그 (원문, Service Catalog)
 id: service-catalog
-date: 2018-04-12
 full_link: 
 short_description: >
   쿠버네티스 클러스터 내에서 실행되는 응용 프로그램이, 클라우드 공급자가 제공하는 데이터 저장소 서비스와 같은 외부 관리 소프트웨어 제품을 쉽게 사용할 수 있도록 해주던 이전의 확장 API이다.

--- a/content/ko/docs/reference/glossary/service.md
+++ b/content/ko/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: 서비스 (원문, Service)
 id: service
-date: 2018-04-12
 full_link: /ko/docs/concepts/services-networking/service/
 short_description: >
   네트워크 서비스로 파드 집합에서 실행 중인 애플리케이션을 노출하는 방법

--- a/content/ko/docs/reference/glossary/sig.md
+++ b/content/ko/docs/reference/glossary/sig.md
@@ -1,7 +1,6 @@
 ---
 title: SIG(special interest group)
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups 
 short_description: >
   대규모 쿠버네티스 오픈소스 프로젝트에서 진행되는 내용을 공동으로 관리하는 커뮤니티 멤버들이다.

--- a/content/ko/docs/reference/glossary/statefulset.md
+++ b/content/ko/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: 스테이트풀셋 (원문, StatefulSet)
 id: statefulset
-date: 2018-04-12
 full_link: /ko/docs/concepts/workloads/controllers/statefulset/
 short_description: >
   내구성이 있는 스토리지와 파드별로 지속성 식별자를 사용해서 파드 집합의 디플로이먼트와 스케일링을 관리한다.

--- a/content/ko/docs/reference/glossary/static-pod.md
+++ b/content/ko/docs/reference/glossary/static-pod.md
@@ -1,7 +1,6 @@
 ---
 title: 스태틱 파드 (원문, Static Pod)
 id: static-pod
-date: 2019-02-12
 full_link: /ko/docs/tasks/configure-pod-container/static-pod/
 short_description: >
   특정 노드의 Kubelet 데몬이 직접 관리하는 파드

--- a/content/ko/docs/reference/glossary/storage-class.md
+++ b/content/ko/docs/reference/glossary/storage-class.md
@@ -1,7 +1,6 @@
 ---
 title: 스토리지 클래스 (원문, Storage Class)
 id: storageclass
-date: 2018-04-12
 full_link: /ko/docs/concepts/storage/storage-classes
 short_description: >
   스토리지클래스는 관리자가 사용 가능한 다양한 스토리지 유형을 설명할 수 있는 방법을 제공한다.

--- a/content/ko/docs/reference/glossary/sysctl.md
+++ b/content/ko/docs/reference/glossary/sysctl.md
@@ -1,7 +1,6 @@
 ---
 title: sysctl
 id: sysctl
-date: 2019-02-12
 full_link: /ko/docs/tasks/administer-cluster/sysctl-cluster/
 short_description: >
   유닉스 커널 파라미터를 가져오거나 설정하는 데 사용하는 인터페이스

--- a/content/ko/docs/reference/glossary/taint.md
+++ b/content/ko/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: 테인트 (원문, Taint)
 id: taint
-date: 2019-01-11
 full_link: /ko/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   세 가지 필수 속성: 키(key), 값(value), 효과(effect)로 구성된 코어 오브젝트. 테인트는 파드가 노드나 노드 그룹에 스케줄링되는 것을 방지한다.

--- a/content/ko/docs/reference/glossary/toleration.md
+++ b/content/ko/docs/reference/glossary/toleration.md
@@ -1,7 +1,6 @@
 ---
 title: 톨러레이션 (원문, Toleration)
 id: toleration
-date: 2019-01-11
 full_link: /ko/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   세 가지 필수 속성: 키(key), 값(value), 효과(effect)로 구성된 코어 오브젝트. 톨러레이션은 매칭되는 테인트(taint)를 가진 노드나 노드 그룹에 파드가 스케줄링되는 것을 활성화한다.

--- a/content/ko/docs/reference/glossary/uid.md
+++ b/content/ko/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /ko/docs/concepts/overview/working-with-objects/names
 short_description: >
   오브젝트를 중복 없이 식별하기 위해 쿠버네티스 시스템이 생성하는 문자열.

--- a/content/ko/docs/reference/glossary/volume-plugin.md
+++ b/content/ko/docs/reference/glossary/volume-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: 볼륨 플러그인 (원문, Volume Plugin)
 id: volumeplugin
-date: 2018-04-12
 full_link: 
 short_description: >
   볼륨 플러그인은 파드 내에서의 스토리지 통합을 가능하게 한다.

--- a/content/ko/docs/reference/glossary/volume.md
+++ b/content/ko/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: 볼륨 (원문, Volume)
 id: volume
-date: 2018-04-12
 full_link: /ko/docs/concepts/storage/volumes/
 short_description: >
   데이터를 포함하고 있는 디렉터리이며, 파드의 컨테이너에서 접근 가능하다.

--- a/content/ko/docs/reference/glossary/wg.md
+++ b/content/ko/docs/reference/glossary/wg.md
@@ -1,7 +1,6 @@
 ---
 title: WG(working group)
 id: wg
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
 short_description: >
   위원회(committee), SIG 내, 또는 SIG 간 노력을 위한 단기적이거나, 좁은 범위를 다루거나, 혹은 서로 연관되지 않은 프로젝트의 토론 및/또는 구현을 촉진한다.

--- a/content/ko/docs/reference/glossary/workload.md
+++ b/content/ko/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: 워크로드 (원문, Workload)
 id: workloads
-date: 2019-02-13
 full_link: /ko/docs/concepts/workloads/
 short_description: >
    워크로드는 클러스터의 컨테이너를 동작시키고 관리하기 위해 사용하는 오브젝트이다.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all ko/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.