### PR TITLE
Trigger rebuild when CVE feed changes

### DIFF
--- a/.github/workflows/cve-feed-build-on-change.yml
+++ b/.github/workflows/cve-feed-build-on-change.yml
@@ -1,0 +1,70 @@
+name: Rebuild site when CVE feed changes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '4,24,44 * * * *'
+permissions: {} # none
+concurrency:
+  group: cve-feed-build-on-change
+  cancel-in-progress: false
+jobs:
+  trigger-netlify-build:
+    if: github.repository == 'kubernetes/website'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      SOURCE_URL: https://storage.googleapis.com/k8s-cve-feed/official-cve-feed.json
+      PUBLISHED_URL: https://kubernetes.io/docs/reference/issues-security/official-cve-feed/index.json
+      TOKEN: ${{ secrets.NETLIFY_BUILD_HOOK_KEY }}
+    steps:
+      - name: Rebuild Netlify when the published CVE feed is stale
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          fetch_json() {
+            curl --fail --silent --show-error --location \
+              --retry 3 --retry-delay 5 --retry-all-errors \
+              "$1" | jq -cS . > "$2"
+          }
+
+          hash_file() {
+            sha256sum "$1" | cut -d' ' -f1
+          }
+
+          temp_dir=$(mktemp -d)
+          trap 'rm -rf "$temp_dir"' EXIT
+
+          source_file="$temp_dir/source.json"
+          published_file="$temp_dir/published.json"
+
+          fetch_json "$SOURCE_URL" "$source_file"
+          fetch_json "$PUBLISHED_URL" "$published_file"
+
+          source_hash=$(hash_file "$source_file")
+          published_hash=$(hash_file "$published_file")
+          source_updated_at=$(jq -er '._kubernetes_io.updated_at' "$source_file")
+          published_updated_at=$(jq -er '._kubernetes_io.updated_at' "$published_file")
+
+          if [[ "$source_hash" == "$published_hash" ]]; then
+            {
+              echo "Published CVE feed is already up to date."
+              echo "Source updated_at: $source_updated_at"
+              echo "Published updated_at: $published_updated_at"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          curl --fail --silent --show-error \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "{}" \
+            "https://api.netlify.com/build_hooks/${TOKEN}"
+
+          {
+            echo "Triggered a Netlify rebuild because the public CVE feed is stale."
+            echo "Source updated_at: $source_updated_at"
+            echo "Published updated_at: $published_updated_at"
+            echo "The next scheduled run will re-check the feeds."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Description
Add a GitHub Actions workflow that checks every 20 minutes whether the published CVE feed at k8s.io is behind the source data in the GCS bucket, and triggers a Netlify rebuild only when the feeds differ.
as suggested in: https://github.com/kubernetes/website/pull/44074#issuecomment-1828240426
### Issue
Closes: #43968