### PR TITLE
docs: Remove date field from Chinese glossary entries

### DIFF
--- a/content/zh-cn/docs/reference/glossary/daemonset.md
+++ b/content/zh-cn/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/controllers/daemonset/
 short_description: >
   确保 Pod 的副本在集群中的一组节点上运行。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/daemonset
 short_description: >
   Ensures a copy of a Pod is running across a set of nodes in a cluster.

--- a/content/zh-cn/docs/reference/glossary/data-plane.md
+++ b/content/zh-cn/docs/reference/glossary/data-plane.md
@@ -1,7 +1,6 @@
 ---
 title: 数据平面（Data Plane）
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   提供诸如 CPU、内存、网络和存储的能力，以便容器可以运行并连接到网络。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Data Plane
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   The layer that provides capacity such as CPU, memory, network, and storage so that the containers can run and connect to a network.

--- a/content/zh-cn/docs/reference/glossary/deployment.md
+++ b/content/zh-cn/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/controllers/deployment/
 short_description: >
   管理集群上的多副本应用。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Manages a replicated application on your cluster.

--- a/content/zh-cn/docs/reference/glossary/developer.md
+++ b/content/zh-cn/docs/reference/glossary/developer.md
@@ -1,7 +1,6 @@
 ---
 title: 开发者（Developer）
 id: developer
-date: 2018-04-12
 full_link: 
 short_description: >
   指的是：应用开发者、代码贡献者、或平台开发者。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Developer (disambiguation)
 id: developer
-date: 2018-04-12
 full_link: 
 short_description: >
   May refer to&#58; Application Developer, Code Contributor, or Platform Developer.

--- a/content/zh-cn/docs/reference/glossary/device-plugin.md
+++ b/content/zh-cn/docs/reference/glossary/device-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: 设备插件（Device Plugin）
 id: device-plugin
-date: 2019-02-02
 full_link: /zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   一种软件扩展，可以使 Pod 访问由特定厂商初始化或者安装的设备。
@@ -13,7 +12,6 @@ tags:
 <!-- 
 title: Device Plugin
 id: device-plugin
-date: 2019-02-02
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   Software extensions to let Pods access devices that need vendor-specific initialization or setup

--- a/content/zh-cn/docs/reference/glossary/device.md
+++ b/content/zh-cn/docs/reference/glossary/device.md
@@ -1,7 +1,6 @@
 ---
 title: 设备
 id: device
-date: 2025-05-13
 short_description: >
   直接或间接挂接到集群节点上的所有资源，例如 GPU 或电路板。
 
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Device
 id: device
-date: 2025-05-13
 short_description: >
   Any resource that's directly or indirectly attached your cluster's nodes, like
   GPUs or circuit boards.

--- a/content/zh-cn/docs/reference/glossary/deviceclass.md
+++ b/content/zh-cn/docs/reference/glossary/deviceclass.md
@@ -1,7 +1,6 @@
 ---
 title: DeviceClass
 id: deviceclass
-date: 2025-05-26
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#deviceclass
 short_description: >
   集群中设备的一种分类。使用户可以申领 DeviceClass 中的特定设备。
@@ -11,7 +10,6 @@ tags:
 <!--
 title: DeviceClass
 id: deviceclass
-date: 2025-05-26
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#deviceclass
 short_description: >
   A category of devices in the cluster. Users can claim specific

--- a/content/zh-cn/docs/reference/glossary/disruption.md
+++ b/content/zh-cn/docs/reference/glossary/disruption.md
@@ -1,7 +1,6 @@
 ---
 title: 干扰（Disruption）
 id: disruption
-date: 2019-09-10
 full_link: /zh-cn/docs/concepts/workloads/pods/disruptions/
 short_description: >
    导致 Pod 服务停止的事件。
@@ -12,7 +11,6 @@ tags:
 <!-- 
 title: Disruption
 id: disruption
-date: 2019-09-10
 full_link: /docs/concepts/workloads/pods/disruptions/
 short_description: >
   An event that leads to Pod(s) going out of service

--- a/content/zh-cn/docs/reference/glossary/docker.md
+++ b/content/zh-cn/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker 是一种可以提供操作系统级别虚拟化（也称作容器）的软件技术。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker is a software technology providing operating-system-level virtualization also known as containers.

--- a/content/zh-cn/docs/reference/glossary/dockershim.md
+++ b/content/zh-cn/docs/reference/glossary/dockershim.md
@@ -1,7 +1,6 @@
 ---
 title: Dockershim
 id: dockershim
-date: 2022-04-15
 full_link: /zh-cn/dockershim
 short_description: >
    dockershim 是 Kubernetes v1.23 及之前版本中的一个组件，Kubernetes 系统组件通过它与 Docker Engine 通信。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Dockershim
 id: dockershim
-date: 2022-04-15
 full_link: /dockershim
 short_description: >
    A component of Kubernetes v1.23 and earlier, which allows Kubernetes system components to communicate with Docker Engine.

--- a/content/zh-cn/docs/reference/glossary/downstream.md
+++ b/content/zh-cn/docs/reference/glossary/downstream.md
@@ -1,7 +1,6 @@
 ---
 title: 下游（Downstream）
 id: downstream
-date: 2018-04-12
 full_link: 
 short_description: >
   可以指：Kubernetes 生态系统中依赖于核心 Kubernetes 代码库或分支代码库的代码。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Downstream (disambiguation)
 id: downstream
-date: 2018-04-12
 full_link: 
 short_description: >
   May refer to: code in the Kubernetes ecosystem that depends upon the core Kubernetes codebase or a forked repo.

--- a/content/zh-cn/docs/reference/glossary/downward-api.md
+++ b/content/zh-cn/docs/reference/glossary/downward-api.md
@@ -1,7 +1,6 @@
 ---
 title: Downward API
 id: downward-api
-date: 2022-03-21
 short_description: >
   将 Pod 和容器字段值暴露给容器中运行的代码的机制。
 aka:
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Downward API
 id: downward-api
-date: 2022-03-21
 short_description: >
   A mechanism to expose Pod and container field values to code running in a container.
 aka:

--- a/content/zh-cn/docs/reference/glossary/dra.md
+++ b/content/zh-cn/docs/reference/glossary/dra.md
@@ -1,7 +1,6 @@
 ---
 title: 动态资源分配
 id: dra
-date: 2025-05-13
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/
 short_description: >
   Kubernetes 提供的一项特性，用于在 Pod 之间请求和共享资源，例如硬件加速器。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Dynamic Resource Allocation
 id: dra
-date: 2025-05-13
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/
 short_description: >
   A Kubernetes feature for requesting and sharing resources, like hardware

--- a/content/zh-cn/docs/reference/glossary/drain.md
+++ b/content/zh-cn/docs/reference/glossary/drain.md
@@ -1,7 +1,6 @@
 ---
 title: 腾空
 id: drain
-date: 2024-12-27
 full_link:
 short_description: >
   从 Node 中安全地驱逐 Pod，为节点维护或移除做好准备。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Drain
 id: drain
-date: 2024-12-27
 full_link:
 short_description: >
   Safely evicts Pods from a Node to prepare for maintenance or removal.

--- a/content/zh-cn/docs/reference/glossary/duration.md
+++ b/content/zh-cn/docs/reference/glossary/duration.md
@@ -1,7 +1,6 @@
 ---
 title: Duration
 id: duration
-date: 2024-10-05
 full_link:
 short_description: >
   表示时间量的字符串值。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Duration
 id: duration
-date: 2024-10-05
 full_link:
 short_description: >
   A string value representing an amount of time.

--- a/content/zh-cn/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/zh-cn/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,7 +1,6 @@
 ---
 title: 动态卷制备（Dynamic Volume Provisioning）
 id: dynamicvolumeprovisioning
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/storage/dynamic-provisioning/
 short_description: >
   允许用户请求自动创建存储卷。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Dynamic Volume Provisioning
 id: dynamicvolumeprovisioning
