### PR TITLE
[WIP][LFX] Add test suite defining detector contract for content-based outdated l10n detection

### DIFF
--- a/scripts/content_detection_benchmark/README.md
+++ b/scripts/content_detection_benchmark/README.md
@@ -1,0 +1,358 @@
+# Content Drift Detection Benchmark
+
+## Overview
+
+This benchmark provides a standardized way to measure and compare outdated-content
+detectors for Kubernetes documentation translations.
+
+Given any two detectors — a baseline and a candidate — it runs both against a
+controlled set of 47 deterministic scenarios derived from three real EN/KO page
+pairs, scores each detector's outputs against ground-truth labels, and writes a
+structured report. The goal is to make it easy to experiment with new approaches
+and see concretely where they improve or regress relative to a baseline.
+
+All detectors must follow the standardized detector contract:
+- **Input:** `<en_doc_path> <l10n_doc_path>`
+- **Output:** JSON with a `"status"` field set to one of:
+  `up_to_date`, `candidate_outdated`, `outdated_low_severity`,
+  `no_english_version`, `not_translated`
+- **Example:** `{"status": "candidate_outdated", "signals": [...], "sections": [...]}`
+
+---
+
+## Background
+
+### The problem (Issue [#54896](https://github.com/kubernetes/website/issues/54896))
+
+Kubernetes localization teams often use tools that determine whether a translation
+is outdated by comparing commit timestamps or commit ordering. These timestamp-based
+signals are cheap to compute but tend to produce two systematic failure modes:
+
+**Failure mode 1 — False positives**
+
+English documentation often changes in ways that do not require translation
+updates: formatting adjustments, link canonicalization, shortcode syntax changes.
+These edits advance the English file's commit timestamp, causing timestamp-based
+tools to flag the translation as outdated even though nothing meaningful changed.
+
+**Failure mode 2 — False negatives (false synchronization points)**
+
+A more serious failure occurs when a small localized edit is committed after a
+meaningful English update. Because such tools look for English commits *newer
+than the latest Korean commit*, they conclude the translation is current — even
+though the meaningful English change was never translated.
+
+Example:
+1. English documentation is updated with a deprecation warning.
+2. The Korean translation is now silently out of date.
+3. A contributor later fixes a typo in the Korean file.
+4. The tool reports: *still in sync* — the older English update is masked.
+
+### A content-based approach
+
+One alternative is to compare the *current English file* directly against the
+*current localized file* by analyzing document structure: headings, paragraphs,
+code blocks, lists, and shortcodes.
+
+Because translations typically preserve the structural skeleton of the original
+document, meaningful upstream updates generally appear as structural differences
+— detectable without cross-language semantic analysis.
+
+This benchmark is designed to evaluate whether such an approach outperforms
+commit-history methods on the failure modes described above. Any detector
+following the standardized detector contract can be plugged in as the candidate.
+
+---
+
+## Files
+
+```
+website/scripts/content_detection_benchmark/
+  generate_repo.py    — build the deterministic test git repository
+  scenarios.json      — ground-truth scenarios (47 scenarios, 14 families, 3 pages)
+  run_eval.py         — run detectors, validate outputs against contract, score, write report.md
+  README.md           — this file
+
+  (generated, not committed)
+  report.md           — evaluation report written by run_eval.py
+```
+
+Detector scripts are passed at runtime via `--baseline` and `--candidate` and
+can live anywhere. Each must follow the standardized detector contract described
+in the Overview above.
+
+---
+
+## How the benchmark works
+
+### Step 1 — Generate the test repository
+
+`generate_repo.py` creates a deterministic git repository at
+`/tmp/k8s-l10n-test-repo` containing 47 controlled scenarios, committed in the
+exact pattern each detector expects.
+
+**Group 1 scenarios** use multi-commit histories. The indexed-job page is
+initialized, then an English mutation is committed on top. A timestamp-based
+detector fires based on the commit delta; a content-based detector fires based on
+structural content differences.
+
+**Group 2 scenarios** are committed in a single snapshot (all EN + KO files
+together). A timestamp-based detector sees no history delta and returns
+*up_to_date* for all of them. Only a content-aware detector can detect genuine
+drift in this group.
+
+### Step 2 — Run the evaluation
+
+`run_eval.py` loads `scenarios.json`, runs both detectors against every scenario,
+validates their outputs against the standardized detector contract, resolves
+pass/fail against the manifest's expected labels, computes precision/recall/F1,
+and writes `report.md`.
+
+### The canonical label set
+
+All detectors must follow the standardized detector contract
+and return one of these status values:
+
+| Label | Meaning |
+|---|---|
+| `up_to_date` | Translation is current; no action needed |
+| `candidate_outdated` | Translation likely needs updating |
+| `outdated_low_severity` | Low-severity structural difference detected (shortcode-only drift) |
+| `no_english_version` | English source file not found |
+| `not_translated` | Localized file not found |
+| `error` | Tool execution failure or non-contract output |
+
+`no_english_version`, `not_translated`, and `error` outputs are excluded from all metric calculations.
+
+### Scoring
+
+Both `candidate_outdated` and `outdated_low_severity` count as a **positive
+detection**. This reflects the tool's design intent: surface anything that
+signals drift, and let a maintainer decide its severity.
+
+---
+
+## Scenarios
+
+The benchmark contains **47 scenarios** drawn from three real Kubernetes
+documentation page pairs (EN + KO):
+
+| Page ID | Source file |
+|---|---|
+| `indexed-job` | `tasks/job/indexed-parallel-processing-static.md` |
+| `redis-tutorial` | `tutorials/configuration/configure-redis-using-configmap.md` |
+| `configure-liveness` | `tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md` |
+
+### Group 1 — Git-history scenarios (5 scenarios)
+
+These scenarios are designed to expose where commit-timestamp detection produces
+false positives and false negatives. All five use the indexed-job page. A
+timestamp-based baseline is expected to struggle on 4 of 5; a content-aware
+candidate should handle all 5 correctly.
+
+| Scenario | What changes | Ground truth | Expected baseline | Expected candidate |
+|---|---|---|---|---|
+| `fp_formatting` | Emphasis style swap (`_x_` → `*x*`) in EN | `not_outdated` | `candidate_outdated` (FP) | `up_to_date` |
+| `fp_links` | Link canonicalization (relative → absolute URL) in EN | `not_outdated` | `candidate_outdated` (FP) | `up_to_date` |
+| `fp_shortcodes` | Shortcode delimiter swap (`{{< >}}` → `{{% %}}`) in EN | `not_outdated` | `candidate_outdated` (FP) | `up_to_date` |
+| `fn_false_sync` | Meaningful EN addition, then cosmetic KO commit masks it | `outdated` | `up_to_date` (FN) | `candidate_outdated` |
+| `tp_normal_change` | New section appended to EN | `outdated` | `candidate_outdated` | `candidate_outdated` |
+
+### Group 2 — Structural scenarios (42 scenarios, 14 per page)
+
+Each of the three pages gets the same 14 mutation families applied. Because all
+files are committed together, a timestamp-based baseline always returns
+`up_to_date` — only the candidate is scored in this group.
+
+All families belong to the same formal group (`group2_structural`). Notes on
+individual families explain known detector limitations — these are informational,
+not separate scoring buckets.
+
+#### Control and cosmetic families
+
+| Family | What changes | Ground truth | Expected candidate | Notes |
+|---|---|---|---|---|
+| `baseline_unmodified` | Nothing — raw base pair | `not_outdated` | `up_to_date` | Control case |
+| `paragraph_reflow` | KO sentence extended with a benign extra clause | `not_outdated` | `up_to_date` or `outdated_low_severity` | KO-side reflow only |
+| `shortcode_only_change` | EN shortcode alias renamed (cosmetic) | `not_outdated` | `up_to_date` | Detector should ignore it |
+| `paragraph_reorder` | KO paragraphs swapped in position | `not_outdated` | `up_to_date` or `outdated_low_severity` | Currently limited by block alignment |
+
+#### Reliable detection families
+
+These families represent the current reliable capability of structural comparison.
+
+| Family | What changes | Ground truth | Expected candidate |
+|---|---|---|---|
+| `missing_paragraph` | KO paragraph deleted | `outdated` | `candidate_outdated` |
+| `paragraph_extended_in_english` | EN paragraph extended with new meaningful info | `outdated` | `candidate_outdated` |
+| `list_item_added_in_english` | New step appended to EN overview list | `outdated` | `candidate_outdated` |
+| `list_item_removed_translation` | List item deleted from KO | `outdated` | `candidate_outdated` |
+| `heading_rename` | EN section heading renamed | `outdated` | `outdated_low_severity` |
+| `combined_drift` | Paragraph extension + heading rename + list item (stress test) | `outdated` | `candidate_outdated` |
+
+#### Capability probe families
+
+These families probe harder detection cases. Known limitations are noted; partial
+results are still informative.
+
+| Family | What changes | Ground truth | Expected candidate | Notes |
+|---|---|---|---|---|
+| `missing_code_block` | KO code block deleted | `outdated` | `candidate_outdated` or `outdated_low_severity` | Currently limited by block alignment |
+| `paragraph_rewritten_in_english` | EN paragraph semantically rewritten | `outdated` | `candidate_outdated` or `outdated_low_severity` | Currently limited by intra-block comparison |
+| `code_command_changed` | `kubectl apply` → `kubectl create` in EN code block | `outdated` | `candidate_outdated` | Currently limited by intra-block comparison |
+| `code_parameters_changed` | `--namespace=default` flag added to EN code block | `outdated` | `candidate_outdated` | Currently limited by intra-block comparison |
+
+---
+
+## How to run
+
+### Prerequisites
+
+- Python 3.9+
+- `git` available in PATH
+- Two detector scripts (any location; each must follow the standardized detector contract)
+
+### Step 1 — Generate the test repository
+
+```bash
+cd website/scripts/content_detection_benchmark
+
+# Minimal (indexed-job page only, 5 Group 1 + 14 Group 2 = 19 scenarios)
+python3 generate_repo.py \
+  --base-en   ../../content/en/docs/tasks/job/indexed-parallel-processing-static.md \
+  --base-l10n ../../content/ko/docs/tasks/job/indexed-parallel-processing-static.md
+# Output: /tmp/k8s-l10n-test-repo
+```
+
+```bash
+# Full benchmark (all 3 pages, 47 scenarios) — also updates scenarios.json
+python3 generate_repo.py \
+  --base-en   ../../content/en/docs/tasks/job/indexed-parallel-processing-static.md \
+  --base-l10n ../../content/ko/docs/tasks/job/indexed-parallel-processing-static.md \
+  --extra-page redis-tutorial:\
+../../content/en/docs/tutorials/configuration/configure-redis-using-configmap.md:\
+../../content/ko/docs/tutorials/configuration/configure-redis-using-configmap.md \
+  --extra-page configure-liveness:\
+../../content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md:\
+../../content/ko/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md \
+  --update-manifest
+# Output: /tmp/k8s-l10n-test-repo  +  scenarios.json updated in place
+```
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--base-en PATH` | EN source for the indexed-job page (required) |
+| `--base-l10n PATH` | KO source for the indexed-job page (required) |
+| `--extra-page ID:EN:KO` | Additional page pair; repeatable |
+| `--lang CODE` | Language code (default: `ko`) |
+| `--output-dir PATH` | Test repo directory (default: `/tmp/k8s-l10n-test-repo`) |
+| `--update-manifest` | Rewrite `scenarios.json` with all generated scenarios |
+
+### Step 2 — Run the evaluation
+
+Detector commands are resolved relative to wherever you invoke `run_eval.py`.
+Use absolute paths, or `cd` to the directory containing your detector scripts
+before running.
+
+```bash
+python3 run_eval.py \
+  --repo      /tmp/k8s-l10n-test-repo \
+  --baseline  "python3 /path/to/baseline_detector.py" \
+  --candidate "python3 /path/to/candidate_detector.py"
+# Output: report.md
+```
+
+**If your detector does not already follow the standardized contract**, write a
+thin adapter script that calls it and converts its output to the required JSON
+format, then pass the adapter as the detector command.
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--repo PATH` | Path to the generated test repository (required) |
+| `--baseline CMD` | Baseline detector command (required) |
+| `--candidate CMD` | Candidate detector command (required) |
+| `--lang CODE` | Language code (default: `ko`) |
+| `--manifest PATH` | Path to scenarios.json (default: same directory as run_eval.py) |
+| `--output PATH` | Output report path (default: `report.md`) |
+
+### Reading the report
+
+`report.md` has five sections:
+
+| Section | What it shows |
+|---|---|
+| **1. Group 1 summary** | Git-history scenarios: baseline vs. candidate, side by side |
+| **2. Group 2 summary** | Structural scenarios: candidate labels and pass/fail per scenario |
+| **3. By-family summary** | Aggregate metrics per mutation family across all pages |
+| **4. By-page summary** | Aggregate metrics per page across all families |
+| **5. Interpretation notes** | Prose explanation of what failures mean and how to read the numbers |
+
+**Primary metric:** F1 score on the combined candidate run. Higher is better.
+
+---
+
+## Adding new page pairs
+
+To evaluate detectors on additional real pages, add them as `--extra-page`
+arguments and re-run with `--update-manifest`:
+
+```bash
+python3 generate_repo.py \
+  --base-en   ../../content/en/docs/tasks/job/indexed-parallel-processing-static.md \
+  --base-l10n ../../content/ko/docs/tasks/job/indexed-parallel-processing-static.md \
+  --extra-page my-page:../../content/en/path/to/my-page.md:../../content/ko/path/to/my-page.md \
+  --update-manifest
+```
+
+`generate_repo.py` will:
+1. Inspect the new page for structural capabilities (paragraphs, code blocks,
+   headings, lists, kubectl commands, shortcodes).
+2. Apply all applicable mutation families (skipping families whose required
+   content element is absent from the page).
+3. Commit all scenarios and update `scenarios.json`.
+
+New scenarios inherit their `ground_truth` and `expected_candidate` from the
+mutation family definitions in `scenarios.json`. No per-scenario field edits are
+needed unless you want page-specific overrides.
+
+---
+
+## Design notes
+
+**Detector contract.** The benchmark enforces a standardized detector contract.
+All detectors are expected to conform to it directly — accepting
+`<en_doc_path> <l10n_doc_path>` as arguments and returning JSON with a `"status"`
+field using one of the five defined values. Any output that does not match the
+contract is treated as `error` and excluded from metrics. If an existing tool does
+not already follow the contract, write a thin adapter script that invokes it and
+converts its output to the required JSON format.
+
+**Group 1 stays hardcoded.** The five git-history scenarios depend on specific
+content strings and multi-commit sequences that are tied to the indexed-job page.
+They are generated with explicit `replace()` / `insert_before()` calls, not the
+mutation family registry. This is intentional: git-history testing requires
+controlled commit authorship and cannot be abstracted into a generic transform.
+
+**Mutation families as the primary abstraction.** All Group 2 scenarios are
+instances of a named mutation family. Families define the transform logic,
+applicability requirements, ground truth, and expected detector outputs in one
+place. Scenarios are thin references to their family. This keeps `scenarios.json`
+compact and avoids copy-pasting expectations across 42 Group 2 entries.
+
+---
+
+## Relationship to Issue #54896
+
+This benchmark was developed as part of the
+[LFX Mentorship project on AI-assisted automation for SIG Docs localization workflows](https://github.com/kubernetes/website/issues/54075).
+The two failure modes it targets (false positives from cosmetic EN edits, false
+negatives from sync point masking) are the core motivation for
+[Issue #54896](https://github.com/kubernetes/website/issues/54896).
+
+The benchmark is an evaluation harness, independent of any specific detector. It
+can be run against any detector pair to measure how well a candidate improves on
+the known failure cases and harder structural mutations.

--- a/scripts/content_detection_benchmark/generate_repo.py
+++ b/scripts/content_detection_benchmark/generate_repo.py
@@ -1,0 +1,1031 @@
+#!/usr/bin/env python3
+"""
+generate_repo.py
+Build the deterministic test repository for the content-drift detection benchmark.
+
+Internal organization:
+  1. Data structures (PageFixture, MutationFamily, MutationResult)
+  2. Generic markdown parsers
+  3. Generic mutation functions (gm_*)
+  4. Page introspection / capability discovery
+  5. Mutation family transforms (_tf_*)
+  6. Mutation family registry (MUTATION_FAMILIES)
+  7. Scenario expansion (Group 2)
+  8. Manifest emission
+  9. Main (Group 1 hardcoded + Group 2 via registry)
+
+Groups:
+  Group 1 (git-history scenarios): separate commits per scenario, testing lsync's
+    commit-based detection. Hardcoded to the indexed-job page.
+  Group 2 (structural scenarios): all files in one commit per page; only the
+    content-based detector can detect drift. Uses the mutation family registry
+    for all pages uniformly.
+
+Mutation families are the primary abstraction for Group 2. Each family defines
+reusable applicability logic and a pure content transform. Maturity/limitation
+notes are stored on families instead of being modeled as formal subgroups.
+The suite uses only one formal grouping for all Group 2 scenarios.
+
+Usage:
+    python generate_repo.py \\
+      --base-en REPO/content/en/docs/tasks/job/indexed-parallel-processing-static.md \\
+      --base-l10n REPO/content/ko/docs/tasks/job/indexed-parallel-processing-static.md \\
+      [--lang ko] \\
+      [--output-dir /tmp/k8s-l10n-test-repo] \\
+      [--extra-page page_id:en_path:ko_path ...] \\
+      [--update-manifest]
+
+    --extra-page can be repeated. Each value is: page_id:en_path:ko_path
+    --update-manifest rewrites scenarios.json for all pages.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Git + file helpers
+# ---------------------------------------------------------------------------
+
+def git(args, cwd):
+    subprocess.run(["git"] + args, cwd=cwd, check=True, capture_output=True)
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def write(path, text):
+    d = os.path.dirname(path)
+    if d:
+        os.makedirs(d, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def cp(src, dst):
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def replace(path, find, repl):
+    write(path, read(path).replace(find, repl, 1))
+
+
+def insert_before(path, find, insert):
+    write(path, read(path).replace(find, insert + find, 1))
+
+
+def delete_block(path, start, end):
+    """Delete all lines from the line containing start to the line containing end (inclusive)."""
+    lines, inside = [], False
+    for line in read(path).split("\n"):
+        if start in line:
+            inside = True
+        if not inside:
+            lines.append(line)
+        if inside and end in line:
+            inside = False
+    write(path, "\n".join(lines))
+
+
+def delete_line(path, pattern):
+    write(path, "\n".join(l for l in read(path).split("\n") if pattern not in l))
+
+
+def file_append(path, content):
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(content)
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MutationResult:
+    """Output of a mutation transform: possibly modified line lists and applied flag."""
+    en_lines: list
+    ko_lines: list
+    applied: bool
+
+
+@dataclass
+class MutationFamily:
+    """
+    A named family of content mutations for Group 2 scenario generation.
+
+    Each family captures:
+      - transform: pure function (en_lines, ko_lines, en_fm, ko_fm) -> MutationResult
+      - applicability: inspect_page capability key required, or None (always applicable)
+      - ground_truth / expected_candidate: default expectations for all scenarios
+      - notes: maturity/limitation descriptions (informational, not formal subgroups)
+
+    The suite keeps only one formal grouping (group2_structural) for all Group 2 families.
+    Notes explain differences in detector maturity instead of creating extra scoring buckets.
+    """
+    name: str
+    group: str
+    target: str
+    ground_truth: str
+    expected_candidate: list
+    applicability: object   # str key into inspect_page() dict, or None
+    transform: object       # Callable: (en_lines, ko_lines, en_fm, ko_fm) -> MutationResult
+    notes: list = field(default_factory=list)
+
+
+@dataclass
+class PageFixture:
+    """A real page pair used as the base for Group 2 scenario generation."""
+    page_id: str
+    en_src: str         # absolute path to EN source
+    ko_src: str         # absolute path to KO source
+    name_prefix: str    # '' for indexed-job; 'page_id__' for extra pages
+    info: dict          # result of inspect_page(en_src, ko_src)
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Generic markdown parsers
+# ---------------------------------------------------------------------------
+
+def _frontmatter_end(lines):
+    """Return the index of the first line after the closing --- of frontmatter."""
+    if not lines or lines[0].strip() != "---":
+        return 0
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return i + 1
+    return 0
+
+
+def _find_content_paragraphs(lines, fm):
+    """
+    Return list of (start, end) for content paragraphs (exclusive end).
+    Skips headings, code fences, shortcode lines, HTML comments, and table rows.
+    """
+    paras, in_code, para_start = [], False, None
+    for i in range(fm, len(lines)):
+        line = lines[i]
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code = not in_code
+            if para_start is not None:
+                paras.append((para_start, i))
+                para_start = None
+            continue
+        if in_code:
+            continue
+        if not stripped:
+            if para_start is not None:
+                paras.append((para_start, i))
+                para_start = None
+            continue
+        if (stripped.startswith("#") or stripped.startswith("{{")
+                or stripped.startswith("{%") or stripped.startswith("<!--")
+                or stripped.startswith("|") or stripped.startswith(">")):
+            if para_start is not None:
+                paras.append((para_start, i))
+                para_start = None
+            continue
+        if para_start is None:
+            para_start = i
+    if para_start is not None:
+        paras.append((para_start, len(lines)))
+    return paras
+
+
+def _find_code_blocks(lines, fm):
+    """Return list of (start, end) for fenced code blocks (end is line after closing fence)."""
+    blocks, start = [], None
+    for i in range(fm, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            if start is None:
+                start = i
+            else:
+                blocks.append((start, i + 1))
+                start = None
+    return blocks
+
+
+def _find_headings(lines, fm, level=2):
+    """Return list of (idx, line) for level-N headings that are not shortcode wrappers."""
+    prefix = "#" * level + " "
+    return [
+        (i, lines[i]) for i in range(fm, len(lines))
+        if lines[i].startswith(prefix) and "{{" not in lines[i] and "{%" not in lines[i]
+    ]
+
+
+def _find_list_items(lines, fm):
+    """Return list of (idx, line) for bullet/numbered list items outside code fences."""
+    result, in_code = [], False
+    for i in range(fm, len(lines)):
+        if lines[i].strip().startswith("```") or lines[i].strip().startswith("~~~"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        if re.match(r"^(\s{0,3})([-*+]|\d+\.)\s", lines[i]):
+            result.append((i, lines[i]))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Generic mutation functions
+# Each takes a list of lines + frontmatter-end index and returns (new_lines, applied).
+# These are pure transforms: no file I/O, no scoring policy.
+# ---------------------------------------------------------------------------
+
+def _last_content_line(lines, start, end):
+    idx = end - 1
+    while idx >= start and not lines[idx].strip():
+        idx -= 1
+    return idx
+
+
+def gm_extend_paragraph(lines, fm, extension, n=0):
+    """Append extension to the last line of the nth content paragraph."""
+    paras = _find_content_paragraphs(lines, fm)
+    if not paras:
+        return lines, False
+    n = min(n, len(paras) - 1)
+    start, end = paras[n]
+    idx = _last_content_line(lines, start, end)
+    lines = list(lines)
+    lines[idx] = lines[idx].rstrip() + extension
+    return lines, True
+
+
+def gm_insert_sentence(lines, fm, sentence, n=1):
+    """Insert a new sentence line after the last line of the nth content paragraph."""
+    paras = _find_content_paragraphs(lines, fm)
+    if not paras:
+        return lines, False
+    n = min(n, len(paras) - 1)
+    start, end = paras[n]
+    idx = _last_content_line(lines, start, end)
+    lines = list(lines)
+    lines.insert(idx + 1, sentence)
+    return lines, True
+
+
+def gm_delete_paragraph(lines, fm, n=1):
+    """Delete the nth content paragraph (0-indexed)."""
+    paras = _find_content_paragraphs(lines, fm)
+    if len(paras) <= n:
+        return lines, False
+    start, end = paras[n]
+    rest = lines[end:]
+    if rest and not rest[0].strip():
+        rest = rest[1:]
+    return lines[:start] + rest, True
+
+
+def gm_reorder_paragraphs(lines, fm):
+    """Swap the first two content paragraphs."""
+    paras = _find_content_paragraphs(lines, fm)
+    if len(paras) < 2:
+        return lines, False
+    s1, e1 = paras[0]
+    s2, e2 = paras[1]
+    block1, gap, block2 = lines[s1:e1], lines[e1:s2], lines[s2:e2]
+    return lines[:s1] + block2 + gap + block1 + lines[e2:], True
+
+
+def gm_delete_code_block(lines, fm, n=0):
+    """Delete the nth fenced code block."""
+    blocks = _find_code_blocks(lines, fm)
+    if len(blocks) <= n:
+        return lines, False
+    start, end = blocks[n]
+    before = lines[:start]
+    while before and not before[-1].strip():
+        before.pop()
+    before.append("")
+    rest = lines[end:]
+    if rest and not rest[0].strip():
+        rest = rest[1:]
+    return before + rest, True
+
+
+def gm_rename_heading(lines, fm, n=0):
+    """Append ' (Updated)' to the nth ## heading."""
+    headings = _find_headings(lines, fm, level=2)
+    if len(headings) <= n:
+        return lines, False
+    idx, line = headings[n]
+    lines = list(lines)
+    lines[idx] = line.rstrip() + " (Updated)"
+    return lines, True
+
+
+def gm_add_list_item(lines, fm):
+    """Append a new item to the first list."""
+    items = _find_list_items(lines, fm)
+    if not items:
+        return lines, False
+    last_idx = items[0][0]
+    for i in range(1, len(items)):
+        if items[i][0] <= last_idx + 3:
+            last_idx = items[i][0]
+        else:
+            break
+    m = re.match(r"^(\s{0,3})([-*+]|\d+\.)\s", lines[last_idx])
+    if not m:
+        return lines, False
+    indent, bullet = m.group(1), m.group(2)
+    if re.match(r"\d+", bullet):
+        new_item = f"{indent}{int(bullet[:-1]) + 1}. Verify the operation completed successfully."
+    else:
+        new_item = f"{indent}{bullet} Verify the operation completed successfully."
+    lines = list(lines)
+    lines.insert(last_idx + 1, new_item)
+    return lines, True
+
+
+def gm_remove_list_item(lines, fm, n=0):
+    """Remove the nth list item."""
+    items = _find_list_items(lines, fm)
+    if not items:
+        return lines, False
+    lines = list(lines)
+    del lines[items[min(n, len(items) - 1)][0]]
+    return lines, True
+
+
+def gm_change_kubectl_apply(lines, fm):
+    """Replace first 'kubectl apply' in a code block with 'kubectl create'."""
+    in_code = False
+    for i in range(fm, len(lines)):
+        if lines[i].strip().startswith("```") or lines[i].strip().startswith("~~~"):
+            in_code = not in_code
+            continue
+        if in_code and "kubectl apply" in lines[i]:
+            lines = list(lines)
+            lines[i] = lines[i].replace("kubectl apply", "kubectl create", 1)
+            return lines, True
+    return lines, False
+
+
+def gm_add_namespace_flag(lines, fm):
+    """Append --namespace=default to the first kubectl command in a code block."""
+    in_code = False
+    for i in range(fm, len(lines)):
+        if lines[i].strip().startswith("```") or lines[i].strip().startswith("~~~"):
+            in_code = not in_code
+            continue
+        if in_code and re.search(r"kubectl \w", lines[i]) and "--namespace" not in lines[i]:
+            lines = list(lines)
+            lines[i] = lines[i].rstrip() + " --namespace=default"
+            return lines, True
+    return lines, False
+
+
+def gm_rename_shortcode(lines, fm):
+    """Rename the first occurrence of a known shortcode alias."""
+    swaps = [
+        ("{{% code_sample", "{{% codenew"),
+        ("{{< code_sample", "{{< codenew"),
+        ("{{< include",     "{{< import"),
+        ("{{% include",     "{{% import"),
+    ]
+    for i in range(fm, len(lines)):
+        for old, new in swaps:
+            if old in lines[i]:
+                lines = list(lines)
+                lines[i] = lines[i].replace(old, new, 1)
+                return lines, True
+    return lines, False
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Page introspection / capability discovery
+# ---------------------------------------------------------------------------
+
+def _all_headings_in_order(lines, fm):
+    """Return all ## / ### / #### headings in document order, skipping shortcode headings."""
+    result, in_code = [], False
+    for i in range(fm, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        if (re.match(r"^#{2,4} ", lines[i])
+                and "{{" not in lines[i] and "{%" not in lines[i]):
+            result.append(lines[i].rstrip())
+    return result
+
+
+def inspect_page(en_path, ko_path):
+    """
+    Compute structural capabilities of a page pair.
+    Used to determine which mutation families are applicable.
+    """
+    en_lines = read(en_path).split("\n")
+    ko_lines = read(ko_path).split("\n")
+    en_fm = _frontmatter_end(en_lines)
+    ko_fm = _frontmatter_end(ko_lines)
+    return {
+        "has_en_paragraphs":    len(_find_content_paragraphs(en_lines, en_fm)) >= 2,
+        "has_ko_paragraphs":    len(_find_content_paragraphs(ko_lines, ko_fm)) >= 2,
+        "has_en_code_blocks":   len(_find_code_blocks(en_lines, en_fm)) > 0,
+        "has_ko_code_blocks":   len(_find_code_blocks(ko_lines, ko_fm)) > 0,
+        "has_en_headings":      len(_find_headings(en_lines, en_fm)) > 0,
+        "has_en_list_items":    len(_find_list_items(en_lines, en_fm)) > 0,
+        "has_ko_list_items":    len(_find_list_items(ko_lines, ko_fm)) > 0,
+        "has_kubectl_apply":    any("kubectl apply" in l for l in en_lines),
+        "has_kubectl_command":  any(re.search(r"kubectl \w", l) for l in en_lines),
+        "has_shortcode":        any(s in l for l in en_lines
+                                    for s in ("{{% code_sample", "{{< code_sample",
+                                               "{{< include", "{{% include")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Mutation family transforms
+# Each _tf_* function is a pure content transform:
+#   (en_lines, ko_lines, en_fm, ko_fm) -> MutationResult
+# No file I/O or scoring policy here.
+# ---------------------------------------------------------------------------
+
+def _tf_baseline(en, ko, en_fm, ko_fm):
+    return MutationResult(en, ko, True)
+
+
+def _tf_paragraph_reflow(en, ko, en_fm, ko_fm):
+    ko, applied = gm_extend_paragraph(
+        ko, ko_fm, " 이 내용은 독자들의 이해를 돕기 위한 추가 설명입니다.")
+    return MutationResult(en, ko, applied)
+
+
+def _tf_shortcode_only_change(en, ko, en_fm, ko_fm):
+    en, applied = gm_rename_shortcode(en, en_fm)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_missing_paragraph(en, ko, en_fm, ko_fm):
+    ko, applied = gm_delete_paragraph(ko, ko_fm, n=1)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_paragraph_reorder(en, ko, en_fm, ko_fm):
+    ko, applied = gm_reorder_paragraphs(ko, ko_fm)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_missing_code_block(en, ko, en_fm, ko_fm):
+    ko, applied = gm_delete_code_block(ko, ko_fm, n=0)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_paragraph_extended(en, ko, en_fm, ko_fm):
+    en, applied = gm_extend_paragraph(
+        en, en_fm,
+        " Note that this behavior may change in future versions of Kubernetes.")
+    return MutationResult(en, ko, applied)
+
+
+def _tf_paragraph_rewritten(en, ko, en_fm, ko_fm):
+    en, applied = gm_insert_sentence(
+        en, en_fm,
+        "This represents updated behavior from previous Kubernetes versions.",
+        n=1)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_heading_rename(en, ko, en_fm, ko_fm):
+    en, applied = gm_rename_heading(en, en_fm, n=0)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_list_item_added(en, ko, en_fm, ko_fm):
+    en, applied = gm_add_list_item(en, en_fm)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_list_item_removed(en, ko, en_fm, ko_fm):
+    ko, applied = gm_remove_list_item(ko, ko_fm, n=0)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_code_command_changed(en, ko, en_fm, ko_fm):
+    en, applied = gm_change_kubectl_apply(en, en_fm)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_code_parameters_changed(en, ko, en_fm, ko_fm):
+    en, applied = gm_add_namespace_flag(en, en_fm)
+    return MutationResult(en, ko, applied)
+
+
+def _tf_combined_drift(en, ko, en_fm, ko_fm):
+    en, ok1 = gm_extend_paragraph(
+        en, en_fm,
+        " Note that this behavior may change in future versions of Kubernetes.")
+    en, ok2 = gm_rename_heading(en, en_fm, n=0)
+    en, ok3 = gm_add_list_item(en, en_fm)
+    return MutationResult(en, ko, ok1 or ok2 or ok3)
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Mutation family registry
+#
+# This is the source of truth for Group 2 scenario generation.
+# Each family's applicability key must match a key returned by inspect_page().
+# Families with applicability=None are attempted for every page.
+#
+# Notes explain detector maturity/limitations instead of formal subgrouping.
+# All families share the same group label (group2_structural).
+# ---------------------------------------------------------------------------
+
+MUTATION_FAMILIES = [
+    MutationFamily(
+        name="baseline_unmodified",
+        group="group2_structural",
+        target="none",
+        ground_truth="not_outdated",
+        expected_candidate=["up_to_date"],
+        applicability=None,
+        transform=_tf_baseline,
+        notes=["control case: no mutations applied; both detectors should agree up_to_date"],
+    ),
+    MutationFamily(
+        name="paragraph_reflow",
+        group="group2_structural",
+        target="paragraph_structure",
+        ground_truth="not_outdated",
+        expected_candidate=["up_to_date", "outdated_low_severity"],
+        applicability="has_ko_paragraphs",
+        transform=_tf_paragraph_reflow,
+        notes=["KO-side reflow only; expected to be tolerated as up_to_date or outdated_low_severity"],
+    ),
+    MutationFamily(
+        name="shortcode_only_change",
+        group="group2_structural",
+        target="shortcode",
+        ground_truth="not_outdated",
+        expected_candidate=["up_to_date"],
+        applicability="has_shortcode",
+        transform=_tf_shortcode_only_change,
+        notes=["cosmetic EN shortcode alias rename; content-based detector should ignore it"],
+    ),
+    MutationFamily(
+        name="missing_paragraph",
+        group="group2_structural",
+        target="paragraph_structure",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability="has_ko_paragraphs",
+        transform=_tf_missing_paragraph,
+        notes=["expected to be reliably detectable with current structural comparison"],
+    ),
+    MutationFamily(
+        name="paragraph_reorder",
+        group="group2_structural",
+        target="paragraph_structure",
+        ground_truth="not_outdated",
+        expected_candidate=["up_to_date", "outdated_low_severity"],
+        applicability="has_ko_paragraphs",
+        transform=_tf_paragraph_reorder,
+        notes=[
+            "same content at different paragraph positions in KO",
+            "currently limited by block alignment",
+        ],
+    ),
+    MutationFamily(
+        name="missing_code_block",
+        group="group2_structural",
+        target="code_block",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated", "outdated_low_severity"],
+        applicability="has_ko_code_blocks",
+        transform=_tf_missing_code_block,
+        notes=[
+            "KO code block deleted",
+            "currently limited by block alignment; outdated_low_severity also acceptable",
+        ],
+    ),
+    MutationFamily(
+        name="paragraph_extended_in_english",
+        group="group2_structural",
+        target="paragraph_content",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability="has_en_paragraphs",
+        transform=_tf_paragraph_extended,
+        notes=["expected to be reliably detectable with current structural comparison"],
+    ),
+    MutationFamily(
+        name="paragraph_rewritten_in_english",
+        group="group2_structural",
+        target="paragraph_content",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated", "outdated_low_severity"],
+        applicability="has_en_paragraphs",
+        transform=_tf_paragraph_rewritten,
+        notes=[
+            "EN paragraph semantically rewritten at similar length",
+            "currently limited by intra-block comparison",
+            "useful as a capability probe",
+        ],
+    ),
+    MutationFamily(
+        name="heading_rename",
+        group="group2_structural",
+        target="heading",
+        ground_truth="outdated",
+        expected_candidate=["outdated_low_severity"],
+        applicability="has_en_headings",
+        transform=_tf_heading_rename,
+        notes=["expected to be reliably detectable with current structural comparison"],
+    ),
+    MutationFamily(
+        name="list_item_added_in_english",
+        group="group2_structural",
+        target="list",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability="has_en_list_items",
+        transform=_tf_list_item_added,
+        notes=["expected to be reliably detectable with current structural comparison"],
+    ),
+    MutationFamily(
+        name="list_item_removed_translation",
+        group="group2_structural",
+        target="list",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability="has_ko_list_items",
+        transform=_tf_list_item_removed,
+        notes=["expected to be reliably detectable with current structural comparison"],
+    ),
+    MutationFamily(
+        name="code_command_changed",
+        group="group2_structural",
+        target="code_block",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability="has_kubectl_apply",
+        transform=_tf_code_command_changed,
+        notes=[
+            "kubectl apply → kubectl create in EN code block",
+            "currently limited by intra-block comparison",
+            "useful as a capability probe",
+        ],
+    ),
+    MutationFamily(
+        name="code_parameters_changed",
+        group="group2_structural",
+        target="code_block",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability="has_kubectl_command",
+        transform=_tf_code_parameters_changed,
+        notes=[
+            "kubectl command gains --namespace=default flag in EN code block",
+            "currently limited by intra-block comparison",
+            "useful as a capability probe",
+        ],
+    ),
+    MutationFamily(
+        name="combined_drift",
+        group="group2_structural",
+        target="combined",
+        ground_truth="outdated",
+        expected_candidate=["candidate_outdated"],
+        applicability=None,
+        transform=_tf_combined_drift,
+        notes=["stress test: paragraph extension + heading rename + list item addition"],
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Scenario expansion (Group 2)
+# ---------------------------------------------------------------------------
+
+def expand_group2_scenarios(fixture, en_fn, ko_fn):
+    """
+    Apply all applicable mutation families to a PageFixture, materialize
+    files in the test repo, and return (entries, paths).
+
+    entries: thin manifest entry dicts {id, group, page_id, family}
+    paths:   list of all materialized file paths (for git add)
+
+    Each entry contains only {id, group, page_id, family}. The ground_truth
+    and expected_candidate are inherited at runtime from the manifest's
+    mutation_families block, keeping scenarios minimal and defaults centralized.
+    """
+    entries = []
+    paths = []
+    applicable = [f for f in MUTATION_FAMILIES
+                  if f.applicability is None or fixture.info.get(f.applicability)]
+    print(f"    applicable families: {[f.name for f in applicable]}")
+
+    for family in applicable:
+        scenario_id = fixture.name_prefix + family.name
+
+        cp(fixture.en_src, en_fn(scenario_id))
+        cp(fixture.ko_src, ko_fn(scenario_id))
+
+        en_lines = read(en_fn(scenario_id)).split("\n")
+        ko_lines = read(ko_fn(scenario_id)).split("\n")
+        en_fm = _frontmatter_end(en_lines)
+        ko_fm = _frontmatter_end(ko_lines)
+
+        result = family.transform(en_lines, ko_lines, en_fm, ko_fm)
+
+        if not result.applied:
+            os.remove(en_fn(scenario_id))
+            os.remove(ko_fn(scenario_id))
+            print(f"    [SKIP] {scenario_id}")
+            continue
+
+        # Only write files that were actually mutated to preserve original line endings
+        if result.en_lines is not en_lines:
+            write(en_fn(scenario_id), "\n".join(result.en_lines))
+        if result.ko_lines is not ko_lines:
+            write(ko_fn(scenario_id), "\n".join(result.ko_lines))
+
+        paths.extend([en_fn(scenario_id), ko_fn(scenario_id)])
+        entries.append({
+            "id":      scenario_id,
+            "group":   "group2_structural",
+            "page_id": fixture.page_id,
+            "family":  family.name,
+        })
+        print(f"    [OK]   {scenario_id}")
+
+    return entries, paths
+
+
+# ---------------------------------------------------------------------------
+# Section 8: Manifest emission
+# ---------------------------------------------------------------------------
+
+# Group 1 scenarios are static: they are tied to the indexed-job page and
+# cannot be generated by the mutation family registry.
+GROUP1_SCENARIOS = [
+    {
+        "id":                "fp_formatting",
+        "group":             "group1_git_history",
+        "description":       "False positive: emphasis style swap",
+        "ground_truth":      "not_outdated",
+        "expected_baseline": ["candidate_outdated"],
+        "expected_candidate":["up_to_date"],
+    },
+    {
+        "id":                "fp_links",
+        "group":             "group1_git_history",
+        "description":       "False positive: relative link canonicalized to absolute URL",
+        "ground_truth":      "not_outdated",
+        "expected_baseline": ["candidate_outdated"],
+        "expected_candidate":["up_to_date"],
+    },
+    {
+        "id":                "fp_shortcodes",
+        "group":             "group1_git_history",
+        "description":       "False positive: shortcode delimiter swap",
+        "ground_truth":      "not_outdated",
+        "expected_baseline": ["candidate_outdated"],
+        "expected_candidate":["up_to_date"],
+    },
+    {
+        "id":                "fn_false_sync",
+        "group":             "group1_git_history",
+        "description":       "False negative: cosmetic KO edit masks meaningful EN addition",
+        "ground_truth":      "outdated",
+        "expected_baseline": ["up_to_date"],
+        "expected_candidate":["candidate_outdated"],
+    },
+    {
+        "id":                "tp_normal_change",
+        "group":             "group1_git_history",
+        "description":       "True positive: new EN section appended",
+        "ground_truth":      "outdated",
+        "expected_baseline": ["candidate_outdated"],
+        "expected_candidate":["candidate_outdated"],
+    },
+]
+
+def emit_manifest(manifest_path, fixtures, group2_entries):
+    """
+    Write scenarios.json with mutation_families (ground truth defaults) and scenarios.
+
+    Group 2 scenarios are thin: each scenario references its family for ground_truth
+    and expected_candidate defaults, reducing repetition.
+    """
+    mutation_families = {}
+    for fam in MUTATION_FAMILIES:
+        mutation_families[fam.name] = {
+            "ground_truth":       fam.ground_truth,
+            "expected_candidate": fam.expected_candidate,
+        }
+
+    manifest = {
+        "mutation_families": mutation_families,
+        "scenarios": GROUP1_SCENARIOS + group2_entries,
+    }
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    print(f"\nManifest updated: {manifest_path}")
+    print(f"  {len(GROUP1_SCENARIOS)} Group 1 + {len(group2_entries)} Group 2 scenarios")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate content-drift detection benchmark test repository."
+    )
+    parser.add_argument("--base-en",    required=True, metavar="PATH",
+                        help="Path to English source file (indexed job page).")
+    parser.add_argument("--base-l10n",  required=True, metavar="PATH",
+                        help="Path to localized source file (indexed job page).")
+    parser.add_argument("--lang",       default="ko",
+                        help="Language code (default: ko).")
+    parser.add_argument("--output-dir", default="/tmp/k8s-l10n-test-repo", metavar="PATH",
+                        help="Output directory for the test repository.")
+    parser.add_argument("--extra-page", action="append", metavar="ID:EN_PATH:KO_PATH",
+                        help="Additional page pair (repeatable). Format: page_id:en_path:ko_path")
+    parser.add_argument("--update-manifest", action="store_true",
+                        help="Rewrite scenarios.json with entries for all pages.")
+    args = parser.parse_args()
+
+    en_src = os.path.abspath(args.base_en)
+    ko_src = os.path.abspath(args.base_l10n)
+    out    = os.path.abspath(args.output_dir)
+    lang   = args.lang
+
+    for f in [en_src, ko_src]:
+        if not os.path.isfile(f):
+            print(f"Error: file not found: {f}", file=sys.stderr)
+            sys.exit(1)
+
+    # Parse extra pages
+    extra_pages = []
+    for spec in (args.extra_page or []):
+        parts = spec.split(":", 2)
+        if len(parts) != 3:
+            print(f"Error: --extra-page must be ID:EN_PATH:KO_PATH, got: {spec}", file=sys.stderr)
+            sys.exit(1)
+        page_id, ep_en, ep_ko = parts[0], os.path.abspath(parts[1]), os.path.abspath(parts[2])
+        for f in [ep_en, ep_ko]:
+            if not os.path.isfile(f):
+                print(f"Error: file not found: {f}", file=sys.stderr)
+                sys.exit(1)
+        extra_pages.append((page_id, ep_en, ep_ko))
+
+    if os.path.exists(out):
+        shutil.rmtree(out)
+    os.makedirs(out)
+
+    git(["init"], out)
+    git(["config", "user.name", "L10n Test Bot"], out)
+    git(["config", "user.email", "test@example.com"], out)
+
+    # Path helpers inside the repo
+    def en(name): return os.path.join(out, "content/en/docs/tasks/job", f"{name}.md")
+    def ko(name): return os.path.join(out, f"content/{lang}/docs/tasks/job", f"{name}.md")
+
+    def init(name):
+        """Copy base files and commit as the initial state (T0)."""
+        cp(en_src, en(name))
+        cp(ko_src, ko(name))
+        git(["add", en(name), ko(name)], out)
+        git(["commit", "-m", f"Initialize {name}"], out)
+        time.sleep(1)  # ensure timestamp delta for lsync detection
+
+    print(f"Building test repo at {out}")
+
+    # ======================================================================
+    # GROUP 1: Separate-commit scenarios (git-history scenarios 1-5)
+    # Pattern: T0 = base commit, T1+ = EN mutation commit(s)
+    # Tests lsync's commit-timestamp-based detection against the content-based
+    # detector. Hardcoded to the indexed-job page with page-specific mutations.
+    # ======================================================================
+
+    # Scenario 1: fp_formatting
+    # Cosmetic EN change: emphasis style swap (_x_ → *x*)
+    # lsync: candidate_outdated (false positive)  |  content-based: up_to_date (correct)
+    print("  Scenario 1: fp_formatting")
+    init("fp_formatting")
+    replace(en("fp_formatting"), "_index number_", "*index number*")
+    git(["add", en("fp_formatting")], out)
+    git(["commit", "-m", "fp_formatting: cosmetic emphasis swap"], out)
+
+    # Scenario 2: fp_links
+    # Cosmetic EN change: relative link canonicalized to absolute URL
+    # lsync: candidate_outdated (false positive)  |  content-based: up_to_date (correct)
+    print("  Scenario 2: fp_links")
+    init("fp_links")
+    replace(en("fp_links"),
+        "[downward API](/docs/concepts/workloads/pods/downward-api/)",
+        "[downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/)")
+    git(["add", en("fp_links")], out)
+    git(["commit", "-m", "fp_links: canonicalize relative link to absolute URL"], out)
+
+    # Scenario 3: fp_shortcodes
+    # Cosmetic EN change: shortcode delimiter swap ({{< >}} → {{% %}})
+    # lsync: candidate_outdated (false positive)  |  content-based: up_to_date (correct)
+    print("  Scenario 3: fp_shortcodes")
+    init("fp_shortcodes")
+    replace(en("fp_shortcodes"),
+        '{{< include "task-tutorial-prereqs.md" >}}',
+        '{{% include "task-tutorial-prereqs.md" %}}')
+    git(["add", en("fp_shortcodes")], out)
+    git(["commit", "-m", "fp_shortcodes: swap shortcode delimiter style"], out)
+
+    # Scenario 4: fn_false_sync
+    # T1: meaningful EN addition (deprecation warning paragraph)
+    # T2: cosmetic KO edit advances lsync's sync point, masking T1
+    # lsync: up_to_date (false negative)  |  content-based: candidate_outdated (correct)
+    print("  Scenario 4: fn_false_sync")
+    init("fn_false_sync")
+    insert_before(en("fn_false_sync"),
+        "Here is an overview of the steps in this example:",
+        "\n**Warning: Multi-level parallel jobs will be deprecated in v1.35 due to redundancy.**\n\n")
+    git(["add", en("fn_false_sync")], out)
+    git(["commit", "-m", "fn_false_sync (T1): add deprecation warning paragraph"], out)
+    time.sleep(1)
+    replace(ko("fn_false_sync"), "이 예제에서는, 여러 병렬", "이 예제에서는 여러 병렬")
+    git(["add", ko("fn_false_sync")], out)
+    git(["commit", "-m", "fn_false_sync (T2): cosmetic KO punctuation fix (masks T1)"], out)
+
+    # Scenario 5: tp_normal_change
+    # Meaningful EN change: new section appended
+    # lsync: candidate_outdated (correct)  |  content-based: candidate_outdated (correct)
+    print("  Scenario 5: tp_normal_change")
+    init("tp_normal_change")
+    file_append(en("tp_normal_change"),
+        "\n\n## New Configuration Requirements\n"
+        "You must now enable the alpha feature gate to use this feature with external workloads.\n")
+    git(["add", en("tp_normal_change")], out)
+    git(["commit", "-m", "tp_normal_change: add new requirements section"], out)
+
+    # ======================================================================
+    # GROUP 2: Single-commit scenarios (structural scenarios)
+    # Pattern: all EN + KO files staged and committed together (one commit per page).
+    # lsync sees no EN delta since KO was committed → reports up_to_date for all.
+    # Only the content-based detector can catch genuine drift here.
+    # Uses the mutation family registry uniformly for all pages.
+    # ======================================================================
+
+    print("  Group 2: building structural scenarios via mutation family registry")
+
+    ij_info = inspect_page(en_src, ko_src)
+    ij_fixture = PageFixture(
+        page_id="indexed-job",
+        en_src=en_src,
+        ko_src=ko_src,
+        name_prefix="",
+        info=ij_info,
+    )
+
+    all_fixtures = [ij_fixture]
+    for page_id, ep_en, ep_ko in extra_pages:
+        info = inspect_page(ep_en, ep_ko)
+        all_fixtures.append(PageFixture(
+            page_id=page_id,
+            en_src=ep_en,
+            ko_src=ep_ko,
+            name_prefix=f"{page_id}__",
+            info=info,
+        ))
+
+    all_g2_entries = []
+
+    # All Group 2 files land in the same repo directory structure regardless of page.
+    # The scenario_id already has the page prefix for extra pages (e.g. "redis-tutorial__...").
+    for fixture in all_fixtures:
+        print(f"  Page: {fixture.page_id}")
+        entries, page_paths = expand_group2_scenarios(fixture, en, ko)
+        if page_paths:
+            git(["add"] + page_paths, out)
+            git(["commit", "-m", f"Group 2 scenarios: {fixture.page_id}"], out)
+        all_g2_entries.extend(entries)
+        print(f"    {len(entries)} scenarios generated")
+
+    # Optionally update scenarios.json
+    if args.update_manifest:
+        manifest_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scenarios.json")
+        emit_manifest(manifest_path, all_fixtures, all_g2_entries)
+
+    print(f"\nTest repository ready at: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/content_detection_benchmark/run_eval.py
+++ b/scripts/content_detection_benchmark/run_eval.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""
+run_eval.py
+Evaluation harness for the content-drift detection benchmark.
+
+Reads scenarios.json, runs detectors against each scenario, validates
+outputs against the contract defined by content_based_outdated.py,
+resolves expectations from the manifest (family defaults for Group 2,
+inline values for Group 1), scores results, aggregates by group/family/page,
+and writes report.md.
+
+All detectors must follow the contract defined by content_based_outdated.py:
+  Input:  <en_doc_path> <l10n_doc_path>
+  Output: JSON with a "status" field using one of these values:
+            up_to_date
+            candidate_outdated
+            outdated_low_severity
+            no_english_version
+            not_translated
+  Example: {"status": "candidate_outdated", "signals": [...], "sections": [...]}
+
+Internal steps:
+  1. Load manifest
+  2. Run detectors
+  3. Validate outputs against contract
+  4. Resolve scenario expectations
+  5. Score scenarios
+  6. Aggregate results
+  7. Render report
+
+Usage:
+    python run_eval.py \\
+      --repo /tmp/k8s-l10n-test-repo \\
+      --baseline path/to/baseline.py \\
+      --candidate path/to/candidate.py
+
+Output:
+    report.md (or path set by --output)
+"""
+
+import argparse
+import collections
+import datetime
+import json
+import os
+import shlex
+import subprocess
+import sys
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Contract status values from content_based_outdated.py
+_CONTRACT_STATUSES = {
+    "up_to_date",
+    "candidate_outdated",
+    "outdated_low_severity",
+    "no_english_version",
+    "not_translated",
+}
+
+# Scoring sets — no_english_version, not_translated, and error are excluded from metrics
+POSITIVE = {"candidate_outdated", "outdated_low_severity"}
+NEGATIVE = {"up_to_date"}
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Output normalization
+# ---------------------------------------------------------------------------
+
+def normalize_output(stdout, exit_code):
+    """
+    Validate detector JSON output and return the status string.
+
+    Detectors must return JSON with a "status" field whose value is one of
+    the contract statuses defined by content_based_outdated.py.
+    Any other status or malformed output is returned as "error".
+    """
+    if exit_code not in (0, 1):
+        return "error"
+    try:
+        data = json.loads(stdout.strip())
+        entry = data[0] if isinstance(data, list) else data
+        status = entry.get("status", "")
+        return status if status in _CONTRACT_STATUSES else "error"
+    except (json.JSONDecodeError, IndexError, AttributeError, TypeError):
+        return "error"
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Tool execution
+# ---------------------------------------------------------------------------
+
+def run_detector(cmd, en_path, l10n_path, repo_dir):
+    """
+    Run a detector with (en_path, l10n_path) and return a canonical label.
+
+    Paths are made absolute before passing to the detector so that detector
+    commands (e.g. "python3 adapter_content_based.py") resolve relative to
+    the invocation directory, not the test repository root.
+
+    The detector is invoked as: <cmd> <en_abs_path> <l10n_abs_path>
+    It must produce JSON output following the stable detector interface.
+    """
+    en_abs   = os.path.join(repo_dir, en_path)
+    l10n_abs = os.path.join(repo_dir, l10n_path)
+    parts = shlex.split(cmd) + [en_abs, l10n_abs]
+    try:
+        proc = subprocess.run(parts, capture_output=True, text=True, timeout=60)
+        stdout, exit_code = proc.stdout, proc.returncode
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return "error"
+    return normalize_output(stdout, exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Resolve scenario expectations
+# ---------------------------------------------------------------------------
+
+def resolve_expectations(scenario, manifest):
+    """
+    Return (ground_truth, expected_baseline, expected_candidate) for a scenario.
+
+    For Group 1 scenarios: expectations are read directly from the scenario dict.
+    For Group 2 scenarios: ground_truth and expected_candidate are inherited from
+    the manifest's mutation_families block, reducing repetition in the scenarios
+    list. Scenario-level overrides (ground_truth_override, expected_candidate_override)
+    take precedence when present.
+    """
+    if scenario.get("group") == "group1_git_history":
+        return {
+            "ground_truth":       scenario["ground_truth"],
+            "expected_baseline":  scenario.get("expected_baseline"),
+            "expected_candidate": scenario.get("expected_candidate"),
+        }
+    # Group 2: inherit from family
+    family_name = scenario["family"]
+    family = manifest["mutation_families"][family_name]
+    return {
+        "ground_truth":       scenario.get("ground_truth_override", family["ground_truth"]),
+        "expected_baseline":  None,   # baseline not applicable to Group 2
+        "expected_candidate": scenario.get("expected_candidate_override",
+                                           family["expected_candidate"]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Scoring
+# ---------------------------------------------------------------------------
+
+def classify_binary(label):
+    """Classify a label as positive, negative, or None (excluded from metrics)."""
+    if label in POSITIVE:
+        return "positive"
+    if label in NEGATIVE:
+        return "negative"
+    return None
+
+
+def score_scenario(ground_truth, label):
+    """Return TP/TN/FP/FN, or None to exclude non-scorable statuses from metrics."""
+    binary = classify_binary(label)
+    if binary is None:
+        return None
+    positive = (binary == "positive")
+    if ground_truth == "outdated":
+        return "TP" if positive else "FN"
+    return "FP" if positive else "TN"
+
+
+def compute_metrics(results, label_key):
+    scored = [score_scenario(r["ground_truth"], r[label_key]) for r in results]
+    tp = scored.count("TP")
+    tn = scored.count("TN")
+    fp = scored.count("FP")
+    fn = scored.count("FN")
+    total = tp + tn + fp + fn
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall    = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1        = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    accuracy  = (tp + tn) / total if total > 0 else 0.0
+    return {"TP": tp, "TN": tn, "FP": fp, "FN": fn,
+            "precision": precision, "recall": recall, "f1": f1, "accuracy": accuracy}
+
+
+def _pass_fail(label, expected_list):
+    """
+    Return PASS if label is in expected_list.
+    Return SKIP if expected_list is None or label indicates a non-scorable
+    condition (no_english_version, not_translated, error).
+    Return FAIL otherwise.
+    """
+    if expected_list is None:
+        return "SKIP"
+    if label in ("no_english_version", "not_translated", "error"):
+        return "SKIP"
+    return "PASS" if label in expected_list else "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Aggregation
+# ---------------------------------------------------------------------------
+
+def aggregate_by_group(results):
+    """Return per-group metrics dicts."""
+    g1 = [r for r in results if r["group"] == "group1_git_history"]
+    g2 = [r for r in results if r["group"] == "group2_structural"]
+    return {
+        "g1_baseline":        compute_metrics(g1,      "baseline_label"),
+        "g1_candidate":       compute_metrics(g1,      "candidate_label"),
+        "g2_candidate":       compute_metrics(g2,      "candidate_label"),
+        "combined_candidate": compute_metrics(results, "candidate_label"),
+    }
+
+
+def aggregate_by_family(results):
+    """Return {family_name: candidate_metrics} for Group 2 scenarios."""
+    by_family = collections.defaultdict(list)
+    for r in results:
+        if r["group"] == "group2_structural" and r.get("family"):
+            by_family[r["family"]].append(r)
+    return {fam: compute_metrics(rows, "candidate_label")
+            for fam, rows in by_family.items()}
+
+
+def aggregate_by_page(results):
+    """Return {page_id: candidate_metrics} for Group 2 scenarios."""
+    by_page = collections.defaultdict(list)
+    for r in results:
+        if r["group"] == "group2_structural" and r.get("page_id"):
+            by_page[r["page_id"]].append(r)
+    return {page: compute_metrics(rows, "candidate_label")
+            for page, rows in by_page.items()}
+
+
+# ---------------------------------------------------------------------------
+# Step 7: Report generation
+# ---------------------------------------------------------------------------
+
+def _f(v):
+    return f"{v:.2f}"
+
+
+def _metrics_line(label, m):
+    return (
+        f"**{label}** — "
+        f"precision: {_f(m['precision'])}  recall: {_f(m['recall'])}  "
+        f"f1: {_f(m['f1'])}  accuracy: {_f(m['accuracy'])}  "
+        f"TP={m['TP']}  TN={m['TN']}  FP={m['FP']}  FN={m['FN']}"
+    )
+
+
+def _metrics_row(label, m):
+    return (
+        f"| {label} "
+        f"| {m['TP']} | {m['TN']} | {m['FP']} | {m['FN']} "
+        f"| {_f(m['precision'])} | {_f(m['recall'])} | {_f(m['f1'])} |"
+    )
+
+
+def generate_report(results, metrics, by_family, by_page, manifest,
+                    baseline_cmd, candidate_cmd, timestamp):
+    g1 = [r for r in results if r["group"] == "group1_git_history"]
+    g2 = [r for r in results if r["group"] == "group2_structural"]
+
+    lines = [
+        "# Content Detection Benchmark Report", "",
+        f"**Generated:** {timestamp}",
+        f"**Baseline:** `{baseline_cmd}`",
+        f"**Candidate:** `{candidate_cmd}`", "",
+    ]
+
+    # ------------------------------------------------------------------
+    # Section 1: Group 1 — git-history scenarios
+    # ------------------------------------------------------------------
+    lines += [
+        "## Section 1: Group 1 — Git-history scenarios", "",
+        "Scenarios where EN and KO are committed separately; "
+        "lsync detects EN updated after KO (may produce false positives/negatives).", "",
+        "| Scenario | Ground Truth | Baseline | Exp Baseline | Candidate | Exp Candidate | Baseline Pass | Candidate Pass |",
+        "|----------|-------------|----------|-------------|-----------|---------------|---------------|----------------|",
+    ]
+    for r in g1:
+        exp_bl   = ", ".join(r["expected_baseline"])  if r.get("expected_baseline")  else ""
+        exp_cand = ", ".join(r["expected_candidate"]) if r.get("expected_candidate") else ""
+        lines.append(
+            f"| {r.get('description', r['id'])} "
+            f"| {r['ground_truth']} "
+            f"| {r['baseline_label']} "
+            f"| {exp_bl} "
+            f"| {r['candidate_label']} "
+            f"| {exp_cand} "
+            f"| {r['baseline_pass']} "
+            f"| {r['candidate_pass']} |"
+        )
+    lines += [
+        "",
+        _metrics_line("Group 1 — Baseline",  metrics["g1_baseline"]),
+        _metrics_line("Group 1 — Candidate", metrics["g1_candidate"]),
+        "",
+    ]
+
+    # ------------------------------------------------------------------
+    # Section 2: Group 2 — structural scenarios
+    # ------------------------------------------------------------------
+    lines += [
+        "## Section 2: Group 2 — Structural scenarios", "",
+        "Scenarios where EN + KO are committed together; lsync always reports "
+        "up_to_date. Only the candidate detector can catch genuine drift here.", "",
+        "| Page | Family | Ground Truth | Candidate | Exp Candidate | Candidate Pass |",
+        "|------|--------|-------------|-----------|---------------|----------------|",
+    ]
+    for r in g2:
+        exp_cand = ", ".join(r["expected_candidate"]) if r.get("expected_candidate") else ""
+        lines.append(
+            f"| {r.get('page_id', '')} "
+            f"| {r.get('family', '')} "
+            f"| {r['ground_truth']} "
+            f"| {r['candidate_label']} "
+            f"| {exp_cand} "
+            f"| {r['candidate_pass']} |"
+        )
+    lines += [
+        "",
+        _metrics_line("Group 2 — Candidate", metrics["g2_candidate"]),
+        _metrics_line("Combined Candidate",  metrics["combined_candidate"]),
+        "",
+    ]
+
+    # ------------------------------------------------------------------
+    # Section 3: Summary by mutation family (Group 2 candidate)
+    # ------------------------------------------------------------------
+    lines += [
+        "## Section 3: Summary by mutation family", "",
+        "| Family | TP | TN | FP | FN | Precision | Recall | F1 | Notes |",
+        "|--------|----|----|----|----|-----------|--------|----|-------|",
+    ]
+    fam_defs = manifest.get("mutation_families", {})
+    for fam_name, m in by_family.items():
+        notes = "; ".join(fam_defs.get(fam_name, {}).get("notes", []))
+        lines.append(
+            f"| {fam_name} "
+            f"| {m['TP']} | {m['TN']} | {m['FP']} | {m['FN']} "
+            f"| {_f(m['precision'])} | {_f(m['recall'])} | {_f(m['f1'])} "
+            f"| {notes} |"
+        )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Section 4: Summary by page (Group 2 candidate)
+    # ------------------------------------------------------------------
+    lines += [
+        "## Section 4: Summary by page", "",
+        "| Page | TP | TN | FP | FN | Precision | Recall | F1 |",
+        "|------|----|----|----|----|-----------|--------|----|",
+    ]
+    for page_id, m in by_page.items():
+        lines.append(_metrics_row(page_id, m))
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Section 5: Interpretation notes
+    # ------------------------------------------------------------------
+    lines += [
+        "## Section 5: Interpretation notes", "",
+        "**Group 1** tests lsync's git-history detection. "
+        "Baseline false positives (fp_*) are expected: lsync sees EN updated after KO "
+        "even for cosmetic changes. The candidate detector is evaluated on whether it "
+        "correctly ignores these cosmetic changes. "
+        "The false-negative scenario (fn_false_sync) tests whether the candidate "
+        "detects genuine drift that lsync missed because a later cosmetic KO edit "
+        "advanced the sync point.", "",
+        "**Group 2** evaluates structural and semantic drift detection. "
+        "Lsync always outputs up_to_date for these scenarios (both EN and KO committed together). "
+        "Only the candidate detector's labels are scored.", "",
+        "**Families marked 'expected to be reliably detectable'** represent the current "
+        "core capability of the structural comparison approach.",
+        "",
+        "**Families with 'currently limited by block alignment' or 'intra-block comparison'** "
+        "reflect known detector limitations. These are informational notes, not formal subgroups. "
+        "All Group 2 families are scored with the same standard.",
+        "",
+        "**Families marked 'useful as a capability probe'** are included to track progress "
+        "on harder detection cases.",
+        "",
+        "**F1 score** is the primary quality metric for the candidate detector. "
+        "no_english_version, not_translated, and error outputs are excluded from all metrics.",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run the content-drift detection benchmark."
+    )
+    parser.add_argument("--repo",      required=True, help="Test repository path.")
+    parser.add_argument("--baseline",  required=True, help="Baseline detector command.")
+    parser.add_argument("--candidate", required=True, help="Candidate detector command.")
+    parser.add_argument("--lang",    default="ko",        help="Language code (default: ko).")
+    parser.add_argument("--manifest", default=None,       help="Path to scenarios.json.")
+    parser.add_argument("--output",  default="report.md", help="Output report path.")
+    args = parser.parse_args()
+
+    repo_dir = os.path.abspath(args.repo)
+    manifest_path = args.manifest or os.path.join(_SCRIPT_DIR, "scenarios.json")
+
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    results = []
+    for s in manifest["scenarios"]:
+        scenario_id = s["id"]
+        grp         = s.get("group", "")
+        exp         = resolve_expectations(s, manifest)
+
+        en_path   = f"content/en/docs/tasks/job/{scenario_id}.md"
+        l10n_path = f"content/{args.lang}/docs/tasks/job/{scenario_id}.md"
+        print(f"  {scenario_id} ...", end=" ", flush=True)
+        baseline_label  = run_detector(args.baseline,  en_path, l10n_path, repo_dir)
+        candidate_label = run_detector(args.candidate, en_path, l10n_path, repo_dir)
+        print(f"baseline={baseline_label}  candidate={candidate_label}")
+
+        baseline_pass  = _pass_fail(baseline_label,  exp["expected_baseline"])
+        candidate_pass = _pass_fail(candidate_label, exp["expected_candidate"])
+
+        results.append({
+            "id":                 scenario_id,
+            "ground_truth":       exp["ground_truth"],
+            "group":              grp,
+            "description":        s.get("description"),      # Group 1
+            "page_id":            s.get("page_id"),           # Group 2
+            "family":             s.get("family"),            # Group 2
+            "expected_baseline":  exp["expected_baseline"],
+            "expected_candidate": exp["expected_candidate"],
+            "baseline_label":     baseline_label,
+            "candidate_label":    candidate_label,
+            "baseline_pass":      baseline_pass,
+            "candidate_pass":     candidate_pass,
+        })
+
+    metrics   = aggregate_by_group(results)
+    by_family = aggregate_by_family(results)
+    by_page   = aggregate_by_page(results)
+
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    report = generate_report(results, metrics, by_family, by_page, manifest,
+                             args.baseline, args.candidate, timestamp)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(report)
+
+    bm = metrics["g1_baseline"]
+    cm = metrics["combined_candidate"]
+    print(f"\nGroup 1 Baseline:   P={_f(bm['precision'])} R={_f(bm['recall'])} F1={_f(bm['f1'])} Acc={_f(bm['accuracy'])}")
+    print(f"Combined Candidate: P={_f(cm['precision'])} R={_f(cm['recall'])} F1={_f(cm['f1'])} Acc={_f(cm['accuracy'])}")
+    print(f"Report written to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/content_detection_benchmark/scenarios.json
+++ b/scripts/content_detection_benchmark/scenarios.json
@@ -1,0 +1,406 @@
+{
+  "mutation_families": {
+    "baseline_unmodified": {
+      "ground_truth": "not_outdated",
+      "expected_candidate": [
+        "up_to_date"
+      ]
+    },
+    "paragraph_reflow": {
+      "ground_truth": "not_outdated",
+      "expected_candidate": [
+        "up_to_date",
+        "outdated_low_severity"
+      ]
+    },
+    "shortcode_only_change": {
+      "ground_truth": "not_outdated",
+      "expected_candidate": [
+        "up_to_date"
+      ]
+    },
+    "missing_paragraph": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    "paragraph_reorder": {
+      "ground_truth": "not_outdated",
+      "expected_candidate": [
+        "up_to_date",
+        "outdated_low_severity"
+      ]
+    },
+    "missing_code_block": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated",
+        "outdated_low_severity"
+      ]
+    },
+    "paragraph_extended_in_english": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    "paragraph_rewritten_in_english": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated",
+        "outdated_low_severity"
+      ]
+    },
+    "heading_rename": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "outdated_low_severity"
+      ]
+    },
+    "list_item_added_in_english": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    "list_item_removed_translation": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    "code_command_changed": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    "code_parameters_changed": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    "combined_drift": {
+      "ground_truth": "outdated",
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "fp_formatting",
+      "group": "group1_git_history",
+      "description": "False positive: emphasis style swap",
+      "ground_truth": "not_outdated",
+      "expected_baseline": [
+        "candidate_outdated"
+      ],
+      "expected_candidate": [
+        "up_to_date"
+      ]
+    },
+    {
+      "id": "fp_links",
+      "group": "group1_git_history",
+      "description": "False positive: relative link canonicalized to absolute URL",
+      "ground_truth": "not_outdated",
+      "expected_baseline": [
+        "candidate_outdated"
+      ],
+      "expected_candidate": [
+        "up_to_date"
+      ]
+    },
+    {
+      "id": "fp_shortcodes",
+      "group": "group1_git_history",
+      "description": "False positive: shortcode delimiter swap",
+      "ground_truth": "not_outdated",
+      "expected_baseline": [
+        "candidate_outdated"
+      ],
+      "expected_candidate": [
+        "up_to_date"
+      ]
+    },
+    {
+      "id": "fn_false_sync",
+      "group": "group1_git_history",
+      "description": "False negative: cosmetic KO edit masks meaningful EN addition",
+      "ground_truth": "outdated",
+      "expected_baseline": [
+        "up_to_date"
+      ],
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    {
+      "id": "tp_normal_change",
+      "group": "group1_git_history",
+      "description": "True positive: new EN section appended",
+      "ground_truth": "outdated",
+      "expected_baseline": [
+        "candidate_outdated"
+      ],
+      "expected_candidate": [
+        "candidate_outdated"
+      ]
+    },
+    {
+      "id": "baseline_unmodified",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "baseline_unmodified"
+    },
+    {
+      "id": "paragraph_reflow",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "paragraph_reflow"
+    },
+    {
+      "id": "shortcode_only_change",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "shortcode_only_change"
+    },
+    {
+      "id": "missing_paragraph",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "missing_paragraph"
+    },
+    {
+      "id": "paragraph_reorder",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "paragraph_reorder"
+    },
+    {
+      "id": "missing_code_block",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "missing_code_block"
+    },
+    {
+      "id": "paragraph_extended_in_english",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "paragraph_extended_in_english"
+    },
+    {
+      "id": "paragraph_rewritten_in_english",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "paragraph_rewritten_in_english"
+    },
+    {
+      "id": "heading_rename",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "heading_rename"
+    },
+    {
+      "id": "list_item_added_in_english",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "list_item_added_in_english"
+    },
+    {
+      "id": "list_item_removed_translation",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "list_item_removed_translation"
+    },
+    {
+      "id": "code_command_changed",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "code_command_changed"
+    },
+    {
+      "id": "code_parameters_changed",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "code_parameters_changed"
+    },
+    {
+      "id": "combined_drift",
+      "group": "group2_structural",
+      "page_id": "indexed-job",
+      "family": "combined_drift"
+    },
+    {
+      "id": "redis-tutorial__baseline_unmodified",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "baseline_unmodified"
+    },
+    {
+      "id": "redis-tutorial__paragraph_reflow",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "paragraph_reflow"
+    },
+    {
+      "id": "redis-tutorial__shortcode_only_change",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "shortcode_only_change"
+    },
+    {
+      "id": "redis-tutorial__missing_paragraph",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "missing_paragraph"
+    },
+    {
+      "id": "redis-tutorial__paragraph_reorder",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "paragraph_reorder"
+    },
+    {
+      "id": "redis-tutorial__missing_code_block",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "missing_code_block"
+    },
+    {
+      "id": "redis-tutorial__paragraph_extended_in_english",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "paragraph_extended_in_english"
+    },
+    {
+      "id": "redis-tutorial__paragraph_rewritten_in_english",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "paragraph_rewritten_in_english"
+    },
+    {
+      "id": "redis-tutorial__heading_rename",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "heading_rename"
+    },
+    {
+      "id": "redis-tutorial__list_item_added_in_english",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "list_item_added_in_english"
+    },
+    {
+      "id": "redis-tutorial__list_item_removed_translation",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "list_item_removed_translation"
+    },
+    {
+      "id": "redis-tutorial__code_command_changed",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "code_command_changed"
+    },
+    {
+      "id": "redis-tutorial__code_parameters_changed",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "code_parameters_changed"
+    },
+    {
+      "id": "redis-tutorial__combined_drift",
+      "group": "group2_structural",
+      "page_id": "redis-tutorial",
+      "family": "combined_drift"
+    },
+    {
+      "id": "configure-liveness__baseline_unmodified",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "baseline_unmodified"
+    },
+    {
+      "id": "configure-liveness__paragraph_reflow",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "paragraph_reflow"
+    },
+    {
+      "id": "configure-liveness__shortcode_only_change",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "shortcode_only_change"
+    },
+    {
+      "id": "configure-liveness__missing_paragraph",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "missing_paragraph"
+    },
+    {
+      "id": "configure-liveness__paragraph_reorder",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "paragraph_reorder"
+    },
+    {
+      "id": "configure-liveness__missing_code_block",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "missing_code_block"
+    },
+    {
+      "id": "configure-liveness__paragraph_extended_in_english",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "paragraph_extended_in_english"
+    },
+    {
+      "id": "configure-liveness__paragraph_rewritten_in_english",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "paragraph_rewritten_in_english"
+    },
+    {
+      "id": "configure-liveness__heading_rename",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "heading_rename"
+    },
+    {
+      "id": "configure-liveness__list_item_added_in_english",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "list_item_added_in_english"
+    },
+    {
+      "id": "configure-liveness__list_item_removed_translation",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "list_item_removed_translation"
+    },
+    {
+      "id": "configure-liveness__code_command_changed",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "code_command_changed"
+    },
+    {
+      "id": "configure-liveness__code_parameters_changed",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "code_parameters_changed"
+    },
+    {
+      "id": "configure-liveness__combined_drift",
+      "group": "group2_structural",
+      "page_id": "configure-liveness",
+      "family": "combined_drift"
+    }
+  ]
+}


### PR DESCRIPTION
> ⚠️ This PR is NOT intended to be merged.
> It is created for mentorship discussion, design feedback, and review purposes only.

This PR is part of the LFX mentorship project (#54075) and is intended for feedback on the proposed contract and test suite design. It serves as a benchmark for evaluating proposed content-based detection scripts during the mentorship project.

It should not be merged in its current form.

---

Add a test suite and standardized contract for content-based outdated l10n detection, as part of #54896.

This establishes how outdated content detectors are evaluated before exploring or introducing a content-based detection script.

#### What this does
- Define a canonical status label set:
  - `up_to_date`, `candidate_outdated`, `outdated_low_severity`, `no_english_version`, `not_translated`, `error`
- Establish evaluation rules:
  - exclude non-comparable cases from metrics
- Add test cases reflecting common localization scenarios:
  - structural changes (sections, paragraphs, code blocks)
  - formatting-only changes
  - missing or unmatched files

Candidate scripts exploring the content-based approach are expected to follow this contract and will be evaluated using this test suite.