### PR TITLE
Fix color for hovered nav bar text

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -12,8 +12,8 @@ $white: #ffffff;
 
 // Navbar colors
 $navbar-dark-color: #ffffff;
-$navbar-dark-hover-color: #326ce5;
-$navbar-dark-active-color: #326ce5;
+$navbar-dark-hover-color: $primary;
+$navbar-dark-active-color: $primary;
 
 // feature gate colors
 $feature: #daeaf9;


### PR DESCRIPTION
This PR fixes the hover state of navigation links to maintain visibility when the navbar background is white.

Before:
<img width="1347" height="629" alt="Screenshot 2026-03-17 153802" src="https://github.com/user-attachments/assets/67d33b92-fc79-4811-8bd8-dc4f627c5163" />

After:
<img width="1348" height="625" alt="Screenshot 2026-03-17 153713" src="https://github.com/user-attachments/assets/3bc3683f-2695-4b9d-a4c4-562bc91924e4" />


#54938