### PR TITLE
add release blog links to release pages

### DIFF
--- a/content/en/blog/_posts/2016/kubernetes-1-2-even-more-performance-upgrades-plus-easier-application-deployment-and-management-.md
+++ b/content/en/blog/_posts/2016/kubernetes-1-2-even-more-performance-upgrades-plus-easier-application-deployment-and-management-.md
@@ -4,6 +4,8 @@ date: 2016-03-17
 slug: kubernetes-1-2-even-more-performance-upgrades-plus-easier-application-deployment-and-management
 url: /:section/:year/:month/:slug/
 evergreen: true
+release_announcement:
+  minor_version: "1.2"
 author: >
   David Aronchick (Google)
 ---

--- a/content/en/blog/_posts/2016/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads.md
+++ b/content/en/blog/_posts/2016/kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads.md
@@ -4,6 +4,8 @@ date: 2016-07-06
 slug: kubernetes-1-3-bridging-cloud-native-and-enterprise-workloads
 url: /:section/:year/:month/:slug/
 evergreen: true
+release_announcement:
+  minor_version: "1.3"
 author: >
   Aparna Sinha (Google)
 ---

--- a/content/en/blog/_posts/2016/kubernetes-1-4-making-it-easy-to-run-on-kuberentes-anywhere.md
+++ b/content/en/blog/_posts/2016/kubernetes-1-4-making-it-easy-to-run-on-kuberentes-anywhere.md
@@ -3,6 +3,8 @@ title: " Kubernetes 1.4: Making it easy to run on Kubernetes anywhere "
 date: 2016-09-26
 slug: kubernetes-1-4-making-it-easy-to-run-on-kuberentes-anywhere
 url: /:section/:year/:month/:slug/
+release_announcement:
+  minor_version: "1.4"
 author: >
   Aparna Sinha (Google)
 ---

--- a/content/en/blog/_posts/2016/kubernetes-1-5-supporting-production-workloads.md
+++ b/content/en/blog/_posts/2016/kubernetes-1-5-supporting-production-workloads.md
@@ -3,6 +3,8 @@ title: " Kubernetes 1.5: Supporting Production Workloads "
 date: 2016-12-13
 slug: kubernetes-1-5-supporting-production-workloads
 url: /:section/:year/:month/:slug/
+release_announcement:
+  minor_version: "1.5"
 author: >
   Aparna Sinha(Google)
 ---

--- a/content/en/blog/_posts/2017/kubernetes-1-6-multi-user-multi-workloads-at-scale.md
+++ b/content/en/blog/_posts/2017/kubernetes-1-6-multi-user-multi-workloads-at-scale.md
@@ -3,6 +3,8 @@ title: " Kubernetes 1.6: Multi-user, Multi-workloads at Scale "
 date: 2017-03-28
 slug: kubernetes-1-6-multi-user-multi-workloads-at-scale
 url: /:section/:year/:month/:slug/
+release_announcement:
+  minor_version: "1.6"
 author: >
   Aparna Sinha (Google)
 ---

--- a/content/en/blog/_posts/2017/kubernetes-1-7-security-hardening-stateful-application-extensibility-updates.md
+++ b/content/en/blog/_posts/2017/kubernetes-1-7-security-hardening-stateful-application-extensibility-updates.md
@@ -3,6 +3,8 @@ title: " Kubernetes 1.7: Security Hardening, Stateful Application Updates and Ex
 date: 2017-06-30
 slug: kubernetes-1-7-security-hardening-stateful-application-extensibility-updates
 url: /:section/:year/:month/:slug/
+release_announcement:
+  minor_version: "1.7"
 author: >
    Aparna Sinha (Google),
    Ihor Dvoretskyi (Mirantis)

--- a/content/en/blog/_posts/2017/kubernetes-18-security-workloads-and.md
+++ b/content/en/blog/_posts/2017/kubernetes-18-security-workloads-and.md
@@ -4,6 +4,8 @@ date: 2017-09-29
 slug: kubernetes-18-security-workloads-and
 url: /:section/:year/:month/:slug/
 evergreen: true
+release_announcement:
+  minor_version: "1.8"
 author: >
   [Kubernetes v1.8 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.8/release_team.md)
 ---

--- a/content/en/blog/_posts/2017/kubernetes-19-workloads-expanded-ecosystem.md
+++ b/content/en/blog/_posts/2017/kubernetes-19-workloads-expanded-ecosystem.md
@@ -4,6 +4,8 @@ date: 2017-12-15
 slug: kubernetes-19-workloads-expanded-ecosystem
 url: /:section/:year/:month/:slug/
 evergreen: true
+release_announcement:
+  minor_version: "1.9"
 author: >
   [Kubernetes v1.9 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.9/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-10-stabilizing-storage-security-networking.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-10-stabilizing-storage-security-networking.md
@@ -4,6 +4,8 @@ date: 2018-03-26
 modified_time: '2018-03-27T11:01:39.569-07:00'
 slug: kubernetes-1.10-stabilizing-storage-security-networking
 evergreen: true
+release_announcement:
+  minor_version: "1.10"
 author: >
   [Kubernetes v1.10 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.10/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-11-release-announcement.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-11-release-announcement.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.11: In-Cluster Load Balancing and CoreDNS Plugin Graduate t
 date:  2018-06-27
 slug: kubernetes-1.11-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.11"
 author: >
   [Kubernetes v1.11 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-12-release-announcement.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-12-release-announcement.md
@@ -3,6 +3,9 @@ layout: blog
 title:  'Kubernetes 1.12: Kubelet TLS Bootstrap and Azure Virtual Machine Scale Sets (VMSS) Move to General Availability'
 date:   2018-09-27
 evergreen: true
+slug: kubernetes-1-12-release-announcement
+release_announcement:
+  minor_version: "1.12"
 author: >
   [Kubernetes v1.12 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-13-release-announcement.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-13-release-announcement.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.13: Simplified Cluster Management with Kubeadm, Container S
 date: 2018-12-03
 slug: kubernetes-1-13-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.13"
 author: >
   [Kubernetes v1.13 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.13/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/1-14-release-announcement.md
+++ b/content/en/blog/_posts/2019/1-14-release-announcement.md
@@ -3,6 +3,8 @@ title: 'Kubernetes 1.14: Production-level support for Windows Nodes, Kubectl Upd
 date: 2019-03-25
 slug: kubernetes-1-14-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.14"
 author: >
   [Kubernetes v1.14 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.14/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/kubernetes-1-15-release-announcement.md
+++ b/content/en/blog/_posts/2019/kubernetes-1-15-release-announcement.md
@@ -4,6 +4,8 @@ title: "Kubernetes 1.15: Extensibility and Continuous Improvement"
 date: 2019-06-19
 slug: kubernetes-1-15-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.15"
 author: >
   [Kubernetes 1.15 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.15/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/kubernetes-1-16-release-announcement.md
+++ b/content/en/blog/_posts/2019/kubernetes-1-16-release-announcement.md
@@ -3,6 +3,8 @@ layout: blog
 title: "Kubernetes 1.16: Custom Resources, Overhauled Metrics, and Volume Extensions"
 date: 2019-09-18
 slug: kubernetes-1-16-release-announcement
+release_announcement:
+  minor_version: "1.16"
 author: >
   [Kubernetes 1.16 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.16/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/kubernetes-1.17-release-announcement.md
+++ b/content/en/blog/_posts/2019/kubernetes-1.17-release-announcement.md
@@ -4,6 +4,8 @@ title: "Kubernetes 1.17: Stability"
 date: 2019-12-09T13:00:00-08:00
 slug: kubernetes-1-17-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.17"
 author: >
   [Kubernetes 1.17 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.17/release_team.md)
 ---

--- a/content/en/blog/_posts/2020/kubernetes-1.18-release-announcement.md
+++ b/content/en/blog/_posts/2020/kubernetes-1.18-release-announcement.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.18: Fit & Finish'
 date: 2020-03-25
 slug: kubernetes-1-18-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.18"
 author: >
   [Kubernetes 1.18 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.18/release_team.md) 
 ---

--- a/content/en/blog/_posts/2020/kubernetes-release-1.19.md
+++ b/content/en/blog/_posts/2020/kubernetes-release-1.19.md
@@ -4,6 +4,8 @@ title: 'Kubernetes  1.19: Accentuate the Paw-sitive'
 date: 2020-08-26
 slug: kubernetes-release-1.19-accentuate-the-paw-sitive
 evergreen: true
+release_announcement:
+  minor_version: "1.19"
 author: >
   [Kubernetes 1.19 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.19/release_team.md)
 ---

--- a/content/en/blog/_posts/2020/kubernetes-release-1.20.md
+++ b/content/en/blog/_posts/2020/kubernetes-release-1.20.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.20: The Raddest Release'
 date: 2020-12-08
 slug: kubernetes-1-20-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.20"
 author: >
   [Kubernetes 1.20 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release_team.md)
 ---

--- a/content/en/blog/_posts/2021/kubernetes-release-1.21.md
+++ b/content/en/blog/_posts/2021/kubernetes-release-1.21.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.21: Power to the Community'
 date: 2021-04-08
 slug: kubernetes-1-21-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.21"
 author: >
   [Kubernetes 1.21 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md)
 ---

--- a/content/en/blog/_posts/2021/kubernetes-release-1.22.md
+++ b/content/en/blog/_posts/2021/kubernetes-release-1.22.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.22: Reaching New Peaks'
 date: 2021-08-04
 slug: kubernetes-1-22-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.22"
 author: >
   [Kubernetes 1.22 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.22/release-team.md)
 ---

--- a/content/en/blog/_posts/2021/kubernetes-release-1.23.md
+++ b/content/en/blog/_posts/2021/kubernetes-release-1.23.md
@@ -4,6 +4,8 @@ title: 'Kubernetes 1.23: The Next Frontier'
 date: 2021-12-07
 slug: kubernetes-1-23-release-announcement
 evergreen: true
+release_announcement:
+  minor_version: "1.23"
 author: >
   [Kubernetes 1.23 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/release-team.md)
 ---

--- a/content/en/blog/_posts/2022/kubernetes-1.25-blog.md
+++ b/content/en/blog/_posts/2022/kubernetes-1.25-blog.md
@@ -3,6 +3,8 @@ layout: blog
 title: "Kubernetes v1.25: Combiner"
 date: 2022-08-23
 slug: kubernetes-v1-25-release
+release_announcement:
+  minor_version: "1.25"
 author: >
   [Kubernetes 1.25 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.25/release-team.md)
 ---

--- a/content/en/blog/_posts/2022/kubernetes-1.26-blog.md
+++ b/content/en/blog/_posts/2022/kubernetes-1.26-blog.md
@@ -3,6 +3,8 @@ layout: blog
 title: "Kubernetes v1.26: Electrifying"
 date: 2022-12-09
 slug: kubernetes-v1-26-release
+release_announcement:
+  minor_version: "1.26"
 author: >
   [Kubernetes 1.26 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)
 ---

--- a/content/en/blog/_posts/2022/kubernetes-release-1.24.md
+++ b/content/en/blog/_posts/2022/kubernetes-release-1.24.md
@@ -3,6 +3,8 @@ layout: blog
 title: "Kubernetes 1.24: Stargazer"
 date: 2022-05-03
 slug: kubernetes-1-24-release-announcement
+release_announcement:
+  minor_version: "1.24"
 author: >
   [Kubernetes 1.24 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)
 ---

--- a/content/en/blog/_posts/2023/kubernetes-1.27-release.md
+++ b/content/en/blog/_posts/2023/kubernetes-1.27-release.md
@@ -3,6 +3,8 @@ layout: blog
 title: "Kubernetes v1.27: Chill Vibes"
 date: 2023-04-11
 slug: kubernetes-v1-27-release
+release_announcement:
+  minor_version: "1.27"
 author: >
    [Kubernetes v1.27 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.27/release-team.md)
 ---

--- a/content/en/blog/_posts/2023/kubernetes-1.28-blog.md
+++ b/content/en/blog/_posts/2023/kubernetes-1.28-blog.md
@@ -3,6 +3,8 @@ layout: blog
 title: "Kubernetes v1.28: Planternetes"
 date: 2023-08-15T12:00:00+0000
 slug: kubernetes-v1-28-release
+release_announcement:
+  minor_version: "1.28"
 author: >
   [Kubernetes v1.28 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/release-team.md)
 ---

--- a/content/en/blog/_posts/2023/kubernetes-1.29.md
+++ b/content/en/blog/_posts/2023/kubernetes-1.29.md
@@ -3,6 +3,8 @@ layout: blog
 title: 'Kubernetes v1.29: Mandala'
 date: 2023-12-13
 slug: kubernetes-v1-29-release
+release_announcement:
+  minor_version: "1.29"
 author: >
  [Kubernetes v1.29 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release-team.md)
 ---

--- a/content/en/blog/_posts/2024/kubernetes-v1-30-release.md
+++ b/content/en/blog/_posts/2024/kubernetes-v1-30-release.md
@@ -3,6 +3,8 @@ layout: blog
 title: 'Kubernetes v1.30: Uwubernetes'
 date: 2024-04-17
 slug: kubernetes-v1-30-release
+release_announcement:
+  minor_version: "1.30"
 author: >
   [Kubernetes v1.30 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.30/release-team.md)
 ---

--- a/content/en/blog/_posts/2024/kubernetes-v1-31-release.md
+++ b/content/en/blog/_posts/2024/kubernetes-v1-31-release.md
@@ -3,6 +3,8 @@ layout: blog
 title: 'Kubernetes v1.31: Elli'
 date: 2024-08-13
 slug: kubernetes-v1-31-release
+release_announcement:
+  minor_version: "1.31"
 author: >
   [Kubernetes v1.31 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.31/release-team.md)
 ---

--- a/content/en/blog/_posts/2024/kubernetes-v1-32-release/index.md
+++ b/content/en/blog/_posts/2024/kubernetes-v1-32-release/index.md
@@ -3,6 +3,8 @@ layout: blog
 title: 'Kubernetes v1.32: Penelope'
 date: 2024-12-11
 slug: kubernetes-v1-32-release
+release_announcement:
+  minor_version: "1.32"
 author: >
   [Kubernetes v1.32 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.32/release-team.md)
 ---

--- a/content/en/blog/_posts/2025/kubernetes-v1-33-release/index.md
+++ b/content/en/blog/_posts/2025/kubernetes-v1-33-release/index.md
@@ -4,6 +4,8 @@ title: 'Kubernetes v1.33: Octarine'
 date: 2025-04-23T10:30:00-08:00
 slug: kubernetes-v1-33-release
 evergreen: true
+release_announcement:
+  minor_version: "1.33"
 author: >
   [Kubernetes v1.33 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.33/release-team.md)
 ---

--- a/content/en/blog/_posts/2025/kubernetes-v1-34-release/index.md
+++ b/content/en/blog/_posts/2025/kubernetes-v1-34-release/index.md
@@ -4,6 +4,8 @@ title: "Kubernetes v1.34: Of Wind & Will (O' WaW)"
 date: 2025-08-27T10:30:00-08:00
 evergreen: true
 slug: kubernetes-v1-34-release
+release_announcement:
+  minor_version: "1.34"
 author: >
   [Kubernetes v1.34 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.34/release-team.md)
 ---

--- a/content/en/blog/_posts/2025/kubernetes-v1-35-release/index.md
+++ b/content/en/blog/_posts/2025/kubernetes-v1-35-release/index.md
@@ -4,6 +4,8 @@ title: "Kubernetes v1.35: Timbernetes (The World Tree Release)"
 date: 2025-12-17T10:30:00-08:00
 evergreen: true
 slug: kubernetes-v1-35-release
+release_announcement:
+  minor_version: "1.35"
 author: >
   [Kubernetes v1.35 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.35/release-team.md)
 ---

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -483,6 +483,9 @@ other = "Patch Releases:"
 [release_actively_supported]
 other = "Actively Supported"
 
+[release_announcement_blog]
+other = "Release Announcement Blog"
+
 # The following text is displayed when JavaScript isn't available.
 [release_binary_alternate_links]
 other  = """You can find links to download Kubernetes components (and their checksums) in the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files.

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -110,6 +110,24 @@
         {{ T "release_github_tag" }} ({{ .Params.latestPatchVersion }})
       </a>
     </li>
+    {{/* Build release blog URL map by scanning all blog posts */}}
+    {{ $releaseBlogMap := dict }}
+    {{ range where site.Pages "Section" "blog" }}
+      {{ $releaseAnnouncement := .Params.release_announcement }}
+      {{ if $releaseAnnouncement }}
+        {{ $version := $releaseAnnouncement.minor_version }}
+        {{ if $version }}
+          {{ $releaseBlogMap = merge $releaseBlogMap (dict $version .RelPermalink) }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+    {{ with index $releaseBlogMap .Params.minorVersion }}
+      <li>
+        <a href="{{ . }}">
+          {{ T "release_announcement_blog" }}
+        </a>
+      </li>
+    {{ end }}
   </ul>
 </article>
 {{ end }}


### PR DESCRIPTION
### Description

Add release announcement blog post links to release series pages.

### Comment (or Discussion)

Added `release_announcement.minor_version` field to all release announcement blog posts (v1.2 - v1.35).

Example:

```yaml
release_announcement:
  minor_version: "1.35"
```

### Issue

Closes: #54876

### Preview
v1.35: https://deploy-preview-54885--kubernetes-io-main-staging.netlify.app/releases/1.35/
v1.31: https://deploy-preview-54885--kubernetes-io-main-staging.netlify.app/releases/1.31/
v1.2: https://deploy-preview-54885--kubernetes-io-main-staging.netlify.app/releases/1.2/