### PR TITLE
Show version and language selectors on tablet screens

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -38,12 +38,12 @@
     </li>
     {{ end }}
     {{ if .Site.Params.versions -}}
-      <li class="nav-item dropdown mr-4 d-none d-lg-block">
+      <li class="nav-item dropdown mr-4 d-none d-md-block">
         {{ partial "navbar-version-selector.html" . -}}
       </li>
       {{ end -}}
       {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item dropdown mr-xl-4 d-none d-lg-block">
+      <li class="nav-item dropdown mr-xl-4 d-none d-md-block">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}


### PR DESCRIPTION
On some tablet screens (iPad air, iPad mini, also tried when using my mobile phone in desktop mode) the version and language selectors are missing as show below:

<img width="1332" height="228" alt="image" src="https://github.com/user-attachments/assets/736f437b-5934-4192-a2c3-7fb976252aab" />


this pr fixes the navbar to `d-md-block` (768px+) 

<img width="1488" height="374" alt="image" src="https://github.com/user-attachments/assets/802677ff-e301-4f72-8b2e-821f812ad609" />



preview on a tablet or mobile phone with browser in desktop mode

https://deploy-preview-54928--kubernetes-io-main-staging.netlify.app/


## Issues
Closes https://github.com/kubernetes/website/issues/54939