### PR TITLE
How Kubernetes builds on the Lease API

### DIFF
--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -68,12 +68,18 @@ such as:
 
 These fields indicate which instance holds leadership and how long that leadership remains valid.
 
-When the Lease does not exist or has expired (current time > `renewTime` + `leaseDurationSeconds`), candidate instances attempt to update the Lease with their identity. Kubernetes relies on **optimistic concurrency control** via the object's `resourceVersion`: only one update succeeds due to version mismatch on concurrent attempts. The instance whose update is accepted becomes the **leader**.
+When the [Lease](/docs/concepts/architecture/leases/) does not exist or has expired (current time > `renewTime` + `leaseDurationSeconds`), candidate instances attempt to update the Lease with their identity. Kubernetes relies on _optimistic concurrency control_ via the object's `resourceVersion`: only one update succeeds due to version mismatch on concurrent attempts. The instance whose update is accepted becomes the _leader_.
+
+Kubernetes uses the [LeaseCandidate](/docs/reference/kubernetes-api/cluster-resources/lease-candidate-v1beta1/) 
+API to manage leader elections. Control plane components such as `kube-controller-manager` and `kube-scheduler` register their role as a candidate by creating LeaseCandidate objects, which track all instances competing for leadership and carry metadata including the candidate's identity, binary version, and emulation version.
+
+During an election, candidates coordinate through a shared [Lease](/docs/concepts/architecture/leases/). 
+The Kubernetes control plane guarantees that only one candidate successfully acquires the [Lease](/docs/concepts/architecture/leases/) and assumes the role of _leader_, while all others remain as followers. If the current _leader_ fails to renew the [Lease](/docs/concepts/architecture/leases/) within the selected timeout period, the remaining candidates compete to acquire leadership and elect a new _leader_.
 
 Once elected, the leader periodically renews its Lease by updating the `renewTime` field
 
-(for example, performing renewal every `leaseDurationSeconds` ÷ 2, in order to avoid conflicts when the lease is about to expire).
+(for example, performing renewal every `leaseDurationSeconds` ÷ 2, in order to avoid conflicts when the [Lease](/docs/concepts/architecture/leases/) is about to expire).
 As long as renewals occur before the lease expires, the current leader instance retains leadership.
-If the leader crashes, becomes unreachable, or stops renewing the Lease, that Lease expires expires. Other healthy instances detect the expired Lease and attempt a new election.
+If the leader crashes, becomes unreachable, or stops renewing the Lease, that Lease expires. Other healthy instances detect the expired Lease and attempt a new election.
 
-This mechanism ensures that even though multiple replicas of a component may be running for stability and recovery, **only one instance actively performs control tasks at a time**, while the others remain on standby, watching the Lease and ready to take over quickly if needed.
+This mechanism ensures that even though multiple replicas of a component may be running for stability and recovery, _only one instance actively performs control tasks at a time_, while the others remain on standby, watching the Lease and ready to take over quickly if needed.

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -42,11 +42,11 @@ leader election when the feature gate and API group are enabled.
 
 ## How Kubernetes Builds on the Lease API to Select a Leader
 
