### PR TITLE
[zh-tw] translate part of best-practices/*

### DIFF
--- a/content/zh-tw/docs/setup/best-practices/_index.md
+++ b/content/zh-tw/docs/setup/best-practices/_index.md
@@ -1,0 +1,10 @@
+---
+title: 最佳實務
+weight: 40
+---
+<!--
+---
+title: Best practices
+weight: 40
+---
+-->

--- a/content/zh-tw/docs/setup/best-practices/cluster-large.md
+++ b/content/zh-tw/docs/setup/best-practices/cluster-large.md
@@ -1,0 +1,255 @@
+---
+title: 大型叢集的考量事項
+weight: 10
+---
+<!--
+---
+reviewers:
+- davidopp
+- lavalamp
+title: Considerations for large clusters
+weight: 10
+---
+-->
+
+<!--
+A cluster is a set of {{< glossary_tooltip text="nodes" term_id="node" >}} (physical
+or virtual machines) running Kubernetes agents, managed by the
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}}.
+Kubernetes {{< param "version" >}} supports clusters with up to 5,000 nodes. More specifically,
+Kubernetes is designed to accommodate configurations that meet *all* of the following criteria:
+-->
+叢集是由一組執行 Kubernetes 代理程式的{{< glossary_tooltip text="節點" term_id="node" >}}
+（實體機器或虛擬機器）所組成，並由{{< glossary_tooltip text="控制平面" term_id="control-plane" >}}進行管理。
+Kubernetes {{< param "version" >}} 支援最多 5,000 個節點的叢集。
+更具體來說，Kubernetes 的設計可支援符合以下所有準則的配置：
+
+<!--
+* No more than 110 pods per node
+* No more than 5,000 nodes
+* No more than 150,000 total pods
+* No more than 300,000 total containers
+-->
+* 每個節點不超過 110 個 Pod
+* 不超過 5,000 個節點
+* Pod 總數不超過 150,000
+* 容器總數不超過 300,000
+
+<!--
+You can scale your cluster by adding or removing nodes. The way you do this depends
+on how your cluster is deployed.
+-->
+您可以透過新增或移除節點來調整叢集規模。具體作法取決於叢集的部署方式。
+
+<!--
+## Cloud provider resource quotas {#quota-issues}
+-->
+## 雲端供應商資源配額 {#quota-issues}
+
+<!--
+To avoid running into cloud provider quota issues, when creating a cluster with many nodes,
+consider:
+* Requesting a quota increase for cloud resources such as:
+    * Computer instances
+    * CPUs
+    * Storage volumes
+    * In-use IP addresses
+    * Packet filtering rule sets
+    * Number of load balancers
+    * Network subnets
+    * Log streams
+* Gating the cluster scaling actions to bring up new nodes in batches, with a pause
+  between batches, because some cloud providers rate limit the creation of new instances.
+-->
+為了避免碰到雲端供應商的配額問題，在建立多個節點的叢集時，建議考量：
+* 申請提高雲端資源的配額，例如：
+  * 運算執行個體
+  * CPU
+  * 儲存卷
+  * 使用中的 IP 位址
+  * 封包過濾規則
+  * 負載平衡器的數量
+  * 子網路
+  * 日誌串流
+* 控制叢集的擴展流程，分批啟動新節點，並在各批之間加入間隔，
+  因為部分雲端供應商會限制新執行個體的建立速率。
+
+<!--
+## Control plane components
+-->
+## 控制平面組件 {#control-plane-components}
+
+<!--
+For a large cluster, you need a control plane with sufficient compute and other
+resources.
+
+Typically you would run one or two control plane instances per failure zone,
+scaling those instances vertically first and then scaling horizontally after reaching
+the point of falling returns to (vertical) scale.
+-->
+對於大型叢集，您需要一個具備足夠運算及其他資源的控制平面。
+
+通常您會在每個故障區執行一到兩個控制平面執行個體，並優先對這些執行個體進行垂直擴展；
+直到垂直擴展達到邊際效益遞減的臨界點後，再進行水平擴展。
+
+<!--
+You should run at least one instance per failure zone to provide fault-tolerance. Kubernetes
+nodes do not automatically steer traffic towards control-plane endpoints that are in the
+same failure zone; however, your cloud provider might have its own mechanisms to do this.
+
+For example, using a managed load balancer, you configure the load balancer to send traffic
+that originates from the kubelet and Pods in failure zone _A_, and direct that traffic only
+to the control plane hosts that are also in zone _A_. If a single control-plane host or
+endpoint failure zone _A_ goes offline, that means that all the control-plane traffic for
+nodes in zone _A_ is now being sent between zones. Running multiple control plane hosts in
+each zone makes that outcome less likely.
+-->
+您應該在每個故障區執行至少一個執行個體來提供容錯能力。
+Kubernetes 節點不會自動將流量導向位於相同故障區的控制平面端點；然而，
+您的雲端供應商可能有其獨有的機制來做到這一點。
+
+例如，使用託管的負載平衡器時，
+您可以設定此負載平衡器將源於故障區 **A** 的 kubelet 與 Pod 流量僅導向同樣位於故障區 **A** 的控制平面主機。
+如果故障區 **A** 內的單一控制平面主機或端點離線，這意味著 **A** 區節點的所有控制平面流量現在都將改為跨區傳輸。
+在每個區域中執行多個控制平面主機可以降低發生這種情況的可能性。
+
+<!--
+### etcd storage
+-->
+### etcd 儲存 {#etcd-storage}
+
+<!--
+To improve performance of large clusters, you can store Event objects in a separate
+dedicated etcd instance.
+-->
+為了提升大型叢集的效能，您可以將 Event 物件儲存於一個獨立且專屬的 etcd 執行個體中。
+
+<!--
+When creating a cluster, you can (using custom tooling):
+
+* start and configure additional etcd instance
+* configure the {{< glossary_tooltip term_id="kube-apiserver" text="API server" >}} to use it for storing events
+-->
+您可以使用自訂工具，在建立叢集時：
+
+* 啟動並設定額外的 etcd 執行個體
+* 設定 {{< glossary_tooltip term_id="kube-apiserver" text="API 伺服器" >}}將 Event 儲存在該執行個體中
+
+<!--
+See [Operating etcd clusters for Kubernetes](/docs/tasks/administer-cluster/configure-upgrade-etcd/) and
+[Set up a High Availability etcd cluster with kubeadm](/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)
+for details on configuring and managing etcd for a large cluster.
+-->
+請參閱[針對 Kubernetes 維運 etcd 叢集](/zh-tw/docs/tasks/administer-cluster/configure-upgrade-etcd/)
+與[使用 kubeadm 架設高可用性 etcd 叢集](/zh-tw/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)，
+以了解為大型叢集設定與管理 etcd 的詳細資訊。
+
+<!--
+## Addon resources
+-->
+## 附加元件資源 {#addon-resources}
+
+<!--
+Kubernetes [resource limits](/docs/concepts/configuration/manage-resources-containers/)
+help to minimize the impact of memory leaks and other ways that pods and containers can
+impact on other components. These resource limits apply to
+{{< glossary_tooltip text="addon" term_id="addons" >}} resources just as they apply to application workloads.
+
+For example, you can set CPU and memory limits for a logging component:
+-->
+Kubernetes [資源限制](/zh-tw/docs/concepts/configuration/manage-resources-containers/)有助於將記憶體洩漏，
+以及 Pod 與容器對其他組件的影響降至最低。
+這些資源限制同樣適用於{{< glossary_tooltip text="附加元件" term_id="addons" >}}的資源，
+也適用於應用程式工作負載。
+
+例如，您可以為日誌組件設定 CPU 與記憶體限制：
+
+```yaml
+  ...
+  containers:
+  - name: fluentd-cloud-logging
+    image: fluent/fluentd-kubernetes-daemonset:v1
+    resources:
+      limits:
+        cpu: 100m
+        memory: 200Mi
+```
+
+<!--
+Addons' default limits are typically based on data collected from experience running
+each addon on small or medium Kubernetes clusters. When running on large
+clusters, addons often consume more of some resources than their default limits.
+If a large cluster is deployed without adjusting these values, the addon(s)
+may continuously get killed because they keep hitting the memory limit.
+Alternatively, the addon may run but with poor performance due to CPU time
+slice restrictions.
+-->
+附加元件的預設限制，通常是基於在小型或中型 Kubernetes 叢集上執行各個附加元件的經驗所蒐集的資料。
+當在大型叢集上執行時，某些資源的使用量可能會超過預設限制。若在部署大型叢集時未調整這些數值，
+附加元件可能會因為不斷觸及記憶體限制而反覆被終止；或者，附加元件雖能維持執行，
+但會受 CPU 時間切片限制影響而效能低落。
+
+<!--
+To avoid running into cluster addon resource issues, when creating a cluster with
+many nodes, consider the following:
+-->
+為了避免遇到叢集附加元件的資源問題，在建立包含多個節點的叢集時，建議考量以下事項：
+
+<!--
+* Some addons scale vertically - there is one replica of the addon for the cluster
+  or serving a whole failure zone. For these addons, increase requests and limits
+  as you scale out your cluster.
+* Many addons scale horizontally - you add capacity by running more pods - but with
+  a very large cluster you may also need to raise CPU or memory limits slightly.
+  The [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#readme) can run in _recommender_ mode to provide suggested
+  figures for requests and limits.
+* Some addons run as one copy per node, controlled by a {{< glossary_tooltip text="DaemonSet"
+  term_id="daemonset" >}}: for example, a node-level log aggregator. Similar to
+  the case with horizontally-scaled addons, you may also need to raise CPU or memory
+  limits slightly.
+-->
+* 部分附加元件採垂直擴展 — 整個叢集或每個故障區僅執行一個附加元件副本。
+  對於此類附加元件，當您擴展叢集規模時，請增加其資源請求與限制。
+* 許多附加元件採水平擴展 — 透過增加 Pod 數量來提升容量；但在超大型叢集中，您可能仍需稍微提高 CPU 或記憶體限制。
+  [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#readme)
+  可以以**recommender 模式**執行，以提供資源請求與限制的建議值。
+* 部分附加元件以每個節點一個副本的方式執行，並由 {{< glossary_tooltip text="DaemonSet" term_id="daemonset" >}} 進行控制：
+  例如節點級別的日誌聚合器。與水平擴展的附加元件類似，您可能也需要稍微調高 CPU 或記憶體限制。
+
+<!--
+## Prioritizing cluster-essential components
+-->
+## 優先處理叢集關鍵組件 {#prioritizing-cluster-essential-components}
+
+<!--
+To ensure cluster-essential components (such as CoreDNS, metrics-server, and other critical add-ons) are scheduled ahead of other workloads and are not preempted by lower-priority pods, run them with a system [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/), such as `system-cluster-critical` or `system-node-critical`.
+-->
+為了確保叢集的必要組件（例如 CoreDNS、metrics-server 與其他關鍵附加元件）優先於其他工作負載進行排程，且不會被較低優先權的 Pod 搶佔，
+請使用系統的 [PriorityClass](/zh-tw/docs/concepts/scheduling-eviction/pod-priority-preemption/) 來設定這些組件的優先順序，
+例如 `system-cluster-critical` 或 `system-node-critical`。
+
+## {{% heading "whatsnext" %}}
+
+<!--
+* `VerticalPodAutoscaler` is a custom resource that you can deploy into your cluster
+to help you manage resource requests and limits for pods.  
+Learn more about [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#readme) 
+and how you can use it to scale cluster
+components, including cluster-critical addons.
+-->
+* `VerticalPodAutoscaler` 是一個您可以部署到叢集中的自訂資源，用來協助您管理 Pod 的資源請求與限制。
+請參閱 [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#readme) 以了解更多資訊，
+並學習如何使用它來調整叢集組件的規模，包括叢集關鍵的附加元件。
+
+<!--
+* Read about [Node autoscaling](/docs/concepts/cluster-administration/node-autoscaling/)
+-->
+* 請參閱[節點自動擴展](/zh-tw/docs/concepts/cluster-administration/node-autoscaling/)
+
+<!--
+* The [addon resizer](https://github.com/kubernetes/autoscaler/tree/master/addon-resizer#readme)
+helps you in resizing the addons automatically as your cluster's scale changes.
+-->
+* [addon resizer](https://github.com/kubernetes/autoscaler/tree/master/addon-resizer#readme) 可協助您隨著叢集規模的變化，
+自動調整附加元件的資源配置。
+---

--- a/content/zh-tw/docs/setup/best-practices/multiple-zones.md
+++ b/content/zh-tw/docs/setup/best-practices/multiple-zones.md
@@ -1,0 +1,274 @@
+---
+title: 跨區域執行
+weight: 20
+content_type: concept
+---
+<!--
+---
+reviewers:
+- jlowdermilk
+- justinsb
+- quinton-hoole
+title: Running in multiple zones
+weight: 20
+content_type: concept
+---
+-->
+
+<!-- overview -->
+
+<!--
+This page describes running Kubernetes across multiple zones.
+-->
+本頁面說明如何跨多個區域執行 Kubernetes。
+
+<!-- body -->
+
+<!--
+## Background
+-->
+## 背景 {#background}
+
+<!--
+Kubernetes is designed so that a single Kubernetes cluster can run
+across multiple failure zones, typically where these zones fit within
+a logical grouping called a _region_. Major cloud providers define a region
+as a set of failure zones (also called _availability zones_) that provide
+a consistent set of features: within a region, each zone offers the same
+APIs and services.
+-->
+Kubernetes 的設計使單一叢集能夠跨多個故障區（Failure Zone）執行；
+這些故障區通常隸屬於一個稱為**「地區」（Region）**的邏輯分組。主要的雲端供應商將地區定義為一組故障區，亦稱為**可用區（Availability Zone）**，
+並提供一致的功能：在同一個地區內，各故障區提供相同的 API 與服務。
+
+<!--
+Typical cloud architectures aim to minimize the chance that a failure in
+one zone also impairs services in another zone.
+-->
+典型的雲端架構旨在將單一故障區故障對其他故障區服務的影響降至最低。
+
+<!--
+## Control plane behavior
+-->
+## 控制平面行為 {#control-plane-behavior}
+
+<!--
+All [control plane components](/docs/concepts/architecture/#control-plane-components)
+support running as a pool of interchangeable resources, replicated per
+component.
+-->
+所有[控制平面組件](/zh-tw/docs/concepts/architecture/#control-plane-components)都支援以可互換資源池的方式執行，
+並為各個組件建立多個副本
+
+<!--
+When you deploy a cluster control plane, place replicas of
+control plane components across multiple failure zones. If availability is
+an important concern, select at least three failure zones and replicate
+each individual control plane component (API server, scheduler, etcd,
+cluster controller manager) across at least three failure zones.
+If you are running a cloud controller manager then you should
+also replicate this across all the failure zones you selected.
+-->
+當您部署叢集控制平面時，需將控制平面組件的副本分散部署於多個故障區。
+若高可用性是重要考量，應選擇至少三個故障區，並為各個控制平面組件（API 伺服器、排程器、etcd、叢集控制器管理器）建立多個副本，分散部署於這些故障區中。
+若有使用雲端控制器管理器，也應將它複製到您所選擇的所有故障區中。
+
+<!--
+{{< note >}}
+Kubernetes does not provide cross-zone resilience for the API server
+endpoints. You can use various techniques to improve availability for
+the cluster API server, including DNS round-robin, SRV records, or
+a third-party load balancing solution with health checking.
+{{< /note >}}
+-->
+{{< note >}}
+Kubernetes 不會為 API 伺服器端點提供跨故障區的系統韌性。您可以使用多種技術來改善叢集 API 伺服器的可用性，
+包括 DNS 輪詢、SRV 記錄，或是具備健康檢查功能的第三方負載平衡方案。
+{{< /note >}}
+
+<!--
+## Node behavior
+-->
+## 節點行為 {#node-behavior}
+
+<!--
+Kubernetes automatically spreads the Pods for
+workload resources (such as {{< glossary_tooltip text="Deployment" term_id="deployment" >}}
+or {{< glossary_tooltip text="StatefulSet" term_id="statefulset" >}})
+across different nodes in a cluster. This spreading helps
+reduce the impact of failures.
+-->
+Kubernetes 會自動將工作負載資源
+（例如 {{< glossary_tooltip text="Deployment" term_id="deployment" >}} 或 {{< glossary_tooltip text="StatefulSet" term_id="statefulset" >}}）
+的 Pod 分散部署於叢集中的不同節點。這種分散部署有助於降低故障造成的影響。
+
+<!--
+When nodes start up, the kubelet on each node automatically adds
+{{< glossary_tooltip text="labels" term_id="label" >}} to the Node object
+that represents that specific kubelet in the Kubernetes API.
+These labels can include
+[zone information](/docs/reference/labels-annotations-taints/#topologykubernetesiozone).
+-->
+當節點啟動時，每個節點上的 kubelet 會自動在 Kubernetes API 中代表此特定節點的 Node 物件加上{{< glossary_tooltip text="標籤" term_id="label" >}}。
+這些標籤可以包含[區域資訊](/zh-tw/docs/reference/labels-annotations-taints/#topologykubernetesiozone)。
+
+<!--
+If your cluster spans multiple zones or regions, you can use node labels
+in conjunction with
+[Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+to control how Pods are spread across your cluster among fault domains:
+regions, zones, and even specific nodes.
+These hints enable the
+{{< glossary_tooltip text="scheduler" term_id="kube-scheduler" >}} to place
+Pods for better expected availability, reducing the risk that a correlated
+failure affects your whole workload.
+-->
+如果您的叢集跨越多個故障區或地區，您可以結合使用節點標籤與 [Pod 拓撲散佈限制](/zh-tw/docs/concepts/scheduling-eviction/topology-spread-constraints/)，
+來控制 Pod 在叢集中的各個故障域（地區、故障區，甚至特定節點）之間的分佈方式。
+這些提示可讓{{< glossary_tooltip text="排程器" term_id="kube-scheduler" >}}將 Pod 排程到更有利於可用性的位置，
+從而降低相關故障影響整個工作負載的風險。
+
+<!--
+For example, you can set a constraint to make sure that the
+3 replicas of a StatefulSet are all running in different zones to each
+other, whenever that is feasible. You can define this declaratively
+without explicitly defining which availability zones are in use for
+each workload.
+-->
+例如，您可以設定一項限制：確保在可行的情況下，一個 StatefulSet 的 3 個副本分別執行於不同的故障區
+您可以透過宣告式的方式來定義此限制，不需要為每個工作負載明確指定使用哪些可用區。
+
+<!--
+### Distributing nodes across zones
+-->
+### 跨區域分散節點 {#distributing-nodes-across-zones}
+
+<!--
+Kubernetes' core does not create nodes for you; you need to do that yourself,
+or use a tool such as the [Cluster API](https://cluster-api.sigs.k8s.io/) to
+manage nodes on your behalf.
+-->
+Kubernetes 核心本身不會為您建立節點；您需要自行建立，
+或使用像是 [Cluster API](https://cluster-api.sigs.k8s.io/) 的工具來代為管理節點。
+
+<!--
+Using tools such as the Cluster API you can define sets of machines to run as
+worker nodes for your cluster across multiple failure domains, and rules to
+automatically heal the cluster in case of whole-zone service disruption.
+-->
+透過使用 Cluster API 等工具，您可以定義一組機器，將其分散在多個故障域中作為叢集的工作節點執行，
+並定義規則，在發生整個區域的服務中斷時自動修復叢集。
+
+<!--
+## Manual zone assignment for Pods
+-->
+## 手動為 Pod 指定區域 {#manual-zone-assignment-for-pods}
+
+<!--
+You can apply [node selector constraints](/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+to Pods that you create, as well as to Pod templates in workload resources
+such as Deployment, StatefulSet, or Job.
+-->
+您可以套用[節點選擇器限制](/zh-tw/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)到您建立的 Pod，
+以及 Deployment、StatefulSet 或 Job 等工作負載資源中的 Pod 模板。
+
+<!--
+## Storage access for zones
+-->
+## 區域的儲存存取 {#storage-access-for-zones}
+
+<!--
+When persistent volumes are created, Kubernetes automatically adds zone labels 
+to any PersistentVolumes that are linked to a specific zone.
+The {{< glossary_tooltip text="scheduler" term_id="kube-scheduler" >}} then ensures,
+through its `NoVolumeZoneConflict` predicate, that pods which claim a given PersistentVolume
+are only placed into the same zone as that volume.
+-->
+當建立持久卷時，Kubernetes 會自動為連結至特定故障區的 PersistentVolume 加上區域標籤。
+接著{{< glossary_tooltip text="排程器" term_id="kube-scheduler" >}}會透過 `NoVolumeZoneConflict` 預選規則，
+確保使用該 PersistentVolume 的 Pod 只會被排程到與該卷相同的故障區。
+
+<!--
+Please note that the method of adding zone labels can depend on your 
+cloud provider and the storage provisioner you’re using. Always refer to the specific 
+documentation for your environment to ensure correct configuration.
+-->
+請注意到區域標籤的新增方式可能取決於您使用的雲端供應商與儲存佈建器。
+請務必參考適用於您環境的特定文件，確保配置正確。
+
+<!--
+You can specify a {{< glossary_tooltip text="StorageClass" term_id="storage-class" >}}
+for PersistentVolumeClaims that specifies the failure domains (zones) that the
+storage in that class may use.
+To learn about configuring a StorageClass that is aware of failure domains or zones,
+see [Allowed topologies](/docs/concepts/storage/storage-classes/#allowed-topologies).
+-->
+您可以為 PersistentVolumeClaims 指定一個{{< glossary_tooltip text="StorageClass" term_id="storage-class" >}}，
+用來指定該類別中的儲存空間可以使用的故障域（區域）。
+要了解配置能夠感知到故障域或區域的 StorageClass，請參閱[允許的拓撲](/zh-tw/docs/concepts/storage/storage-classes/#allowed-topologies)。
+
+<!--
+## Networking
+-->
+## 網路 {#networking}
+
+<!--
+By itself, Kubernetes does not include zone-aware networking. You can use a
+[network plugin](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)
+to configure cluster networking, and that network solution might have zone-specific
+elements. For example, if your cloud provider supports Services with
+`type=LoadBalancer`, the load balancer might only send traffic to Pods running in the
+same zone as the load balancer element processing a given connection.
+Check your cloud provider's documentation for details.
+-->
+Kubernetes 本身並不包含故障區感知的網路功能。
+您可以使用[網路外掛](/zh-tw/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)來配置叢集網路，
+而選用的網路解決方案可能包含與特定故障區相關的設定。例如，如果您的雲端供應商支援 `type=LoadBalancer` 的 Service，
+負載平衡器可能只會將流量傳送至與處理此連線的負載平衡器位於相同區域的 Pod。請查看您的雲端供應商文件以瞭解詳情。
+
+<!--
+For custom or on-premises deployments, similar considerations apply.
+{{< glossary_tooltip text="Service" term_id="service" >}} and
+{{< glossary_tooltip text="Ingress" term_id="ingress" >}} behavior, including handling
+of different failure zones, does vary depending on exactly how your cluster is set up.
+-->
+對於自訂或本地端部署，類似的考量同樣適用。
+{{< glossary_tooltip text="Service" term_id="service" >}} 與 {{< glossary_tooltip text="Ingress" term_id="ingress" >}} 的行為，包含對不同故障區的處理方式，
+會根據您叢集的實際部署方式而有所不同。
+
+<!--
+## Fault recovery
+-->
+## 故障復原 {#fault-recovery}
+
+<!--
+When you set up your cluster, you might also need to consider whether and how
+your setup can restore service if all the failure zones in a region go
+off-line at the same time. For example, do you rely on there being at least
+one node able to run Pods in a zone?  
+Make sure that any cluster-critical repair work does not rely
+on there being at least one healthy node in your cluster. For example: if all nodes
+are unhealthy, you might need to run a repair Job with a special
+{{< glossary_tooltip text="toleration" term_id="toleration" >}} so that the repair
+can complete enough to bring at least one node into service.
+-->
+當您架設叢集時，還需要考慮：若某個地區內的所有故障區同時離線，您的架構是否能恢復服務，以及應如何恢復。
+例如，是否仰賴某個故障區中至少有一個節點能夠執行 Pod？
+請確保任何叢集關鍵的修復工作，都不依賴叢集中至少有一個健康節點。例如：如果所有節點皆處於不健康狀態，
+您可能需要執行一個帶有特殊 {{< glossary_tooltip text="容許" term_id="toleration" >}} 的修復 Job，
+使修復能順利完成，並讓至少一個節點恢復運作。
+
+<!--
+Kubernetes doesn't come with an answer for this challenge; however, it's
+something to consider.
+-->
+Kubernetes 並未提供此問題的解法；但在規劃時仍需納入考量。
+
+## {{% heading "whatsnext" %}}
+
+<!--
+To learn how the scheduler places Pods in a cluster, honoring the configured constraints,
+visit [Scheduling and Eviction](/docs/concepts/scheduling-eviction/).
+-->
+若想了解排程器如何在叢集中依照設定的限制來排程 Pod，
+請參閱[排程與驅逐](/zh-tw/docs/concepts/scheduling-eviction/)。


### PR DESCRIPTION
### Description

This PR provides the Traditional Chinese (zh-tw) translation for the part of `content/zh-tw/docs/setup/best-practices/`.

- `content/zh-tw/docs/setup/best-practices/_index.md`
- `content/zh-tw/docs/setup/best-practices/cluster-large.md`
- `content/zh-tw/docs/setup/best-practices/multiple-zones.md`

#55006
#54645

/kind documentation
/area localization
/language zh-tw