### PR TITLE
docs: Remove date field from Vietnamese glossary entries

### DIFF
--- a/content/vi/docs/reference/glossary/addons.md
+++ b/content/vi/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Add-on
 id: addons
-date: 2019-12-15
 full_link: /docs/concepts/cluster-administration/addons/
 short_description: >
   Các tài nguyên giúp mở rộng chức năng của Kubernetes.

--- a/content/vi/docs/reference/glossary/admission-controller.md
+++ b/content/vi/docs/reference/glossary/admission-controller.md
@@ -1,7 +1,6 @@
 ---
 title: Admission Controller
 id: admission-controller
-date: 2019-06-28
 full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   Một đoạn code chặn các yêu cầu đến Kubernetes API server trước khi lưu trữ đối tượng.

--- a/content/vi/docs/reference/glossary/affinity.md
+++ b/content/vi/docs/reference/glossary/affinity.md
@@ -1,7 +1,6 @@
 ---
 title: Affinity
 id: affinity
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
      Các quy tắc được scheduler sử dụng để xác định vị trí phân phối pod

--- a/content/vi/docs/reference/glossary/annotation.md
+++ b/content/vi/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: Chú thích (Annotation)
 id: annotation
-date: 2019-12-16
 full_link: /docs/concepts/overview/working-with-objects/annotations
 short_description: >
   Một cặp khóa-giá trị được sử dụng để đính kèm tùy ý một metadata không xác định cụ thể vào các đối tượng.

--- a/content/vi/docs/reference/glossary/api-group.md
+++ b/content/vi/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: API Group
 id: api-group
-date: 2019-12-16
 full_link: /docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
 short_description: >
   Một tập những đường dẫn tương đối đến Kubernetes API.

--- a/content/vi/docs/reference/glossary/api-resource.md
+++ b/content/vi/docs/reference/glossary/api-resource.md
@@ -1,7 +1,6 @@
 ---
 title: API resource
 id: api-resource
-date: 2025-02-09
 full_link: /docs/reference/using-api/api-concepts/#standard-api-terminology
 short_description: >
   Một thực thể Kubernetes, đại diện cho một endpoint trên Kubernetes API server.

--- a/content/vi/docs/reference/glossary/app-container.md
+++ b/content/vi/docs/reference/glossary/app-container.md
@@ -1,7 +1,6 @@
 ---
 title: App Container
 id: app-container
-date: 2019-02-12
 full_link:
 short_description: >
   Container được sử dụng để chạy một phần của workload. So sánh với init container.

--- a/content/vi/docs/reference/glossary/application-architect.md
+++ b/content/vi/docs/reference/glossary/application-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Kiến trúc sư ứng dụng
 id: application-architect
-date: 2018-04-12
 full_link: 
 short_description: >
   Người chịu trách nhiệm về thiết kế cấp cao của một ứng dụng.

--- a/content/vi/docs/reference/glossary/applications.md
+++ b/content/vi/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: Ứng dụng
 id: applications
-date: 2019-12-16
 full_link:
 short_description: >
   Một lớp nơi các ứng được đã được container-hóa chạy.

--- a/content/vi/docs/reference/glossary/cgroup.md
+++ b/content/vi/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-12-16
 full_link:
 short_description: >
   Một nhóm các process trên Linux với sự tùy chọn trong cô lập tài nguyên, trách nhiệm và giới hạn.

--- a/content/vi/docs/reference/glossary/cloud-provider.md
+++ b/content/vi/docs/reference/glossary/cloud-provider.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Provider
 id: cloud-provider
-date: 2018-04-12
 short_description: >
   Một tổ chức cung cấp nền tảng điện toán đám mây.
 

--- a/content/vi/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/vi/docs/reference/glossary/cluster-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster Infrastructure
 id: cluster-infrastructure
-date: 2019-05-12
 full_link:
 short_description: >
  Lớp hạ tầng cung cấp và duy trì các máy ảo (VM), mạng, nhóm bảo mật và các thành phần khác.

--- a/content/vi/docs/reference/glossary/cluster-operations.md
+++ b/content/vi/docs/reference/glossary/cluster-operations.md
@@ -1,7 +1,6 @@
 ---
 title: Vận hành cụm máy chủ
 id: cluster-operations
-date: 2019-05-12
 full_link:
 short_description: >
   Công việc liên quan đến việc quản lý cụm Kubernetes.

--- a/content/vi/docs/reference/glossary/cluster.md
+++ b/content/vi/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster
 id: cluster
-date: 2020-02-26
 full_link: 
 short_description: >
    Một tập các worker machine, được gọi là node, dùng để chạy các các ứng dụng được đóng gói (containerized application). Mỗi cụm (cluster) có ít nhất một worker node.

--- a/content/vi/docs/reference/glossary/cncf.md
+++ b/content/vi/docs/reference/glossary/cncf.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Native Computing Foundation (CNCF)
 id: cncf
-date: 2019-05-26
 full_link: https://cncf.io/
 short_description: >
   Cloud Native Computing Foundation

--- a/content/vi/docs/reference/glossary/cni.md
+++ b/content/vi/docs/reference/glossary/cni.md
@@ -1,7 +1,6 @@
 ---
 title: Container network interface (CNI)
 id: cni
-date: 2025-04-22
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 short_description: >
     Container network interface (CNI) plugin là một loại Network plugin mà tuân thủ đặc điểm kỹ thuật của appc/CNI.

--- a/content/vi/docs/reference/glossary/configmap.md
+++ b/content/vi/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2018-04-12
 full_link: /docs/concepts/configuration/configmap/
 short_description: >
   Một đối tượng API được sử dụng để lưu trữ dữ liệu không bảo mật trong cặp giá trị key-value. Có thể được dùng như các biến môi trường, các tham số dòng lệnh, hoặc các file cấu hình trong một volume.

--- a/content/vi/docs/reference/glossary/container-env-variables.md
+++ b/content/vi/docs/reference/glossary/container-env-variables.md
@@ -1,7 +1,6 @@
 ---
 title: Biến môi trường trong Container
 id: container-env-variables
-date: 2019-12-16
 full_link: /docs/concepts/containers/container-environment-variables/
 short_description: >
   Biến môi trường của container là một cặp Tên-Giá trị nhằm cung cấp những thông tin hữu ích vô trong những containers bên trong một Pod.

--- a/content/vi/docs/reference/glossary/container-runtime.md
+++ b/content/vi/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Container Runtime
 id: container-runtime
-date: 2025-04-22
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
     Container runtime là một phần mềm có nhiệm vụ khởi chạy các container.

--- a/content/vi/docs/reference/glossary/container.md
+++ b/content/vi/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Container
 id: container
-date: 2019-11-29
 full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
 short_description: >
   Một image nhẹ, khả chuyển và có khả năng thực thi, chứa phần mềm và tất cả các dependencies của nó.

--- a/content/vi/docs/reference/glossary/containerd.md
+++ b/content/vi/docs/reference/glossary/containerd.md
@@ -1,7 +1,6 @@
 ---
 title: containerd
 id: containerd
-date: 2020-03-04
 full_link: https://containerd.io/docs/
 short_description: >
   Một container runtime tập trung vào sự đơn giản, mạnh mẽ và linh động.

--- a/content/vi/docs/reference/glossary/contributor.md
+++ b/content/vi/docs/reference/glossary/contributor.md
@@ -1,7 +1,6 @@
 ---
 title: Người đóng góp
 id: contributor
-date: 2018-04-12
 full_link: 
 short_description: >
   Người đóng góp mã nguồn, tài liệu hoặc thời gian để hỗ trợ dự án hoặc cộng đồng Kubernetes.

--- a/content/vi/docs/reference/glossary/control-plane.md
+++ b/content/vi/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Control Plane
 id: control-plane
-date: 2020-03-04
 full_link:
 short_description: >
   Tầng điều khiển container, được dùng để đưa ra API và các interface để định nghĩa, triển khai, và quản lý vòng đời của các container.

--- a/content/vi/docs/reference/glossary/controller.md
+++ b/content/vi/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Vòng điều khiển (Controller)
 id: controller
-date: 2020-01-09
 full_link: /docs/concepts/architecture/controller/
 short_description: >
   Vòng điều khiển lặp lại theo dõi trạng thái chung của cluster thông qua apiserver và tự động thay đổi để hệ thống từ trạng thái hiện tại đạt tới trạng thái mong muốn.

--- a/content/vi/docs/reference/glossary/cri-o.md
+++ b/content/vi/docs/reference/glossary/cri-o.md
@@ -1,7 +1,6 @@
 ---
 title: CRI-O
 id: cri-o
-date: 2020-03-05
 full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   Một container runtime nhẹ dành riêng cho Kubernetes

--- a/content/vi/docs/reference/glossary/cri.md
+++ b/content/vi/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: Container runtime interface (CRI)
 id: cri
-date: 2019-11-29
 full_link: /docs/concepts/overview/components/#container-runtime
 short_description: >
   Một API phục vụ cho việc tích hợp container runtimes với kubelet.

--- a/content/vi/docs/reference/glossary/csi.md
+++ b/content/vi/docs/reference/glossary/csi.md
@@ -1,7 +1,6 @@
 ---
 title: Giao thức lưu trữ cho container (Container Storage Interface - CSI)
 id: csi
-date: 2018-06-25
 full_link: /docs/concepts/storage/volumes/#csi
 short_description: >
     Container Storage Interface (CSI) định nghĩa một giao thức chuẩn để expose các hệ thống lưu trữ cho containers.

--- a/content/vi/docs/reference/glossary/customresourcedefinition.md
+++ b/content/vi/docs/reference/glossary/customresourcedefinition.md
@@ -1,7 +1,6 @@
 ---
 title: CustomResourceDefinition
 id: CustomResourceDefinition
-date: 2020-01-09
 full_link: docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
 short_description: >
   Những đoạn custom code chỉ định một loại tài nguyên được thêm vào Kubenretes API server mà không cần thiết phải xây dựng một custom server hoàn chỉnh.

--- a/content/vi/docs/reference/glossary/daemonset.md
+++ b/content/vi/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2020-03-05
 full_link: /docs/concepts/workloads/controllers/daemonset
 short_description: >
   Đảm bảo một bản sao của Pod đang chạy trên một tập các node của cluster.

--- a/content/vi/docs/reference/glossary/deployment.md
+++ b/content/vi/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2019-11-29
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Một API object quản lý việc nhân rộng bản sao của ứng dụng.

--- a/content/vi/docs/reference/glossary/developer.md
+++ b/content/vi/docs/reference/glossary/developer.md
@@ -1,7 +1,6 @@
 ---
 title: Developer (làm rõ nghĩa)
 id: developer
-date: 2018-04-12
 full_link: 
 short_description: >
   Có thể đề cập đến&#58; Application Developer, Code Contributor, hoặc Platform Developer.

--- a/content/vi/docs/reference/glossary/device-plugin.md
+++ b/content/vi/docs/reference/glossary/device-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: Device Plugin
 id: device-plugin
-date: 2019-02-02
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
 short_description: >
   Phần mở rộng phần mềm cho phép Pod truy cập các thiết bị cần khởi tạo hoặc thiết lập đặc thù từ nhà cung cấp

--- a/content/vi/docs/reference/glossary/disruption.md
+++ b/content/vi/docs/reference/glossary/disruption.md
@@ -1,7 +1,6 @@
 ---
 title: Disruption
 id: disruption
-date: 2019-09-10
 full_link: /docs/concepts/workloads/pods/disruptions/
 short_description: >
   Một sự kiện dẫn đến Pod(s) bị ngừng hoạt động

--- a/content/vi/docs/reference/glossary/docker.md
+++ b/content/vi/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2019-11-29
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker là một công nghệ phần mềm thực hiện việc ảo hóa tầng hệ điều hành được gọi là container.

--- a/content/vi/docs/reference/glossary/dockershim.md
+++ b/content/vi/docs/reference/glossary/dockershim.md
@@ -1,7 +1,6 @@
 ---
 title: Dockershim
 id: dockershim
-date: 2022-04-15
 full_link: /dockershim
 short_description: >
    Một thành phần của Kubernetes v1.23 và cũ hơn, cho phép các thành phần trong hệ thống Kubernetes giao tiếp với Docker Engine.

--- a/content/vi/docs/reference/glossary/downstream.md
+++ b/content/vi/docs/reference/glossary/downstream.md
@@ -1,7 +1,6 @@
 ---
 title: Downstream (disambiguation)
 id: downstream
-date: 2018-04-12
 full_link: 
 short_description: >
   Có thể đề cập đến: mã nguồn trong hệ sinh thái Kubernetes phụ thuộc vào mã nguồn lõi của Kubernetes hoặc một repo được forked.

--- a/content/vi/docs/reference/glossary/downward-api.md
+++ b/content/vi/docs/reference/glossary/downward-api.md
@@ -1,7 +1,6 @@
 ---
 title: Downward API
 id: downward-api
-date: 2022-03-21
 short_description: >
   Một cơ chế để cung cấp các trường giá trị của Pod và container cho đoạn mã đang chạy bên trong container.
 aka:

--- a/content/vi/docs/reference/glossary/drain.md
+++ b/content/vi/docs/reference/glossary/drain.md
@@ -1,7 +1,6 @@
 ---
 title: Drain
 id: drain
-date: 2024-12-27
 full_link:
 short_description: >
   Thực hiện việc loại bỏ các Pod khỏi một Node một cách an toàn để chuẩn bị cho việc bảo trì hoặc gỡ bỏ.

--- a/content/vi/docs/reference/glossary/duration.md
+++ b/content/vi/docs/reference/glossary/duration.md
@@ -1,7 +1,6 @@
 ---
 title: Khoảng thời gian (Duration)
 id: duration
-date: 2024-10-05
 full_link:
 short_description: >
   Một chuỗi đại diện cho một khoảng thời gian.

--- a/content/vi/docs/reference/glossary/dynamic-volume-provisioning.md
+++ b/content/vi/docs/reference/glossary/dynamic-volume-provisioning.md
@@ -1,7 +1,6 @@
 ---
 title: Cấp phát volume động
 id: dynamicvolumeprovisioning
