### PR TITLE
Add CHANGELOG and Github Tag to release page

### DIFF
--- a/content/en/releases/_content.gotmpl
+++ b/content/en/releases/_content.gotmpl
@@ -65,6 +65,14 @@
   {{ $parts := split $version "." }}
   {{ $major := int (index $parts 0) }}
   {{ $minor := int (index $parts 1) }}
+
+  {{/* 
+    Calculate the previous minor version (e.g., X.5 -> X.4).
+    NOTE: This logic assumes the major version stays constant. 
+    If Kubernetes releases a major version (e.g., 2.0), this will need to be updated 
+    to handle major version transitions (e.g., 2.0 -> 1.Y).
+  */}}
+  {{ $previousMinorVersion := printf "%d.%d" $major (sub $minor 1) }}
   {{ $weight := mul -1 (add (mul $major 1000) $minor) }}
 
   {{ $sectionPage := dict
@@ -83,6 +91,7 @@
       "latestPatchVersion" (index $info "latestPatchVersion")
       "latestReleaseDate" (index $info "latestReleaseDate")
       "isLatestVersion" (eq $version $latestSupportedVersion)
+      "previousMinorVersion" $previousMinorVersion
       "toc_hide" true
     )
   }}

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -591,6 +591,9 @@ other = "End Of Life Date"
 other = """This release has reached End of Life on {{ .release_eol_date }}.
 Kubernetes {{ .minor_version }} is no longer receiving security updates or bug fixes. Upgrade to a [supported version](/releases/)."""
 
+[release_github_tag]
+other = "GitHub Tag"
+
 [release_latest_patch]
 other = "Latest patch release"
 

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -65,8 +65,8 @@
   </dl>
 
   <h2>{{ T "release_links" }}</h2>
-  {{ if .Params.status | in (slice "supported" "maintenance") }}
   <ul>
+    {{ if .Params.status | in (slice "supported" "maintenance") }}
     <li>
       {{ if .Params.isLatestVersion }}
       <a href="/releases/download/">
@@ -83,7 +83,33 @@
       </a>
       {{ end }}
     </li>
+    {{ end }}
+    <li>
+      {{ $changelogAnchor := "changelog-since" }}
+      {{ $changelogHash := "" }}
+      {{ if eq .Params.minorVersion "1.2" }}
+        {{ $changelogAnchor = "changes-since" }}
+        {{ $changelogHash = "111" }}
+      {{ else if eq .Params.minorVersion "1.3" }}
+        {{ $changelogAnchor = "changes-since" }}
+        {{ $changelogHash = "120" }}
+      {{ else if eq .Params.minorVersion "1.4" }}
+        {{ $changelogHash = "130" }}
+      {{ else if eq .Params.minorVersion "1.5" }}
+        {{ $changelogHash = "140-alpha3" }}
+      {{ else }}
+        {{ $combined := replace .Params.previousMinorVersion "." "" }}
+        {{ $changelogHash = print $combined "0" }}
+      {{ end }}
+      <a href="https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{ .Params.minorVersion }}.md#{{ $changelogAnchor }}-v{{ $changelogHash }}">
+        {{ T "release_changelog" | upper }}
+      </a>
+    </li>
+    <li>
+      <a href="https://github.com/kubernetes/kubernetes/releases/tag/v{{ .Params.latestPatchVersion }}">
+        {{ T "release_github_tag" }} ({{ .Params.latestPatchVersion }})
+      </a>
+    </li>
   </ul>
-  {{ end }}
 </article>
 {{ end }}


### PR DESCRIPTION
### Description

Add CHANGELOG and GitHub tag links to release series pages for all versions.

### Issue

Closes: #54739