### PR TITLE
docs: Remove date field from Brazilian Portuguese glossary entries

### DIFF
--- a/content/pt-br/docs/reference/glossary/addons.md
+++ b/content/pt-br/docs/reference/glossary/addons.md
@@ -1,7 +1,6 @@
 ---
 title: Complementos
 id: addons
-date: 2019-12-15
 full_link: /pt-br/docs/concepts/cluster-administration/addons/
 short_description: >
   Recursos que estendem a funcionalidade do Kubernetes.

--- a/content/pt-br/docs/reference/glossary/affinity.md
+++ b/content/pt-br/docs/reference/glossary/affinity.md
@@ -1,7 +1,6 @@
 ---
 title: Afinidade
 id: affinity
-date: 2019-01-11
 full_link: /docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 short_description: >
      Regras utilizadas pelo escalonador para determinar onde alocar os Pods

--- a/content/pt-br/docs/reference/glossary/aggregation-layer.md
+++ b/content/pt-br/docs/reference/glossary/aggregation-layer.md
@@ -1,7 +1,6 @@
 ---
 title: Camada de Agregação
 id: aggregation-layer
-date: 2018-10-08
 full_link: /pt-br/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
 short_description: >
   A camada de agregação permite que você instale APIs adicionais no estilo Kubernetes em seu cluster.

--- a/content/pt-br/docs/reference/glossary/alternate-x509-schemes.md
+++ b/content/pt-br/docs/reference/glossary/alternate-x509-schemes.md
@@ -1,7 +1,6 @@
 ---
 title: Esquemas alternativos x509 
 id: alternate-x509-schemes
-date: 2021-03-16
 full_link: 
 short_description: >
    X.509 é um formato padrão para certificados de chave pública, documentos digitais que associam com segurança pares de chaves criptográficas a identidades como sites, indivíduos ou organizações.

--- a/content/pt-br/docs/reference/glossary/annotation.md
+++ b/content/pt-br/docs/reference/glossary/annotation.md
@@ -1,7 +1,6 @@
 ---
 title: Anotação
 id: annotation
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/annotations
 short_description: >
   Um par de chave-valor (key-value) é usado para anexar metadados arbitrários não identificáveis a objetos.

--- a/content/pt-br/docs/reference/glossary/api-group.md
+++ b/content/pt-br/docs/reference/glossary/api-group.md
@@ -1,7 +1,6 @@
 ---
 title: Grupo de APIs
 id: api-group
-date: 2019-09-02
 full_link: /docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
 short_description: >
   Um conjunto de caminhos relacionados da API Kubernetes.

--- a/content/pt-br/docs/reference/glossary/application-architect.md
+++ b/content/pt-br/docs/reference/glossary/application-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Arquiteto de Aplicativos
 id: application-architect
-date: 2018-04-12
 full_link: 
 short_description: >
  É uma pessoa responsável pelo projeto de alto nível de uma aplicação.

--- a/content/pt-br/docs/reference/glossary/application-developer.md
+++ b/content/pt-br/docs/reference/glossary/application-developer.md
@@ -1,7 +1,6 @@
 ---
 title: Desenvolvedor de Aplicativos
 id: application-developer
-date: 2018-04-12
 full_link: 
 short_description: >
   Uma pessoa que escreve um aplicativo que é executado em um cluster Kubernetes.

--- a/content/pt-br/docs/reference/glossary/applications.md
+++ b/content/pt-br/docs/reference/glossary/applications.md
@@ -1,7 +1,6 @@
 ---
 title: Aplicações
 id: applications
-date: 2019-05-12
 full_link:
 short_description: >
   A camada onde vários aplicativos em contêiner são executados.

--- a/content/pt-br/docs/reference/glossary/approver.md
+++ b/content/pt-br/docs/reference/glossary/approver.md
@@ -1,7 +1,6 @@
 ---
 title: Aprovador
 id: approver
-date: 2018-04-12
 full_link: 
 short_description: >
   Uma pessoa que pode revisar e aprovar as contribuições do código Kubernetes.

--- a/content/pt-br/docs/reference/glossary/cadvisor.md
+++ b/content/pt-br/docs/reference/glossary/cadvisor.md
@@ -1,7 +1,6 @@
 ---
 title: cAdvisor
 id: cadvisor
-date: 2021-12-09
 full_link: https://github.com/google/cadvisor/
 short_description: >
   Ferramenta que fornece o entendimento do uso de recursos e características de desempenho para contêineres

--- a/content/pt-br/docs/reference/glossary/certificate.md
+++ b/content/pt-br/docs/reference/glossary/certificate.md
@@ -1,7 +1,6 @@
 ---
 title: Certificado
 id: certificate
-date: 2018-04-12
 full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
 short_description: >
   Um arquivo criptograficamente seguro usado para validar o acesso ao cluster Kubernetes.

--- a/content/pt-br/docs/reference/glossary/cgroup.md
+++ b/content/pt-br/docs/reference/glossary/cgroup.md
@@ -1,7 +1,6 @@
 ---
 title: cgroup (control group)
 id: cgroup
