### PR TITLE
Revise mobile nav to Bootstrap structure, aligned with Docsy

### DIFF
--- a/assets/js/legacy-script.js
+++ b/assets/js/legacy-script.js
@@ -144,26 +144,13 @@ var kub = (function () {
     }
 
     function toggleMenu() {
-        if (window.innerWidth < 800) {
-            pushmenu.show('primary');
-        }
-
-        else {
-            var newHeight = HEADER_HEIGHT;
-
-            if (!html.hasClass('open-nav')) {
-                newHeight = mainNav.outerHeight();
-            }
-
-            header.css({height: px(newHeight)});
-            html.toggleClass('open-nav');
-        }
+        $('#main_navbar').collapse('toggle');
     }
 
     function handleKeystrokes(e) {
         switch (e.which) {
             case 27: {
-                if (html.hasClass('open-nav')) {
+                if ($('#main_navbar').hasClass('show')) {
                     toggleMenu();
                 }
                 break;
@@ -364,109 +351,6 @@ var kub = (function () {
     }
 })();
 
-
-var pushmenu = (function(){
-    var allPushMenus = {};
-
-    $(document).ready(function(){
-        $('[data-auto-burger]').each(function(){
-            var container = this;
-            var id = container.getAttribute('data-auto-burger');
-
-            var autoBurger = document.getElementById(id) || newDOMElement('div', 'pi-pushmenu', id);
-            var ul = autoBurger.querySelector('ul') || newDOMElement('ul');
-
-            $(container).find('a[href], button').each(function () {
-                if (!booleanAttributeValue(this, 'data-auto-burger-exclude', false)) {
-                    var clone = this.cloneNode(true);
-                    clone.id = '';
-
-                    if (clone.tagName == "BUTTON") {
-                        var aTag = newDOMElement('a');
-                        aTag.href = '';
-                        aTag.innerHTML = clone.innerHTML;
-                        aTag.onclick = clone.onclick;
-                        clone = aTag;
-                    }
-                    var li = newDOMElement('li');
-                    li.appendChild(clone);
-                    ul.appendChild(li);
-                }
-            });
-
-            autoBurger.appendChild(ul);
-            body.append(autoBurger);
-        });
-
-        $(".pi-pushmenu").each(function(){
-            allPushMenus[this.id] = PushMenu(this);
-        });
-    });
-
-    function show(objId) {
-        allPushMenus[objId].expose();
-    }
-
-    function PushMenu(el) {
-        var html = document.querySelector('html');
-
-        var overlay = newDOMElement('div', 'overlay');
-        var content = newDOMElement('div', 'content');
-        content.appendChild(el.querySelector('*'));
-
-        var side = el.getAttribute("data-side") || "right";
-
-        var sled = newDOMElement('div', 'sled');
-        $(sled).css(side, 0);
-
-        sled.appendChild(content);
-
-        var closeButton = newDOMElement('button', 'btn fa fa-times');
-        closeButton.onclick = closeMe;
-
-        sled.appendChild(closeButton);
-
-        overlay.appendChild(sled);
-        el.innerHTML = '';
-        el.appendChild(overlay);
-
-        sled.onclick = function(e){
-            e.stopPropagation();
-        };
-
-        overlay.onclick = closeMe;
-
-        window.addEventListener('resize', closeMe);
-
-        function closeMe(e) {
-            if (e.target == sled) return;
-
-            $(el).removeClass('on');
-            setTimeout(function(){
-                $(el).css({display: 'none'});
-            }, 300);
-        }
-
-        function exposeMe(){
-            $(el).css({
-                display: 'block',
-                zIndex: highestZ()
-            });
-
-            setTimeout(function(){
-                $(el).addClass('on');
-            }, 10);
-        }
-
-        return {
-            expose: exposeMe
-        };
-    }
-
-    return {
-        show: show
-    };
-})();
 
 $(function() {
     // If vendor strip doesn't exist add className

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,13 +1,18 @@
 $(document).ready(async function () {
   await switchLogoOnResize();
   flipNavColor()
+  initMobileDrawer();
 
   window.addEventListener('resize', switchLogoOnResize);
   window.addEventListener('scroll', flipNavColor);
+  window.addEventListener('resize', collapseDrawerOnDesktop);
 
   document.onunload = function () {
     window.removeEventListener('resize', switchLogoOnResize);
     window.removeEventListener('scroll', flipNavColor);
+    window.removeEventListener('resize', collapseDrawerOnDesktop);
+    $("#main_navbar").off('show.bs.collapse shown.bs.collapse hide.bs.collapse hidden.bs.collapse');
+    $('body').removeClass('td-navbar-drawer-opening td-navbar-drawer-open td-navbar-drawer-closing');
   };
 });
 
@@ -19,7 +24,7 @@ async function switchLogoOnResize() {
   // No-op if the navbar logo is disabled via hugo params
   {{- if ne .ui.navbar_logo false }}
   const logoSpan = $("nav .navbar-brand__logo");
-  const breakpointMd = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--breakpoint-md').trim());
+  const breakpointMd = getBreakpointMd();
   let svg
 
   if (window.innerWidth < breakpointMd) {
@@ -42,6 +47,67 @@ async function switchLogoOnResize() {
 
   $(logoSpan).html(svg)
   {{ end -}}
+}
+
+function initMobileDrawer() {
+  const drawer = $("#main_navbar");
+  if (!drawer.length) {
+    return;
+  }
+
+  drawer.on('show.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-navbar-drawer-closing')
+      .addClass('td-navbar-drawer-opening td-navbar-drawer-open');
+  });
+
+  drawer.on('shown.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-navbar-drawer-opening td-navbar-drawer-closing')
+      .addClass('td-navbar-drawer-open');
+  });
+
+  drawer.on('hide.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-navbar-drawer-opening td-navbar-drawer-open')
+      .addClass('td-navbar-drawer-closing');
+  });
+
+  drawer.on('hidden.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body').removeClass('td-navbar-drawer-opening td-navbar-drawer-open td-navbar-drawer-closing');
+  });
+}
+
+function collapseDrawerOnDesktop() {
+  const drawer = $("#main_navbar");
+  if (!drawer.length) {
+    return;
+  }
+
+  if (window.innerWidth >= getBreakpointMd() && drawer.hasClass('show')) {
+    drawer.collapse('hide');
+  }
+}
+
+function getBreakpointMd() {
+  const breakpointMd = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--breakpoint-md').trim(), 10);
+  return Number.isNaN(breakpointMd) ? 768 : breakpointMd;
 }
 
 // Copied over from Docsy's assets/js/base.js

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -308,32 +308,6 @@ footer .row > .order-2 { flex: 0 0 66.6667%; max-width: 66.6667%; }
 footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
-/* SIDE-DRAWER MENU */
-
-.pi-pushmenu .sled {
-  .content ul {
-    padding: 0;
-
-    li {
-      &:first-child {
-        display: none;
-      }
-
-      a.nav-link {
-        padding: 0;
-      }
-    }
-  }
-  .push-menu-close-button {
-    background: transparent;
-    border: none;
-
-    &:focus {
-      outline: none;
-    }
-  }
-}
-
 // Home page dark-mode
 @media (prefers-color-scheme: dark) {
   body.cid-home {

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -1,6 +1,11 @@
+// Shared toggler icon shape: keep geometry/thickness identical across states; only stroke color changes.
+@function td-navbar-toggler-icon($stroke-color) {
+  @return escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$stroke-color}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='3.5' d='M4 7h22M4 15h22M4 23h22'/></svg>"));
+}
+
 .td-navbar {
-  background: transparent !important;
-  position: fixed !important;
+  background: transparent;
+  position: fixed;
   transition: 0.3s;
   width: 100%;
 
@@ -16,7 +21,11 @@
 
   .navbar-brand {
     @include media-breakpoint-down(sm) {
-      margin-left: auto;
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-left: 0;
+      z-index: 1039;
     }
 
     svg {
@@ -30,20 +39,182 @@
     }
   }
 
-  #hamburger {
+  .navbar-toggler {
+    margin-left: auto;
+    border: 0;
     color: $navbar-dark-color;
 
-    &:hover:focus {
+    &:hover,
+    &:focus {
       color: $navbar-dark-hover-color;
     }
 
-    margin-left: auto;
-    font-size: xx-large;
+    .navbar-toggler-icon {
+      width: 1.7em;
+      height: 2em;
+      background-image: td-navbar-toggler-icon($navbar-dark-color);
+    }
 
-    // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the hamburger button
+    // Bootstrap buttons have a noticeable depression effect when clicked.
     &:focus,
     &:active {
-      box-shadow: none !important;
+      box-shadow: none;
+      outline: 0;
+    }
+  }
+
+  @include media-breakpoint-up(md) {
+    #main_navbar.navbar-collapse {
+      flex-grow: 0;
+      flex-basis: auto;
+      width: auto;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    .td-navbar-nav-scroll {
+      width: 100%;
+    }
+
+    #main_navbar {
+      // Keep drawer in the render tree for transform-based slide animation;
+      // collapse events still drive state, visibility, and interaction.
+      display: block;
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: 100vw;
+      max-width: 400px;
+      // Bootstrap Collapse writes inline `height`; force full-height drawer.
+      height: 100vh !important;
+      margin-top: 0;
+      padding: .75rem 1.25rem 1rem;
+      background: $white;
+      box-shadow: -2px 0 12px rgba(0, 0, 0, 0.25);
+      transform: translateX(100%);
+      transition: transform 0.3s ease;
+      visibility: hidden;
+      pointer-events: none;
+      overflow-y: auto;
+      z-index: 1041;
+    }
+
+    #main_navbar.collapsing {
+      display: block;
+      // Bootstrap Collapse writes inline `height` while transitioning.
+      height: 100vh !important;
+      margin-top: 0;
+      visibility: visible;
+      pointer-events: auto;
+      transition: transform 0.3s ease;
+      overflow-y: auto;
+    }
+
+    #main_navbar .navbar-nav {
+      display: block;
+      margin-top: 2.5rem;
+      padding: 0;
+      white-space: normal;
+    }
+
+    #main_navbar .nav-item {
+      display: block;
+      // Override Bootstrap `.mr-4` utility, which is declared with `!important`.
+      margin-right: 0 !important;
+      // Override Bootstrap `.mb-2` utility, which is declared with `!important`.
+      margin-bottom: 0 !important;
+      min-height: 2.75rem;
+      padding: 0;
+      border-bottom: 1px solid #cccccc;
+    }
+
+    #main_navbar .navbar-nav .nav-link {
+      display: block;
+      padding: 0 2rem 0 0;
+      line-height: 2.75rem;
+      font-size: 1.25rem;
+      font-weight: 400;
+      color: $primary;
+      box-shadow: none;
+    }
+
+    #main_navbar .navbar-nav .active > .nav-link,
+    #main_navbar .navbar-nav .nav-link.active {
+      color: $primary;
+      box-shadow: none;
+    }
+
+    .td-navbar-drawer-close {
+      position: absolute;
+      top: .25rem;
+      right: .5rem;
+      z-index: 1;
+      font-size: 2.66rem;
+      line-height: 1;
+      color: $dark-grey;
+      background: transparent;
+      border: 0;
+
+      &:focus,
+      &:active {
+        box-shadow: none;
+        outline: 0;
+      }
+    }
+
+    .td-navbar-mobile-group {
+      display: block;
+    }
+
+    .td-navbar-mobile-group-toggle {
+      width: 100%;
+      margin: 0;
+      padding: 0 2rem 0 0;
+      text-align: left;
+      background: transparent;
+      border: 0;
+      color: $primary;
+      font-size: 1.25rem;
+      font-weight: 400;
+      box-shadow: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      &:focus,
+      &:active {
+        box-shadow: none;
+        outline: 0;
+      }
+
+      i {
+        font-size: .95rem;
+        transition: transform 0.2s ease;
+      }
+
+      &:not(.collapsed) i {
+        transform: rotate(180deg);
+      }
+    }
+
+    .td-navbar-mobile-group-menu {
+      margin-bottom: .5rem;
+    }
+
+    .td-navbar-mobile-group-item {
+      display: block;
+      padding: 0 2rem 0 1rem;
+      line-height: 2.35rem;
+      font-size: 1.05rem;
+      font-weight: 400;
+      color: $primary;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        color: $primary;
+        text-decoration: underline;
+      }
     }
   }
 
