### PR TITLE
[hi] Localize tasks/configure-pod-container page into Hindi

### DIFF
--- a/content/hi/docs/tasks/configure-liveness-readiness-startup-probes.md
+++ b/content/hi/docs/tasks/configure-liveness-readiness-startup-probes.md
@@ -1,0 +1,578 @@
+---
+title: Liveness, Readiness और Startup Probes कॉन्फ़िगर करें
+content_type: task
+weight: 140
+---
+
+<!-- overview -->
+
+यह पेज दिखाता है कि containers के लिए liveness, readiness और startup probes कैसे कॉन्फ़िगर करें।
+
+probes के बारे में अधिक जानकारी के लिए देखें:
+[Liveness, Readiness और Startup Probes](/docs/concepts/configuration/liveness-readiness-startup-probes)
+
+[kubelet](/docs/reference/command-line-tools-reference/kubelet/) यह जानने के लिए
+liveness probes का उपयोग करता है कि container को कब restart करना है।
+उदाहरण के लिए, liveness probes deadlock पकड़ सकते हैं, जहाँ application चल तो रही होती है
+लेकिन आगे प्रगति नहीं कर पा रही होती। ऐसे state में container restart करना,
+bugs होने के बावजूद application की availability बेहतर कर सकता है।
+
+liveness probes का एक सामान्य pattern यह है कि readiness probes वाली
+same low-cost HTTP endpoint का उपयोग किया जाए, लेकिन higher failureThreshold के साथ।
+इससे Pod को hard kill करने से पहले कुछ समय तक not-ready के रूप में observe किया जाता है।
+
+kubelet readiness probes का उपयोग यह जानने के लिए करता है कि container traffic
+स्वीकार करने के लिए कब तैयार है। इस signal का एक उपयोग यह नियंत्रित करना है कि
+किन Pods को Services के backends के रूप में उपयोग किया जाए।
+Pod तब ready माना जाता है जब उसका `Ready`
+[condition](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions) true हो।
+जब Pod ready नहीं होता, तो उसे Service load balancers से हटा दिया जाता है।
+Pod की `Ready` condition false होती है जब उसके Node की `Ready` condition true न हो,
+या Pod के किसी `readinessGates` की condition false हो, या उसके containers में से कम से कम एक ready न हो।
+
+kubelet startup probes का उपयोग यह जानने के लिए करता है कि container application शुरू हुई या नहीं।
+यदि ऐसा probe कॉन्फ़िगर है, तो liveness और readiness probes तब तक शुरू नहीं होतीं
+जब तक startup probe सफल न हो जाए। इससे यह सुनिश्चित होता है कि वे probes application startup में हस्तक्षेप न करें।
+इससे धीमे शुरू होने वाले containers पर liveness checks अपनाई जा सकती हैं और container को
+पूरी तरह शुरू होने से पहले kubelet द्वारा kill होने से बचाया जा सकता है।
+
+{{< caution >}}
+Liveness probes application failures से recovery का शक्तिशाली तरीका हो सकती हैं, लेकिन
+इन्हें सावधानी से उपयोग करना चाहिए। Liveness probes को बहुत ध्यान से कॉन्फ़िगर करना चाहिए
+ताकि वे वास्तव में unrecoverable application failure (जैसे deadlock) को ही दर्शाएँ।
+{{< /caution >}}
+
+{{< note >}}
+Liveness probes का गलत implementation cascading failures का कारण बन सकता है। इसका परिणाम
+high load में containers के बार-बार restart होने, application की scalability घटने से client requests fail होने,
+और कुछ pods fail होने के कारण बाकी pods पर workload बढ़ने के रूप में हो सकता है।
+अपने app के लिए readiness और liveness probes का अंतर और उनके सही उपयोग को समझें।
+{{< /note >}}
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+## liveness command परिभाषित करें
+
+लंबे समय तक चलने वाले कई applications अंततः broken states में पहुँच जाते हैं
+और restart किए बिना recover नहीं कर पाते।
+Kubernetes ऐसी स्थितियों का पता लगाने और सुधारने के लिए liveness probes देता है।
+
+इस अभ्यास में आप ऐसा Pod बनाते हैं जो `registry.k8s.io/busybox:1.27.2` image पर आधारित container चलाता है।
+यह Pod की configuration file है:
+
+{{% code_sample file="pods/probe/exec-liveness.yaml" %}}
+
+configuration file में आप देख सकते हैं कि Pod में एक ही `Container` है।
+`periodSeconds` field बताती है कि kubelet हर 5 seconds में liveness probe चलाए।
+`initialDelaySeconds` field बताती है कि पहली probe चलाने से पहले kubelet 5 seconds प्रतीक्षा करे।
+probe चलाने के लिए kubelet target container में `cat /tmp/healthy` command execute करता है।
+अगर command सफल होती है, तो 0 return होता है और kubelet container को जीवित और healthy मानता है।
+अगर command non-zero return करती है, तो kubelet container को kill करके restart कर देता है।
+
+जब container शुरू होता है, तो वह यह command चलाता है:
+
+```shell
+/bin/sh -c "touch /tmp/healthy; sleep 30; rm -f /tmp/healthy; sleep 600"
+```
+
+container के जीवन के पहले 30 seconds तक `/tmp/healthy` फ़ाइल मौजूद रहती है।
+इसलिए पहले 30 seconds के दौरान `cat /tmp/healthy` success code लौटाता है।
+30 seconds के बाद `cat /tmp/healthy` failure code लौटाता है।
+
+Pod बनाएं:
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/probe/exec-liveness.yaml
+```
+
+30 seconds के भीतर Pod events देखें:
+
+```shell
+kubectl describe pod liveness-exec
+```
+
+आउटपुट दर्शाता है कि अभी तक कोई liveness probe fail नहीं हुई:
+
+```none
+Type    Reason     Age   From               Message
+----    ------     ----  ----               -------
+Normal  Scheduled  11s   default-scheduler  Successfully assigned default/liveness-exec to node01
+Normal  Pulling    9s    kubelet, node01    Pulling image "registry.k8s.io/busybox:1.27.2"
+Normal  Pulled     7s    kubelet, node01    Successfully pulled image "registry.k8s.io/busybox:1.27.2"
+Normal  Created    7s    kubelet, node01    Created container liveness
+Normal  Started    7s    kubelet, node01    Started container liveness
+```
+
+35 seconds के बाद Pod events फिर देखें:
+
+```shell
+kubectl describe pod liveness-exec
+```
+
+आउटपुट के नीचे ऐसे messages होंगे जो दिखाते हैं कि liveness probes fail हुईं
+और failed containers को kill करके दोबारा बनाया गया।
+
+```none
+Type     Reason     Age                From               Message
+----     ------     ----               ----               -------
+Normal   Scheduled  57s                default-scheduler  Successfully assigned default/liveness-exec to node01
+Normal   Pulling    55s                kubelet, node01    Pulling image "registry.k8s.io/busybox:1.27.2"
+Normal   Pulled     53s                kubelet, node01    Successfully pulled image "registry.k8s.io/busybox:1.27.2"
+Normal   Created    53s                kubelet, node01    Created container liveness
+Normal   Started    53s                kubelet, node01    Started container liveness
+Warning  Unhealthy  10s (x3 over 20s)  kubelet, node01    Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory
+Normal   Killing    10s                kubelet, node01    Container liveness failed liveness probe, will be restarted
+```
+
+और 30 seconds प्रतीक्षा करें, फिर सत्यापित करें कि container restart हुआ है:
+
+```shell
+kubectl get pod liveness-exec
+```
+
+आउटपुट दिखाता है कि `RESTARTS` बढ़ गया है। ध्यान दें कि `RESTARTS` counter
+जैसे ही failed container फिर running state में आता है, बढ़ जाता है:
+
+```none
+NAME            READY     STATUS    RESTARTS   AGE
+liveness-exec   1/1       Running   1          1m
+```
+
+## liveness HTTP request परिभाषित करें
+
+liveness probe का दूसरा प्रकार HTTP GET request का उपयोग करता है।
+यहाँ उस Pod की configuration file है जो `registry.k8s.io/e2e-test-images/agnhost` image पर आधारित container चलाता है।
+
+{{% code_sample file="pods/probe/http-liveness.yaml" %}}
+
+configuration file में आप देख सकते हैं कि Pod में एक ही container है।
+`periodSeconds` field बताती है कि kubelet हर 3 seconds में liveness probe चलाए।
+`initialDelaySeconds` field बताती है कि पहली probe से पहले kubelet 3 seconds प्रतीक्षा करे।
+probe चलाने के लिए kubelet container में चल रहे server को HTTP GET request भेजता है,
+जो port 8080 पर listen कर रहा है। अगर server के `/healthz` path का handler success code लौटाता है,
+तो kubelet container को alive और healthy मानता है। अगर handler failure code लौटाए,
+तो kubelet container को kill करके restart कर देता है।
+
+200 या उससे बड़ा और 400 से छोटा कोई भी code success दर्शाता है।
+अन्य कोई भी code failure दर्शाता है।
+
+आप server का source code यहाँ देख सकते हैं:
+[server.go](https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/liveness/server.go)।
+
+container के जीवित रहने के पहले 10 seconds तक `/healthz` handler
+status 200 लौटाता है। उसके बाद handler status 500 लौटाता है।
+
+```go
+http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+    duration := time.Now().Sub(started)
+    if duration.Seconds() > 10 {
+        w.WriteHeader(500)
+        w.Write([]byte(fmt.Sprintf("error: %v", duration.Seconds())))
+    } else {
+        w.WriteHeader(200)
+        w.Write([]byte("ok"))
+    }
+})
+```
+
+container start होने के 3 seconds बाद kubelet health checks शुरू करता है।
+इसलिए शुरुआती कुछ checks सफल होंगी। लेकिन 10 seconds के बाद checks fail होंगी
+और kubelet container को kill करके restart कर देगा।
+
+HTTP liveness check आज़माने के लिए Pod बनाएं:
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/probe/http-liveness.yaml
+```
+
+10 seconds बाद Pod events देखें और सत्यापित करें कि liveness probes fail हुईं
+और container restart हुआ:
+
+```shell
+kubectl describe pod liveness-http
+```
+
+v1.13 के बाद के releases में local HTTP proxy environment variable settings
+HTTP liveness probe को प्रभावित नहीं करतीं।
+
+## TCP liveness probe परिभाषित करें
+
+liveness probe का तीसरा प्रकार TCP socket का उपयोग करता है।
+इस configuration के साथ kubelet निर्दिष्ट port पर आपके container से socket connection खोलने की कोशिश करेगा।
+यदि connection बन जाता है तो container healthy माना जाता है, अन्यथा इसे failure माना जाता है।
+
+{{% code_sample file="pods/probe/tcp-liveness-readiness.yaml" %}}
+
+जैसा आप देख सकते हैं, TCP check की configuration HTTP check जैसी ही है।
+यह उदाहरण readiness और liveness दोनों probes का उपयोग करता है।
+kubelet container शुरू होने के 15 seconds बाद पहली liveness probe चलाएगा।
+यह port 8080 पर `goproxy` container से connect करने की कोशिश करेगा।
+अगर liveness probe fail होती है, तो container restart होगा।
+kubelet हर 10 seconds में यह check चलाता रहेगा।
+
+liveness probe के अलावा इस configuration में readiness probe भी शामिल है।
+kubelet container शुरू होने के 15 seconds बाद पहली readiness probe चलाएगा।
+liveness probe की तरह यह भी port 8080 पर `goproxy` container से connect करने की कोशिश करेगा।
+यदि probe सफल होती है, तो Pod ready mark होगा और services से traffic प्राप्त करेगा।
+यदि readiness probe fail होती है, तो Pod unready mark होगा और किसी भी service से traffic नहीं पाएगा।
+
+TCP liveness check आज़माने के लिए Pod बनाएं:
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/probe/tcp-liveness-readiness.yaml
+```
+
+15 seconds बाद Pod events देखें और liveness probes की स्थिति सत्यापित करें:
+
+```shell
+kubectl describe pod goproxy
+```
+
+## gRPC liveness probe परिभाषित करें
+
+{{< feature-state for_k8s_version="v1.27" state="stable" >}}
+
+यदि आपकी application
+[gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md)
+implement करती है, तो यह उदाहरण दिखाता है कि application liveness checks के लिए
+Kubernetes को इसका उपयोग करने हेतु कैसे कॉन्फ़िगर करें।
+इसी तरह आप readiness और startup probes भी कॉन्फ़िगर कर सकते हैं।
+
+यहाँ एक example manifest है:
+
+{{% code_sample file="pods/probe/grpc-liveness.yaml" %}}
+
+gRPC probe उपयोग करने के लिए `port` कॉन्फ़िगर होना आवश्यक है।
+अगर आप अलग प्रकार की probes और अलग features की probes में भेद करना चाहते हैं,
+तो `service` field उपयोग कर सकते हैं।
+आप `service` को `liveness` सेट कर सकते हैं और gRPC Health Checking endpoint को
+यह request मिलने पर `service` को `readiness` सेट करने से अलग response देने के लिए कॉन्फ़िगर कर सकते हैं।
+इससे आप दो अलग ports पर listen करने के बजाय एक ही endpoint का उपयोग
+विभिन्न प्रकार के container health checks के लिए कर सकते हैं।
+यदि आप अपना custom service name भी देना चाहते हैं और probe type भी बताना चाहते हैं,
+तो Kubernetes project सुझाव देता है कि आप दोनों को जोड़कर नाम रखें।
+उदाहरण: `myservice-liveness` (`-` separator के रूप में)।
+
+{{< note >}}
+HTTP या TCP probes के विपरीत, आप health check port को नाम से specify नहीं कर सकते,
+और custom hostname भी कॉन्फ़िगर नहीं कर सकते।
+{{< /note >}}
+
+configuration problems (उदाहरण: गलत port/service, health checking protocol implement न होना)
+को probe failure माना जाता है, ठीक HTTP और TCP probes की तरह।
+
+gRPC liveness check आज़माने के लिए नीचे दी गई command से Pod बनाएं।
+नीचे के उदाहरण में etcd pod को gRPC liveness probe उपयोग करने के लिए कॉन्फ़िगर किया गया है।
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/probe/grpc-liveness.yaml
+```
+
+15 seconds बाद Pod events देखें और सत्यापित करें कि liveness check fail नहीं हुई:
+
+```shell
+kubectl describe pod etcd-with-grpc
+```
+
+gRPC probe का उपयोग करते समय कुछ तकनीकी बातें ध्यान रखने योग्य हैं:
+
+- probes pod IP address या उसके hostname पर चलती हैं।
+  सुनिश्चित करें कि आपका gRPC endpoint Pod के IP address पर listen करे।
+- probes किसी authentication parameter (जैसे `-tls`) को support नहीं करतीं।
+- built-in probes के लिए error codes नहीं होते। सभी errors को probe failure माना जाता है।
+- यदि `ExecProbeTimeout` feature gate `false` पर सेट है, तो grpc-health-probe
+  `timeoutSeconds` setting (जिसका default 1s है) का पालन **नहीं** करता, जबकि built-in probe timeout पर fail हो जाती है।
+
+## named port का उपयोग करें
+
+आप HTTP और TCP probes के लिए named [`port`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#ports)
+उपयोग कर सकते हैं। gRPC probes named ports को support नहीं करतीं।
+
+उदाहरण:
+
+```yaml
+ports:
+- name: liveness-port
+  containerPort: 8080
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: liveness-port
+```
+
+## startup probes से धीमे शुरू होने वाले containers को सुरक्षित रखें {#define-startup-probes}
+
+कभी-कभी आपको ऐसी applications से निपटना पड़ता है जिन्हें पहली initialization पर
+अतिरिक्त startup time चाहिए। ऐसे मामलों में liveness probe parameters सेट करना मुश्किल हो सकता है,
+क्योंकि deadlock पर तेज प्रतिक्रिया भी चाहिए और startup समय पर probe से समस्या भी नहीं होनी चाहिए।
+इसका समाधान है startup probe सेट करना जिसमें वही command, HTTP या TCP check हो, और
+`failureThreshold * periodSeconds` इतना लंबा हो कि worst-case startup time कवर हो जाए।
+
+तो पिछला उदाहरण इस प्रकार बन जाएगा:
+
+```yaml
+ports:
+- name: liveness-port
+  containerPort: 8080
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: liveness-port
+  failureThreshold: 1
+  periodSeconds: 10
+
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: liveness-port
+  failureThreshold: 30
+  periodSeconds: 10
+```
+
+startup probe की वजह से application को startup पूरा करने के लिए अधिकतम 5 minutes
+(30 * 10 = 300s) मिलेंगे।
+startup probe एक बार सफल होते ही liveness probe takeover करती है
+ताकि container deadlocks पर तेज प्रतिक्रिया मिल सके।
+अगर startup probe कभी सफल नहीं होती, तो container 300s के बाद kill हो जाएगा
+और Pod की `restartPolicy` लागू होगी।
+
+## readiness probes परिभाषित करें
+
+कभी-कभी applications अस्थायी रूप से traffic serve नहीं कर पातीं।
+उदाहरण के लिए startup के दौरान application को बड़े data या configuration files load करने पड़ सकते हैं,
+या startup के बाद external services पर निर्भर होना पड़ सकता है।
+ऐसी स्थितियों में आप application को kill नहीं करना चाहते,
+लेकिन उसे requests भी नहीं भेजना चाहते। Kubernetes इसके लिए readiness probes प्रदान करता है।
+जिस pod में containers report करते हैं कि वे ready नहीं हैं, उसे Kubernetes Services के जरिए traffic नहीं मिलता।
+
+{{< note >}}
+Readiness probes container के पूरे lifecycle में चलती हैं।
+{{< /note >}}
+
+{{< caution >}}
+readiness और liveness probes एक-दूसरे पर निर्भर नहीं होतीं।
+अगर आप readiness probe चलाने से पहले प्रतीक्षा करना चाहते हैं, तो
+`initialDelaySeconds` या `startupProbe` का उपयोग करें।
+{{< /caution >}}
+
+Readiness probes, liveness probes की तरह ही कॉन्फ़िगर होती हैं।
+केवल अंतर यह है कि `livenessProbe` के बजाय `readinessProbe` field उपयोग होती है।
+
+```yaml
+readinessProbe:
+  exec:
+    command:
+    - cat
+    - /tmp/healthy
+  initialDelaySeconds: 5
+  periodSeconds: 5
+```
+
+HTTP और TCP readiness probes की configuration भी liveness probes जैसी ही रहती है।
+
+Readiness और liveness probes एक ही container के लिए parallel में उपयोग की जा सकती हैं।
+दोनों का उपयोग यह सुनिश्चित कर सकता है कि traffic ऐसे container तक न पहुँचे जो उसके लिए ready नहीं है,
+और failure होने पर containers restart हों।
+
+## Probes कॉन्फ़िगर करें
+
+<!--Eventually, some of this section could be moved to a concept topic.-->
+
+[प्रोब्स (Probes)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#probe-v1-core)
+में कई fields होती हैं जिनसे आप startup, liveness और readiness checks के behavior को अधिक सटीक रूप से नियंत्रित कर सकते हैं:
+
+* `initialDelaySeconds`: container start होने के बाद startup, liveness या readiness probes शुरू करने से पहले कितने seconds प्रतीक्षा करनी है।
+  यदि startup probe परिभाषित है, तो liveness और readiness की delays तब तक शुरू नहीं होतीं जब तक startup probe सफल न हो जाए।
+  Kubernetes के कुछ पुराने versions में, यदि periodSeconds को initialDelaySeconds से बड़ा सेट किया गया हो,
+  तो initialDelaySeconds को नज़रअंदाज़ किया जा सकता था। लेकिन वर्तमान versions में initialDelaySeconds हमेशा मान्य होती है
+  और probe इस शुरुआती delay के बाद ही शुरू होती है। Default 0 seconds, minimum 0।
+* `periodSeconds`: probe कितनी बार (seconds में) चलानी है। Default 10 seconds।
+  Minimum value 1 है।
+  जब container Ready नहीं होता, तो `ReadinessProbe` कभी-कभी configured `periodSeconds` interval से अलग समय पर भी चल सकती है,
+  ताकि Pod जल्दी ready हो सके।
+* `timeoutSeconds`: probe timeout होने से पहले कितने seconds प्रतीक्षा करनी है।
+  Default 1 second, minimum 1।
+* `successThreshold`: fail होने के बाद probe को successful मानने के लिए लगातार सफल probes की न्यूनतम संख्या।
+  Default 1। liveness और startup Probes के लिए यह 1 ही होना चाहिए।
+  Minimum value 1।
+* `failureThreshold`: probe लगातार `failureThreshold` बार fail हो जाए तो Kubernetes
+  overall check को failed मानता है: container _ready/healthy/live_ नहीं है।
+  Default 3। Minimum value 1।
+  startup या liveness probe के मामले में, यदि कम से कम `failureThreshold` probes fail हों,
+  तो Kubernetes container को unhealthy मानता है और उसी specific container का restart trigger करता है।
+  kubelet उस container के `terminationGracePeriodSeconds` setting का सम्मान करता है।
+  readiness probe fail होने पर kubelet failed container को चलाता रहता है और probes भी जारी रखता है;
+  check fail होने के कारण kubelet Pod की `Ready`
+  [condition](/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions) को `false` सेट कर देता है।
+* `terminationGracePeriodSeconds`: failed container को shutdown trigger करने और फिर container runtime को उसे force stop करने के बीच
+  kubelet कितना grace period दे, यह कॉन्फ़िगर करता है।
+  Default रूप से यह Pod-level `terminationGracePeriodSeconds` को inherit करता है
+  (यदि न दिया हो तो 30 seconds), और minimum value 1 है।
+  अधिक जानकारी के लिए [probe-level `terminationGracePeriodSeconds`](#probe-level-terminationgraceperiodseconds) देखें।
+
+{{< caution >}}
+readiness probes का गलत implementation container में processes की संख्या को लगातार बढ़ा सकता है,
+और अगर इसे नियंत्रित न किया जाए तो resource starvation हो सकती है।
+{{< /caution >}}
+
+### HTTP प्रोब्स
+
+[HTTP प्रोब्स](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#httpgetaction-v1-core)
+में `httpGet` पर कुछ अतिरिक्त fields सेट की जा सकती हैं:
+
+* `host`: connect करने के लिए host name; default pod IP होता है।
+  आमतौर पर इसके बजाय `httpHeaders` में "Host" सेट करना बेहतर है।
+* `scheme`: host से connect करने के लिए scheme (HTTP या HTTPS)। Default "HTTP" है।
+* `path`: HTTP server पर access करने का path। Default "/" है।
+* `httpHeaders`: request में सेट करने के लिए custom headers। HTTP repeated headers को अनुमति देता है।
+* `port`: container पर access करने वाले port का नाम या संख्या। संख्या 1 से 65535 के बीच होनी चाहिए।
+
+HTTP probe के लिए kubelet निर्दिष्ट port और path पर HTTP request भेजकर check करता है।
+kubelet probe को Pod के IP address पर भेजता है, जब तक `httpGet` में optional `host` field से address override न हो।
+अगर `scheme` field `HTTPS` हो, तो kubelet certificate verification skip करते हुए HTTPS request भेजता है।
+अधिकांश स्थितियों में आप `host` field सेट नहीं करना चाहेंगे।
+एक स्थिति जहाँ आप इसे सेट करेंगे: मान लें container 127.0.0.1 पर listen करता है
+और Pod की `hostNetwork` field true है। तब `httpGet` के अंतर्गत `host` को 127.0.0.1 सेट करना चाहिए।
+अगर आपका pod virtual hosts पर निर्भर है (जो अधिक सामान्य मामला है),
+तो `host` का उपयोग न करें; बल्कि `httpHeaders` में `Host` header सेट करें।
+
+HTTP probe के लिए kubelet अनिवार्य `Host` header के अलावा दो request headers भेजता है:
+- `User-Agent`: default value `kube-probe/{{< skew currentVersion >}}` है,
+  जहाँ `{{< skew currentVersion >}}` kubelet का version है।
+- `Accept`: default value `*/*` है।
+
+आप probe के लिए `httpHeaders` define करके default headers override कर सकते हैं।
+उदाहरण:
+
+```yaml
+livenessProbe:
+  httpGet:
+    httpHeaders:
+      - name: Accept
+        value: application/json
+
+startupProbe:
+  httpGet:
+    httpHeaders:
+      - name: User-Agent
+        value: MyUserAgent
+```
+
+इन दोनों headers को empty value देकर आप इन्हें हटा भी सकते हैं।
+
+```yaml
+livenessProbe:
+  httpGet:
+    httpHeaders:
+      - name: Accept
+        value: ""
+
+startupProbe:
+  httpGet:
+    httpHeaders:
+      - name: User-Agent
+        value: ""
+```
+
+{{< note >}}
+जब kubelet HTTP का उपयोग करके Pod probe करता है, तो वह redirects केवल तब follow करता है जब redirect उसी host पर हो।
+अगर probing के दौरान kubelet को 11 या उससे अधिक redirects मिलते हैं, तो probe को successful माना जाता है
+और संबंधित Event बनाया जाता है:
+
+```none
+Events:
+  Type     Reason        Age                     From               Message
+  ----     ------        ----                    ----               -------
+  Normal   Scheduled     29m                     default-scheduler  Successfully assigned default/httpbin-7b8bc9cb85-bjzwn to daocloud
+  Normal   Pulling       29m                     kubelet            Pulling image "docker.io/kennethreitz/httpbin"
+  Normal   Pulled        24m                     kubelet            Successfully pulled image "docker.io/kennethreitz/httpbin" in 5m12.402735213s
+  Normal   Created       24m                     kubelet            Created container httpbin
+  Normal   Started       24m                     kubelet            Started container httpbin
+ Warning  ProbeWarning  4m11s (x1197 over 24m)  kubelet            Readiness probe warning: Probe terminated redirects
+```
+
+यदि kubelet को ऐसा redirect मिलता है जिसमें hostname request से अलग है, तो probe outcome को successful माना जाता है
+और kubelet redirect failure रिपोर्ट करने के लिए event बनाता है।
+{{< /note >}}
+
+{{< caution >}}
+**httpGet** probe process करते समय kubelet response body का केवल पहले 10KiB तक पढ़ता है।
+probe की success केवल response status code से तय होती है, जो response headers में मिलता है।
+
+यदि आप ऐसे endpoint को probe करते हैं जो **10KiB** से बड़ा response body लौटाता है,
+तो kubelet status code के आधार पर probe को successful mark कर सकता है,
+लेकिन 10KiB limit पर पहुंचने के बाद connection बंद कर देगा।
+इस अचानक closure से application logs में **connection reset by peer** या **broken pipe errors** दिख सकती हैं,
+जिन्हें वास्तविक network issues से अलग पहचानना कठिन हो सकता है।
+
+विश्वसनीय `httpGet` probes के लिए strongly recommended है कि dedicated health check endpoints उपयोग करें
+जो minimal response body लौटाएँ। यदि बड़े payload वाले existing endpoint का उपयोग करना ही पड़े,
+तो उसके बजाय HEAD request करने के लिए `exec` probe उपयोग करने पर विचार करें।
+{{< /caution >}}
+
+### TCP प्रोब्स
+
+TCP probe के लिए kubelet probe connection node से बनाता है, Pod के अंदर से नहीं।
+इसका मतलब है कि `host` parameter में service name का उपयोग नहीं किया जा सकता,
+क्योंकि kubelet उसे resolve नहीं कर पाता।
+
+### प्रोब-स्तरीय `terminationGracePeriodSeconds`
+
+{{< feature-state for_k8s_version="v1.28" state="stable" >}}
+
+1.25 और उसके बाद, users probe specification के हिस्से के रूप में
+probe-level `terminationGracePeriodSeconds` सेट कर सकते हैं।
+जब pod-level और probe-level दोनों `terminationGracePeriodSeconds` सेट हों,
+तो kubelet probe-level value का उपयोग करेगा।
+
+`terminationGracePeriodSeconds` सेट करते समय निम्न बातों का ध्यान रखें:
+
+* kubelet हमेशा probe-level `terminationGracePeriodSeconds` field का सम्मान करता है
+  यदि वह Pod पर मौजूद है।
+
+* यदि आपके पास existing Pods हैं जिनमें `terminationGracePeriodSeconds` field सेट है और
+  आप per-probe termination grace periods का उपयोग नहीं करना चाहते,
+  तो आपको वे existing Pods delete करने होंगे।
+
+उदाहरण:
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 3600  # pod-level
+  containers:
+  - name: test
+    image: ...
+
+    ports:
+    - name: liveness-port
+      containerPort: 8080
+
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: liveness-port
+      failureThreshold: 1
+      periodSeconds: 60
+      # Override pod-level terminationGracePeriodSeconds #
+      terminationGracePeriodSeconds: 60
+```
+
+readiness probes के लिए probe-level `terminationGracePeriodSeconds` सेट नहीं किया जा सकता।
+API server इसे reject कर देगा।
+
+## {{% heading "whatsnext" %}}
+
+* इसके बारे में और जानें:
+  [Container Probes](/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)।
+
+आप API references भी पढ़ सकते हैं:
+
+* [Pod](/docs/reference/kubernetes-api/workload-resources/pod-v1/), और विशेष रूप से:
+  * [container(s)](/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
+  * [probe(s)](/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe)

--- a/content/hi/docs/tasks/configure-pod-configmap.md
+++ b/content/hi/docs/tasks/configure-pod-configmap.md
@@ -1,0 +1,928 @@
+---
+title: ConfigMap का उपयोग करने के लिए Pod कॉन्फ़िगर करें
+content_type: task
+weight: 190
+card:
+  name: tasks
+  weight: 50
+---
+
+<!-- overview -->
+कई एप्लिकेशन कॉन्फ़िगरेशन पर निर्भर करते हैं, जिसका उपयोग एप्लिकेशन के initialization के दौरान या runtime में किया जाता है।
+ज़्यादातर बार, कॉन्फ़िगरेशन पैरामीटर को दिए गए मानों को समायोजित करने की आवश्यकता होती है।
+ConfigMap, Kubernetes का एक मैकेनिज़्म है जो आपको कॉन्फ़िगरेशन डेटा को एप्लिकेशन
+{{< glossary_tooltip text="pods" term_id="pod" >}} में inject करने देता है।
+
+ConfigMap का कॉन्सेप्ट आपको कॉन्फ़िगरेशन artifacts को image content से अलग (decouple) करने देता है,
+ताकि containerized applications पोर्टेबल बनी रहें। उदाहरण के लिए, आप एक ही
+{{< glossary_tooltip text="container image" term_id="image" >}} को डाउनलोड और रन करके
+local development, system test, या live end-user workload चलाने के लिए कंटेनर शुरू कर सकते हैं।
+
+यह पेज उपयोग के कई उदाहरण देता है, जिनसे यह दिखाया गया है कि ConfigMap कैसे बनाएँ और
+ConfigMap में स्टोर किए गए डेटा का उपयोग करके Pods को कैसे कॉन्फ़िगर करें।
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+आपके सिस्टम में `wget` टूल इंस्टॉल होना चाहिए। अगर आपके पास कोई दूसरा टूल
+जैसे `curl` है और `wget` नहीं है, तो आपको example data डाउनलोड करने वाला
+step उसी के अनुसार बदलना होगा।
+
+<!-- steps -->
+
+## ConfigMap बनाएं
+
+ConfigMap बनाने के लिए आप या तो `kubectl create configmap` का उपयोग कर सकते हैं या
+`kustomization.yaml` में ConfigMap generator का।
+
+### `kubectl create configmap` का उपयोग करके ConfigMap बनाएं
+
+`kubectl create configmap` कमांड का उपयोग करके आप
+[directories](#create-configmaps-from-directories), [files](#create-configmaps-from-files),
+या [literal values](#create-configmaps-from-literal-values) से ConfigMap बना सकते हैं:
+
+```shell
+kubectl create configmap <map-name> <data-source>
+```
+
+जहाँ \<map-name> वह नाम है जो आप ConfigMap को देना चाहते हैं और \<data-source> वह
+directory, file, या literal value है जिससे डेटा लिया जाएगा।
+ConfigMap ऑब्जेक्ट का नाम एक वैध
+[DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) होना चाहिए।
+
+जब आप किसी फ़ाइल के आधार पर ConfigMap बनाते हैं, तो \<data-source> में key डिफ़ॉल्ट रूप से
+उस फ़ाइल का basename होती है, और value डिफ़ॉल्ट रूप से फ़ाइल का content होता है।
+
+आप [`kubectl describe`](/docs/reference/generated/kubectl/kubectl-commands/#describe) या
+[`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) का उपयोग करके
+ConfigMap की जानकारी प्राप्त कर सकते हैं।
+
+#### डायरेक्टरी से ConfigMap बनाएं {#create-configmaps-from-directories}
+
+आप `kubectl create configmap` का उपयोग करके एक ही डायरेक्टरी में मौजूद कई फ़ाइलों से
+ConfigMap बना सकते हैं। जब आप डायरेक्टरी के आधार पर ConfigMap बनाते हैं, तो kubectl उन
+फ़ाइलों की पहचान करता है जिनका filename वैध key होता है, और हर ऐसी फ़ाइल को नए
+ConfigMap में पैकेज करता है। सामान्य फ़ाइलों (regular files) के अलावा बाकी डायरेक्टरी entries
+नज़रअंदाज़ कर दी जाती हैं (जैसे: subdirectories, symlinks, devices, pipes, आदि)।
+
+{{< note >}}
+ConfigMap बनाने के लिए उपयोग होने वाला हर filename केवल स्वीकार्य अक्षरों से बना होना चाहिए:
+letters (`A` से `Z` और `a` से `z`), digits (`0` से `9`), '-', '_', या '.'।
+अगर आप `kubectl create configmap` को ऐसी डायरेक्टरी पर चलाते हैं जहाँ किसी फ़ाइल के नाम में
+अस्वीकार्य कैरेक्टर हो, तो `kubectl` कमांड fail हो सकती है।
+
+जब `kubectl` कमांड को invalid filename मिलता है, तो यह हमेशा error प्रिंट नहीं करता।
+{{< /note >}}
+
+लोकल डायरेक्टरी बनाएं:
+
+```shell
+mkdir -p configure-pod-container/configmap/
+```
+
+अब sample configuration डाउनलोड करें और ConfigMap बनाएं:
+
+```shell
+# Download the sample files into `configure-pod-container/configmap/` directory
+wget https://kubernetes.io/examples/configmap/game.properties -O configure-pod-container/configmap/game.properties
+wget https://kubernetes.io/examples/configmap/ui.properties -O configure-pod-container/configmap/ui.properties
+
+# Create the ConfigMap
+kubectl create configmap game-config --from-file=configure-pod-container/configmap/
+```
+
+ऊपर दी गई कमांड हर फ़ाइल को पैकेज करती है, इस केस में `game.properties` और `ui.properties`
+को `configure-pod-container/configmap/` डायरेक्टरी से `game-config` ConfigMap में जोड़ती है।
+आप नीचे दी गई कमांड से ConfigMap का विवरण देख सकते हैं:
+
+```shell
+kubectl describe configmaps game-config
+```
+
+आउटपुट कुछ इस तरह होगा:
+```
+Name:         game-config
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+
+Data
+====
+game.properties:
+----
+enemies=aliens
+lives=3
+enemies.cheat=true
+enemies.cheat.level=noGoodRotten
+secret.code.passphrase=UUDDLRLRBABAS
+secret.code.allowed=true
+secret.code.lives=30
+ui.properties:
+----
+color.good=purple
+color.bad=yellow
+allow.textmode=true
+how.nice.to.look=fairlyNice
+```
+
+`configure-pod-container/configmap/` डायरेक्टरी में मौजूद `game.properties` और `ui.properties`
+फ़ाइलें ConfigMap के `data` सेक्शन में प्रदर्शित होती हैं।
+
+```shell
+kubectl get configmaps game-config -o yaml
+```
+आउटपुट कुछ इस तरह होगा:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2022-02-18T18:52:05Z
+  name: game-config
+  namespace: default
+  resourceVersion: "516"
+  uid: b4952dc3-d670-11e5-8cd0-68f728db1985
+data:
+  game.properties: |
+    enemies=aliens
+    lives=3
+    enemies.cheat=true
+    enemies.cheat.level=noGoodRotten
+    secret.code.passphrase=UUDDLRLRBABAS
+    secret.code.allowed=true
+    secret.code.lives=30
+  ui.properties: |
+    color.good=purple
+    color.bad=yellow
+    allow.textmode=true
+    how.nice.to.look=fairlyNice
+```
+
+#### फ़ाइलों से ConfigMap बनाएं
+
+आप `kubectl create configmap` का उपयोग करके एक फ़ाइल या
+कई फ़ाइलों से ConfigMap बना सकते हैं।
+
+उदाहरण के लिए,
+
+```shell
+kubectl create configmap game-config-2 --from-file=configure-pod-container/configmap/game.properties
+```
+
+यह निम्न ConfigMap बनाएगा:
+
+```shell
+kubectl describe configmaps game-config-2
+```
+
+जहाँ आउटपुट कुछ इस तरह होगा:
+
+```
+Name:         game-config-2
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+
+Data
+====
+game.properties:
+----
+enemies=aliens
+lives=3
+enemies.cheat=true
+enemies.cheat.level=noGoodRotten
+secret.code.passphrase=UUDDLRLRBABAS
+secret.code.allowed=true
+secret.code.lives=30
+```
+
+कई data sources से ConfigMap बनाने के लिए आप `--from-file` argument को कई बार दे सकते हैं।
+
+```shell
+kubectl create configmap game-config-2 --from-file=configure-pod-container/configmap/game.properties --from-file=configure-pod-container/configmap/ui.properties
+```
+
+आप नीचे दी गई कमांड से `game-config-2` ConfigMap का विवरण देख सकते हैं:
+
+```shell
+kubectl describe configmaps game-config-2
+```
+
+आउटपुट कुछ इस तरह होगा:
+
+```
+Name:         game-config-2
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+
+Data
+====
+game.properties:
+----
+enemies=aliens
+lives=3
+enemies.cheat=true
+enemies.cheat.level=noGoodRotten
+secret.code.passphrase=UUDDLRLRBABAS
+secret.code.allowed=true
+secret.code.lives=30
+ui.properties:
+----
+color.good=purple
+color.bad=yellow
+allow.textmode=true
+how.nice.to.look=fairlyNice
+```
+
+env-file से ConfigMap बनाने के लिए `--from-env-file` विकल्प का उपयोग करें, उदाहरण के लिए:
+
+```shell
+# Env-files contain a list of environment variables.
+# These syntax rules apply:
+#   Each line in an env file has to be in VAR=VAL format.
+#   Lines beginning with # (i.e. comments) are ignored.
+#   Blank lines are ignored.
+#   There is no special handling of quotation marks (i.e. they will be part of the ConfigMap value)).
+
+# Download the sample files into `configure-pod-container/configmap/` directory
+wget https://kubernetes.io/examples/configmap/game-env-file.properties -O configure-pod-container/configmap/game-env-file.properties
+wget https://kubernetes.io/examples/configmap/ui-env-file.properties -O configure-pod-container/configmap/ui-env-file.properties
+
+# The env-file `game-env-file.properties` looks like below
+cat configure-pod-container/configmap/game-env-file.properties
+enemies=aliens
+lives=3
+allowed="true"
+
+# This comment and the empty line above it are ignored
+```
+
+```shell
+kubectl create configmap game-config-env-file \
+       --from-env-file=configure-pod-container/configmap/game-env-file.properties
+```
+
+यह एक ConfigMap बनाएगा। ConfigMap देखें:
+
+```shell
+kubectl get configmap game-config-env-file -o yaml
+```
+
+आउटपुट कुछ इस तरह होगा:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2019-12-27T18:36:28Z
+  name: game-config-env-file
+  namespace: default
+  resourceVersion: "809965"
+  uid: d9d1ca5b-eb34-11e7-887b-42010a8002b8
+data:
+  allowed: '"true"'
+  enemies: aliens
+  lives: "3"
+```
+
+Kubernetes v1.23 से, `kubectl` में `--from-env-file` argument को
+कई बार specify करके कई data sources से ConfigMap बनाना समर्थित है।
+
+```shell
+kubectl create configmap config-multi-env-files \
+        --from-env-file=configure-pod-container/configmap/game-env-file.properties \
+        --from-env-file=configure-pod-container/configmap/ui-env-file.properties
+```
+
+यह निम्न ConfigMap बनाएगा:
+
+```shell
+kubectl get configmap config-multi-env-files -o yaml
+```
+
+जहाँ आउटपुट कुछ इस तरह होगा:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2019-12-27T18:38:34Z
+  name: config-multi-env-files
+  namespace: default
+  resourceVersion: "810136"
+  uid: 252c4572-eb35-11e7-887b-42010a8002b8
+data:
+  allowed: '"true"'
+  color: purple
+  enemies: aliens
+  how: fairlyNice
+  lives: "3"
+  textmode: "true"
+```
+
+#### फ़ाइल से ConfigMap बनाते समय उपयोग होने वाली key परिभाषित करें
+
+जब आप `--from-file` argument का उपयोग करते हैं, तब ConfigMap के `data` सेक्शन में
+फ़ाइल नाम के बजाय कोई दूसरी key भी परिभाषित कर सकते हैं:
+
+```shell
+kubectl create configmap game-config-3 --from-file=<my-key-name>=<path-to-file>
+```
+
+जहाँ `<my-key-name>` वह key है जिसे आप ConfigMap में उपयोग करना चाहते हैं और `<path-to-file>`
+वह data source फ़ाइल का स्थान है जिसे वह key represent करेगी।
+
+उदाहरण के लिए:
+
+```shell
+kubectl create configmap game-config-3 --from-file=game-special-key=configure-pod-container/configmap/game.properties
+```
+
+यह निम्न ConfigMap बनाएगा:
+```
+kubectl get configmaps game-config-3 -o yaml
+```
+
+जहाँ आउटपुट कुछ इस तरह होगा:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2022-02-18T18:54:22Z
+  name: game-config-3
+  namespace: default
+  resourceVersion: "530"
+  uid: 05f8da22-d671-11e5-8cd0-68f728db1985
+data:
+  game-special-key: |
+    enemies=aliens
+    lives=3
+    enemies.cheat=true
+    enemies.cheat.level=noGoodRotten
+    secret.code.passphrase=UUDDLRLRBABAS
+    secret.code.allowed=true
+    secret.code.lives=30
+```
+
+#### literal values से ConfigMap बनाएं
+
+आप `kubectl create configmap` के साथ `--from-literal` argument का उपयोग करके
+command line से literal value परिभाषित कर सकते हैं:
+
+```shell
+kubectl create configmap special-config --from-literal=special.how=very --from-literal=special.type=charm
+```
+
+आप कई key-value pairs दे सकते हैं। command line पर दिया गया हर pair ConfigMap के
+`data` सेक्शन में अलग entry के रूप में दिखता है।
+
+```shell
+kubectl get configmaps special-config -o yaml
+```
+
+आउटपुट कुछ इस तरह होगा:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2022-02-18T19:14:38Z
+  name: special-config
+  namespace: default
+  resourceVersion: "651"
+  uid: dadce046-d673-11e5-8cd0-68f728db1985
+data:
+  special.how: very
+  special.type: charm
+```
+
+### generator से ConfigMap बनाएं
+
+आप generators से भी ConfigMap बना सकते हैं और फिर उसे apply करके cluster के API server
+में object बना सकते हैं।
+आपको generators को किसी डायरेक्टरी के भीतर `kustomization.yaml` फ़ाइल में define करना चाहिए।
+
+#### फ़ाइलों से ConfigMap generate करें
+
+उदाहरण के लिए, फ़ाइल `configure-pod-container/configmap/game.properties` से ConfigMap generate करने के लिए:
+
+```shell
+# Create a kustomization.yaml file with ConfigMapGenerator
+cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: game-config-4
+  options:
+    labels:
+      game-config: config-4
+  files:
+  - configure-pod-container/configmap/game.properties
+EOF
+```
+
+ConfigMap object बनाने के लिए kustomization डायरेक्टरी apply करें:
+
+```shell
+kubectl apply -k .
+```
+```
+configmap/game-config-4-m9dm2f92bt created
+```
+
+आप यह इस तरह जांच सकते हैं कि ConfigMap बना है:
+
+```shell
+kubectl get configmap
+```
+```
+NAME                       DATA   AGE
+game-config-4-m9dm2f92bt   1      37s
+```
+
+और यह भी:
+
+```shell
+kubectl describe configmaps/game-config-4-m9dm2f92bt
+```
+```
+Name:         game-config-4-m9dm2f92bt
+Namespace:    default
+Labels:       game-config=config-4
+Annotations:  kubectl.kubernetes.io/last-applied-configuration:
+                {"apiVersion":"v1","data":{"game.properties":"enemies=aliens\nlives=3\nenemies.cheat=true\nenemies.cheat.level=noGoodRotten\nsecret.code.p...
+
+Data
+====
+game.properties:
+----
+enemies=aliens
+lives=3
+enemies.cheat=true
+enemies.cheat.level=noGoodRotten
+secret.code.passphrase=UUDDLRLRBABAS
+secret.code.allowed=true
+secret.code.lives=30
+Events:  <none>
+```
+
+ध्यान दें कि generated ConfigMap नाम के अंत में content का hash जोड़कर एक suffix लगाया जाता है।
+इससे यह सुनिश्चित होता है कि content बदलने पर हर बार नया ConfigMap generate हो।
+
+#### फ़ाइल से ConfigMap generate करते समय उपयोग होने वाली key परिभाषित करें
+
+आप ConfigMap generator में फ़ाइल नाम के बजाय दूसरी key परिभाषित कर सकते हैं।
+उदाहरण के लिए, `configure-pod-container/configmap/game.properties` से `game-special-key`
+key के साथ ConfigMap generate करने के लिए:
+
+```shell
+# Create a kustomization.yaml file with ConfigMapGenerator
+cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: game-config-5
+  options:
+    labels:
+      game-config: config-5
+  files:
+  - game-special-key=configure-pod-container/configmap/game.properties
+EOF
+```
+
+ConfigMap object बनाने के लिए kustomization डायरेक्टरी apply करें।
+```shell
+kubectl apply -k .
+```
+```
+configmap/game-config-5-m67dt67794 created
+```
+
+#### literals से ConfigMap generate करें
+
+यह उदाहरण दिखाता है कि Kustomize और kubectl का उपयोग करके दो literal key/value pairs
+`special.type=charm` और `special.how=very` से `ConfigMap` कैसे बनाया जाए।
+इसके लिए आप `ConfigMap` generator specify कर सकते हैं। `kustomization.yaml` बनाएं (या replace करें),
+ताकि उसका content नीचे जैसा हो:
+
+```yaml
+---
+# kustomization.yaml contents for creating a ConfigMap from literals
+configMapGenerator:
+- name: special-config-2
+  literals:
+  - special.how=very
+  - special.type=charm
+```
+
+ConfigMap object बनाने के लिए kustomization डायरेक्टरी apply करें:
+```shell
+kubectl apply -k .
+```
+```
+configmap/special-config-2-c92b5mmcf2 created
+```
+
+## अंतरिम सफ़ाई
+
+आगे बढ़ने से पहले, बनाए गए कुछ ConfigMaps को साफ़ करें:
+
+```bash
+kubectl delete configmap special-config
+kubectl delete configmap env-config
+kubectl delete configmap -l 'game-config in (config-4,config-5)'
+```
+
+अब आपने ConfigMap परिभाषित करना सीख लिया है, तो आप अगले सेक्शन में जाकर
+सीख सकते हैं कि Pods के साथ इन ऑब्जेक्ट्स का उपयोग कैसे करें।
+
+---
+
+## ConfigMap डेटा का उपयोग करके कंटेनर environment variables परिभाषित करें
+
+### एक single ConfigMap के डेटा से कंटेनर environment variable परिभाषित करें
+
+1. ConfigMap में key-value pair के रूप में एक environment variable परिभाषित करें:
+
+   ```shell
+   kubectl create configmap special-config --from-literal=special.how=very
+   ```
+
+2. ConfigMap में परिभाषित `special.how` मान को Pod specification में `SPECIAL_LEVEL_KEY`
+   environment variable को असाइन करें।
+
+   {{% code_sample file="pods/pod-single-configmap-env-variable.yaml" %}}
+
+   Pod बनाएं:
+
+   ```shell
+   kubectl create -f https://kubernetes.io/examples/pods/pod-single-configmap-env-variable.yaml
+   ```
+
+   अब Pod के आउटपुट में environment variable `SPECIAL_LEVEL_KEY=very` शामिल होगा।
+
+### कई ConfigMaps के डेटा से कंटेनर environment variables परिभाषित करें
+
+पिछले उदाहरण की तरह पहले ConfigMaps बनाएं।
+यहाँ वह manifest है जिसका आप उपयोग करेंगे:
+
+{{% code_sample file="configmap/configmaps.yaml" %}}
+
+* ConfigMap बनाएं:
+
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/configmap/configmaps.yaml
+  ```
+
+* Pod specification में environment variables परिभाषित करें।
+
+  {{% code_sample file="pods/pod-multiple-configmap-env-variable.yaml" %}}
+
+  Pod बनाएं:
+
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/pods/pod-multiple-configmap-env-variable.yaml
+  ```
+
+  अब Pod के आउटपुट में environment variables `SPECIAL_LEVEL_KEY=very` और `LOG_LEVEL=INFO` शामिल होंगे।
+
+  आगे बढ़ने के बाद, वह Pod और ConfigMap हटा दें:
+  ```shell
+  kubectl delete pod dapi-test-pod --now
+  kubectl delete configmap special-config
+  kubectl delete configmap env-config
+  ```
+
+## ConfigMap में मौजूद सभी key-value pairs को कंटेनर environment variables के रूप में कॉन्फ़िगर करें
+
+* कई key-value pairs वाला एक ConfigMap बनाएं।
+
+  {{% code_sample file="configmap/configmap-multikeys.yaml" %}}
+
+  ConfigMap बनाएं:
+
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
+  ```
+
+* `envFrom` का उपयोग करके ConfigMap के सभी डेटा को कंटेनर environment variables के रूप में परिभाषित करें।
+  ConfigMap की key, Pod में environment variable नाम बन जाती है।
+
+  {{% code_sample file="pods/pod-configmap-envFrom.yaml" %}}
+
+  Pod बनाएं:
+
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-envFrom.yaml
+  ```
+  अब Pod के आउटपुट में environment variables `SPECIAL_LEVEL=very` और
+  `SPECIAL_TYPE=charm` शामिल होंगे।
+
+  आगे बढ़ने के बाद, वह Pod हटा दें:
+  ```shell
+  kubectl delete pod dapi-test-pod --now
+  ```
+
+## Pod commands में ConfigMap-परिभाषित environment variables का उपयोग करें
+
+आप कंटेनर के `command` और `args` में ConfigMap-परिभाषित environment variables का उपयोग
+Kubernetes substitution syntax `$(VAR_NAME)` के साथ कर सकते हैं।
+
+उदाहरण के लिए, नीचे दिया गया Pod manifest:
+
+{{% code_sample file="pods/pod-configmap-env-var-valueFrom.yaml" %}}
+
+उस Pod को चलाकर बनाएं:
+
+```shell
+kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-env-var-valueFrom.yaml
+```
+
+वह Pod `test-container` कंटेनर से नीचे दिया गया आउटपुट देता है:
+```shell
+kubectl logs dapi-test-pod
+```
+
+```
+very charm
+```
+
+आगे बढ़ने के बाद, वह Pod हटा दें:
+```shell
+kubectl delete pod dapi-test-pod --now
+```
+
+## ConfigMap डेटा को Volume में जोड़ें
+
+[फ़ाइलों से ConfigMap बनाएं](#create-configmaps-from-files) में बताए अनुसार, जब आप
+`--from-file` का उपयोग करके ConfigMap बनाते हैं, तो filename, ConfigMap के `data` सेक्शन में
+store होने वाली key बन जाता है। फ़ाइल का content उस key की value बनता है।
+
+इस सेक्शन के उदाहरण `special-config` नाम के ConfigMap को refer करते हैं:
+
+{{% code_sample file="configmap/configmap-multikeys.yaml" %}}
+
+ConfigMap बनाएं:
+
+```shell
+kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
+```
+
+### ConfigMap में stored डेटा से Volume populate करें
+
+Pod specification के `volumes` सेक्शन में ConfigMap का नाम जोड़ें।
+इससे ConfigMap डेटा `volumeMounts.mountPath` द्वारा बताए गए डायरेक्टरी में जुड़ता है (इस
+उदाहरण में `/etc/config`)। `command` सेक्शन डायरेक्टरी की उन फ़ाइलों को सूचीबद्ध करता है
+जिनके नाम ConfigMap की keys से मेल खाते हैं।
+
+{{% code_sample file="pods/pod-configmap-volume.yaml" %}}
+
+Pod बनाएं:
+
+```shell
+kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-volume.yaml
+```
+
+जब Pod चलता है, तो `ls /etc/config/` कमांड नीचे जैसा आउटपुट देता है:
+
+```
+SPECIAL_LEVEL
+SPECIAL_TYPE
+```
+
+Text data को UTF-8 character encoding के साथ फ़ाइलों के रूप में expose किया जाता है।
+अगर आप कोई दूसरी character encoding उपयोग करना चाहते हैं, तो `binaryData` उपयोग करें
+(अधिक जानकारी के लिए [ConfigMap object](/docs/concepts/configuration/configmap/#configmap-object) देखें)।
+
+{{< note >}}
+अगर उस container image की `/etc/config` डायरेक्टरी में कोई फ़ाइलें मौजूद हैं, तो volume
+mount image की उन फ़ाइलों को inaccessible बना देगा।
+{{< /note >}}
+
+आगे बढ़ने के बाद, वह Pod हटा दें:
+```shell
+kubectl delete pod dapi-test-pod --now
+```
+
+### Volume में ConfigMap डेटा को किसी specific path पर जोड़ें
+
+specific ConfigMap items के लिए इच्छित फ़ाइल पथ बताने हेतु `path` फ़ील्ड उपयोग करें।
+इस केस में `SPECIAL_LEVEL` item, `config-volume` volume में `/etc/config/keys` पर mount होगा।
+
+{{% code_sample file="pods/pod-configmap-volume-specific-key.yaml" %}}
+
+Pod बनाएं:
+
+```shell
+kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-volume-specific-key.yaml
+```
+
+जब Pod चलता है, तो `cat /etc/config/keys` कमांड नीचे जैसा आउटपुट देता है:
+
+```
+very
+```
+
+{{< caution >}}
+पहले की तरह, `/etc/config/` डायरेक्टरी में मौजूद सभी पहले की फ़ाइलें हट जाएँगी।
+{{< /caution >}}
+
+वह Pod हटा दें:
+```shell
+kubectl delete pod dapi-test-pod --now
+```
+
+### keys को specific paths और file permissions पर project करें
+
+आप keys को specific paths पर project कर सकते हैं। syntax के लिए [Secrets](/docs/tasks/inject-data-application/distribute-credentials-secure/#project-secret-keys-to-specific-file-paths) गाइड के संबंधित सेक्शन को देखें।  
+आप keys के लिए POSIX permissions सेट कर सकते हैं। syntax के लिए [Secrets](/docs/tasks/inject-data-application/distribute-credentials-secure/#set-posix-permissions-for-secret-keys) गाइड के संबंधित सेक्शन को देखें।
+
+### वैकल्पिक संदर्भ
+
+ConfigMap reference को _optional_ के रूप में चिह्नित किया जा सकता है। अगर ConfigMap मौजूद नहीं है,
+तो mounted volume खाली होगा। अगर ConfigMap मौजूद है लेकिन referenced key मौजूद नहीं है, तो
+mount point के नीचे वह path मौजूद नहीं होगा। अधिक जानकारी के लिए [Optional ConfigMaps](#optional-configmaps) देखें।
+
+### Mounted ConfigMaps अपने-आप अपडेट होते हैं
+
+जब mounted ConfigMap अपडेट होता है, तो projected content भी eventually अपडेट हो जाता है।
+यह उस केस में भी लागू होता है जहाँ optional रूप से referenced ConfigMap, pod शुरू होने के बाद अस्तित्व में आता है।
+
+Kubelet हर periodic sync पर जांचता है कि mounted ConfigMap fresh है या नहीं। हालांकि,
+current value लाने के लिए यह अपना local TTL-based cache इस्तेमाल करता है। परिणामस्वरूप,
+ConfigMap अपडेट होने के समय से लेकर pod में नई keys project होने तक कुल देरी अधिकतम
+kubelet sync period (डिफ़ॉल्ट 1 मिनट) + kubelet में ConfigMaps cache का TTL (डिफ़ॉल्ट 1 मिनट)
+जितनी हो सकती है। आप pod की किसी annotation को अपडेट करके तुरंत refresh ट्रिगर कर सकते हैं।
+
+{{< note >}}
+[subPath](/docs/concepts/storage/volumes/#using-subpath) volume के रूप में ConfigMap का उपयोग करने वाला कंटेनर,
+ConfigMap updates प्राप्त नहीं करेगा।
+{{< /note >}}
+
+<!-- discussion -->
+
+## ConfigMaps और Pods को समझना
+
+ConfigMap API resource, configuration data को key-value pairs के रूप में store करता है। इस डेटा को
+pods में उपयोग किया जा सकता है या controllers जैसे system components के configurations देने के लिए।
+ConfigMap, [Secrets](/docs/concepts/configuration/secret/) जैसा है, लेकिन यह ऐसे strings के साथ काम करने का तरीका देता है
+जिनमें संवेदनशील जानकारी नहीं होती। उपयोगकर्ता और system components, दोनों ConfigMap में configuration data store कर सकते हैं।
+
+{{< note >}}
+ConfigMaps को properties files को replace नहीं, बल्कि refer करना चाहिए। ConfigMap को Linux की
+`/etc` डायरेक्टरी और उसके content जैसी किसी चीज़ का प्रतिनिधित्व करने वाला समझें। उदाहरण के लिए,
+अगर आप ConfigMap से [Kubernetes Volume](/docs/concepts/storage/volumes/) बनाते हैं, तो ConfigMap का
+हर data item volume में एक अलग फ़ाइल के रूप में दर्शाया जाता है।
+{{< /note >}}
+
+ConfigMap के `data` फ़ील्ड में configuration data होता है। नीचे दिए उदाहरण की तरह, यह साधारण भी हो सकता है
+(जैसे `--from-literal` से परिभाषित individual properties) या जटिल भी
+(जैसे `--from-file` से परिभाषित configuration files या JSON blobs)।
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-02-18T19:14:38Z
+  name: example-config
+  namespace: default
+data:
+  # example of a simple property defined using --from-literal
+  example.property.1: hello
+  example.property.2: world
+  # example of a complex property defined using --from-file
+  example.property.file: |-
+    property.1=value-1
+    property.2=value-2
+    property.3=value-3
+```
+
+जब `kubectl` ऐसे inputs से ConfigMap बनाता है जो ASCII या UTF-8 नहीं होते, तो टूल
+उन्हें ConfigMap के `binaryData` फ़ील्ड में रखता है, `data` में नहीं। text और binary
+दोनों data sources को एक ConfigMap में मिलाया जा सकता है।
+
+अगर आप ConfigMap में `binaryData` keys (और उनकी values) देखना चाहते हैं, तो आप
+`kubectl get configmap -o jsonpath='{.binaryData}' <name>` चला सकते हैं।
+
+Pods, `data` या `binaryData` में से किसी का उपयोग करने वाले ConfigMap से डेटा लोड कर सकते हैं।
+
+## वैकल्पिक ConfigMaps
+
+आप Pod specification में ConfigMap reference को _optional_ के रूप में चिह्नित कर सकते हैं।
+अगर ConfigMap मौजूद नहीं है, तो Pod में वह configuration जिसके लिए ConfigMap डेटा देता
+है (उदाहरण: environment variable, mounted volume) खाली रहेगा।
+अगर ConfigMap मौजूद है, लेकिन referenced key मौजूद नहीं है, तो डेटा भी खाली रहेगा।
+
+उदाहरण के लिए, नीचे दिया Pod specification ConfigMap से environment variable को optional चिह्नित करता है:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-test-pod
+spec:
+  containers:
+    - name: test-container
+      image: gcr.io/google_containers/busybox
+      command: ["/bin/sh", "-c", "env"]
+      env:
+        - name: SPECIAL_LEVEL_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: a-config
+              key: akey
+              optional: true # mark the variable as optional
+  restartPolicy: Never
+```
+
+अगर आप यह pod चलाते हैं और `a-config` नाम का ConfigMap मौजूद नहीं है, तो आउटपुट खाली होगा।
+अगर आप यह pod चलाते हैं और `a-config` नाम का ConfigMap मौजूद है लेकिन उसमें `akey` नाम की key नहीं है,
+तो आउटपुट फिर भी खाली होगा। अगर आप `a-config` ConfigMap में `akey` के लिए value सेट करते हैं,
+तो यह pod वह value प्रिंट करके terminate हो जाता है।
+
+आप ConfigMap द्वारा प्रदान किए गए volumes और files को भी optional चिह्नित कर सकते हैं। Kubernetes,
+भले ही referenced ConfigMap या key मौजूद न हो, volume के mount paths हमेशा बनाता है। उदाहरण के लिए,
+नीचे दिया Pod specification ConfigMap को refer करने वाले volume को optional चिह्नित करता है:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-test-pod
+spec:
+  containers:
+    - name: test-container
+      image: gcr.io/google_containers/busybox
+      command: ["/bin/sh", "-c", "ls /etc/config"]
+      volumeMounts:
+      - name: config-volume
+        mountPath: /etc/config
+  volumes:
+    - name: config-volume
+      configMap:
+        name: no-config
+        optional: true # mark the source ConfigMap as optional
+  restartPolicy: Never
+```
+
+
+
+## प्रतिबंध
+
+- Pod specification में reference करने से पहले आपको `ConfigMap` object बनाना होगा।
+  वैकल्पिक रूप से, Pod spec में ConfigMap reference को `optional` चिह्नित करें (देखें
+  [Optional ConfigMaps](#optional-configmaps))। अगर आप ऐसे ConfigMap को reference करते हैं जो मौजूद नहीं है
+  और reference को `optional` नहीं चिह्नित करते, तो Pod शुरू नहीं होगा। इसी तरह ConfigMap में
+  मौजूद न रहने वाली keys के references भी Pod को शुरू होने से रोकेंगे, जब तक कि आप key references
+  को `optional` चिह्नित न करें।
+
+- अगर आप ConfigMaps से environment variables परिभाषित करने के लिए `envFrom` उपयोग करते हैं, तो
+  invalid मानी जाने वाली keys skip कर दी जाती हैं। pod शुरू हो जाएगा, लेकिन invalid names event log
+  (`InvalidVariableNames`) में रिकॉर्ड किए जाएंगे। log message हर skipped key की सूची देता है।
+  उदाहरण के लिए:
+
+  ```shell
+  kubectl get events
+  ```
+
+  आउटपुट कुछ इस तरह होगा:
+  ```
+  LASTSEEN FIRSTSEEN COUNT NAME          KIND  SUBOBJECT  TYPE      REASON                            SOURCE                MESSAGE
+  0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
+  ```
+
+- ConfigMaps किसी विशेष {{< glossary_tooltip term_id="namespace" >}} में रहते हैं।
+  Pods केवल उसी namespace के ConfigMaps को refer कर सकते हैं जिसमें वह Pod मौजूद है।
+
+- आप ConfigMaps का उपयोग
+  {{< glossary_tooltip text="static pods" term_id="static-pod" >}} के लिए नहीं कर सकते, क्योंकि
+  kubelet इसका समर्थन नहीं करता।
+
+## {{% heading "cleanup" %}}
+
+आपके बनाए हुए ConfigMaps और Pods हटाएं:
+
+```bash
+kubectl delete configmaps/game-config configmaps/game-config-2 configmaps/game-config-3 \
+               configmaps/game-config-env-file
+kubectl delete pod dapi-test-pod --now
+
+# You might already have removed the next set
+kubectl delete configmaps/special-config configmaps/env-config
+kubectl delete configmap -l 'game-config in (config-4,config-5)'
+```
+
+ConfigMap generate करने के लिए उपयोग की गई `kustomization.yaml` फ़ाइल हटाएं:
+
+```bash
+rm kustomization.yaml
+```
+
+अगर आपने `configure-pod-container` नाम की डायरेक्टरी बनाई थी और अब उसकी ज़रूरत नहीं है, तो उसे भी हटाएँ
+या उसे trash / deleted files location में ले जाएँ।
+
+```bash
+rm -r configure-pod-container
+```
+
+## {{% heading "whatsnext" %}}
+
+* इसका वास्तविक उदाहरण देखें:
+  [Configuring Redis using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)।
+* एक और उदाहरण देखें:
+  [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/)।

--- a/content/hi/docs/tasks/configure-pod-initialization.md
+++ b/content/hi/docs/tasks/configure-pod-initialization.md
@@ -1,0 +1,93 @@
+---
+title: Pod Initialization कॉन्फ़िगर करें
+content_type: task
+weight: 170
+---
+
+<!-- overview -->
+
+यह पेज दिखाता है कि किसी एप्लिकेशन Container के चलने से पहले Pod को initialize करने के लिए
+Init Container का उपयोग कैसे करें।
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+<!-- steps -->
+
+## ऐसा Pod बनाएं जिसमें Init Container हो
+
+इस अभ्यास में आप ऐसा Pod बनाते हैं जिसमें एक application Container और एक
+Init Container होता है। application container शुरू होने से पहले init container
+पूरा चलकर समाप्त हो जाता है।
+
+यह Pod की configuration file है:
+
+{{% code_sample file="pods/init-containers.yaml" %}}
+
+configuration file में आप देख सकते हैं कि Pod में एक Volume है जिसे init
+container और application container share करते हैं।
+
+init container shared Volume को `/work-dir` पर mount करता है, और application container
+shared Volume को `/usr/share/nginx/html` पर mount करता है। init container नीचे दी गई कमांड चलाता है
+और फिर समाप्त हो जाता है:
+
+```shell
+wget -O /work-dir/index.html http://info.cern.ch
+```
+
+ध्यान दें कि init container, nginx server की root directory में `index.html` फ़ाइल लिखता है।
+
+Pod बनाएं:
+
+```shell
+kubectl apply -f https://k8s.io/examples/pods/init-containers.yaml
+```
+
+जांचें कि nginx container चल रहा है:
+
+```shell
+kubectl get pod init-demo
+```
+
+आउटपुट दिखाता है कि nginx container चल रहा है:
+
+```
+NAME        READY     STATUS    RESTARTS   AGE
+init-demo   1/1       Running   0          1m
+```
+
+init-demo Pod में चल रहे nginx container के अंदर shell खोलें:
+
+```shell
+kubectl exec -it init-demo -- /bin/bash
+```
+
+अपनी shell में, nginx server पर GET request भेजें:
+
+```
+root@nginx:~# apt-get update
+root@nginx:~# apt-get install curl
+root@nginx:~# curl localhost
+```
+
+आउटपुट दिखाता है कि nginx वही web page serve कर रहा है जिसे init container ने लिखा था:
+
+```html
+<html><head></head><body><header>
+<title>http://info.cern.ch</title>
+</header>
+
+<h1>http://info.cern.ch - home of the first website</h1>
+  ...
+  <li><a href="http://info.cern.ch/hypertext/WWW/TheProject.html">Browse the first website</a></li>
+  ...
+```
+
+## {{% heading "whatsnext" %}}
+
+* इसके बारे में और जानें:
+  [एक ही Pod में चल रहे Containers के बीच communication](/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/)।
+* [Init Containers](/docs/concepts/workloads/pods/init-containers/) के बारे में और जानें।
+* [Volumes](/docs/concepts/storage/volumes/) के बारे में और जानें।
+* [Debugging Init Containers](/docs/tasks/debug/debug-application/debug-init-containers/) के बारे में और जानें।

--- a/content/hi/docs/tasks/configure-projected-volume-storage.md
+++ b/content/hi/docs/tasks/configure-projected-volume-storage.md
@@ -1,0 +1,87 @@
+---
+reviewers:
+- jpeeler
+- pmorie
+title: Storage के लिए Projected Volume उपयोग करने हेतु Pod कॉन्फ़िगर करें
+content_type: task
+weight: 100
+---
+
+<!-- overview -->
+यह पेज दिखाता है कि एक ही directory में कई मौजूदा volume sources को mount करने के लिए
+[`projected`](/docs/concepts/storage/volumes/#projected) Volume का उपयोग कैसे करें।
+वर्तमान में `secret`, `configMap`, `downwardAPI` और `serviceAccountToken` volumes को project किया जा सकता है।
+
+{{< note >}}
+`serviceAccountToken` कोई volume type नहीं है।
+{{< /note >}}
+
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+
+<!-- steps -->
+## Pod के लिए projected volume कॉन्फ़िगर करें
+
+इस अभ्यास में आप local files से username और password वाले {{< glossary_tooltip text="Secrets" term_id="secret" >}} बनाते हैं।
+फिर आप एक ऐसा Pod बनाते हैं जिसमें एक container चलता है, और [`projected`](/docs/concepts/storage/volumes/#projected) Volume का उपयोग करके
+Secrets को उसी shared directory में mount किया जाता है।
+
+यह Pod की configuration file है:
+
+{{% code_sample file="pods/storage/projected.yaml" %}}
+
+1. Secrets बनाएं:
+
+    ```shell
+    # Create files containing the username and password:
+    echo -n "admin" > ./username.txt
+    echo -n "1f2d1e2e67df" > ./password.txt
+
+    # Package these files into secrets:
+    kubectl create secret generic user --from-file=./username.txt
+    kubectl create secret generic pass --from-file=./password.txt
+    ```
+1. Pod बनाएं:
+
+    ```shell
+    kubectl apply -f https://k8s.io/examples/pods/storage/projected.yaml
+    ```
+1. जांचें कि Pod का container चल रहा है, और फिर Pod में होने वाले बदलाव देखें:
+
+    ```shell
+    kubectl get --watch pod test-projected-volume
+    ```
+    आउटपुट इस तरह दिखेगा:
+    ```
+    NAME                    READY     STATUS    RESTARTS   AGE
+    test-projected-volume   1/1       Running   0          14s
+    ```
+1. दूसरे terminal में, चल रहे container का shell खोलें:
+
+    ```shell
+    kubectl exec -it test-projected-volume -- /bin/sh
+    ```
+1. अपनी shell में, जांचें कि `projected-volume` directory में आपके projected sources मौजूद हैं:
+
+    ```shell
+    ls /projected-volume/
+    ```
+
+## साफ़-सफ़ाई
+
+Pod और Secrets हटाएँ:
+
+```shell
+kubectl delete pod test-projected-volume
+kubectl delete secret user pass
+```
+
+
+
+## {{% heading "whatsnext" %}}
+
+* [`projected`](/docs/concepts/storage/volumes/#projected) volumes के बारे में और जानें।
+* [all-in-one volume](https://git.k8s.io/design-proposals-archive/node/all-in-one-volume.md) design document पढ़ें।

--- a/content/hi/docs/tasks/configure-runasusername.md
+++ b/content/hi/docs/tasks/configure-runasusername.md
@@ -1,0 +1,144 @@
+---
+title: Windows Pods और Containers के लिए RunAsUserName कॉन्फ़िगर करें
+content_type: task
+weight: 40
+---
+
+<!-- overview -->
+
+{{< feature-state for_k8s_version="v1.18" state="stable" >}}
+
+यह पेज दिखाता है कि Windows nodes पर चलने वाले Pods और containers के लिए
+`runAsUserName` सेटिंग का उपयोग कैसे करें। यह लगभग Linux-विशिष्ट `runAsUser`
+सेटिंग के समकक्ष है, जिससे आप container में applications को default username से
+अलग username पर चला सकते हैं।
+
+
+
+## {{% heading "prerequisites" %}}
+
+
+आपके पास Kubernetes cluster होना चाहिए और kubectl command-line tool आपके cluster से
+communicate करने के लिए configured होना चाहिए। cluster में Windows worker nodes होने चाहिए,
+जहाँ Windows workloads चलाने वाले containers वाले pods schedule किए जा सकें।
+
+
+
+<!-- steps -->
+
+## Pod के लिए Username सेट करें
+
+Pod के container processes किस username से execute हों, यह बताने के लिए Pod specification में
+`securityContext` field ([PodSecurityContext](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podsecuritycontext-v1-core))
+शामिल करें, और उसके अंदर `windowsOptions`
+([WindowsSecurityContextOptions](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#windowssecuritycontextoptions-v1-core))
+field में `runAsUserName` field दें।
+
+Pod के लिए जो Windows security context options आप specify करते हैं, वे Pod के सभी Containers
+और init Containers पर लागू होते हैं।
+
+यहाँ Windows Pod की configuration file है जिसमें `runAsUserName` field सेट है:
+
+{{% code_sample file="windows/run-as-username-pod.yaml" %}}
+
+Pod बनाएं:
+
+```shell
+kubectl apply -f https://k8s.io/examples/windows/run-as-username-pod.yaml
+```
+
+जांचें कि Pod का Container चल रहा है:
+
+```shell
+kubectl get pod run-as-username-pod-demo
+```
+
+चल रहे Container में shell खोलें:
+
+```shell
+kubectl exec -it run-as-username-pod-demo -- powershell
+```
+
+जांचें कि shell सही username के रूप में चल रही है:
+
+```powershell
+echo $env:USERNAME
+```
+
+आउटपुट यह होना चाहिए:
+
+```
+ContainerUser
+```
+
+## Container के लिए Username सेट करें
+
+Container के processes किस username से execute हों, यह बताने के लिए Container manifest में
+`securityContext` field ([SecurityContext](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#securitycontext-v1-core))
+शामिल करें, और उसके अंदर `windowsOptions`
+([WindowsSecurityContextOptions](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#windowssecuritycontextoptions-v1-core))
+field में `runAsUserName` field दें।
+
+Container के लिए जो Windows security context options आप specify करते हैं, वे केवल उसी
+Container पर लागू होते हैं, और Pod level पर की गई settings को override करते हैं।
+
+यहाँ Pod की configuration file है जिसमें एक Container है, और `runAsUserName` field
+Pod level तथा Container level दोनों पर सेट है:
+
+{{% code_sample file="windows/run-as-username-container.yaml" %}}
+
+Pod बनाएं:
+
+```shell
+kubectl apply -f https://k8s.io/examples/windows/run-as-username-container.yaml
+```
+
+जांचें कि Pod का Container चल रहा है:
+
+```shell
+kubectl get pod run-as-username-container-demo
+```
+
+चल रहे Container में shell खोलें:
+
+```shell
+kubectl exec -it run-as-username-container-demo -- powershell
+```
+
+जांचें कि shell सही username के रूप में चल रही है (यानी वही जो Container level पर सेट है):
+
+```powershell
+echo $env:USERNAME
+```
+
+आउटपुट यह होना चाहिए:
+
+```
+ContainerAdministrator
+```
+
+## Windows Username सीमाएँ
+
+इस feature का उपयोग करने के लिए `runAsUserName` field में दिया गया मान एक वैध username होना चाहिए।
+यह format `DOMAIN\USER` में होना चाहिए, जहाँ `DOMAIN\` वैकल्पिक है। Windows usernames case insensitive होते हैं।
+इसके अलावा `DOMAIN` और `USER` के संबंध में कुछ प्रतिबंध हैं:
+
+- `runAsUserName` field खाली नहीं हो सकती और इसमें control characters (ASCII values: `0x00-0x1F`, `0x7F`) नहीं होने चाहिए।
+- `DOMAIN` या तो NetBios नाम होना चाहिए या DNS नाम, और दोनों पर अलग-अलग सीमाएँ लागू होती हैं:
+  - NetBios names: अधिकतम 15 characters, `.` (dot) से शुरू नहीं होना चाहिए, और इन characters को शामिल नहीं कर सकता: `\ / : * ? " < > |`
+  - DNS names: अधिकतम 255 characters, केवल alphanumeric characters, dots और dashes शामिल हों, और `.` (dot) या `-` (dash) से शुरू/समाप्त न हो।
+- `USER` अधिकतम 20 characters का होना चाहिए, केवल dots या spaces से बना नहीं होना चाहिए, और इनमें से कोई character शामिल नहीं होना चाहिए: `" / \ [ ] : ; | = , + * ? < > @`।
+
+`runAsUserName` field के स्वीकार्य मानों के उदाहरण:
+`ContainerAdministrator`, `ContainerUser`, `NT AUTHORITY\NETWORK SERVICE`, `NT AUTHORITY\LOCAL SERVICE`।
+
+इन सीमाओं के बारे में अधिक जानकारी के लिए [here](https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and) और [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/new-localuser?view=powershell-5.1) देखें।
+
+
+
+## {{% heading "whatsnext" %}}
+
+
+* [Kubernetes में Windows containers schedule करने की guide](/docs/concepts/windows/user-guide/)
+* [Group Managed Service Accounts (GMSA) के साथ Workload Identity प्रबंधन](/docs/concepts/windows/user-guide/#managing-workload-identity-with-group-managed-service-accounts)
+* [Windows pods और containers के लिए GMSA कॉन्फ़िगर करें](/docs/tasks/configure-pod-container/configure-gmsa/)

--- a/content/hi/docs/tasks/configure-service-account.md
+++ b/content/hi/docs/tasks/configure-service-account.md
@@ -1,0 +1,542 @@
+---
+reviewers:
+- enj
+- liggitt
+- thockin
+title: Pods के लिए Service Accounts कॉन्फ़िगर करें
+content_type: task
+weight: 120
+---
+
+Kubernetes उन clients के लिए, जो आपके cluster के भीतर चलते हैं
+या जिनका आपके cluster के
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}}
+से किसी प्रकार का संबंध होता है, authentication के दो अलग तरीके प्रदान करता है ताकि वे
+{{< glossary_tooltip text="API server" term_id="kube-apiserver" >}} से प्रमाणित हो सकें।
+
+एक _service account_ Pod में चलने वाली processes के लिए identity प्रदान करता है,
+और यह ServiceAccount object से map होता है। जब आप API server से authenticate करते हैं,
+तो आप स्वयं को एक विशेष _user_ के रूप में पहचानते हैं। Kubernetes user की अवधारणा को पहचानता है,
+लेकिन स्वयं Kubernetes में User API **नहीं** है।
+
+यह task guide ServiceAccounts के बारे में है, जो Kubernetes API में मौजूद हैं।
+यह guide आपको Pods के लिए ServiceAccounts कॉन्फ़िगर करने के कुछ तरीके दिखाती है।
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+## API server तक पहुँचने के लिए default service account का उपयोग करें
+
+जब Pods API server से संपर्क करते हैं, तो वे किसी विशेष ServiceAccount
+(उदाहरण के लिए `default`) के रूप में authenticate करते हैं।
+हर {{< glossary_tooltip text="namespace" term_id="namespace" >}} में हमेशा कम से कम एक ServiceAccount होता है।
+
+हर Kubernetes namespace में कम से कम एक ServiceAccount होता है:
+उस namespace का default ServiceAccount, जिसका नाम `default` होता है।
+अगर आप Pod बनाते समय ServiceAccount specify नहीं करते,
+तो Kubernetes उस namespace का `default` ServiceAccount अपने-आप असाइन कर देता है।
+
+आप अपने बनाए Pod का विवरण प्राप्त कर सकते हैं। उदाहरण के लिए:
+
+```shell
+kubectl get pods/<podname> -o yaml
+```
+
+आउटपुट में आपको `spec.serviceAccountName` field दिखाई देगी।
+अगर Pod बनाते समय आप यह मान सेट नहीं करते, तो Kubernetes इसे अपने-आप सेट करता है।
+
+Pod के अंदर चल रहा application, automatically mounted service account credentials का उपयोग करके
+Kubernetes API तक पहुँच सकता है।
+अधिक जानने के लिए [accessing the Cluster](/docs/tasks/access-application-cluster/access-cluster/) देखें।
+
+जब Pod, ServiceAccount के रूप में authenticate करता है, तो उसका access level
+उपयोग में मौजूद [authorization plugin and policy](/docs/reference/access-authn-authz/authorization/#authorization-modules)
+पर निर्भर करता है।
+
+Pod delete होने पर API credentials अपने-आप revoke हो जाते हैं, भले ही
+finalizers लगे हों। विशेष रूप से, Pod पर `.metadata.deletionTimestamp` सेट होने के 60 seconds बाद
+API credentials revoke हो जाते हैं (deletion timestamp आमतौर पर वह समय होता है जब **delete**
+request स्वीकार की गई, plus Pod का termination grace period)।
+
+### API credential automounting से बाहर निकलें
+
+अगर आप नहीं चाहते कि {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}
+ServiceAccount की API credentials अपने-आप mount करे, तो आप default behavior से बाहर निकल सकते हैं।
+आप service account पर `automountServiceAccountToken: false` सेट करके
+`/var/run/secrets/kubernetes.io/serviceaccount/token` पर API credentials की automounting बंद कर सकते हैं:
+
+उदाहरण के लिए:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+automountServiceAccountToken: false
+...
+```
+
+आप किसी विशेष Pod के लिए भी API credentials की automounting बंद कर सकते हैं:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  serviceAccountName: build-robot
+  automountServiceAccountToken: false
+  ...
+```
+
+यदि ServiceAccount और Pod की `.spec` दोनों में
+`automountServiceAccountToken` का मान दिया गया है, तो Pod spec को प्राथमिकता मिलती है।
+
+## एक से अधिक ServiceAccount का उपयोग करें {#use-multiple-service-accounts}
+
+हर namespace में कम से कम एक ServiceAccount होता है: default ServiceAccount
+resource, जिसका नाम `default` है। आप
+[वर्तमान namespace](/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference)
+में सभी ServiceAccount resources की सूची इस तरह देख सकते हैं:
+
+```shell
+kubectl get serviceaccounts
+```
+
+आउटपुट इस प्रकार होगा:
+
+```
+NAME      SECRETS    AGE
+default   1          1d
+```
+
+आप अतिरिक्त ServiceAccount objects इस तरह बना सकते हैं:
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+EOF
+```
+
+ServiceAccount object का नाम एक वैध
+[DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) होना चाहिए।
+
+अगर आप service account object का पूरा dump ऐसे लेते हैं:
+
+```shell
+kubectl get serviceaccounts/build-robot -o yaml
+```
+
+तो आउटपुट इस तरह होगा:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2019-06-16T00:12:34Z
+  name: build-robot
+  namespace: default
+  resourceVersion: "272500"
+  uid: 721ab723-13bc-11e5-aec2-42010af0021e
+```
+
+आप authorization plugins का उपयोग करके
+[service accounts पर permissions सेट](/docs/reference/access-authn-authz/rbac/#service-account-permissions)
+कर सकते हैं।
+
+non-default service account का उपयोग करने के लिए Pod के `spec.serviceAccountName`
+field में उस ServiceAccount का नाम सेट करें जिसे आप उपयोग करना चाहते हैं।
+
+आप `serviceAccountName` field केवल Pod बनाते समय या नए Pod के template में ही सेट कर सकते हैं।
+पहले से मौजूद Pod की `.spec.serviceAccountName` field अपडेट नहीं की जा सकती।
+
+{{< note >}}
+`.spec.serviceAccount` field, `.spec.serviceAccountName` का deprecated alias है।
+अगर आप workload resource से fields हटाना चाहते हैं, तो [pod template](/docs/concepts/workloads/pods#pod-templates)
+पर दोनों fields को स्पष्ट रूप से empty सेट करें।
+{{< /note >}}
+
+### साफ़-सफ़ाई {#cleanup-use-multiple-service-accounts}
+
+अगर आपने ऊपर के उदाहरण से `build-robot` ServiceAccount बनाया है,
+तो इसे हटाने के लिए यह चलाएँ:
+
+```shell
+kubectl delete serviceaccount/build-robot
+```
+
+## ServiceAccount के लिए API token manually बनाएं
+
+मान लीजिए आपके पास पहले बताए अनुसार "build-robot" नाम का service account मौजूद है।
+
+आप `kubectl` से उस ServiceAccount के लिए time-limited API token प्राप्त कर सकते हैं:
+
+```shell
+kubectl create token build-robot
+```
+
+इस command का आउटपुट एक token होता है, जिससे आप उस
+ServiceAccount के रूप में authenticate कर सकते हैं। आप `kubectl create token` में
+`--duration` command line argument देकर token की विशेष duration मांग सकते हैं
+(हालांकि वास्तविक issued token duration छोटी भी हो सकती है या कभी-कभी लंबी भी)।
+
+{{< feature-state feature_gate_name="ServiceAccountTokenNodeBinding" >}}
+
+`kubectl` v1.31 या बाद के version में आप ऐसा service account token बना सकते हैं
+जो सीधे किसी Node से bound हो:
+
+```shell
+kubectl create token build-robot --bound-object-kind Node --bound-object-name node-001 --bound-object-uid 123...456
+```
+
+token तब तक वैध रहेगा जब तक वह expire न हो जाए, या उससे संबंधित Node या service account delete न हो जाए।
+
+{{< note >}}
+Kubernetes v1.22 से पहले के versions Kubernetes API access करने के लिए long term credentials
+स्वतः बनाते थे। यह पुराना तरीका token Secrets बनाने पर आधारित था जिन्हें फिर running Pods में mount किया जा सकता था।
+अधिक नए versions में, जिनमें Kubernetes v{{< skew currentVersion >}} भी शामिल है, API credentials सीधे
+[TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API के जरिए प्राप्त की जाती हैं,
+और इन्हें Pods में
+[projected volume (प्रोजेक्टेड वॉल्यूम)](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume)
+के जरिए mount किया जाता है।
+इस तरीके से प्राप्त tokens की सीमित lifetime होती है, और जिस Pod में वे mount हैं उसके delete होने पर
+वे स्वतः invalid हो जाते हैं।
+
+आप फिर भी manually service account token Secret बना सकते हैं; उदाहरण के लिए
+अगर आपको ऐसा token चाहिए जो कभी expire न हो। हालांकि API access के लिए token लेने का
+recommended तरीका [TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+subresource ही है।
+{{< /note >}}
+
+### ServiceAccount के लिए manually long-lived API token बनाएं
+
+अगर आप ServiceAccount के लिए API token लेना चाहते हैं, तो आपको
+एक नई Secret बनानी होगी जिसमें special annotation `kubernetes.io/service-account.name` हो।
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: build-robot-secret
+  annotations:
+    kubernetes.io/service-account.name: build-robot
+type: kubernetes.io/service-account-token
+EOF
+```
+
+अगर आप Secret को इस तरह देखें:
+
+```shell
+kubectl get secret/build-robot-secret -o yaml
+```
+
+तो आप देखेंगे कि अब इस Secret में "build-robot" ServiceAccount के लिए API token मौजूद है।
+
+आपके द्वारा सेट annotation की वजह से control plane उस ServiceAccount के लिए अपने-आप token बनाता है
+और उसे संबंधित Secret में store करता है। control plane delete किए गए ServiceAccounts के tokens भी साफ करता है।
+
+```shell
+kubectl describe secrets/build-robot-secret
+```
+
+आउटपुट इस तरह होगा:
+
+```
+Name:           build-robot-secret
+Namespace:      default
+Labels:         <none>
+Annotations:    kubernetes.io/service-account.name: build-robot
+                kubernetes.io/service-account.uid: da68f9c6-9d26-11e7-b84e-002dc52800da
+
+Type:   kubernetes.io/service-account-token
+
+Data
+====
+ca.crt:         1338 bytes
+namespace:      7 bytes
+token:          ...
+```
+
+{{< note >}}
+यहाँ `token` की सामग्री छोड़ी गई है।
+
+ध्यान रखें कि `kubernetes.io/service-account-token` Secret की सामग्री ऐसी जगह display न करें
+जहाँ कोई अन्य व्यक्ति आपकी terminal/computer screen देख सके।
+{{< /note >}}
+
+जब आप associated Secret वाले ServiceAccount को delete करते हैं, तो Kubernetes
+control plane उस Secret से long-lived token अपने-आप साफ कर देता है।
+
+{{< note >}}
+अगर आप ServiceAccount को इस तरह देखते हैं:
+
+` kubectl get serviceaccount build-robot -o yaml`
+
+तो ServiceAccount API object के
+[`.secrets`](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/) field में
+आपको `build-robot-secret` Secret नहीं दिखेगी, क्योंकि वह field केवल auto-generated Secrets से भरी जाती है।
+{{< /note >}}
+
+## Service account में ImagePullSecrets जोड़ें
+
+पहले, [imagePullSecret बनाएं](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)।
+फिर जांचें कि वह बन चुकी है। उदाहरण के लिए:
+
+- imagePullSecret बनाएं, जैसा कि
+  [Specifying ImagePullSecrets on a Pod](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) में बताया गया है।
+
+  ```shell
+  kubectl create secret docker-registry myregistrykey --docker-server=<registry name> \
+          --docker-username=DUMMY_USERNAME --docker-password=DUMMY_DOCKER_PASSWORD \
+          --docker-email=DUMMY_DOCKER_EMAIL
+  ```
+
+- जांचें कि यह बन चुकी है।
+
+  ```shell
+  kubectl get secrets myregistrykey
+  ```
+
+  आउटपुट इस तरह होगा:
+
+  ```
+  NAME             TYPE                              DATA    AGE
+  myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
+  ```
+
+### Service account में image pull secret जोड़ें
+
+अब namespace के default service account को modify करें ताकि वह इस Secret को imagePullSecret के रूप में उपयोग करे।
+
+```shell
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
+```
+
+आप object को manually edit करके भी यही परिणाम पा सकते हैं:
+
+```shell
+kubectl edit serviceaccount/default
+```
+
+`sa.yaml` file का आउटपुट कुछ ऐसा होगा:
+
+आपके चुने हुए text editor में कुछ इस तरह की configuration खुलेगी:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2021-07-07T22:02:39Z
+  name: default
+  namespace: default
+  resourceVersion: "243024"
+  uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
+```
+
+अपने editor का उपयोग करके `resourceVersion` key वाली line हटाएँ, `imagePullSecrets:`
+के लिए lines जोड़ें और save करें। `uid` value को उसी तरह रहने दें जैसा मिला था।
+
+इन बदलावों के बाद edited ServiceAccount कुछ ऐसा दिखेगा:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2021-07-07T22:02:39Z
+  name: default
+  namespace: default
+  uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
+imagePullSecrets:
+  - name: myregistrykey
+```
+
+### सत्यापित करें कि नए Pods के लिए imagePullSecrets सेट हैं
+
+अब जब current namespace में default ServiceAccount का उपयोग करते हुए नया Pod बनाया जाएगा,
+तो नए Pod की `spec.imagePullSecrets` field अपने-आप सेट होगी:
+
+```shell
+kubectl run nginx --image=<registry name>/nginx --restart=Never
+kubectl get pod nginx -o=jsonpath='{.spec.imagePullSecrets[0].name}{"\n"}'
+```
+
+आउटपुट:
+
+```
+myregistrykey
+```
+
+## ServiceAccount token वॉल्यूम प्रोजेक्शन
+
+{{< feature-state for_k8s_version="v1.20" state="stable" >}}
+
+{{< note >}}
+token request projection को enable और उपयोग करने के लिए, आपको `kube-apiserver` में
+निम्न command line arguments specify करने होंगे:
+
+`--service-account-issuer`
+: service account token issuer का Identifier परिभाषित करता है। आप
+  `--service-account-issuer` argument कई बार दे सकते हैं; यह issuer को बिना बाधा बदलेने के लिए उपयोगी हो सकता है।
+  जब यह flag कई बार दिया जाता है, तो पहला token generate करने के लिए उपयोग होता है और सभी values
+  accepted issuers तय करने के लिए उपयोग होती हैं। `--service-account-issuer` को कई बार
+  specify करने के लिए Kubernetes v1.22 या बाद का version आवश्यक है।
+
+`--service-account-key-file`
+: PEM-encoded X.509 private/public keys (RSA या ECDSA) वाली फ़ाइल का path बताता है,
+  जो ServiceAccount tokens verify करने के लिए उपयोग होती हैं। इस फ़ाइल में कई keys हो सकती हैं
+  और यह flag अलग-अलग files के साथ कई बार दिया जा सकता है।
+  यदि कई बार दिया जाए, तो किसी भी निर्दिष्ट key से signed tokens को Kubernetes API server वैध मानता है।
+
+`--service-account-signing-key-file`
+: उस फ़ाइल का path बताता है जिसमें service account token issuer की वर्तमान private key होती है।
+  issuer इसी private key से ID tokens sign करता है।
+
+`--api-audiences` (छोड़ा जा सकता है)
+: ServiceAccount tokens के audiences परिभाषित करता है। service account token authenticator
+  verify करता है कि API के विरुद्ध उपयोग हो रहे tokens इनमें से कम से कम एक audience से bound हों।
+  यदि `api-audiences` कई बार दिया जाए, तो किसी भी निर्दिष्ट audience के tokens Kubernetes API server द्वारा वैध माने जाते हैं।
+  यदि आप `--service-account-issuer` सेट करते हैं लेकिन `--api-audiences` नहीं सेट करते,
+  तो control plane default रूप से एक single-element audience list उपयोग करता है जिसमें केवल issuer URL होता है।
+
+{{< /note >}}
+
+kubelet ServiceAccount token को Pod में project भी कर सकता है। आप token की
+वांछित properties (जैसे audience और validity duration) specify कर सकते हैं।
+ये properties default ServiceAccount token पर configurable नहीं होतीं।
+Pod या ServiceAccount में से किसी एक के delete होने पर token API के लिए invalid हो जाएगा।
+
+Pod की `spec` में आप यह behavior
+[projected volume (प्रोजेक्टेड वॉल्यूम)](/docs/concepts/storage/volumes/#projected) type
+`ServiceAccountToken` का उपयोग करके कॉन्फ़िगर कर सकते हैं।
+
+इस projected volume का token एक {{<glossary_tooltip term_id="jwt" text="JSON Web Token">}} (JWT) होता है।
+इस token का JSON payload एक well-defined schema का पालन करता है। Pod-bound token का उदाहरण payload:
+
+```yaml
+{
+  "aud": [  # matches the requested audiences, or the API server's default audiences when none are explicitly requested
+    "https://kubernetes.default.svc"
+  ],
+  "exp": 1731613413,
+  "iat": 1700077413,
+  "iss": "https://kubernetes.default.svc",  # matches the first value passed to the --service-account-issuer flag
+  "jti": "ea28ed49-2e11-4280-9ec5-bc3d1d84661a", 
+  "kubernetes.io": {
+    "namespace": "kube-system",
+    "node": {
+      "name": "127.0.0.1",
+      "uid": "58456cb0-dd00-45ed-b797-5578fdceaced"
+    },
+    "pod": {
+      "name": "coredns-69cbfb9798-jv9gn",
+      "uid": "778a530c-b3f4-47c0-9cd5-ab018fb64f33"
+    },
+    "serviceaccount": {
+      "name": "coredns",
+      "uid": "a087d5a0-e1dd-43ec-93ac-f13d89cd13af"
+    },
+    "warnafter": 1700081020
+  },
+  "nbf": 1700077413,
+  "sub": "system:serviceaccount:kube-system:coredns"
+}
+```
+
+### Service account token projection का उपयोग करते हुए Pod लॉन्च करें
+
+Pod को `vault` audience और दो घंटे की validity duration वाला token देने के लिए
+आप ऐसा Pod manifest define कर सकते हैं:
+
+{{% code_sample file="pods/pod-projected-svc-token.yaml" %}}
+
+Pod बनाएं:
+
+```shell
+kubectl create -f https://k8s.io/examples/pods/pod-projected-svc-token.yaml
+```
+
+kubelet यह करेगा: Pod की ओर से token request और store करेगा;
+token को Pod में configurable file path पर उपलब्ध कराएगा;
+और expiration के करीब आते ही token refresh करेगा।
+यदि token अपनी कुल time-to-live (TTL) का 80% से पुराना हो जाए,
+या token 24 घंटे से पुराना हो, तो kubelet proactively rotation request करता है।
+
+token rotate होने पर application को token reload करना जिम्मेदारी है।
+अक्सर application के लिए token को schedule पर reload करना पर्याप्त होता है
+(उदाहरण: हर 5 मिनट), बिना वास्तविक expiry time track किए।
+
+### Service account issuer डिस्कवरी
+
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
+
+यदि आपने अपने cluster में ServiceAccounts के लिए
+[token projection](#serviceaccount-token-volume-projection) enable किया है,
+तो आप discovery feature भी उपयोग कर सकते हैं। Kubernetes clients को
+_identity provider_ की तरह federate करने का तरीका देता है, ताकि एक या अधिक
+external systems _relying party_ की तरह काम कर सकें।
+
+{{< note >}}
+issuer URL को
+[OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html) का पालन करना चाहिए।
+व्यवहार में इसका अर्थ है कि URL `https` scheme का उपयोग करे और
+`{service-account-issuer}/.well-known/openid-configuration` पर OpenID provider configuration serve करे।
+
+यदि URL इसका पालन नहीं करता, तो ServiceAccount issuer discovery endpoints
+register या accessible नहीं होंगे।
+{{< /note >}}
+
+enable होने पर Kubernetes API server HTTP के जरिए OpenID Provider
+Configuration document publish करता है। यह document
+`/.well-known/openid-configuration` पर उपलब्ध होता है।
+OpenID Provider Configuration को कभी-कभी _discovery document_ भी कहा जाता है।
+Kubernetes API server इससे संबंधित JSON Web Key Set (JWKS) भी HTTP के जरिए
+`/openid/v1/jwks` पर publish करता है।
+
+{{< note >}}
+`/.well-known/openid-configuration` और `/openid/v1/jwks` पर मिलने वाले responses
+OIDC compatible होने के लिए डिज़ाइन किए गए हैं, लेकिन strictly OIDC compliant नहीं हैं।
+इन documents में केवल वे parameters होते हैं जो Kubernetes service account tokens को
+validate करने के लिए आवश्यक हैं।
+{{< /note >}}
+
+जो clusters {{< glossary_tooltip text="RBAC" term_id="rbac">}} का उपयोग करते हैं, उनमें
+`system:service-account-issuer-discovery` नाम का एक default ClusterRole शामिल होता है।
+एक default ClusterRoleBinding यह role `system:serviceaccounts` group को assign करता है,
+जिससे सभी ServiceAccounts निहित रूप से जुड़े होते हैं।
+इससे cluster पर चल रहे pods अपने mounted service account token के जरिए
+service account discovery document access कर सकते हैं।
+इसके अतिरिक्त administrators अपनी सुरक्षा आवश्यकताओं और जिन external systems से वे federate करना चाहते हैं,
+उनके आधार पर इस role को `system:authenticated` या `system:unauthenticated` से भी bind कर सकते हैं।
+
+JWKS response में public keys होती हैं जिन्हें relying party Kubernetes service account tokens
+validate करने के लिए उपयोग कर सकती है। Relying parties पहले OpenID Provider Configuration query करती हैं,
+और response में `jwks_uri` field का उपयोग करके JWKS location प्राप्त करती हैं।
+
+कई स्थितियों में Kubernetes API servers public internet पर उपलब्ध नहीं होते,
+लेकिन API server से cached responses serve करने वाले public endpoints users या service providers द्वारा उपलब्ध कराए जा सकते हैं।
+ऐसे मामलों में OpenID Provider Configuration में `jwks_uri` को override किया जा सकता है ताकि वह API server address के बजाय
+public endpoint पर point करे। इसके लिए API server पर `--service-account-jwks-uri` flag पास किया जाता है।
+issuer URL की तरह JWKS URI में भी `https` scheme आवश्यक है।
+
+## {{% heading "whatsnext" %}}
+
+यह भी देखें:
+
+- [Cluster Admin Guide to Service Accounts](/docs/reference/access-authn-authz/service-accounts-admin/) पढ़ें।
+- [Authorization in Kubernetes](/docs/reference/access-authn-authz/authorization/) के बारे में पढ़ें।
+- [Secrets](/docs/concepts/configuration/secret/) के बारे में पढ़ें।
+  - या [Secrets का उपयोग करके credentials को सुरक्षित रूप से distribute करें](/docs/tasks/inject-data-application/distribute-credentials-secure/) सीखें।
+  - लेकिन यह भी ध्यान रखें कि ServiceAccount के रूप में authenticate करने के लिए Secrets का उपयोग deprecated है।
+    इसके लिए recommended विकल्प [ServiceAccount token volume projection](#serviceaccount-token-volume-projection) है।
+- [projected volumes](/docs/tasks/configure-pod-container/configure-projected-volume-storage/) के बारे में पढ़ें।
+- OIDC discovery की पृष्ठभूमि के लिए
+  [ServiceAccount signing key retrieval (प्राप्ति)](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1393-oidc-discovery)
+  Kubernetes Enhancement Proposal पढ़ें।
+- [OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html) पढ़ें।

--- a/content/hi/docs/tasks/configure-volume-storage.md
+++ b/content/hi/docs/tasks/configure-volume-storage.md
@@ -1,0 +1,135 @@
+---
+title: Storage के लिए Volume उपयोग करने हेतु Pod कॉन्फ़िगर करें
+content_type: task
+weight: 80
+---
+
+<!-- overview -->
+
+यह पेज दिखाता है कि storage के लिए Volume उपयोग करने हेतु Pod को कैसे कॉन्फ़िगर करें।
+
+किसी Container का file system केवल उतनी देर तक रहता है जितनी देर Container रहता है।
+इसलिए जब कोई Container terminate होकर फिर restart होता है, तो filesystem में किए गए बदलाव खो जाते हैं।
+Container से स्वतंत्र और अधिक consistent storage के लिए आप
+[Volume](/docs/concepts/storage/volumes/) का उपयोग कर सकते हैं।
+यह stateful applications (जैसे key-value stores, उदाहरण के लिए Redis, और databases) के लिए
+विशेष रूप से महत्वपूर्ण है।
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+<!-- steps -->
+
+## Pod के लिए volume कॉन्फ़िगर करें
+
+इस अभ्यास में आप ऐसा Pod बनाते हैं जिसमें एक Container चलता है। इस Pod में
+[emptyDir](/docs/concepts/storage/volumes/#emptydir) प्रकार का Volume होता है
+जो Pod के जीवनकाल तक बना रहता है, भले ही Container terminate होकर restart हो जाए।
+यह Pod की configuration file है:
+
+{{% code_sample file="pods/storage/redis.yaml" %}}
+
+1. Pod बनाएं:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/storage/redis.yaml
+   ```
+
+1. जांचें कि Pod का Container चल रहा है, और फिर Pod में होने वाले बदलाव देखें:
+
+   ```shell
+   kubectl get pod redis --watch
+   ```
+
+   आउटपुट इस तरह दिखेगा:
+
+   ```console
+   NAME      READY     STATUS    RESTARTS   AGE
+   redis     1/1       Running   0          13s
+   ```
+
+1. दूसरे terminal में, चल रहे Container का shell खोलें:
+
+   ```shell
+   kubectl exec -it redis -- /bin/bash
+   ```
+
+1. अपनी shell में `/data/redis` पर जाएँ, और फिर एक फ़ाइल बनाएं:
+
+   ```shell
+   root@redis:/data# cd /data/redis/
+   root@redis:/data/redis# echo Hello > test-file
+   ```
+
+1. अपनी shell में चल रही processes की सूची देखें:
+
+   ```shell
+   root@redis:/data/redis# apt-get update
+   root@redis:/data/redis# apt-get install procps
+   root@redis:/data/redis# ps aux
+   ```
+
+   आउटपुट इस तरह होगा:
+
+   ```console
+   USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+   redis        1  0.1  0.1  33308  3828 ?        Ssl  00:46   0:00 redis-server *:6379
+   root        12  0.0  0.0  20228  3020 ?        Ss   00:47   0:00 /bin/bash
+   root        15  0.0  0.0  17500  2072 ?        R+   00:48   0:00 ps aux
+   ```
+
+1. अपनी shell में Redis process को kill करें:
+
+   ```shell
+   root@redis:/data/redis# kill <pid>
+   ```
+
+   जहाँ `<pid>` Redis process ID (PID) है।
+
+1. अपने मूल terminal में Redis Pod में होने वाले बदलाव देखें। अंततः
+   आपको कुछ ऐसा दिखाई देगा:
+
+   ```console
+   NAME      READY     STATUS     RESTARTS   AGE
+   redis     1/1       Running    0          13s
+   redis     0/1       Completed  0         6m
+   redis     1/1       Running    1         6m
+   ```
+
+इस बिंदु पर Container terminate होकर restart हो चुका है। ऐसा इसलिए है क्योंकि
+Redis Pod की
+[restartPolicy](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core)
+`Always` है।
+
+1. restarted Container के अंदर shell खोलें:
+
+   ```shell
+   kubectl exec -it redis -- /bin/bash
+   ```
+
+1. अपनी shell में `/data/redis` पर जाएँ, और सत्यापित करें कि `test-file` अभी भी मौजूद है।
+
+   ```shell
+   root@redis:/data/redis# cd /data/redis/
+   root@redis:/data/redis# ls
+   test-file
+   ```
+
+1. इस अभ्यास के लिए बनाया गया Pod हटाएं:
+
+   ```shell
+   kubectl delete pod redis
+   ```
+
+## {{% heading "whatsnext" %}}
+
+- [Volume](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#volume-v1-core) देखें।
+
+- [Pod](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core) देखें।
+
+- `emptyDir` द्वारा दिए गए local disk storage के अलावा, Kubernetes कई प्रकार के
+  network-attached storage solutions को सपोर्ट करता है, जिनमें GCE पर PD और EC2 पर EBS शामिल हैं।
+  ये critical data के लिए अधिक उपयुक्त हैं और nodes पर devices को mount/unmount करने जैसे
+  विवरण संभालते हैं। अधिक जानकारी के लिए
+  [Volumes](/docs/concepts/storage/volumes/) देखें।

--- a/content/hi/docs/tasks/enforce-standards-admission-controller.md
+++ b/content/hi/docs/tasks/enforce-standards-admission-controller.md
@@ -1,0 +1,70 @@
+---
+title: Built-in Admission Controller कॉन्फ़िगर करके Pod Security Standards लागू करें
+reviewers:
+- tallclair
+- liggitt
+content_type: task
+weight: 240
+---
+
+Kubernetes, [Pod Security Standards](/docs/concepts/security/pod-security-standards) को लागू करने के लिए
+एक built-in [admission controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity) प्रदान करता है।
+आप इस admission controller को cluster-wide defaults और
+[exemptions](/docs/concepts/security/pod-security-admission/#exemptions) सेट करने के लिए कॉन्फ़िगर कर सकते हैं।
+
+## {{% heading "prerequisites" %}}
+
+Kubernetes v1.22 में alpha release के बाद,
+Pod Security Admission Kubernetes v1.23 में beta रूप में default रूप से उपलब्ध हुआ।
+version 1.25 से आगे, Pod Security Admission सामान्य रूप से उपलब्ध (generally available) है।
+
+{{% version-check %}}
+
+अगर आप Kubernetes {{< skew currentVersion >}} नहीं चला रहे हैं, तो आप इस पेज का
+वह documentation version चुन सकते हैं जो आपके चल रहे Kubernetes version से मेल खाता है।
+
+## Admission Controller कॉन्फ़िगर करें
+
+{{< note >}}
+`pod-security.admission.config.k8s.io/v1` configuration के लिए v1.25+ आवश्यक है।
+v1.23 और v1.24 के लिए [v1beta1](https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/) उपयोग करें।
+v1.22 के लिए [v1alpha1](https://v1-22.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/) उपयोग करें।
+{{< /note >}}
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1 # see compatibility note
+    kind: PodSecurityConfiguration
+    # Defaults applied when a mode label is not set.
+    #
+    # Level label values must be one of:
+    # - "privileged" (default)
+    # - "baseline"
+    # - "restricted"
+    #
+    # Version label values must be one of:
+    # - "latest" (default) 
+    # - specific version like "v{{< skew currentVersion >}}"
+    defaults:
+      enforce: "privileged"
+      enforce-version: "latest"
+      audit: "privileged"
+      audit-version: "latest"
+      warn: "privileged"
+      warn-version: "latest"
+    exemptions:
+      # Array of authenticated usernames to exempt.
+      usernames: []
+      # Array of runtime class names to exempt.
+      runtimeClasses: []
+      # Array of namespaces to exempt.
+      namespaces: []
+```
+
+{{< note >}}
+ऊपर दिया गया manifest, kube-apiserver के लिए `--admission-control-config-file` के माध्यम से specify करना होगा।
+{{< /note >}}

--- a/content/hi/docs/tasks/enforce-standards-namespace-labels.md
+++ b/content/hi/docs/tasks/enforce-standards-namespace-labels.md
@@ -1,0 +1,94 @@
+---
+title: Namespace Labels के साथ Pod Security Standards लागू करें
+reviewers:
+- tallclair
+- liggitt
+content_type: task
+weight: 250
+---
+
+Namespaces को label करके [Pod Security Standards](/docs/concepts/security/pod-security-standards) लागू किए जा सकते हैं।
+तीन policies
+[privileged (प्रिविलेज्ड)](/docs/concepts/security/pod-security-standards/#privileged), [baseline (बेसलाइन)](/docs/concepts/security/pod-security-standards/#baseline)
+और [restricted](/docs/concepts/security/pod-security-standards/#restricted) सुरक्षा स्पेक्ट्रम को व्यापक रूप से कवर करती हैं
+और इन्हें [Pod Security](/docs/concepts/security/pod-security-admission/)
+{{< glossary_tooltip text="admission controller" term_id="admission-controller" >}} द्वारा लागू किया जाता है।
+
+## {{% heading "prerequisites" %}}
+
+Pod Security Admission Kubernetes v1.23 में beta रूप में default रूप से उपलब्ध था।
+version 1.25 से आगे, Pod Security Admission सामान्य रूप से उपलब्ध (generally available) है।
+
+{{% version-check %}}
+
+## Namespace labels के साथ `baseline` Pod Security Standard अनिवार्य करना
+
+यह manifest `my-baseline-namespace` नाम का Namespace परिभाषित करता है, जो:
+
+- ऐसे किसी भी pods को _block_ करता है जो `baseline` policy requirements पूरी नहीं करते।
+- बनाए गए उन pods के लिए user-facing warning जनरेट करता है और audit annotation जोड़ता है जो
+  `restricted` policy requirements पूरी नहीं करते।
+- `baseline` और `restricted` policies के versions को v{{< skew currentVersion >}} पर pin करता है।
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-baseline-namespace
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: v{{< skew currentVersion >}}
+
+    # We are setting these to our _desired_ `enforce` level.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v{{< skew currentVersion >}}
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v{{< skew currentVersion >}}
+```
+
+## `kubectl label` के साथ मौजूदा namespaces में labels जोड़ें
+
+{{< note >}}
+जब `enforce` policy (या version) label जोड़ा या बदला जाता है, admission plugin namespace के
+हर pod को नई policy के विरुद्ध test करता है। उल्लंघन user को warnings के रूप में लौटाए जाते हैं।
+{{< /note >}}
+
+namespaces के लिए security profile changes का प्रारंभिक मूल्यांकन करते समय `--dry-run` flag लगाना उपयोगी होता है।
+Pod Security Standard checks _dry run_ mode में भी चलेंगी, जिससे आपको यह जानकारी मिलेगी
+कि नई policy मौजूदा pods को कैसे treat करेगी, बिना वास्तव में policy अपडेट किए।
+
+```shell
+kubectl label --dry-run=server --overwrite ns --all \
+    pod-security.kubernetes.io/enforce=baseline
+```
+
+### सभी namespaces पर लागू करना
+
+अगर आप Pod Security Standards के साथ शुरुआत कर रहे हैं, तो एक उपयुक्त पहला कदम यह होगा कि
+सभी namespaces में `baseline` जैसे अधिक सख्त स्तर के लिए audit annotations कॉन्फ़िगर करें:
+
+```shell
+kubectl label --overwrite ns --all \
+  pod-security.kubernetes.io/audit=baseline \
+  pod-security.kubernetes.io/warn=baseline
+```
+
+ध्यान दें कि यह enforce level सेट नहीं कर रहा है, ताकि जिन namespaces का स्पष्ट रूप से
+मूल्यांकन नहीं हुआ है उन्हें अलग पहचाना जा सके। आप explicit enforce level के बिना namespaces को
+इस कमांड से सूचीबद्ध कर सकते हैं:
+
+```shell
+kubectl get namespaces --selector='!pod-security.kubernetes.io/enforce'
+```
+
+### एक single namespace पर लागू करना
+
+आप किसी specific namespace को भी अपडेट कर सकते हैं। यह कमांड `my-existing-namespace` में
+`enforce=restricted` policy जोड़ती है, और restricted policy version को
+v{{< skew currentVersion >}} पर pin करती है।
+
+```shell
+kubectl label --overwrite ns my-existing-namespace \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/enforce-version=v{{< skew currentVersion >}}
+```


### PR DESCRIPTION
This PR adds Hindi localization for the tasks/configure-pod-container documentation page.
It translates the English documentation while keeping code blocks and commands unchanged.