### PR TITLE
Correct grammatical issue in ResourceQuota glossary entry

### DIFF
--- a/content/en/docs/reference/glossary/resource-quota.md
+++ b/content/en/docs/reference/glossary/resource-quota.md
@@ -16,7 +16,7 @@ consumption, per {{< glossary_tooltip term_id="namespace" >}}.
 
 <!--more-->
 
-A ResourceQuota can either limits the quantity of {{< glossary_tooltip text="API resources" term_id="api-resource" >}}
+A ResourceQuota can either limit the quantity of {{< glossary_tooltip text="API resources" term_id="api-resource" >}}
 that can be created in a namespace by type, or it can set a limit on the total amount of
 {{< glossary_tooltip text="infrastructure resources" term_id="infrastructure-resource" >}}
 that may be consumed on behalf of the namespace (and the objects within it).


### PR DESCRIPTION
### Description

This PR corrects a grammatical issue in the `ResourceQuota` glossary entry by changing “can either _limits_” to “can either _limit_”.