### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/resourceclaim.md
+++ b/content/fr/docs/reference/glossary/resourceclaim.md
@@ -1,0 +1,20 @@
+---
+title: ResourceClaim
+id: resourceclaim
+full_link: /docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates
+short_description: >
+  Décrit les ressources dont un workload a besoin, comme des périphériques. Les ResourceClaims peuvent demander des périphériques à partir de DeviceClasses.
+
+tags:
+- workload
+---
+
+Décrit les ressources nécessaires à un {{< glossary_tooltip text="workload" term_id="workload" >}}, comme des
+{{< glossary_tooltip text="devices" term_id="device" >}}. Les ResourceClaims sont
+utilisés dans la [allocation dynamique de ressources (DRA)](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+pour fournir aux Pods l’accès à une ressource spécifique.
+
+<!--more-->
+
+Les ResourceClaims peuvent être créés par les opérateurs de workload ou générés par Kubernetes
+à partir d’un {{< glossary_tooltip text="ResourceClaimTemplate" term_id="resourceclaimtemplate" >}}.

--- a/content/fr/docs/reference/glossary/service-catalog.md
+++ b/content/fr/docs/reference/glossary/service-catalog.md
@@ -1,0 +1,17 @@
+---
+title: Catalogue de services
+id: service-catalog
+full_link: 
+short_description: >
+  Ancienne API d’extension permettant aux applications dans Kubernetes d’utiliser facilement des services managés externes, comme un service de base de données fourni par un cloud provider.
+
+aka: 
+tags:
+- extension
+---
+
+Ancienne API d’extension permettant aux applications dans Kubernetes d’utiliser facilement des services managés externes, comme un service de base de données fourni par un cloud provider.
+
+<!--more-->
+
+Elle permettait de lister, provisionner et lier des {{< glossary_tooltip text="Managed Services" term_id="managed-service" >}} externes sans nécessiter de connaissances détaillées sur leur création ou gestion.

--- a/content/fr/docs/reference/glossary/shuffle-sharding.md
+++ b/content/fr/docs/reference/glossary/shuffle-sharding.md
@@ -1,0 +1,21 @@
+---
+title: Shuffle-sharding
+id: shuffle-sharding
+full_link:
+short_description: >
+  Technique d’attribution de requêtes à des files offrant une meilleure isolation qu’un simple hash modulo le nombre de files.
+
+aka:
+tags:
+- fundamental
+---
+
+Technique d’attribution de requêtes à des files offrant une meilleure isolation qu’un simple hash modulo le nombre de files.
+
+<!--more-->
+
+L’objectif est d’isoler différents flux de requêtes afin qu’un flux intense ne bloque pas des flux moins chargés.  
+Une approche simple consiste à hasher certaines caractéristiques de la requête modulo le nombre de files pour obtenir l’indice de la file. Mais un flux intense peut alors monopoliser toutes les files correspondant au même hash.
+
+Le shuffle-sharding améliore l’isolation : il produit un hash à haute entropie, simule un « mélange de cartes », puis attribue une « main » de files. La requête est placée dans la file la plus courte parmi celles examinées.  
+Avec une main de taille modeste, cette technique permet aux flux faibles de contourner l’effet des flux intenses. Une main trop grande rend le processus coûteux et réduit l’efficacité de l’isolation. La taille de la main doit donc être choisie judicieusement.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire liées à la gestion avancée des workloads et du réseau.

**Fichiers inclus :**

* `service-catalog.md`
* `shuffle-sharding.md`
* `resourceclaim.md`

Cette contribution fait partie du suivi du plan de traduction du glossaire Kubernetes #54874.