-date: 2018-04-12
 full_link: /docs/concepts/storage/dynamic-provisioning
 short_description: >
   Cho phép người dùng yêu cầu hệ thống tự động tạo các Volume lưu trũ.

--- a/content/vi/docs/reference/glossary/endpoint-slice.md
+++ b/content/vi/docs/reference/glossary/endpoint-slice.md
@@ -1,7 +1,6 @@
 ---
 title: EndpointSlice
 id: endpoint-slice
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/endpoint-slices/
 short_description: >
   EndpointSlice theo dõi địa chỉ IP của các Pod trùng với các Service selector.

--- a/content/vi/docs/reference/glossary/endpoint.md
+++ b/content/vi/docs/reference/glossary/endpoint.md
@@ -1,7 +1,6 @@
 ---
 title: Endpoints
 id: endpoints
-date: 2020-04-23
 full_link:
 short_description: >
   Một endpoint của một Service là một trong các Pod (hoặc máy chủ bên ngoài) triển khai Service.

--- a/content/vi/docs/reference/glossary/ephemeral-container.md
+++ b/content/vi/docs/reference/glossary/ephemeral-container.md
@@ -1,7 +1,6 @@
 ---
 title: Ephemeral Container
 id: ephemeral-container
-date: 2019-08-26
 full_link: /docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
   Một loại container mà bạn có thể chạy tạm thời trong một Pod

--- a/content/vi/docs/reference/glossary/etcd.md
+++ b/content/vi/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2020-02-27
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Key value store nhất quán (consistent) và sẵn sàng cao (highly-available) được sử dụng như một kho lưu trữ của Kubernetes cho tất cả dữ liệu của cluster.

--- a/content/vi/docs/reference/glossary/event.md
+++ b/content/vi/docs/reference/glossary/event.md
@@ -1,7 +1,6 @@
 ---
 title: Event
 id: event
-date: 2022-01-16
 full_link: /docs/reference/kubernetes-api/cluster-resources/event-v1/
 short_description: >
    Các Event là các đối tượng Kubernetes mô tả một vài thay đổi về trạng thái trong hệ thống.

--- a/content/vi/docs/reference/glossary/eviction.md
+++ b/content/vi/docs/reference/glossary/eviction.md
@@ -1,7 +1,6 @@
 ---
 title: Eviction
 id: eviction
-date: 2021-05-08
 full_link: /docs/concepts/scheduling-eviction/
 short_description: >
     Quá trình chấm dứt một hoặc nhiều Pod trên các Node

--- a/content/vi/docs/reference/glossary/extensions.md
+++ b/content/vi/docs/reference/glossary/extensions.md
@@ -1,7 +1,6 @@
 ---
 title: Extensions
 id: Extensions
-date: 2019-02-01
 full_link: /docs/concepts/extend-kubernetes/#extensions
 short_description: >
   Extensions là các thành phần phần mềm mở rộng và tích hợp sâu với Kubernetes để hỗ trợ

--- a/content/vi/docs/reference/glossary/finalizer.md
+++ b/content/vi/docs/reference/glossary/finalizer.md
@@ -1,7 +1,6 @@
 ---
 title: Finalizer
 id: finalizer
-date: 2021-07-07
 full_link: /docs/concepts/overview/working-with-objects/finalizers/
 short_description: >
     Một khóa có phạm vi namespace dùng để yêu cầu Kubernetes chờ đến khi thỏa mãn các điều kiện cụ thể trước khi xóa hoàn toàn một đối tượng đã được đánh dấu để xóa.

--- a/content/vi/docs/reference/glossary/garbage-collection.md
+++ b/content/vi/docs/reference/glossary/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 title: Thu gom rác (Garbage Collection)
 id: garbage-collection
-date: 2021-07-07
 full_link: /docs/concepts/architecture/garbage-collection/
 short_description: >
     Thuật ngữ tổng quát chỉ các cơ chế khác nhau mà Kubernetes sử dụng để dọn dẹp tài nguyên trong cụm.

--- a/content/vi/docs/reference/glossary/group-version-resource.md
+++ b/content/vi/docs/reference/glossary/group-version-resource.md
@@ -1,7 +1,6 @@
 ---
 title: Group Version Resource
 id: gvr
-date: 2023-07-24
 short_description: >
   Nhóm API, phiên bản API và tên của một Kubernetes API. 
 

--- a/content/vi/docs/reference/glossary/helm-chart.md
+++ b/content/vi/docs/reference/glossary/helm-chart.md
@@ -1,7 +1,6 @@
 ---
 title: Helm Chart
 id: helm-chart
