### PR TITLE
Rework home page to bring it closer to Docsy

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -270,7 +270,8 @@ $ocean-nodes-h3-margin-bottom: 30px;
 }
 
 // OCEAN NODES
-#oceanNodes, .td-home .k8s-overview {
+// TODO: Remove this id from here and fron translated home pages
+#oceanNodes {
 
   padding-top: $ocean-nodes-padding-Y;
   padding-bottom: $ocean-nodes-padding-Y;

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -434,63 +434,6 @@ $ocean-nodes-h3-margin-bottom: 30px;
   font-size: 14px;
 }
 
-// Features
-body.td-home section.features-container {
-  padding: 0; // reset
-  padding-top: 140px; // make room for logo
-
-  background-color: $light-grey;
-  background-image: url(/images/wheel.svg);
-  background-position: center 60px;
-  background-repeat: no-repeat;
-  background-size: 60px;
-
-  padding-bottom: 2em;
-
-  .k8s-features-heading {
-    color: $primary;
-    text-align: center;
-  }
-
-  & > div {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: stretch;
-    gap: 1.2rem;
-
-    margin-top: 1.8em;
-
-    max-width: clamp(75em, 25cm, 90vw);
-    margin-left: auto;
-    margin-right: auto;
-
-    background: initial;
-
-    & > .feature-box {
-        margin: 0;
-
-        h3 {
-          text-align: center;
-          line-height: normal;
-          font-size: 1.3em;
-          margin-bottom: 1rem;
-        }
-
-        flex-basis: calc(min(75vw, 12.5cm, 35em));
-        flex-shrink: 0;
-
-        border-radius: 0.5em;
-        padding: 1em;
-        padding-bottom: 1.2em;
-
-        background-color: #daeaf9; // light blue
-    }
-  }
-}
-
 // Talk to us
 #talkToUs {
   h3,

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -375,26 +375,7 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
         }
       }
 
-      section.features-container .k8s-features-heading {
-        color: $white;
-        background-color: $dark-bg-color-1;
-      }
-
-      section.features-container > div > .feature-box {
-        background-color: $dark-bg-color-2;
-        color:$dark-text-color-1;
-
-        h3 a, h4 a, h5 a {
-          color: $white;
-          background: transparent;
-        }
-
-        h3 a:hover, h4 a:hover, h5 a:hover {
-          text-decoration: underline;
-        }
-      }
-
-        section.section-feature#kubeweekly {
+      section.section-feature#kubeweekly {
         background-color: $dark-bg-color-2;
         color: $dark-text-color-1;
 
@@ -1956,65 +1937,6 @@ body.td-home section#upcoming-events > .col > .row {
         content: '• ';
       }
     }
