### PR TITLE
KEP-3541: Add docs for Recreate update strategy for StatefulSet for alpha release

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -384,6 +384,10 @@ After reverting the template, you must also delete any Pods that StatefulSet had
 already attempted to run with the bad configuration.
 StatefulSet will then begin to recreate the Pods using the reverted template.
 
+### Recreate Update Strategy
+
+TBD
+
 ## Revision history
 
 ControllerRevision is a Kubernetes API resource used by controllers, such as the StatefulSet controller, to track historical configuration changes.


### PR DESCRIPTION
### Description
Update StatefulSet docs to include the new Recreate Update Strategy for alpha release.



### Issue

KEP Issue: [link](https://github.com/kubernetes/enhancements/issues/3541)
KEP: [link](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3541-add-recreate-strategy-to-statefulset)

/sig apps

Closes: #