### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/api-eviction.md
+++ b/content/fr/docs/reference/glossary/api-eviction.md
@@ -1,0 +1,22 @@
+---
+title: Éviction initiée par l’API
+id: api-eviction
+full_link: /docs/concepts/scheduling-eviction/api-eviction/
+short_description: >
+  Processus consistant à utiliser l’API d’éviction pour créer un objet Eviction qui déclenche l’arrêt gracieux d’un Pod.
+
+aka:
+tags:
+- operation
+---
+
+L’éviction initiée par l’API est le processus par lequel vous utilisez l’API d’éviction pour créer un objet `Eviction` qui déclenche l’arrêt gracieux d’un Pod.
+
+<!--more-->
+
+Vous pouvez demander une éviction en appelant directement l’API d’éviction à l’aide d’un client du kube-apiserver, comme la commande `kubectl drain`.  
+Lorsqu’un objet `Eviction` est créé, le serveur API termine le Pod.
+
+Les évictions initiées par l’API respectent les `PodDisruptionBudgets` configurés ainsi que le paramètre `terminationGracePeriodSeconds`.
+
+L’éviction initiée par l’API est différente de l’éviction due à la pression sur les nœuds.

--- a/content/fr/docs/reference/glossary/drain.md
+++ b/content/fr/docs/reference/glossary/drain.md
@@ -1,0 +1,19 @@
+---
+title: Drain
+id: drain
+full_link:
+short_description: >
+  Évacuation sécurisée des Pods d’un nœud afin de préparer une maintenance ou son retrait.
+tags:
+- fundamental
+- operation
+---
+
+Le drain est le processus consistant à évacuer de manière sécurisée les Pods d’un nœud afin de le préparer à une maintenance ou à son retrait du cluster.
+
+<!--more-->
+
+La commande `kubectl drain` permet de marquer un nœud comme étant hors service.  
+Lorsqu’elle est exécutée, elle évacue tous les Pods présents sur ce nœud.
+
+Si une demande d’éviction est temporairement refusée, `kubectl drain` réessaie jusqu’à ce que tous les Pods soient terminés ou qu’un délai configurable soit atteint.

--- a/content/fr/docs/reference/glossary/group-version-resource.md
+++ b/content/fr/docs/reference/glossary/group-version-resource.md
@@ -1,0 +1,21 @@
+---
+title: Group Version Resource
+id: gvr
+short_description: >
+  Le groupe d’API, la version d’API et le nom d’une ressource Kubernetes.
+
+aka: ["GVR"]
+tags:
+- architecture
+---
+
+Un moyen de représenter de manière unique une API Kubernetes.
+
+<!--more-->
+
+Les Group Version Resource (GVR) définissent le groupe d’API, la version d’API et la ressource (le nom de l’objet tel qu’il apparaît dans l’URI) utilisés pour accéder à un objet Kubernetes spécifique.
+
+Les GVR permettent de définir et de distinguer différents objets Kubernetes, ainsi que de fournir un moyen d’y accéder de manière stable, même lorsque les API évoluent.
+
+Dans ce contexte, le terme _resource_ désigne une ressource HTTP.  
+Étant donné que certaines API sont associées à des espaces de noms (namespaces), un GVR ne correspond pas nécessairement à une ressource API spécifique.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire liées à la gestion des évictions, à la maintenance des nœuds et à la structuration de l’API Kubernetes.

**Fichiers inclus :**

* `api-eviction.md`
* `drain.md`
* `group-version-resource.md`

Cette contribution s’inscrit dans le cadre du suivi du plan de traduction du glossaire Kubernetes #54874.