### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/infrastructure-resource.md
+++ b/content/fr/docs/reference/glossary/infrastructure-resource.md
@@ -1,0 +1,23 @@
+---
+title: Ressource (infrastructure)
+id: infrastructure-resource
+short_description: >
+  Une quantité définie de ressources d’infrastructure disponibles à la consommation (CPU, mémoire, etc.).
+
+aka:
+tags:
+- architecture
+---
+
+Des capacités fournies à un ou plusieurs nœuds (CPU, mémoire, GPU, etc.) et mises à disposition des Pods exécutés sur ces nœuds.
+
+Kubernetes utilise également le terme _ressource_ pour désigner une ressource API.
+
+<!--more-->
+
+Les ordinateurs fournissent des ressources matérielles fondamentales : puissance de calcul, mémoire, stockage, réseau, etc.  
+Ces ressources ont une capacité limitée, mesurée dans une unité adaptée (nombre de CPU, quantité de mémoire, etc.).
+
+Kubernetes abstrait ces ressources afin de les allouer aux workloads et utilise des mécanismes du système d’exploitation (par exemple les cgroups sous Linux) pour gérer leur consommation.
+
+Vous pouvez également utiliser l’allocation dynamique de ressources pour gérer automatiquement des besoins plus complexes.

--- a/content/fr/docs/reference/glossary/qos-class.md
+++ b/content/fr/docs/reference/glossary/qos-class.md
@@ -1,0 +1,24 @@
+---
+title: Classe QoS
+id: qos-class
+full_link: /docs/concepts/workloads/pods/pod-qos/
+short_description: >
+  La classe QoS (Quality of Service) permet à Kubernetes de classer les Pods afin de prendre des décisions d’ordonnancement et d’éviction.
+
+aka: 
+tags:
+- fundamental
+- architecture
+related:
+ - pod
+---
+
+La classe QoS (Quality of Service) permet à Kubernetes de classer les Pods en différentes catégories afin de prendre des décisions concernant leur ordonnancement et leur éviction.
+
+<!--more-->
+
+La classe QoS d’un Pod est définie lors de sa création, en fonction des paramètres de requêtes et de limites de ressources.
+
+Ces classes sont utilisées pour prioriser les Pods lors de l’ordonnancement et pour déterminer lesquels peuvent être évincés en cas de manque de ressources.
+
+Kubernetes peut attribuer l’une des classes QoS suivantes à un Pod : `Guaranteed`, `Burstable` ou `BestEffort`.

--- a/content/fr/docs/reference/glossary/sysctl.md
+++ b/content/fr/docs/reference/glossary/sysctl.md
@@ -1,0 +1,19 @@
+---
+title: sysctl
+id: sysctl
+full_link: /docs/tasks/administer-cluster/sysctl-cluster/
+short_description: >
+  Une interface permettant de lire et modifier les paramètres du noyau Unix.
+
+aka:
+tags:
+- tool
+---
+
+`sysctl` est une interface standardisée permettant de lire ou de modifier les paramètres du noyau Unix en cours d’exécution.
+
+<!--more-->
+
+Sur les systèmes de type Unix, `sysctl` désigne à la fois l’outil utilisé par les administrateurs pour consulter et modifier ces paramètres, ainsi que l’appel système utilisé par cet outil.
+
+Les runtimes de conteneurs et les plugins réseau peuvent dépendre de certaines valeurs `sysctl` correctement configurées.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire liées à la gestion des ressources, à la configuration système et au comportement des Pods dans Kubernetes.

**Fichiers inclus :**

* `infrastructure-resource.md` : décrit les ressources matérielles (CPU, mémoire, etc.) mises à disposition des Pods.
* `sysctl.md` : explique l’interface permettant de configurer les paramètres du noyau.
* `qos-class.md` : présente les classes QoS, utilisées pour classer les Pods et prendre des décisions d’ordonnancement et d’éviction.

Cette contribution s’inscrit dans le cadre du suivi du plan de traduction du glossaire Kubernetes #54874.