### PR TITLE
Fix capitalization in guestbook port-forward 

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -297,7 +297,7 @@ balancers and you want to use it, uncomment `type: LoadBalancer`.
    Forwarding from [::1]:8080 -> 80
    ```
 
-1. load the page [http://localhost:8080](http://localhost:8080) in your browser to view your guestbook.
+1. Load the page [http://localhost:8080](http://localhost:8080) in your browser to view your guestbook.
 
 ### Viewing the Frontend Service via `LoadBalancer`
 

--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -317,7 +317,7 @@ you need to find the IP address to view your Guestbook.
    frontend   LoadBalancer   10.51.242.136   109.197.92.229     80:32372/TCP   1m
    ```
 
-1. Copy the external IP address, and load the page in your browser to view your guestbook.
+1. Copy the external IP address, and Load the page in your browser to view your guestbook.
 
 {{< note >}}
 Try adding some guestbook entries by typing in a message, and clicking Submit.

--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -317,7 +317,7 @@ you need to find the IP address to view your Guestbook.
    frontend   LoadBalancer   10.51.242.136   109.197.92.229     80:32372/TCP   1m
    ```
 
-1. Copy the external IP address, and Load the page in your browser to view your guestbook.
+1. Copy the external IP address, and load the page in your browser to view your guestbook.
 
 {{< note >}}
 Try adding some guestbook entries by typing in a message, and clicking Submit.


### PR DESCRIPTION
This PR fixes a minor grammar inconsistency in the Guestbook tutorial.

The instruction:
"load the page http://localhost:8080/ in your browser to view your guestbook."

has been updated to start with a capital letter for consistency with other instructional steps:

"Load the page http://localhost:8080/ in your browser to view your guestbook."

Fixes #53607