### PR TITLE
fix: long formulas should be scrollable

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -560,3 +560,9 @@ main {
     }
   }
 }
+
+/* Math overflow scroll fix */
+.math .katex .base {
+  overflow-x: scroll;
+  width: 100%;
+}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

For pages with long formulas, the layout breaks and creates a blank space to the right. Adding a overflow scrollbar fixes it.

Closes: #54801