-date: 2018-04-12
 full_link: /docs/concepts/storage/dynamic-provisioning
 short_description: >
   Allows users to request automatic creation of storage  Volumes.

--- a/content/zh-cn/docs/reference/glossary/endpoint-slice.md
+++ b/content/zh-cn/docs/reference/glossary/endpoint-slice.md
@@ -1,7 +1,6 @@
 ---
 title: EndpointSlice
 id: endpoint-slice
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/services-networking/endpoint-slices/
 short_description: >
   EndpointSlices 跟踪提供 Service 的 Pod 的 IP 地址。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: EndpointSlice
 id: endpoint-slice
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/endpoint-slices/
 short_description: >
   EndpointSlices track the IP addresses of Pods for Services.

--- a/content/zh-cn/docs/reference/glossary/endpoint.md
+++ b/content/zh-cn/docs/reference/glossary/endpoint.md
@@ -1,7 +1,6 @@
 ---
 title: 端点（Endpoints）
 id: endpoints
-date: 2020-04-23
 full_link: /zh-cn/docs/concepts/services-networking/service/#endpoints
 short_description: >
   表示 Service 端点的 API（已弃用）
@@ -11,7 +10,6 @@ tags:
 <!--
 title: Endpoints
 id: endpoints
-date: 2020-04-23
 full_link: /docs/concepts/services-networking/service/#endpoints
 short_description: >
   (Deprecated) API representing endpoints of a Service

--- a/content/zh-cn/docs/reference/glossary/ephemeral-container.md
+++ b/content/zh-cn/docs/reference/glossary/ephemeral-container.md
@@ -1,7 +1,6 @@
 ---
 title: 临时容器（Ephemeral Container）
 id: ephemeral-container
-date: 2019-08-26
 full_link: /zh-cn/docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
   你可以在 Pod 中临时运行的一种容器类型
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Ephemeral Container
 id: ephemeral-container
-date: 2019-08-26
 full_link: /docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
   A type of container type that you can temporarily run inside a Pod

--- a/content/zh-cn/docs/reference/glossary/etcd.md
+++ b/content/zh-cn/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /zh-cn/docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   一致且高可用的键值存储，用作 Kubernetes 所有集群数据的后台数据库。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Consistent and highly-available key value store used as backing store of Kubernetes for all cluster data.

--- a/content/zh-cn/docs/reference/glossary/event.md
+++ b/content/zh-cn/docs/reference/glossary/event.md
@@ -1,7 +1,6 @@
 ---
 title: 事件（Event）
 id: event
-date: 2022-01-16
 full_link: /zh-cn/docs/reference/kubernetes-api/cluster-resources/event-v1/
 short_description: >
   描述集群中某些状态变化的 Kubernetes 对象。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Event
 id: event
-date: 2022-01-16
 full_link: /docs/reference/kubernetes-api/cluster-resources/event-v1/
 short_description: >
    Kubernetes objects that describe some state change in the cluster.

--- a/content/zh-cn/docs/reference/glossary/eviction.md
+++ b/content/zh-cn/docs/reference/glossary/eviction.md
@@ -1,7 +1,6 @@
 ---
 title: 驱逐（Eviction）
 id: eviction
-date: 2021-05-08
 full_link: /zh-cn/docs/concepts/scheduling-eviction/
 short_description: >
     终止节点上一个或多个 Pod 的过程。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Eviction
 id: eviction
-date: 2021-05-08
 full_link: /docs/concepts/scheduling-eviction/
 short_description: >
     Process of terminating one or more Pods on Nodes

--- a/content/zh-cn/docs/reference/glossary/extensions.md
+++ b/content/zh-cn/docs/reference/glossary/extensions.md
@@ -1,7 +1,6 @@
 ---
 title: 扩展组件（Extensions）
 id: Extensions
-date: 2019-02-01
 full_link: /zh-cn/docs/concepts/extend-kubernetes/#extensions
 short_description: >
   扩展组件（Extensions）是扩展并与 Kubernetes 深度集成以支持新型硬件的软件组件。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Extensions
 id: Extensions
-date: 2019-02-01
 full_link: /docs/concepts/extend-kubernetes/#extensions
 short_description: >
   Extensions are software components that extend and deeply integrate with Kubernetes to support

--- a/content/zh-cn/docs/reference/glossary/feature-gates.md
+++ b/content/zh-cn/docs/reference/glossary/feature-gates.md
@@ -1,7 +1,6 @@
 ---
 title: 特性门控（Feature gate）
 id: feature-gate
-date: 2023-01-12
 full_link: /zh-cn/docs/reference/command-line-tools-reference/feature-gates/
 short_description: >
   一种控制是否启用某特定 Kubernetes 特性的方法。
@@ -15,7 +14,6 @@ tags:
 ---
 title: Feature gate
 id: feature-gate
-date: 2023-01-12
 full_link: /docs/reference/command-line-tools-reference/feature-gates/
 short_description: >
   A way to control whether or not a particular Kubernetes feature is enabled.

--- a/content/zh-cn/docs/reference/glossary/finalizer.md
+++ b/content/zh-cn/docs/reference/glossary/finalizer.md
@@ -1,7 +1,6 @@
 ---
 title: Finalizer
 id: finalizer
-date: 2021-07-07
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
   一个带有命名空间的键，告诉 Kubernetes 等到特定的条件被满足后，
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Finalizer
 id: finalizer
-date: 2021-07-07
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
   A namespaced key that tells Kubernetes to wait until specific conditions are met

--- a/content/zh-cn/docs/reference/glossary/flexvolume.md
+++ b/content/zh-cn/docs/reference/glossary/flexvolume.md
@@ -1,7 +1,6 @@
 ---
 title: FlexVolume
 id: flexvolume
-date: 2018-06-25
 full_link: /zh-cn/docs/concepts/storage/volumes/#flexvolume
 short_description: >
   FlexVolume 是一个已弃用的接口，用于创建树外卷插件。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: FlexVolume
 id: flexvolume
-date: 2018-06-25
 full_link: /docs/concepts/storage/volumes/#flexvolume
 short_description: >
   FlexVolume is a deprecated interface for creating out-of-tree volume plugins. The {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}} is a newer interface that addresses several problems with FlexVolume.

--- a/content/zh-cn/docs/reference/glossary/garbage-collection.md
+++ b/content/zh-cn/docs/reference/glossary/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 title: 垃圾收集（Garbage Collection）
 id: garbage-collection
-date: 2021-07-07
 full_link: /zh-cn/docs/concepts/architecture/garbage-collection/
 short_description: >
   Kubernetes 用于清理集群资源的各种机制的统称。
@@ -14,7 +13,6 @@ tags:
 <!-- 
 title: Garbage Collection
 id: garbage-collection
-date: 2021-07-07
 full_link: /docs/concepts/architecture/garbage-collection/
 short_description: >
   A collective term for the various mechanisms Kubernetes uses to clean up cluster

--- a/content/zh-cn/docs/reference/glossary/gateway.md
+++ b/content/zh-cn/docs/reference/glossary/gateway.md
@@ -1,7 +1,6 @@
 ---
 title: Gateway API
 id: gateway-api
-date: 2023-10-19
 full_link: /zh-cn/docs/concepts/services-networking/gateway/
 short_description: >
   Kubernetes 中服务网络建模所用的 API。
@@ -16,7 +15,6 @@ tags:
 <!--
 title: Gateway API
 id: gateway-api
-date: 2023-10-19
 full_link: /docs/concepts/services-networking/gateway/
 short_description: >
   An API for modeling service networking in Kubernetes.

--- a/content/zh-cn/docs/reference/glossary/group-version-resource.md
+++ b/content/zh-cn/docs/reference/glossary/group-version-resource.md
@@ -1,7 +1,6 @@
 ---
 title: 组版本资源（Group Version Resource）
 id: gvr
-date: 2023-07-24
 short_description: >
   Kubernetes API 的 API 组、API 版本和名称。
 aka: ["GVR"]
