### PR TITLE
Fix blog link path in ingress2gateway-v1-0-release post

### DIFF
--- a/content/en/blog/_posts/2026/ingress2gateway-v1-0-release.md
+++ b/content/en/blog/_posts/2026/ingress2gateway-v1-0-release.md
@@ -44,7 +44,7 @@ The tests:
 * translate Ingress resources to Gateway API with `ingress2gateway` and apply generated manifests
 * verify that the Gateway API controllers and the Ingress controller exhibit equivalent behavior.
 
-A comprehensive test suite not only catches bugs in development, but also ensures the correctness of the translation, especially given [surprising edge cases and unexpected defaults](/blog/2026/ingress-nginx-before-you-migrate),
+A comprehensive test suite not only catches bugs in development, but also ensures the correctness of the translation, especially given [surprising edge cases and unexpected defaults](/blog/2026/02/27/ingress-nginx-before-you-migrate),
 so that you don't find out about them in production.
 
 ### Notification & error handling


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Fix incorrect internal blog link path in the ingress2gateway-v1-0-release blog post.

The link to the "ingress-nginx-before-you-migrate" post was missing the date
segment in the URL path.

- Before: `/blog/2026/ingress-nginx-before-you-migrate`
- After: `/blog/2026/02/27/ingress-nginx-before-you-migrate`

The target post (`ingress-nginx-before-you-migrate.md`) has `date: 2026-02-27`,
so the correct URL path requires the `02/27` date segment.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #