### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/fr/docs/reference/glossary/persistent-volume-claim.md
@@ -1,0 +1,20 @@
+---
+title: Persistent Volume Claim
+id: persistent-volume-claim
+full_link: /docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+short_description: >
+  Permet de réclamer des ressources de stockage définies dans un PersistentVolume afin de les monter comme volume dans un conteneur.
+
+aka: 
+tags:
+- core-object
+- storage
+---
+
+Permet de réclamer des {{< glossary_tooltip text="ressources" term_id="infrastructure-resource" >}} de stockage définies dans un
+{{< glossary_tooltip text="PersistentVolume" term_id="persistent-volume" >}}, afin que ce stockage puisse être monté
+comme volume dans un {{< glossary_tooltip text="conteneur" term_id="container" >}}.
+
+<!--more-->
+
+Spécifie la quantité de stockage, la manière dont il sera accédé (lecture seule, lecture-écriture et/ou exclusif) ainsi que la façon dont il est récupéré (conservé, recyclé ou supprimé). Les détails du stockage lui-même sont décrits dans l’objet PersistentVolume.

--- a/content/fr/docs/reference/glossary/pod-disruption.md
+++ b/content/fr/docs/reference/glossary/pod-disruption.md
@@ -1,0 +1,22 @@
+---
+id: pod-disruption
+title: Pod Disruption
+full_link: /docs/concepts/workloads/pods/disruptions/
+short_description: >
+  Processus par lequel des Pods sur des nœuds sont terminés de manière volontaire ou involontaire.
+
+aka:
+related:
+ - pod
+ - container
+tags:
+ - operation
+---
+
+La [Pod disruption](/docs/concepts/workloads/pods/disruptions/) est le processus par lequel 
+des Pods sur des nœuds sont terminés de manière volontaire ou involontaire.
+
+<!--more-->
+
+Les perturbations volontaires sont déclenchées intentionnellement par les propriétaires d'applications ou les administrateurs du cluster. Les perturbations involontaires sont non intentionnelles et peuvent être causées par des problèmes inévitables, comme des nœuds à court de {{< glossary_tooltip text="ressources" term_id="infrastructure-resource" >}},
+ou par des suppressions accidentelles.

--- a/content/fr/docs/reference/glossary/pod-priority.md
+++ b/content/fr/docs/reference/glossary/pod-priority.md
@@ -1,0 +1,17 @@
+---
+title: Pod Priority
+id: pod-priority
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+short_description: >
+  La priorité d’un Pod indique son importance relative par rapport aux autres Pods.
+
+aka:
+tags:
+- operation
+---
+
+La priorité d’un {{< glossary_tooltip term_id="pod" >}} indique son importance relative par rapport aux autres Pods.
+
+<!--more-->
+
+La [Pod Priority](/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) permet de définir une priorité d’ordonnancement pour un Pod, afin qu’il puisse être priorisé plus ou moins que d’autres Pods — une fonctionnalité importante pour les charges de travail en production.

--- a/content/fr/docs/reference/glossary/preemption.md
+++ b/content/fr/docs/reference/glossary/preemption.md
@@ -1,0 +1,17 @@
+---
+title: Preemption
+id: preemption
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
+short_description: >
+  Le mécanisme de préemption dans Kubernetes permet à un Pod en attente de trouver un nœud adapté en évincant des Pods de priorité inférieure présents sur ce nœud.
+
+aka:
+tags:
+- operation
+---
+
+Le mécanisme de préemption dans Kubernetes permet à un {{< glossary_tooltip term_id="pod" >}} en attente de trouver un {{< glossary_tooltip term_id="node" >}} adapté en évincant des Pods de priorité inférieure présents sur ce nœud.
+
+<!--more-->
+
+Si un Pod ne peut pas être planifié, le scheduler tente de [préempter](/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption) des Pods de priorité inférieure afin de permettre la planification du Pod en attente.


### PR DESCRIPTION
### Description

Traduction de quatre entrées du glossaire liées à la gestion du stockage, des perturbations et de l’ordonnancement des Pods.

**Fichiers inclus :**

* `persistent-volume-claim.md` : permet de réclamer des ressources de stockage afin de les monter dans un conteneur.
* `pod-disruption.md` : décrit les perturbations volontaires et involontaires affectant les Pods.
* `pod-priority.md` : indique l’importance relative d’un Pod pour l’ordonnancement.
* `preemption.md` : mécanisme permettant de planifier un Pod en évincant des Pods de priorité inférieure.

Cette contribution fait partie du plan de suivi #54874.