### PR TITLE
[KEP-4006] Docs v1.36

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/extend-websockets-to-kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/extend-websockets-to-kubelet.md
@@ -1,0 +1,19 @@
+---
+title: ExtendWebSocketsToKubelet
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.36"
+---
+When ExtendWebSocketsToKubelet is enabled and a kubelet node advertises support,
+exec/attach/portforward streams are proxied directly to the kubelet rather than
+being translated or tunneled at the API server. Critically, the same
+stream translation and tunneling handlers used at the API server are now set up
+identically at the kubelet — the logic is simply moved closer to the container
+runtime. This feature depends on NodeDeclaredFeatures graduating to beta so that
+kubelet capability advertisement is reliable in production clusters.


### PR DESCRIPTION
### [KEP-4006] Docs for ExtendWebSocketsToKubelet

* Docs for new `ExtendWebSocketsToKubelet` feature gate, which is Beta and on by default.

* KEP PR for v1.36: https://github.com/kubernetes/enhancements/pull/5792
* PR for v1.36: https://github.com/kubernetes/kubernetes/pull/136256

[KEP-4006](https://github.com/kubernetes/enhancements/issues/4006)

