### PR TITLE
Improve update-schedule workflow to prevent branch divergence

### DIFF
--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0


### PR DESCRIPTION
This PR improves the update-schedule.yml workflow to prevent future failures caused by diverged branches.

PROBLEM:
The workflow has been failing because:
1. The update-schedule branch has diverged from main
2. Branch protection rules prevent force-pushing
3. The workflow cannot update the branch, causing silent failures

CHANGES MADE:
- Added explicit ref: main to the checkout step to ensure the workflow always starts from the latest main branch
- This ensures the workflow creates changes based on the current main branch state

IMPORTANT NOTE:
This PR alone will not fix the current failure. A maintainer with appropriate permissions needs to delete the stale update-schedule branch first. Once deleted, this improved workflow will:
1. Start fresh from main
2. Create a new update-schedule branch with the latest changes
3. Prevent future divergence issues

TESTING:
After the stale branch is deleted by a maintainer:
- The workflow should run successfully
- It will create a new PR with schedule updates
- Future runs will work correctly

Fixes #54940