### PR TITLE
docs: Remove date field from Polish glossary entries

### DIFF
--- a/content/pl/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/pl/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Controller Manager
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /docs/concepts/architecture/cloud-controller/
 short_description: >
   Element warstwy sterowania, który integruje Kubernetesa z zewnętrznymi usługami chmurowymi.

--- a/content/pl/docs/reference/glossary/cluster.md
+++ b/content/pl/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Klaster
 id: cluster
-date: 2019-06-15
 full_link: 
 short_description: >
    Zestaw maszyn roboczych, nazywanych {{< glossary_tooltip text="węzłami" term_id="node" >}}, na których uruchamiane są aplikacje w kontenerach.

--- a/content/pl/docs/reference/glossary/container-runtime.md
+++ b/content/pl/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime
 id: container-runtime
-date: 2019-06-05
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
  *Container runtime* to oprogramowanie zajmujące się uruchamianiem kontenerów.

--- a/content/pl/docs/reference/glossary/etcd.md
+++ b/content/pl/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Magazyn typu klucz-wartość *(key/value store)*, zapewniający spójność i wysoką dostępność, używany do przechowywania wszystkich danych o klastrze Kubernetesa.

--- a/content/pl/docs/reference/glossary/kube-apiserver.md
+++ b/content/pl/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: Serwer API
 id: kube-apiserver
-date: 2018-04-12
 full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Składnik warstwy sterowania udostępniający API Kubernetesa.

--- a/content/pl/docs/reference/glossary/kube-controller-manager.md
+++ b/content/pl/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   Składnik *master* odpowiedzialny za uruchamianie kontrolerów.

--- a/content/pl/docs/reference/glossary/kube-proxy.md
+++ b/content/pl/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` to *proxy* sieciowe, które uruchomione jest na każdym węźle klastra.

--- a/content/pl/docs/reference/glossary/kube-scheduler.md
+++ b/content/pl/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-scheduler/
 short_description: >
   Składnik warstwy sterowania, który śledzi tworzenie nowych podów i przypisuje im węzły, na których powinny zostać uruchomione.

--- a/content/pl/docs/reference/glossary/kubelet.md
+++ b/content/pl/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kubelet
 short_description: >
   Agent, który działa na każdym węźle klastra. Odpowiada za uruchamianie kontenerów w ramach poda.

--- a/content/pl/docs/reference/glossary/name.md
+++ b/content/pl/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: Name
 id: name
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   Ciąg znaków dostarczony przez klienta, który odnosi się do obiektu w adresie URL zasobu, na przykład `/api/v1/pods/some-name`.

--- a/content/pl/docs/reference/glossary/pod-disruption.md
+++ b/content/pl/docs/reference/glossary/pod-disruption.md
@@ -2,7 +2,6 @@
 id: pod-disruption
 title: Przerwanie działania Poda
 full_link: /docs/concepts/workloads/pods/disruptions/
-date: 2021-05-12
 short_description: >
   Dobrowolnie lub wymuszone zakończenie działania Podów na węzłach.
 

--- a/content/pl/docs/reference/glossary/uid.md
+++ b/content/pl/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   Unikalny identyfikator obiektu generowany automatycznie przez system Kubernetes.

--- a/content/pl/docs/reference/glossary/workload.md
+++ b/content/pl/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: Workload
 id: workload
-date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
    Workload to ogólne określenie aplikacji działającej na Kubernetesie.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all pl/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.