@@ -11,7 +10,6 @@ tags:
 <!--
 title: Group Version Resource
 id: gvr
-date: 2023-07-24
 short_description: >
   The API group, API version and name of a Kubernetes API.
 

--- a/content/zh-cn/docs/reference/glossary/helm-chart.md
+++ b/content/zh-cn/docs/reference/glossary/helm-chart.md
@@ -1,7 +1,6 @@
 ---
 title: Helm Chart
 id: helm-chart
-date: 2018-04-12
 full_link: https://helm.sh/zh/docs/topics/charts/
 short_description: >
   Helm Chart 是一组预先定义的 Kubernetes 配置所构成的包，可以使用 Helm 工具对其进行管理。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Helm Chart
 id: helm-chart
-date: 2018-04-12
 full_link: https://helm.sh/docs/topics/charts/
 short_description: >
   A package of pre-configured Kubernetes configurations that can be managed with the Helm tool.

--- a/content/zh-cn/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/zh-cn/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,7 +1,6 @@
 ---
 title: Pod 水平自动扩缩器
 id: horizontal-pod-autoscaler
-date: 2018-04-12
 full_link: /zh-cn/docs/tasks/run-application/horizontal-pod-autoscale/
 short_description: >
   此对象根据目标资源利用率或自定义度量目标自动扩缩 Pod 副本的数量。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Horizontal Pod Autoscaler
 id: horizontal-pod-autoscaler
-date: 2018-04-12
 full_link: /docs/tasks/run-application/horizontal-pod-autoscale/
 short_description: >
   Object that automatically scales the number of pod replicas based on targeted resource utilization or custom metric targets.

--- a/content/zh-cn/docs/reference/glossary/host-aliases.md
+++ b/content/zh-cn/docs/reference/glossary/host-aliases.md
@@ -1,7 +1,6 @@
 ---
 title: HostAliases
 id: HostAliases
-date: 2019-01-31
 full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
 short_description: >
   主机别名 (HostAliases) 是一组 IP 地址和主机名的映射，用于注入到 Pod 内的 hosts 文件。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: HostAliases
 id: HostAliases
-date: 2019-01-31
 full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
 short_description: >
   A HostAliases is a mapping between the IP address and hostname to be injected into a Pod's hosts file.

--- a/content/zh-cn/docs/reference/glossary/image.md
+++ b/content/zh-cn/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: 镜像（Image）
 id: image
-date: 2018-04-12
 full_link: 
 short_description: >
   镜像（Image）是保存的容器实例，它打包了应用运行所需的一组软件。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Image
 id: image
-date: 2018-04-12
 full_link: 
 short_description: >
   Stored instance of a container that holds a set of software needed to run an application.

--- a/content/zh-cn/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/zh-cn/docs/reference/glossary/immutable-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: 不可变基础设施
 id: immutable-infrastructure
-date: 2024-03-25
 full_link:
 short_description: >
   不可变基础设施指的是一旦部署就不能变更的计算机基础设施（虚拟机、容器和网络设施）
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Immutable Infrastructure
 id: immutable-infrastructure
-date: 2024-03-25
 full_link:
 short_description: >
   Immutable Infrastructure refers to computer infrastructure (virtual machines, containers, network appliances) that cannot be changed once deployed

--- a/content/zh-cn/docs/reference/glossary/infrastructure-resource.md
+++ b/content/zh-cn/docs/reference/glossary/infrastructure-resource.md
@@ -1,7 +1,6 @@
 ---
 title: 资源（基础设施）
 id: infrastructure-resource
-date: 2025-02-09
 short_description: >
   数量确定的可供使用的基础设施（CPU、内存等）。
 
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Resource (infrastructure)
 id: infrastructure-resource
-date: 2025-02-09
 short_description: >
   A defined amount of infrastructure available for consumption (CPU, memory, etc).
 

--- a/content/zh-cn/docs/reference/glossary/ingress.md
+++ b/content/zh-cn/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/services-networking/ingress/
 short_description: >
   Ingress 是对集群中服务的外部访问进行管理的 API 对象，典型的访问方式是 HTTP。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/ingress/
 short_description: >
   An API object that manages external access to the services in a cluster, typically HTTP.

--- a/content/zh-cn/docs/reference/glossary/init-container.md
+++ b/content/zh-cn/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: Init 容器（Init Container）
 id: init-container
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/pods/init-containers/
 short_description: >
   应用容器运行前必须先运行完成的一个或多个 Init 容器（Init Container）。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Init Container
 id: init-container
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/init-containers/
 short_description: >
   One or more initialization containers that must run to completion before any app containers run.

--- a/content/zh-cn/docs/reference/glossary/istio.md
+++ b/content/zh-cn/docs/reference/glossary/istio.md
@@ -1,7 +1,6 @@
 ---
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   Istio 是一个（非 Kubernetes 特有的）开放平台，提供了一种统一的方式来集成微服务、管理流量、实施策略和汇总度量数据。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   An open platform (not Kubernetes-specific) that provides a uniform way to integrate microservices, manage traffic flow, enforce policies, and aggregate telemetry data.

--- a/content/zh-cn/docs/reference/glossary/job.md
+++ b/content/zh-cn/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/controllers/job/
 short_description: >
   Job 是需要运行完成的确定性的或批量的任务。
@@ -16,7 +15,6 @@ tags:
 <!--
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/job/
 short_description: >
   A finite or batch task that runs to completion.

--- a/content/zh-cn/docs/reference/glossary/jwt.md
+++ b/content/zh-cn/docs/reference/glossary/jwt.md
@@ -1,7 +1,6 @@
 ---
 title: JSON Web 令牌 (JWT)
 id: jwt
-date: 2023-01-17
 full_link: https://www.rfc-editor.org/rfc/rfc7519
 short_description: >
   JWT 是用来表示在两方之间所转移的权限声明的一种方式。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: JSON Web Token (JWT)
 id: jwt
-date: 2023-01-17
 full_link: https://www.rfc-editor.org/rfc/rfc7519
 short_description: >
   A means of representing claims to be transferred between two parties.

--- a/content/zh-cn/docs/reference/glossary/kops.md
+++ b/content/zh-cn/docs/reference/glossary/kops.md
@@ -1,7 +1,6 @@
 ---
 title: kOps (Kubernetes Operations)
 id: kops
-date: 2018-04-12
 full_link: /docs/setup/production-environment/kops/
 short_description: >
   kOps 不仅会帮助你创建、销毁、升级和维护生产级、高可用性的 Kubernetes 集群，
@@ -15,7 +14,6 @@ tags:
 <!--
 title: kOps (Kubernetes Operations)
 id: kops
-date: 2018-04-12
 full_link: /docs/setup/production-environment/kops/
 short_description: >
   kOps will not only help you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes cluster, but it will also provision the necessary cloud infrastructure.

--- a/content/zh-cn/docs/reference/glossary/kube-apiserver.md
+++ b/content/zh-cn/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: API 服务器
 id: kube-apiserver
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/architecture/#kube-apiserver
 short_description: >
   提供 Kubernetes API 服务的控制面组件。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: API server
 id: kube-apiserver
-date: 2018-04-12
 full_link: /docs/concepts/architecture/#kube-apiserver
 short_description: >
   Control plane component that serves the Kubernetes API.

--- a/content/zh-cn/docs/reference/glossary/kube-controller-manager.md
+++ b/content/zh-cn/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   主节点上运行控制器的组件。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   Component on the master that runs controllers.

--- a/content/zh-cn/docs/reference/glossary/kube-proxy.md
+++ b/content/zh-cn/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` 是集群中每个节点上运行的网络代理。
@@ -14,7 +13,6 @@ tags:
 <!-- ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` is a network proxy that runs on each node in the cluster.

