### PR TITLE
KEP 3962: Mutating Admission Policies (Stable v1.36)

### DIFF
--- a/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/mutating-admission-policy.md
@@ -9,7 +9,7 @@ content_type: concept
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.34" state="beta" >}}
+{{< feature-state feature_gate_name="MutatingAdmissionPolicy" >}}
 <!-- due to feature gate history, use manual version specification here -->
 
 This page provides an overview of _MutatingAdmissionPolicies_.
@@ -19,7 +19,7 @@ If you want to use declarative policies just to prevent a particular kind of cha
 is
 a simpler and more effective alternative.
 
-To use the feature, enable the `MutatingAdmissionPolicy` feature gate (which is off by default) and set `--runtime-config=admissionregistration.k8s.io/v1beta1=true` on the kube-apiserver.
+
 
 <!-- body -->
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MutatingAdmissionPolicy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MutatingAdmissionPolicy.md
@@ -6,13 +6,17 @@ _build:
   render: false
 
 stages:
-  - stage: alpha 
+  - stage: alpha
     defaultValue: false
     fromVersion: "1.30"
     toVersion: "1.33"
   - stage: beta
     defaultValue: false
     fromVersion: "1.34"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 
 Enable [MutatingAdmissionPolicy](/docs/reference/access-authn-authz/mutating-admission-policy/) support, which allows

--- a/content/en/examples/mutatingadmissionpolicy/applyconfiguration-example.yaml
+++ b/content/en/examples/mutatingadmissionpolicy/applyconfiguration-example.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "sidecar-policy.example.com"

--- a/content/en/examples/mutatingadmissionpolicy/json-patch-example.yaml
+++ b/content/en/examples/mutatingadmissionpolicy/json-patch-example.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "sidecar-policy.example.com"


### PR DESCRIPTION
This PR addresses [KEP 3962](https://github.com/kubernetes/enhancements/issues/3962) targeting v1.36 stable.

@jpbetz @cici37 This PR updates the feature state to Stable and adds the feature gate stage for 1.36.