### PR TITLE
docs: remove broken Summary API link from node metrics page

### DIFF
--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -9,8 +9,7 @@ description: >-
 
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
 gathers metric statistics at the node, volume, pod and container level,
-and emits this information in the
-[Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/).
+and emits this information via the kubelet stats summary API.
 
 You can send a proxied request to the stats summary API via the
 Kubernetes API server.
@@ -50,7 +49,7 @@ the kubelet [fetches Pod- and container-level metric data using CRI](/docs/refer
 As a beta feature, Kubernetes lets you configure kubelet to collect Linux kernel
 [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
 (PSI) for CPU, memory, and I/O usage. The information is collected at node, pod and container level.
-See [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/) for detailed schema.
+See the kubelet stats summary API for detailed schema information.
 This feature is enabled by default, by setting the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/). The information is also exposed in
 [Prometheus metrics](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 


### PR DESCRIPTION
### Description
Removes the broken link to the deprecated kubelet stats v1alpha1 Summary API
from the Node metrics data page.

### Issue
Fixes #52308