-  }
-}
-
-body.td-home section.case-studies {
-   h2, h3 {
-     text-align: center;
-   }
-  .case-study-list {
-    display: flex;
-    flex-direction: row;
-    max-width: 80vw;
-    margin-left: auto;
-    margin-right: auto;
-    align-items: stretch;
-    gap: clamp(1rem, 4em, 10vw);
-    > .case-study-item {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      text-align: center;
-      width: clamp(6rem, 20%, 50vw);
-      picture, picture img {
-        height: 4.8rem;
-        text-align: center;
-      }
-      > a {
-        display: block;
-        text-align: right;
-      }
-    }
-    padding-bottom: 2em;
-  }
-  padding-top: 4rem;
-}
-
-@media screen and (max-width: 768px) {
-  .case-study-list {
-    justify-content: center;
-    flex-wrap: wrap;
-    > .case-study-item {
-      min-width: 34vw;
-    }
-  }
-}
-
-@media screen and (max-width: 650px) {
-  .case-study-list {
-    > .case-study-item {
-     min-width: 51vw;
-    }
-  }
-}
-
-
-
-// handle main page features on narrow viewports
-@media screen and (max-width: 768px) {
-  .features-container div.feature-box {
-     min-width: 80vw;
   }
 }
 

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -7,9 +7,6 @@ $announcement-size-adjustment: 8px;
 
 /* GLOBAL */
 .td-main {
-  .row {
-    margin: 0;
-  }
 
   main {
     *:not(figure) > img {
@@ -341,7 +338,7 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
       background-color: $dark-bg-color-2;
       color:$dark-text-color-1;
 
-      section:not(#video):not(#cncf) {
+      section:not(#video):not(#cncf):not(#search-bar) {
         background-color: $dark-bg-color-1;
         color:$dark-text-color-1;
       }
@@ -372,8 +369,10 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
         background-color: $dark-bg-color-1;
       }
 
-      section#cncf {
-        background-color: $dark-bg-color-2;
+      section {
+        &#cncf, &#search-bar {
+          background-color: $dark-bg-color-2;
+        }
       }
 
       section.features-container .k8s-features-heading {
@@ -400,11 +399,11 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
         color: $dark-text-color-1;
 
         .kubeweekly-inner form p {
-          color: $white; 
+          color: $white;
         }
 
         a.kubeweekly-signup, a.kubeweekly-signup:hover {
-          color: $white; 
+          color: $white;
         }
       }
 
@@ -451,8 +450,8 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
 
-.td-home section#video.section-with-bgimage {
-  background: #13110f; // match video
+.td-home section#video {
+  background-color: #13110f; // match video
   background-position: 65% center, left center;
   background-repeat: no-repeat, repeat;
   background-size: auto 100%, cover;
@@ -481,7 +480,7 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
 @media only screen and (max-width: 1024px) {
-  .td-home section#video.section-with-bgimage {
+  .td-home section#video {
     background-size: contain, cover;
     .video-text-optional {
       padding: 0.5rem;

--- a/assets/scss/_k8s_home.scss
+++ b/assets/scss/_k8s_home.scss
@@ -1,0 +1,239 @@
+$k8s-overview-y: 4em;
+$k8s-overview-h3-margin-bottom: 2em;
+
+body.td-home {
+  section {
+    padding-top: 0;
+    padding-bottom: 0;
+
+    &#search-bar {
+      padding-top: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    &#k8s-overview {
+      padding-top: $k8s-overview-y;
+      padding-bottom: $k8s-overview-y;
+
+      @media (prefers-color-scheme: light) {
+        background-color: #fff;
+        color: #222
+      }
+
+      a {
+        color: $primary;
+      }
+
+      .main-section {
+        margin-bottom: $k8s-overview-y;
+        min-height: 160px;
+
+        @media screen and (min-width: 768px) {
+          position: relative;
+          clear: both;
+          display: table;
+
+          .content {
+            display: table-cell;
+            position: relative;
+            vertical-align: middle;
+          }
+
+          &:nth-child(odd) {
+            padding-right: 210px;
+
+            .image-wrapper {
+              right: 0;
+              text-align: right;
+            }
+          }
+
+          &:nth-child(even) {
+            padding-left: 210px;
+
+            .image-wrapper {
+              left: 0;
+              text-align: left;
+            }
+          }
+        }
+
+        &:first-child {
+          .image-wrapper {
+            max-width: 100%;
+
+            img {
+              max-width: 491px;
+            }
+          }
+
+          @media screen and (min-width: 768px) {
+            padding-right: 0;
+
+            p {
+              text-align: center;
+            }
+
+            .image-wrapper {
+              position: relative;
+              display: block;
+              float: none;
+              text-align: center;
+              max-width: 100%;
+              transform: none;
+            }
+
+            .content {
+              display: block;
+            }
+          }
+        }
+
+        .image-wrapper {
+          max-width: 75%;
+          margin: 0 auto 20px;
+          text-align: center;
+
+          @media screen and (min-width: 768px) {
+            position: absolute;
+            top: 50%;
+            max-width: 25%;
+            max-height: 100%;
+            transform: translateY(-50%);
+            width: 100%;
+          }
+
+          img {
+            width: 100%;
+            max-width: 160px;
+          }
+        }
+      }
+    }
+
+    &#features {
+      padding: 140px 0 2em; // make room for logo
+
+      background-color: $light-grey;
+      background-image: url(/images/wheel.svg);
+      background-position: center 60px;
+      background-repeat: no-repeat;
+      background-size: 60px;
+
+      h2 {
+        color: $primary;
+        text-align: center;
+
+        @media (prefers-color-scheme: dark) {
+          color: $white;
+          background-color: $dark-bg-color-1;
+        }
+      }
+
+      #feature-flex {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        flex-wrap: wrap;
+        align-content: flex-start;
+        align-items: stretch;
+        gap: 1.2rem;
+
+        margin-top: 1.8em;
+
+        max-width: clamp(75em, 25cm, 90vw);
+        margin-left: auto;
+        margin-right: auto;
+
+        background: initial;
+
+        #feature-box {
+          margin: 0;
+
+          flex-basis: calc(min(75vw, 12.5cm, 35em));
+          flex-shrink: 0;
+
+          border-radius: 0.5em;
+          padding: 1em 1em 1.2em;
+
+          background-color: #daeaf9; // light blue
+
+          @media screen and (min-width: 768px) {
+            min-width: clamp(20rem, 6cm, 90vw);
+            max-width: clamp(90rem, 10cm, 90vw);
+          }
+
+          @media screen and (max-width: 768px) {
+            min-width: 80vw;
+          }
+
+          @media (prefers-color-scheme: dark) {
+            background-color: $dark-bg-color-2;
+            color:$dark-text-color-1;
+
+            h3 a {
+              color: $white;
+            }
+          }
+
+          h3 {
+            text-align: center;
+            line-height: normal;
+            font-size: 1.3em;
+            margin-bottom: 1rem;
+          }
+        }
+      }
+    }
+
+    &#case-studies {
+      padding-top: 4rem;
+
+      h3 {
+        text-align: center;
+      }
+
+      #case-study-list {
+        display: flex;
+        flex-direction: row;
+        max-width: 80vw;
+        margin-left: auto;
+        margin-right: auto;
+        align-items: stretch;
+        gap: clamp(1rem, 4em, 10vw);
+        padding-bottom: 2em;
+
+        @media screen and (max-width: 768px) {
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+
+        #case-study-item {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          text-align: center;
+          width: clamp(6rem, 20%, 50vw);
+
+          @media screen and (max-width: 768px) {
+            min-width: 34vw;
+          }
+
+          @media screen and (max-width: 650px) {
+            min-width: 51vw;
+          }
+
+          picture, picture img {
+            height: 4.8rem;
+            text-align: center;
+          }
+
+          a {
+            display: block;
+            text-align: right;
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/scss/_k8s_home.scss
+++ b/assets/scss/_k8s_home.scss
@@ -11,7 +11,8 @@ body.td-home {
       padding-bottom: 1rem;
     }
 
-    &#k8s-overview {
+    //TODO: The class .k8s-overview is set to be removed and should not be used
+    &#k8s-overview, &.k8s-overview {
       padding-top: $k8s-overview-y;
       padding-bottom: $k8s-overview-y;
 

--- a/assets/scss/_k8s_home.scss
+++ b/assets/scss/_k8s_home.scss
@@ -17,7 +17,7 @@ body.td-home {
 
       @media (prefers-color-scheme: light) {
         background-color: #fff;
-        color: #222
+        color: #222;
       }
 
       a {
@@ -130,7 +130,7 @@ body.td-home {
         }
       }
 
-      #feature-flex {
+      .feature-flex {
         display: flex;
         flex-direction: row;
         justify-content: center;
@@ -147,7 +147,7 @@ body.td-home {
 
         background: initial;
 
-        #feature-box {
+        .feature-box {
           margin: 0;
 
           flex-basis: calc(min(75vw, 12.5cm, 35em));

--- a/assets/scss/_k8s_home.scss
+++ b/assets/scss/_k8s_home.scss
@@ -208,7 +208,7 @@ body.td-home {
           flex-wrap: wrap;
         }
 
-        #case-study-item {
+        .case-study-item {
           display: flex;
           flex-direction: column;
           justify-content: space-between;

--- a/assets/scss/_k8s_search.scss
+++ b/assets/scss/_k8s_search.scss
@@ -9,6 +9,14 @@
   }
 }
 
+main section .td-search {
+  @media only screen and (min-width: 576px) {
+    max-width: 50%;
+  }
+  margin: 0 auto;
+  width: 100%;
+}
+
 .td-search {
   width: unset;
 }

--- a/assets/scss/_k8s_search.scss
+++ b/assets/scss/_k8s_search.scss
@@ -15,6 +15,10 @@ main section .td-search {
   }
   margin: 0 auto;
   width: 100%;
+
+  // Override the padding provided by .row
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .td-search {

--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -14,6 +14,10 @@
   background-repeat: no-repeat;
   background-position: 50%;
 
+  // Override the padding provided by .row
+  padding-left: 0;
+  padding-right: 0;
+
   &.gutter-horizontal {
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
     cursor: col-resize;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,6 +7,7 @@ Add styles or import other files. */
 @import "custom";
 
 // Base styles
+@import "k8s_home";
 @import "k8s_community";
 @import "k8s_nav";
 @import "k8s_search";

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,8 +7,8 @@ Add styles or import other files. */
 @import "custom";
 
 // Base styles
-@import "k8s_home";
 @import "k8s_community";
+@import "k8s_home";
 @import "k8s_nav";
 @import "k8s_search";
 @import "k8s_sidebar-tree";

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -45,7 +45,8 @@ $vendor-strip-font-size: 16px;
     }
   }
 
-  #oceanNodes, .td-home .k8s-overview {
+  // TODO: Remove this id from here and fron translated home pages
+  #oceanNodes {
     h3 {
       text-align: left;
       margin-bottom: 18px;
@@ -91,7 +92,6 @@ $vendor-strip-font-size: 16px;
       }
 
       &:nth-child(1) {
-        padding-right: 0;
 
         h3,
         p {

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -150,9 +150,4 @@ $vendor-strip-font-size: 16px;
       width: 48%;
     }
   }
-
-  .features-container div.feature-box {
-     min-width: clamp(20rem, 6cm, 90vw);
-     max-width: clamp(90rem, 10cm, 90vw);
-  }
 }

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -7,7 +7,7 @@ sitemap:
   priority: 1.0
 ---
 
-{{< blocks/section class="k8s-overview" >}}
+{{< blocks/section id="k8s-overview" >}}
 {{% blocks/feature image="flower" id="feature-primary" %}}
 [Kubernetes]({{< relref "/docs/concepts/overview/" >}}), also known as K8s, is an open source system for automating deployment, scaling, and management of containerized applications.
 
@@ -31,7 +31,7 @@ Whether testing locally or running a global enterprise, Kubernetes flexibility g
 {{% blocks/feature image="suitcase" %}}
 #### Run K8s anywhere
 
-Kubernetes is open source giving you the freedom to take advantage of on-premises, hybrid, or public cloud infrastructure, letting you effortlessly move workloads to where it matters to you.
+Kubernetes is open source, giving you the freedom to take advantage of on-premises, hybrid, or public cloud infrastructure, letting you effortlessly move workloads to where it matters to you.
 
 To download Kubernetes, visit the [download](/releases/download/) section.
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,13 +1,10 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="{{.Params.class}} no-js" dir="{{ or .Site.Language.LanguageDirection `ltr` }}">
-{{- if eq hugo.Environment "preview" -}}
-  <!-- deploy preview -->
-{{- end -}}
+<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="{{.Params.class}} no-js" dir="{{ or .Site.Language.LanguageDirection `ltr` }}">
   <head{{- if hugo.IsProduction}} class="live-site"{{- end -}}>
     {{ partial "head.html" . }}
     {{ partial "css.html" . }}
   </head>
-  <body class="td-{{ .Kind }}{{- if ne (lower .Params.cid) "" -}}{{- printf " cid-%s" (lower .Params.cid) -}}{{- end -}}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+  <body class='td-{{ .Kind }}{{- if ne (lower .Params.cid) "" -}}{{- printf " cid-%s" (lower .Params.cid) -}}{{- end -}}{{ with .Page.Params.body_class }} {{ . }}{{ end }}'>
     <header>
       {{ partial "navbar.html" . }}
       {{ block "announcement" . }}
@@ -25,7 +22,7 @@
 		</section>
     {{ end }}
     </header>
-    <div class="td-outer">
+    <div class="container-fluid td-default td-outer">
       <main role="main" class="td-main" {{ if (or (ne .FirstSection "case-studies") (not .IsSection) ) }}data-pagefind-body{{ end }}>
         {{ block "deprecation_warning" . }}
           {{ if or .IsHome ( eq .Params.cid "partners" ) ( eq .Params.cid "community" ) }}

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -1,14 +1,14 @@
-{{- define "main" -}}
+{{ define "main" }}
 <section class="case-study-header">
 	<div class="banner {{ if .Params.use_gradient_overlay }}overlay{{ end }}" {{ if isset .Params "heading_background" }}style="background-image: url({{ .Params.heading_background }});"{{ end }}>
-		<h2>
+		<h1>
 			{{- .Params.title_prefix | default ( T "case_study_prefix" ) -}}&nbsp;
 			{{- if isset .Params "heading_title_logo" -}}
 				<img class="heading-logo" src="{{ .Params.heading_title_logo}}" />
 			{{- else if isset .Params "heading_title_text" -}}
 				{{- .Params.heading_title_text -}}
 			{{- end -}}
-		</h2>
+		</h1>
 		<span class="subheading">{{ .Params.subheading }}</span>
 	</div>
 	<!-- Details -->

--- a/layouts/page/home.html
+++ b/layouts/page/home.html
@@ -1,10 +1,17 @@
 {{ define "main" }}
-<div class="col-sm-6 col-md-6 col-lg-6 mx-auto py-3">
+
+{{/*
+The class that has been added to the two sections in here is based on the
+ones present in the shortcode "blocks/section.html", which makes these two partials
+look and behave the same as the sections created by the shortcode
+*/}}
+
+<section id="search-bar" class="row td-box td-box---1 td-box--gradient td-box--height-auto">
   {{ partial "search-input" .}}
-</div>
+</section>
 {{ partial "tutorial-signpost.html" . }}
 {{ .Content }}
-<section id="cncf">
+<section id="cncf" class="row td-box td-box---1 td-box--gradient td-box--height-auto">
     {{ partial "cncf.html" . }}
 </section>
 {{- end -}}

--- a/layouts/partials/kubernetes-overview.html
+++ b/layouts/partials/kubernetes-overview.html
@@ -1,3 +1,0 @@
-<section id="{{ .id }}"{{ with .class }} class="{{ . }}"{{ end }}>
-  {{ .inner }}
-</section>

--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -3,28 +3,30 @@
 {{ errorf "[%s] No case-studies section found. Create content/%s/case-studies/_index.md"  $.Page.Lang $.Page.Lang }}
 {{- else -}}
 {{ $caseStudiesPages := where $caseStudiesSection.Pages "Params.featured" true | first 4 }}
-<section class="case-studies">
-  <h3><a href="{{ $caseStudiesSection.RelPermalink }}">{{ $caseStudiesSection.LinkTitle }}</a></h3>
-  <div class="case-study-list">
-      {{- range $caseStudiesPages -}}
-			{{ $dark := .Resources.GetMatch "**{dark_logo}*.svg" }}
-			{{ $logo := .Resources.GetMatch "**{featured_logo}*.svg" }}
-			
-			{{ if not $logo }}
-				{{ $logo = .Resources.GetMatch "**logo*.png" }}
-			{{ end }}
-			{{- if not $dark -}}
-				{{ $dark = $logo }}
-			{{- end -}}
-	  <div class="case-study-item">
+<section id="case-studies" class="row td-box td-box---1 td-box--gradient td-box--height-auto">
+  <div class="flex-fill">
+    <h3><a href="{{ $caseStudiesSection.RelPermalink }}">{{ $caseStudiesSection.LinkTitle }}</a></h3>
+    <div id="case-study-list">
+        {{- range $caseStudiesPages -}}
+        {{ $dark := .Resources.GetMatch "**{dark_logo}*.svg" }}
+        {{ $logo := .Resources.GetMatch "**{featured_logo}*.svg" }}
+
+        {{ if not $logo }}
+          {{ $logo = .Resources.GetMatch "**logo*.png" }}
+        {{ end }}
+        {{- if not $dark -}}
+          {{ $dark = $logo }}
+        {{- end -}}
+      <div id="case-study-item">
         <picture>
-	  	  <source srcset="{{$dark.RelPermalink}}" media="(prefers-color-scheme: dark)">
-	  	    <img src="{{ $logo.RelPermalink }}" alt="{{ .Title }}">
-		</picture>
-        <p>"{{ .Params.quote | truncate 100 }}"</p>
-        <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
+          <source srcset="{{$dark.RelPermalink}}" media="(prefers-color-scheme: dark)">
+            <img src="{{ $logo.RelPermalink }}" alt="{{ .Title }}">
+        </picture>
+          <p>"{{ .Params.quote | truncate 100 }}"</p>
+          <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
       </div>
-     {{- end -}}  
+      {{- end -}}
+    </div>
   </div>
 </section>
 {{- end -}}

--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -17,7 +17,7 @@
         {{- if not $dark -}}
           {{ $dark = $logo }}
         {{- end -}}
-      <div id="case-study-item">
+      <div class="case-study-item">
         <picture>
           <source srcset="{{$dark.RelPermalink}}" media="(prefers-color-scheme: dark)">
             <img src="{{ $logo.RelPermalink }}" alt="{{ .Title }}">

--- a/layouts/shortcodes/blocks/kubernetes-features.html
+++ b/layouts/shortcodes/blocks/kubernetes-features.html
@@ -1,6 +1,6 @@
-{{/* 
+{{/*
 
-This shortcode lists pages that have a "feature" section configured in front matter. 
+This shortcode lists pages that have a "feature" section configured in front matter.
 
 This creates a set of feature boxes as seen on the home page.
 
@@ -11,25 +11,30 @@ feature:
   description: >
     No need to modify your application to use an unfamiliar service discovery mechanism. Kubernetes gives containers their own IP addresses and a single DNS name for a set of containers, and can load-balance across them.
 
-Note that markdown can be used in the description.
+Note that Markdown can be used in the description.
+
+Also note that the class added to the section is based on the ones present in the shortcode "blocks/section.html",
+which makes this partial look and behave the same as the sections created by the shortcode.
 
  */}}
-<section class="features-container" id="features">
+<section id="features" class="row td-box td-box---1 td-box--gradient td-box--height-auto">
+  <div class="flex-fill">
     {{- with resources.Get "images/wheel.svg" -}}
     <img class="kubernetes-logo wheel" src="{{ .RelPermalink }}" alt="">
     {{- end -}}
 
-    <h2 class="k8s-features-heading">{{ T "main_kubernetes_features" }}</h2>
-    <div>
-        {{ $pages := where site.Pages ".Params.feature" "!=" nil }}
-        {{ range $i, $p := $pages }}
-            <div class="feature-box">
-                {{ with .Params.feature }}
-                <h3><a href="{{ $p.RelPermalink}}{{ with .anchor }}#{{ . | anchorize }}{{ end }}">{{ .title }}</a></h3>
-                {{ $description := .description | default $p.Params.description }}
-                {{ $description | markdownify }}
-                {{ end }}
-            </div>
-        {{ end }}
+    <h2>{{ T "main_kubernetes_features" }}</h2>
+    <div id="feature-flex">
+      {{ $pages := where site.Pages ".Params.feature" "!=" nil }}
+      {{ range $i, $p := $pages }}
+      <div id="feature-box">
+          {{ with .Params.feature }}
+          <h3><a href="{{ $p.RelPermalink}}{{ with .anchor }}#{{ . | anchorize }}{{ end }}">{{ .title }}</a></h3>
+          {{ $description := .description | default $p.Params.description }}
+          {{ $description | markdownify }}
+          {{ end }}
+      </div>
+      {{ end }}
     </div>
+  </div>
 </section>

--- a/layouts/shortcodes/blocks/kubernetes-features.html
+++ b/layouts/shortcodes/blocks/kubernetes-features.html
@@ -24,10 +24,10 @@ which makes this partial look and behave the same as the sections created by the
     {{- end -}}
 
     <h2>{{ T "main_kubernetes_features" }}</h2>
-    <div id="feature-flex">
+    <div class="feature-flex">
       {{ $pages := where site.Pages ".Params.feature" "!=" nil }}
       {{ range $i, $p := $pages }}
-      <div id="feature-box">
+      <div class="feature-box">
           {{ with .Params.feature }}
           <h3><a href="{{ $p.RelPermalink}}{{ with .anchor }}#{{ . | anchorize }}{{ end }}">{{ .title }}</a></h3>
           {{ $description := .description | default $p.Params.description }}

--- a/layouts/shortcodes/blocks/section.html
+++ b/layouts/shortcodes/blocks/section.html
@@ -1,22 +1,23 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
-{{- $col_id := .Get "color" | default .Ordinal -}}
-{{- $height := .Get "height" | default "auto"  -}}
-{{- $type   := .Get "type" | default "" -}}
-{{- $style := .Get "style" -}}
-{{- $id_fallback := ( printf "td-block-%d" .Ordinal ) -}}
-{{- $id := .Get "id" | default (printf "%s%s" $id_fallback "-section" ) -}}
-{{- $class := .Get "class" -}}
-{{- $bg := .Get "background-image" -}}
-{{- if $bg -}}
-  {{- template "shortcodes-blocks_getimage" (dict "name" $bg "ctx" . "target" "bg") }}
-{{- end -}}
-{{/* special case Kubernetes overview */}}
-{{- if eq $class "k8s-overview" -}}
- {{- partial "kubernetes-overview.html" (dict "id" $id "class" $class "inner" $.Inner ) -}}
-{{- else -}}
-<a id="{{ $id_fallback }}" class="td-offset-anchor"></a>
-{{- $image := $.Scratch.Get "bg" -}}
-<section id="{{ $id }}" class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }}{{ with $class }} {{ . }}{{ end }}{{ with $image }} section-with-bgimage {{ end }}" style="{{ with $image }}background-image: url({{ .Permalink }}); {{ end }}{{ with $style }}{{ . | safeCSS }}{{ end }}">
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $col_id := .Get "color" | default .Ordinal }}
+{{ $height := .Get "height" | default "auto"  }}
+{{ $type   := .Get "type" | default "" }}
+{{ $bg     := .Get "background-image" }}
+{{ $id := .Get "id" | default (printf "td-block-%d-section" .Ordinal ) }}
+{{/* Image background based on Docsy's blocks/cover shortcode */}}
+{{ if $bg }}
+{{ template "shortcodes-blocks_getimage" (dict "name" $bg "ctx" . "target" "bg") }}
+{{ end }}
+{{ $image := $.Scratch.Get "bg" }}
+{{ with $image }}
+<style>
+#{{ $id }} {
+  background-image: url({{ .Permalink }});
+}
+</style>
+{{ end }}
+<a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a>
+<section id="{{ $id }}" class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }}">
 	<div class="col">
 		<div class="row {{ $type }}">
 			{{ if eq .Page.File.Ext "md" }}
