### PR TITLE
[pl] Clarify POSIX shell requirement for Kubernetes Basics tutorial - sync with PR 54857

### DIFF
--- a/content/pl/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
+++ b/content/pl/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
@@ -9,6 +9,17 @@ weight: 10
 - Dowiedz się, czym jest Minikube.
 * Uruchom klaster Kubernetesa.
 
+## {{% heading "prerequisites" %}}
+
+Polecenia w tym poradniku są napisane w składni zgodnej ze standardem POSIX, którą
+obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh). Jeśli
+używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub
+[Git Bash](https://gitforwindows.org/), żeby
+uruchomić je w takiej formie. Polecenia z `export`, `$()` i podobnymi
+elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
+
+
 ## Klastry Kubernetesa {#kubernetes-clusters}
 
 {{% alert %}}

--- a/content/pl/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
+++ b/content/pl/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.md
@@ -8,6 +8,18 @@ weight: 10
 * Poznaj sposób wdrażania aplikacji.
 * Wdróż swoją pierwszą aplikację na Kubernetesie za pomocą narzędzia kubectl.
 
+
+## {{% heading "prerequisites" %}}
+
+Polecenia w tym poradniku są napisane w składni zgodnej ze standardem POSIX, którą
+obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh). Jeśli
+używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub
+[Git Bash](https://gitforwindows.org/), żeby
+uruchomić je w takiej formie. Polecenia z `export`, `$()` i podobnymi
+elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
+
+
 ## Deploymenty w Kubernetesie {#kubernetes-deployments}
 
 {{% alert %}}

--- a/content/pl/docs/tutorials/kubernetes-basics/explore/explore-intro.md
+++ b/content/pl/docs/tutorials/kubernetes-basics/explore/explore-intro.md
@@ -9,6 +9,17 @@ weight: 10
 * Zrozumieć, jak działają węzły Kubernetesa.
 * Nauczyć się rozwiązywać problemy z aplikacjami.
 
+## {{% heading "prerequisites" %}}
+
+Polecenia w tym poradniku są napisane w składni zgodnej ze standardem POSIX, którą
+obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh). Jeśli
+używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub
+[Git Bash](https://gitforwindows.org/), żeby
+uruchomić je w takiej formie. Polecenia z `export`, `$()` i podobnymi
+elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
+
+
 ## Pody Kubernetesa {#kubernetes-pods}
 
 {{% alert %}}

--- a/content/pl/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/pl/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -9,6 +9,17 @@ weight: 10
 * Zrozum, jak etykiety (labels) i selektory (selectors) są powiązane z Service.
 * Wystaw aplikację na zewnątrz klastra Kubernetesa.
 
+## {{% heading "prerequisites" %}}
+
+Polecenia w tym poradniku są napisane w składni zgodnej ze standardem POSIX, którą
+obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh). Jeśli
+używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub
+[Git Bash](https://gitforwindows.org/), żeby
+uruchomić je w takiej formie. Polecenia z `export`, `$()` i podobnymi
+elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
+
+
 ## Kubernetes Services - przegląd {#overview-of-kubernetes-services}
 
 [Pody](/docs/concepts/workloads/pods/) Kubernetesa są nietrwałe. Pody mają swój

--- a/content/pl/docs/tutorials/kubernetes-basics/scale/scale-intro.md
+++ b/content/pl/docs/tutorials/kubernetes-basics/scale/scale-intro.md
@@ -7,6 +7,18 @@ weight: 10
 
 * Ręczne skalowanie istniejącej aplikacji za pomocą narzędzia kubectl.
 
+## {{% heading "prerequisites" %}}
+
+Polecenia w tym poradniku są napisane w składni zgodnej ze standardem POSIX, którą
+obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh). Jeśli
+używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub
+[Git Bash](https://gitforwindows.org/), żeby
+uruchomić je w takiej formie. Polecenia z `export`, `$()` i podobnymi
+elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
+
+
+
 ## Skalowanie aplikacji {#scaling-an-application}
 
 {{% alert %}}

--- a/content/pl/docs/tutorials/kubernetes-basics/update/update-intro.md
+++ b/content/pl/docs/tutorials/kubernetes-basics/update/update-intro.md
@@ -7,6 +7,17 @@ weight: 10
 
 Wykonaj aktualizację Rolling Update używając kubectl.
 
+## {{% heading "prerequisites" %}}
+
+Polecenia w tym poradniku są napisane w składni zgodnej ze standardem POSIX, którą
+obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh). Jeśli
+używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub
+[Git Bash](https://gitforwindows.org/), żeby
+uruchomić je w takiej formie. Polecenia z `export`, `$()` i podobnymi
+elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
+
+
 ## Aktualizowanie aplikacji {#updating-an-application}
 
 {{% alert %}}


### PR DESCRIPTION
[pl] Clarify POSIX shell requirement for Kubernetes Basics tutorial - sync with PR #54857

---

6 plikow - w kadym dodano taki sam akapit : 

"
Polecenia w tym poradniku są napisane w składni POSIX, którą obsługują domyślne powłoki w Linuxie i macOS (np. bash, zsh, sh).
Jeśli używasz Windowsa, potrzebujesz powłoki zgodnej z POSIX, np. WSL [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lub [Git Bash](https://gitforwindows.org/), żeby uruchomić je w takiej formie.
Polecenia z `export`, `$()` i podobnymi elementami **nie** zadziałają w PowerShellu ani w zwykłym wierszu polecenia.
"