### PR TITLE
Add Bootstrap mobile navbar drawer for docs and blog pages

### DIFF
--- a/assets/js/legacy-script.js
+++ b/assets/js/legacy-script.js
@@ -144,26 +144,13 @@ var kub = (function () {
     }
 
     function toggleMenu() {
-        if (window.innerWidth < 800) {
-            pushmenu.show('primary');
-        }
-
-        else {
-            var newHeight = HEADER_HEIGHT;
-
-            if (!html.hasClass('open-nav')) {
-                newHeight = mainNav.outerHeight();
-            }
-
-            header.css({height: px(newHeight)});
-            html.toggleClass('open-nav');
-        }
+        $('#main_navbar').collapse('toggle');
     }
 
     function handleKeystrokes(e) {
         switch (e.which) {
             case 27: {
-                if (html.hasClass('open-nav')) {
+                if ($('#main_navbar').hasClass('show')) {
                     toggleMenu();
                 }
                 break;
@@ -364,109 +351,6 @@ var kub = (function () {
     }
 })();
 
-
-var pushmenu = (function(){
-    var allPushMenus = {};
-
-    $(document).ready(function(){
-        $('[data-auto-burger]').each(function(){
-            var container = this;
-            var id = container.getAttribute('data-auto-burger');
-
-            var autoBurger = document.getElementById(id) || newDOMElement('div', 'pi-pushmenu', id);
-            var ul = autoBurger.querySelector('ul') || newDOMElement('ul');
-
-            $(container).find('a[href], button').each(function () {
-                if (!booleanAttributeValue(this, 'data-auto-burger-exclude', false)) {
-                    var clone = this.cloneNode(true);
-                    clone.id = '';
-
-                    if (clone.tagName == "BUTTON") {
-                        var aTag = newDOMElement('a');
-                        aTag.href = '';
-                        aTag.innerHTML = clone.innerHTML;
-                        aTag.onclick = clone.onclick;
-                        clone = aTag;
-                    }
-                    var li = newDOMElement('li');
-                    li.appendChild(clone);
-                    ul.appendChild(li);
-                }
-            });
-
-            autoBurger.appendChild(ul);
-            body.append(autoBurger);
-        });
-
-        $(".pi-pushmenu").each(function(){
-            allPushMenus[this.id] = PushMenu(this);
-        });
-    });
-
-    function show(objId) {
-        allPushMenus[objId].expose();
-    }
-
-    function PushMenu(el) {
-        var html = document.querySelector('html');
-
-        var overlay = newDOMElement('div', 'overlay');
-        var content = newDOMElement('div', 'content');
-        content.appendChild(el.querySelector('*'));
-
-        var side = el.getAttribute("data-side") || "right";
-
-        var sled = newDOMElement('div', 'sled');
-        $(sled).css(side, 0);
-
-        sled.appendChild(content);
-
-        var closeButton = newDOMElement('button', 'btn fa fa-times');
-        closeButton.onclick = closeMe;
-
-        sled.appendChild(closeButton);
-
-        overlay.appendChild(sled);
-        el.innerHTML = '';
-        el.appendChild(overlay);
-
-        sled.onclick = function(e){
-            e.stopPropagation();
-        };
-
-        overlay.onclick = closeMe;
-
-        window.addEventListener('resize', closeMe);
-
-        function closeMe(e) {
-            if (e.target == sled) return;
-
-            $(el).removeClass('on');
-            setTimeout(function(){
-                $(el).css({display: 'none'});
-            }, 300);
-        }
-
-        function exposeMe(){
-            $(el).css({
-                display: 'block',
-                zIndex: highestZ()
-            });
-
-            setTimeout(function(){
-                $(el).addClass('on');
-            }, 10);
-        }
-
-        return {
-            expose: exposeMe
-        };
-    }
-
-    return {
-        show: show
-    };
-})();
 
 $(function() {
     // If vendor strip doesn't exist add className

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,13 +1,18 @@
 $(document).ready(async function () {
   await switchLogoOnResize();
   flipNavColor()
+  initMobileDrawer();
 
   window.addEventListener('resize', switchLogoOnResize);
   window.addEventListener('scroll', flipNavColor);
+  window.addEventListener('resize', collapseDrawerOnDesktop);
 
   document.onunload = function () {
     window.removeEventListener('resize', switchLogoOnResize);
     window.removeEventListener('scroll', flipNavColor);
+    window.removeEventListener('resize', collapseDrawerOnDesktop);
+    $("#main_navbar").off('show.bs.collapse shown.bs.collapse hide.bs.collapse hidden.bs.collapse');
+    $('body').removeClass('td-navbar-drawer-opening td-navbar-drawer-open td-navbar-drawer-closing');
   };
 });
 
@@ -19,7 +24,7 @@ async function switchLogoOnResize() {
   // No-op if the navbar logo is disabled via hugo params
   {{- if ne .ui.navbar_logo false }}
   const logoSpan = $("nav .navbar-brand__logo");
-  const breakpointMd = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--breakpoint-md').trim());
+  const breakpointMd = getBreakpointMd();
   let svg
 
   if (window.innerWidth < breakpointMd) {
@@ -42,6 +47,67 @@ async function switchLogoOnResize() {
 
   $(logoSpan).html(svg)
   {{ end -}}
+}
+
+function initMobileDrawer() {
+  const drawer = $("#main_navbar");
+  if (!drawer.length) {
+    return;
+  }
+
+  drawer.on('show.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-navbar-drawer-closing')
+      .addClass('td-navbar-drawer-opening td-navbar-drawer-open');
+  });
+
+  drawer.on('shown.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-navbar-drawer-opening td-navbar-drawer-closing')
+      .addClass('td-navbar-drawer-open');
+  });
+
+  drawer.on('hide.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-navbar-drawer-opening td-navbar-drawer-open')
+      .addClass('td-navbar-drawer-closing');
+  });
+
+  drawer.on('hidden.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body').removeClass('td-navbar-drawer-opening td-navbar-drawer-open td-navbar-drawer-closing');
+  });
+}
+
+function collapseDrawerOnDesktop() {
+  const drawer = $("#main_navbar");
+  if (!drawer.length) {
+    return;
+  }
+
+  if (window.innerWidth >= getBreakpointMd() && drawer.hasClass('show')) {
+    drawer.collapse('hide');
+  }
+}
+
+function getBreakpointMd() {
+  const breakpointMd = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--breakpoint-md').trim(), 10);
+  return Number.isNaN(breakpointMd) ? 768 : breakpointMd;
 }
 
 // Copied over from Docsy's assets/js/base.js

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -2,6 +2,7 @@ $(document).ready(async function () {
   await switchLogoOnResize();
   flipNavColor()
   initMobileDrawer();
+  initTocDrawer();
 
   window.addEventListener('resize', switchLogoOnResize);
   window.addEventListener('scroll', flipNavColor);
@@ -12,7 +13,8 @@ $(document).ready(async function () {
     window.removeEventListener('scroll', flipNavColor);
     window.removeEventListener('resize', collapseDrawerOnDesktop);
     $("#main_navbar").off('show.bs.collapse shown.bs.collapse hide.bs.collapse hidden.bs.collapse');
-    $('body').removeClass('td-navbar-drawer-opening td-navbar-drawer-open td-navbar-drawer-closing');
+    $("#td_toc_drawer").off('show.bs.collapse shown.bs.collapse hide.bs.collapse hidden.bs.collapse');
+    $('body').removeClass('td-navbar-drawer-opening td-navbar-drawer-open td-navbar-drawer-closing td-toc-drawer-opening td-toc-drawer-open td-toc-drawer-closing');
   };
 });
 
@@ -21,32 +23,35 @@ $(document).ready(async function () {
 // which is not present in the logo only SVG. This helps us prevent fetch calls for any resize event, ensuring
 // that a logo is only fetched when the current logo is the wrong one.
 async function switchLogoOnResize() {
-  // No-op if the navbar logo is disabled via hugo params
-  {{- if ne .ui.navbar_logo false }}
   const logoSpan = $("nav .navbar-brand__logo");
+  if (!logoSpan.length || logoSpan.find("svg").length === 0) {
+    return;
+  }
+
   const breakpointMd = getBreakpointMd();
-  let svg
+  let svg;
 
   if (window.innerWidth < breakpointMd) {
     if ($("nav .navbar-brand__logo svg g#its-pronounced").length !== 0) {
-      const logo = await fetch("/images/kubernetes-icon-color.svg")
+      const logo = await fetch("/images/kubernetes-icon-color.svg");
       if (!logo.ok) {
-        throw new Error(`Response status: ${logo.status}`)
+        throw new Error(`Response status: ${logo.status}`);
       }
-      svg = await logo.text()
+      svg = await logo.text();
     }
   } else {
     if ($("nav .navbar-brand__logo svg g#its-pronounced").length === 0) {
-      const logo = await fetch("/images/kubernetes-horizontal-white-text.svg")
+      const logo = await fetch("/images/kubernetes-horizontal-white-text.svg");
       if (!logo.ok) {
-        throw new Error(`Response status: ${logo.status}`)
+        throw new Error(`Response status: ${logo.status}`);
       }
-      svg = await logo.text()
+      svg = await logo.text();
     }
   }
 
-  $(logoSpan).html(svg)
-  {{ end -}}
+  if (svg) {
+    logoSpan.html(svg);
+  }
 }
 
 function initMobileDrawer() {
@@ -58,6 +63,11 @@ function initMobileDrawer() {
   drawer.on('show.bs.collapse', function (event) {
     if (event.target !== this) {
       return;
+    }
+
+    const tocDrawer = $("#td_toc_drawer");
+    if (tocDrawer.length && tocDrawer.hasClass('show')) {
+      tocDrawer.collapse('hide');
     }
 
     $('body')
@@ -94,14 +104,69 @@ function initMobileDrawer() {
   });
 }
 
-function collapseDrawerOnDesktop() {
-  const drawer = $("#main_navbar");
+function initTocDrawer() {
+  const drawer = $("#td_toc_drawer");
   if (!drawer.length) {
     return;
   }
 
-  if (window.innerWidth >= getBreakpointMd() && drawer.hasClass('show')) {
-    drawer.collapse('hide');
+  drawer.on('show.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    const navDrawer = $("#main_navbar");
+    if (navDrawer.length && navDrawer.hasClass('show')) {
+      navDrawer.collapse('hide');
+    }
+
+    $('body')
+      .removeClass('td-toc-drawer-closing')
+      .addClass('td-toc-drawer-opening td-toc-drawer-open');
+  });
+
+  drawer.on('shown.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-toc-drawer-opening td-toc-drawer-closing')
+      .addClass('td-toc-drawer-open');
+  });
+
+  drawer.on('hide.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body')
+      .removeClass('td-toc-drawer-opening td-toc-drawer-open')
+      .addClass('td-toc-drawer-closing');
+  });
+
+  drawer.on('hidden.bs.collapse', function (event) {
+    if (event.target !== this) {
+      return;
+    }
+
+    $('body').removeClass('td-toc-drawer-opening td-toc-drawer-open td-toc-drawer-closing');
+  });
+}
+
+function collapseDrawerOnDesktop() {
+  if (window.innerWidth < getBreakpointMd()) {
+    return;
+  }
+
+  const navDrawer = $("#main_navbar");
+  if (navDrawer.length && navDrawer.hasClass('show')) {
+    navDrawer.collapse('hide');
+  }
+
+  const tocDrawer = $("#td_toc_drawer");
+  if (tocDrawer.length && tocDrawer.hasClass('show')) {
+    tocDrawer.collapse('hide');
   }
 }
 

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -308,32 +308,6 @@ footer .row > .order-2 { flex: 0 0 66.6667%; max-width: 66.6667%; }
 footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
-/* SIDE-DRAWER MENU */
-
-.pi-pushmenu .sled {
-  .content ul {
-    padding: 0;
-
-    li {
-      &:first-child {
-        display: none;
-      }
-
-      a.nav-link {
-        padding: 0;
-      }
-    }
-  }
-  .push-menu-close-button {
-    background: transparent;
-    border: none;
-
-    &:focus {
-      outline: none;
-    }
-  }
-}
-
 // Home page dark-mode
 @media (prefers-color-scheme: dark) {
   body.cid-home {

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -1,6 +1,11 @@
+// Shared toggler icon shape: keep geometry/thickness identical across states; only stroke color changes.
+@function td-navbar-toggler-icon($stroke-color) {
+  @return escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$stroke-color}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='3.5' d='M4 7h22M4 15h22M4 23h22'/></svg>"));
+}
+
 .td-navbar {
-  background: transparent !important;
-  position: fixed !important;
+  background: transparent;
+  position: fixed;
   transition: 0.3s;
   width: 100%;
 
@@ -16,7 +21,11 @@
 
   .navbar-brand {
     @include media-breakpoint-down(sm) {
-      margin-left: auto;
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-left: 0;
+      z-index: 1039;
     }
 
     svg {
@@ -30,20 +39,182 @@
     }
   }
 
-  #hamburger {
+  .navbar-toggler {
+    margin-left: auto;
+    border: 0;
     color: $navbar-dark-color;
 
-    &:hover:focus {
+    &:hover,
+    &:focus {
       color: $navbar-dark-hover-color;
     }
 
-    margin-left: auto;
-    font-size: xx-large;
+    .navbar-toggler-icon {
+      width: 1.7em;
+      height: 2em;
+      background-image: td-navbar-toggler-icon($navbar-dark-color);
+    }
 
-    // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the hamburger button
+    // Bootstrap buttons have a noticeable depression effect when clicked.
     &:focus,
     &:active {
-      box-shadow: none !important;
+      box-shadow: none;
+      outline: 0;
+    }
+  }
+
+  @include media-breakpoint-up(md) {
+    #main_navbar.navbar-collapse {
+      flex-grow: 0;
+      flex-basis: auto;
+      width: auto;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    .td-navbar-nav-scroll {
+      width: 100%;
+    }
+
+    #main_navbar {
+      // Keep drawer in the render tree for transform-based slide animation;
+      // collapse events still drive state, visibility, and interaction.
+      display: block;
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: 100vw;
+      max-width: 400px;
+      // Bootstrap Collapse writes inline `height`; force full-height drawer.
+      height: 100vh !important;
+      margin-top: 0;
+      padding: .75rem 1.25rem 1rem;
+      background: $white;
+      box-shadow: -2px 0 12px rgba(0, 0, 0, 0.25);
+      transform: translateX(100%);
+      transition: transform 0.3s ease;
+      visibility: hidden;
+      pointer-events: none;
+      overflow-y: auto;
+      z-index: 1041;
+    }
+
+    #main_navbar.collapsing {
+      display: block;
+      // Bootstrap Collapse writes inline `height` while transitioning.
+      height: 100vh !important;
+      margin-top: 0;
+      visibility: visible;
+      pointer-events: auto;
+      transition: transform 0.3s ease;
+      overflow-y: auto;
+    }
+
+    #main_navbar .navbar-nav {
+      display: block;
+      margin-top: 2.5rem;
+      padding: 0;
+      white-space: normal;
+    }
+
+    #main_navbar .nav-item {
+      display: block;
+      // Override Bootstrap `.mr-4` utility, which is declared with `!important`.
+      margin-right: 0 !important;
+      // Override Bootstrap `.mb-2` utility, which is declared with `!important`.
+      margin-bottom: 0 !important;
+      min-height: 2.75rem;
+      padding: 0;
+      border-bottom: 1px solid #cccccc;
+    }
+
+    #main_navbar .navbar-nav .nav-link {
+      display: block;
+      padding: 0 2rem 0 0;
+      line-height: 2.75rem;
+      font-size: 1.25rem;
+      font-weight: 400;
+      color: $primary;
+      box-shadow: none;
+    }
+
+    #main_navbar .navbar-nav .active > .nav-link,
+    #main_navbar .navbar-nav .nav-link.active {
+      color: $primary;
+      box-shadow: none;
+    }
+
+    .td-navbar-drawer-close {
+      position: absolute;
+      top: .25rem;
+      right: .5rem;
+      z-index: 1;
+      font-size: 2.66rem;
+      line-height: 1;
+      color: $dark-grey;
+      background: transparent;
+      border: 0;
+
+      &:focus,
+      &:active {
+        box-shadow: none;
+        outline: 0;
+      }
+    }
+
+    .td-navbar-mobile-group {
+      display: block;
+    }
+
+    .td-navbar-mobile-group-toggle {
+      width: 100%;
+      margin: 0;
+      padding: 0 2rem 0 0;
+      text-align: left;
+      background: transparent;
+      border: 0;
+      color: $primary;
+      font-size: 1.25rem;
+      font-weight: 400;
+      box-shadow: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      &:focus,
+      &:active {
+        box-shadow: none;
+        outline: 0;
+      }
+
+      i {
+        font-size: .95rem;
+        transition: transform 0.2s ease;
+      }
+
+      &:not(.collapsed) i {
+        transform: rotate(180deg);
+      }
+    }
+
+    .td-navbar-mobile-group-menu {
+      margin-bottom: .5rem;
+    }
+
+    .td-navbar-mobile-group-item {
+      display: block;
+      padding: 0 2rem 0 1rem;
+      line-height: 2.35rem;
+      font-size: 1.05rem;
+      font-weight: 400;
+      color: $primary;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        color: $primary;
+        text-decoration: underline;
+      }
     }
   }
 
@@ -59,14 +230,72 @@
 }
 }
 
+@include media-breakpoint-down(sm) {
+  body.td-navbar-drawer-opening #main_navbar,
+  body.td-navbar-drawer-open #main_navbar {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-navbar-drawer-closing #main_navbar {
+    transform: translateX(100%);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .td-navbar .td-navbar-drawer-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 1040;
+  }
+
+  body.td-navbar-drawer-opening .td-navbar .td-navbar-drawer-backdrop,
+  body.td-navbar-drawer-open .td-navbar .td-navbar-drawer-backdrop,
+  body.td-navbar-drawer-closing .td-navbar .td-navbar-drawer-backdrop {
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-navbar-drawer-opening .td-navbar .td-navbar-drawer-backdrop,
+  body.td-navbar-drawer-open .td-navbar .td-navbar-drawer-backdrop {
+    opacity: 1;
+  }
+}
+
 .navbar-bg-onscroll {
+  // Override Docsy `.navbar-bg-onscroll` background, which is `!important`.
   background: white !important;
   box-shadow: 0 1px 2px $medium-grey;
 
-  .navbar-nav .nav-link, #hamburger {
+  .navbar-nav .nav-link,
+  .navbar-toggler {
     color: $dark-grey;
 
-    &:hover:focus {
+    &:hover,
+    &:focus {
+      color: $medium-grey;
+    }
+  }
+
+  .navbar-toggler .navbar-toggler-icon {
+    background-image: td-navbar-toggler-icon($dark-grey);
+  }
+
+  .navbar-nav .nav-link {
+    color: $dark-grey;
+
+    &:hover,
+    &:focus {
       color: $medium-grey;
     }
   }
@@ -87,89 +316,5 @@
 
   .navbar-brand__logo.navbar-logo svg #its-pronounced path {
     fill: $primary;
-  }
-}
-
-/* Small/Mobile viewport nav menu */
-
-.pi-pushmenu {
-  display: none;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  transition: opacity 0.3s;
-
-  &.on {
-    opacity: 1;
-
-    .sled {
-      width: 400px;
-      max-width: 100vw;
-    }
-  }
-
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.4);
-  }
-
-  .sled {
-    position: absolute;
-    top: 0;
-    width: 0;
-    height: 100%;
-    background-color: white;
-    overflow: auto;
-    transition: 0.3s;
-
-    .content ul {
-      padding: 0;
-      margin-top: 25px;
-
-      li {
-        position: relative;
-        display: block;
-        width: 100%;
-        min-height: 2.75rem;
-        padding: 0 60px 0 20px;
-        border-bottom: 1px solid #cccccc;
-
-        // Hides the logo that will be in the list
-        &:first-child {
-          display: none;
-        }
-
-        a {
-          display: inline-block;
-          width: 100%;
-          height: 2.75rem;
-          line-height: 2.75rem;
-          font-size: 1.25rem;
-          color: $primary;
-
-          .nav-link {
-            padding: 0;
-          }
-        }
-      }
-    }
-
-    button {
-      position: absolute;
-      top: 0;
-      right: 0;
-      font-size: xx-large;
-
-      &:focus,
-      &:active {
-        box-shadow: none !important;
-      }
-    }
   }
 }

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -3,6 +3,10 @@
   @return escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$stroke-color}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='3.5' d='M4 7h22M4 15h22M4 23h22'/></svg>"));
 }
 
