### PR TITLE
Add mount and network options to the cleanup of network rules

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -67,7 +67,7 @@ which was used in your cluster and the `--cleanup` flag of the
 `kube-proxy` binary:
 
 ```bash
-docker run --privileged --rm registry.k8s.io/kube-proxy:v{{< skew currentPatchVersion >}} sh -c "kube-proxy --cleanup && echo DONE"
+docker run --privileged -v /lib/modules:/lib/modules:ro --rm registry.k8s.io/kube-proxy:v{{< skew currentPatchVersion >}} sh -c "kube-proxy --cleanup && echo DONE"
 ```
 
 The output of the above command should print `DONE` at the end.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -67,7 +67,7 @@ which was used in your cluster and the `--cleanup` flag of the
 `kube-proxy` binary:
 
 ```bash
-docker run --privileged -v /lib/modules:/lib/modules:ro --rm registry.k8s.io/kube-proxy:v{{< skew currentPatchVersion >}} sh -c "kube-proxy --cleanup && echo DONE"
+docker run --privileged --network=host -v /lib/modules:/lib/modules:ro --rm registry.k8s.io/kube-proxy:v{{< skew currentPatchVersion >}} sh -c "kube-proxy --cleanup && echo DONE"
 ```
 
 The output of the above command should print `DONE` at the end.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR attempts to make minor changes to the command of the network traffic cleanup:
1. mount volume of `/lib/modules`, and
2. add `--network=host`

Firstly, the cleanup runs inside container and invokes the command `kube-proxy --cleanup`, which instead invokes `modprobe -va ip_vs` and fails due to the fact that `/lib/modules` is not mounted.

```
root@server:~# docker run --privileged --rm registry.k8s.io/kube-proxy:v1.33.8 sh -c "kube-proxy --cleanup && echo DONE"
I0216 08:55:39.440757       7 server_linux.go:63] "Using iptables proxy"
time="2026-02-16T08:55:39Z" level=warning msg="Running modprobe ip_vs failed with message: `modprobe: WARNING: Module ip_vs not found in directory /lib/modules/6.8.0-90-generic`, error: exit status 1"
DONE
```

This warning won't cause kubeproxy to fail, but it is somewhat frustrating. Adding read-only mount of `-v /lib/modules:/lib/modules:ro ` eliminate this warning.

```
root@server:~# docker run --privileged -v /lib/modules:/lib/modules:ro --rm registry.k8s.io/kube-proxy:v1.33.8 sh -c "kube-proxy --cleanup && echo DONE"
I0216 08:55:46.996953       7 server_linux.go:63] "Using iptables proxy"
DONE
root@server:~# 
```

Secondly, without `--network=host`, kube-proxy inside container cannot touch the host's network namespace. Adding this option allows kube-proxy to remove iptable rules.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #