### PR TITLE
fix: replace deprecated argument `--cpu-percent` with `--cpu`

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale.md
@@ -607,7 +607,7 @@ You can list autoscalers by `kubectl get hpa` or get detailed description by `ku
 Finally, you can delete an autoscaler using `kubectl delete hpa`.
 
 In addition, there is a special `kubectl autoscale` command for creating a HorizontalPodAutoscaler object.
-For instance, executing `kubectl autoscale rs foo --min=2 --max=5 --cpu-percent=80`
+For instance, executing `kubectl autoscale rs foo --min=2 --max=5 --cpu=80%`
 will create an autoscaler for ReplicaSet _foo_, with target CPU utilization set to `80%`
 and the number of replicas between 2 and 5.
 

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -642,7 +642,7 @@ in your cluster, you can set up an autoscaler for your Deployment and choose the
 Pods you want to run based on the CPU utilization of your existing Pods.
 
 ```shell
-kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80
+kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80%
 ```
 The output is similar to this:
 ```

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -139,7 +139,7 @@ Operation       | Syntax    |       Description
 `apply`            | `kubectl apply -f FILENAME [flags]`| Apply a configuration change to a resource from a file or stdin.
 `attach`        | `kubectl attach POD -c CONTAINER [-i] [-t] [flags]` | Attach to a running container either to view the output stream or interact with the container (stdin).
 `auth`    | `kubectl auth [flags] [options]` | Inspect authorization.
-`autoscale`    | <code>kubectl autoscale (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu-percent=CPU] [flags]</code> | Automatically scale the set of pods that are managed by a replication controller.
+`autoscale`    | <code>kubectl autoscale (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu=CPU] [flags]</code> | Automatically scale the set of pods that are managed by a replication controller.
 `certificate`    | `kubectl certificate SUBCOMMAND [options]` | Modify certificate resources.
 `cluster-info`    | `kubectl cluster-info [flags]` | Display endpoint information about the master and services in the cluster.
 `completion`    | `kubectl completion SHELL [options]` | Output shell completion code for the specified shell (bash or zsh).

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -414,7 +414,7 @@ kubectl apply -f https://k8s.io/examples/application/ssa/nginx-deployment.yaml -
 Then later, automatic scaling is enabled for the Deployment; for example:
 
 ```shell
-kubectl autoscale deployment nginx-deployment --cpu-percent=50 --min=1 --max=10
+kubectl autoscale deployment nginx-deployment --cpu=50% --min=1 --max=10
 ```
 
 Now, the user would like to remove `replicas` from their configuration, so they

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -100,7 +100,7 @@ on the algorithm.
 Create the HorizontalPodAutoscaler:
 
 ```shell
-kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
+kubectl autoscale deployment php-apache --cpu=50% --min=1 --max=10
 ```
 
 ```


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Replace deprecated flag `--cpu-percent` by using `--cpu` with percentage format.

```
kubectl autoscale deployment php-apache --cpu-percent=50% --min=1 --max=10
Flag --cpu-percent has been deprecated, Use --cpu with percentage or resource quantity format (e.g., '70%' for utilization or '500m' for milliCPU).
```

```
kubectl version
Client Version: v1.35.0
```

```
    --cpu='':
        Target CPU utilization over all the pods. When specified as a percentage (e.g."70%" for
        70% of requested CPU) it will target average utilization. When specified as quantity
        (e.g."500m" for 500 milliCPU) it will target average value. Value without units is treated
        as a quantity with miliCPU being the unit (e.g."500" is "500m").
```

Quick check for deprecated flag: https://github.com/search?q=repo%3Akubernetes%2Fwebsite++--cpu-percent+path%3A%2Fen%2Fdocs%2F&type=code

<img width="1011" height="932" alt="image" src="https://github.com/user-attachments/assets/ef04deac-bc2a-4486-b759-59001a05903e" />


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: https://github.com/kubernetes/website/issues/54830 [updated]

/label tide/merge-method-squash