### PR TITLE
Fix broken kubelet Summary API links in instrumentation docs

### DIFF
--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -10,7 +10,7 @@ description: >-
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
 gathers metric statistics at the node, volume, pod and container level,
 and emits this information in the
-[Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/).
+[Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1).
 
 You can send a proxied request to the stats summary API via the
 Kubernetes API server.
@@ -50,7 +50,7 @@ the kubelet [fetches Pod- and container-level metric data using CRI](/docs/refer
 As a beta feature, Kubernetes lets you configure kubelet to collect Linux kernel
 [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
 (PSI) for CPU, memory, and I/O usage. The information is collected at node, pod and container level.
-See [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/) for detailed schema.
+See [Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1) for detailed schema.
 This feature is enabled by default, by setting the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/). The information is also exposed in
 [Prometheus metrics](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 

--- a/content/en/docs/reference/instrumentation/understand-psi-metrics.md
+++ b/content/en/docs/reference/instrumentation/understand-psi-metrics.md
@@ -16,7 +16,7 @@ As a beta feature, Kubernetes lets you configure the kubelet to collect Linux ke
 This feature is enabled by default by setting the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 
 PSI metrics are exposed through two different sources:
-- The kubelet's [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/), which provides PSI data at the node, pod, and container level.
+- The kubelet's [Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1), which provides PSI data at the node, pod, and container level.
 - The `/metrics/cadvisor` endpoint on the kubelet, which exposes PSI metrics in the [Prometheus format](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 
 ### Requirements


### PR DESCRIPTION
## What this PR does

Fixes broken links to `/docs/reference/config-api/kubelet-stats.v1alpha1/` which returns **404** as the page does not exist.

Replaces them with the correct working URL: `https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1` which documents the actual Summary API schema.

## Files changed

- `content/en/docs/reference/instrumentation/node-metrics.md` — 2 links fixed
- `content/en/docs/reference/instrumentation/understand-psi-metrics.md` — 1 link fixed

## Related issue

Related to: https://github.com/kubernetes/website/issues/56087