### PR TITLE
Blog: KEP-4680 Resource Health Status reaches Beta in v1.36

### DIFF
--- a/content/en/blog/_posts/2026-04-22-resource-health-status-beta.md
+++ b/content/en/blog/_posts/2026-04-22-resource-health-status-beta.md
@@ -1,0 +1,21 @@
+---
+layout: blog
+title: "Kubernetes v1.36: Resource Health Status in Pod Status Reaches Beta"
+date: 2026-04-22
+draft: true
+slug: resource-health-status-beta
+author: >
+  [Harshal Patil](https://github.com/harche)
+---
+
+Placeholder for the KEP-4680 feature blog.
+
+## Summary
+
+KEP-4680 adds a new `allocatedResourcesStatus` field to Pod Status that exposes
+the health of devices (GPUs, FPGAs, etc.) allocated to a Pod via Device Plugin
+or Dynamic Resource Allocation (DRA). This enables users and controllers to
+detect when a Pod is using an unhealthy device, improving troubleshooting for
+device-related failures.
+
+<!-- TODO: expand with motivation, what's new in beta, examples, and next steps -->


### PR DESCRIPTION
## Summary

Placeholder PR for the KEP-4680 feature blog, as requested by the v1.36 Communications Team
in https://github.com/kubernetes/enhancements/issues/4680#issuecomment-3918572340.

KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4680-add-resource-health-to-pod-status/README.md

This blog covers the Resource Health Status feature reaching Beta in v1.36,
which exposes device health information (from Device Plugin and DRA) in Pod Status.

/sig node