### PR TITLE
docs: Remove date field from Ukrainian glossary entries

### DIFF
--- a/content/uk/docs/reference/glossary/addons.md
+++ b/content/uk/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Надбудови
 id: addons
-date: 2019-12-15
 full_link: /docs/concepts/cluster-administration/addons/
 short_description: >
   Ресурси, які розширюють функціональність Kubernetes.

--- a/content/uk/docs/reference/glossary/admission-controller.md
+++ b/content/uk/docs/reference/glossary/admission-controller.md
@@ -1,7 +1,6 @@
 ---
 title: Контролер допуску
 id: admission-controller
-date: 2019-06-28
 full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   Фрагмент коду, який перехоплює запити до сервера API Kubernetes перед збереженням обʼєкта.

--- a/content/uk/docs/reference/glossary/applications.md
+++ b/content/uk/docs/reference/glossary/applications.md
@@ -2,7 +2,6 @@
 # title: Applications
 title: Застосунки
 id: applications
-date: 2019-05-12
 full_link:
 # short_description: >
 #   The layer where various containerized applications run.

--- a/content/uk/docs/reference/glossary/cgroup.md
+++ b/content/uk/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   Група процесів в середовищі Linux із можливістю ізоляції, обліку та встановлення обмежень ресурсів.

--- a/content/uk/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/uk/docs/reference/glossary/cluster-infrastructure.md
@@ -2,7 +2,6 @@
 # title: Cluster Infrastructure
 title: Інфраструктура кластера
 id: cluster-infrastructure
-date: 2019-05-12
 full_link:
 # short_description: >
 #  The infrastructure layer provides and maintains VMs, networking, security groups and others.

--- a/content/uk/docs/reference/glossary/cluster-operations.md
+++ b/content/uk/docs/reference/glossary/cluster-operations.md
@@ -2,7 +2,6 @@
 # title: Cluster Operations
 title: Операції з кластером
 id: cluster-operations
-date: 2019-05-12
 full_link:
 # short_description: >
 #  Activities such as upgrading the clusters, implementing security, storage, ingress, networking, logging and monitoring, and other operations involved in managing a Kubernetes cluster.

--- a/content/uk/docs/reference/glossary/cluster.md
+++ b/content/uk/docs/reference/glossary/cluster.md
@@ -2,7 +2,6 @@
 # title: Cluster
 title: Кластер
 id: cluster
-date: 2019-06-15
 full_link: 
 # short_description: >
 #    A set of worker machines, called nodes, that run containerized applications. Every cluster has at least one worker node.

--- a/content/uk/docs/reference/glossary/cncf.md
+++ b/content/uk/docs/reference/glossary/cncf.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Native Computing Foundation
 id: cncf
-date: 2019-05-26
 full_link: https://cncf.io/
 short_description: >
   Cloud Native Computing Foundation

--- a/content/uk/docs/reference/glossary/configmap.md
+++ b/content/uk/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2018-04-12
 full_link: /docs/concepts/configuration/configmap/
 short_description: >
   Обʼєкт API, призначений для зберігання неконфіденційних даних у вигляді пар ключ-значення. Може використовуватися як змінні середовища, аргументи командного рядка чи файли конфігурації у томі.

--- a/content/uk/docs/reference/glossary/container-runtime.md
+++ b/content/uk/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Середовища виконання контейнерів
 id: container-runtime
-date: 2019-06-05
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
   Середовище виконання контейнера — це програмне забезпечення, яке відповідає за запуск та виконання контейнерів.

--- a/content/uk/docs/reference/glossary/container.md
+++ b/content/uk/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Контейнер
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/containers/
 short_description: >
   Легкий та переносний виконуваний образ, який містить програмне забезпечення та всі його залежності.

--- a/content/uk/docs/reference/glossary/control-plane.md
+++ b/content/uk/docs/reference/glossary/control-plane.md
@@ -2,7 +2,6 @@
 # title: Control Plane
 title: Площина управління
 id: control-plane
-date: 2019-05-12
 full_link:
 # short_description: >
 #   The container orchestration layer that exposes the API and interfaces to define, deploy, and manage the lifecycle of containers.

--- a/content/uk/docs/reference/glossary/controller.md
+++ b/content/uk/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Контролер
 id: controller
-date: 2018-04-12
 full_link: /docs/concepts/architecture/controller/
 short_description: >
   Контролер — цикл управління, що спостерігає за загальним станом кластера через apiserver і вносить зміни в намаганні наблизити поточний стан до бажаного.

--- a/content/uk/docs/reference/glossary/data-plane.md
+++ b/content/uk/docs/reference/glossary/data-plane.md
@@ -2,7 +2,6 @@
 # title: Data Plane
 title: Площина даних
 id: data-plane
-date: 2019-05-12
 full_link:
 # short_description: >
 #   The layer that provides capacity such as CPU, memory, network, and storage so that the containers can run and connect to a network.

--- a/content/uk/docs/reference/glossary/deployment.md
+++ b/content/uk/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Керує реплікованим застосунком у вашому кластері.

--- a/content/uk/docs/reference/glossary/etcd.md
+++ b/content/uk/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Сумісне та високодоступне сховище ключ-значення, яке використовується як сховище Kubernetes для резервування всіх даних кластера.