+@function td-navbar-book-icon($stroke-color) {
+  @return escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='none' stroke='#{$stroke-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2.4' d='M4.5 7.5c2.9-1.3 5.8-1.5 9-0.7v15.7c-3-0.8-5.9-0.5-9 0.9zM25.5 7.5c-2.9-1.3-5.8-1.5-9-0.7v15.7c3-0.8 5.9-0.5 9 0.9zM15 6.8v16.3'/></svg>"));
+}
+
 .td-navbar {
   background: transparent;
   position: fixed;
@@ -56,6 +60,38 @@
     }
 
     // Bootstrap buttons have a noticeable depression effect when clicked.
+    &:focus,
+    &:active {
+      box-shadow: none;
+      outline: 0;
+    }
+  }
+
+  .td-toc-toggler {
+    margin-left: 0;
+    margin-right: auto;
+    border: 0;
+    color: $navbar-dark-color;
+
+    &:hover,
+    &:focus {
+      color: $navbar-dark-hover-color;
+
+      .td-toc-toggler-icon {
+        background-image: td-navbar-book-icon($navbar-dark-hover-color);
+      }
+    }
+
+    .td-toc-toggler-icon {
+      display: block;
+      width: 1.7em;
+      height: 2em;
+      background-image: td-navbar-book-icon($navbar-dark-color);
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 1.6em 1.6em;
+    }
+
     &:focus,
     &:active {
       box-shadow: none;
@@ -216,6 +252,114 @@
         text-decoration: underline;
       }
     }
