### PR TITLE
Remove misleading SYS_PTRACE requirement from share-process-namespace

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -62,7 +62,7 @@ Process namespace sharing is enabled using the `shareProcessNamespace` field of
    ```
 
 You can signal processes in other containers. For example, send `SIGHUP` to
-`nginx` to restart the worker process. This requires the `SYS_PTRACE` capability.
+`nginx` to restart the worker process.
 
 ```shell
 # run this inside the "shell" container

--- a/content/en/examples/pods/share-process-namespace.yaml
+++ b/content/en/examples/pods/share-process-namespace.yaml
@@ -10,9 +10,5 @@ spec:
   - name: shell
     image: busybox:1.28
     command: ["sleep", "3600"]
-    securityContext:
-      capabilities:
-        add:
-        - SYS_PTRACE
     stdin: true
     tty: true


### PR DESCRIPTION
## Summary
- Remove the incorrect claim that `SYS_PTRACE` capability is required to signal processes in other containers sharing a process namespace
- Remove the unnecessary `securityContext` from the example YAML
- Sending signals via `kill()` only requires standard Unix permission checks (same UID or `CAP_KILL`), not ptrace access

This prevents users from unnecessarily weakening their pod security posture by adding `SYS_PTRACE` when it is not needed.

Continues the work from #50672.

## Test plan
- [ ] Verify that `kill -HUP` works without `SYS_PTRACE` in a shared process namespace pod
- [ ] Example YAML validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)