### PR TITLE
[ru] Add Careers and Partners pages in Russian

### DIFF
--- a/content/ru/careers/_index.html
+++ b/content/ru/careers/_index.html
@@ -1,0 +1,23 @@
+---
+title: Карьера
+bigheader: Карьера с Kubernetes
+abstract: Объявления о работе, ориентированной на использование Kubernetes и Cloud Native-подходов.
+class: gridPage
+cid: careers
+body_class: careers
+menu:
+  main:
+    weight: 35
+---
+
+<div class="d-flex flex-column justify-content-center mt-4 mt-md-5 px-2 px-md-3 px-lg-0">
+  <iframe id="gitjobs" class="mx-auto" src="https://gitjobs.dev/embed?ts_query=kubernetes" style="width:100%;max-width:870px;height:100%;display:block;border:none;"></iframe>
+  <div class="mb-4 mb-md-5 mt-1 mx-auto gitjobs-legend">
+    Работает на базе <a href="https://gitjobs.dev" target="_blank">GitJobs</a>
+  </div>
+</div>
+
+<script type="module">
+  import { initialize } from "https://cdn.jsdelivr.net/npm/@open-iframe-resizer/core@latest/dist/index.js";
+  initialize({}, "#gitjobs");
+</script>

--- a/content/ru/partners/_index.html
+++ b/content/ru/partners/_index.html
@@ -1,0 +1,47 @@
+---
+title: Партнёры
+bigheader: Партнёры Kubernetes
+abstract: Развиваем экосистему Kubernetes.
+class: gridPage
+cid: partners
+body_class: partners
+menu:
+  main:
+    weight: 40
+---
+
+<section id="users">
+    <h5>Kubernetes работает с партнёрами, чтобы сформировать мощную кодовую базу, которая обеспечивает поддержку различных платформ.</h5>
+    <div class="col-container">
+      <div class="col-nav">
+          <h5>
+            <b>Сертифицированные поставщики услуг по Kubernetes</b>
+          </h5>
+          <br>Kubernetes Certified Service Providers (KCSP) — проверенные поставщики услуг, обладающие опытом успешного внедрения Kubernetes в компаниях.
+          <br><br><br>
+          <button class="button landscape-trigger landscape-default" data-landscape-types="special--kubernetes-certified-service-provider" id="kcsp">См. KCSP</button>
+          <br><br>Хотите присоединиться к списку
+          <a href="https://www.cncf.io/certification/kcsp/">KCSP</a>?
+      </div>
+      <div class="col-nav">
+          <h5>
+            <b>Сертифицированные дистрибутивы, hosted-платформы и инсталляторы Kubernetes</b>
+          </h5>Согласованность программного обеспечения (software conformance) гарантирует, что разные версии Kubernetes от вендоров поддерживают все необходимые API.
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="platform" id="conformance">См. Certified Kubernetes</button>
+          <br><br>Хотите присоединиться к программе
+          <a href="https://www.cncf.io/certification/software-conformance/">Certified Kubernetes</a>?
+      </div>
+      <div class="col-nav">
+          <h5>
+            <b>Партнёры по обучению Kubernetes</b>
+          </h5>
+          <br>Проверенные компании, предлагающие обучение и имеющие опыт в обучении cloud native-технологиям.
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="special--kubernetes-training-partner" id="ktp">См. Kubernetes Training Partner</button>
+          <br><br>Хотите присоединиться к списку
+          <a href="https://www.cncf.io/certification/training/">KTP</a>?
+      </div>
+    </div>
+    {{< cncf-landscape helpers=true >}}
+</section>


### PR DESCRIPTION
The _Careers_ and _Partners_ pages feature mostly autogenerated content that can be easily shared across various localisations. However, the Russian version of the website currently lacks them (they are not even displayed in the top menu). This PR adds these pages.