@@ -59,14 +230,72 @@
 }
 }
 
+@include media-breakpoint-down(sm) {
+  body.td-navbar-drawer-opening #main_navbar,
+  body.td-navbar-drawer-open #main_navbar {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-navbar-drawer-closing #main_navbar {
+    transform: translateX(100%);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .td-navbar .td-navbar-drawer-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 1040;
+  }
+
+  body.td-navbar-drawer-opening .td-navbar .td-navbar-drawer-backdrop,
+  body.td-navbar-drawer-open .td-navbar .td-navbar-drawer-backdrop,
+  body.td-navbar-drawer-closing .td-navbar .td-navbar-drawer-backdrop {
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-navbar-drawer-opening .td-navbar .td-navbar-drawer-backdrop,
+  body.td-navbar-drawer-open .td-navbar .td-navbar-drawer-backdrop {
+    opacity: 1;
+  }
+}
+
 .navbar-bg-onscroll {
+  // Override Docsy `.navbar-bg-onscroll` background, which is `!important`.
   background: white !important;
   box-shadow: 0 1px 2px $medium-grey;
 
-  .navbar-nav .nav-link, #hamburger {
+  .navbar-nav .nav-link,
+  .navbar-toggler {
     color: $dark-grey;
 
-    &:hover:focus {
+    &:hover,
+    &:focus {
+      color: $medium-grey;
+    }
+  }
+
+  .navbar-toggler .navbar-toggler-icon {
+    background-image: td-navbar-toggler-icon($dark-grey);
+  }
+
+  .navbar-nav .nav-link {
+    color: $dark-grey;
+
+    &:hover,
+    &:focus {
       color: $medium-grey;
     }
   }
@@ -87,89 +316,5 @@
 
   .navbar-brand__logo.navbar-logo svg #its-pronounced path {
     fill: $primary;
-  }
-}
-
-/* Small/Mobile viewport nav menu */
-
-.pi-pushmenu {
-  display: none;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  transition: opacity 0.3s;
-
-  &.on {
-    opacity: 1;
-
-    .sled {
-      width: 400px;
-      max-width: 100vw;
-    }
-  }
-
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.4);
-  }
-
-  .sled {
-    position: absolute;
-    top: 0;
-    width: 0;
-    height: 100%;
-    background-color: white;
-    overflow: auto;
-    transition: 0.3s;
-
-    .content ul {
-      padding: 0;
-      margin-top: 25px;
-
-      li {
-        position: relative;
-        display: block;
-        width: 100%;
-        min-height: 2.75rem;
-        padding: 0 60px 0 20px;
-        border-bottom: 1px solid #cccccc;
-
-        // Hides the logo that will be in the list
-        &:first-child {
-          display: none;
-        }
-
-        a {
-          display: inline-block;
-          width: 100%;
-          height: 2.75rem;
-          line-height: 2.75rem;
-          font-size: 1.25rem;
-          color: $primary;
-
-          .nav-link {
-            padding: 0;
-          }
-        }
-      }
-    }
-
-    button {
-      position: absolute;
-      top: 0;
-      right: 0;
-      font-size: xx-large;
-
-      &:focus,
-      &:active {
-        box-shadow: none !important;
-      }
-    }
   }
 }

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -14,10 +14,6 @@ $vendor-strip-font-size: 16px;
 @media screen and (min-width: 768px) {
   @import "size";
 
-  #hamburger {
-    display: none;
-  }
-
   body:dir(rtl) {
     overflow-x: hidden;
   }

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -727,6 +727,12 @@ other = "Translated By"
 [ui_search]
 other = "Search this site"
 
