### PR TITLE
[KEP-5366] Add ControllerManagerReleaseLeaderElectionLockOnExit feature gate docs

### DIFF
--- a/content/en/docs/concepts/architecture/leases.md
+++ b/content/en/docs/concepts/architecture/leases.md
@@ -38,6 +38,15 @@ Read [coordinated leader election](/docs/concepts/cluster-administration/coordin
 to learn about how Kubernetes builds on the Lease API to select which component instance
 acts as leader.
 
+### Kube controller manager lock release on exit
+
+{{< feature-state feature_gate_name="ControllerManagerReleaseLeaderElectionLockOnExit" >}}
+
+When the `ControllerManagerReleaseLeaderElectionLockOnExit` feature gate is enabled,
+the `kube-controller-manager` actively releases its leader election lock during
+leader transitions, rather than waiting for the lock's TTL to expire. This allows
+a new leader to be elected more quickly, reducing leader transition latency.
+
 ## API server identity
 
 {{< feature-state feature_gate_name="APIServerIdentity" >}}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
@@ -1,0 +1,15 @@
+---
+title: ControllerManagerReleaseLeaderElectionLockOnExit
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.36"
+---
+Enables the `kube-controller-manager` to actively release its leader election lock
+during leader transitions, rather than waiting for the lock's TTL to expire.
+This allows a new leader to be elected more quickly.


### PR DESCRIPTION
Add feature gate page for `ControllerManagerReleaseLeaderElectionLockOnExit` (Alpha, default false, v1.36)
Update doc to reference corresponding feature gate.

https://github.com/kubernetes/enhancements/issues/5366