### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/cel.md
+++ b/content/fr/docs/reference/glossary/cel.md
@@ -1,0 +1,19 @@
+---
+title: CEL (Common Expression Language)
+id: cel
+full_link: https://cel.dev
+short_description: >
+  Un langage d’expression conçu pour être sûr lors de l’exécution de code utilisateur.
+
+tags:
+- extension
+- fundamental
+aka:
+- CEL
+---
+Un langage d’expression généraliste conçu pour être rapide, portable et sûr à exécuter.
+
+<!--more-->
+
+Dans Kubernetes, CEL peut être utilisé pour exécuter des requêtes et effectuer un filtrage fin.  
+Par exemple, vous pouvez utiliser des expressions CEL avec le [contrôle d’admission dynamique](/docs/reference/access-authn-authz/extensible-admission-controllers/) pour filtrer certains champs dans les requêtes, et avec [l’allocation dynamique de ressources (DRA)](/docs/concepts/scheduling-eviction/dynamic-resource-allocation) pour sélectionner des ressources en fonction d’attributs spécifiques.

--- a/content/fr/docs/reference/glossary/sig.md
+++ b/content/fr/docs/reference/glossary/sig.md
@@ -1,0 +1,19 @@
+---
+title: SIG (Special Interest Group)
+id: sig
+full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
+short_description: >
+  Membres de la communauté qui gèrent collectivement une partie ou un aspect continu du projet open source Kubernetes.
+
+aka: 
+tags:
+- community
+---
+{{< glossary_tooltip text="Membres de la communauté" term_id="member" >}} qui gèrent collectivement une partie ou un aspect continu du projet open source Kubernetes.
+
+<!--more-->
+
+Les membres d’un SIG partagent un intérêt pour l’avancement d’un domaine spécifique, comme l’architecture, la machinerie API ou la documentation.  
+Les SIG doivent suivre les [lignes directrices de gouvernance des SIG](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md), mais peuvent avoir leur propre politique de contribution et leurs canaux de communication.
+
+Pour plus d’informations, voir le dépôt [kubernetes/community](https://github.com/kubernetes/community) et la liste actuelle des [SIGs et groupes de travail](https://github.com/kubernetes/community/blob/master/sig-list.md).

--- a/content/fr/docs/reference/glossary/wg.md
+++ b/content/fr/docs/reference/glossary/wg.md
@@ -1,0 +1,18 @@
+---
+title: WG (Working Group)
+id: wg
+full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list
+short_description: >
+  Facilite la discussion et/ou la mise en œuvre d’un projet limité, ciblé ou découplé pour un comité, un SIG ou un effort inter-SIG.
+
+aka: 
+tags:
+- community
+---
+Facilite la discussion et/ou la mise en œuvre d’un projet limité, ciblé ou découplé pour un comité, {{< glossary_tooltip text="SIG" term_id="sig" >}} ou un effort inter-SIG.
+
+<!--more-->
+
+Les groupes de travail sont un moyen d’organiser des personnes pour accomplir une tâche précise.
+
+Pour plus d’informations, voir le dépôt [kubernetes/community](https://github.com/kubernetes/community) et la liste actuelle des [SIGs et groupes de travail](https://github.com/kubernetes/community/blob/master/sig-list.md).


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire.

**Fichiers inclus :**

* `sig.md` : explique l'organisation des SIG, leur rôle, et les lignes directrices de gouvernance qu'ils suivent.
* `wg.md` : explique les groupes de travail, qui sont des équipes temporaires ou spécialisées créées par un SIG ou un comité pour accomplir une tâche spécifique.
* `cel.md` : un langage d'expression sécurisé et rapide utilisé dans Kubernetes.

Cette contribution fait partie du plan de suivi #54874.