### PR TITLE
[bn] Add Bengali translation for kubectl

### DIFF
--- a/content/bn/docs/reference/glossary/kubectl.md
+++ b/content/bn/docs/reference/glossary/kubectl.md
@@ -1,0 +1,23 @@
+---
+title: Kubectl
+id: kubectl
+full_link: /bn/docs/reference/kubectl/
+short_description: >
+  একটি কুবারনেটিস ক্লাস্টারের সাথে যোগাযোগের জন্য একটি কমান্ড লাইন টুল।
+
+aka:
+- kubectl
+tags:
+- tool
+- fundamental
+---
+একটি কুবারনেটিস ক্লাস্টারের
+{{< glossary_tooltip text="কন্ট্রোল প্লেনের" term_id="control-plane" >}} সাথে যোগাযোগের জন্য কমান্ড লাইন টুল,
+যা কুবারনেটিস API ব্যবহার করে।
+
+<!--more--> 
+
+আপনি কুবারনেটিস অবজেক্ট তৈরি, পরিদর্শন, আপডেট এবং মুছে ফেলতে `kubectl` ব্যবহার করতে পারেন।
+
+<!-- localization note: OK to omit the rest of this entry -->
+ইংরেজিতে, `kubectl` (আনুষ্ঠানিকভাবে) উচ্চারণ করা হয় /kjuːb/ /kənˈtɹəʊl/ (যেমন "cube control")।


### PR DESCRIPTION
This PR adds Bengali translation for kubectl.

Changes Made:
- Translated the page to Bengali

Related Issue:
Part of Bengali localization effort. Split from previous PRs as requested by maintainers to have one PR per translated page.

Checklist:
- Translation follows Kubernetes style guidelines
- All links and references are updated for Bengali locale
- Front matter is properly configured