### PR TITLE
Update schedule.yaml for March 2026 patch releases

### DIFF
--- a/data/releases/eol.yaml
+++ b/data/releases/eol.yaml
@@ -4,6 +4,9 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 branches:
+- endOfLifeDate: "2026-02-28"
+  finalPatchRelease: 1.32.13
+  release: "1.32"
 - endOfLifeDate: "2025-11-11"
   finalPatchRelease: 1.31.14
   release: "1.31"

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,12 +7,17 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-03-06"
-    release: 1.35.3
-    targetDate: "2026-03-10"
+    cherryPickDeadline: "2026-04-10"
+    release: 1.35.4
+    targetDate: "2026-04-14"
   previousPatches:
+  - cherryPickDeadline: "2026-03-13"
+    release: 1.35.3
+    targetDate: "2026-03-19"
   - cherryPickDeadline: "2026-02-26"
-    note: Out of band patch release to pick up a new version of Go to [address several Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ). No other changes.
+    note: Out of band patch release to pick up a new version of Go to [address several
+      Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ).
+      No other changes.
     release: 1.35.2
     targetDate: "2026-02-26"
   - cherryPickDeadline: "2026-02-06"
@@ -24,12 +29,17 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2026-03-06"
-    release: 1.34.6
-    targetDate: "2026-03-10"
+    cherryPickDeadline: "2026-04-10"
+    release: 1.34.7
+    targetDate: "2026-04-14"
   previousPatches:
+  - cherryPickDeadline: "2026-03-13"
+    release: 1.34.6
+    targetDate: "2026-03-19"
   - cherryPickDeadline: "2026-02-26"
-    note: Out of band patch release to pick up a new version of Go to [address several Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ). No other changes.
+    note: Out of band patch release to pick up a new version of Go to [address several
+      Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ).
+      No other changes.
     release: 1.34.5
     targetDate: "2026-02-26"
   - cherryPickDeadline: "2026-02-06"
@@ -53,12 +63,17 @@ schedules:
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2026-03-06"
-    release: 1.33.10
-    targetDate: "2026-03-10"
+    cherryPickDeadline: "2026-04-10"
+    release: 1.33.11
+    targetDate: "2026-04-14"
   previousPatches:
+  - cherryPickDeadline: "2026-03-13"
+    release: 1.33.10
+    targetDate: "2026-03-19"
   - cherryPickDeadline: "2026-02-26"
-    note: Out of band patch release to pick up a new version of Go to [address several Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ). No other changes.
+    note: Out of band patch release to pick up a new version of Go to [address several
+      Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ).
+      No other changes.
     release: 1.33.9
     targetDate: "2026-02-26"
   - cherryPickDeadline: "2026-02-06"
@@ -89,63 +104,10 @@ schedules:
     targetDate: "2025-05-15"
   release: "1.33"
   releaseDate: "2025-04-23"
-- endOfLifeDate: "2026-02-28"
-  maintenanceModeStartDate: "2025-12-28"
-  next:
-    cherryPickDeadline: "2026-03-06"
-    release: 1.32.14
-    targetDate: "2026-03-10"
-  previousPatches:
-  - cherryPickDeadline: "2026-02-26"
-    note: Out of band patch release to pick up a new version of Go to [address several Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ). No other changes.
-    release: 1.32.13
-    targetDate: "2026-02-26"
-  - cherryPickDeadline: "2026-02-06"
-    note: January 2026 patches consolidated with February
-    release: 1.32.12
-    targetDate: "2026-02-10"
-  - cherryPickDeadline: "2025-12-05"
-    release: 1.32.11
-    targetDate: "2025-12-09"
-  - cherryPickDeadline: "2025-11-07"
-    note: October 2025 patches consolidated with November
-    release: 1.32.10
-    targetDate: "2025-11-11"
-  - cherryPickDeadline: "2025-09-05"
-    release: 1.32.9
-    targetDate: "2025-09-09"
-  - cherryPickDeadline: "2025-08-08"
-    release: 1.32.8
-    targetDate: "2025-08-12"
-  - cherryPickDeadline: "2025-07-11"
-    release: 1.32.7
-    targetDate: "2025-07-15"
-  - cherryPickDeadline: "2025-06-06"
-    release: 1.32.6
-    targetDate: "2025-06-17"
-  - cherryPickDeadline: "2025-05-09"
-    release: 1.32.5
-    targetDate: "2025-05-15"
-  - cherryPickDeadline: "2025-04-11"
-    release: 1.32.4
-    targetDate: "2025-04-22"
-  - cherryPickDeadline: "2025-03-07"
-    release: 1.32.3
-    targetDate: "2025-03-11"
-  - cherryPickDeadline: "2025-02-07"
-    release: 1.32.2
-    targetDate: "2025-02-11"
-  - cherryPickDeadline: "2025-01-10"
-    release: 1.32.1
-    targetDate: "2025-01-14"
-  - release: 1.32.0
-    targetDate: "2024-12-11"
-  release: "1.32"
-  releaseDate: "2024-12-11"
 upcoming_releases:
-- cherryPickDeadline: "2026-03-06"
-  targetDate: "2026-03-10"
 - cherryPickDeadline: "2026-04-10"
   targetDate: "2026-04-14"
 - cherryPickDeadline: "2026-05-08"
   targetDate: "2026-05-12"
+- cherryPickDeadline: "2026-06-05"
+  targetDate: "2026-06-09"


### PR DESCRIPTION
### Description

Update schedule for v1.33.10, v1.34.6, and v1.35.3 patch releases (released 2026-03-19). Set next patch releases to v1.33.11, v1.34.7, and v1.35.4 targeting 2026-04-14. Remove EOL 1.32 from schedule.yaml and add it to eol.yaml with final patch release 1.32.13.

### Issue

None