### PR TITLE
docs: add caution about DNS being blocked by deny-all egress

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -241,6 +241,12 @@ that selects all pods but does not allow any egress traffic from those pods.
 This ensures that even pods that aren't selected by any other NetworkPolicy will not be allowed
 egress traffic. This policy does not change the ingress isolation behavior of any pod.
 
+{{< caution >}}
+A default deny-all egress policy also blocks DNS traffic. If your workloads need DNS
+resolution, you must add a separate NetworkPolicy that allows egress to your
+cluster's DNS service.
+{{< /caution >}}
+
 ### Allow all egress traffic
 
 If you want to allow all connections from all pods in a namespace, you can create a policy that


### PR DESCRIPTION
## what this PR does / why we need it

adds a `caution` callout to the "Default deny all egress traffic"
section of the NetworkPolicy concept page, warning that a deny-all
egress policy also blocks DNS traffic and that a separate NetworkPolicy
allowing DNS egress is needed if workloads require name resolution.

## Which issue this PR fixes

Fixes #54997