### PR TITLE
[fr] : Add 4 glossary entries (Pod-lifecycle, eviction, network-policy, persistent-volume)

### DIFF
--- a/content/fr/docs/reference/glossary/eviction.md
+++ b/content/fr/docs/reference/glossary/eviction.md
@@ -1,0 +1,18 @@
+---
+title: Eviction
+id: eviction
+full_link: /docs/concepts/scheduling-eviction/
+short_description: >
+  Processus de terminaison d’un ou plusieurs Pods sur des nœuds.
+aka:
+tags:
+- operation
+---
+
+L’éviction est le processus de terminaison d’un ou plusieurs Pods sur des nœuds.
+
+<!--more-->
+
+Il existe deux types d’éviction :
+* [Node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+* [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/)

--- a/content/fr/docs/reference/glossary/network-policy.md
+++ b/content/fr/docs/reference/glossary/network-policy.md
@@ -1,0 +1,25 @@
+---
+title: Network Policy
+id: network-policy
+full_link: /docs/concepts/services-networking/network-policies/
+short_description: >
+  Une spécification définissant comment des groupes de Pods sont autorisés à communiquer entre eux et avec d'autres points de terminaison réseau.
+
+aka: 
+tags:
+- networking
+- architecture
+- extension
+- core-object
+---
+
+Une spécification définissant comment des groupes de Pods sont autorisés à communiquer entre eux et avec d'autres points de terminaison réseau.
+
+<!--more-->
+
+Les NetworkPolicies permettent de configurer de manière déclarative quels Pods sont autorisés à se connecter entre eux, quels namespaces sont autorisés à communiquer,
+et plus précisément quels numéros de port sont concernés par chaque politique. Les objets NetworkPolicy utilisent des {{< glossary_tooltip text="labels" term_id="label" >}}
+pour sélectionner des Pods et définir des règles spécifiant quel trafic est autorisé vers les Pods sélectionnés.
+
+Les NetworkPolicies sont implémentées par un plugin réseau compatible fourni par un fournisseur réseau.
+Notez que la création d’un objet NetworkPolicy sans contrôleur pour l’implémenter n’aura aucun effet.

--- a/content/fr/docs/reference/glossary/persistent-volume.md
+++ b/content/fr/docs/reference/glossary/persistent-volume.md
@@ -1,0 +1,18 @@
+---
+title: Persistent Volume
+id: persistent-volume
+full_link: /docs/concepts/storage/persistent-volumes/
+short_description: >
+  Objet API représentant une unité de stockage dans le cluster.
+
+aka: 
+tags:
+- core-object
+- storage
+---
+
+Objet API représentant une unité de stockage dans le cluster. Il s’agit d’une représentation d’une {{< glossary_tooltip text="ressource" term_id="infrastructure-resource" >}} de stockage générale et extensible, pouvant persister au-delà du cycle de vie de tout {{< glossary_tooltip text="Pod" term_id="pod" >}} individuel.
+
+<!--more-->
+
+Les PersistentVolumes (PV) fournissent une API qui abstrait les détails de la manière dont le stockage est fourni de la manière dont il est consommé. Les PV sont utilisés directement dans les cas où le stockage peut être créé à l’avance (provisionnement statique). Pour les cas nécessitant un stockage à la demande (provisionnement dynamique), des PersistentVolumeClaims (PVC) sont utilisés à la place.

--- a/content/fr/docs/reference/glossary/pod-lifecycle.md
+++ b/content/fr/docs/reference/glossary/pod-lifecycle.md
@@ -1,0 +1,19 @@
+---
+title: Pod Lifecycle
+id: pod-lifecycle
+full-link: /docs/concepts/workloads/pods/pod-lifecycle/
+related:
+ - pod
+ - container
+tags:
+ - fundamental
+short_description: >
+  La succession des états par lesquels passe un Pod au cours de son cycle de vie.
+ 
+---
+
+La succession des états par lesquels passe un Pod au cours de son cycle de vie.
+
+<!--more-->
+
+Le [Pod Lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/) est défini par les états ou phases d’un Pod. Il existe cinq phases possibles pour un Pod : Pending, Running, Succeeded, Failed et Unknown. Une description synthétique de l’état du Pod est fournie dans le champ `phase` de [PodStatus](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podstatus-v1-core).


### PR DESCRIPTION
### Description

Traduction de quatre entrées du glossaire liées au cycle de vie des Pods, au stockage et au réseau dans Kubernetes.

**Fichiers inclus :**

* `pod-lifecycle.md` : décrit les différentes phases du cycle de vie d’un Pod.
* `eviction.md` : processus de terminaison d’un ou plusieurs Pods sur des nœuds.
* `network-policy.md` : définit comment les Pods peuvent communiquer entre eux et avec d’autres endpoints réseau.
* `persistent-volume.md` : représente une unité de stockage persistante dans le cluster.

Cette contribution fait partie du plan de suivi #54874.