### PR TITLE
Moved PersistentVolume storage page to tutorials section

### DIFF
--- a/content/en/blog/_posts/2021/read-write-once-pod-access-mode-alpha.md
+++ b/content/en/blog/_posts/2021/read-write-once-pod-access-mode-alpha.md
@@ -157,7 +157,7 @@ Lastly you may edit your PersistentVolume's `spec.persistentVolumeReclaimPolicy`
 kubectl patch pv cat-pictures-pv -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
 ```
 
-You can read [Configure a Pod to Use a PersistentVolume for Storage](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/) for more details on working with PersistentVolumes and PersistentVolumeClaims.
+You can read [Configure a Pod to Use a PersistentVolume for Storage](/docs/tutorials/configuration/configure-persistent-volume-storage/) for more details on working with PersistentVolumes and PersistentVolumeClaims.
 
 ## What volume plugins support this?
 

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -55,7 +55,7 @@ offer a variety of PersistentVolumes that differ in more ways than size and acce
 modes, without exposing users to the details of how those volumes are implemented.
 For these needs, there is the _StorageClass_ resource.
 
-See the [detailed walkthrough with working examples](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
+See the [detailed walkthrough with working examples](/docs/tutorials/configuration/configure-persistent-volume-storage).
 
 ## Lifecycle of a volume and claim
 
@@ -972,7 +972,8 @@ possible within one namespace.
 
 A `hostPath` PersistentVolume uses a file or directory on the Node to emulate
 network-attached storage. See
-[an example of `hostPath` typed volume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
+[an example of `hostPath` typed volume](/docs/tutorials/configuration/configure-persistent-volume-storage/#create-a-persistentvolume).
+
 
 ## Raw Block Volume Support
 
@@ -1306,8 +1307,8 @@ and need persistent storage, it is recommended that you use the following patter
 
 ## {{% heading "whatsnext" %}}
 
-* Learn more about [Creating a PersistentVolume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
-* Learn more about [Creating a PersistentVolumeClaim](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim).
+* Learn more about [Creating a PersistentVolume](/docs/tutorials/configuration/configure-persistent-volume-storage/#create-a-persistentvolume).
+* Learn more about [Creating a PersistentVolumeClaim](/docs/tutorials/configuration/configure-persistent-volume-storage/#create-a-persistentvolumeclaim).
 * Read the [Persistent Storage design document](https://git.k8s.io/design-proposals-archive/storage/persistent-storage.md).
 
 ### API references {#reference}

--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -577,7 +577,7 @@ the `.spec.replicas` field automatically.
   * Learn how to [scale a StatefulSet](/docs/tasks/run-application/scale-stateful-set/).
   * Learn what's involved when you [delete a StatefulSet](/docs/tasks/run-application/delete-stateful-set/).
   * Learn how to [configure a Pod to use a volume for storage](/docs/tasks/configure-pod-container/configure-volume-storage/).
-  * Learn how to [configure a Pod to use a PersistentVolume for storage](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
+  * Learn how to [configure a Pod to use a PersistentVolume for storage](/docs/tutorials/configuration/configure-persistent-volume-storage/).
 * `StatefulSet` is a top-level resource in the Kubernetes REST API.
   Read the {{< api-reference page="workload-resources/stateful-set-v1" >}}
   object definition to understand the API for stateful sets.

--- a/content/en/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod.md
@@ -184,4 +184,4 @@ kubectl patch pv cat-pictures-pv -p '{"spec":{"persistentVolumeReclaimPolicy":"D
 
 * Learn more about [PersistentVolumes](/docs/concepts/storage/persistent-volumes/).
 * Learn more about [PersistentVolumeClaims](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
-* Learn more about [Configuring a Pod to Use a PersistentVolume for Storage](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/)
+* Learn more about [Configuring a Pod to Use a PersistentVolume for Storage](/docs/tutorials/configuration/configure-persistent-volume-storage/)

--- a/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
+++ b/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
@@ -2,8 +2,6 @@
 title: Configure a Pod to Use a PersistentVolume for Storage
 content_type: tutorial
 weight: 90
-redirect_from:
-- /docs/tasks/configure-pod-container/configure-persistent-volume-storage/
 ---
 
 <!-- overview -->

--- a/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
+++ b/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
@@ -1,7 +1,9 @@
 ---
 title: Configure a Pod to Use a PersistentVolume for Storage
-content_type: task
+content_type: tutorial
 weight: 90
+redirect_from:
+- /docs/tasks/configure-pod-container/configure-persistent-volume-storage/
 ---
 
 <!-- overview -->

--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -486,4 +486,4 @@
 /kubertenes     /blog/2024/06/06/10-years-of-kubernetes/ 302
 /docs/concepts/architecture/cri/   /docs/concepts/containers/cri/   301
 
-/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage/     /en/docs/tutorials/configuration/configure-persistent-volume-storage   301
+/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage/     /en/docs/tutorials/configuration/configure-persistent-volume-storage/   301

--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -485,3 +485,5 @@
 
 /kubertenes     /blog/2024/06/06/10-years-of-kubernetes/ 302
 /docs/concepts/architecture/cri/   /docs/concepts/containers/cri/   301
+
+/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage/     /en/docs/tutorials/configuration/configure-persistent-volume-storage   301

--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -486,4 +486,4 @@
 /kubertenes     /blog/2024/06/06/10-years-of-kubernetes/ 302
 /docs/concepts/architecture/cri/   /docs/concepts/containers/cri/   301
 
-/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage/     /en/docs/tutorials/configuration/configure-persistent-volume-storage/   301
+/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage/     /en/docs/tutorials/configuration/configure-persistent-volume-storage/   301!


### PR DESCRIPTION
This PR moves the page  at `content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md` from the tasks section to the tutorials section at `content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md` because the content reads more like a tutorial than a task reference.

Issue: #54864