### PR TITLE
Blog for breaking SELinux changes in 1.37

### DIFF
--- a/content/en/blog/_posts/2026/breaking-changes-in-selinux-volume-labeling.md
+++ b/content/en/blog/_posts/2026/breaking-changes-in-selinux-volume-labeling.md
@@ -167,7 +167,7 @@ selinux_warning_controller_selinux_volume_conflict{pod1_name="my-other-pod",pod1
 ```
 
 There is a security consequence from enabling this opt-in controller: it may reveal namespace names, which are always present in the metric.
-The Kubernetes project assumes only cluster admins can access kube-controller-manager metrics.
+The Kubernetes project assumes only cluster administrators can access kube-controller-manager metrics.
 
 ## Suggested upgrade path
 


### PR DESCRIPTION
and how to prepare 1.36 clusters before upgrade to 1.37

### Description

A feature blog that describes state of SELinuxMount related feature gates in 1.36 and the upcoming breaking change (likely in 1.37). To be linked from 1.37 release notes + 1.37 announcement article ("ACTION REQUIRED: \<short sentence\>, see **this** blog for details")

Goal: 

1. Warn users that use SELinux that breaking change is very likely coming in 1.37. They have some homework in 1.36 to make sure their applications keep working during / after upgrade to 1.37
1. Calm down users that don't use SELinux, nothing changes for them.

Proposed content:

1. Describe how SELinux works today.
1. Describe what we're improving.
1. Describe what breaks, very likely in 1.37.
1. Describe how to identify pods that could break in 1.37.
1. Describe how to fix those pods or opt-out from the new relabelling in 1.36 to ensure a smooth uprade to 1.37.

See [the KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling) and especially its [Story 3: cluster upgrade](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling#story-3-cluster-upgrade). 
* In the story, `1.N` is 1.36 (the last version without breaking changes) and `1.M` is 1.37.

1.37 plan: add a Urgent Upgrade Note to changelog with a brief warning, linking this blog for details.

Issues:

* We aim at 1.37 with the breaking change, but it's not 100%. I know we should not document future releases, still, I'd prefer to warn users now.