### PR TITLE
 doc: add documentation for VPA installation 

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -43,10 +43,11 @@ the amount of resources available in the cluster, and real-time events such as o
 
 The VerticalPodAutoscaler is defined as a {{< glossary_tooltip text="Custom Resource Definition" term_id="customresourcedefinition" >}} (CRD) in Kubernetes. Unlike HorizontalPodAutoscaler, which is part of the core Kubernetes API, VPA must be installed separately in your cluster.
 
-The current stable API version is `autoscaling.k8s.io/v1`. To install the VPA control plane with Helm, see
-[Install the Vertical Pod Autoscaler using Helm](/docs/tasks/run-application/install-vertical-pod-autoscaler-helm/).
-API documentation, release information, and other project resources are in the
+The current stable API version is `autoscaling.k8s.io/v1`. API documentation, release information, and other project resources are in the
 [VPA GitHub repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
+
+To install the VPA control plane in your cluster, see
+[Install the Vertical Pod Autoscaler using Helm](/docs/tasks/run-application/install-vertical-pod-autoscaler-helm/).
 
 ## How does a VerticalPodAutoscaler work?
 

--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -43,7 +43,10 @@ the amount of resources available in the cluster, and real-time events such as o
 
 The VerticalPodAutoscaler is defined as a {{< glossary_tooltip text="Custom Resource Definition" term_id="customresourcedefinition" >}} (CRD) in Kubernetes. Unlike HorizontalPodAutoscaler, which is part of the core Kubernetes API, VPA must be installed separately in your cluster.
 
-The current stable API version is `autoscaling.k8s.io/v1`. More details about the VPA installation and API can be found in the [VPA GitHub repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
+The current stable API version is `autoscaling.k8s.io/v1`. To install the VPA control plane with Helm, see
+[Install the Vertical Pod Autoscaler using Helm](/docs/tasks/run-application/install-vertical-pod-autoscaler-helm/).
+Script-based installation, API details, and release information are documented in the
+[VPA GitHub repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
 
 ## How does a VerticalPodAutoscaler work?
 
@@ -212,6 +215,9 @@ The admission controller and updater VPA components post-process recommendations
 For example, if the `max` field in a Container LimitRange resource is exceeded, both VPA components lower the limit to the value defined in the `max` field, and the request is proportionally decreased to maintain the request-to-limit ratio in the Pod spec.
 
 ## {{% heading "whatsnext" %}}
+
+To deploy the VPA components, you can follow
+[Install the Vertical Pod Autoscaler using Helm](/docs/tasks/run-application/install-vertical-pod-autoscaler-helm/).
 
 If you configure autoscaling in your cluster, you may also want to consider using
 [node autoscaling](/docs/concepts/cluster-administration/node-autoscaling/)

--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -45,7 +45,7 @@ The VerticalPodAutoscaler is defined as a {{< glossary_tooltip text="Custom Reso
 
 The current stable API version is `autoscaling.k8s.io/v1`. To install the VPA control plane with Helm, see
 [Install the Vertical Pod Autoscaler using Helm](/docs/tasks/run-application/install-vertical-pod-autoscaler-helm/).
-Script-based installation, API details, and release information are documented in the
+API documentation, release information, and other project resources are in the
 [VPA GitHub repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
 
 ## How does a VerticalPodAutoscaler work?

--- a/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
+++ b/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
@@ -26,12 +26,6 @@ For how VPA adjusts workload resource requests and limits, see
   because VPA reads resource metrics from the `metrics.k8s.io` API. For background, see
   [Resource metrics pipeline](/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-server).
 
-{{< caution >}}
-The chart in the
-[Vertical Pod Autoscaler repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler)
-is under active development. Review the chart `README` and release notes before using it in production clusters.
-{{< /caution >}}
-
 <!-- steps -->
 
 ## Add the Autoscaler Helm repository
@@ -64,8 +58,7 @@ kubectl --namespace=kube-system get pods -l app.kubernetes.io/instance=vertical-
 
 ## {{% heading "whatsnext" %}}
 
-* Read [Vertical Pod Autoscaling](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) for API objects, update modes, and limitations.
-* Follow the [VPA quick start](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/quickstart.md) to create a `VerticalPodAutoscaler` resource.
-* For values, webhook TLS modes, and upgrades, see the
+* Read [Vertical Pod Autoscaling](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) to create and configure a `VerticalPodAutoscaler` object: the API, [update modes](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#update-modes), [resource policies](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#resource-policies), and limitations of the feature.
+* For Helm chart values, webhook TLS options, and upgrades, see the
   [chart README](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md)
   in the Autoscaler repository.

--- a/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
+++ b/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
@@ -46,8 +46,7 @@ helm repo update
 ## Install the VPA chart
 
 Install a release named `vertical-pod-autoscaler`. The following example deploys into the `kube-system` namespace,
-which matches the namespace used by the `vpa-up.sh` installation path in the
-[VPA documentation](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/docs/installation.md).
+a common choice for cluster add-ons. Use another namespace if your organization standardizes components elsewhere.
 
 ```shell
 helm upgrade --install vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler \
@@ -57,10 +56,10 @@ helm upgrade --install vertical-pod-autoscaler autoscalers/vertical-pod-autoscal
 ## Verify the installation
 
 Check that the recommender, updater, and admission controller are running.
-
+The label value matches the Helm release name from the install command above.
 
 ```shell
-kubectl --namespace=kube-system get pods | grep vertical-pod-autoscaler
+kubectl --namespace=kube-system get pods -l app.kubernetes.io/instance=vertical-pod-autoscaler
 ```
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
+++ b/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
@@ -30,7 +30,7 @@ For how VPA adjusts workload resource requests and limits, see
 
 ## Add the Autoscaler Helm repository
 
-The Kubernetes Autoscaler project publishes charts, including VPA, at `https://kubernetes.github.io/autoscaler`.
+The Kubernetes project publishes charts, including VPA, at `https://kubernetes.github.io/autoscaler`.
 
 ```shell
 helm repo add autoscalers https://kubernetes.github.io/autoscaler

--- a/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
+++ b/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
@@ -1,0 +1,72 @@
+---
+reviewers:
+- adrianmoisey
+- omerap12
+title: Install the Vertical Pod Autoscaler Using Helm
+content_type: task
+weight: 98
+min-kubernetes-server-version: 1.28
+---
+
+<!-- overview -->
+
+The [VerticalPodAutoscaler](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) (VPA)
+is provided as a separate component; it is not included in the core Kubernetes release.
+This task shows how to install the VPA control plane using [Helm](https://helm.sh/docs/).
+
+For how VPA adjusts workload resource requests and limits, see
+[Vertical Pod Autoscaling](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/).
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+* [Helm](https://helm.sh/docs/intro/install/) 3.
+* [Metrics Server](https://github.com/kubernetes-sigs/metrics-server#readme) running in the cluster,
+  because VPA reads resource metrics from the `metrics.k8s.io` API. For background, see
+  [Resource metrics pipeline](/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-server).
+
+{{< caution >}}
+The chart in the
+[Vertical Pod Autoscaler repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler)
+is under active development. Review the chart `README` and release notes before using it in production clusters.
+{{< /caution >}}
+
+<!-- steps -->
+
+## Add the Autoscaler Helm repository
+
+The Kubernetes Autoscaler project publishes charts, including VPA, at `https://kubernetes.github.io/autoscaler`.
+
+```shell
+helm repo add autoscalers https://kubernetes.github.io/autoscaler
+helm repo update
+```
+
+## Install the VPA chart
+
+Install a release named `vertical-pod-autoscaler`. The following example deploys into the `kube-system` namespace,
+which matches the namespace used by the `vpa-up.sh` installation path in the
+[VPA documentation](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/docs/installation.md).
+
+```shell
+helm upgrade --install vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler \
+  --namespace kube-system
+```
+
+## Verify the installation
+
+Check that the recommender, updater, and admission controller are running.
+
+
+```shell
+kubectl --namespace=kube-system get pods | grep vertical-pod-autoscaler
+```
+
+## {{% heading "whatsnext" %}}
+
+* Read [Vertical Pod Autoscaling](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) for API objects, update modes, and limitations.
+* Follow the [VPA quick start](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/quickstart.md) to create a `VerticalPodAutoscaler` resource.
+* For values, webhook TLS modes, and upgrades, see the
+  [chart README](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md)
+  in the Autoscaler repository.

--- a/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
+++ b/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
@@ -49,6 +49,15 @@ helm upgrade --install vertical-pod-autoscaler autoscalers/vertical-pod-autoscal
   --namespace kube-system
 ```
 
+## Admission webhook TLS
+
+By default, the chart provisions TLS for the VPA admission webhook by running a Job that uses the
+`registry.k8s.io/ingress-nginx/kube-webhook-certgen` image to generate certificates and configure the
+webhook. For other TLS modes or customization (for example, supplying your own certificates or using
+cert-manager), see
+[Webhook management](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md#webhook-management)
+in the chart README.
+
 ## Verify the installation
 
 Check that the recommender, updater, and admission controller are running.
@@ -61,6 +70,6 @@ kubectl --namespace=kube-system get pods -l app.kubernetes.io/instance=vertical-
 ## {{% heading "whatsnext" %}}
 
 * Read [Vertical Pod Autoscaling](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) to create and configure a `VerticalPodAutoscaler` object: the API, [update modes](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#update-modes), [resource policies](/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#resource-policies), and limitations of the feature.
-* For Helm chart values, webhook TLS options, and upgrades, see the
+* For Helm chart values and upgrades, see the
   [chart README](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md)
   in the Autoscaler repository.

--- a/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
+++ b/content/en/docs/tasks/run-application/install-vertical-pod-autoscaler-helm.md
@@ -22,9 +22,11 @@ For how VPA adjusts workload resource requests and limits, see
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * [Helm](https://helm.sh/docs/intro/install/) 3.
-* [Metrics Server](https://github.com/kubernetes-sigs/metrics-server#readme) running in the cluster,
-  because VPA reads resource metrics from the `metrics.k8s.io` API. For background, see
-  [Resource metrics pipeline](/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-server).
+* A working [resource metrics pipeline](/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/)
+  that serves the [Metrics API](/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-api)
+  (`metrics.k8s.io`), which VPA uses for CPU and memory data. Many clusters run
+  [Metrics Server](https://github.com/kubernetes-sigs/metrics-server#readme); any other implementation
+  of that API is also valid.
 
 <!-- steps -->
 


### PR DESCRIPTION
## Summary
This PR addresses [kubernetes/autoscaler#9407](https://github.com/kubernetes/autoscaler/issues/9407) by adding documentation for installing the Vertical Pod Autoscaler (VPA) with the official Helm chart and linking it from the existing VPA concept page.

What type of PR is this?
/kind documentation

### What this PR does / why we need it
The VPA Helm chart now ships with the [Kubernetes Autoscaler](https://github.com/kubernetes/autoscaler) project and is published in the Autoscaler Helm repository, but kubernetes.io did not yet describe how to deploy VPA with Helm. This PR:

Adds a new Task page under Run Applications that documents adding the Autoscaler Helm repo, installing the vertical-pod-autoscaler chart (example: kube-system), verifying workloads, and where to go next (concept page, upstream quick start, chart README).
Updates [Vertical Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) so the API object section and What’s next point readers at that Helm task instead of only the GitHub tree / script path.
This matches maintainer guidance for the issue: task-focused install doc, no duplicate explanation of what vertical autoscaling is, and pointers to upstream for values, webhook modes, and API details.

### Which issue(s) this PR fixes
Ref [kubernetes/autoscaler#9407](https://github.com/kubernetes/autoscaler/issues/9407)

(If you also file or use a kubernetes/website issue, add e.g. Fixes #nnnnn here.)

### Special notes for your reviewer
Install commands align with the chart’s published flow: helm repo add autoscalers https://kubernetes.github.io/autoscaler and helm upgrade --install vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler (see [chart README](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md)).
Prerequisites call out Helm 3, Metrics Server, and a supported Kubernetes version consistent with the chart’s stated VPA/Kubernetes compatibility.
Verification uses kubectl --namespace=kube-system get pods | grep vertical-pod-autoscaler because Helm-generated pod names use the vertical-pod-autoscaler prefix; a label-based kubectl get pods example is included as an alternative (grep vpa matches the older vpa-up.sh naming, not the default Helm release name from the doc).
A short caution notes the chart is still under active development, per upstream README.
No OCI-first install is documented unless/until the project publishes a documented oci:// reference; the HTTP repo is what the chart README currently specifies.