### PR TITLE
Enhance kubectl alias support for bash completion

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -92,6 +92,7 @@ your shell sessions. There are multiple ways to achieve this:
 - If you have an alias for kubectl, you can extend shell completion to work with that alias:
 
     ```bash
+    echo 'source <(kubectl completion bash)' 
     echo 'alias k=kubectl' >>~/.bash_profile
     echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```


### PR DESCRIPTION
Added instructions for extending shell completion with kubectl alias.

Without adding this line I get the error:
```
$ k bash: completion: function `__start_kubectl' not found
```

The __start_kubectl function doesn't exist yet when the .bashrc runs the complete.  The kubectl bash completion script hasn't been sourced, so the function is undefined.

after adding this line, it works for me

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #