### PR TITLE
KEP-5304: add docs for downward API for device attribtues

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -1177,10 +1177,183 @@ kube-scheduler, and kubelet. In the alpha phase, the kubelet does not account
 for these resources when determining QoS classes, configuring cgroups, or making
 eviction decisions.
 
+### DRA device metadata in containers {#device-metadata}
+
+{{< feature-state state="alpha" for_k8s_version="v1.36" >}}
+
+DRA drivers can expose device metadata such as device attributes (PCI bus
+addresses or mdevUUID for mediated devices) or network configuration directly
+to containers as JSON files.
+This lets applications inside the container discover information about allocated
+devices without querying the Kubernetes API or building custom controllers.
+
+KEP-5304 defines a
+[device metadata protocol](#device-metadata-protocol) that drivers must
+follow so applications inside the container see a consistent layout across
+drivers and clusters. The
+[DRA kubelet plugin library](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/kubeletplugin)
+implements this protocol for you; the rest of this section describes how to
+use it.
+
+Device metadata follows the same rules as device access: it is available inside
+a container only when that container requests the device in its container
+specification, and not otherwise. For how to request DRA devices in Pods and
+containers, see
+[Request devices in workloads using DRA](/docs/tasks/configure-pod-container/assign-resources/allocate-devices-dra/#request-devices-workloads).
+
+#### Device metadata protocol {#device-metadata-protocol}
+
+The protocol consists of four rules:
+
+1. **File paths.** Metadata files live inside containers under
+   `/var/run/kubernetes.io/dra-device-attributes`. For a directly referenced
+   ResourceClaim the path is
+   `resourceclaims/<claimName>/<requestName>/<driverName>-metadata.json`; for a
+   claim created from a ResourceClaimTemplate the path is
+   `resourceclaimtemplates/<podClaimName>/<requestName>/<driverName>-metadata.json`
+   (where `podClaimName` is `pod.spec.resourceClaims[].name`).
+
+   In cases where the ResourceClaim request uses the
+   [prioritized list](#prioritized-list) feature, only the top-level request
+   name is used for the `<requestName>` segment in the file path (that is,
+   the `/<subrequest>` portion is dropped). Inside the
+   JSON file, the `requests[].name` field carries the full
+   `<request>/<subrequest>` reference (for example, `gpu/high-memory`) so
+   that consumers can identify which alternative was allocated.
+
+   The path constants are defined in
+   [`k8s.io/dynamic-resource-allocation/api/metadata`](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/api/metadata).
+
+1. **JSON API.** Each file is a stream of one or more
+   [`DeviceMetadata`](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1#DeviceMetadata)
+   objects serialized as versioned JSON with `apiVersion` and `kind`, following
+   Kubernetes API conventions. The same metadata is encoded once per supported
+   API version (newest first). All objects in the stream are semantically
+   equivalent; consumers should use the first object they can decode.
+
+1. **Generation.** When a driver updates a metadata file the embedded
+   `metadata.generation` field must increase so consumers can detect changes.
+
+1. **Container exposure.** Files are typically exposed via
+   {{< glossary_tooltip text="CDI" term_id="cdi" >}} bind-mounts, but other
+   mechanisms are permitted as long as the file appears at the correct path and
+   is read-only inside the container.
+
+#### How device metadata works {#device-metadata-how-it-works}
+
+Device metadata is a driver-side feature that does not require any Kubernetes
+API changes or feature gates. Using the DRA kubelet plugin library is a common
+way to implement a driver, but drivers can be built in other ways as well.
+Drivers that use the kubelet plugin enable this feature by passing the
+`EnableDeviceMetadata` and `MetadataVersions`
+[options](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/kubeletplugin#Option)
+when starting the plugin. `MetadataVersions` specifies which API versions are
+serialized into the metadata file and must be set explicitly by the driver.
+Check the documentation of your DRA driver to learn whether device metadata is
+supported and how to enable it.
+
+When device metadata is enabled, the driver generates metadata files and CDI
+bind-mount specifications while preparing the allocated devices for the pod,
+before the consuming containers start. The metadata appears inside containers at
+the well-known paths as [defined above](#device-metadata-protocol).
+
+When a single request allocates devices from multiple DRA drivers, each driver
+writes its own metadata file. Containers enumerate `*-metadata.json` files in
+the request directory to discover all devices.
+
+The Go package
+[`k8s.io/dynamic-resource-allocation/devicemetadata`](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/devicemetadata)
+provides utilities for reading and decoding these metadata files by applications
+inside the container.
+
+#### Metadata schema {#device-metadata-schema}
+
+Each metadata file conforms to the
+[`DeviceMetadata`](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1#DeviceMetadata)
+API (`metadata.resource.k8s.io/v1alpha1`).
+The following example shows a metadata file for a GPU device allocated through
+a ResourceClaimTemplate:
+
+```json
+{
+  "kind": "DeviceMetadata",
+  "apiVersion": "metadata.resource.k8s.io/v1alpha1",
+  "metadata": {
+    "name": "pod0-gpu-2kqrd",
+    "namespace": "gpu-test1",
+    "uid": "c7e7b22e-239b-4498-b27c-7f1344481e14",
+    "generation": 1
+  },
+  "podClaimName": "gpu",
+  "requests": [
+    {
+      "name": "gpu",
+      "devices": [
+        {
+          "driver": "gpu.example.com",
+          "pool": "worker-0",
+          "name": "gpu-0",
+          "attributes": {
+            "driverVersion": {
+              "version": "1.0.0"
+            },
+            "index": {
+              "int": 0
+            },
+            "model": {
+              "string": "LATEST-GPU-MODEL"
+            },
+            "uuid": {
+              "string": "gpu-18db0e85-99e9-c746-8531-ffeb86328b39"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Immediate and deferred metadata {#device-metadata-lifecycle}
+
+Drivers provide metadata in one of two ways:
+
+Immediate
+: The driver populates metadata while preparing the claim on the
+  node and writes the metadata file before the container starts. This is
+  typical for GPU drivers where device information is known at preparation time.
+
+Deferred
+: In some cases, for example a network driver, the device information is
+  not available during device allocation time but becomes available after the
+  pod sandbox is created. In those cases the driver creates the CDI mount with
+  an empty metadata file and writes the actual metadata later via an NRI hook
+  that runs before the container starts. This ensures applications never see a
+  missing or partially written file. Each update must increment
+  `metadata.generation` so consumers can detect changes. The `MetadataUpdater`
+  API in the DRA kubelet plugin library handles generation bookkeeping
+  automatically for driver authors.
+
+In both cases, metadata remains available to each consuming container for the
+lifetime of that container. Metadata files are cleaned up after all containers
+in the Pod have terminated.
+
+To learn how to use device metadata in your workloads, see
+[Access DRA device metadata](/docs/tasks/configure-pod-container/assign-resources/access-dra-device-metadata/).
+
+#### Custom drivers {#device-metadata-custom-drivers}
+
+Custom, hand-crafted drivers that do not use the DRA kubelet plugin library
+must implement the [device metadata protocol](#device-metadata-protocol)
+themselves. That means writing `DeviceMetadata` JSON at the correct file paths,
+incrementing `metadata.generation` on every update, and exposing the files
+read-only inside the container through CDI or an equivalent mechanism.
+
 ## {{% heading "whatsnext" %}}
 
 - [Set Up DRA in a Cluster](/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster/)
 - [Allocate devices to workloads using DRA](/docs/tasks/configure-pod-container/assign-resources/allocate-devices-dra/)
+- [Access DRA device metadata](/docs/tasks/configure-pod-container/assign-resources/access-dra-device-metadata/)
 - For more information on the design, see the
   [Dynamic Resource Allocation with Structured Parameters](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters)
   KEP.

--- a/content/en/docs/reference/glossary/cdi.md
+++ b/content/en/docs/reference/glossary/cdi.md
@@ -1,0 +1,22 @@
+---
+title: Container Device Interface (CDI)
+id: cdi
+full_link: /docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
+short_description: >
+  A CNCF specification for describing device configuration that container runtimes
+  apply when creating containers.
+
+aka:
+tags:
+- extension
+---
+The Container Device Interface (CDI) is a specification for how to configure
+devices inside containers. Kubernetes uses CDI together with device plugins and
+with Dynamic Resource Allocation so that workloads receive device setup such as
+bind mounts or environment variables from the runtime.
+
+<!--more-->
+
+* [Device Plugins](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+* [Container Device Interface](https://github.com/cncf-tags/container-device-interface)
+  specification repository

--- a/content/en/docs/tasks/configure-pod-container/assign-resources/access-dra-device-metadata.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-resources/access-dra-device-metadata.md
@@ -1,0 +1,177 @@
+---
+title: Access DRA Device Metadata
+content_type: task
+min-kubernetes-server-version: v1.36
+weight: 30
+---
+
+{{< feature-state state="alpha" for_k8s_version="v1.36" >}}
+
+<!-- overview -->
+
+This page shows you how to access
+[device metadata](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-metadata)
+from containers that use _dynamic resource allocation (DRA)_. Device metadata
+lets workloads discover information about allocated devices such as device
+attributes or network interface details — by reading JSON files at
+well-known paths inside the container.
+
+Before reading this page, familiarize yourself with
+[Dynamic Resource Allocation (DRA)](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+and how to
+[allocate devices to workloads](/docs/tasks/configure-pod-container/assign-resources/allocate-devices-dra/).
+
+<!-- body -->
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+* Ensure that your cluster admin has set up DRA, attached devices, and installed
+  drivers. For more information, see
+  [Set Up DRA in a Cluster](/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster).
+* Ensure that the DRA driver deployed in your cluster supports device metadata.
+  Drivers that use the [DRA kubelet plugin](https://pkg.go.dev/k8s.io/dynamic-resource-allocation/kubeletplugin) enable the `EnableDeviceMetadata` and
+  `MetadataVersions` options when starting the plugin. Check the driver's
+  documentation for details.
+
+## Access device metadata with a ResourceClaim {#access-metadata-resourceclaim}
+
+When you use a directly referenced ResourceClaim to allocate devices, the
+device metadata files appear inside the container at:
+
+```
+/var/run/kubernetes.io/dra-device-attributes/resourceclaims/<claimName>/<requestName>/<driverName>-metadata.json
+```
+
+1. Review the following example manifest:
+
+   {{% code_sample file="dra/dra-device-metadata-pod.yaml" %}}
+
+   This manifest creates a ResourceClaim named `gpu-claim` that requests a
+   device from the `gpu.example.com` DeviceClass, and a Pod that reads the
+   device metadata.
+
+1. Create the ResourceClaim and Pod:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/dra/dra-device-metadata-pod.yaml
+   ```
+
+1. After the Pod is running, view the container logs to see the metadata:
+
+   ```shell
+   kubectl logs gpu-metadata-reader
+   ```
+
+   The output is similar to:
+
+   ```
+   === DRA device metadata ===
+   /var/run/kubernetes.io/dra-device-attributes/resourceclaims/gpu-claim/gpu/gpu.example.com-metadata.json
+   {
+     "kind": "DeviceMetadata",
+     "apiVersion": "metadata.resource.k8s.io/v1alpha1",
+     ...
+   }
+   ```
+
+1. To inspect the full metadata file, exec into the container:
+
+   ```shell
+   kubectl exec gpu-metadata-reader -- \
+     cat /var/run/kubernetes.io/dra-device-attributes/resourceclaims/gpu-claim/gpu/gpu.example.com-metadata.json
+   ```
+
+   The output is a JSON object containing device attributes like the model,
+   driver version, and device UUID. See
+   [metadata schema](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-metadata-schema)
+   for details on the JSON structure.
+
+## Access device metadata with a ResourceClaimTemplate {#access-metadata-template}
+
+When you use a ResourceClaimTemplate, Kubernetes generates a ResourceClaim for
+each Pod. Because the generated claim name is not predictable, the metadata
+files appear at a path that uses the Pod's claim reference name instead:
+
+```
+/var/run/kubernetes.io/dra-device-attributes/resourceclaimtemplates/<podClaimName>/<requestName>/<driverName>-metadata.json
+```
+
+The `<podClaimName>` corresponds to the `name` field in the Pod's
+`spec.resourceClaims[]` entry. The JSON metadata also includes a
+`podClaimName` field that records this mapping.
+
+1. Review the following example manifest:
+
+   {{% code_sample file="dra/dra-device-metadata-template-pod.yaml" %}}
+
+   This manifest creates a ResourceClaimTemplate and a Pod. Each Pod gets its
+   own generated ResourceClaim. The metadata path uses the Pod's claim
+   reference name `my-gpu`.
+
+1. Create the ResourceClaimTemplate and Pod:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/dra/dra-device-metadata-template-pod.yaml
+   ```
+
+1. After the Pod is running, view the metadata:
+
+   ```shell
+   kubectl exec gpu-metadata-template-reader -- \
+     cat /var/run/kubernetes.io/dra-device-attributes/resourceclaimtemplates/my-gpu/gpu/gpu.example.com-metadata.json
+   ```
+
+## Read metadata in your application {#read-metadata-application}
+
+### Go applications
+
+The `k8s.io/dynamic-resource-allocation/devicemetadata` package provides
+ready-made functions for reading metadata files. These functions handle
+version negotiation automatically, decoding the metadata stream and converting
+it to internal types so your code works across schema versions without manual
+version checks.
+
+For a directly referenced ResourceClaim:
+
+```go
+import "k8s.io/dynamic-resource-allocation/devicemetadata"
+
+dm, err := devicemetadata.ReadResourceClaimMetadata("gpu-claim", "gpu")
+```
+
+For a template-generated claim (using the Pod's claim reference name):
+
+```go
+dm, err := devicemetadata.ReadResourceClaimTemplateMetadata("my-gpu", "gpu")
+```
+
+If you know the specific driver name, you can read a single driver's metadata
+file:
+
+```go
+dm, err := devicemetadata.ReadResourceClaimMetadataWithDriverName("gpu.example.com", "gpu-claim", "gpu")
+```
+
+The returned `*metadata.DeviceMetadata` contains the claim metadata, requests,
+and per-device attributes.
+
+Applications in other languages can read the JSON file directly and inspect
+the `apiVersion` field to determine the schema version before parsing.
+
+## Clean up {#clean-up}
+
+Delete the resources that you created:
+
+```shell
+kubectl delete -f https://k8s.io/examples/dra/dra-device-metadata-pod.yaml
+kubectl delete -f https://k8s.io/examples/dra/dra-device-metadata-template-pod.yaml
+```
+
+## {{% heading "whatsnext" %}}
+
+* [Learn more about DRA device metadata](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-metadata)
+* [Allocate devices to workloads with DRA](/docs/tasks/configure-pod-container/assign-resources/allocate-devices-dra/)
+* For more information on the design, see
+  [KEP-5304](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5304-dra-attributes-downward-api).

--- a/content/en/examples/dra/dra-device-metadata-pod.yaml
+++ b/content/en/examples/dra/dra-device-metadata-pod.yaml
@@ -1,0 +1,34 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: gpu-claim
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.example.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-metadata-reader
+spec:
+  resourceClaims:
+  - name: my-gpu
+    resourceClaimName: gpu-claim
+  containers:
+  - name: workload
+    image: ubuntu:24.04
+    resources:
+      claims:
+      - name: my-gpu
+        request: gpu
+    command:
+    - sh
+    - -c
+    - |
+      echo "=== DRA device metadata ==="
+      find /var/run/kubernetes.io/dra-device-attributes -name '*-metadata.json' -print -exec cat {} \;
+      sleep 3600
+  restartPolicy: Never

--- a/content/en/examples/dra/dra-device-metadata-template-pod.yaml
+++ b/content/en/examples/dra/dra-device-metadata-template-pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-claim-template
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.example.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-metadata-template-reader
+spec:
+  resourceClaims:
+  - name: my-gpu
+    resourceClaimTemplateName: gpu-claim-template
+  containers:
+  - name: workload
+    image: ubuntu:24.04
+    resources:
+      claims:
+      - name: my-gpu
+        request: gpu
+    command:
+    - sh
+    - -c
+    - |
+      echo "=== DRA device metadata (from template) ==="
+      find /var/run/kubernetes.io/dra-device-attributes -name '*-metadata.json' -print -exec cat {} \;
+      sleep 3600
+  restartPolicy: Never


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR adds documentation for KEP-5034, device metadata API with CDI mounts.
With this feature workloads will be able to discover metadata about devices that
driver authors wishes to publish in through an API that will evolve with kubernetes
API conventions.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #