### PR TITLE
Improve security clarification for Kubernetes Secrets

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -650,7 +650,7 @@ Secrets it expects to interact with, other apps within the same namespace can
 render those assumptions invalid.
 
 Authorization configuration affects how Secret data can be accessed within a namespace. 
-For example, granting `list` or `watch` permissions on Secrets allows a subject 
+For example, granting **list** or **watch** permissions on Secrets allows a subject
 to read all Secret data in that namespace, not only the Secrets explicitly 
 referenced by its Pods. Restrict access to the minimum set of permissions 
 required for a workload to function, and avoid granting broad roles such as 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR adds a dedicated "Security considerations" section to the Secrets documentation.
The goal is to clarify that base64 encoding does not provide confidentiality and to emphasize the importance of encryption at rest and proper RBAC restrictions.
This change improves operator awareness and helps reduce the risk of secret exposure or privilege escalation due to misconfiguration.
The update applies to all currently supported Kubernetes versions and does not introduce version-specific behavior.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

