### PR TITLE
[fr] : Add 4 glossary entries (PodDisruptionBudget, ResourceQuota, LimitRange, PriorityClass)

### DIFF
--- a/content/fr/docs/reference/glossary/limitrange.md
+++ b/content/fr/docs/reference/glossary/limitrange.md
@@ -1,0 +1,26 @@
+---
+title: LimitRange
+id: limitrange
+full_link: /docs/concepts/policy/limit-range/
+short_description: >
+  Fournit des contraintes pour limiter la consommation de ressources par conteneur ou par Pod dans un namespace.
+
+aka: 
+tags:
+- core-object
+- fundamental
+- architecture
+related:
+ - pod
+ - container
+---
+
+Limite la consommation de ressources par {{< glossary_tooltip text="conteneur" term_id="container" >}} ou {{< glossary_tooltip text="Pod" term_id="pod" >}},
+définie pour un {{< glossary_tooltip text="namespace" term_id="namespace" >}} donné.
+
+<!--more-->
+
+Un [LimitRange](/docs/concepts/policy/limit-range/) peut soit limiter la quantité de {{< glossary_tooltip text="ressources API" term_id="api-resource" >}}
+qui peuvent être créées (pour un type de ressource particulier),
+soit la quantité de {{< glossary_tooltip text="ressources d’infrastructure" term_id="infrastructure-resource" >}}
+qui peut être demandée ou consommée par des conteneurs ou des Pods individuels au sein d’un namespace.

--- a/content/fr/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/fr/docs/reference/glossary/pod-disruption-budget.md
@@ -1,0 +1,21 @@
+---
+id: pod-disruption-budget
+title: Pod Disruption Budget
+full-link: /docs/concepts/workloads/pods/disruptions/
+short_description: >
+  Un objet qui limite le nombre de Pods d'une application répliquée pouvant être indisponibles simultanément en raison de perturbations volontaires.
+
+aka:
+ - PDB
+related:
+ - pod
+ - container
+tags:
+ - operation
+---
+
+Un [Pod Disruption Budget](/docs/concepts/workloads/pods/disruptions/) permet au propriétaire d'une application de créer un objet pour une application répliquée, afin de garantir qu'un certain nombre ou pourcentage de {{< glossary_tooltip text="Pods" term_id="pod" >}} portant un label attribué ne sera pas évincé volontairement à un moment donné.
+
+<!--more-->
+
+Les perturbations involontaires ne peuvent pas être empêchées par les PDB ; cependant, elles sont comptabilisées dans le budget.

--- a/content/fr/docs/reference/glossary/priority-class.md
+++ b/content/fr/docs/reference/glossary/priority-class.md
@@ -1,0 +1,20 @@
+---
+title: PriorityClass
+id: priority-class
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+short_description: >
+  Une correspondance entre un nom de classe et la priorité d’ordonnancement qu’un Pod doit avoir.
+
+aka:
+tags:
+- core-object
+---
+
+Une PriorityClass est une classe nommée représentant la priorité d’ordonnancement qui doit être attribuée à un Pod appartenant à cette classe.
+
+<!--more-->
+
+Une [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption)
+est un objet non associé à un namespace qui associe un nom à une priorité entière, utilisée pour un Pod. Le nom est
+spécifié dans le champ `metadata.name`, et la valeur de priorité dans le champ `value`. Les priorités vont de
+-2147483648 à 1000000000 inclus. Des valeurs plus élevées indiquent une priorité plus élevée.

--- a/content/fr/docs/reference/glossary/resource-quota.md
+++ b/content/fr/docs/reference/glossary/resource-quota.md
@@ -1,0 +1,22 @@
+---
+title: ResourceQuota
+id: resource-quota
+full_link: /docs/concepts/policy/resource-quotas/
+short_description: >
+  Fournit des contraintes qui limitent la consommation agrégée de ressources par namespace.
+
+aka: 
+tags:
+- fundamental
+- operation
+- architecture
+---
+
+Objet qui contraint la consommation agrégée de ressources par {{< glossary_tooltip term_id="namespace" >}}.
+
+<!--more-->
+
+Un ResourceQuota peut soit limiter la quantité de {{< glossary_tooltip text="ressources API" term_id="api-resource" >}}
+qui peuvent être créées dans un namespace par type, soit définir une limite sur la quantité totale de
+{{< glossary_tooltip text="ressources d’infrastructure" term_id="infrastructure-resource" >}}
+pouvant être consommées au nom du namespace (et des objets qu’il contient).


### PR DESCRIPTION
### Description

Traduction de quatre entrées du glossaire liées à la haute disponibilité, à la gestion des ressources et à l’ordonnancement.

**Fichiers inclus :**

* `pod-disruption-budget.md` : gestion des perturbations volontaires affectant les Pods.
* `resource-quota.md` : limites agrégées de ressources par namespace.
* `limitrange.md` : limites de ressources par défaut pour les conteneurs ou Pods individuels.
* `priority-class.md` : priorité d’ordonnancement et mécanisme de préemption.

Cette contribution fait partie du plan de suivi #54874.
