### PR TITLE
Correct examples for Metadata-only fetches

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -881,7 +881,9 @@ For example: `Accept: application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=
 for JSON for a specific object and: 
 `Accept: application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1` for a list.
 
-NOTE: `as=PartialObjectMetadata;` should be used in specific object requests and `as=PartialObjectMetadataList;` should be used for lists.
+{{< note >}}
+`as=PartialObjectMetadata` should be used in specific resource requests, and `as=PartialObjectMetadataList` should be used for lists.
+{{< /note >}}
 
 For example, to list all of the pods in a cluster, across all namespaces, but returning only the metadata for each pod:
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Clarified usage of Accept header for specific object and list requests. When requesting a list you have to specify `PartialObjectMetadataList` and when requesting a single object you specify `PartialObjectMetadata`.

The example as is doesn't work. [For reference the rust implementation](https://github.com/kube-rs/kube/blob/main/kube-core/src/request.rs#L16-L18) uses the different mime types as such.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->