### PR TITLE
Fix readiness probe example

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -374,9 +374,7 @@ is that you use the `readinessProbe` field instead of the `livenessProbe` field.
 readinessProbe:
   exec:
     command:
-    - /bin/sh
-    - -c
-    - cat
+    - /bin/cat
     - /tmp/healthy
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -374,6 +374,8 @@ is that you use the `readinessProbe` field instead of the `livenessProbe` field.
 readinessProbe:
   exec:
     command:
+    - /bin/sh
+    - -c
     - cat
     - /tmp/healthy
   initialDelaySeconds: 5


### PR DESCRIPTION
This PR updates the `readinessProbe` example to ensure it works reliably in all Linux containers. The previous example, which ran `cat` `/tmp/healthy` directly, can fail if `cat` is not in the container’s PATH. The corrected version uses `/bin/sh` `-c`  `cat` `/tmp/healthy` so the command is executed as a single string through the shell.

Issue: #54854