### PR TITLE
Fix the layout in launch-card

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -479,15 +479,8 @@ body.docs-portal {
       row-gap: 1rem;
       column-gap: 1rem;
       .launch-card {
-        .card-content {
-          width: fit-content;
-          flex-grow: initial;
-        }
         max-width: calc(min(80vw, 40em));
         padding: 0.75rem;
-        > .card-content button {
-          align-self: flex-end;
-        }
       }
     }
     @media (max-width: 60rem) {


### PR DESCRIPTION
Removed the unwanted bad layout conditions in `xl` and above sized displays

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

It appears that the problem was caused due to seperate formatting in case of xl and above sized screens.

Before - On large screens:
- It says the content width to only how much is requred (shrink fit type)
- It says the button to be right aligned

Now - On large screens:
- Does nothing like the above, and keept it clean and perfectly aligned!



<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #54949


cc : @divya-mohan0209 @nate-double-u 