### PR TITLE
Fix truncated Generated API reference descriptions

### DIFF
--- a/content/en/docs/reference/kubernetes-api/authentication-resources/cluster-trust-bundle-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/cluster-trust-bundle-v1beta1.md
@@ -4,7 +4,7 @@ api_metadata:
   import: "k8s.io/api/certificates/v1beta1"
   kind: "ClusterTrustBundle"
 content_type: "api_reference"
-description: "ClusterTrustBundle is a cluster-scoped container for X."
+description: "ClusterTrustBundle is a cluster-scoped container for X.509 trust anchors (root certificates)."
 title: "ClusterTrustBundle v1beta1"
 weight: 5
 auto_generated: true

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/service-cidr-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/service-cidr-v1.md
@@ -4,7 +4,7 @@ api_metadata:
   import: "k8s.io/api/networking/v1"
   kind: "ServiceCIDR"
 content_type: "api_reference"
-description: "ServiceCIDR defines a range of IP addresses using CIDR format (e."
+description: "ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64)."
 title: "ServiceCIDR"
 weight: 10
 auto_generated: true


### PR DESCRIPTION
- ClusterTrustBundle description was truncated to `"X."` instead of `"X.509 trust anchors (root certificates)."` ( https://github.com/kubernetes/website/issues/55021)

- ServiceCIDR description was truncated to `"(e."` instead of `"(e.g. 192.168.0.0/24 or 2001:db2::/64)."`

> **Depends on:** https://github.com/kubernetes-sigs/reference-docs/pull/429 (fix sentence boundary regex
> to correctly handle abbreviations like `X.509`, `e.g.`, `i.e.`)

## Related issues

- Closes https://github.com/kubernetes/website/issues/55071
- Relates to https://github.com/kubernetes/website/issues/55021
