### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/cidr.md
+++ b/content/fr/docs/reference/glossary/cidr.md
@@ -1,0 +1,20 @@
+---
+title: CIDR
+id: cidr
+full_link: 
+short_description: >
+  CIDR est une notation permettant de décrire des plages d’adresses IP, largement utilisée dans les configurations réseau.
+
+aka:
+tags:
+- networking
+---
+
+CIDR (Classless Inter-Domain Routing) est une notation permettant de décrire des plages d’adresses IP, largement utilisée dans les configurations réseau.
+
+<!--more-->
+
+Dans le contexte de Kubernetes, chaque nœud se voit attribuer une plage d’adresses IP définie par une adresse de départ et un masque de sous-réseau en notation CIDR.  
+Cela permet aux nœuds d’attribuer une adresse IP unique à chaque Pod.
+
+Bien que ce concept ait été initialement conçu pour IPv4, il a été étendu pour prendre en charge IPv6.

--- a/content/fr/docs/reference/glossary/gateway.md
+++ b/content/fr/docs/reference/glossary/gateway.md
@@ -1,0 +1,19 @@
+---
+title: Gateway API
+id: gateway-api
+full_link: /docs/concepts/services-networking/gateway/
+short_description: >
+  Une API permettant de modéliser le réseau des services dans Kubernetes.
+
+aka:
+tags:
+- networking
+- architecture
+- extension
+---
+
+Une famille de types d’API permettant de modéliser le réseau des services dans Kubernetes.
+
+<!--more--> 
+
+La Gateway API fournit un ensemble de types d’API extensibles, orientés rôles et conscients des protocoles, pour définir et gérer le réseau des services dans Kubernetes.

--- a/content/fr/docs/reference/glossary/host-aliases.md
+++ b/content/fr/docs/reference/glossary/host-aliases.md
@@ -1,0 +1,19 @@
+---
+title: HostAliases
+id: HostAliases
+full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
+short_description: >
+  HostAliases permet de définir une correspondance entre des adresses IP et des noms d’hôte à injecter dans le fichier hosts d’un Pod.
+
+aka:
+tags:
+- operation
+---
+
+HostAliases est un mécanisme permettant de définir une correspondance entre des adresses IP et des noms d’hôte à injecter dans le fichier hosts d’un Pod.
+
+<!--more-->
+
+HostAliases correspond à une liste optionnelle de noms d’hôte et d’adresses IP qui seront ajoutés au fichier hosts du Pod si elle est définie.
+
+Cette fonctionnalité est uniquement valable pour les Pods qui n’utilisent pas le mode hostNetwork.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire liées au réseau et à la configuration des communications dans Kubernetes.

**Fichiers inclus :**

* `cidr.md`
* `gateway.md`
* `host-aliases.md`

Cette contribution s’inscrit dans le cadre du suivi du plan de traduction du glossaire Kubernetes #54874.