-date: 2019-06-25
 full_link:
 short_description: >
   Um grupo de processos do Linux com isolamento de recursos opcional, contagem e limites.

--- a/content/pt-br/docs/reference/glossary/cidr.md
+++ b/content/pt-br/docs/reference/glossary/cidr.md
@@ -1,7 +1,6 @@
 ---
 title: CIDR
 id: cidr
-date: 2019-11-12
 full_link: 
 short_description: >
   CIDR é uma notação para descrever blocos de endereços IP e é muito usada em várias configurações de rede.

--- a/content/pt-br/docs/reference/glossary/cla.md
+++ b/content/pt-br/docs/reference/glossary/cla.md
@@ -1,7 +1,6 @@
 ---
 title: CLA (Contrato de Licença de Colaborador)
 id: cla
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md
 short_description: >
   Termos sob os quais um colaborador concede uma licença a um projeto de código aberto por suas contribuições.

--- a/content/pt-br/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/pt-br/docs/reference/glossary/cloud-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: Gerenciador de controle de nuvem
 id: cloud-controller-manager
-date: 2018-04-12
 full_link: /docs/concepts/architecture/cloud-controller/
 short_description: >
   Componente da camada de gerenciamento que integra Kubernetes com provedores de nuvem de terceiros.

--- a/content/pt-br/docs/reference/glossary/cloud-provider.md
+++ b/content/pt-br/docs/reference/glossary/cloud-provider.md
@@ -1,7 +1,6 @@
 ---
 title: Provedor de Nuvem
 id: cloud-provider
-date: 2018-04-12
 short_description: >
   Uma organização que oferece uma plataforma de computação em nuvem.
 

--- a/content/pt-br/docs/reference/glossary/cluster-architect.md
+++ b/content/pt-br/docs/reference/glossary/cluster-architect.md
@@ -1,7 +1,6 @@
 ---
 title: Arquiteto de Cluster
 id: cluster-architect
-date: 2018-04-12
 full_link: 
 short_description: >
   Uma pessoa que projeta infraestrutura que envolve um ou mais clusters Kubernetes.

--- a/content/pt-br/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/pt-br/docs/reference/glossary/cluster-infrastructure.md
@@ -1,7 +1,6 @@
 ---
 title: Infraestrutura de Cluster
 id: cluster-infrastructure
-date: 2019-05-12
 full_link:
 short_description: >
  A camada de infraestrutura fornece e mantém máquinas virtuais, redes, grupos de segurança e outros.

--- a/content/pt-br/docs/reference/glossary/cluster-operations.md
+++ b/content/pt-br/docs/reference/glossary/cluster-operations.md
@@ -1,7 +1,6 @@
 ---
 title: Operações do Cluster
 id: cluster-operations
-date: 2019-05-12
 full_link:
 short_description: >
  O trabalho envolvido no gerenciamento de um cluster Kubernetes.

--- a/content/pt-br/docs/reference/glossary/cluster-operator.md
+++ b/content/pt-br/docs/reference/glossary/cluster-operator.md
@@ -1,7 +1,6 @@
 ---
 title: Operador de Cluster
 id: cluster-operator
-date: 2018-04-12
 full_link: 
 short_description: >
   Uma pessoa que configura, controla e monitora clusters.

--- a/content/pt-br/docs/reference/glossary/cluster.md
+++ b/content/pt-br/docs/reference/glossary/cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster
 id: cluster
-date: 2020-08-03
 full_link: 
 short_description: >
   Um conjunto de servidores de processamento, também chamados de nós, que

--- a/content/pt-br/docs/reference/glossary/cncf.md
+++ b/content/pt-br/docs/reference/glossary/cncf.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Native Computing Foundation (CNCF)
 id: cncf
-date: 2019-05-26
 full_link: https://cncf.io/
 short_description: >
   Cloud Native Computing Foundation

--- a/content/pt-br/docs/reference/glossary/cni.md
+++ b/content/pt-br/docs/reference/glossary/cni.md
@@ -1,7 +1,6 @@
 ---
 title: Container network interface (CNI)
 id: cni
-date: 2018-05-25
 full_link: /docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 short_description: >
     Plugins Container network interface (CNI) são um tipo de plugin de Rede em conformidade com a especificação appc/CNI.

--- a/content/pt-br/docs/reference/glossary/code-contributor.md
+++ b/content/pt-br/docs/reference/glossary/code-contributor.md
@@ -1,7 +1,6 @@
 ---
 title: Colaborador de Código
 id: code-contributor
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
 short_description: >
  Uma pessoa que desenvolve e contribui com código para o código aberto do Kubernetes.

--- a/content/pt-br/docs/reference/glossary/configmap.md
+++ b/content/pt-br/docs/reference/glossary/configmap.md
@@ -1,7 +1,6 @@
 ---
 title: ConfigMap
 id: configmap
-date: 2021-08-24
 full_link: /pt-br/docs/concepts/configuration/configmap
 short_description: >
   Um objeto da API usado para armazenar dados não-confidenciais em pares chave-valor. Pode ser consumido como variáveis de ambiente, argumentos de linha de comando, ou arquivos de configuração em um volume.