+[ui_toggle_navigation]
+other = "Toggle navigation"
+
+[ui_close_navigation]
+other = "Close navigation"
+
 [version_check_mustbe]
 other = "Your Kubernetes server must be version "
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -3,8 +3,8 @@
     (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark
-            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-auto-burger="primary">
+<nav class="js-navbar-scroll navbar navbar-expand-md navbar-dark
+            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
@@ -20,9 +20,28 @@
     </span>
     {{- /**/ -}}
   </a>
-  <div class="td-navbar-nav-scroll d-none d-md-block ml-xl-auto" id="main_navbar">
+  <button
+    class="navbar-toggler ml-auto"
+    type="button"
+    data-toggle="collapse"
+    data-target="#main_navbar"
+    aria-controls="main_navbar"
+    aria-expanded="false"
+    aria-label="{{ T "ui_toggle_navigation" | default "Toggle navigation" }}">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse td-navbar-nav-scroll ml-xl-auto" id="main_navbar">
+    <button
+      class="btn td-navbar-drawer-close d-md-none"
+      type="button"
+      data-toggle="collapse"
+      data-target="#main_navbar"
+      aria-controls="main_navbar"
+      aria-label="{{ T "ui_close_navigation" | default "Close navigation" }}">
+      &times;
+    </button>
     {{- /* In Docsy, the mt-2 class is used but that causes issues. This should be re-visited after 0.7 migration */ -}}
-    <ul class="navbar-nav mt-lg-0">
+    <ul class="navbar-nav mt-2 mt-lg-0">
     {{ $p := . }}
     {{ range .Site.Menus.main }}
     <li class="nav-item mr-4 mb-2 mb-lg-0">
@@ -38,15 +57,39 @@
     </li>
     {{ end }}
     {{ if .Site.Params.versions -}}
+      <li class="nav-item td-navbar-mobile-group d-md-none">
+        <button class="nav-link td-navbar-mobile-group-toggle collapsed" type="button" data-toggle="collapse" data-target="#td-mobile-versions" aria-expanded="false" aria-controls="td-mobile-versions">
+          <span>{{ T "version_menu" }}</span>
+          <i class="fas fa-chevron-down" aria-hidden="true"></i>
+        </button>
+        <div id="td-mobile-versions" class="collapse td-navbar-mobile-group-menu" data-parent="#main_navbar">
+          <a class="td-navbar-mobile-group-item" href="{{ "releases" | relLangURL }}">{{ i18n "release_information_navbar" . }}</a>
+          {{ range .Site.Params.versions }}
+          <a class="td-navbar-mobile-group-item" href="{{ .url }}{{ $p.RelPermalink }}">{{ .version }}</a>
+          {{ end }}
+        </div>
+      </li>
       <li class="nav-item dropdown mr-4 d-none d-lg-block">
         {{ partial "navbar-version-selector.html" . -}}
       </li>
-      {{ end -}}
-      {{ if (gt (len .Site.Home.Translations) 0) -}}
+    {{ end -}}
+    {{ $langPage := cond (gt (len .Translations) 0) . .Site.Home -}}
+    {{ if (gt (len .Site.Home.Translations) 0) -}}
+      <li class="nav-item td-navbar-mobile-group d-md-none">
+        <button class="nav-link td-navbar-mobile-group-toggle" type="button" data-toggle="collapse" data-target="#td-mobile-languages" aria-expanded="true" aria-controls="td-mobile-languages">
+          <span>{{ $langPage.Language.LanguageName }}</span>
+          <i class="fas fa-chevron-down" aria-hidden="true"></i>
+        </button>
+        <div id="td-mobile-languages" class="collapse show td-navbar-mobile-group-menu" data-parent="#main_navbar">
+          {{ range $langPage.Translations }}
+          <a class="td-navbar-mobile-group-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+          {{ end }}
+        </div>
+      </li>
       <li class="nav-item dropdown mr-xl-4 d-none d-lg-block">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
-      {{ end -}}
+    {{ end -}}
     </ul>
   </div>
   {{- /*
@@ -56,9 +99,13 @@
   <div class="navbar-nav d-none k8s-1500-block">
     {{ partial "search-input.html" . }}
   </div>
-  {{- /*
-    The menu overlay is added to the DOM and shown/hidden all by JS.
-    We should explore a Hugo way of doing this.
-  */ -}}
-  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" data-auto-burger-exclude></button>
+  <button
+    class="td-navbar-drawer-backdrop d-md-none"
+    type="button"
+    data-toggle="collapse"
+    data-target="#main_navbar"
+    aria-controls="main_navbar"
+    aria-label="{{ T "ui_close_navigation" | default "Close navigation" }}">
+    <span class="sr-only">{{ T "ui_close_navigation" | default "Close navigation" }}</span>
+  </button>
 </nav>


### PR DESCRIPTION
## Summary

To better align with the [Docsy migration #41171](https://github.com/kubernetes/website/issues/41171), which integrates Bootstrap, this PR reworks the mobile header/navigation to use Bootstrap collapse-driven structure and behavior in a Docsy-aligned implementation. The resulting UI is near-identical to the original in form and function with several bug fixes implemented, no impact on desktop, and better maintainability than the prior custom coded solution. A migration plan to Docsy 0.7 with Bootstrap 5.2 is included.

## Changes

- Replaces the legacy pushmenu flow with a right-side mobile drawer pattern built on Bootstrap primitives and existing site navigation data.

- Updates versions/languages mobile accordion behavior so both sections are no longer stuck in an always-open state. The versions section is closed by default since it is not universally essential to see immediately. Languages stays open by default to let users quickly navigate to their needed language.

- Localizes mobile navigation ARIA labels for toggle/close controls to improve accessibility and translation support.

## Migration Plan for Docsy 0.7 with Bootstrap 5.2

**Required for BS5.2 compatibility**

1) Update Bootstrap data attributes in layouts/partials/navbar.html
- data-toggle -> data-bs-toggle
- data-target -> data-bs-target
- data-parent -> data-bs-parent

2) Update Bootstrap utility classes in layouts/partials/navbar.html
- ml-* -> ms-*
- mr-* -> me-*
- sr-only -> visually-hidden

**Out of scope (optional follow-up)**

A) Migrate Bootstrap collapse API calls to native BS5 instances
- $().collapse('hide'|'toggle') -> bootstrap.Collapse instance methods.
- Not required: BS5.2 exposes a jQuery bridge when jQuery is present on window (Docsy 0.7 still loads jQuery). Works as-is unless jQuery is removed or disabled via data-bs-no-jquery.
- Recommended as best practice to remove conditional dependency.

B) Full jQuery-to-vanilla DOM rewrite in nav.js and legacy-script.js
- This is a broader dependency cleanup and not required for BS5.2 navbar compatibility once Bootstrap plugin calls are migrated.

C) Convert current collapse-based drawer to BS5 offcanvas
- Recommended later to reduce custom drawer state/animation code.

**Why jQuery calls can survive this migration**
- BS5.2 can expose a jQuery bridge when jQuery is present on window and not disabled via data-bs-no-jquery on <body>.
- Result: $().collapse() calls can continue to work under BS5.2 as long as jQuery remains loaded and the bridge is not disabled.
- Because this is conditional behavior, native bootstrap.Collapse calls are still the more durable long-term target.
