### PR TITLE
Clarify POSIX shell requirement for Kubernetes Basics tutorial

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
@@ -9,6 +9,17 @@ weight: 10
 * Learn what Minikube is.
 * Start a Kubernetes cluster on your computer.
 
+## {{% heading "prerequisites" %}}
+
+The shell commands in this tutorial use POSIX shell syntax, which is supported by
+the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
+Windows users must use a POSIX-compatible shell such as
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+or [Git Bash](https://gitforwindows.org/) to run the commands as written.
+Commands that use `export`, `$()`, and similar constructs are **not** compatible
+with PowerShell or the Windows Command Prompt.
+
+
 ## Kubernetes Clusters
 
 {{% alert %}}

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
@@ -11,12 +11,14 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-The shell commands in this tutorial use POSIX shell syntax, which is the default
-on Linux and macOS terminals. Windows users must use a POSIX-compatible shell such
-as [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+The shell commands in this tutorial use POSIX shell syntax, which is supported by
+the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
+Windows users must use a POSIX-compatible shell such as
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
 or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
+
 
 ## Kubernetes Deployments
 

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.md
@@ -11,12 +11,14 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-The shell commands in this tutorial use POSIX shell syntax, which is the default
-on Linux and macOS terminals. Windows users must use a POSIX-compatible shell such
-as [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+The shell commands in this tutorial use POSIX shell syntax, which is supported by
+the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
+Windows users must use a POSIX-compatible shell such as
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
 or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
+
 
 ## Kubernetes Pods
 

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -11,12 +11,14 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-The shell commands in this tutorial use POSIX shell syntax, which is the default
-on Linux and macOS terminals. Windows users must use a POSIX-compatible shell such
-as [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+The shell commands in this tutorial use POSIX shell syntax, which is supported by
+the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
+Windows users must use a POSIX-compatible shell such as
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
 or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
+
 
 ## Overview of Kubernetes Services
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.md
@@ -9,12 +9,14 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
-The shell commands in this tutorial use POSIX shell syntax, which is the default
-on Linux and macOS terminals. Windows users must use a POSIX-compatible shell such
-as [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+The shell commands in this tutorial use POSIX shell syntax, which is supported by
+the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
+Windows users must use a POSIX-compatible shell such as
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
 or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
+
 
 
 ## Scaling an application

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.md
@@ -9,12 +9,14 @@ Perform a rolling update using kubectl.
 
 ## {{% heading "prerequisites" %}}
 
-The shell commands in this tutorial use POSIX shell syntax, which is the default
-on Linux and macOS terminals. Windows users must use a POSIX-compatible shell such
-as [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+The shell commands in this tutorial use POSIX shell syntax, which is supported by
+the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
+Windows users must use a POSIX-compatible shell such as
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
 or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
+
 
 ## Updating an application
 


### PR DESCRIPTION
### Description

This PR updates the "Using a Service to Expose Your App" Kubernetes Basics
tutorial to call out that the example commands assume a POSIX-compatible shell
(such as Bash or Zsh). As suggested by @lmktfy in the linked issue discussion,
the tutorial now explains this prerequisite so that Windows users know they need
to switch to a POSIX shell when following along. It also adds a short note for
Windows users explaining that the commands will not work as written in PowerShell
or cmd and suggesting they use WSL or Git Bash instead.

### Issue

 #54836