--- a/content/pt-br/docs/reference/glossary/container-env-variables.md
+++ b/content/pt-br/docs/reference/glossary/container-env-variables.md
@@ -1,7 +1,6 @@
 ---
 title: Variáveis de Ambiente de Contêineres
 id: container-env-variables
-date: 2021-11-20
 full_link: /pt-br/docs/concepts/containers/container-environment/
 short_description: >
   Variáveis de ambiente de contêineres são pares nome=valor que trazem informações úteis para os contêineres rodando dentro de um Pod.

--- a/content/pt-br/docs/reference/glossary/container-runtime.md
+++ b/content/pt-br/docs/reference/glossary/container-runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Agente de execução de contêiner
 id: container-runtime
-date: 2019-06-05
 full_link: /docs/setup/production-environment/container-runtimes
 short_description: >
   O agente de execução de contêiner é o software responsável por executar os contêineres.

--- a/content/pt-br/docs/reference/glossary/container.md
+++ b/content/pt-br/docs/reference/glossary/container.md
@@ -1,7 +1,6 @@
 ---
 title: Contêiner
 id: container
-date: 2018-04-12
 full_link: /docs/concepts/containers/
 short_description: >
   Uma imagem executável leve e portável que contém software e todas as suas dependências.

--- a/content/pt-br/docs/reference/glossary/containerd.md
+++ b/content/pt-br/docs/reference/glossary/containerd.md
@@ -1,7 +1,6 @@
 ---
 title: containerd
 id: containerd
-date: 2019-05-14
 full_link: https://containerd.io/docs/
 short_description: >
   Um agente de execução de contêiner com enfase em simplicidade, robustez e portabilidade

--- a/content/pt-br/docs/reference/glossary/contributor.md
+++ b/content/pt-br/docs/reference/glossary/contributor.md
@@ -1,7 +1,6 @@
 ---
 title: Contribuidor
 id: contributor
-date: 2018-04-12
 full_link: 
 short_description: >
   Alguém que doa código, documentação ou tempo para ajudar o projeto ou a comunidade Kubernetes.

--- a/content/pt-br/docs/reference/glossary/control-plane.md
+++ b/content/pt-br/docs/reference/glossary/control-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Camada de gerenciamento
 id: control-plane
-date: 2020-04-19
 full_link:
 short_description: >
   A camada de gerenciamento de contêiner que expõe a API e as interfaces para definir, implantar e gerenciar o ciclo de vida dos contêineres.

--- a/content/pt-br/docs/reference/glossary/controller.md
+++ b/content/pt-br/docs/reference/glossary/controller.md
@@ -1,7 +1,6 @@
 ---
 title: Controlador
 id: controller
-date: 2020-03-23
 full_link: /pt-br/docs/concepts/architecture/controller/
 short_description: >
   Um ciclo de controle que observa o estado partilhado do cluster através do API Server e efetua

--- a/content/pt-br/docs/reference/glossary/cri-o.md
+++ b/content/pt-br/docs/reference/glossary/cri-o.md
@@ -1,7 +1,6 @@
 ---
 title: CRI-O
 id: cri-o
-date: 2019-05-14
 full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   Um agente de execução leve de contêineres criado especificamente para o Kubernetes

--- a/content/pt-br/docs/reference/glossary/cri.md
+++ b/content/pt-br/docs/reference/glossary/cri.md
@@ -1,7 +1,6 @@
 ---
 title: Container runtime interface (CRI)
 id: cri
-date: 2019-03-07
 full_link: /docs/concepts/overview/components/#container-runtime
 short_description: >
     Uma API para agentes de execução de contêineres se integrarem com o kubelet

--- a/content/pt-br/docs/reference/glossary/cronjob.md
+++ b/content/pt-br/docs/reference/glossary/cronjob.md
@@ -1,7 +1,6 @@
 ---
 title: CronJob
 id: cronjob
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/cron-jobs/
 short_description: >
   Uma tarefa repetida (um trabalho) que é executada regularmente.

--- a/content/pt-br/docs/reference/glossary/csi.md
+++ b/content/pt-br/docs/reference/glossary/csi.md
@@ -1,7 +1,6 @@
 ---
 title: Interface de Armazenamento de Contêiner
 id: csi
-date: 2018-06-25
 full_link: /pt-br/docs/concepts/storage/volumes/#csi
 short_description: >
  A Interface de Armazenamento de Contêiner (_Container Storage Interface_, CSI) define um padrão de interface para expor sistemas de armazenamento a contêineres.

--- a/content/pt-br/docs/reference/glossary/customresourcedefinition.md
+++ b/content/pt-br/docs/reference/glossary/customresourcedefinition.md
@@ -1,7 +1,6 @@
 ---
 title: CustomResourceDefinition
 id: CustomResourceDefinition
-date: 2018-04-12
 full_link: /docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 short_description: >
   Código customizado que define um recurso a ser adicionado ao seu servidor de API Kubernetes sem a necessidade de construir um servidor customizado.

--- a/content/pt-br/docs/reference/glossary/daemonset.md
+++ b/content/pt-br/docs/reference/glossary/daemonset.md
@@ -1,7 +1,6 @@
 ---
 title: DaemonSet
 id: daemonset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/daemonset
 short_description: >
   Garante que uma cópia de um Pod esteja sendo executada em um conjunto de nós em um cluster.

