### PR TITLE
Update ccm details: api-server no longer supports cloud-provider argument

### DIFF
--- a/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -46,7 +46,7 @@ integration, it should not be too different from the requirements when running
 
 Successfully running cloud-controller-manager requires some changes to your cluster configuration.
 
-* `kubelet`, `kube-apiserver`, and `kube-controller-manager` must be set according to the
+* `kubelet` and `kube-controller-manager` must be set according to the
   user's usage of external CCM. If the user has an external CCM (not the internal cloud
   controller loops in the Kubernetes Controller Manager), then `--cloud-provider=external`
   must be specified. Otherwise, it should not be specified.


### PR DESCRIPTION

### Description

Clarified requirements for kubelet and kube-controller-manager configuration when using external cloud controller manager.

api-server fails, if the cloud-provider flag is given.

