### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/label.md
+++ b/content/fr/docs/reference/glossary/label.md
@@ -1,0 +1,17 @@
+---
+title: Label
+id: label
+full_link: /docs/concepts/overview/working-with-objects/labels
+short_description: >
+  Associe aux objets des attributs d’identification pertinents et significatifs pour les utilisateurs.
+
+aka: 
+tags:
+- fundamental
+---
+
+Associe aux objets des attributs d’identification pertinents et significatifs pour les utilisateurs.
+
+<!--more-->
+
+Les labels sont des paires clé/valeur attachées à des objets tels que les {{< glossary_tooltip text="Pods" term_id="pod" >}}. Ils sont utilisés pour organiser et sélectionner des sous-ensembles d’objets.

--- a/content/fr/docs/reference/glossary/object.md
+++ b/content/fr/docs/reference/glossary/object.md
@@ -1,0 +1,24 @@
+---
+title: Object
+id: object
+full_link: /docs/concepts/overview/working-with-objects/#kubernetes-objects
+short_description: >
+  Entité du système Kubernetes représentant une partie de l’état de votre cluster.
+aka:
+tags:
+- architecture
+- fundamental
+---
+
+Une entité du système Kubernetes. Un objet est une
+{{< glossary_tooltip text="ressource API" term_id="api-resource" >}} que l’API Kubernetes
+utilise pour représenter l’état de votre cluster.
+
+<!--more-->
+
+Un objet Kubernetes est généralement un « enregistrement d’intention » — une fois l’objet créé, le
+{{< glossary_tooltip text="plan de contrôle" term_id="control-plane" >}} de Kubernetes travaille en permanence pour garantir
+que l’élément qu’il représente existe effectivement.
+
+En créant un objet, vous indiquez au système Kubernetes à quoi vous souhaitez que cette partie de
+la charge de travail de votre cluster ressemble ; cela correspond à l’état souhaité de votre cluster.

--- a/content/fr/docs/reference/glossary/spec.md
+++ b/content/fr/docs/reference/glossary/spec.md
@@ -1,0 +1,20 @@
+---
+title: Spec
+id: spec
+full_link: /docs/concepts/overview/working-with-objects/#object-spec-and-status
+short_description: >
+  Champ dans les manifestes Kubernetes qui définit l’état souhaité ou la configuration.
+
+aka:
+tags:
+- fundamental
+- architecture
+---
+
+Définit la manière dont chaque objet, comme les Pods ou les Services, doit être configuré ainsi que son état souhaité.
+
+<!--more-->
+
+Presque tous les objets Kubernetes incluent deux champs imbriqués qui régissent leur configuration : le spec de l’objet et le status de l’objet. Pour les objets qui possèdent un spec, celui-ci doit être défini lors de la création de l’objet, en fournissant une description des caractéristiques que la {{< glossary_tooltip text="ressource" term_id="api-resource" >}} doit avoir : son état souhaité.
+
+Ce champ varie selon les objets tels que les Pods, StatefulSets et Services, en détaillant des paramètres comme les conteneurs, les volumes, les réplicas, les ports et d’autres spécifications propres à chaque type d’objet. Il représente l’état que Kubernetes doit maintenir pour l’objet défini.


### PR DESCRIPTION
### Description

Traduction de quatre entrées du glossaire liées aux concepts fondamentaux des objets et de la configuration dans Kubernetes.

**Fichiers inclus :**

* `spec.md` : définit l’état souhaité et la configuration d’un objet Kubernetes.
* `label.md` : permet d’identifier et d’organiser les objets à l’aide de paires clé/valeur.
* `object.md` : représente une entité du système Kubernetes décrivant une partie de l’état du cluster.

Cette contribution fait partie du plan de suivi #54874.