### PR TITLE
Fix navbar version and language selectors visibility on tablet screens

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -38,12 +38,12 @@
     </li>
     {{ end }}
     {{ if .Site.Params.versions -}}
-      <li class="nav-item dropdown mr-4 d-none d-lg-block">
+      <li class="nav-item dropdown mr-4 d-none d-md-block">
         {{ partial "navbar-version-selector.html" . -}}
       </li>
       {{ end -}}
       {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item dropdown mr-xl-4 d-none d-lg-block">
+      <li class="nav-item dropdown mr-xl-4 d-none d-md-block">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}


### PR DESCRIPTION
This PR fixes the navbar version and language selectors not being visible on tablet screens (iPad, iPad mini, and mobile devices in desktop mode).

Problem:
The version and language selector dropdowns in the navbar were using the Bootstrap class d-lg-block, which only displays elements on large screens (992px and above). This caused the selectors to be hidden on tablet screens (768px-991px), making it impossible for tablet users to switch versions or languages.

Solution:
Changed the responsive display classes from d-none d-lg-block to d-none d-md-block for both version selector dropdown and language selector dropdown. This change makes the selectors visible on medium screens and above (768px and above), which includes tablet devices.

Changes Made:
- Modified layouts/partials/navbar.html
- Changed version selector class: d-none d-lg-block to d-none d-md-block
- Changed language selector class: d-none d-lg-block to d-none d-md-block

Testing:
The fix ensures that selectors remain hidden on mobile screens (less than 768px) where hamburger menu is used instead, selectors are now visible on tablet screens (768px-991px), selectors continue to work on desktop screens (992px and above), and there is no visual regression on existing layouts.

Related Issue: 54939