### PR TITLE
make bluesky feed on community page localizable

### DIFF
--- a/assets/js/bluesky-feed.js
+++ b/assets/js/bluesky-feed.js
@@ -1,0 +1,33 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("bluesky-feed-container");
+  if (!container) return;
+
+  const handle = container.dataset.handle;
+  const limit = container.dataset.limit || 3;
+  const template = document.getElementById("bluesky-post-template");
+  const fallback = document.getElementById("bluesky-feed-fallback");
+
+  fetch(`https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${handle}&limit=${limit}`)
+    .then(res => {
+      if (!res.ok) throw new Error("Bluesky feed unavailable");
+      return res.json();
+    })
+    .then(data => {
+      container.innerHTML = "";
+      data.feed.forEach(item => {
+        const post = item.post;
+        const clone = template.content.cloneNode(true);
+
+        clone.querySelector('[data-field="text"]').textContent = post.record.text;
+        clone.querySelector('[data-field="date"]').textContent = new Date(post.indexedAt).toLocaleDateString();
+        const link = clone.querySelector('[data-field="link"]');
+        link.href = `https://bsky.app/profile/${handle}/post/${post.uri.split("/").pop()}`;
+
+        container.appendChild(clone);
+      });
+    })
+    .catch(() => {
+      container.hidden = true;
+      fallback.hidden = false;
+    });
+});

--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -193,42 +193,5 @@ menu:
 
 <div class="community-section community-frame" id="news">
   <h2>Recent News</h2>
-  <div id="bluesky-feed-container">
-    <p>Loading the latest news from Bluesky...</p>
-  </div>
+  {{< social-media-feed kind="bluesky" >}}
 </div>
-
-<script>
-  (async function() {
-    const feedContainer = document.getElementById('bluesky-feed-container');
-    const bskyHandle = 'kubernetes.io';
-    
-    try {
-      // Fetching from the public Bluesky XRPC API
-      const response = await fetch(`https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${bskyHandle}&limit=3`);
-      if (!response.ok) throw new Error('Bluesky feed unavailable');
-      
-      const data = await response.json();
-      feedContainer.innerHTML = ''; // Clear the loading message
-
-      data.feed.forEach(item => {
-        const post = item.post;
-        const postDate = new Date(post.indexedAt).toLocaleDateString();
-        const postUrl = `https://bsky.app/profile/${bskyHandle}/post/${post.uri.split('/').pop()}`;
-        
-        const postElement = document.createElement('div');
-        postElement.className = 'bsky-post';
-        postElement.style.padding = "15px 0";
-        postElement.style.borderBottom = "1px solid #eee";
-        
-        postElement.innerHTML = `
-          <p style="margin-bottom: 5px;">${post.record.text}</p>
-          <small>${postDate} • <a href="${postUrl}" target="_blank" rel="noopener">View on Bluesky</a></small>
-        `;
-        feedContainer.appendChild(postElement);
-      });
-    } catch (err) {
-      feedContainer.innerHTML = '<p>Follow us on <a href="https://bsky.app/profile/kubernetes.io">Bluesky</a> for the latest updates.</p>';
-    }
-  })();
-</script>

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -43,6 +43,15 @@ other = "You can also read about our {{ .link }}."
 [community_bluesky_name]
 other = "Bluesky"
 
+[community_bluesky_fallback_text]
+other = "Follow us on"
+
+[community_bluesky_link]
+other = "View on Bluesky"
+
+[community_bluesky_loading]
+other = "Loading the latest news from Bluesky..."
+
 [community_calendar_name]
 other = "Events Calendar"
 

--- a/layouts/shortcodes/social-media-feed.html
+++ b/layouts/shortcodes/social-media-feed.html
@@ -1,0 +1,38 @@
+{{ $kind := .Get "kind" }}
+
+{{ if eq $kind "bluesky" }}
+  <template id="bluesky-post-template">
+    <div class="bluesky-post">
+      <div data-field="text"></div>
+      <small>
+        <span data-field="date"></span> •
+        <a data-field="link" target="_blank" rel="noopener">{{ T "community_bluesky_link" }}</a>
+      </small>
+      <hr>
+    </div>
+  </template>
+
+  <div id="bluesky-feed-container"
+       data-handle="kubernetes.io"
+       data-limit="5"
+  >
+    <p>{{ T "community_bluesky_loading" }}</p>
+  </div>
+
+  <div id="bluesky-feed-fallback" hidden>
+    <p>
+      {{ T "community_bluesky_fallback_text" }}
+      <a href="https://bsky.app/profile/kubernetes.io">{{ T "community_bluesky_name" }}</a>
+    </p>
+  </div>
+
+  {{ $js := resources.Get "js/bluesky-feed.js" }}
+  {{ if hugo.IsProduction }}
+    {{ $js = $js | minify | fingerprint }}
+    <script defer src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
+  {{ else }}
+    <script defer src="{{ $js.RelPermalink }}"></script>
+  {{ end }}
+{{ else }}
+  {{ errorf "social-media-feed: unsupported kind %q" $kind }}
+{{ end }}


### PR DESCRIPTION
### Description

Refactor the inline Bluesky feed script into a `{{< social-media-feed >}}` shortcode.
I checked loading message display under browser throttling (x20) and fallback display by forcing a fetch error.

### Issue

Closes: #55065

### Preview

https://deploy-preview-55105--kubernetes-io-main-staging.netlify.app/community/