### PR TITLE
Update Storage Version Migration feature state to "enabled by default" in v1.35

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StorageVersionMigrator.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StorageVersionMigrator.md
@@ -11,7 +11,7 @@ stages:
     fromVersion: "1.30"
     toVersion: "1.34"
   - stage: beta 
-    defaultValue: false
+    defaultValue: true
     fromVersion: "1.35"
 ---
 Enables the migration of the [storage


### PR DESCRIPTION
The Kubernetes v1.35 release blog states that Storage Version Migration graduated to beta and is enabled by default. However, the task documentation page currently lists the feature as beta and disabled by default.

This PR updates the feature state in the documentation to reflect that the feature is enabled by default in v1.35.

Issue: #54883