--- a/content/pt-br/docs/reference/glossary/data-plane.md
+++ b/content/pt-br/docs/reference/glossary/data-plane.md
@@ -1,7 +1,6 @@
 ---
 title: Plano de Dados
 id: data-plane
-date: 2019-05-12
 full_link:
 short_description: >
   A camada que fornece capacidade, tais como CPU, memória, rede e armazenamento, para que os contêineres possam ser executados e conectados a uma rede.

--- a/content/pt-br/docs/reference/glossary/deployment.md
+++ b/content/pt-br/docs/reference/glossary/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 id: deployment
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/deployment/
 short_description: >
   Gerencia uma aplicação replicada no seu cluster.

--- a/content/pt-br/docs/reference/glossary/developer.md
+++ b/content/pt-br/docs/reference/glossary/developer.md
@@ -1,7 +1,6 @@
 ---
 title: Desenvolvedor (desambiguação)
 id: developer
-date: 2018-04-12
 full_link: 
 short_description: >
   Pode se referir a&#58; Desenvolvedor de Aplicativos, Colaborador de Código ou Desenvolvedor de Plataforma.

--- a/content/pt-br/docs/reference/glossary/docker.md
+++ b/content/pt-br/docs/reference/glossary/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker
 id: docker
-date: 2018-04-12
 full_link: https://docs.docker.com/engine/
 short_description: >
   Docker é uma tecnologia de software que fornece virtualização a nível do sistema operacional, também conhecida como contêineres.

--- a/content/pt-br/docs/reference/glossary/duration.md
+++ b/content/pt-br/docs/reference/glossary/duration.md
@@ -1,7 +1,6 @@
 ---
 title: Duração
 id: duration
-date: 2024-10-05
 full_link:
 short_description: >
   Um valor em forma de string que representa uma quantidade de tempo.

--- a/content/pt-br/docs/reference/glossary/ephemeral-container.md
+++ b/content/pt-br/docs/reference/glossary/ephemeral-container.md
@@ -1,7 +1,6 @@
 ---
 title: Contêiner Efêmero
 id: ephemeral-container
-date: 2019-08-26
 full_link: /docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
   Um tipo de contêiner que você pode executar temporariamente dentro de um Pod

--- a/content/pt-br/docs/reference/glossary/etcd.md
+++ b/content/pt-br/docs/reference/glossary/etcd.md
@@ -1,7 +1,6 @@
 ---
 title: etcd
 id: etcd
-date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
 short_description: >
   Armazenamento do tipo chave-valor consistente e de alta-disponibilidade, usado

--- a/content/pt-br/docs/reference/glossary/event.md
+++ b/content/pt-br/docs/reference/glossary/event.md
@@ -1,7 +1,6 @@
 ---
 title: Evento
 id: event
-date: 2022-01-16
 full_link: /docs/reference/kubernetes-api/cluster-resources/event-v1/
 short_description: >
    Um relatório de um evento em algum lugar do cluster. Geralmente denota alguma mudança de estado no sistema.

--- a/content/pt-br/docs/reference/glossary/eviction.md
+++ b/content/pt-br/docs/reference/glossary/eviction.md
@@ -1,7 +1,6 @@
 ---
 title: Evicção
 id: eviction
-date: 2022-03-05
 full_link: /pt-br/docs/concepts/scheduling-eviction/
 short_description: >
     Processo de encerramento de um ou mais Pods em Nós

--- a/content/pt-br/docs/reference/glossary/garbage-collection.md
+++ b/content/pt-br/docs/reference/glossary/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 title: Coleta de lixo
 id: garbage-collection
-date: 2021-07-07
 full_link: /docs/concepts/architecture/garbage-collection/
 short_description: >
   Um termo coletivo para os vários mecanismos que o Kubernetes usa para limpar os recursos do cluster.

--- a/content/pt-br/docs/reference/glossary/image.md
+++ b/content/pt-br/docs/reference/glossary/image.md
@@ -1,7 +1,6 @@
 ---
 title: Imagem
 id: image
-date: 2021-08-24
 full_link: 
 short_description: >
   Instância armazenada de um contêiner que contém o conjunto de softwares necessários para rodar uma aplicação.

--- a/content/pt-br/docs/reference/glossary/ingress.md
+++ b/content/pt-br/docs/reference/glossary/ingress.md
@@ -1,7 +1,6 @@
 ---
 title: Ingress
 id: ingress
-date: 2018-04-12
 full_link: /pt-br/docs/concepts/services-networking/ingress/
 short_description: >
   Um objeto da API que gerencia o acesso externo aos serviços em um cluster, normalmente HTTP.

--- a/content/pt-br/docs/reference/glossary/init-container.md
+++ b/content/pt-br/docs/reference/glossary/init-container.md
@@ -1,7 +1,6 @@
 ---
 title: Contêiner de inicialização
 id: init-container
-date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/init-containers/
 short_description: >
   Um ou mais contêineres de inicialização que devem ser executados até a conclusão antes que qualquer contêiner de aplicação seja executado.

