### PR TITLE
[fr] : Add glossary entries

### DIFF
--- a/content/fr/docs/reference/glossary/member.md
+++ b/content/fr/docs/reference/glossary/member.md
@@ -1,0 +1,14 @@
+---
+title: Membre
+id: member
+full_link: 
+short_description: >
+  Un contributeur actif de façon continue dans la communauté Kubernetes.
+tags:
+- communauté
+---
+Un {{< glossary_tooltip text="contributeur" term_id="contributor" >}} actif en continu dans la communauté Kubernetes.
+
+<!--more--> 
+
+Les membres peuvent se voir assigner des issues et des PR, et participer à des {{< glossary_tooltip text="special interest groups (SIGs)" term_id="sig" >}} via les équipes GitHub. Des tests préalables sont exécutés automatiquement sur leurs PR. Un membre doit rester un contributeur actif au sein de la communauté.

--- a/content/fr/docs/reference/glossary/upstream.md
+++ b/content/fr/docs/reference/glossary/upstream.md
@@ -1,0 +1,15 @@
+---
+title: Upstream (désambiguïsation)
+id: upstream
+full_link: 
+short_description: >
+  Peut désigner : Kubernetes « core » ou le dépôt source à partir duquel un fork a été créé.
+tags:
+- communauté
+---
+Peut désigner : Kubernetes « core » ou le dépôt source à partir duquel un fork a été créé.
+
+<!--more--> 
+
+* Dans la **communauté Kubernetes** : Le terme *upstream* est souvent utilisé pour parler du code de base de Kubernetes, sur lequel s’appuie l’écosystème général, d’autres codes ou des outils tiers. Par exemple, des [membres de la communauté](#term-member) peuvent suggérer qu’une fonctionnalité soit déplacée *upstream* pour qu’elle fasse partie du code de base plutôt que d’un plugin ou d’un outil tiers.
+* Dans **GitHub** ou **git** : La convention consiste à appeler le dépôt source *upstream*, tandis que le dépôt forké est considéré comme *downstream*.


### PR DESCRIPTION
### Description

Traduction de trois entrées du glossaire.

**Fichiers inclus :**

* `member.md` : explique ce qu’est un membre de la communauté Kubernetes : un contributeur actif, avec participation aux PR, issues et SIGs, et soumis aux tests automatiques.
* `upstream.md`

Cette contribution fait partie du plan de suivi #54874.