### PR TITLE
fix: api reference links were getting generated after the meta sidebar was generated

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -21,6 +21,8 @@
             {{ partial "sidebar.html" . }}
           </aside>
           <aside class="d-none d-xl-block td-sidebar-toc d-print-none">
+            {{/* Partial "docs/api-reference-links" determines API reference links for 'partial/page-meta-links.html' */}}
+            {{ partial "docs/api-reference-links" . }}
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
           </aside>
@@ -33,8 +35,6 @@
               {{ partial "docs/outdated_content.html" . }}
             {{ end }}
             {{ block "main" . }}{{ end }}
-            {{/* Partial "docs/api-reference-links" determines API reference links for 'partial/page-meta-links.html' */}}
-              {{ partial "docs/api-reference-links" . }}
             {{- if .HasShortcode "thirdparty-content" -}}
             {{ block "thirdparty-disclaimer" . }}
               {{ partial "docs/thirdparty-disclaimer.html" . }}

--- a/layouts/partials/docs/api-reference-links.html
+++ b/layouts/partials/docs/api-reference-links.html
@@ -2,11 +2,11 @@
 {{- $apiReferenceMetaLinks := slice -}}
 {{- $apiReferenceText := T "api_reference_title" -}}
 
-<!-- Clear exisiting $.Store values --> 
+<!-- Clear exisiting $.Store values -->
 {{ $.Store.Delete "apiReferenceMetaLinks" }}
 {{ $.Store.Delete "pageApiReferenceLinksMap" }}
 
-<!-- Check if 'api_metadata' is an empty interface slice 
+<!-- Check if 'api_metadata' is an empty interface slice
     (Used for excluding auto-generated files and their localized versions) -->
 {{- $ignoreCondition := (printf "%T" .Page.Params.api_metadata | eq "[]interface {}") -}}
 
@@ -20,7 +20,7 @@
     {{- $kind := $metadata.kind -}}
     {{- $version := $apiVersion -}}
     {{- $linkText := $metadata.override_link_text  | default $kind -}}
-    
+
     <!-- Get all sections under the specified directory -->
     {{- $apiRefBaseDir := "docs/reference/kubernetes-api/" -}}
     {{- $apiRefSections := site.GetPage "section" $apiRefBaseDir -}}
@@ -34,7 +34,7 @@
 
         <!-- Loop through API reference files -->
         {{- range $apiRefFile := $apiReferenceFiles.RegularPages -}}
-        {{- $apiRefFileDirPath:= printf "/%s" $apiRefFile.File.Dir -}}
+        {{- $apiRefFileDirPath:= printf "%s/" ( path.Dir $apiRefFile.Path ) -}}
 
         {{- if and (ne $apiRefFile.Section "") (in $apiRefFileDirPath $apiRefDir) -}}
             <!-- Check if the file's metadata matches -->


### PR DESCRIPTION
This PR fixes API reference links not being generated after a refactor in #54543. See https://github.com/kubernetes/website/pull/54543#issuecomment-4005347432 for the original report.

The issue was that the reference links list was getting generated after the meta sidebar was. So, it was a small fix.

This PR also adds a fix to how `$apiRefFileDirPath` was calculated which resulted in the path string having OS dependant path separators, which breaks the logic on non POSIX systems.