-date: 2018-04-12
 full_link: https://helm.sh/docs/topics/charts/
 short_description: >
   Một gói tài nguyên Kubernetes được cấu hình sẵn có thể được quản lý bằng công cụ Helm.

--- a/content/vi/docs/reference/glossary/horizontal-pod-autoscaler.md
+++ b/content/vi/docs/reference/glossary/horizontal-pod-autoscaler.md
@@ -1,7 +1,6 @@
 ---
 title: Tự động điều chỉnh Pod theo chiều ngang (Horizontal Pod Autoscaler)
 id: horizontal-pod-autoscaler
-date: 2018-04-12
 full_link: /docs/tasks/run-application/horizontal-pod-autoscale/
 short_description: >
   Một tài nguyên API tự động điều chỉnh số lượng bản sao (replica) của pod dựa vào mức sử dụng CPU mục tiêu hoặc các chỉ số tùy chỉnh.

--- a/content/vi/docs/reference/glossary/host-aliases.md
+++ b/content/vi/docs/reference/glossary/host-aliases.md
@@ -1,7 +1,6 @@
 ---
 title: Khai báo hosts tùy chỉnh cho Pod (HostAliases)
 id: HostAliases
-date: 2019-01-31
 full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
 short_description: >
   HostAliases là danh sách ánh xạ giữa địa chỉ IP và tên máy (hostname) sẽ được chèn vào tệp hosts của Pod.

--- a/content/vi/docs/reference/glossary/image.md
+++ b/content/vi/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: Image
 id: image
-date: 2018-04-12
 full_link:
 short_description: >
   Phiên bản lưu trữ của một container chứa một tập hợp các phần mềm cần thiết để chạy một ứng dụng.

--- a/content/vi/docs/reference/glossary/immutable-infrastructure.md
+++ b/content/vi/docs/reference/glossary/immutable-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: Hạ tầng bất biến (Immutable Infrastructure)
 id: immutable-infrastructure
-date: 2024-03-25
 full_link:
 short_description: >
   Hạ tầng bất biến là kiểu hạ tầng máy tính (máy ảo, container, thiết bị mạng) không được thay đổi sau khi đã triển khai.

--- a/content/vi/docs/reference/glossary/infrastructure-resource.md
+++ b/content/vi/docs/reference/glossary/infrastructure-resource.md
@@ -1,7 +1,6 @@
 ---
 title: Tài nguyên (hạ tầng)
 id: infrastructure-resource
-date: 2025-02-09
 short_description: >
   Một lượng hạ tầng được định nghĩa sẵn để tiêu thụ (CPU, bộ nhớ, v.v.).
 

--- a/content/vi/docs/reference/glossary/ingress.md
+++ b/content/vi/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/ingress/
 short_description: >
   Một đối tượng API quản lý quyền truy cập từ bên ngoài vào các dịch vụ trong cụm, thường là qua HTTP.

--- a/content/vi/docs/reference/glossary/init-container.md
+++ b/content/vi/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: Init Container
 id: init-container
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/init-containers/
 short_description: >
   Một hoặc nhiều container khởi tạo phải chạy hoàn tất trước khi bất kỳ app container nào chạy.

--- a/content/vi/docs/reference/glossary/istio.md
+++ b/content/vi/docs/reference/glossary/istio.md
@@ -1,7 +1,6 @@
 ---
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   Một nền tảng mã nguồn mở (không chỉ dành riêng cho Kubernetes) cung cấp cách thống nhất để tích hợp microservices, quản lý luồng lưu lượng, thực thi chính sách và thu thập dữ liệu telemetry.

--- a/content/vi/docs/reference/glossary/job.md
+++ b/content/vi/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/job/
 short_description: >
   Một tác vụ hữu hạn hoặc dạng batch chạy cho đến khi hoàn tất.

--- a/content/vi/docs/reference/glossary/jwt.md
+++ b/content/vi/docs/reference/glossary/jwt.md
@@ -1,7 +1,6 @@
 ---
 title: JSON Web Token (JWT)
 id: jwt
-date: 2023-01-17
 full_link: https://www.rfc-editor.org/rfc/rfc7519
 short_description: >
   Một phương thức để biểu diễn các thông tin xác nhận (claims) được truyền giữa hai bên.

--- a/content/vi/docs/reference/glossary/kops.md
+++ b/content/vi/docs/reference/glossary/kops.md
@@ -1,7 +1,6 @@
 ---
 title: kOps (Kubernetes Operations)
 id: kops
-date: 2018-04-12
 full_link: /docs/setup/production-environment/kops/
 short_description: >
   kOps không chỉ hỗ trợ khởi tạo, hủy bỏ, nâng cấp và duy trì các cụm (cluster) Kubernetes chuẩn vận hành (production-grade) với độ sẵn sàng cao, mà còn tự động cấp phát các hạ tầng cloud cần thiết.

