### PR TITLE
Update scripts Python dependencies for Python 3.10+ compatibility

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.20.1
-click==6.7
-jinja2==2.10.1
+requests>=2.28,<3
+click>=8.0,<9
+jinja2>=3.1,<4


### PR DESCRIPTION
Fixes #55069.

This PR updates stale shared dependencies in `scripts/requirements.txt` that currently break helper scripts on Python 3.10+.

Updated:

```
requests → >=2.28,<3
click → >=8.0,<9
jinja2 → >=3.1,<4
```

These are the dependencies implicated in the reproduced failures. I used bounded ranges to fix the current issue while avoiding untested future major-version upgrades.

This is a repo-wide scripts compatibility fix, and it should also help PR #53519 since that PR adds `fetch_kubecon_events.py` on top of the same shared `scripts/requirements.txt`.