### PR TITLE
[ru] Sync main page content and layout in Russian

### DIFF
--- a/content/ru/_index.html
+++ b/content/ru/_index.html
@@ -2,13 +2,14 @@
 title: "Оркестрация контейнеров промышленного уровня"
 abstract: "Автоматизированное развёртывание, масштабирование и управление контейнерами"
 cid: home
+layout: home
 sitemap:
   priority: 1.0
 ---
 
-{{< blocks/section id="oceanNodes" >}}
-{{% blocks/feature image="flower" %}}
-### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) — это открытое программное обеспечение для автоматизации развёртывания, масштабирования и управления контейнеризированными приложениями.
+{{< blocks/section class="k8s-overview" >}}
+{{% blocks/feature image="flower" id="feature-primary" %}}
+### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/" >}}) — это открытое программное обеспечение для автоматизации развёртывания, масштабирования и управления контейнеризированными приложениями.
 
 Kubernetes группирует контейнеры, составляющие приложение, в логические единицы для более простого управления и обнаружения. При создании Kubernetes использован [15-летний опыт эксплуатации производственных нагрузок Google](https://queue.acm.org/detail.cfm?id=2898444), который был совмещён с лучшими идеями и практиками сообщества.
 {{% /blocks/feature %}}
@@ -38,20 +39,26 @@ Kubernetes — это проект с открытым исходным кодо
 
 {{< /blocks/section >}}
 
-{{< blocks/section id="video" background-image="kub_video_banner_homepage" >}}
-<div class="light-text">
-<h2>О сложности миграции 150+ микросервисов в Kubernetes</h2>
-        <p>Сара Уэллс, технический директор по эксплуатации и надёжности в Financial Times</p>
-        <button id="desktopShowVideoButton" onclick="kub.showVideo()">Смотреть видео</button>
-
-    <h3>Посетите следующие KubeCon + CloudNativeCon</h3>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Амстердам, Мар 23-26, 2026)</a>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/" class="desktopKCButton"><strong>North America</strong> (Солт-Лейк-Сити, Ноябрь 9-12, 2026)</a>
+{{< blocks/section id="video" background-image="video_banner_homepage_XNZvGHlpJ_4" >}}
+<div class="video-text-optional">
+    <h2>Гайд по Cloud Native для абсолютного новичка</h2>
+    <p class="presenter-byline">авторы: Kyle Penfound, Dagger &amp; Cortney Nickerson, Kubeshop</p>
+    <button id="desktopShowVideoButton" onclick="kub.showVideo()">Смотреть видео</button>
 </div>
 <div id="videoPlayer">
-    <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>
+    <iframe data-url="https://www.youtube.com/embed/XNZvGHlpJ_4?autoplay=1" frameborder="0" allowfullscreen></iframe>
     <button id="closeButton"></button>
 </div>
+{{< /blocks/section >}}
+{{< blocks/section id="upcoming-events" >}}
+<h2>Посетите следующие события KubeCon + CloudNativeCon</h2>
+  <!-- TODO: change this to a shortcode that auto-updates from a schedule -->
+  <div>
+    <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/" class="desktopKCButton"><strong>Europe</strong> (Амстердам, Мар 23-26, 2026)</a>
+  </div>
+  <div>
+    <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/" class="desktopKCButton"><strong>North America</strong> (Солт-Лейк-Сити, Ноябрь 9-12, 2026)</a>
+  </div>
 {{< /blocks/section >}}
 
 {{< blocks/kubernetes-features >}}

--- a/content/ru/docs/tutorials/hello-minikube.md
+++ b/content/ru/docs/tutorials/hello-minikube.md
@@ -2,12 +2,6 @@
 title: Привет, Minikube
 content_type: tutorial
 weight: 5
-menu:
-  main:
-    title: "Начало"
-    weight: 10
-    post: >
-      <p>Готовы приступить к делу? Создайте простой кластер Kubernetes и запустите в нём тестовое приложение.</p>
 card:
   name: tutorials
   weight: 10

--- a/i18n/ru/ru.toml
+++ b/i18n/ru/ru.toml
@@ -361,7 +361,7 @@ other = """Репозитории `apt.kubernetes.io` и `yum.kubernetes.io` с 
 other = "от"
 
 [main_cncf_project]
-other = """Мы являемся проектом <a href="https://cncf.io/">CNCF</a></p>"""
+other = """Мы являемся graduated-проектом <a href="https://cncf.io/">CNCF</a></p>"""
 
 [main_community_explore]
 other = "Познакомиться с сообществом"


### PR DESCRIPTION
Due to recent changes in the layout and related metadata, the https://kubernetes.io/ru/ page in Russian is currently broken — see the top menu, the main background colour, and the video section. This PR fixes everything and makes this page look identical to the original (English) main page.

P.S. However, we'll also need to work on the "Kubernetes Features" section, which is currently empty in Russian. The reason is the absence of localised docs pages with `feature` metadata (such as `docs/concepts/services-networking/service.md`). Fixing it requires substantial effort (translating all those pages), which can be done later.