### PR TITLE
Improve rendering of CJK paragraphs

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -54,6 +54,10 @@ enableGitInfo = true
      autoHeadingIDType = "blackfriday"
    [markup.goldmark.renderer]
      unsafe = true
+   [markup.goldmark.extensions.cjk]
+     eastAsianLineBreaks = true
+     eastAsianLineBreaksStyle = "css3draft"
+     enable = true
   [markup.highlight]
     codeFences = true
     guessSyntax = false


### PR DESCRIPTION
### Description

The goldmark markup extension has 'cjk' option that can help improve the rendering of soft breaks in markdown source. We should enable that for better outputs.

### Issue

N/A
