### PR TITLE
KEP-2862: KubeletFineGrainedAuthz Graduate to STABLE

### DIFF
--- a/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
+++ b/content/en/docs/reference/access-authn-authz/kubelet-authn-authz.md
@@ -100,10 +100,10 @@ flags passed to the apiserver is authorized for the following attributes:
 
 {{< feature-state feature_gate_name="KubeletFineGrainedAuthz" >}}
 
-When the feature gate `KubeletFineGrainedAuthz` is enabled kubelet performs a
-fine-grained check before falling back to the `proxy` subresource for the `/pods`,
-`/runningPods`, `/configz` and `/healthz` endpoints. The resource and subresource 
-are determined from the incoming request's path:
+Kubelet performs a fine-grained check before falling back to the `proxy`
+subresource for the `/pods`, `/runningPods`, `/configz` and `/healthz`
+endpoints. The resource and subresource are determined from the incoming
+request's path:
 
 Kubelet API   | resource | subresource
 --------------|----------|------------

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletFineGrainedAuthz.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/KubeletFineGrainedAuthz.md
@@ -13,6 +13,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.33"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 Enable [fine-grained authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/#fine-grained-authorization) 
 for the kubelet's HTTP(s) API.


### PR DESCRIPTION
### Description

Update feature-gate documentation for KubeletFineGrainedAuthz and remove the reference to the feature gate in the documentation.

### Issue

xref: kubernetes/enhancements/issues/2862