+
+    #td_toc_drawer {
+      // Keep drawer in the render tree for transform-based slide animation;
+      // collapse events still drive state, visibility, and interaction.
+      display: block;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      max-width: 400px;
+      // Bootstrap Collapse writes inline `height`; force full-height drawer.
+      height: 100vh !important;
+      margin-top: 0;
+      padding: .75rem 1.25rem 1rem;
+      background: $white;
+      box-shadow: 2px 0 12px rgba(0, 0, 0, 0.25);
+      transform: translateX(-100%);
+      transition: transform 0.3s ease;
+      visibility: hidden;
+      pointer-events: none;
+      overflow-y: auto;
+      z-index: 1041;
+    }
+
+    #td_toc_drawer.collapsing {
+      display: block;
+      // Bootstrap Collapse writes inline `height` while transitioning.
+      height: 100vh !important;
+      margin-top: 0;
+      visibility: visible;
+      pointer-events: auto;
+      transition: transform 0.3s ease;
+      overflow-y: auto;
+    }
+
+    #td_toc_drawer .td-toc-drawer-content {
+      margin-top: 2.5rem;
+      padding-right: .125rem;
+    }
+
+    #td_toc_drawer .td-sidebar__inner {
+      // Keep the copied sidebar wrapper visible in the drawer context.
+      display: block !important;
+    }
+
+    #td_toc_drawer .td-sidebar__search {
+      margin-bottom: .75rem;
+    }
+
+    #td_toc_drawer .td-search__input.form-control.dark-theme-focus,
+    #td_toc_drawer .td-search__input.form-control.dark-theme-focus::placeholder {
+      background-color: #d3d3d3;
+      color: #222;
+    }
+
+    #td_toc_drawer .td-search__input.form-control.dark-theme-focus:focus {
+      color: #222;
+    }
+
+    #td_toc_drawer .td-sidebar__toggle {
+      display: none;
+    }
+
+    #td_toc_drawer .td-sidebar-nav {
+      // Ensure copied blog sidebar nav remains expanded in drawer context.
+      display: block !important;
+      // Prevent Bootstrap collapse inline height from clipping the list.
+      height: auto !important;
+    }
+
+    #td_toc_drawer .td-page-meta {
+      // Override Bootstrap `.ml-2` utility, which is declared with `!important`.
+      margin-left: 0 !important;
+      padding-top: 0;
+    }
+
+    #td_toc_drawer .td-page-blog-meta {
+      // Override Bootstrap `.ml-2` utility, which is declared with `!important`.
+      margin-left: 0 !important;
+      padding-top: 0;
+    }
+
+    #td_toc_drawer .td-toc-drawer-content .widget-link {
+      color: $primary;
+
+      &:hover,
+      &:focus {
+        color: $primary;
+      }
+    }
+
+    .td-toc-drawer-close {
+      position: absolute;
+      top: .25rem;
+      left: .5rem;
+      z-index: 1;
+      font-size: 2.66rem;
+      line-height: 1;
+      color: $dark-grey;
+      background: transparent;
+      border: 0;
+
+      &:focus,
+      &:active {
+        box-shadow: none;
+        outline: 0;
+      }
+    }
   }
 
 /* Centers logo without offset horizontally and vertically in the navbar on small / mobile viewports */