--- a/content/uk/docs/reference/glossary/job.md
+++ b/content/uk/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/job/
 short_description: >
   Скінченне або пакетне завдання, яке виконується до завершення.

--- a/content/uk/docs/reference/glossary/kube-apiserver.md
+++ b/content/uk/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,6 @@
 # title: API server
 title: API-сервер
 id: kube-apiserver
-date: 2018-04-12
 full_link: /docs/concepts/architecture/#kube-apiserver
 # short_description: >
 #  Control plane component that serves the Kubernetes API.

--- a/content/uk/docs/reference/glossary/kube-controller-manager.md
+++ b/content/uk/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 # short_description: >
 #   Control Plane component that runs controller processes.

--- a/content/uk/docs/reference/glossary/kube-proxy.md
+++ b/content/uk/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 # short_description: >
 #   `kube-proxy` is a network proxy that runs on each node in the cluster.

--- a/content/uk/docs/reference/glossary/kube-scheduler.md
+++ b/content/uk/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 # short_description: >
 #   Control Plane component that watches for newly created pods with no assigned node, and selects a node for them to run on.

--- a/content/uk/docs/reference/glossary/kubelet.md
+++ b/content/uk/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kubelet
 short_description: >
   Агент, запущений на кожному вузлі кластера. Забезпечує запуск і роботу контейнерів у Podʼах.

--- a/content/uk/docs/reference/glossary/label.md
+++ b/content/uk/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: Мітка
 id: label
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   Позначає обʼєкти атрибутами ідентифікації, які мають значення і є важливими для користувачів.

--- a/content/uk/docs/reference/glossary/manifest.md
+++ b/content/uk/docs/reference/glossary/manifest.md
@@ -1,7 +1,6 @@
 ---
 title: Манфіест
 id: manifest
-date: 2019-06-28
 short_description: >
   Серіалізована специфікація одного чи кількох обʼєктів API Kubernetes.
 

--- a/content/uk/docs/reference/glossary/mirror-pod.md
+++ b/content/uk/docs/reference/glossary/mirror-pod.md
@@ -1,7 +1,6 @@
 ---
 title: Дзеркальний Pod
 id: mirror-pod
-date: 2019-08-06
 short_description: >
     Обʼєкт в API-сервері, який відстежує статичний Pod на kubelet.
 

--- a/content/uk/docs/reference/glossary/namespace.md
+++ b/content/uk/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2018-04-12
 short_description: >
   Абстракція, що використовується в Kubernetes для ізоляції груп ресурсів в межах одного кластера.
 

--- a/content/uk/docs/reference/glossary/object.md
+++ b/content/uk/docs/reference/glossary/object.md
@@ -1,7 +1,6 @@
 ---
 title: Обʼєкт
 id: object
-date: 2020-10-12
 full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
 short_description: >
    Сутність у системі Kubernetes, що представляє частину стану вашого кластера.

--- a/content/uk/docs/reference/glossary/operator-pattern.md
+++ b/content/uk/docs/reference/glossary/operator-pattern.md
@@ -1,7 +1,6 @@
 ---
 title: Шаблон Operator
 id: operator-pattern
-date: 2019-05-21
 full_link: /docs/concepts/extend-kubernetes/operator/
 short_description: >
   Спеціалізований контролер, призначений для управління власним ресурсом.

--- a/content/uk/docs/reference/glossary/pod.md
+++ b/content/uk/docs/reference/glossary/pod.md
@@ -2,7 +2,6 @@
 # title: Pod
 title: Pod
 id: pod
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/pod-overview/
 # short_description: >
 #   The smallest and simplest Kubernetes object. A Pod represents a set of running containers on your cluster.

--- a/content/uk/docs/reference/glossary/rbac.md
+++ b/content/uk/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: Керування доступом на основі ролей
 id: rbac
-date: 2018-04-12
 full_link: /docs/reference/access-authn-authz/rbac/
 short_description: >
   Управління рішеннями з авторизації, яке дозволяє адміністраторам динамічно налаштовувати політики доступу через API Kubernetes.

--- a/content/uk/docs/reference/glossary/secret.md
+++ b/content/uk/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: Secret
 id: secret
-date: 2018-04-12
 full_link: /docs/concepts/configuration/secret/
 short_description: >
   Зберігає конфіденційну інформацію, таку як паролі, токени OAuth та ключі SSH.

--- a/content/uk/docs/reference/glossary/selector.md
+++ b/content/uk/docs/reference/glossary/selector.md
@@ -2,7 +2,6 @@
 # title: Selector
 title: Селектор
 id: selector
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels/
 # short_description: >
 #   Allows users to filter a list of resources based on labels.

--- a/content/uk/docs/reference/glossary/service.md
+++ b/content/uk/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2018-04-12
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   Спосіб відкрити доступ до застосунку, що запущений на декількох Podʼах у вигляді мережевої служби.

--- a/content/uk/docs/reference/glossary/static-pod.md
+++ b/content/uk/docs/reference/glossary/static-pod.md
@@ -1,7 +1,6 @@
 ---
 title: Статичний Pod
 id: static-pod
-date: 2019-02-12
 full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
   Pod, яким управляє безпосередньо демон kubelet на певному вузлі.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all uk/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.