### PR TITLE
chore: add 2 return type hints in update-user-guide-links.py

### DIFF
--- a/content/en/docs/update-user-guide-links.py
+++ b/content/en/docs/update-user-guide-links.py
@@ -27,7 +27,7 @@ def find_documents_to_rewrite():
 # Returns the location of the documentation as we will refer to it in the markdown.
 # /docs/path/to/foo/index.md are available at /docs/path/to/foo/
 # /docs/path/to/foo/bar.md are available at /docs/path/to/foo/bar/
-def doc_location(filename):
+def doc_location(filename) -> str:
     if filename.endswith('/index.md'):
         return "/docs/" + filename[:-9] + "/"
     else:
@@ -35,7 +35,7 @@ def doc_location(filename):
 
 REDIRECT_REGEX = re.compile("^.*\[(.*)\]\((.*)\)$")
 
-def get_destinations_for_doc(filename):
+def get_destinations_for_doc(filename) -> list:
     destination_paths = []
     with open(filename) as f:
         lines = [line.rstrip('\n').rstrip('\r') for line in f.readlines()]


### PR DESCRIPTION
## Summary
Added concrete return type annotations to functions in `content/en/docs/update-user-guide-links.py` based on static analysis of return statements.

## Changes
- Add return type hint `-> list` to function
- Add return type hint `-> str` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

## Motivation
These type annotations are inferred from actual return values in the function bodies (e.g. `return True` → `-> bool`, `return []` → `-> list`). They improve:
- **IDE autocompletion** and type checking (mypy/pyright)
- **Code readability** for contributors navigating the codebase
- **Bug prevention** via static analysis

No functional changes — only type annotations added.
