### PR TITLE
blog: Use https://kep.k8s.io for userns GA blog

### DIFF
--- a/content/en/blog/_posts/2026/user-namespaces-goes-ga.md
+++ b/content/en/blog/_posts/2026/user-namespaces-goes-ga.md
@@ -91,7 +91,7 @@ If you're interested in user namespaces or want to contribute, here
 are some useful links:
 
 - [User Namespaces documentation](/docs/concepts/workloads/pods/user-namespaces/)
-- [KEP-127: Support User Namespaces](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/127-user-namespaces)
+- [KEP-127: Support User Namespaces](https://kep.k8s.io/127)
 - [SIG Node](https://github.com/kubernetes/community/tree/master/sig-node)
 
 ## Acknowledgments


### PR DESCRIPTION
As requested here:
	https://github.com/kubernetes/website/pull/54370#discussion_r3017526955

### Description
A follow-up for https://github.com/kubernetes/website/pull/54370 to use kep.k8s.io to link the KEP.

### Issue