### PR TITLE
Add gateway.networking.k8s.io/generator annotation to reference

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1474,6 +1474,20 @@ Starting from v1.20, this annotation is deprecated.
 Experimental Hyper-V support was removed in 1.21.
 {{< /note >}}
 
+### gateway.networking.k8s.io/generator
+
+Type: Annotation
+
+Example: `gateway.networking.k8s.io/generator: "ingress2gateway"`
+
+Used on: Gateway, HTTPRoute, and other Gateway API resources
+
+This annotation is added by tools that automatically generate
+[Gateway API](/docs/concepts/services-networking/gateway/) resources.
+The value identifies the tool that created the resource (for example,
+`ingress2gateway`). The annotation is informational only and does not
+affect the behavior of any Gateway API implementation.
+
 ### ingressclass.kubernetes.io/is-default-class
 
 Type: Annotation


### PR DESCRIPTION

### Description
Adds documentation for the `gateway.networking.k8s.io/generator` annotation to the well-known labels, annotations and taints reference page. This annotation is used by tools that automatically generate Gateway API resources (such as ingress2gateway)  resources (such as `ingress2gateway`) to identify themselves as the creator of thoseresources. It was previously undocumented.
### Issue
Closes: #54675