### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/downward-api.md
+++ b/content/fr/docs/reference/glossary/downward-api.md
@@ -1,0 +1,25 @@
+---
+title: Downward API
+id: downward-api
+short_description: >
+  Un mécanisme permettant d’exposer des informations sur le Pod et les conteneurs à une application en cours d’exécution.
+aka:
+full_link: /docs/concepts/workloads/pods/downward-api/
+tags:
+- architecture
+---
+
+Un mécanisme de Kubernetes permettant d’exposer des informations sur le Pod et les conteneurs à une application exécutée dans un conteneur.
+
+<!--more-->
+
+Il peut être utile pour un conteneur d’avoir des informations sur lui-même sans avoir à modifier son code pour l’intégrer directement avec Kubernetes.
+
+La Downward API permet aux conteneurs d’accéder à des informations sur leur propre contexte dans le cluster Kubernetes, sans que l’application ait besoin d’interagir directement avec l’API Kubernetes.
+
+Il existe deux façons d’exposer ces informations à un conteneur en cours d’exécution :
+
+- via des variables d’environnement  
+- via un volume `downwardAPI`  
+
+Ces deux mécanismes sont regroupés sous le nom de _Downward API_.

--- a/content/fr/docs/reference/glossary/duration.md
+++ b/content/fr/docs/reference/glossary/duration.md
@@ -1,0 +1,22 @@
+---
+title: Durée
+id: duration
+full_link:
+short_description: >
+  Une valeur de type chaîne représentant une durée.
+tags:
+- fundamental
+---
+
+Une valeur de type chaîne représentant une durée.
+
+<!--more-->
+
+Le format d’une durée dans Kubernetes est basé sur le type `time.Duration` du langage Go.
+
+Dans les API Kubernetes utilisant des durées, la valeur est exprimée comme une combinaison d’entiers non négatifs associés à un suffixe d’unité de temps.  
+Une durée peut contenir plusieurs unités, et correspond à la somme de ces différentes valeurs.
+
+Les unités de temps valides sont : `ns`, `µs` (ou `us`), `ms`, `s`, `m` et `h`.
+
+Par exemple : `5s` représente une durée de cinq secondes, et `1m30s` représente une durée d’une minute et trente secondes.

--- a/content/fr/docs/reference/glossary/feature-gates.md
+++ b/content/fr/docs/reference/glossary/feature-gates.md
@@ -1,0 +1,22 @@
+---
+title: Feature gate
+id: feature-gate
+full_link: /docs/reference/command-line-tools-reference/feature-gates/
+short_description: >
+  Un mécanisme permettant d’activer ou de désactiver des fonctionnalités dans Kubernetes.
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+
+Les feature gates sont un ensemble de clés (chaînes de caractères) utilisées pour contrôler quelles fonctionnalités de Kubernetes sont activées dans un cluster.
+
+<!--more-->
+
+Vous pouvez activer ou désactiver ces fonctionnalités en utilisant le paramètre `--feature-gates` dans la ligne de commande de chaque composant Kubernetes.
+
+Chaque composant Kubernetes permet d’activer ou de désactiver un ensemble de feature gates qui lui sont propres.
+
+La documentation Kubernetes fournit la liste des feature gates disponibles ainsi que les fonctionnalités qu’elles contrôlent.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire liées à la gestion du temps, à la configuration des conteneurs et au contrôle des fonctionnalités dans Kubernetes.

**Fichiers inclus :**

* `duration.md`
* `downward-api.md`
* `feature-gates.md`

Cette contribution s’inscrit dans le cadre du suivi du plan de traduction du glossaire Kubernetes #54874.