### PR TITLE
KEP-4800: promote prefer-align-cpus-by-uncore-cache to GA

### DIFF
--- a/content/en/docs/concepts/policy/node-resource-managers.md
+++ b/content/en/docs/concepts/policy/node-resource-managers.md
@@ -207,7 +207,7 @@ listed in alphabetical order:
 : Prevent all the pods regardless of their Quality of Service class to run on reserved CPUs
   (available since Kubernetes v1.32, GA since Kubernetes v1.35)
 
-`prefer-align-cpus-by-uncorecache` (beta, visible by default)
+`prefer-align-cpus-by-uncorecache` (GA, visible by default)
 : Align CPUs by uncore (Last-Level) cache boundary on a best-effort way
   (available since Kubernetes v1.32)
 

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -156,7 +156,7 @@ The following policy options exist for the static `CPUManager` policy:
 * `align-by-socket` (alpha, hidden by default) (1.25 or higher)
 * `distribute-cpus-across-cores` (alpha, hidden by default) (1.31 or higher)
 * `strict-cpu-reservation` (GA, visible by default) (1.35 or higher)
-* `prefer-align-cpus-by-uncorecache` (beta, visible by default) (1.34 or higher)
+* `prefer-align-cpus-by-uncorecache` (GA, visible by default) (1.36 or higher)
 
 The `full-pcpus-only` option can be enabled by adding `full-pcpus-only=true` to
 the CPUManager policy options.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Promote `prefer-align-cpus-by-uncore-cache` static CPUManager policy option to GA. No user-visible changes.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
Closes: KEP https://github.com/kubernetes/enhancements/issues/5109
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #