### PR TITLE
add resource requests and limits trade-off

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -381,6 +381,33 @@ For advanced security context configuration including capabilities, seccomp prof
 * To learn more about the Pod security context, see
   [Configure a Security Context for a Pod or Container](/docs/tasks/configure-pod-container/security-context/).
 
+## Resource requests and limits
+
+When you specify a Pod, you can optionally specify how much of each resource
+a container needs. The most common resources to specify are CPU and memory (RAM).
+
+When you specify the resource _request_ for containers in a Pod, the
+kube-scheduler uses this information to decide which node to place the Pod on.
+When you specify a resource _limit_ for a container, the kubelet enforces
+those limits so that the running container is not allowed to use more of that
+resource than the limit you set.
+
+CPU limits are enforced by CPU throttling. When a container approaches its
+CPU limit, the kernel restricts its access to CPU. Memory limits are enforced
+by the kernel with out-of-memory (OOM) kills when a container exceeds its limit.
+
+{{< note >}}
+Setting CPU limits involves a trade-off. CPU limits help prevent noisy neighbor
+problems where a single workload starves others on the same node. This is
+especially important in multi-tenant environments. However, CPU limits can cause
+throttling even when the node has spare CPU capacity, potentially degrading
+latency-sensitive workload performance. Whether to set CPU limits depends on
+your environment, workload characteristics, and isolation requirements.
+{{< /note >}}
+
+For details on resource units, enforcement behavior, and configuration examples,
+see [Resource Management for Pods and Containers](/docs/concepts/configuration/manage-resources-containers/).
+
 ## Static Pods
 
 _Static Pods_ are managed directly by the kubelet daemon on a specific node,


### PR DESCRIPTION
### Description

Added a "Resource requests and limits" section to the Pod concepts page.

The Pod page was missing information about resource management.
Also added a note about the CPU limit trade-off (throttling vs noisy neighbor problem).

Content is based on [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).

### Issue

Closes: #54642