### PR TITLE
Revert CJK line break extension that stripped spaces

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -54,10 +54,6 @@ enableGitInfo = true
      autoHeadingIDType = "blackfriday"
    [markup.goldmark.renderer]
      unsafe = true
-   [markup.goldmark.extensions.cjk]
-     eastAsianLineBreaks = true
-     eastAsianLineBreaksStyle = "css3draft"
-     enable = true
   [markup.highlight]
     codeFences = true
     guessSyntax = false


### PR DESCRIPTION
- Reverts the goldmark CJK extension (`[markup.goldmark.extensions.cjk]`) added in #54897
- The extension removed spaces at soft line breaks, breaking rendering for all multi-line paragraphs site-wide