### PR TITLE
Add a space before hyperlink _index.md

### DIFF
--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -24,7 +24,7 @@ This page is an overview of Kubernetes.
 
 The name Kubernetes originates from Greek, meaning helmsman or pilot. K8s as an abbreviation
 results from counting the eight letters between the "K" and the "s". Google open sourced the
-Kubernetes project in 2014. Kubernetes combines
+Kubernetes project in 2014. Kubernetes combines 
 [over 15 years of Google's experience](/blog/2015/04/borg-predecessor-to-kubernetes/) running
 production workloads at scale with best-of-breed ideas and practices from the community.
 


### PR DESCRIPTION
### Description
When reading the docs, I realized no space is present after the word 'combines'. This makes a minor noticeable issue when reading this docs.

### Issue
Readability issue where no space is present. This PR fixes it.

Closes: #