### PR TITLE
Render Hugo aliases into Netlify redirects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ CONTAINER_HUGO_MOUNTS = \
 	--mount type=bind,source=$(CURDIR)/layouts,target=/src/layouts,readonly \
 	--mount type=bind,source=$(CURDIR)/static,target=/src/static,readonly \
 	--mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \
-	--mount type=bind,source=$(CURDIR)/hugo.toml,target=/src/hugo.toml,readonly
+	--mount type=bind,source=$(CURDIR)/hugo.toml,target=/src/hugo.toml,readonly \
+	--mount type=bind,source=$(CURDIR)/hugo.server.toml,target=/src/hugo.server.toml,readonly
 
 CCRED=\033[0;31m
 CCEND=\033[0m
@@ -72,7 +73,7 @@ non-production-build: module-check ## Build the non-production site, which adds 
 	GOMAXPROCS=1 hugo --cleanDestinationDir --enableGitInfo --environment nonprod
 
 serve: module-check ## Boot the development server.
-	hugo server --buildDrafts --buildFuture --environment development --renderSegments $(segments)
+	hugo server --config hugo.toml,hugo.server.toml --buildDrafts --buildFuture --environment development --renderSegments $(segments)
 
 docker-image:
 	@echo -e "$(CCRED)**** The use of docker-image is deprecated. Use container-image instead. ****$(CCEND)"
@@ -121,7 +122,7 @@ container-build: module-check
 container-serve: module-check ## Boot the development server using container.
 	$(CONTAINER_RUN_TTY) --cap-drop=ALL --cap-add=AUDIT_WRITE $(CONTAINER_HUGO_MOUNTS) \
 		-p 1313:1313 $(CONTAINER_IMAGE) \
-		hugo server --buildDrafts --buildFuture --environment development --bind 0.0.0.0 --destination /tmp/public --cleanDestinationDir --noBuildLock --renderSegments $(segments)
+		hugo server --config hugo.toml,hugo.server.toml --buildDrafts --buildFuture --environment development --bind 0.0.0.0 --destination /tmp/public --cleanDestinationDir --noBuildLock --renderSegments $(segments)
 
 test-examples:
 	scripts/test_examples.sh install

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To install dependencies, deploy and test the site locally, run:
 
   ```powershell
   npm ci
-  hugo.exe server --buildFuture --environment development
+  hugo.exe server --config hugo.toml,hugo.server.toml --buildFuture --environment development
   ```
 
 This will start the local Hugo server on port 1313. Open up your browser to <http://localhost:1313> to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.

--- a/content/en/docs/contribute/new-content/preview-locally.md
+++ b/content/en/docs/contribute/new-content/preview-locally.md
@@ -75,7 +75,7 @@ Alternately, install and use the `hugo` command on your computer:
    If you're on a Windows machine or unable to run the `make` command, use the following command:
 
    ```
-   hugo server --buildFuture
+   hugo server --config hugo.toml,hugo.server.toml --buildFuture
    ```
 
 1. In a web browser, navigate to `http://localhost:1313`. Hugo watches the

--- a/hugo.server.toml
+++ b/hugo.server.toml
@@ -1,0 +1,7 @@
+# Re-enable Hugo alias pages for local preview.
+#
+# Production and deploy builds use Netlify redirects rendered from
+# layouts/index.redirects, so hugo.toml keeps disableAliases = true.
+# Local preview still runs through Hugo directly, so alias pages must exist
+# there to avoid 404s for alias URLs.
+disableAliases = false

--- a/hugo.toml
+++ b/hugo.toml
@@ -15,6 +15,7 @@ timeZone = "UTC"
 
 enableRobotsTXT = true
 disableBrowserError = true
+disableAliases = true
 
 disableKinds = ["taxonomy"]
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,4 +1,81 @@
-{{- $latest := or .Site.Params.latest (errorf "missing .Site.Params.latest") -}}
+{{- $site := .Site -}}
+{{- $defaultLang := (index $site.Sites 0).Language.Lang -}}
+{{/* Hugo runs this template once per language. Only the default-language run
+should write the shared `_redirects` file. */}}
+{{- if eq $site.Language.Lang $defaultLang -}}
+{{- $latest := or $site.Params.latest (errorf "missing .Site.Params.latest") -}}
+{{- $baseRedirectsText := readFile "static/_redirects.base" -}}
+{{- $languages := dict -}}
+{{- range $language := $site.Languages -}}
+  {{- $languages = merge $languages (dict $language.Lang true) -}}
+{{- end -}}
+{{- $pagePermalinks := dict -}}
+{{- $aliasOwners := dict -}}
+{{- $aliasRedirects := slice -}}
+
+{{- range $languageSite := $site.Sites -}}
+  {{- range sort $languageSite.Pages "RelPermalink" -}}
+    {{- $owner := .RelPermalink -}}
+    {{- with .File -}}
+      {{- $owner = .Path -}}
+    {{- end -}}
+    {{- $pagePermalinks = merge $pagePermalinks (dict .RelPermalink $owner) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $languageSite := $site.Sites -}}
+  {{- range $page := sort $languageSite.Pages "RelPermalink" -}}
+    {{- $target := $page.RelPermalink -}}
+    {{- $owner := $target -}}
+    {{- with $page.File -}}
+      {{- $owner = .Path -}}
+    {{- end -}}
+    {{- range $alias := sort $page.Aliases -}}
+      {{- if findRE `\s` $alias -}}
+        {{- errorf "alias %q on %s contains whitespace" $alias $owner -}}
+      {{- end -}}
+
+      {{- $source := $alias -}}
+      {{- if not (hasPrefix $source "/") -}}
+        {{- $source = path.Join (path.Dir (replaceRE `/$` "" $target)) $source -}}
+        {{- if not (hasPrefix $source "/") -}}
+          {{- $source = printf "/%s" $source -}}
+        {{- end -}}
+        {{- if and (not (hasSuffix $source "/")) (not (findRE `/[^/]+\.[^/]+$` $source)) -}}
+          {{- $source = printf "%s/" $source -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- if eq $source $target -}}
+        {{- errorf "alias %q on %s resolves to %q, which matches that page's permalink" $alias $owner $source -}}
+      {{- end -}}
+
+      {{/* Paths without a locale prefix are default-language paths. */}}
+      {{- $sourceLang := $defaultLang -}}
+      {{- $segments := split (trim $source "/") "/" -}}
+      {{- if gt (len $segments) 0 -}}
+        {{- $first := index $segments 0 -}}
+        {{- if index $languages $first -}}
+          {{- $sourceLang = $first -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if ne $sourceLang $page.Lang -}}
+        {{- errorf "alias %q on %s resolves to %q and crosses localizations: alias path resolves as %s but the page language is %s" $alias $owner $source $sourceLang $page.Lang -}}
+      {{- end -}}
+
+      {{- with index $pagePermalinks $source -}}
+        {{- errorf "alias %q on %s resolves to %q and conflicts with the real page %s" $alias $owner $source . -}}
+      {{- end -}}
+      {{- with index $aliasOwners $source -}}
+        {{- errorf "alias %q on %s resolves to %q and conflicts with an alias already owned by %s" $alias $owner $source . -}}
+      {{- end -}}
+
+      {{- $aliasOwners = merge $aliasOwners (dict $source $owner) -}}
+      {{- $aliasRedirects = $aliasRedirects | append (printf "%s     %s 301" $source $target) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 ###############################################
 # set server-side redirects in this file      #
 # see https://www.netlify.com/docs/redirects/ #
@@ -10,8 +87,16 @@
 # Dynamic latest API redirect - automatically points to current latest version
 /docs/reference/generated/kubernetes-api/latest/     /docs/reference/generated/kubernetes-api/{{ $latest }}/ 307
 /docs/reference/generated/kubernetes-api/latest/*   /docs/reference/generated/kubernetes-api/{{ $latest }}/:splat 307
-{{- end -}}
+{{ end }}
 
-# Include all existing static redirects
-{{- $staticRedirects := readFile "static/_redirects.base" -}}
-{{ $staticRedirects }}
+# Include redirects declared in static/_redirects.base
+{{ $baseRedirectsText }}
+
+{{ if gt (len $aliasRedirects) 0 }}
+
+# Generated from page aliases
+{{- range sort $aliasRedirects }}
+{{ . }}
+{{- end }}
+{{ end }}
+{{- end -}}


### PR DESCRIPTION
### Description
This PR renders Hugo page aliases into the generated Netlify `_redirects` output by updating `layouts/index.redirects` to collect aliases across all site langauges and emit them as `301` redirects, while keeping the existing `static/_redirects.base` entries  and dynamic `latest` API redirects in place.
For local previews, sets `disableAliases = true` in normal builds and adds `hugo.server.toml` so `hugo server` still renders alias pages locally.

It also updates the Indonesian CVE aliases to use localized `/id/...` paths so they pass the new validation checks.

### Issues
Fixes #53396
FIxes #46295
