### PR TITLE
Remove references to play-with-k8s.com (vi)

### DIFF
--- a/content/vi/includes/task-tutorial-prereqs.md
+++ b/content/vi/includes/task-tutorial-prereqs.md
@@ -3,6 +3,5 @@ Bạn cần có một cluster Kubernetes, và kubectl phải được cấu hìn
 * [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)
 
 Để kiểm tra phiên bản của kubectl, hãy chạy lệnh `kubectl version`.


### PR DESCRIPTION
The Play with Kubernetes system has been deprecated and is no longer online. This PR removes the links to the system.

Originally part of https://github.com/kubernetes/website/pull/54749, but splitting into per-locale PRs.