### PR TITLE
Add imagePullSecrets via ServiceAccount to credentials list

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -265,6 +265,10 @@ Credentials can be provided in several ways:
 
   Only Pods which provide their own keys can access the private registry.
 
+- [Add image pull secrets to a ServiceAccount](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
+
+  Add `imagePullSecrets` to the ServiceAccount (for example, the default service account) that will be used to deploy the Pod. In contrast to the per-Pod approach above, the pull secret only has to be stored once in the ServiceAccount configuration, so the Pod spec can remain independent of the cluster.
+
 - [Configuring Nodes to Authenticate to a Private Registry](#configuring-nodes-to-authenticate-to-a-private-registry)
   - All Pods can read any configured private registries.
   - Requires node configuration by cluster administrator.


### PR DESCRIPTION
## Summary
- Add the ServiceAccount `imagePullSecrets` option to the "Credentials can be provided in several ways" list on the Images concept page
- This method was already documented later in the page and in the ServiceAccount tasks guide, but was missing from the overview list

Continues the work from #51429.

## Test plan
- [ ] Verify the link `/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account` resolves correctly
- [ ] Confirm no Latin abbreviations per style guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)