### PR TITLE
feat: align navbar to docsy to use menu entries in frontmatter instead of hardcoding

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -24,15 +24,26 @@
     {{- /* In Docsy, the mt-2 class is used but that causes issues. This should be re-visited after 0.7 migration */ -}}
     <ul class="navbar-nav mt-lg-0">
       {{ $p := . -}}
-      {{/* The below code needs to be aligned to Docsy to use the menu data from the front matter wherever possible */}}
-      {{ $sections := slice "docs" "blog" "training" "careers" "partners" "community" }}
-      {{ range $sections }}
-      {{ with site.GetPage "section" . }}
+      {{ range .Site.Menus.main -}}
       <li class="nav-item mr-4 mb-2 mb-lg-0">
-        {{ $active := eq .Section $.Section }}
-        <a class="nav-link{{if $active }} active{{end}}" href="{{ .RelPermalink }}" >{{ .Title }}</a>
+        {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+        {{ with .Page }}{{ $active = or $active ( $.IsDescendant .) }}{{ end -}}
+        {{ $pre := .Pre -}}
+        {{ $post := .Post -}}
+        {{ $url := urls.Parse .URL -}}
+        {{ $baseurl := urls.Parse $.Site.Params.Baseurl -}}
+        <a {{/**/ -}}
+          class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+          href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"
+          {{- if ne $url.Host $baseurl.Host }} target="_blank" {{- end -}}
+        >
+            {{- with .Pre }}{{ $pre }}{{ end -}}
+            <span {{- if $active }} class="active" {{- end }}>
+              {{- .Name -}}
+            </span>
+            {{- with .Post }}{{ $post }}{{ end -}}
+        </a>
       </li>
-      {{ end -}}
       {{ end -}}
       {{ if .Site.Params.versions -}}
       <li class="nav-item dropdown mr-4 d-none d-lg-block">
@@ -40,7 +51,7 @@
       </li>
       {{ end -}}
       {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item dropdown mr-xl-4 d-none d-lg-block">
+      <li class="nav-item dropdown mr-4 d-none d-lg-block">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}


### PR DESCRIPTION
This PR changes how the list of main menu items in the navbar is detected. Right now, the list is hardcoded in the customised `navbar.html` partial, but in Docsy, it's generated using the Hugo-provided `Site.menus.main`.

The section pages already have the `menu` property in their frontmatter, so this change just aligns the logic with Docsy. The only change is that the order of the items changes a bit, from ... Careers, Partners, Community ... to ... Partners, Community, Careers ... The reason is the `weights` provided in the frontmatter. If we _must_ keep the order the same, I will update the weights in the frontmatter to reflect it.

This overall makes the navbar logic almost the same as Docsy and helps with #41171.