### PR TITLE
fix: splitter and toc for some pages

### DIFF
--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -27,6 +27,8 @@
 
 #maindoc {
   overflow-wrap: break-word;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 @include media-breakpoint-down(sm)  {


### PR DESCRIPTION
### Description

This PR fixes weird behaviour by the left menu splitter, which would jump unexpectedly and also squish the TOC menu.

Closes: #54778