### PR TITLE
Remove reference to play-with-k8s.com (de)

### DIFF
--- a/content/de/includes/task-tutorial-prereqs.md
+++ b/content/de/includes/task-tutorial-prereqs.md
@@ -2,4 +2,3 @@ Sie benötigen einen Kubernetes-Cluster, und das Kommandozeilen-Tool kubectl mus
 
 Oder Sie können einen dieser Kubernetes-Spielplätze benutzen:
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
The Play with Kubernetes system has been deprecated and is no longer online. This PR removes the links to the system.

Originally part of https://github.com/kubernetes/website/pull/54749, but splitting into per-locale PRs.