### PR TITLE
remove duplicate links on api-extension page

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Extending the Kubernetes API
 weight: 30
+no_list: true
 ---
 
 Custom resources are extensions of the Kubernetes API. Kubernetes provides two ways to add custom resources to your cluster:


### PR DESCRIPTION
### Description
 
Add `no_list: true` to the front matter of `/docs/concepts/extend-kubernetes/api-extension/`.
 
The page already links to both child pages (Custom Resources and API Aggregation) inline, so the auto-generated child page list at the bottom is fully redundant.

https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/

### Issue
 
Related to #54995 (umbrella issue)
 