--- a/content/zh-cn/docs/reference/glossary/kube-scheduler.md
+++ b/content/zh-cn/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/command-line-tools-reference/kube-scheduler/
 short_description: >
   控制平面组件，负责监视新创建的、未指定运行节点的 Pod，选择节点让 Pod 在上面运行。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-scheduler/
 short_description: >
   Control plane component that watches for newly created pods with no assigned node, and selects a node for them to run on.

--- a/content/zh-cn/docs/reference/glossary/kubeadm.md
+++ b/content/zh-cn/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/setup-tools/kubeadm/
 short_description: >
   用来快速安装 Kubernetes 并搭建安全稳定的集群的工具。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /docs/reference/setup-tools/kubeadm/
 short_description: >
   A tool for quickly installing Kubernetes and setting up a secure cluster.

--- a/content/zh-cn/docs/reference/glossary/kubectl.md
+++ b/content/zh-cn/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/kubectl/
 short_description: >
   kubectl 是用来和 Kubernetes 集群进行通信的命令行工具。
@@ -17,7 +16,6 @@ tags:
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /docs/reference/kubectl/
 short_description: >
   A command line tool for communicating with a Kubernetes cluster.

--- a/content/zh-cn/docs/reference/glossary/kubelet.md
+++ b/content/zh-cn/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/command-line-tools-reference/kubelet
 short_description: >
   一个在集群中每个节点上运行的代理。它保证容器都运行在 Pod 中。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kubelet
 short_description: >
   An agent that runs on each node in the cluster. It makes sure that containers are running in a pod.

--- a/content/zh-cn/docs/reference/glossary/kubernetes-api.md
+++ b/content/zh-cn/docs/reference/glossary/kubernetes-api.md
@@ -1,7 +1,6 @@
 ---
 title: Kubernetes API
 id: kubernetes-api
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/overview/kubernetes-api/
 short_description: >
   Kubernetes API 是通过 RESTful 接口提供 Kubernetes 功能服务并负责集群状态存储的应用程序。
@@ -16,7 +15,6 @@ tags:
 ---
 title: Kubernetes API
 id: kubernetes-api
-date: 2018-04-12
 full_link: /docs/concepts/overview/kubernetes-api/
 short_description: >
   The application that serves Kubernetes functionality through a RESTful interface and stores the state of the cluster.

--- a/content/zh-cn/docs/reference/glossary/label.md
+++ b/content/zh-cn/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: 标签（Label）
 id: label
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/labels/
 short_description: >
   用来为对象设置可标识的属性标记；这些标记对用户而言是有意义且重要的。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Label
 id: label
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Tags objects with identifying attributes that are meaningful and relevant to users.

--- a/content/zh-cn/docs/reference/glossary/limitrange.md
+++ b/content/zh-cn/docs/reference/glossary/limitrange.md
@@ -1,7 +1,6 @@
 ---
 title: LimitRange
 id: limitrange
-date: 2019-04-15
 full_link:  /zh-cn/docs/concepts/policy/limit-range/
 short_description: >
   提供约束来限制命名空间中每个容器或 Pod 的资源消耗。
@@ -17,7 +16,6 @@ related:
 <!--
 title: LimitRange
 id: limitrange
-date: 2019-04-15
 full_link:  /docs/concepts/policy/limit-range/
 short_description: >
   Provides constraints to limit resource consumption per Containers or Pods in a namespace.

--- a/content/zh-cn/docs/reference/glossary/logging.md
+++ b/content/zh-cn/docs/reference/glossary/logging.md
@@ -1,7 +1,6 @@
 ---
 title: 日志（Logging）
 id: logging
-date: 2019-04-04
 full_link: /zh-cn/docs/concepts/cluster-administration/logging/
 short_description: >
   日志是集群或应用程序记录的事件列表。
@@ -17,7 +16,6 @@ tags:
 ---
 title: Logging
 id: logging
-date: 2019-04-04
 full_link: /zh-cn/docs/concepts/cluster-administration/logging/
 short_description: >
   Logs are the list of events that are logged by cluster or application.

--- a/content/zh-cn/docs/reference/glossary/managed-service.md
+++ b/content/zh-cn/docs/reference/glossary/managed-service.md
@@ -1,7 +1,6 @@
 ---
 title: 托管服务
 id: managed-service
-date: 2018-04-12
 full_link: 
 short_description: >
   由第三方供应商负责维护的一种软件产品。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Managed Service
 id: managed-service
-date: 2018-04-12
 full_link: 
 short_description: >
   A software offering maintained by a third-party provider.

--- a/content/zh-cn/docs/reference/glossary/manifest.md
+++ b/content/zh-cn/docs/reference/glossary/manifest.md
@@ -1,7 +1,6 @@
 ---
 title: 清单（Manifest）
 id: manifest
-date: 2019-06-28
 short_description: >
   一个或多个 Kubernetes API 对象的序列化规范。
 
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Manifest
 id: manifest
-date: 2019-06-28
 short_description: >
   A serialized specification of one or more Kubernetes API objects.
 

--- a/content/zh-cn/docs/reference/glossary/master.md
+++ b/content/zh-cn/docs/reference/glossary/master.md
@@ -1,7 +1,6 @@
 ---
 title: Master
 id: master
-date: 2020-04-16
 short_description: >
   遗留术语，作为运行控制平面的节点的同义词使用。
 
@@ -15,7 +14,6 @@ tags:
 ---
 title: Master
 id: master
-date: 2020-04-16
 short_description: >
   Legacy term, used as synonym for nodes running the control plane.
 

--- a/content/zh-cn/docs/reference/glossary/member.md
+++ b/content/zh-cn/docs/reference/glossary/member.md
@@ -1,7 +1,6 @@
 ---
 title: 成员（Member）
 id: member
-date: 2018-04-12
 full_link: 
 short_description: >
   K8s 社区中持续活跃的贡献者。
@@ -15,7 +14,6 @@ tags:
 ---
 title: Member
 id: member
-date: 2018-04-12
 full_link: 
 short_description: >
   A continuously active contributor in the K8s community.

--- a/content/zh-cn/docs/reference/glossary/minikube.md
+++ b/content/zh-cn/docs/reference/glossary/minikube.md
@@ -1,7 +1,6 @@
 ---
 title: Minikube
 id: minikube
-date: 2018-04-12
 full_link: /docs/tasks/tools/#minikube
 short_description: >
   Minikube 是用来在本地运行 Kubernetes 的一种工具。
@@ -16,7 +15,6 @@ tags:
 ---
 title: Minikube
 id: minikube
-date: 2018-04-12
 full_link: /docs/tasks/tools/#minikube
 short_description: >
   A tool for running Kubernetes locally.

--- a/content/zh-cn/docs/reference/glossary/mirror-pod.md
+++ b/content/zh-cn/docs/reference/glossary/mirror-pod.md
@@ -1,7 +1,6 @@
 ---
 title: 镜像 Pod（Mirror Pod）
 id: 静态-pod
-date: 2019-08-06
 short_description: >
   API 服务器中的一个对象，用于跟踪 kubelet 上的静态 pod。
 
@@ -13,7 +12,6 @@ tags:
 ---
 title: Mirror Pod
 id: mirror-pod
-date: 2019-08-06
 short_description: >
   An object in the API server that tracks a static pod on a kubelet.
 

--- a/content/zh-cn/docs/reference/glossary/mixed-version-proxy.md
+++ b/content/zh-cn/docs/reference/glossary/mixed-version-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: 混合版本代理
 id: mvp
-date: 2023-07-24
 full_link: /zh-cn/docs/concepts/architecture/mixed-version-proxy/
 short_description: >
   此特性使 kube-apiserver 能够将资源请求代理到另一个对等 API 服务器。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Mixed Version Proxy (MVP)
 id: mvp
-date: 2023-07-24
 full_link: /docs/concepts/architecture/mixed-version-proxy/
 short_description: >
   Feature that lets a kube-apiserver proxy a resource request to a different peer API server. 