--- a/content/pt-br/docs/reference/glossary/istio.md
+++ b/content/pt-br/docs/reference/glossary/istio.md
@@ -1,7 +1,6 @@
 ---
 title: Istio
 id: istio
-date: 2018-04-12
 full_link: https://istio.io/latest/about/service-mesh/#what-is-istio
 short_description: >
   Uma plataforma aberta (não específica do Kubernetes) que fornece uma maneira uniforme de integrar microsserviços, gerenciar o fluxo de tráfego, aplicar políticas e agregar dados de telemetria.

--- a/content/pt-br/docs/reference/glossary/job.md
+++ b/content/pt-br/docs/reference/glossary/job.md
@@ -1,7 +1,6 @@
 ---
 title: Job
 id: job
-date: 2021-07-14
 full_link: /docs/concepts/workloads/controllers/job
 short_description: >
   Uma tarefa finita ou em lotes que executa até finalizar.

--- a/content/pt-br/docs/reference/glossary/kerberos.md
+++ b/content/pt-br/docs/reference/glossary/kerberos.md
@@ -1,7 +1,6 @@
 ---
 title: Kerberos
 id: kerberos
-date: 2021-03-16
 full_link: 
 short_description: >
    Kerberos é um protocolo de rede que usa criptografia de chave secreta para autenticar aplicativos cliente-servidor. O Kerberos solicita um tíquete criptografado por meio de uma sequência de servidor autenticada para usar os serviços.

--- a/content/pt-br/docs/reference/glossary/keystone.md
+++ b/content/pt-br/docs/reference/glossary/keystone.md
@@ -1,7 +1,6 @@
 ---
 title: Keystone
 id: keystore
-date: 2020-08-03
 full_link: 
 short_description: >
    Keystone é o serviço de identidade usado pelo OpenStack para autenticação (authN) e autorização de alto nível (authZ). Atualmente, ele oferece suporte a authN com base em token e autorização de serviço do usuário. Recentemente, foi reprojetado para permitir a expansão para oferecer suporte a serviços externos de proxy e mecanismos AuthN / AuthZ, como oAuth, SAML e openID em versões futuras.

--- a/content/pt-br/docs/reference/glossary/kops.md
+++ b/content/pt-br/docs/reference/glossary/kops.md
@@ -1,7 +1,6 @@
 ---
 title: KOps (Kubernetes Operations)
 id: kops
-date: 2018-04-12
 full_link: /pt-br/docs/getting-started-guides/kops/
 short_description: >
   kOps não só te ajudará a criar, destruir, atualizar e manter clusters Kubernetes em nível de produção e altamente disponíveis, mas também provisionará a infraestrutura de nuvem necessária.

--- a/content/pt-br/docs/reference/glossary/kube-apiserver.md
+++ b/content/pt-br/docs/reference/glossary/kube-apiserver.md
@@ -1,7 +1,6 @@
 ---
 title: Servidor da API
 id: kube-apiserver
-date: 2018-04-12
 full_link: /pt-br/docs/concepts/overview/components/#kube-apiserver
 short_description: >
   O componente da camada de gerenciamento que serve a API do Kubernetes.

--- a/content/pt-br/docs/reference/glossary/kube-controller-manager.md
+++ b/content/pt-br/docs/reference/glossary/kube-controller-manager.md
@@ -1,7 +1,6 @@
 ---
 title: kube-controller-manager
 id: kube-controller-manager
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   Componente da camada de gerenciamento que executa os processos de controle.

--- a/content/pt-br/docs/reference/glossary/kube-proxy.md
+++ b/content/pt-br/docs/reference/glossary/kube-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: kube-proxy
 id: kube-proxy
-date: 2018-04-12
 full_link: /docs/reference/command-line-tools-reference/kube-proxy/
 short_description: >
   `kube-proxy` é um _proxy_ de rede executado em cada nó do _cluster_.

--- a/content/pt-br/docs/reference/glossary/kube-scheduler.md
+++ b/content/pt-br/docs/reference/glossary/kube-scheduler.md
@@ -1,7 +1,6 @@
 ---
 title: kube-scheduler
 id: kube-scheduler
-date: 2018-04-12
 full_link: /docs/reference/generated/kube-scheduler/
 short_description: >
   Componente da camada de gerenciamento que observa os Pods recém-criados e que

--- a/content/pt-br/docs/reference/glossary/kubeadm.md
+++ b/content/pt-br/docs/reference/glossary/kubeadm.md
@@ -1,7 +1,6 @@
 ---
 title: Kubeadm
 id: kubeadm
-date: 2018-04-12
 full_link: /docs/admin/kubeadm/
 short_description: >
   Uma ferramenta para instalar rapidamente o Kubernetes e configurar um cluster seguro.

--- a/content/pt-br/docs/reference/glossary/kubectl.md
+++ b/content/pt-br/docs/reference/glossary/kubectl.md
@@ -1,7 +1,6 @@
 ---
 title: Kubectl
 id: kubectl
-date: 2018-04-12
 full_link: /pt-br/docs/user-guide/kubectl-overview/
 short_description: >
   Uma ferramenta de linha de comando para se comunicar com um cluster Kubernetes.

--- a/content/pt-br/docs/reference/glossary/kubelet.md
+++ b/content/pt-br/docs/reference/glossary/kubelet.md
@@ -1,7 +1,6 @@
 ---
 title: Kubelet
 id: kubelet
-date: 2020-04-19
 full_link: /docs/reference/command-line-tools-reference/kubelet
 short_description: >
   Um agente que é executado em cada nó no cluster. Ele garante que os contêineres

--- a/content/pt-br/docs/reference/glossary/label.md
+++ b/content/pt-br/docs/reference/glossary/label.md
@@ -1,7 +1,6 @@
 ---
 title: Label
 id: label
-date: 2018-04-12
 full_link: /docs/concepts/overview/working-with-objects/labels
 short_description: >
   Marca os objetos com atributos de identificação que são significativos e relevantes para os usuários.

--- a/content/pt-br/docs/reference/glossary/ldap.md
+++ b/content/pt-br/docs/reference/glossary/ldap.md
@@ -1,7 +1,6 @@
 ---
 title: LDAP
 id: ldap
-date: 2021-03-16
 full_link: 
 short_description: >
    Abreviatura para "Lightweight Directory Access Protocol". Se você deseja disponibilizar informações de diretório na Internet, esta é a maneira de fazê-lo. O LDAP é uma versão simplificada de um padrão de diretório anterior denominado X.500.

--- a/content/pt-br/docs/reference/glossary/manifest.md
+++ b/content/pt-br/docs/reference/glossary/manifest.md
@@ -1,7 +1,6 @@
 ---
 title: Manifesto
 id: manifest
-date: 2019-06-28
 short_description: >
   Uma especificação serializada de um ou mais objetos da API do Kubernetes.
 aka:

--- a/content/pt-br/docs/reference/glossary/member.md
+++ b/content/pt-br/docs/reference/glossary/member.md
@@ -1,7 +1,6 @@
 ---
 title: Membro
 id: member
-date: 2018-04-12
 full_link: 
 short_description: >
   Um colaborador continuamente ativo na comunidade K8s.

--- a/content/pt-br/docs/reference/glossary/name.md
+++ b/content/pt-br/docs/reference/glossary/name.md
@@ -1,7 +1,6 @@
 ---
 title: Nome
 id: name
-date: 2018-04-12
 full_link: /pt-br/docs/concepts/overview/working-with-objects/names
 short_description: >
   Uma string fornecida pelo cliente que referencia um objeto em uma URL de

--- a/content/pt-br/docs/reference/glossary/namespace.md
+++ b/content/pt-br/docs/reference/glossary/namespace.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace
 id: namespace
-date: 2021-09-17
 full_link: /docs/concepts/overview/working-with-objects/namespaces
 short_description: >
   Uma abstração utilizada pelo Kubernetes para suportar múltiplos clusters virtuais no mesmo cluster físico.

--- a/content/pt-br/docs/reference/glossary/node.md
+++ b/content/pt-br/docs/reference/glossary/node.md
@@ -1,7 +1,6 @@
 ---
 title: Nó
 id: node
-date: 2020-04-19
 full_link: /pt-br/docs/concepts/architecture/nodes/
 short_description: >
   Um Nó é uma máquina de trabalho no Kubernetes.

--- a/content/pt-br/docs/reference/glossary/operator-pattern.md
+++ b/content/pt-br/docs/reference/glossary/operator-pattern.md
@@ -1,7 +1,6 @@
 ---
 title: Padrão Operador
 id: operator-pattern
-date: 2021-09-17
 full_link: /pt-br/docs/concepts/extend-kubernetes/operator/
 short_description: >
   Um controlador especializado que gerencia um recurso personalizado.

--- a/content/pt-br/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/pt-br/docs/reference/glossary/persistent-volume-claim.md
@@ -1,7 +1,6 @@
 ---
 title: Requisição de Volume Persistente
 id: persistent-volume-claim
-date: 2018-04-12
 full_link: /pt-br/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 short_description: >
   Declara recursos de armazenamento definidos em um PersistentVolume para que possa ser montado como um volume em um contêiner.

--- a/content/pt-br/docs/reference/glossary/persistent-volume.md
+++ b/content/pt-br/docs/reference/glossary/persistent-volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume Persistente
 id: persistent-volume
-date: 2018-04-12
 full_link: /pt-br/docs/concepts/storage/persistent-volumes/
 short_description: >
   Um objeto de API que representa uma parte do armazenamento no cluster. Disponível como um recurso geral e conectável que persiste além do ciclo de vida de qualquer pod individual.

--- a/content/pt-br/docs/reference/glossary/pod-disruption.md
+++ b/content/pt-br/docs/reference/glossary/pod-disruption.md
@@ -2,7 +2,6 @@
 id: pod-disruption
 title: Disrupção do Pod
 full_link: /docs/concepts/workloads/pods/disruptions/
-date: 2021-05-12
 short_description: >
   O processo pelo qual Pods ou nós são interrompidos de forma voluntária ou involuntária.
 

