### PR TITLE
Register  `cronjob.kubernetes.io/instantiate` annotation to Official Docs

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1576,6 +1576,18 @@ when that Job is part of a CronJob.
 The control plane sets the value to that timestamp in RFC3339 format. If the Job belongs to a CronJob
 with a timezone specified, then the timestamp is in that timezone. Otherwise, the timestamp is in controller-manager's local time.
 
+### cronjob.kubernetes.io/instantiate {#cronjob-kubernetes-io-instantiate}
+
+Type: Annotation
+
+Example: `cronjob.kubernetes.io/instantiate: "manual"`
+
+Used on: Jobs
+
+When you use `kubectl create job` with the `--from=cronjob/<cronjob-name>` flag to manually create a Job from an existing CronJob template, `kubectl` sets this annotation on the newly created Job. 
+The value of this annotation is always `manual`. This annotation allows you to distinguish 
+Jobs that were created on demand by a user from Jobs that the CronJob controller automatically creates on their scheduled time.
+
 ### kubectl.kubernetes.io/default-container
 
 Type: Annotation


### PR DESCRIPTION
### Description

This PR adds a documentation entry for this annotation `cronjob.kubernetes.io/instantiate` which has been set by `kubectl` on Jobs created manually from a CronJob template via:
```bash
kubectl create job <job-name> --from=cronjob/<cronjob-name>
```
since the feature was introduced, but it was never documented on the Well-Known Labels, Annotations and Taints reference page. The value is always `manual` and it serves to distinguish manually triggered Jobs from Jobs automatically scheduled by the CronJob controller.

### Issue

Fixes #54735

### Special notes for reviewer:
The annotation key and hardcoded "manual" value are confirmed in kubectl create job function [here](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/create/create_job.go#L254) 

Closes: #54735