### PR TITLE
Remove reference to play-with-k8s.com (ko)

### DIFF
--- a/content/ko/includes/task-tutorial-prereqs.md
+++ b/content/ko/includes/task-tutorial-prereqs.md
@@ -7,4 +7,3 @@
 * [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes) 
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
The Play with Kubernetes system has been deprecated and is no longer online. This PR removes the links to the system.

Originally part of https://github.com/kubernetes/website/pull/54749, but splitting into per-locale PRs.