### PR TITLE
Add kube-router CNI to network addons list

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -59,6 +59,12 @@ installation instructions. The list does not try to be exhaustive.
   provides an expressive, extensible, and role-oriented API for modeling service networking.
 * [Knitter](https://github.com/ZTE/Knitter/) is a plugin to support multiple network
   interfaces in a Kubernetes pod.
+* [kube-router](https://github.com/cloudnativelabs/kube-router) is an open
+  source turnkey solution for Kubernetes networking with the aim to provide
+  operational simplicity and high performance. It leverages the Kubernetes API,
+  BGP, and Golang for the control path and Linux networking primitives (IPVS,
+  nftables, etc.) for the data path. It provides a low overhead alternative and
+  is used in both k0s and k3s.
 * [Multus](https://github.com/k8snetworkplumbingwg/multus-cni) is a Multi plugin for
   multiple network support in Kubernetes to support all CNI plugins
   (e.g. Calico, Cilium, Contiv, Flannel), in addition to SRIOV, DPDK, OVS-DPDK and


### PR DESCRIPTION
### Description

Adds kube-router to the list of CNI add-ons. kube-router has been an open source, Kubernetes network conformance test compliant network manager for over 7 years. It is used in [k3s](https://docs.k3s.io/networking/networking-services#network-policy-controller) and [k0s](https://docs.k0sproject.io/v1.21.0+k0s.0/networking/) and has native integration with [kops](https://kops.sigs.k8s.io/networking/kube-router/).