### PR TITLE
docs: clarify deployment selector immutability

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -358,7 +358,9 @@ it cannot be updated via `kubectl patch`, `kubectl edit`, `kubectl apply`, or to
 If you must change the selector, you have to delete the Deployment and recreate it.
 Exercise great caution and ensure you grasp the following implications:
 
-* **Additions:** When you add a new label to the selector, you **must** also update the Pod template labels
+* **Additions:** When you create a new Deployment with a narrower selector, the new Deployment **must** also have a suitable Pod template.
+  If you have an existing manifest and you edit the manifest to narrow the selector, you need to edit the metadata of the Pod template inside that Deployment, adding the
+  new labels
   to match, as otherwise the API server returns a validation error. This is a _non-overlapping_ change:
   the new Deployment will not "see" the old Pods (which lack the new label), causing the old
   ReplicaSet to be **orphaned** and a brand-new ReplicaSet to be created.


### PR DESCRIPTION
The current "Label selector updates" section is confusing because it describes update scenarios for an immutable field. This PR clarifies that in apps/v1, the selector cannot be patched directly and explains what happens to Pods and ReplicaSets when a Deployment is recreated with a new selector.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

 The current "Label selector updates" section is misleading because it describes "update" scenarios (additions, removals, changes) for a field that is explicitly immutable in `apps/v1`. 


This PR clarifies the documentation by:

- Explicitly stating that `spec.selector` is immutable and cannot be patched directly via `kubectl` or tools like Helm.

- Explaining that the described behaviors (orphaning and recreation) occur when a user manually deletes and recreates the Deployment.

- Formatting the text to follow the "one sentence per line" style common in Kubernetes docs for better readability.


### Issue


None. This is a documentation clarity improvement based on community feedback regarding confusing wording in the Workloads section.


Closes: # 
