### PR TITLE
[vi] add Vietnamese translation for WG (working group)

### DIFF
--- a/content/vi/docs/reference/glossary/wg.md
+++ b/content/vi/docs/reference/glossary/wg.md
@@ -1,0 +1,18 @@
+---
+title: WG (working group)
+id: wg
+full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
+short_description: >
+  Hỗ trợ việc thảo luận và/hoặc triển khai một dự án ngắn hạn, phạm vi hẹp, hoặc tách biệt cho một committee, SIG, hoặc nỗ lực xuyên SIG.
+
+aka:
+tags:
+- community
+---
+Hỗ trợ việc thảo luận và/hoặc triển khai một dự án ngắn hạn, phạm vi hẹp, hoặc tách biệt cho một committee, {{< glossary_tooltip text="SIG" term_id="sig" >}}, hoặc nỗ lực xuyên SIG.
+
+<!--more-->
+
+Working groups là một cách tổ chức mọi người để hoàn thành một nhiệm vụ rời rạc.
+
+Để biết thêm thông tin, xem repo [kubernetes/community](https://github.com/kubernetes/community) và danh sách hiện tại của [SIGs và working groups](https://github.com/kubernetes/community/blob/master/sig-list.md).


### PR DESCRIPTION
### Description
add Vietnamese translation for [WG (working group)](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/wg.md)

### Issue

Closes: #