### PR TITLE
docs: clarify kubectl naming in existing docs

### DIFF
--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -13,7 +13,7 @@ card:
 {{< glossary_definition prepend="Kubernetes provides a" term_id="kubectl" length="short" >}}
 
 This tool is named `kubectl`.
-The name is commonly read as "kube control" (`kube` + `ctl`).
+The name combines `kube` and `ctl` (an abbreviation of "control").
 
 For configuration, `kubectl` looks for a file named `config` in the `$HOME/.kube` directory.
 You can specify other [kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)

--- a/content/en/docs/reference/kubectl/introduction.md
+++ b/content/en/docs/reference/kubectl/introduction.md
@@ -4,7 +4,7 @@ content_type: concept
 weight: 1
 ---
 
-`kubectl` is the Kubernetes command-line tool, often read as "kube control".
+`kubectl` is the Kubernetes command-line tool.
 It can create and manage API objects, inspect cluster state, and help
 troubleshoot workloads.
 


### PR DESCRIPTION
## Summary
- clarify `kubectl` wording in the existing reference docs only
- point new users from `kubectl` introduction to the existing learning-environment and tooling pages
- keep the scope limited to `content/en/docs/reference/kubectl/` after earlier review feedback

## Why
This addresses the newcomer-clarity concern from #54478 without adding a new overview page or making pronunciation claims.

## Notes
- docs-only changes
- no generated files changed