--- a/content/zh-cn/docs/reference/glossary/name.md
+++ b/content/zh-cn/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: 名称（Name）
 id: name
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/names/
 short_description: >
   客户端提供的字符串，用来指代资源 URL 中的对象，如 `/api/v1/pods/some-name`。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Name
 id: name
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   A client-provided string that refers to an object in a resource URL, such as `/api/v1/pods/some-name`.

--- a/content/zh-cn/docs/reference/glossary/namespace.md
+++ b/content/zh-cn/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: 名字空间（Namespace）
 id: namespace
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/namespaces/
 short_description: >
   名字空间是 Kubernetes 用来支持隔离单个集群中的资源组的一种抽象。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Namespace
 id: namespace
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/namespaces
 short_description: >
   An abstraction used by Kubernetes to support isolation of groups of resources within a single cluster.

--- a/content/zh-cn/docs/reference/glossary/network-policy.md
+++ b/content/zh-cn/docs/reference/glossary/network-policy.md
@@ -1,7 +1,6 @@
 ---
 title: 网络策略
 id: network-policy
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/services-networking/network-policies/
 short_description: >
   网络策略是一种规范，规定了允许 Pod 组之间、Pod 与其他网络端点之间以怎样的方式进行通信。
@@ -16,7 +15,6 @@ tags:
 <!--
 title: Network Policy
 id: network-policy
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/network-policies/
 short_description: >
   A specification of how groups of Pods are allowed to communicate with each other and with other network endpoints.

--- a/content/zh-cn/docs/reference/glossary/node-pressure-eviction.md
+++ b/content/zh-cn/docs/reference/glossary/node-pressure-eviction.md
@@ -1,7 +1,6 @@
 ---
 title: 节点压力驱逐
 id: node-pressure-eviction
-date: 2021-05-13
 full_link: /zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction/
 short_description: >
   节点压力驱逐是 kubelet 主动使 Pod 失败以回收节点上{{< glossary_tooltip text="资源" term_id="infrastructure-resource" >}}的过程。
@@ -13,7 +12,6 @@ tags:
 <!-- 
 title: Node-pressure eviction
 id: node-pressure-eviction
-date: 2021-05-13
 full_link: /docs/concepts/scheduling-eviction/node-pressure-eviction/
 short_description: >
   Node-pressure eviction is the process by which the kubelet proactively fails

--- a/content/zh-cn/docs/reference/glossary/node.md
+++ b/content/zh-cn/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: 节点（Node）
 id: node
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/architecture/nodes/
 short_description: >
   Kubernetes 中的工作机器称作节点。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Node
 id: node
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/architecture/nodes/
 short_description: >
   A node is a worker machine in Kubernetes.

--- a/content/zh-cn/docs/reference/glossary/object.md
+++ b/content/zh-cn/docs/reference/glossary/object.md
@@ -1,7 +1,6 @@
 ---
 title: 对象（Object）
 id: object
-date: 2020-10-12
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/#kubernetes-objects
 short_description: >
    Kubernetes 系统中的实体，代表了集群的部分状态。
@@ -13,7 +12,6 @@ tags:
 <!-- 
 title: Object
 id: object
-date: 2020-10-12
 full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
 short_description: >
    An entity in the Kubernetes system, representing part of the state of your cluster.

--- a/content/zh-cn/docs/reference/glossary/operator-pattern.md
+++ b/content/zh-cn/docs/reference/glossary/operator-pattern.md
@@ -1,7 +1,6 @@
 ---
 title: Operator 模式
 id: operator-pattern
-date: 2019-05-21
 full_link: /zh-cn/docs/concepts/extend-kubernetes/operator/
 short_description: >
   一种用于管理自定义资源的专用控制器
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Operator pattern
 id: operator-pattern
-date: 2019-05-21
 full_link: /docs/concepts/extend-kubernetes/operator/
 short_description: >
   A specialized controller used to manage a custom resource

--- a/content/zh-cn/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/zh-cn/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: 持久卷申领（Persistent Volume Claim）
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   声明在持久卷中定义的存储资源，以便可以将其挂载为容器中的卷。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Persistent Volume Claim
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   Claims storage resources defined in a PersistentVolume so that it can be mounted as a volume in a container.

--- a/content/zh-cn/docs/reference/glossary/persistent-volume.md
+++ b/content/zh-cn/docs/reference/glossary/persistent-volume.md
@@ -1,7 +1,6 @@
 ---
 title: 持久卷（Persistent Volume）
 id: persistent-volume
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/storage/persistent-volumes/
 short_description: >
   持久卷是代表集群中一块存储空间的 API 对象。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Persistent Volume
 id: persistent-volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/
 short_description: >
   An API object that represents a piece of storage in the cluster.

--- a/content/zh-cn/docs/reference/glossary/platform-developer.md
+++ b/content/zh-cn/docs/reference/glossary/platform-developer.md
@@ -1,7 +1,6 @@
 ---
 title: 平台开发人员（Platform Developer）
 id: platform-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   定制 Kubernetes 平台以满足自己的项目需求的人。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Platform Developer
 id: platform-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   A person who customizes the Kubernetes platform to fit the needs of their project.

--- a/content/zh-cn/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/zh-cn/docs/reference/glossary/pod-disruption-budget.md
@@ -2,7 +2,6 @@
 id: pod-disruption-budget
 title: Pod Disruption Budget
 full-link: /zh-cn/docs/concepts/workloads/pods/disruptions/
-date: 2019-02-12
 short_description: >
   Pod Disruption Budget 是这样一种对象：它保证在出现主动干扰（Voluntary Disruption）时，
   多实例应用的 Pod 不会少于一定的数量。
@@ -21,7 +20,6 @@ tags:
 id: pod-disruption-budget
 title: Pod Disruption Budget
 full-link: /docs/concepts/workloads/pods/disruptions/
-date: 2019-02-12
 short_description: >
  An object that limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions.
 

--- a/content/zh-cn/docs/reference/glossary/pod-disruption.md
+++ b/content/zh-cn/docs/reference/glossary/pod-disruption.md
@@ -2,7 +2,6 @@
 id: pod-disruption
 title: Pod 干扰
 full_link: /zh-cn/docs/concepts/workloads/pods/disruptions/
-date: 2021-05-12
 short_description: >
   自愿或非自愿地终止节点上的 Pod 的过程。
 
@@ -17,7 +16,6 @@ tags:
 id: pod-disruption
 title: Pod Disruption
 full_link: /docs/concepts/workloads/pods/disruptions/
-date: 2021-05-12
 short_description: >
   The process by which Pods on Nodes are terminated either voluntarily or involuntarily.
 

--- a/content/zh-cn/docs/reference/glossary/pod-lifecycle.md
+++ b/content/zh-cn/docs/reference/glossary/pod-lifecycle.md
@@ -1,7 +1,6 @@
 ---
 title: Pod 生命周期
 id: pod-lifecycle
-date: 2019-02-17
 full-link: /zh-cn/docs/concepts/workloads/pods/pod-lifecycle/
 related:
  - pod
@@ -15,7 +14,6 @@ short_description: >
 <!--
 title: Pod Lifecycle
 id: pod-lifecycle
-date: 2019-02-17
 full-link: /docs/concepts/workloads/pods/pod-lifecycle/
 related:
  - pod

--- a/content/zh-cn/docs/reference/glossary/pod-priority.md
+++ b/content/zh-cn/docs/reference/glossary/pod-priority.md
@@ -1,7 +1,6 @@
 ---
 title: Pod 优先级（Pod Priority）
 id: pod-priority
-date: 2019-01-31
 full_link: /zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
 short_description: >
   Pod 优先级表示一个 Pod 相对于其他 Pod 的重要性。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Pod Priority
 id: pod-priority
-date: 2019-01-31
 full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
 short_description: >
   Pod Priority indicates the importance of a Pod relative to other Pods.

