### PR TITLE
docs(ccm): new route controller metric for KEP 5237

### DIFF
--- a/content/en/blog/_posts/2025-12-30-watch-based-route-reconciliation-in-ccm.md
+++ b/content/en/blog/_posts/2025-12-30-watch-based-route-reconciliation-in-ccm.md
@@ -21,6 +21,8 @@ introduced to [k8s.io/cloud-provider](https://github.com/kubernetes/cloud-provid
 To enable this feature you can use `--feature-gate=CloudControllerManagerWatchBasedRoutesReconciliation=true`
 in the CCM implementation you are using.
 
+In Kubernetes v1.36 we introduced a new metric in alpha stage to the route controller in [k8s.io/cloud-provider](https://github.com/kubernetes/cloud-provider). This metric is called `route_controller_route_sync_total` and tracks the amount of times routes are synced with the cloud provider. This metric is not gated and can be used to measure the impact of the feature gate mentioned above.
+
 ## About the feature gate
 
 This feature gate will trigger the route reconciliation loop whenever a node is


### PR DESCRIPTION
### Description

Updating an existing feature blog to also include the new metric, which is added in Kubernetes v1.36. This metric is needed for A/B testing the feature gate, so we can move this forward to beta stage.

Current feature blog: https://kubernetes.io/blog/2025/12/30/kubernetes-v1-35-watch-based-route-reconciliation-in-ccm/

Upon asking, it was decided to update the feature blog, instead of creating a new one: https://github.com/kubernetes/enhancements/issues/5237#issuecomment-3939251800