--- a/content/pt-br/docs/reference/glossary/pod.md
+++ b/content/pt-br/docs/reference/glossary/pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod
 id: pod
-date: 2020-04-19
 full_link: /docs/concepts/workloads/pods/
 short_description: >
   O menor e mais simples objeto Kubernetes. Um Pod representa um conjunto de contêineres em execução no seu cluster.

--- a/content/pt-br/docs/reference/glossary/rbac.md
+++ b/content/pt-br/docs/reference/glossary/rbac.md
@@ -1,7 +1,6 @@
 ---
 title: RBAC (Controle de Acesso Baseado em Funções)
 id: rbac
-date: 2018-04-12
 full_link: /docs/reference/access-authn-authz/rbac/
 short_description: >
   Gerencia decisões de autorização, permitindo que os administradores configurem dinamicamente políticas de acesso por meio da API do Kubernetes.

--- a/content/pt-br/docs/reference/glossary/reviewer.md
+++ b/content/pt-br/docs/reference/glossary/reviewer.md
@@ -1,7 +1,6 @@
 ---
 title: Revisor
 id: reviewer
-date: 2018-04-12
 full_link: 
 short_description: >
   Uma pessoa que revisa o código quanto à qualidade e correção em alguma parte do projeto.

--- a/content/pt-br/docs/reference/glossary/saml.md
+++ b/content/pt-br/docs/reference/glossary/saml.md
@@ -1,7 +1,6 @@
 ---
 title: SAML
 id: saml
-date: 2021-03-16
 full_link: 
 short_description: >
    SAML significa Linguagem de Marcação para Asserção de Segurança. É um padrão aberto baseado em XML para transferência de dados de identidade entre duas partes: um provedor de identidade (IdP) e um provedor de serviços (SP).

--- a/content/pt-br/docs/reference/glossary/secret.md
+++ b/content/pt-br/docs/reference/glossary/secret.md
@@ -1,7 +1,6 @@
 ---
 title: Secret
 id: secret
-date: 2021-08-24
 full_link: /pt-br/docs/concepts/configuration/secret/
 short_description: >
   Armazena dados sensíveis, como senhas, tokens OAuth e chaves SSH.

--- a/content/pt-br/docs/reference/glossary/selector.md
+++ b/content/pt-br/docs/reference/glossary/selector.md
@@ -1,7 +1,6 @@
 ---
 title: Seletor
 id: selector
-date: 2021-09-17
 full_link: /docs/concepts/overview/working-with-objects/labels/
 short_description: >
   Permite ao usuário filtrar uma lista de recursos com base em rótulos (labels).

--- a/content/pt-br/docs/reference/glossary/service-account.md
+++ b/content/pt-br/docs/reference/glossary/service-account.md
@@ -1,7 +1,6 @@
 ---
 title: ServiceAccount
 id: service-account
-date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   Fornece uma identidade para os processos que são executados em um Pod.

--- a/content/pt-br/docs/reference/glossary/service.md
+++ b/content/pt-br/docs/reference/glossary/service.md
@@ -1,7 +1,6 @@
 ---
 title: Service
 id: service
-date: 2021-09-17
 full_link: /docs/concepts/services-networking/service/
 short_description: >
   Uma forma abstrata de expor uma aplicação que está executando em um conjunto de Pods como um serviço de rede.

--- a/content/pt-br/docs/reference/glossary/shuffle-sharding.md
+++ b/content/pt-br/docs/reference/glossary/shuffle-sharding.md
@@ -1,7 +1,6 @@
 ---
 title: Shuffle-sharding
 id: shuffle-sharding
-date: 2020-03-04
 full_link:
 short_description: >
   Uma técnica para atribuir requisições para filas que proporciona melhor isolamento do que efetuar a operação módulo (resto da divisão) do _hash_ da requisição pelo número de filas.

--- a/content/pt-br/docs/reference/glossary/sig.md
+++ b/content/pt-br/docs/reference/glossary/sig.md
@@ -1,7 +1,6 @@
 ---
 title: SIG (grupo de interesse especial)
 id: sig
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
 short_description: >
   Membros da comunidade que gerenciam coletivamente e continuamente uma parte ou projeto maior do código aberto do Kubernetes.

--- a/content/pt-br/docs/reference/glossary/statefulset.md
+++ b/content/pt-br/docs/reference/glossary/statefulset.md
@@ -1,7 +1,6 @@
 ---
 title: StatefulSet
 id: statefulset
-date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/statefulset/
 short_description: >
   Gerencia deployment e escalonamento de um conjunto de Pods, com armazenamento durável e identificadores persistentes para cada Pod.

--- a/content/pt-br/docs/reference/glossary/static-pod.md
+++ b/content/pt-br/docs/reference/glossary/static-pod.md
@@ -1,7 +1,6 @@
 ---
 title: Pod estático
 id: static-pod
-date: 2021-09-17
 full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
   Um pod gerenciado diretamente pelo daemon do kubelet em um nó específico.

--- a/content/pt-br/docs/reference/glossary/storage-class.md
+++ b/content/pt-br/docs/reference/glossary/storage-class.md
@@ -1,7 +1,6 @@
 ---
 title: Classe de Armazenamento
 id: storageclass
