### PR TITLE
Update Kubernetes APT keyring URL to v1.35

### DIFF
--- a/content/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -195,7 +195,7 @@ Les instructions suivantes sont pour Kubernetes v{{< skew currentVersion >}}.
    ```shell
    # Si le répertoire `/etc/apt/keyrings` n'existe pas, vous devez le créer avant la curl, avec la commande ci-dessous par exemple.
    # sudo mkdir -p -m 755 /etc/apt/keyrings
-   curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
 3. Ajoutez le dépôt `apt` approprié pour Kubernetes.


### PR DESCRIPTION
Updated the Kubernetes APT keyring URL from v1.33 to v1.35 in the French documentation.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #54991