### PR TITLE
Remove references to play-with-k8s.com (zh-cn)

### DIFF
--- a/content/zh-cn/docs/setup/learning-environment/_index.md
+++ b/content/zh-cn/docs/setup/learning-environment/_index.md
@@ -117,12 +117,10 @@ Online Kubernetes playgrounds let you try Kubernetes without installing anything
 
 <!--
 - **[Killercoda](https://killercoda.com/kubernetes)** provides interactive Kubernetes scenarios and a playground environment
-- **[Play with Kubernetes](https://labs.play-with-k8s.com/)** gives you a temporary Kubernetes cluster in your browser
 
 These platforms are useful for quick experiments and following tutorials without local setup.
 -->
 - **[Killercoda](https://killercoda.com/kubernetes)** 提供交互式 Kubernetes 场景和实验环境。
-- **[Play with Kubernetes](https://labs.play-with-k8s.com/)** 可在浏览器中创建一个临时的 Kubernetes 集群。
 
 这些平台非常适合快速实验和学习教程，无需本地配置。
 

--- a/content/zh-cn/includes/task-tutorial-prereqs.md
+++ b/content/zh-cn/includes/task-tutorial-prereqs.md
@@ -14,9 +14,7 @@ or you can use one of these Kubernetes playgrounds:
 * [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)
 -->
 * [iximiuz Labs](https://labs.iximiuz.com/playgrounds?category=kubernetes&filter=all)
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)
-* [玩转 Kubernetes](https://labs.play-with-k8s.com/)


### PR DESCRIPTION
The Play with Kubernetes system has been deprecated and is no longer online. This PR removes the links to the system.

Originally part of https://github.com/kubernetes/website/pull/54749, but splitting into per-locale PRs.