--- a/content/vi/docs/reference/glossary/kube-apiserver.md
+++ b/content/vi/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: API server
 id: kube-apiserver
-date: 2020-02-26
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
   Thành phần tầng điểu khiển (control plane), được dùng để phục vụ Kubernetes API.

--- a/content/vi/docs/reference/glossary/kube-controller-manager.md
+++ b/content/vi/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   Thành phần Control Plane chạy các tiến trình controller.

--- a/content/vi/docs/reference/glossary/kube-proxy.md
+++ b/content/vi/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2019-11-29
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` là một network proxy chạy trên mỗi node trong cluster.

--- a/content/vi/docs/reference/glossary/kube-scheduler.md
+++ b/content/vi/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2020-03-05
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Thành phần của Control Plane, được dùng để giám sát việc tạo những pod mới mà chưa được chỉ định vào node nào, và chọn một node để chúng chạy trên đó.

--- a/content/vi/docs/reference/glossary/kubeadm.md
+++ b/content/vi/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /docs/reference/setup-tools/kubeadm/
 short_description: >
   Một công cụ giúp cài đặt Kubernetes một cách nhanh chóng và thiết lập một cụm bảo mật.

--- a/content/vi/docs/reference/glossary/kubectl.md
+++ b/content/vi/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /docs/reference/kubectl/
 short_description: >
   Công cụ dòng lệnh giúp giao tiếp với cụm Kubernetes.

--- a/content/vi/docs/reference/glossary/kubelet.md
+++ b/content/vi/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2019-11-29
 full_link: /docs/reference/generated/kubelet
 short_description: >
   Một agent chạy trên mỗi node nằm trong cluster. Nó giúp đảm bảo rằng các containers đã chạy trong một pod.

--- a/content/vi/docs/reference/glossary/kubernetes-api.md
+++ b/content/vi/docs/reference/glossary/kubernetes-api.md
@@ -1,7 +1,6 @@
 ---
 title: Kubernetes API
 id: kubernetes-api
-date: 2018-04-12
 full_link: /docs/concepts/overview/kubernetes-api/
 short_description: >
   Ứng dụng cung cấp các chức năng của Kubernetes thông qua giao diện RESTful và lưu trữ trạng thái của cluster.

--- a/content/vi/docs/reference/glossary/label.md
+++ b/content/vi/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: Nhãn (Label)
 id: label
-date: 2019-11-29
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   Gán nhãn các đối tượng (tags objects) với các thuộc tính xác định, có ý nghĩa và có liên quan tới người dùng.

--- a/content/vi/docs/reference/glossary/logging.md
+++ b/content/vi/docs/reference/glossary/logging.md
@@ -1,7 +1,6 @@
 ---
 title: Ghi nhật ký (Logging)
 id: logging
-date: 2019-04-04
 full_link: /docs/concepts/cluster-administration/logging/
 short_description: >
   Nhật ký (logs) là danh sách các sự kiện được ghi lại bởi cụm hoặc ứng dụng.

--- a/content/vi/docs/reference/glossary/managed-service.md
+++ b/content/vi/docs/reference/glossary/managed-service.md
@@ -1,7 +1,6 @@
 ---
 title: Managed Service
 id: managed-service
-date: 2018-04-12
 full_link: 
 short_description: >
   Một dịch vụ phần mềm được duy trì bởi nhà cung cấp bên thứ ba.

--- a/content/vi/docs/reference/glossary/manifest.md
+++ b/content/vi/docs/reference/glossary/manifest.md
@@ -1,7 +1,6 @@
 ---
 title: Manifest
 id: manifest
-date: 2019-06-28
 short_description: >
   Đặc tả được tuần tự hóa của một hoặc nhiều Kubernetes API objects.
 

--- a/content/vi/docs/reference/glossary/master.md
+++ b/content/vi/docs/reference/glossary/master.md
@@ -1,7 +1,6 @@
 ---
 title: Master
 id: master
-date: 2020-04-16
 short_description: >
   Thuật ngữ cũ, dùng để chỉ các nodes triển khai control plane.
 

--- a/content/vi/docs/reference/glossary/member.md
+++ b/content/vi/docs/reference/glossary/member.md
@@ -1,7 +1,6 @@
 ---
 title: Thành viên
 id: member
-date: 2018-04-12
 full_link: 
 short_description: >
   Một người đóng góp tích cực, liên tục trong cộng đồng K8s.

--- a/content/vi/docs/reference/glossary/minikube.md
+++ b/content/vi/docs/reference/glossary/minikube.md
@@ -1,7 +1,6 @@
 ---
 title: Minikube
 id: minikube
-date: 2018-04-12
 full_link: /docs/tasks/tools/#minikube
 short_description: >
   Công cụ giúp triển khai Kubernetes trên máy cá nhân.

--- a/content/vi/docs/reference/glossary/mixed-version-proxy.md
+++ b/content/vi/docs/reference/glossary/mixed-version-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: Mixed Version Proxy (MVP)
 id: mvp
-date: 2023-07-24
 full_link: /docs/concepts/architecture/mixed-version-proxy/
 short_description: >
   Tính năng cho phép kube-apiserver ủy quyền (proxy) yêu cầu tài nguyên sang một API server ngang hàng khác.

--- a/content/vi/docs/reference/glossary/namespace.md
+++ b/content/vi/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/namespaces
 short_description: >
   Namespace là một lớp trừu tượng trong Kubernetes dùng để cô lập các nhóm tài nguyên trong một cụm.

--- a/content/vi/docs/reference/glossary/network-policy.md
+++ b/content/vi/docs/reference/glossary/network-policy.md
@@ -1,7 +1,6 @@
 ---
 title: Network Policy
 id: network-policy
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/network-policies/
 short_description: >
   Một đặc tả về cách các nhóm Pod được phép giao tiếp với nhau và với các network endpoint khác.

--- a/content/vi/docs/reference/glossary/node.md
+++ b/content/vi/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: Node
 id: node
-date: 2019-11-29
 full_link: /docs/concepts/architecture/nodes/
 short_description: >
   Một node là một máy worker trong Kubernetes

--- a/content/vi/docs/reference/glossary/object.md
+++ b/content/vi/docs/reference/glossary/object.md
@@ -1,7 +1,6 @@
 ---
 title: Object
 id: object
-date: 2020-10-12
 full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
 short_description: >
    Một thực thể trong hệ thống Kubernetes, đại diện cho một phần trạng thái của cluster của bạn.

--- a/content/vi/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/vi/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: Persistent Volume Claim
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   Yêu cầu (Claim) tài nguyên lưu trữ được định nghĩa trong PersistentVolume để có thể gắn (mount) như một volume trong container.

--- a/content/vi/docs/reference/glossary/persistent-volume.md
+++ b/content/vi/docs/reference/glossary/persistent-volume.md
@@ -1,7 +1,6 @@
 ---
 title: Persistent Volume
 id: persistent-volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/persistent-volumes/
 short_description: >
   Đối tượng API đại diện cho một phần lưu trữ trong cụm.

--- a/content/vi/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/vi/docs/reference/glossary/pod-disruption-budget.md
@@ -2,7 +2,6 @@
 id: pod-disruption-budget
 title: Pod Disruption Budget
 full-link: /docs/concepts/workloads/pods/disruptions/
-date: 2019-02-12
 short_description: >
   Đối tượng giới hạn số lượng Pod trong ứng dụng có nhiều bản sao bị ngừng hoạt động đồng thời do các gián đoạn chủ động.
 

--- a/content/vi/docs/reference/glossary/pod-disruption.md
+++ b/content/vi/docs/reference/glossary/pod-disruption.md
@@ -2,7 +2,6 @@
 id: pod-disruption
 title: Pod Disruption
 full_link: /docs/concepts/workloads/pods/disruptions/
-date: 2021-05-12
 short_description: >
   Tiến trình mà các Pod trên Node bị chấm dứt, có thể là chủ động hoặc bị động.
 

--- a/content/vi/docs/reference/glossary/pod-lifecycle.md
+++ b/content/vi/docs/reference/glossary/pod-lifecycle.md
@@ -1,7 +1,6 @@
 ---
 title: Pod Lifecycle
 id: pod-lifecycle
-date: 2019-02-17
 full-link: /docs/concepts/workloads/pods/pod-lifecycle/
 related:
  - pod

--- a/content/vi/docs/reference/glossary/pod-priority.md
+++ b/content/vi/docs/reference/glossary/pod-priority.md
@@ -1,7 +1,6 @@
 ---
 title: Pod Priority
 id: pod-priority
-date: 2019-01-31
 full-link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
 short_description: >
   Pod Priority cho biết mức độ ưu tiên của một Pod so với các Pod khác.

--- a/content/vi/docs/reference/glossary/pod-security-policy.md
+++ b/content/vi/docs/reference/glossary/pod-security-policy.md
@@ -1,7 +1,6 @@
 ---
 title: Pod Security Policy
 id: pod-security-policy
-date: 2018-04-12
 full-link: /docs/concepts/security/pod-security-policy/
 short_description: >
   API đã bị loại bỏ, trước đây dùng để thực thi các quy tắc bảo mật cho Pod.

--- a/content/vi/docs/reference/glossary/pod.md
+++ b/content/vi/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2019-11-29
 full_link: /docs/concepts/workloads/pods/pod-overview/
 short_description: >
   Đối tượng nhỏ nhất và đơn giản nhất của Kubernetes. Một Pod đại diện cho một tập các containers đang chạy trên cluster.

--- a/content/vi/docs/reference/glossary/probe.md
+++ b/content/vi/docs/reference/glossary/probe.md
@@ -1,7 +1,6 @@
 ---
 title: Probe
 id: probe
-date: 2023-03-21
 full_link: /docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 
 short_description: >

--- a/content/vi/docs/reference/glossary/rbac.md
+++ b/content/vi/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: RBAC (Role-Based Access Control - Kiểm soát truy cập dựa trên vai trò)
 id: rbac
-date: 2018-04-12
 full_link: /docs/reference/access-authn-authz/rbac/
 short_description: >
   Quản lý việc phân quyền, cho phép quản trị viên cấu hình các chính sách truy cập một cách linh hoạt thông qua Kubernetes API.

--- a/content/vi/docs/reference/glossary/replica-set.md
+++ b/content/vi/docs/reference/glossary/replica-set.md
@@ -1,7 +1,6 @@
 ---
 title: ReplicaSet
 id: replica-set
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/replicaset/
 short_description: >
  ReplicaSet đảm bảo số lượng các bản sao của một pod đang hoạt động cùng lúc.

--- a/content/vi/docs/reference/glossary/replica.md
+++ b/content/vi/docs/reference/glossary/replica.md
@@ -1,7 +1,6 @@
 ---
 title: Replica
 id: replica
-date: 2023-06-11
 full_link: 
 short_description: >
   Replicas là các bản sao của các pod, giúp đảm bảo tính sẵn sàng, 

--- a/content/vi/docs/reference/glossary/resource-quota.md
+++ b/content/vi/docs/reference/glossary/resource-quota.md
@@ -1,7 +1,6 @@
 ---
 title: ResourceQuota
 id: resource-quota
-date: 2018-04-12
 full_link: /docs/concepts/policy/resource-quotas/
 short_description: >
   Áp đặt các ràng buộc để giới hạn lượng tài nguyên tiêu thụ trong mỗi namespace.

--- a/content/vi/docs/reference/glossary/selector.md
+++ b/content/vi/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: Selector
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Cho phép người dùng lọc ra một danh sách tài nguyên dựa trên label.

--- a/content/vi/docs/reference/glossary/service.md
+++ b/content/vi/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2019-11-29
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   Một cách để thể hiện ứng dụng đang chạy trong một tập các Pods dưới dạng dịch vụ mạng.

--- a/content/vi/docs/reference/glossary/sidecar-container.md
+++ b/content/vi/docs/reference/glossary/sidecar-container.md
@@ -1,7 +1,6 @@
 ---
 title: Sidecar Container
 id: sidecar-container
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/sidecar-containers/
 short_description: >
   Một container phụ trợ chạy xuyên suốt vòng đời của một Pod.

--- a/content/vi/docs/reference/glossary/sig.md
+++ b/content/vi/docs/reference/glossary/sig.md
@@ -1,7 +1,6 @@
 ---
 title: SIG (nhóm quan tâm đặc biệt)
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups 
 short_description: >
   Các thành viên cộng đồng cùng nhau quản lý một phần hoặc khía cạnh liên tục của dự án mã nguồn mở Kubernetes.

--- a/content/vi/docs/reference/glossary/statefulset.md
+++ b/content/vi/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   StatefulSet quản lý việc triển khai và mở rộng một tập hợp các Pod, với lưu trữ bền vững và định danh cố định cho mỗi Pod.

--- a/content/vi/docs/reference/glossary/static-pod.md
+++ b/content/vi/docs/reference/glossary/static-pod.md
@@ -1,7 +1,6 @@
 ---
 title: Static Pod
 id: static-pod
-date: 2019-02-12
 full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
   Một pod được quản lý trực tiếp bởi kubelet daemon trên một node cụ thể.

--- a/content/vi/docs/reference/glossary/taint.md
+++ b/content/vi/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: Taint
 id: taint
-date: 2019-11-26
 full_link: /docs/concepts/configuration/taint-and-toleration/
 short_description: >
   Là một đối tượng bao gồm ba thuộc tính bắt buộc: key, value, và effect. Taints (dấu chờ) ngăn cản việc lập lịch cho các pod chạy trên các node hay nhóm các node.

--- a/content/vi/docs/reference/glossary/volume.md
+++ b/content/vi/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume
 id: volume
-date: 2018-04-12
 full_link: /docs/concepts/storage/volumes/
 short_description: >
   Một thư mục chứa dữ liệu, có thể truy cập tới các container trong một pod.

--- a/content/vi/docs/reference/glossary/workload.md
+++ b/content/vi/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: Workload
 id: workload
-date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
    Workload là một ứng dụng chạy trên Kubernetes.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all vi/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.