### PR TITLE
[en] Remove outdated Windows Server 2019 reference from OS version compatibility section

### DIFF
--- a/content/en/docs/concepts/windows/intro.md
+++ b/content/en/docs/concepts/windows/intro.md
@@ -332,8 +332,7 @@ See [Install MCR on Windows Servers](https://docs.mirantis.com/mcr/25.0/install/
 ## Windows OS version compatibility {#windows-os-version-support}
 
 On Windows nodes, strict compatibility rules apply where the host OS version must
-match the container base image OS version. Only Windows containers with a container
-operating system of Windows Server 2019 are fully supported.
+match the container base image OS version.
 
 For Kubernetes v{{< skew currentVersion >}}, operating system compatibility for Windows nodes (and Pods)
 is as follows:


### PR DESCRIPTION
### Description

Removes an outdated sentence from the "Windows OS version compatibility" section
that stated "Only Windows containers with a container operating system of
Windows Server 2019 are fully supported." This directly contradicts the
"Windows nodes in Kubernetes" section on the same page, which correctly states
that only Windows Server 2022 and Windows Server 2025 are supported. The LTSC
release table in the same section also lists only 2022 and 2025.

The strict host OS / container base image OS version matching rule is retained.
The specific supported versions are already listed in the LTSC table that
follows, so no information is lost.

### Issue
Fixes https://github.com/kubernetes/website/issues/55058

Closes: #55058

/sig windows
/language en