### PR TITLE
Fix orphaned child page links on Services, Load Balancing, and Networking page

### DIFF
--- a/content/en/docs/concepts/services-networking/_index.md
+++ b/content/en/docs/concepts/services-networking/_index.md
@@ -3,6 +3,7 @@ title: "Services, Load Balancing, and Networking"
 weight: 60
 description: >
   Concepts and resources behind networking in Kubernetes.
+no_list: true
 ---
 
 ## The Kubernetes network model
@@ -103,3 +104,11 @@ tutorial lets you learn about Services and Kubernetes networking with a hands-on
 
 [Cluster Networking](/docs/concepts/cluster-administration/networking/) explains how to set
 up networking for your cluster, and also provides an overview of the technologies involved.
+
+To learn about specific networking concepts, see:
+
+* [Service](/docs/concepts/services-networking/service/) - expose an application behind a single outward-facing endpoint
+* [Ingress](/docs/concepts/services-networking/ingress/) - protocol-aware HTTP/HTTPS routing using URIs, hostnames, and paths
+* [Gateway API](/docs/concepts/services-networking/gateway/) - dynamic infrastructure provisioning and advanced traffic routing
+* [Network Policies](/docs/concepts/services-networking/network-policies/) - control traffic flow at the IP address or port level (OSI layer 3 or 4)
+* [DNS for Services and Pods](/docs/concepts/services-networking/dns-pod-service/) - discover services within your cluster using DNS


### PR DESCRIPTION
### Description

Set `no_list: true` in the front matter of `/docs/concepts/services-networking/_index.md` to remove the auto-generated child page links that appear orphaned after the "What's next" section. The concise descriptions are based on the original page descriptions.

Also added a list of key child pages to the existing "What's next" section.
I personally picked the following 5 topics as the ones worth listing in what's next section:

- [x] Service
- [x] Ingress
- [ ] Ingress Controllers
- [x] Gateway API
- [ ] EndpointSlices
- [x] Network Policies
- [x] DNS for Services and Pods
- [ ] IPv4/IPv6 dual-stack
- [ ] Topology Aware Routing
- [ ] Networking on Windows
- [ ] Service ClusterIP allocation
- [ ] Service Internal Traffic Policy

### Issue

Related to #54995 (umbrella issue)