### PR TITLE
Document kubectl kuberc set --section credentialplugin

### DIFF
--- a/content/en/docs/reference/kubectl/generated/kubectl_alpha/kubectl_alpha_kuberc.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_alpha/kubectl_alpha_kuberc.md
@@ -42,9 +42,6 @@ kubectl alpha kuberc SUBCOMMAND
   
   # Create an alias for a command
   kubectl alpha kuberc set --section aliases --name getn --command get --prependarg nodes --option output=wide
-  
-  # Set the credential plugin policy
-  kubectl alpha kuberc set --section credentialplugin --policy DenyAll
 ```
 
 ## {{% heading "options" %}}

--- a/content/en/docs/reference/kubectl/generated/kubectl_alpha/kubectl_alpha_kuberc_set.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_alpha/kubectl_alpha_kuberc_set.md
@@ -25,16 +25,14 @@ guide. You can file document formatting bugs against the
 
 Set values in the kuberc configuration file.
 
- Use --section to specify whether to set defaults, aliases, or credentialplugin configuration.
+ Use --section to specify whether to set defaults or aliases.
 
  For defaults: Sets default flag values for kubectl commands. The --command flag should specify only the command (e.g., "get", "create", "set env"), not resources.
 
  For aliases: Creates command aliases with optional default flag values and arguments. Use --prependarg and --appendarg to include resources or other arguments.
 
- For credentialplugin: Configures the credential plugin policy and optional allowlist. The --policy flag is required. When --policy=Allowlist, --allowlist-entry must also be provided.
-
 ```
-kubectl alpha kuberc set --section (defaults|aliases|credentialplugin) [flags]
+kubectl alpha kuberc set --section (defaults|aliases) --command COMMAND
 ```
 
 ## {{% heading "examples" %}}
@@ -54,12 +52,6 @@ kubectl alpha kuberc set --section (defaults|aliases|credentialplugin) [flags]
   
   # Overwrite an existing default
   kubectl alpha kuberc set --section defaults --command get --option output=json --overwrite
-  
-  # Set the credential plugin policy to deny all plugins
-  kubectl alpha kuberc set --section credentialplugin --policy DenyAll
-  
-  # Set the credential plugin policy and allowlist
-  kubectl alpha kuberc set --section credentialplugin --policy Allowlist --allowlist-entry command=cloud-credential-helper
 ```
 
 ## {{% heading "options" %}}
@@ -72,13 +64,6 @@ kubectl alpha kuberc set --section (defaults|aliases|credentialplugin) [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--allowlist-entry strings</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Allowlist entry in the form field=value (can be specified multiple times). Only valid when --section=credentialplugin and --policy=Allowlist.</p></td>
-</tr>
-
-<tr>
 <td colspan="2">--appendarg strings</td>
 </tr>
 <tr>
@@ -89,7 +74,7 @@ kubectl alpha kuberc set --section (defaults|aliases|credentialplugin) [flags]
 <td colspan="2">--command string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Command to configure (e.g., 'get', 'create', 'set env'). Required for --section=defaults and --section=aliases.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Command to configure (e.g., 'get', 'create', 'set env')</p></td>
 </tr>
 
 <tr>
@@ -128,13 +113,6 @@ kubectl alpha kuberc set --section (defaults|aliases|credentialplugin) [flags]
 </tr>
 
 <tr>
-<td colspan="2">--policy string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Plugin policy to use for exec credential plugins, must be one of 'AllowAll', 'DenyAll' or 'Allowlist'. Required when --section=credentialplugin.</p></td>
-</tr>
-
-<tr>
 <td colspan="2">--prependarg strings</td>
 </tr>
 <tr>
@@ -145,7 +123,7 @@ kubectl alpha kuberc set --section (defaults|aliases|credentialplugin) [flags]
 <td colspan="2">--section string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Section to modify: 'defaults', 'aliases', or 'credentialplugin'</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Section to modify: 'defaults' or 'aliases'</p></td>
 </tr>
 
 </tbody>


### PR DESCRIPTION
Replaces Draft #54525 
RE https://github.com/kubernetes/enhancements/issues/3104 

Update docs for kubernetes/kubernetes#137300 which adds credential plugin options to kubectl kuberc set:

- Update kuberc.md: fix typo, rename deprecated 'name' field to 'command' in allowlist examples, add 'kubectl kuberc set' management section
- Update kubectl_alpha_kuberc_set.md reference: add --policy and --allowlist-entry flags, credentialplugin synopsis/examples, update --section and --command descriptions
- Update kubectl_alpha_kuberc.md: add credentialplugin example

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #