### PR TITLE
[vi] Add Vietnamese translation for glossary cronjob

### DIFF
--- a/content/vi/docs/reference/glossary/cronjob.md
+++ b/content/vi/docs/reference/glossary/cronjob.md
@@ -1,0 +1,17 @@
+---
+title: CronJob
+id: cronjob
+full_link: /docs/concepts/workloads/controllers/cron-jobs/
+short_description: >
+  Một tác vụ lặp lại (một Job) chạy theo lịch trình định kỳ.
+
+aka:
+tags:
+- core-object
+- workload
+---
+ Quản lý một [Job](/docs/concepts/workloads/controllers/job/) chạy theo lịch trình định kỳ.
+
+<!--more-->
+
+Tương tự như một dòng trong file *crontab*, một CronJob object chỉ định lịch trình sử dụng định dạng [cron](https://en.wikipedia.org/wiki/Cron).


### PR DESCRIPTION
### Description

Add Vietnamese translation for glossary [cronjob](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/cronjob.md)

### Issue

Closes: #