--- a/content/zh-cn/docs/reference/glossary/pod-security-policy.md
+++ b/content/zh-cn/docs/reference/glossary/pod-security-policy.md
@@ -1,7 +1,6 @@
 ---
 title: Pod 安全策略
 id: pod-security-policy
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/security/pod-security-policy/
 short_description: >
   移除了强制执行 Pod 安全限制的 API。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Pod Security Policy
 id: pod-security-policy
-date: 2018-04-12
 full_link: /docs/concepts/security/pod-security-policy/
 short_description: >
   Removed API that enforced Pod security restrictions.

--- a/content/zh-cn/docs/reference/glossary/pod-template.md
+++ b/content/zh-cn/docs/reference/glossary/pod-template.md
@@ -1,7 +1,6 @@
 ---
 title: PodTemplate
 id: pod-template
-date: 2024-10-13
 short_description: >
   创建 Pod 所用的模板。
 
@@ -13,7 +12,6 @@ tags:
 <!--
 title: PodTemplate
 id: pod-template
-date: 2024-10-13
 short_description: >
   A template for creating Pods.
 

--- a/content/zh-cn/docs/reference/glossary/pod.md
+++ b/content/zh-cn/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/pods/
 short_description: >
   Pod 表示你的集群上一组正在运行的容器。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/
 short_description: >
   A Pod represents a set of running containers in your cluster.

--- a/content/zh-cn/docs/reference/glossary/preemption.md
+++ b/content/zh-cn/docs/reference/glossary/preemption.md
@@ -1,7 +1,6 @@
 ---
 title: 抢占（Preemption）
 id: preemption
-date: 2019-01-31
 full_link: /zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
 short_description: >
   Kubernetes 中的抢占逻辑通过驱逐节点上的低优先级 Pod 来帮助悬决的
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Preemption
 id: preemption
-date: 2019-01-31
 full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
 short_description: >
   Preemption logic in Kubernetes helps a pending Pod to find a suitable Node by evicting low priority Pods existing on that Node.

--- a/content/zh-cn/docs/reference/glossary/priority-class.md
+++ b/content/zh-cn/docs/reference/glossary/priority-class.md
@@ -1,7 +1,6 @@
 ---
 title: PriorityClass
 id: priority-class
-date: 2024-03-19
 full_link: /zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
 short_description: >
   从类别名称到 Pod 本身调度优先级的映射。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: PriorityClass
 id: priority-class
-date: 2024-03-19
 full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
 short_description: >
   A mapping from a class name to the scheduling priority that a Pod should have.

--- a/content/zh-cn/docs/reference/glossary/probe.md
+++ b/content/zh-cn/docs/reference/glossary/probe.md
@@ -1,7 +1,6 @@
 ---
 title: 探针（Probe）
 id: probe
-date: 2023-03-21
 full_link: /zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 short_description: >
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Probe
 id: probe
-date: 2023-03-21
 full_link: /docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 short_description: >

--- a/content/zh-cn/docs/reference/glossary/proxy.md
+++ b/content/zh-cn/docs/reference/glossary/proxy.md
@@ -1,7 +1,6 @@
 ---
 title: 代理（Proxy）
 id: proxy
-date: 2019-09-10
 short_description: >
   充当客户端和服务器之间的中介的应用程序
 
@@ -13,7 +12,6 @@ tags:
 ---
 title: Proxy
 id: proxy
-date: 2019-09-10
 short_description: >
   An application acting as an intermediary beween clients and servers
 

--- a/content/zh-cn/docs/reference/glossary/qos-class.md
+++ b/content/zh-cn/docs/reference/glossary/qos-class.md
@@ -1,7 +1,6 @@
 ---
 title: QoS 类（QoS Class）
 id: qos-class
-date: 2019-04-15
 full_link: /zh-cn/docs/concepts/workloads/pods/pod-qos/
 short_description: >
   QoS 类（Quality of Service Class）为 Kubernetes 提供了一种将集群中的 Pod 分为几个类并做出有关调度和驱逐决策的方法。
@@ -18,7 +17,6 @@ related:
 ---
 title: QoS Class
 id: qos-class
-date: 2019-04-15
 full_link: /docs/concepts/workloads/pods/pod-qos/
 short_description: >
   QoS Class (Quality of Service Class) provides a way for Kubernetes to classify pods within the cluster into several classes and make decisions about scheduling and eviction.

--- a/content/zh-cn/docs/reference/glossary/quantity.md
+++ b/content/zh-cn/docs/reference/glossary/quantity.md
@@ -1,7 +1,6 @@
 ---
 title: 量纲（Quantity）
 id: quantity
-date: 2018-08-07
 full_link:
 short_description: >
   使用全数字来表示较小数值或使用 SI 后缀表示较大数值的表示法。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Quantity
 id: quantity
