### PR TITLE
fix: Add limitation about DRA and pod preemption

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -453,13 +453,13 @@ the `.spec.nodeName` field and to use a node selector instead.
 
 ## Limitations
 
-* The Kubernetes scheduler currently does not support
+* The Kubernetes scheduler doesn't support
   [preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/) for
-  DRA resources. This means that a Pod using DRA resources that is scheduled on
-  a node cannot be preempted by a higher-priority Pod that also needs DRA
-  resources. The high-priority Pod will remain pending until the device becomes
-  available by either manually deleting the conflicting Pod or waiting for it to
-  terminate.
+  DRA resources. This means that an existing Pod that's running on a node and is
+  using DRA resources can't be preempted by a higher-priority Pod that also needs
+  DRA resources. The high-priority Pod will remain in a pending state until the device
+  becomes available, which happens when the conflicting Pod terminates or is
+  manually deleted.
 
 ## DRA beta features {#beta-features}
 


### PR DESCRIPTION
### Description

Add a limitations section to DRA and call out the lack of preemption support

Preview: https://deploy-preview-54770--kubernetes-io-main-staging.netlify.app/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#limitations
