### PR TITLE
Reorder probe descriptions to match actual execution order

### DIFF
--- a/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/en/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -6,7 +6,7 @@ weight: 40
 
 <!-- overview -->
 
-Kubernetes uses probes to continuously monitor the health of containers in a running Pod.
+Kubernetes lets you define _probes_ to continuously monitor the health of containers in a Pod.
 Based on probe results, Kubernetes can restart unhealthy containers or stop sending traffic to containers that are not ready.
 
 There are three types of probes, each serving a different purpose:


### PR DESCRIPTION
### Description

Reorder probe sections to match the actual execution order: startup → liveness / readiness.
Also update the startup probe description to be self-contained, since the original wording assumed prior knowledge of liveness probes.

### Comment

The third commit adds a brief overview describing the role of probes. If this is beyond the scope of this PR, I'm going to revert the commit.

As a side note, the [Configure Liveness, Readiness and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) task page contains some conceptual descriptions that might belong on this concept page instead (IMO).
For example, 

> Caution:
Liveness probes can be a powerful way to recover from application failures, but they should be used with caution. Liveness probes must be configured carefully to ensure that they truly indicate unrecoverable application failure, for example a deadlock.

> Note:
Incorrect implementation of liveness probes can lead to cascading failures. This results in restarting of container under high load; failed client requests as your application became less scalable; and increased workload on remaining pods due to some failed pods. Understand the difference between readiness and liveness probes and when to apply them for your app.

I think this is out of scope for this PR, but I can open a separate issue if there's interest.

### Issue

Closes: #54948