### PR TITLE
docs: update declarative validation to reflect updated KEP-5073 lifecycle

### DIFF
--- a/content/en/docs/reference/using-api/declarative-validation.md
+++ b/content/en/docs/reference/using-api/declarative-validation.md
@@ -20,7 +20,7 @@ optimized Go code for API validation.
 
 While primarily a feature impacting Kubernetes contributors and potentially developers of [extension API servers](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/), cluster administrators should understand its behavior, especially during its rollout phases.
 
-Declarative validation tags can apply directly to net-new API fields without requiring any lifecycle mechanism (eg: can just use `+k8s:minimum=1`). For migrating existing hand-written validations where the declarative validation is shadowing the existing hand-written validation logic, the rollout is controlled by the validation lifecycle tags (`+k8s:alpha` and `+k8s:beta`) alongside the `DeclarativeValidationBeta` feature gate:
+Declarative validation tags can apply directly to net-new API fields without requiring any lifecycle mechanism (for example, it is possible to use `+k8s:minimum=1`). For migrating existing hand-written validations where the declarative validation is shadowing the existing hand-written validation logic, the rollout is controlled by the validation lifecycle tags (`+k8s:alpha` and `+k8s:beta`) alongside the `DeclarativeValidationBeta` feature gate:
 
 *   `DeclarativeValidation`: (GA in v1.36, Default: `true`, LockToDefault: `true`) The API server runs *both* the new declarative validation and the old hand-written validation for migrated types/fields in "shadow mode" (Alpha). The results are compared internally.
 *   `DeclarativeValidationBeta`: (Beta, Default: `true`) Introduced in v1.36. This gate controls the enforcement of beta-stage validation rules. When enabled, rules marked as `+k8s:beta` are authoritative; when disabled, they revert to shadow mode.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR updates the declarative validation documentation to reflect the new `+k8s:alpha` and `+k8s:beta` shadow lifecycle semantic detailed in recent KEP-5073 updated:
- https://github.com/kubernetes/enhancements/pull/5848
- https://github.com/kubernetes/enhancements/pull/5898

#### Summary
- Removes the `+k8s:declarativeValidationNative` tag which has been superseded. (previously added in: https://github.com/kubernetes/website/pull/53556)
- Adds documentation for the `+k8s:alpha` and `+k8s:beta` tag, which allows individual validations to run in shadow mode (collecting metrics while still allowing the existing hand-written code to be authoritative) and in authoritative mode respectively. This is used for safely migrating hand-written validation logic.
- Cleans up stability level notes for `isSubresource` and `supportsSubresource` that previously referenced the deprecated native tag.

**NOTE:** a previous version of this PR was submitted here - https://github.com/kubernetes/website/pull/54195. This PR was created to have the changes properly target the `dev-v1.36` branch and that PR was closed.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
N/A

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #
N/A