### PR TITLE
fix architecture page orphan link

### DIFF
--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Cluster Architecture"
 weight: 30
+no_list: true
 description: >
   The architectural concepts behind Kubernetes.
 ---
@@ -207,6 +208,7 @@ Learn more about the following:
   [their communication](/docs/concepts/architecture/control-plane-node-communication/)
   with the control plane.
 - Kubernetes [controllers](/docs/concepts/architecture/controller/).
+- [Garbage collection](/docs/concepts/architecture/garbage-collection/) of cluster objects.
 - [kube-scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) which is the default scheduler for Kubernetes.
 - Etcd's official [documentation](https://etcd.io/docs/).
 - Several [container runtimes](/docs/setup/production-environment/container-runtimes/) in Kubernetes.


### PR DESCRIPTION
### Description

Set `no_list: true` in the front matter of `/docs/concepts/architecture/_index.md` to remove the auto-generated child page links that appear orphaned after the "What's next" section.

Also added Garbage Collection to the existing "What's next" section. While the existing list was already well-curated, Garbage Collection is a fundamental concept for understanding Kubernetes resource lifecycle management and I thought it is worth including.

### Issue

Related to #54995 (umbrella issue)