### PR TITLE
Remove references to play-with-k8s.com (en)

### DIFF
--- a/content/en/docs/setup/learning-environment/_index.md
+++ b/content/en/docs/setup/learning-environment/_index.md
@@ -53,7 +53,6 @@ Refer to each tool's documentation for setup instructions and support.
 Online Kubernetes playgrounds let you try Kubernetes without installing anything on your computer. These environments run in your web browser:
 
 - **[Killercoda](https://killercoda.com/kubernetes)** provides interactive Kubernetes scenarios and a playground environment
-- **[Play with Kubernetes](https://labs.play-with-k8s.com/)** gives you a temporary Kubernetes cluster in your browser
 
 These platforms are useful for quick experiments and following tutorials without local setup.
 

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -7,4 +7,3 @@ or you can use one of these Kubernetes playgrounds:
 * [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
The Play with Kubernetes system has been deprecated and is no longer online. This PR removes the links to the system.

Originally part of https://github.com/kubernetes/website/pull/54749, but splitting into per-locale PRs.