### PR TITLE
[vi] Add Vietnamese translation for glossary code-contributor

### DIFF
--- a/content/vi/docs/reference/glossary/code-contributor.md
+++ b/content/vi/docs/reference/glossary/code-contributor.md
@@ -1,0 +1,17 @@
+---
+title: Người đóng góp mã nguồn
+id: code-contributor
+full_link: https://github.com/kubernetes/community/tree/master/contributors/devel
+short_description: >
+  Người phát triển và đóng góp mã nguồn vào codebase mã nguồn mở của Kubernetes.
+
+aka:
+tags:
+- community
+- user-type
+---
+ Người phát triển và đóng góp mã nguồn vào codebase mã nguồn mở của Kubernetes.
+
+<!--more-->
+
+Họ cũng là {{< glossary_tooltip text="thành viên cộng đồng" term_id="member" >}} tích cực, tham gia vào một hoặc nhiều {{< glossary_tooltip text="Nhóm quan tâm đặc biệt (SIGs)" term_id="sig" >}}.


### PR DESCRIPTION
### Description

Add Vietnamese translation for [glossary code-contributor
](https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/code-contributor.md)

### Issue

Closes: #