@@ -231,6 +375,12 @@
 }
 
 @include media-breakpoint-down(sm) {
+  #sidebarnav,
+  #td-sidebar-menu {
+    // Keep the page sidebar hidden on mobile; drawer is the navigation surface.
+    display: none !important;
+  }
+
   body.td-navbar-drawer-opening #main_navbar,
   body.td-navbar-drawer-open #main_navbar {
     transform: translateX(0);
@@ -240,6 +390,19 @@
 
   body.td-navbar-drawer-closing #main_navbar {
     transform: translateX(100%);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-toc-drawer-opening #td_toc_drawer,
+  body.td-toc-drawer-open #td_toc_drawer {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-toc-drawer-closing #td_toc_drawer {
+    transform: translateX(-100%);
     visibility: visible;
     pointer-events: auto;
   }
@@ -270,6 +433,33 @@
   body.td-navbar-drawer-open .td-navbar .td-navbar-drawer-backdrop {
     opacity: 1;
   }
+
+  .td-navbar .td-toc-drawer-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 1040;
+  }
+
+  body.td-toc-drawer-opening .td-navbar .td-toc-drawer-backdrop,
+  body.td-toc-drawer-open .td-navbar .td-toc-drawer-backdrop,
+  body.td-toc-drawer-closing .td-navbar .td-toc-drawer-backdrop {
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.td-toc-drawer-opening .td-navbar .td-toc-drawer-backdrop,
+  body.td-toc-drawer-open .td-navbar .td-toc-drawer-backdrop {
+    opacity: 1;
+  }
 }
 
 .navbar-bg-onscroll {
@@ -289,6 +479,10 @@
 
   .navbar-toggler .navbar-toggler-icon {
     background-image: td-navbar-toggler-icon($dark-grey);
+  }
+
+  .td-toc-toggler .td-toc-toggler-icon {
+    background-image: td-navbar-book-icon($dark-grey);
   }
 
   .navbar-nav .nav-link {

--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -76,7 +76,8 @@
 }
 
 .td-sidebar-link__page {
-  &#m-docs-test {
+  &#m-docs-test,
+  &#m-drawer-docs-test {
     display: none;
   }
 }

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -14,10 +14,6 @@ $vendor-strip-font-size: 16px;
 @media screen and (min-width: 768px) {
   @import "size";
 
-  #hamburger {
-    display: none;
-  }
-
   body:dir(rtl) {
     overflow-x: hidden;
   }

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -727,6 +727,12 @@ other = "Translated By"
 [ui_search]
 other = "Search this site"
 