-Kubernetes uses the [Lease API](https://kubernetes.io/docs/concepts/architecture/leases/) to perform leader election among multiple instances of the same control-plane component in a high-availability cluster, such as `kube-controller-manager` or `kube-scheduler`.
+Kubernetes uses the [Lease API](/docs/concepts/architecture/leases/) to perform leader election among multiple instances of the same control-plane component in a high-availability cluster, such as `kube-controller-manager` or `kube-scheduler`.
 
-A [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) object in the `coordination.k8s.io/v1` API group acts as a lightweight distributed lock stored in the [Kubernetes API server](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/). All running instances of a component watch or periodically read the same Lease object to determine which instance is currently acting as the leader.
+A [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) object in the `coordination.k8s.io/v1` API group acts as a lightweight distributed lock stored in the [Kubernetes API server](/docs/reference/command-line-tools-reference/kube-apiserver/). All running instances of a component watch or periodically read the same Lease object to determine which instance is currently acting as the leader.
 
-The [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) contains important fields such as:
+The [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) contains important fields such as:
 
 - `holderIdentity`: the identity (e.g., pod name or hostname-based string) of the current leader.
 - `acquireTime`: timestamp when leadership was acquired.
@@ -58,6 +58,6 @@ These fields indicate which instance holds leadership and how long that leadersh
 
 When the Lease does not exist or has expired (current time > `renewTime` + `leaseDurationSeconds`), candidate instances attempt to update the Lease with their identity. Kubernetes relies on **optimistic concurrency control** via the object's `resourceVersion`: only one update succeeds due to version mismatch on concurrent attempts. The instance whose update is accepted becomes the **leader**.
 
-Once elected, the leader periodically renews the [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) by updating the `renewTime` field (typically every `leaseDurationSeconds` to avoid conflicts when the lease is about to expire). As long as renewals occur before the lease expires, the instance retains leadership. If the leader crashes, becomes unreachable, or stops renewing the Lease, it expires. Other instances detect the expired Lease and attempt a new election.
+Once elected, the leader periodically renews the [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) by updating the `renewTime` field (typically every `leaseDurationSeconds` to avoid conflicts when the lease is about to expire). As long as renewals occur before the lease expires, the instance retains leadership. If the leader crashes, becomes unreachable, or stops renewing the Lease, it expires. Other instances detect the expired Lease and attempt a new election.
 
 This mechanism ensures that even though multiple replicas of a component may be running for stability and recovery, **only one instance actively performs control tasks at a time**, while the others remain on standby, watching the Lease and ready to take over quickly if needed.

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -44,7 +44,9 @@ leader election when the feature gate and API group are enabled.
 
 Kubernetes uses the [Lease API](/docs/concepts/architecture/leases/) to perform leader election among multiple instances of the same control-plane component in a high-availability cluster, such as `kube-controller-manager` or `kube-scheduler`.
 
-A [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) object in the `coordination.k8s.io/v1` API group acts as a lightweight distributed lock stored in the [Kubernetes API server](/docs/reference/command-line-tools-reference/kube-apiserver/). All running instances of a component watch or periodically read the same Lease object to determine which instance is currently acting as the leader.
+A [Lease](/docs/concepts/architecture/leases/) acts as a lightweight distributed lock. stored by the [Kubernetes API server](/docs/reference/command-line-tools-reference/kube-apiserver/).
+All running instances of a component watch or periodically read the relevant Lease object
+to determine which instance is currently acting as the leader.
 
 The [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) contains important fields such as:
 

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -48,7 +48,8 @@ A [Lease](/docs/concepts/architecture/leases/) acts as a lightweight distributed
 All running instances of a component watch or periodically read the relevant Lease object
 to determine which instance is currently acting as the leader.
 
-The [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) contains important fields such as:
+The [Lease API](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) defines fields
+such as:
 
 - `holderIdentity`: the identity (e.g., pod name or hostname-based string) of the current leader.
 - `acquireTime`: timestamp when leadership was acquired.

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -38,4 +38,26 @@ as needed.
 
 For Kubernetes {{< skew currentVersion >}}, two control plane components  
 (kube-controller-manager and kube-scheduler) automatically use coordinated  
-leader election when the feature gate and API group are enabled.  
+leader election when the feature gate and API group are enabled.
+
+## How Kubernetes Builds on the Lease API to Select a Leader
+
+Kubernetes uses the [Lease API](https://kubernetes.io/docs/concepts/architecture/leases/) to perform leader election among multiple instances of the same control-plane component in a high-availability cluster, such as `kube-controller-manager` or `kube-scheduler`.
+
+A [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) object in the `coordination.k8s.io/v1` API group acts as a lightweight distributed lock stored in the [Kubernetes API server](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/). All running instances of a component watch or periodically read the same Lease object to determine which instance is currently acting as the leader.
+
+The [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) contains important fields such as:
+
+- `holderIdentity`: the identity (e.g., pod name or hostname-based string) of the current leader.
+- `acquireTime`: timestamp when leadership was acquired.
+- `renewTime`: timestamp of the most recent renewal by the leader.
+- `leaseDurationSeconds`: the validity period of the lease (candidates must wait this long + a small grace period before attempting to acquire an expired lease).
+- `leaseTransitions`: counter of how many times leadership has changed hands.
+
+These fields indicate which instance holds leadership and how long that leadership remains valid.
+
+When the Lease does not exist or has expired (current time > `renewTime` + `leaseDurationSeconds`), candidate instances attempt to update the Lease with their identity. Kubernetes relies on **optimistic concurrency control** via the object's `resourceVersion`: only one update succeeds due to version mismatch on concurrent attempts. The instance whose update is accepted becomes the **leader**.
+
+Once elected, the leader periodically renews the [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) by updating the `renewTime` field (typically every `leaseDurationSeconds` to avoid conflicts when the lease is about to expire). As long as renewals occur before the lease expires, the instance retains leadership. If the leader crashes, becomes unreachable, or stops renewing the Lease, it expires. Other instances detect the expired Lease and attempt a new election.
+
+This mechanism ensures that even though multiple replicas of a component may be running for stability and recovery, **only one instance actively performs control tasks at a time**, while the others remain on standby, watching the Lease and ready to take over quickly if needed.

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -70,6 +70,10 @@ These fields indicate which instance holds leadership and how long that leadersh
 
 When the Lease does not exist or has expired (current time > `renewTime` + `leaseDurationSeconds`), candidate instances attempt to update the Lease with their identity. Kubernetes relies on **optimistic concurrency control** via the object's `resourceVersion`: only one update succeeds due to version mismatch on concurrent attempts. The instance whose update is accepted becomes the **leader**.
 
-Once elected, the leader periodically renews the [Lease](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) by updating the `renewTime` field (typically every `leaseDurationSeconds` to avoid conflicts when the lease is about to expire). As long as renewals occur before the lease expires, the instance retains leadership. If the leader crashes, becomes unreachable, or stops renewing the Lease, it expires. Other instances detect the expired Lease and attempt a new election.
+Once elected, the leader periodically renews its Lease by updating the `renewTime` field
+
+(for example, performing renewal every `leaseDurationSeconds` ÷ 2, in order to avoid conflicts when the lease is about to expire).
+As long as renewals occur before the lease expires, the current leader instance retains leadership.
+If the leader crashes, becomes unreachable, or stops renewing the Lease, that Lease expires expires. Other healthy instances detect the expired Lease and attempt a new election.
 
 This mechanism ensures that even though multiple replicas of a component may be running for stability and recovery, **only one instance actively performs control tasks at a time**, while the others remain on standby, watching the Lease and ready to take over quickly if needed.

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -40,7 +40,7 @@ For Kubernetes {{< skew currentVersion >}}, two control plane components
 (kube-controller-manager and kube-scheduler) automatically use coordinated  
 leader election when the feature gate and API group are enabled.
 
-## How Kubernetes Builds on the Lease API to Select a Leader
+## Leader selection for Kubernetes components
 
 Kubernetes uses the [Lease API](/docs/concepts/architecture/leases/) to perform leader election among multiple instances of the same control-plane component in a high-availability cluster, such as `kube-controller-manager` or `kube-scheduler`.
 

--- a/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
+++ b/content/en/docs/concepts/cluster-administration/coordinated-leader-election.md
@@ -51,11 +51,20 @@ to determine which instance is currently acting as the leader.
 The [Lease API](/docs/reference/kubernetes-api/cluster-resources/lease-v1/) defines fields
 such as:
 
-- `holderIdentity`: the identity (e.g., pod name or hostname-based string) of the current leader.
-- `acquireTime`: timestamp when leadership was acquired.
-- `renewTime`: timestamp of the most recent renewal by the leader.
-- `leaseDurationSeconds`: the validity period of the lease (candidates must wait this long + a small grace period before attempting to acquire an expired lease).
-- `leaseTransitions`: counter of how many times leadership has changed hands.
+`holderIdentity`
+: the identity (for example: pod name or hostname-based string) of the current leader.
+
+`acquireTime`
+: timestamp when leadership was acquired.
+
+`renewTime`
+: timestamp of the most recent renewal by the leader.
+
+`leaseDurationSeconds`
+: the validity period of the lease (candidates should wait this long plus a small grace period before attempting to acquire an expired lease).
+
+`leaseTransitions`
+: counter of how many times leadership has changed hands.
 
 These fields indicate which instance holds leadership and how long that leadership remains valid.
 


### PR DESCRIPTION
The Lease documentation currently links to the [Coordinated Leader Election](https://kubernetes.io/docs/concepts/cluster-administration/coordinated-leader-election/) page under the heading Leader election, suggesting it explains how Kubernetes builds on the Lease API to select which component acts as leader.

However, that page mainly explains how to enable Coordinated Leader Election, and does not describe how Kubernetes builds on the Lease API to select which component instance acts as leader.

This PR adds a detailed explanation of how Kubernetes uses the Lease API to select which component instance acts as leader.

Issue: #51735 