### PR TITLE
community: remove CSS that hides Docsy banner heading

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -400,11 +400,11 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
         color: $dark-text-color-1;
 
         .kubeweekly-inner form p {
-          color: $white; 
+          color: $white;
         }
 
         a.kubeweekly-signup, a.kubeweekly-signup:hover {
-          color: $white; 
+          color: $white;
         }
       }
 
@@ -527,11 +527,17 @@ header:has(#announcement) ~ .td-outer > main section.tutorial-signposting {
 
 /* COMMUNITY */
 
-body.cid-community {
-  main > * h1 {
-    visibility: hidden;
-  }
+body.cid-community .td-main>section.td-box {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
 
+  @media (min-width: 768px) {
+    padding-top: 5rem;
+    padding-bottom: 5rem;
+  }
+}
+
+body.cid-community {
   section.linkbox {
     max-width: calc(clamp(50%, calc(100em + 2vw), 100vw));
     margin-left: auto;


### PR DESCRIPTION
Remove the css rule that was hiding the upstream Docsy community page banner h1 text
("Join the Kubernetes community"), preventing Docsy's default styling from taking effect.

Removing the `community_links.html` partial override discused on the issue will affect other localization

This is a clean and safe fix

preview: https://deploy-preview-54891--kubernetes-io-main-staging.netlify.app/community/

<img width="3024" height="802" alt="image" src="https://github.com/user-attachments/assets/c8303d3e-6649-4369-83cd-9c712c3e9f3d" />



Fixes https://github.com/kubernetes/website/issues/54731
