### PR TITLE
align EN training page styles with Docsy and fix its mobile UX

### DIFF
--- a/assets/scss/_k8s_training.scss
+++ b/assets/scss/_k8s_training.scss
@@ -1,0 +1,316 @@
+body.training section > .main-section.padded > div:first-child,
+body.training .col-container .col-nav > div,
+body.training .two-thirds-centered > div {
+  text-align: center;
+}
+
+body.training #hero {
+  text-align: left;
+  padding-bottom: 20px;
+}
+
+body.training .section {
+  clear: both;
+  padding: 0px;
+  margin-bottom: 2em;
+  width: 100%;
+}
+
+body.training section.call-to-action {
+  color: $white;
+  background-color: $primary;
+}
+
+body.training section.call-to-action .main-section {
+    max-width: initial;
+}
+
+body.training section.call-to-action .main-section > div.call-to-action {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin: initial;
+  padding-block: 5rem;
+}
+
+body.training section.call-to-action .main-section > div.call-to-action > div {
+  padding: 20px;
+}
+
+body.training section.call-to-action .main-section .cta-text {
+  width: 100%;
+  flex-basis: 100%;
+}
+
+body.training section.call-to-action .main-section .cta-text > * {
+  margin-inline: auto;
+  text-align: center;
+  /* if max() and min() are available, use them */
+  min-width: #{'min(20em, 50vw)'};
+  max-width: #{'min(1000px, 50vw)'};
+}
+
+/*Image Container for further position of image in smaller devices*/
+body.training .cta-img-container{
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+body.training section.call-to-action .main-section .cta-image {
+  max-width: #{'max(20vw, 150px)'};
+  flex-basis: auto;
+}
+body.training section.call-to-action .main-section .cta-image > img {
+  display: block;
+  width: 150px;
+  margin: auto;
+}
+
+body.training #logo-cks {
+  order: 2; /* central */
+}
+
+
+
+body.training .col-container {
+  display: flex; /* Make the container element behave like a table */
+  flex-direction: row;
+  width: 100%; /* Set full-width to expand the whole page */
+  padding-bottom: 30px;
+}
+
+body.training .col-nav {
+  display: flex;
+  flex-grow: 1;
+  width: 18%;
+  background-color: $light-grey;
+  padding: 20px;
+  border: 5px solid $white;
+}
+
+body.training #get-certified .col-nav {
+  flex-flow: column nowrap;
+  justify-content: space-between;
+}
+
+body.training #get-certified .col-nav > * {
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
+}
+
+body.training #get-certified .col-nav > br {
+  flex-grow: 1;
+  display: block;
+  min-height: 2em;
+}
+
+body.training #get-certified .col-nav a.button {
+  flex: initial;
+  width: auto;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+
+@media only screen and (max-width: 945px) {
+  body.training section.call-to-action .main-section > div.call-to-action div.cta-image {
+    padding: 0;
+    display: block;
+  }
+
+  body.training   section.call-to-action .main-section .cta-image > img {
+    margin: 0;
+  }
+  body.training   section.call-to-action .main-section .cta-image > img {
+    width: 7rem;
+  }
+  body.training section.call-to-action .main-section > div.call-to-action > div {
+    padding: 0 2rem 0 2rem;
+  }
+  /* Make the CTA text fill 100% of the viewport */
+  body.training section.call-to-action .main-section > div.call-to-action > div.cta-text {
+    width: 100%;
+  }
+
+  /* Resize the div that contains the images so that the images wrap 2 at a time
+ and have no margin issues */
+
+  body.training section.call-to-action .main-section > div.call-to-action {
+    width: 60%;
+    margin: auto;
+    padding-top: 20px;
+  }
+
+  body.training .cta-img-container{
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(2, 120px);
+    justify-content: center;
+    gap: 0;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  body.training  #logo-kcnf{
+    grid-column: 1 / span 2;
+    margin: 0 auto;
+  }
+
+  body.training  #logo-kcnf > img{
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .cta-image:nth-child(-n+2) {
+    grid-row: 1;
+  }
+
+
+  /*Change the display to Grid to prevent stretching of tiles*/
+  body.training .col-container {
+    display: grid;
+    grid-template-columns: auto auto;
+
+  }
+
+  body.training .col-nav {
+    width: 100%;
+    height: 100%;
+  }
+
+  body.training .col-container .col-nav:last-child{
+    justify-self: center;
+    width: 50%;
+    grid-column-start: span 2;
+
+  }
+}
+
+/*  GO FULL WIDTH AT LESS THAN 480 PIXELS */
+
+@media only screen and (max-width: 480px) {
+  body.training .col-container { display: flex; flex-direction: column; }
+  body.training .cta-img-container{
+    display: flex;
+    flex-direction: column;
+  }
+  body.training .col-container .col-nav:last-child{width: 100%;}
+  body.training #logo-cks { order: initial; }
+  body.training  #logo-kcnf > img{
+    position: relative;
+  }
+}
+
+@media only screen and (max-width: 650px) {
+  body.training section.call-to-action .main-section > div.call-to-action {
+    width: 100%;
+    padding-inline: 1rem;
+  }
+  body.training section.call-to-action .main-section .cta-text > * {
+    min-width: 0;
+    max-width: 100%;
+  }
+  body.training .two-thirds-centered {
+    width: 100%;
+    padding-inline: 1rem;
+  }
+  body.training #get-certified h2 {
+    text-align: center;
+  }
+  body.training .col-nav {
+    display: block;
+    width: 100%;
+  }
+  body.training .col-container {display: flex; flex-direction: column; }
+  body.training .col-container .col-nav:last-child{width: 100%;}
+}
+
+body.training .button {
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 1em 0;
+  display: inline-block;
+  border-radius: 6px;
+  padding: 0 20px;
+  line-height: 40px;
+  color: $white;
+  font-size: 16px;
+  background-color: $primary;
+  text-decoration: none;
+  text-align: center;
+}
+
+body.training .button:hover {
+  background-color: darken($primary, 10%);
+}
+
+
+
+body.training h5 {
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.5em;
+  margin-bottom: 2em;
+}
+
+body.training .white-text {
+  color: $white;
+}
+
+body.training .padded {
+  padding-top: 100px;
+  padding-bottom: 100px;
+}
+
+body.training .blue-bg {
+  background-color: $primary;
+}
+
+body.training .lighter-gray-bg {
+  background-color: darken($light-grey, 2%);
+}
+
+body.training .two-thirds-centered {
+  width: 66%;
+  max-width: 950px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+body.training .landscape-section {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1200px;
+  width: 100%;
+}
+
+body.training .landscape-section #frameHolder {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+body.training .landscape-section #frameHolder iframe {
+  display: block;
+  width: 100% !important;
+  min-width: 100% !important;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+body.training #landscape {
+  opacity: 1;
+  visibility: visible;
+  overflow: hidden;
+  width: 100%;
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -11,6 +11,7 @@ Add styles or import other files. */
 @import "k8s_nav";
 @import "k8s_search";
 @import "k8s_sidebar-tree";
+@import "k8s_training";
 
 //Media queries
 @import "base";

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -6,6 +6,9 @@ layout: basic
 cid: training
 class: training
 body_class: training
+# Once all localizations have migrated, we can drop the training_styles_migrated
+# field and simplify the CSS code.
+training_styles_migrated: true
 menu:
   main:
     weight: 30
@@ -41,39 +44,39 @@ menu:
 
 <section>
   <div class="main-section padded">
-    <center>
+    <div>
       <h2>Take a free course on edX</h2>
-    </center>
+    </div>
     <div class="col-container">
       <div class="col-nav">
-        <center>
+        <div>
           <h5>
             <b>Introduction to Kubernetes <br> &nbsp;</b>
           </h5>
           <p>Want to learn Kubernetes? Get an in-depth primer on this powerful system for managing containerized applications.</p>
           <br>
           <a href="https://www.edx.org/course/introduction-to-kubernetes" target="_blank" class="button">Go to Course</a>
-        </center>
+        </div>
       </div>
       <div class="col-nav">
-        <center>
+        <div>
           <h5>
             <b>Introduction to Cloud Infrastructure Technologies</b>
           </h5>
           <p>Learn the fundamentals of building and managing cloud technologies directly from The Linux Foundation, the leader in open source.</p>
           <br>
           <a href="https://www.edx.org/course/introduction-to-cloud-infrastructure-technologies" target="_blank" class="button">Go to Course</a>
-        </center>
+        </div>
       </div>
       <div class="col-nav">
-        <center>
+        <div>
           <h5>
             <b>Introduction to Linux</b>
           </h5>
           <p>Never learned Linux? Want a refresh? Develop a good working knowledge of Linux using both the graphical interface and command line across the major Linux distribution families.</p>
           <br>
           <a href="https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">Go to Course</a>
-        </center>
+        </div>
       </div>
     </div>
   </div>
@@ -81,12 +84,12 @@ menu:
 
 <div class="padded lighter-gray-bg">
   <div class="main-section two-thirds-centered">
-    <center>
+    <div>
       <h2>Learn with the Linux Foundation</h2>
       <p>The Linux Foundation offers instructor-led and self-paced courses for all aspects of the Kubernetes application development and operations lifecycle.</p>
       <br/><br/>
       <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">See Courses</a>
-    </center>
+    </div>
   </div>
 </div>
 
@@ -166,10 +169,10 @@ menu:
 
 <div class="padded lighter-gray-bg">
   <div class="main-section two-thirds-centered">
-    <center>
+    <div>
       <h2>Kubernetes Training Partners</h2>
       <p>Our network of Kubernetes Training Partners provide training services for Kubernetes and cloud native projects.</p>
-    </center>
+    </div>
   </div>
   <div class="main-section landscape-section">
     {{< cncf-landscape helpers=false category="special--kubernetes-training-partner" >}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="{{ "css/gridpage.css" | relURL }}">
 {{- end }}
 
-{{- if eq .Params.class "training" }}
+{{- if and (eq .Params.class "training") (ne .Params.training_styles_migrated true) }}
   <link rel="stylesheet" href="{{ "css/training.css" | relURL }}">
 {{- end }}
 


### PR DESCRIPTION
This PR migrates the English Training page to Docsy-aligned styling via the SCSS pipeline, while preserving legacy styling for other locales.

other locales stay unchanged.

Includes mobile alignment fixes for CTA and training partner sections.
new:

<img width="616" height="1393" alt="image" src="https://github.com/user-attachments/assets/12015b90-a095-4f8b-bfc0-179181fb90e8" />

---
existing:
<img width="586" height="1413" alt="image" src="https://github.com/user-attachments/assets/7bc7dd0a-009d-4138-ad2e-aa963f03cb76" />

similar changes with the kubestronaut program section


Follow-up PRs will migrate each locale individually by enabling training_styles_migrated per locale.

related to https://github.com/kubernetes/website/issues/41171