-date: 2018-04-12
 full_link: /docs/concepts/storage/storage-classes
 short_description: >
   Uma Classe de Armazenamento oferece uma maneira para os administradores descreverem diferentes tipos de armazenamento disponíveis.

--- a/content/pt-br/docs/reference/glossary/sysctl.md
+++ b/content/pt-br/docs/reference/glossary/sysctl.md
@@ -1,7 +1,6 @@
 ---
 title: sysctl
 id: sysctl
-date: 2019-02-12
 full_link: /docs/tasks/administer-cluster/sysctl-cluster/
 short_description: >
   Uma interface para obter e definir parâmetros do kernel Unix.

--- a/content/pt-br/docs/reference/glossary/taint.md
+++ b/content/pt-br/docs/reference/glossary/taint.md
@@ -1,7 +1,6 @@
 ---
 title: Taint
 id: taint
-date: 2019-01-11
 full_link: /pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   Um objeto principal consistindo de três propriedades principais: chave, valor, e efeito. `Taints` previnem a alocação de Pods em nós ou grupos de nós.

--- a/content/pt-br/docs/reference/glossary/tls-common-name.md
+++ b/content/pt-br/docs/reference/glossary/tls-common-name.md
@@ -1,7 +1,6 @@
 ---
 title: TLS Common Name
 id: tls-common-name
-date: 2021-03-16
 full_link: 
 short_description: >
    O nome comum é normalmente composto de Host + Nome de domínio e será semelhante a www.seusite.com ou seusite.com. Os certificados de servidor SSL são específicos para o nome comum para o qual foram emitidos no nível do host.

--- a/content/pt-br/docs/reference/glossary/toleration.md
+++ b/content/pt-br/docs/reference/glossary/toleration.md
@@ -1,7 +1,6 @@
 ---
 title: Tolerância
 id: toleration
-date: 2019-01-11
 full_link: /pt-br/docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
   Um objeto principal consistindo de três propriedades principais: chave, valor, e efeito. Tolerâncias habilitam a alocação de Pods em nós ou grupos de nós que tenham uma taint coincidente.

--- a/content/pt-br/docs/reference/glossary/uid.md
+++ b/content/pt-br/docs/reference/glossary/uid.md
@@ -1,7 +1,6 @@
 ---
 title: UID
 id: uid
-date: 2021-03-16
 full_link: /pt-br/docs/concepts/overview/working-with-objects/names
 short_description: >
    Uma string gerada pelos sistemas do Kubernetes para identificar objetos de

--- a/content/pt-br/docs/reference/glossary/username.md
+++ b/content/pt-br/docs/reference/glossary/username.md
@@ -1,7 +1,6 @@
 ---
 title: Username
 id: username
-date: 2021-03-16
 full_link: 
 short_description: >
    Um nome de usuário é um nome que identifica exclusivamente alguém em um sistema de computador.

--- a/content/pt-br/docs/reference/glossary/userns.md
+++ b/content/pt-br/docs/reference/glossary/userns.md
@@ -1,7 +1,6 @@
 ---
 title: Namespace do usuário
 id: userns
-date: 2021-07-13
 full_link: https://man7.org/linux/man-pages/man7/user_namespaces.7.html
 short_description: >
   Um recurso do kernel Linux para emular privilégios de superusuário para usuários sem privilégios.

--- a/content/pt-br/docs/reference/glossary/volume-plugin.md
+++ b/content/pt-br/docs/reference/glossary/volume-plugin.md
@@ -1,7 +1,6 @@
 ---
 title: Plugin de Volume
 id: volumeplugin
-date: 2018-04-12
 full_link: 
 short_description: >
   Um plugin de volume permite a integração do armazenamento dentro de um Pod.

--- a/content/pt-br/docs/reference/glossary/volume.md
+++ b/content/pt-br/docs/reference/glossary/volume.md
@@ -1,7 +1,6 @@
 ---
 title: Volume
 id: volume
-date: 2021-08-24
 full_link: /docs/concepts/storage/volumes/
 short_description: >
   Um diretório contendo dados, accessível aos contêineres em um pod.

--- a/content/pt-br/docs/reference/glossary/wg.md
+++ b/content/pt-br/docs/reference/glossary/wg.md
@@ -1,7 +1,6 @@
 ---
 title: WG (Grupo de Trabalho)
 id: wg
-date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
 short_description: >
   Facilita a discussão e/ou implementação de um projeto de curta duração, pontual ou dissociado para um comitê, envolvendo um ou mais SIG (grupos de interesse especial).

--- a/content/pt-br/docs/reference/glossary/workload.md
+++ b/content/pt-br/docs/reference/glossary/workload.md
@@ -1,7 +1,6 @@
 ---
 title: Carga de Trabalho
 id: workloads
-date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
    Uma carga de trabalho é uma aplicação sendo executada no Kubernetes.


### PR DESCRIPTION
Fixes #48752

Remove obsolete date fields from all pt-br/ glossary term definitions.

This follows the same pattern as the English glossary cleanup in PR #54296.
Other localizations will be updated in separate PRs to avoid conflicts and coordinate with translation teams.