### PR TITLE
Fix formatting in operator.md

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -6,7 +6,7 @@ weight: 30
 
 <!-- overview -->
 
-Operators are software extensions to Kubernetes that make use of
+Operators are software extensions to Kubernetes that make use of 
 [custom resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to manage applications and their components. Operators follow
 Kubernetes principles, notably the [control loop](/docs/concepts/architecture/controller).


### PR DESCRIPTION
### Description

Add space between **"make use of"** and **["custom resources"](url)** - fixed formatting in the online documentation.