### PR TITLE
Remove reference to play-with-k8s.com (hi)

### DIFF
--- a/content/hi/includes/task-tutorial-prereqs.md
+++ b/content/hi/includes/task-tutorial-prereqs.md
@@ -5,4 +5,3 @@
 की मदद से वह बना सकते है या आप नीचे दिए हुए इन दो कुबरनेट्स प्लेग्राउंड का इस्तेमाल कर सकते हैं:
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
-* [प्ले विथ कुबेरनेट्स](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
The Play with Kubernetes system has been deprecated and is no longer online. This PR removes the links to the system.

Originally part of https://github.com/kubernetes/website/pull/54749, but splitting into per-locale PRs.