-date: 2018-08-07
 full_link:
 short_description: >
   A whole-number representation of small or large numbers using [SI](https://en.wikipedia.org/wiki/International_System_of_Units) suffixes.

--- a/content/zh-cn/docs/reference/glossary/rbac.md
+++ b/content/zh-cn/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: 基于角色的访问控制（RBAC）
 id: rbac
-date: 2018-04-12
 full_link: /zh-cn/docs/reference/access-authn-authz/rbac/
 short_description: >
   管理授权决策，允许管理员通过 Kubernetes API 动态配置访问策略。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: RBAC (Role-Based Access Control)
 id: rbac
-date: 2018-04-12
 full_link: /docs/reference/access-authn-authz/rbac/
 short_description: >
   Manages authorization decisions, allowing admins to dynamically configure access policies through the Kubernetes API.

--- a/content/zh-cn/docs/reference/glossary/replica-set.md
+++ b/content/zh-cn/docs/reference/glossary/replica-set.md
@@ -1,7 +1,6 @@
 ---
 title: ReplicaSet
 id: replica-set
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/controllers/replicaset/
 short_description: >
   ReplicaSet 确保一次运行指定数量的 Pod 副本。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: ReplicaSet
 id: replica-set
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/replicaset/
 short_description: >
  ReplicaSet ensures that a specified number of Pod replicas are running at one time

--- a/content/zh-cn/docs/reference/glossary/replica.md
+++ b/content/zh-cn/docs/reference/glossary/replica.md
@@ -1,7 +1,6 @@
 ---
 title: 副本（Replica）
 id: replica
-date: 2023-06-11
 full_link: 
 short_description: >
   Replicas 是 Pod 的副本，通过维护相同的实例确保可用性、可扩缩性和容错性。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Replica
 id: replica
-date: 2023-06-11
 full_link: 
 short_description: >
   Replicas are copies of pods, ensuring availability, scalability, and fault tolerance by maintaining identical instances.

--- a/content/zh-cn/docs/reference/glossary/replication-controller.md
+++ b/content/zh-cn/docs/reference/glossary/replication-controller.md
@@ -1,7 +1,6 @@
 ---
 title: 副本控制器（ReplicationController）
 id: replication-controller
-date: 2018-04-12
 full_link: 
 short_description: >
   一种管理多副本应用的（已弃用）的 API 对象。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: ReplicationController
 id: replication-controller
-date: 2018-04-12
 full_link: 
 short_description: >
   A (deprecated) API object that manages a replicated application.

--- a/content/zh-cn/docs/reference/glossary/resource-quota.md
+++ b/content/zh-cn/docs/reference/glossary/resource-quota.md
@@ -1,7 +1,6 @@
 ---
 title: 资源配额（ResourceQuota）
 id: resource-quota
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/policy/resource-quotas/
 short_description: >
   资源配额提供了限制每个命名空间的资源消耗总和的约束。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: ResourceQuota
 id: resource-quota
-date: 2018-04-12
 full_link: /docs/concepts/policy/resource-quotas/
 short_description: >
   Provides constraints that limit aggregate resource consumption per namespace.

--- a/content/zh-cn/docs/reference/glossary/resourceclaim.md
+++ b/content/zh-cn/docs/reference/glossary/resourceclaim.md
@@ -1,7 +1,6 @@
 ---
 title: ResourceClaim
 id: resourceclaim
-date: 2025-05-26
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates
 short_description: >
   描述工作负载所需的资源，例如设备。ResourceClaim 可以针对某些 DeviceClass 请求设备。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: ResourceClaim
 id: resourceclaim
-date: 2025-05-26
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates
 short_description: >
   Describes the resources that a workload needs, such as devices. ResourceClaims

--- a/content/zh-cn/docs/reference/glossary/resourceclaimtemplate.md
+++ b/content/zh-cn/docs/reference/glossary/resourceclaimtemplate.md
@@ -1,7 +1,6 @@
 ---
 title: ResourceClaimTemplate
 id: resourceclaimtemplate
-date: 2025-05-26
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates
 short_description: >
   定义一个模板，Kubernetes 据此创建 ResourceClaim。此模板用于为每个 Pod 提供对一些独立、相似的资源的访问权限。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: ResourceClaimTemplate
 id: resourceclaimtemplate
-date: 2025-05-26
 full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates
 short_description: >
   Defines a template for Kubernetes to create ResourceClaims. Used to provide

--- a/content/zh-cn/docs/reference/glossary/resourceslice.md
+++ b/content/zh-cn/docs/reference/glossary/resourceslice.md
@@ -1,7 +1,6 @@
 ---
 title: ResourceSlice
 id: resourceslice
-date: 2025-05-26
 full_link: /docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
 short_description: >
   用一个相似资源所构成的池来表示一个或多个基础设施资源（如设备）。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: ResourceSlice
 id: resourceslice
-date: 2025-05-26
 full_link: /docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
 short_description: >
   Represents one or more infrastructure resources, like devices, in a pool of

--- a/content/zh-cn/docs/reference/glossary/reviewer.md
+++ b/content/zh-cn/docs/reference/glossary/reviewer.md
@@ -1,7 +1,6 @@
 ---
 title: 评审者（Reviewer）
 id: reviewer
-date: 2018-04-12
 full_link: 
 short_description: >
   评审者是负责评审项目的某部分代码以便提高代码质量和正确性的人。
@@ -15,7 +14,6 @@ tags:
 ---
 title: Reviewer
 id: reviewer
-date: 2018-04-12
 full_link: 
 short_description: >
   A person who reviews code for quality and correctness on some part of the project.

--- a/content/zh-cn/docs/reference/glossary/secret.md
+++ b/content/zh-cn/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: Secret
 id: secret
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/configuration/secret/
 short_description: >
   Secret 用于存储敏感信息，如密码、 OAuth 令牌和 SSH 密钥。
@@ -16,7 +15,6 @@ tags:
 ---
 title: Secret
 id: secret
-date: 2018-04-12
 full_link: /docs/concepts/configuration/secret/
 short_description: >
   Stores sensitive information, such as passwords, OAuth tokens, and ssh keys.

--- a/content/zh-cn/docs/reference/glossary/security-context.md
+++ b/content/zh-cn/docs/reference/glossary/security-context.md
@@ -1,7 +1,6 @@
 ---
 title: 安全上下文（Security Context）
 id: security-context
-date: 2018-04-12
 full_link: /zh-cn/docs/tasks/configure-pod-container/security-context/
 short_description: >
   securityContext 字段定义 Pod 或容器的特权和访问控制设置，包括运行时 UID 和 GID。
@@ -15,7 +14,6 @@ tags:
 ---
 title: Security Context
 id: security-context
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/security-context/
 short_description: >
   The securityContext field defines privilege and access control settings for a Pod or container.

--- a/content/zh-cn/docs/reference/glossary/selector.md
+++ b/content/zh-cn/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: 选择算符（Selector）
 id: selector
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/labels/
 short_description: >
   选择算符允许用户通过标签对一组资源对象进行筛选过滤。
@@ -16,7 +15,6 @@ tags:
 ---
 title: Selector
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Allows users to filter a list of resources based on labels.

--- a/content/zh-cn/docs/reference/glossary/service-account.md
+++ b/content/zh-cn/docs/reference/glossary/service-account.md
@@ -1,7 +1,6 @@
 ---
 title: ServiceAccount
 id: service-account
-date: 2018-04-12
 full_link: /zh-cn/docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   为在 Pod 中运行的进程提供标识。
@@ -16,7 +15,6 @@ tags:
 ---
 title: ServiceAccount
 id: service-account
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   Provides an identity for processes that run in a Pod.

--- a/content/zh-cn/docs/reference/glossary/service-catalog.md
+++ b/content/zh-cn/docs/reference/glossary/service-catalog.md
@@ -1,7 +1,6 @@
 ---
 title: 服务目录（Service Catalog）
 id: service-catalog
-date: 2018-04-12
 full_link: 
 short_description: >
   服务目录是一种扩展 API，它能让 Kubernetes 集群中运行的应用易于使用外部托管的软件服务，例如云供应商提供的数据仓库服务。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Service Catalog
 id: service-catalog
-date: 2018-04-12
 full_link: 
 short_description: >
   A former extension API that enables applications running in Kubernetes clusters to easily use external managed software offerings, such as a datastore service offered by a cloud provider.

--- a/content/zh-cn/docs/reference/glossary/service.md
+++ b/content/zh-cn/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: 服务（Service）
 id: service
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/services-networking/service/
 short_description: >
   将运行在一组 Pods 上的应用程序公开为网络服务的抽象方法。
@@ -16,7 +15,6 @@ tags:
 ---
 title: Service
 id: service
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   A way to expose an application running on a set of Pods as a network service.

--- a/content/zh-cn/docs/reference/glossary/shuffle-sharding.md
+++ b/content/zh-cn/docs/reference/glossary/shuffle-sharding.md
@@ -1,7 +1,6 @@
 ---
 title: 混排切片（Shuffle Sharding）
 id: shuffle sharding
-date: 2020-03-04
 full_link:
 short_description: >
   一种将请求指派给队列的技术，其隔离性好过对队列个数哈希取模的方式。
@@ -15,7 +14,6 @@ tags:
 ---
 title: shuffle sharding
 id: shuffle-sharding
-date: 2020-03-04
 full_link:
 short_description: >
   A technique for assigning requests to queues that provides better isolation than hashing modulo the number of queues.

--- a/content/zh-cn/docs/reference/glossary/sidecar-container.md
+++ b/content/zh-cn/docs/reference/glossary/sidecar-container.md
@@ -1,7 +1,6 @@
 ---
 title: 边车容器
 id: sidecar-container
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/pods/sidecar-containers/
 short_description: >
   在 Pod 的整个生命期内保持运行的辅助容器。
@@ -12,7 +11,6 @@ tags:
 <!--
 title: Sidecar Container
 id: sidecar-container
-date: 2018-04-12
 full_link: 
 short_description: >
   An auxilliary container that stays running throughout the lifecycle of a Pod.

--- a/content/zh-cn/docs/reference/glossary/sig.md
+++ b/content/zh-cn/docs/reference/glossary/sig.md
@@ -1,7 +1,6 @@
 ---
 title: 特别兴趣小组（SIG）
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
 short_description: >
   共同管理大范畴 Kubernetes 开源项目中某组件或方面的一组社区成员。
@@ -15,7 +14,6 @@ tags:
 ---
 title: SIG (special interest group)
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
 short_description: >
   Community members who collectively manage an ongoing piece or aspect of the larger Kubernetes open source project.

--- a/content/zh-cn/docs/reference/glossary/spec.md
+++ b/content/zh-cn/docs/reference/glossary/spec.md
@@ -1,7 +1,6 @@
 ---
 title: Spec
 id: spec
-date: 2023-12-17
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/#object-spec-and-status
 short_description: >
   在 Kubernetes 清单中的此字段用来定义预期状态或预期配置。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Spec
 id: spec
-date: 2023-12-17
 full_link: /docs/concepts/overview/working-with-objects/#object-spec-and-status
 short_description: >
   Field in Kubernetes manifests that defines the desired state or configuration.

--- a/content/zh-cn/docs/reference/glossary/statefulset.md
+++ b/content/zh-cn/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/workloads/controllers/statefulset/
 short_description: >
   StatefulSet 用来管理某 Pod 集合的部署和扩缩，并为这些 Pod 提供持久存储和持久标识符。
@@ -16,7 +15,6 @@ tags:
 <!--
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   A StatefulSet manages deployment and scaling of a set of Pods, with durable storage and persistent identifiers for each Pod.

--- a/content/zh-cn/docs/reference/glossary/static-pod.md
+++ b/content/zh-cn/docs/reference/glossary/static-pod.md
@@ -1,7 +1,6 @@
 ---
 title: 静态 Pod（Static Pod）
 id: static-pod
-date: 2019-02-12
 full_link: /zh-cn/docs/tasks/configure-pod-container/static-pod/
 short_description: >
   静态 Pod（Static Pod）是指由特定节点上的 kubelet 守护进程直接管理的 Pod。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: Static Pod
 id: static-pod
-date: 2019-02-12
 full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
   A pod managed directly by the kubelet daemon on a specific node.

--- a/content/zh-cn/docs/reference/glossary/storage-class.md
+++ b/content/zh-cn/docs/reference/glossary/storage-class.md
@@ -1,7 +1,6 @@
 ---
 title: StorageClass
 id: storageclass
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/storage/storage-classes/
 short_description: >
   StorageClass 是管理员用来描述可用的不同存储类型的一种方法。
@@ -17,7 +16,6 @@ tags:
 ---
 title: Storage Class
 id: storageclass
-date: 2018-04-12
 full_link: /docs/concepts/storage/storage-classes
 short_description: >
   A StorageClass provides a way for administrators to describe different available storage types.

--- a/content/zh-cn/docs/reference/glossary/sysctl.md
+++ b/content/zh-cn/docs/reference/glossary/sysctl.md
@@ -1,7 +1,6 @@
 ---
 title: sysctl
 id: sysctl
-date: 2019-02-12
 full_link: /zh-cn/docs/tasks/administer-cluster/sysctl-cluster/
 short_description: >
   用于获取和设置 Unix 内核参数的接口
@@ -15,7 +14,6 @@ tags:
 ---
 title: sysctl
 id: sysctl
-date: 2019-02-12
 full_link: /docs/tasks/administer-cluster/sysctl-cluster/
 short_description: >
   An interface for getting and setting Unix kernel parameters

--- a/content/zh-cn/docs/reference/glossary/taint.md
+++ b/content/zh-cn/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: 污点（Taint）
 id: taint
-date: 2019-01-11
 full_link: /zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   污点是一种核心对象，包含三个必需的属性：key、value 和 effect。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Taint
 id: taint
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of pods on nodes or node groups.

--- a/content/zh-cn/docs/reference/glossary/toleration.md
+++ b/content/zh-cn/docs/reference/glossary/toleration.md
@@ -1,7 +1,6 @@
 ---
 title: 容忍度（Toleration）
 id: toleration
-date: 2019-01-11
 full_link: /zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   容忍度是一种核心对象，包含三个必需的属性：key、value 和 effect。
@@ -16,7 +15,6 @@ tags:
 <!--
 title: Toleration
 id: toleration
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have a matching taint.

--- a/content/zh-cn/docs/reference/glossary/uid.md
+++ b/content/zh-cn/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/overview/working-with-objects/names/
 short_description: >
   由 Kubernetes 系统生成、用来唯一标识对象的字符串。
@@ -15,7 +14,6 @@ tags:
 ---
 title: UID
 id: uid
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/names
 short_description: >
   A Kubernetes systems-generated string to uniquely identify objects.

--- a/content/zh-cn/docs/reference/glossary/upstream.md
+++ b/content/zh-cn/docs/reference/glossary/upstream.md
@@ -1,7 +1,6 @@
 ---
 title: 上游（Uptream）
 id: upstream
-date: 2018-04-12
 full_link: 
 short_description: >
   可以参考：核心 Kubernetes 仓库或作为当前仓库派生来源的来源仓库。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Upstream (disambiguation)
 id: upstream
-date: 2018-04-12
 full_link: 
 short_description: >
   May refer to: core Kubernetes or the source repo from which a repo was forked.

--- a/content/zh-cn/docs/reference/glossary/userns.md
+++ b/content/zh-cn/docs/reference/glossary/userns.md
@@ -1,7 +1,6 @@
 ---
 title: 用户名字空间
 id: userns
-date: 2021-07-13
 full_link: https://man7.org/linux/man-pages/man7/user_namespaces.7.html
 short_description: >
   一种为非特权用户模拟超级用户特权的 Linux 内核功能特性。
@@ -14,7 +13,6 @@ tags:
 <!--
 title: user namespace
 id: userns
-date: 2021-07-13
 full_link: https://man7.org/linux/man-pages/man7/user_namespaces.7.html
 short_description: >
   A Linux kernel feature to emulate superuser privilege for unprivileged users.

--- a/content/zh-cn/docs/reference/glossary/volume-plugin.md
+++ b/content/zh-cn/docs/reference/glossary/volume-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: 卷插件（Volume Plugin）
 id: volumeplugin
-date: 2018-04-12
 full_link: 
 short_description: >
   卷插件可以让 Pod 集成存储。
@@ -15,7 +14,6 @@ tags:
 ---
 title: Volume Plugin
 id: volumeplugin
-date: 2018-04-12
 full_link: 
 short_description: >
   A Volume Plugin enables integration of storage within a Pod.

--- a/content/zh-cn/docs/reference/glossary/volume.md
+++ b/content/zh-cn/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: 卷（Volume）
 id: volume
-date: 2018-04-12
 full_link: /zh-cn/docs/concepts/storage/volumes/
 short_description: >
   包含可被 Pod 中容器访问的数据的目录。
@@ -13,7 +12,6 @@ tags:
 <!--
 title: Volume
 id: volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/volumes/
 short_description: >
   A directory containing data, accessible to the containers in a pod.

--- a/content/zh-cn/docs/reference/glossary/watch.md
+++ b/content/zh-cn/docs/reference/glossary/watch.md
@@ -1,7 +1,6 @@
 ---
 title: 监视（Watch）
 id: watch
-date: 2024-07-02
 full_link: /zh-cn/docs/reference/using-api/api-concepts/#api-verbs
 short_description: >
   用于以流的形式跟踪 Kubernetes 中对象变化的动词。
@@ -15,7 +14,6 @@ tags:
 <!--
 title: Watch
 id: watch
-date: 2024-07-02
 full_link: /docs/reference/using-api/api-concepts/#api-verbs
 short_description: >
   A verb that is used to track changes to an object in Kubernetes as a stream.

--- a/content/zh-cn/docs/reference/glossary/wg.md
+++ b/content/zh-cn/docs/reference/glossary/wg.md
@@ -1,7 +1,6 @@
 ---
 title: 工作组（Working Group，WG）
 id: wg
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
 short_description: >
   工作组是为了方便讨论和（或）推进执行一些短周期、窄范围、或者从委员会和 SIG 分离出来的项目、以及跨 SIG 的活动。
@@ -15,7 +14,6 @@ tags:
 ---
 title: WG (working group)
 id: wg
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
 short_description: >
   Facilitates the discussion and/or implementation of a short-lived, narrow, or decoupled project for a committee, SIG, or cross-SIG effort.

--- a/content/zh-cn/docs/reference/glossary/workload.md
+++ b/content/zh-cn/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: 工作负载（Workload）
 id: workload
-date: 2019-02-13
 full_link: /zh-cn/docs/concepts/workloads/
 short_description: >
    工作负载是在 Kubernetes 上运行的应用程序。
@@ -13,7 +12,6 @@ tags:
 <!-- 
 title: Workload
 id: workload
-date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
    A workload is an application running on Kubernetes.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all zh-cn/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.