+[ui_toggle_navigation]
+other = "Toggle navigation"
+
+[ui_close_navigation]
+other = "Close navigation"
+
 [version_check_mustbe]
 other = "Your Kubernetes server must be version "
 

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -733,6 +733,12 @@ other = "Toggle navigation"
 [ui_close_navigation]
 other = "Close navigation"
 
+[ui_toggle_page_panel]
+other = "Toggle page panel"
+
+[ui_close_page_panel]
+other = "Close page panel"
+
 [version_check_mustbe]
 other = "Your Kubernetes server must be version "
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -3,8 +3,8 @@
     (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark
-            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-auto-burger="primary">
+<nav class="js-navbar-scroll navbar navbar-expand-md navbar-dark
+            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
@@ -20,9 +20,28 @@
     </span>
     {{- /**/ -}}
   </a>
-  <div class="td-navbar-nav-scroll d-none d-md-block ml-xl-auto" id="main_navbar">
+  <button
+    class="navbar-toggler ml-auto"
+    type="button"
+    data-toggle="collapse"
+    data-target="#main_navbar"
+    aria-controls="main_navbar"
+    aria-expanded="false"
+    aria-label="{{ T "ui_toggle_navigation" | default "Toggle navigation" }}">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse td-navbar-nav-scroll ml-xl-auto" id="main_navbar">
+    <button
+      class="btn td-navbar-drawer-close d-md-none"
+      type="button"
+      data-toggle="collapse"
+      data-target="#main_navbar"
+      aria-controls="main_navbar"
+      aria-label="{{ T "ui_close_navigation" | default "Close navigation" }}">
+      &times;
+    </button>
     {{- /* In Docsy, the mt-2 class is used but that causes issues. This should be re-visited after 0.7 migration */ -}}
-    <ul class="navbar-nav mt-lg-0">
+    <ul class="navbar-nav mt-2 mt-lg-0">
     {{ $p := . }}
     {{ range .Site.Menus.main }}
     <li class="nav-item mr-4 mb-2 mb-lg-0">
@@ -38,15 +57,39 @@
     </li>
     {{ end }}
     {{ if .Site.Params.versions -}}
+      <li class="nav-item td-navbar-mobile-group d-md-none">
+        <button class="nav-link td-navbar-mobile-group-toggle collapsed" type="button" data-toggle="collapse" data-target="#td-mobile-versions" aria-expanded="false" aria-controls="td-mobile-versions">
+          <span>{{ T "version_menu" }}</span>
+          <i class="fas fa-chevron-down" aria-hidden="true"></i>
+        </button>
+        <div id="td-mobile-versions" class="collapse td-navbar-mobile-group-menu" data-parent="#main_navbar">
+          <a class="td-navbar-mobile-group-item" href="{{ "releases" | relLangURL }}">{{ i18n "release_information_navbar" . }}</a>
+          {{ range .Site.Params.versions }}
+          <a class="td-navbar-mobile-group-item" href="{{ .url }}{{ $p.RelPermalink }}">{{ .version }}</a>
+          {{ end }}
+        </div>
+      </li>
       <li class="nav-item dropdown mr-4 d-none d-lg-block">
         {{ partial "navbar-version-selector.html" . -}}
       </li>
-      {{ end -}}
-      {{ if (gt (len .Site.Home.Translations) 0) -}}
+    {{ end -}}
+    {{ $langPage := cond (gt (len .Translations) 0) . .Site.Home -}}
+    {{ if (gt (len .Site.Home.Translations) 0) -}}
+      <li class="nav-item td-navbar-mobile-group d-md-none">
+        <button class="nav-link td-navbar-mobile-group-toggle" type="button" data-toggle="collapse" data-target="#td-mobile-languages" aria-expanded="true" aria-controls="td-mobile-languages">
+          <span>{{ $langPage.Language.LanguageName }}</span>
+          <i class="fas fa-chevron-down" aria-hidden="true"></i>
+        </button>
+        <div id="td-mobile-languages" class="collapse show td-navbar-mobile-group-menu" data-parent="#main_navbar">
+          {{ range $langPage.Translations }}
+          <a class="td-navbar-mobile-group-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+          {{ end }}
+        </div>
+      </li>
       <li class="nav-item dropdown mr-xl-4 d-none d-lg-block">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
-      {{ end -}}
+    {{ end -}}
     </ul>
   </div>
   {{- /*
@@ -56,9 +99,13 @@
   <div class="navbar-nav d-none k8s-1500-block">
     {{ partial "search-input.html" . }}
   </div>
-  {{- /*
-    The menu overlay is added to the DOM and shown/hidden all by JS.
-    We should explore a Hugo way of doing this.
-  */ -}}
-  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" data-auto-burger-exclude></button>
+  <button
+    class="td-navbar-drawer-backdrop d-md-none"
+    type="button"
+    data-toggle="collapse"
+    data-target="#main_navbar"
+    aria-controls="main_navbar"
+    aria-label="{{ T "ui_close_navigation" | default "Close navigation" }}">
+    <span class="sr-only">{{ T "ui_close_navigation" | default "Close navigation" }}</span>
+  </button>
 </nav>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -2,9 +2,23 @@
     (.HasShortcode "blocks/cover")
     (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
+{{ $showPagePanel := or (eq .Section "docs") (eq .Section "blog") (eq .Type "docs") (eq .Type "blog") -}}
+{{ $isBlogPagePanel := or (eq .Section "blog") (eq .Type "blog") -}}
 
 <nav class="js-navbar-scroll navbar navbar-expand-md navbar-dark
             {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar">
+  {{- if $showPagePanel -}}
+  <button
+    class="navbar-toggler td-toc-toggler d-md-none"
+    type="button"
+    data-toggle="collapse"
+    data-target="#td_toc_drawer"
+    aria-controls="td_toc_drawer"
+    aria-expanded="false"
+    aria-label="{{ T "ui_toggle_page_panel" | default "Toggle page panel" }}">
+    <span class="td-toc-toggler-icon"></span>
+  </button>
+  {{- end -}}
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
@@ -108,4 +122,51 @@
     aria-label="{{ T "ui_close_navigation" | default "Close navigation" }}">
     <span class="sr-only">{{ T "ui_close_navigation" | default "Close navigation" }}</span>
   </button>
+  {{- if $showPagePanel -}}
+  <div class="collapse td-toc-drawer d-md-none" id="td_toc_drawer">
+    <button
+      class="btn td-toc-drawer-close"
+      type="button"
+      data-toggle="collapse"
+      data-target="#td_toc_drawer"
+      aria-controls="td_toc_drawer"
+      aria-label="{{ T "ui_close_page_panel" | default "Close page panel" }}">
+      &times;
+    </button>
+    <div class="td-toc-drawer-content td-toc">
+      {{- if $isBlogPagePanel -}}
+        {{- $blogSidebar := partial "blog-sidebar-tree.html" . -}}
+        {{- $blogSidebar = replace $blogSidebar " d-none" "" -}}
+        {{- $blogSidebar = replace $blogSidebar "id=\"td-sidebar-menu\"" "id=\"td-sidebar-menu-drawer\"" -}}
+        {{- $blogSidebar = replace $blogSidebar "id=\"td-section-nav\"" "id=\"td-section-nav-drawer\"" -}}
+        {{- $blogSidebar = replace $blogSidebar "data-target=\"#td-section-nav\"" "data-target=\"#td-section-nav-drawer\"" -}}
+        {{- $blogSidebar = replace $blogSidebar "aria-controls=\"td-section-nav\"" "aria-controls=\"td-section-nav-drawer\"" -}}
+        {{- $blogSidebar = replace $blogSidebar "class=\"collapse td-sidebar-nav" "class=\"collapse show td-sidebar-nav" -}}
+        {{- $blogSidebar = replace $blogSidebar "id=\"m-" "id=\"m-drawer-" -}}
+        {{- $blogSidebar = replace $blogSidebar "for=\"m-" "for=\"m-drawer-" -}}
+        {{- $blogSidebar | safeHTML -}}
+      {{- else -}}
+        {{- $docsSidebar := partial "sidebar-tree.html" . -}}
+        {{- $docsSidebar = replace $docsSidebar " d-none" "" -}}
+        {{- $docsSidebar = replace $docsSidebar "id=\"td-sidebar-menu\"" "id=\"td-sidebar-menu-drawer\"" -}}
+        {{- $docsSidebar = replace $docsSidebar "id=\"td-section-nav\"" "id=\"td-section-nav-drawer\"" -}}
+        {{- $docsSidebar = replace $docsSidebar "data-target=\"#td-section-nav\"" "data-target=\"#td-section-nav-drawer\"" -}}
+        {{- $docsSidebar = replace $docsSidebar "aria-controls=\"td-section-nav\"" "aria-controls=\"td-section-nav-drawer\"" -}}
+        {{- $docsSidebar = replace $docsSidebar "class=\"collapse td-sidebar-nav" "class=\"collapse show td-sidebar-nav" -}}
+        {{- $docsSidebar = replace $docsSidebar "id=\"m-" "id=\"m-drawer-" -}}
+        {{- $docsSidebar = replace $docsSidebar "for=\"m-" "for=\"m-drawer-" -}}
+        {{- $docsSidebar | safeHTML -}}
+      {{- end -}}
+    </div>
+  </div>
+  <button
+    class="td-toc-drawer-backdrop d-md-none"
+    type="button"
+    data-toggle="collapse"
+    data-target="#td_toc_drawer"
+    aria-controls="td_toc_drawer"
+    aria-label="{{ T "ui_close_page_panel" | default "Close page panel" }}">
+    <span class="sr-only">{{ T "ui_close_page_panel" | default "Close page panel" }}</span>
+  </button>
+  {{- end -}}
 </nav>


### PR DESCRIPTION
## Summary

Stacked on top of #54700, this PR extends the Bootstrap-aligned mobile navigation work tied to [Docsy migration #41171](https://github.com/kubernetes/website/issues/41171) by moving docs/blog page navigation into a navbar drawer.

It introduces a left-side, book-shaped toggle that opens the page navigation drawer on mobile, removes hamburger-icon ambiguity (Addresses #22021), and makes page navigation available while scrolled instead of only near the top-of-page sidebar area (Addresses #53998).

Desktop behavior remains unchanged and non-docs/blog sections are unaffected.

## Changes

- Adds a conditional, Bootstrap collapse-based page drawer to the navbar for `/docs` and `/blog` on mobile.

- Adds a book-shaped toggle icon in the mobile navbar for opening the page drawer.

- Reuses the existing docs/blog sidebar markup, navigation structure, and search UI in the drawer instead of duplicating navigation data.

- Remaps copied element IDs and collapse targets in drawer-rendered markup to avoid collisions and keep nested expand/collapse controls working.

- Adds localized accessibility labels for the new open/close controls.

- Hides the in-page mobile sidebar for docs/blog and replaces it with the navbar drawer flow.

- Keeps desktop behavior unchanged.

## Related

- Stacked on: #54700
- Migration context: [Docsy migration #41171](https://github.com/kubernetes/website/issues/41171)
- Addresses: #22021
- Addresses: #53998

## Migration Plan for Docsy 0.7 with Bootstrap 5.2

**Required for BS5.2 compatibility**

Rename Bootstrap data attributes (BS4 -> BS5).
data-toggle -> data-bs-toggle
data-target -> data-bs-target
data-parent -> data-bs-parent
Must update in:
navbar.html
sidebar-tree.html
blog-sidebar-tree.html
Rename directional utility classes.
ml-* -> ms-*
mr-* -> me-*
pl-* -> ps-*
pr-* -> pe-*
Also change sr-only -> visually-hidden.
Must update in:
navbar.html
sidebar-tree.html
blog-sidebar-tree.html
docs/baseof.html
blog/baseof.html
Fix your drawer string-rewrite logic for BS5 attrs.
In navbar.html, you currently replace data-target="#td-section-nav" when cloning sidebar partial HTML into the drawer.
After migration, those source partials will use data-bs-target, so your replace patterns must be updated or drawer toggle targets will break.
Audit Bootstrap breakpoint mixin behavior in custom SCSS.
You use @include media-breakpoint-down(sm) in:
_k8s_nav.scss
_k8s_sidebar-tree.scss
Docsy’s 0.7 migration notes call out Bootstrap breakpoint-map changes that can shift behavior. Re-verify mobile/tablet boundaries after upgrade.

**Out of scope (optional follow-up)**

A) Migrate Bootstrap collapse API calls to native BS5 instances
- $().collapse('hide'|'toggle') -> bootstrap.Collapse instance methods.
- Not required: BS5.2 exposes a jQuery bridge when jQuery is present on window (Docsy 0.7 still loads jQuery). Works as-is unless jQuery is removed or disabled via data-bs-no-jquery.
- Recommended as best practice to remove conditional dependency.

B) Full jQuery-to-vanilla DOM rewrite in nav.js and legacy-script.js
- This is a broader dependency cleanup and not required for BS5.2 navbar compatibility once Bootstrap plugin calls are migrated.

C) Convert current collapse-based drawer to BS5 offcanvas
- Recommended later to reduce custom drawer state/animation code.

**Why jQuery calls can survive this migration**
- BS5.2 can expose a jQuery bridge when jQuery is present on window and not disabled via data-bs-no-jquery on <body>.
- Result: $().collapse() calls can continue to work under BS5.2 as long as jQuery remains loaded and the bridge is not disabled.
- Because this is conditional behavior, native bootstrap.Collapse calls are still the more durable long-term target.