@@ -27,4 +28,3 @@
 		</div>
 	</div>
 </section>
-{{- end -}}

--- a/layouts/shortcodes/blocks/section.html
+++ b/layouts/shortcodes/blocks/section.html
@@ -17,7 +17,11 @@
 </style>
 {{ end }}
 <a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a>
-<section id="{{ $id }}" class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }}">
+<!--
+TODO: `k8s-overview` is added here as a class only for backwards compatibility and should be removed once
+      all the localised home pages move from using `k8s-overview` as an id instead of a class
+-->
+<section id="{{ $id }}" class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }} k8s-overview">
 	<div class="col">
 		<div class="row {{ $type }}">
 			{{ if eq .Page.File.Ext "md" }}


### PR DESCRIPTION
This PR align the homepage layouts and shortcodes to upstream Docsy and helps with #41171.

The primary task was to align `shortcode/blocks/section.html` by removing unnecessary customisations. One of them is the kubernetes-overview, which itself was using a partial that is no longer necessary.

In the `kubernetes-features` and `case-studies` shortcodes, single identifying classes on an element have been replaced by `id` attributes since they don't lead to proliferations of classes. Changes to the stylesheets were made accordingly. Moreover, most of the styles used in the homepage were moved to a new partial `_k8s_home.scss`.