### PR TITLE
fix navbar link hover color invisible on white background

### DIFF
--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -66,10 +66,8 @@
   .navbar-nav .nav-link, #hamburger {
     color: $dark-grey;
 
-    &:hover,
-    &:focus,
     &:hover:focus {
-      color: $medium-grey !important;
+      color: $medium-grey;
     }
   }
 
@@ -90,6 +88,13 @@
   .navbar-brand__logo.navbar-logo svg #its-pronounced path {
     fill: $primary;
   }
+}
+
+nav.navbar-bg-onscroll .navbar-nav .nav-link:hover,
+nav.navbar-bg-onscroll .navbar-nav .nav-link:focus,
+nav.navbar-bg-onscroll #hamburger:hover,
+nav.navbar-bg-onscroll #hamburger:focus {
+  color: $medium-grey;
 }
 
 /* Small/Mobile viewport nav menu */


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

The navbar has two states:
- Dark background (top of page): nav links are white — correct
- White background (after scrolling): nav links should be dark

When `.navbar-bg-onscroll` is active (white background), hovering 
over nav links was triggering `.navbar-dark`'s hover rule which set 
text color to white — making links invisible (white text on white background).

**Root cause:** The original code only handled `&:hover:focus` 
(both simultaneously) but was missing separate `&:hover` and `&:focus` 
rules. So a simple hover had no override and `.navbar-dark` took over.

**Fix:** Added separate `&:hover` and `&:focus` selectors with 
`$medium-grey !important` to override `.navbar-dark` correctly.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #54938