### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/condition.md
+++ b/content/fr/docs/reference/glossary/condition.md
@@ -1,0 +1,19 @@
+---
+title: Condition
+id: condition
+full_link: /docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+short_description: >
+  Une condition représente l’état actuel d’une ressource Kubernetes et indique si certains aspects sont vrais.
+
+aka:
+tags:
+- fondamental
+---
+
+Une condition est un champ dans le statut d’une ressource Kubernetes qui décrit l’état actuel de cette ressource.
+
+<!--more-->
+
+Les conditions fournissent un moyen standardisé pour les composants Kubernetes de communiquer le statut des ressources.  
+Chaque condition possède un `type`, un `status` (True, False, ou Unknown), et éventuellement des champs comme `reason` et `message` pour fournir des informations supplémentaires.  
+Par exemple, un Pod peut avoir des conditions telles que `Ready`, `ContainersReady` ou `PodScheduled`.

--- a/content/fr/docs/reference/glossary/pod-template.md
+++ b/content/fr/docs/reference/glossary/pod-template.md
@@ -1,0 +1,21 @@
+---
+title: Modèle de Pod
+id: pod-template
+short_description: >
+  Un modèle utilisé pour créer des Pods.
+
+aka: 
+  - pod template
+tags:
+- core-object
+---
+
+Un objet API qui définit un modèle pour créer des Pods.  
+Le PodTemplate API est également intégré dans les définitions d’objets pour la gestion des workloads, comme les Deployments ou StatefulSets.
+
+<!--more--> 
+
+Les modèles de Pod permettent de définir des métadonnées communes (labels, nom du Pod, etc.) et de spécifier l’état souhaité d’un Pod.  
+Les contrôleurs de gestion des workloads utilisent ces modèles (souvent intégrés dans un autre objet, comme Deployment ou StatefulSet) pour définir et gérer un ou plusieurs Pods.  
+Lorsque plusieurs Pods sont créés à partir du même modèle, on parle de répliques (replicas).  
+Bien qu’il soit possible de créer un objet PodTemplate directement, cela est rarement nécessaire.

--- a/content/fr/docs/reference/glossary/sidecar-container.md
+++ b/content/fr/docs/reference/glossary/sidecar-container.md
@@ -1,0 +1,19 @@
+---
+title: Conteneur Sidecar
+id: sidecar-container
+full_link: /docs/concepts/workloads/pods/sidecar-containers/
+short_description: >
+  Un conteneur auxiliaire qui reste actif pendant tout le cycle de vie d’un Pod.
+
+tags:
+- fondamental
+---
+
+Un ou plusieurs conteneurs qui sont généralement démarrés avant les conteneurs principaux de l’application.
+
+<!--more--> 
+
+Les conteneurs sidecar fonctionnent comme des conteneurs d’application classiques, mais avec un objectif différent : le sidecar fournit un service local au Pod pour le conteneur principal.  
+Contrairement aux init containers, les sidecars continuent de s’exécuter après le démarrage du Pod.
+
+Pour plus de détails, lire [Sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/).


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire essentielles pour comprendre le cycle de vie des Pods et la gestion des conteneurs dans Kubernetes.

**Fichiers inclus :**

* `condition.md`
* `pod-template.md` 
* `sidecar-container.md`

Cette contribution fait partie du suivi du plan de traduction du glossaire Kubernetes #54874.