### PR TITLE
blog: Fix millicore confusion regarding cgroup v1 CPU shares to v2 CPU weight

### DIFF
--- a/content/en/blog/_posts/2026/new-cgroup-v1-to-v2-conversion-formula/index.md
+++ b/content/en/blog/_posts/2026/new-cgroup-v1-to-v2-conversion-formula/index.md
@@ -15,11 +15,17 @@ running on systems with cgroup v2.
 
 ## Background
 
-Kubernetes was originally designed with cgroup v1 in mind, where CPU shares 
-were defined simply by assigning the container's CPU requests in millicpu 
-form. 
+Kubernetes was originally designed with cgroup v1 in mind, where CPU shares
+were derived from a container's CPU requests using the following formula:
 
-For example, a container requesting 1 CPU (1000m) would get \(cpu.shares = 1024\).
+```math
+cpu.shares = milliCPU \times \frac{1024}{1000}
+```
+
+Note that the value 1024 in this formula is the default `cpu.shares` value
+in cgroup v1, and is unrelated to millicores. For example, a container
+requesting 1 CPU (1000m) would get \(cpu.shares = 1000 \times 1024 / 1000 = 1024\),
+and a container requesting 100m would get \(cpu.shares = 100 \times 1024 / 1000 = 102\).
 
 After a while, cgroup v1 started being replaced by its successor, 
 cgroup v2. In cgroup v2, the concept of CPU shares (which ranges from 2 to 
@@ -146,6 +152,15 @@ This is particularly relevant for:
 - Custom resource management tools that predict CPU weight values.
 - Monitoring systems that validate or expect specific weight values.
 - Applications that programmatically set or verify CPU weight values.
+
+Also note that reversing the conversion from `cpu.weight` back to milliCPU
+will not always yield the exact original value. There are two sources of
+information loss: the milliCPU to `cpu.shares` conversion involves integer
+truncation (e.g. 100m becomes 102 shares, not 102.4), and more significantly,
+the shares-to-weight mapping is many-to-one (e.g. milliCPU values 90
+through 109 all map to `cpu.weight = 17`). Tools that need precise CPU
+request values should read them directly from the pod spec rather than
+deriving them from cgroup parameters.
 
 The Kubernetes project recommends testing the new conversion formula in non-production
 environments before upgrading OCI runtimes to ensure compatibility with existing tooling.

--- a/content/en/blog/_posts/2026/new-cgroup-v1-to-v2-conversion-formula/index.md
+++ b/content/en/blog/_posts/2026/new-cgroup-v1-to-v2-conversion-formula/index.md
@@ -19,7 +19,7 @@ Kubernetes was originally designed with cgroup v1 in mind, where CPU shares
 were defined simply by assigning the container's CPU requests in millicpu 
 form. 
 
-For example, a container requesting 1 CPU (1024m) would get \(cpu.shares = 1024\).
+For example, a container requesting 1 CPU (1000m) would get \(cpu.shares = 1024\).
 
 After a while, cgroup v1 started being replaced by its successor, 
 cgroup v2. In cgroup v2, the concept of CPU shares (which ranges from 2 to 
@@ -48,11 +48,11 @@ In cgroup v1, the default value for CPU shares is `1024`, meaning a container
 requesting 1 CPU has equal priority with system processes that live outside 
 of Kubernetes' scope.
 However, in cgroup v2, the default CPU weight is `100`, but the current 
-formula converts 1 CPU (1024m) to only `≈39` weight - less than 40% of the 
+formula converts 1 CPU (1000m) to only `≈39` weight - less than 40% of the 
 default.
 
 **Example:**
-- Container requesting 1 CPU (1024m)
+- Container requesting 1 CPU (1000m)
 - cgroup v1: `cpu.shares = 1024` (equal to default)
 - cgroup v2 (current): `cpu.weight = 39` (much lower than default 100)
 
@@ -115,7 +115,7 @@ cross.
 ### How it solves the problems
 
 1. **Better priority alignment:**
-   - A container requesting 1 CPU (1024m) will now get a `cpu.weight = 102`. This 
+   - A container requesting 1 CPU (1000m) will now get a `cpu.weight = 102`. This 
      value is close to cgroup v2's default 100.
      This restores the intended priority relationship between Kubernetes 
      workloads and system processes.


### PR DESCRIPTION

### Description
- Fix all instances of "1 CPU (1024m)" to "1 CPU (1000m)" - 1024 is the default cpu.shares value in cgroup v1, not a millicore value.
- Add the milliCPU to cpu.shares conversion formula (`cpu.shares = milliCPU × 1024/1000`) with worked examples, clarifying the previously undocumented first half of the conversion pipeline.
- Add a note explaining why reversing the conversion from cpu.weight back to milliCPU is lossy (integer truncation and many-to-one mapping in the shares-to-weight step).

### Issue
Closes: https://github.com/kubernetes/website/issues/54411