### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/ephemeral-container.md
+++ b/content/fr/docs/reference/glossary/ephemeral-container.md
@@ -1,0 +1,21 @@
+---
+title: Conteneur éphémère
+id: ephemeral-container
+full_link: /docs/concepts/workloads/pods/ephemeral-containers/
+short_description: >
+  Un type de conteneur que vous pouvez exécuter temporairement dans un Pod.
+
+aka:
+tags:
+- fundamental
+---
+
+Un type de conteneur que vous pouvez exécuter temporairement dans un Pod.
+
+<!--more-->
+
+Si vous souhaitez analyser un Pod en cours d’exécution présentant des problèmes, vous pouvez y ajouter un conteneur éphémère afin d’effectuer des diagnostics.
+
+Les conteneurs éphémères ne disposent pas de garanties en termes de ressources ou d’ordonnancement, et ne doivent pas être utilisés pour exécuter une partie du workload lui-même.
+
+Les conteneurs éphémères ne sont pas pris en charge par les Pods statiques.

--- a/content/fr/docs/reference/glossary/logging.md
+++ b/content/fr/docs/reference/glossary/logging.md
@@ -1,0 +1,19 @@
+---
+title: Journalisation
+id: logging
+full_link: /docs/concepts/cluster-administration/logging/
+short_description: >
+  Les logs sont des enregistrements d’événements produits par le cluster ou les applications.
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+
+Les logs sont des enregistrements d’événements produits par le cluster ou les applications.
+
+<!--more--> 
+
+Les logs des applications et du système permettent de comprendre ce qui se passe à l’intérieur de votre cluster.  
+Ils sont particulièrement utiles pour le débogage des problèmes et la surveillance de l’activité du cluster.

--- a/content/fr/docs/reference/glossary/node-pressure-eviction.md
+++ b/content/fr/docs/reference/glossary/node-pressure-eviction.md
@@ -1,0 +1,21 @@
+---
+title: Éviction sous pression du nœud
+id: node-pressure-eviction
+full_link: /docs/concepts/scheduling-eviction/node-pressure-eviction/
+short_description: >
+  Processus par lequel le kubelet termine de manière proactive des Pods afin de libérer des ressources sur les nœuds.
+
+aka:
+- kubelet eviction
+tags:
+- operation
+---
+
+L’éviction sous pression du nœud est le processus par lequel le kubelet termine de manière proactive des Pods afin de libérer des ressources sur les nœuds.
+
+<!--more-->
+
+Le kubelet surveille les ressources telles que le CPU, la mémoire, l’espace disque et les inodes du système de fichiers sur les nœuds du cluster.  
+Lorsque l’une ou plusieurs de ces ressources atteignent un certain seuil d’utilisation, le kubelet peut interrompre un ou plusieurs Pods sur le nœud afin de libérer des ressources et éviter une saturation.
+
+L’éviction sous pression du nœud est différente de l’éviction initiée via l’API.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire liées au diagnostic, à l’observabilité et à la gestion des ressources dans Kubernetes.

**Fichiers inclus :**

* `logging.md`
* `ephemeral-container.md`
* `node-pressure-eviction.md`

Cette contribution s’inscrit dans le cadre du suivi du plan de traduction du glossaire Kubernetes #54874.