### PR TITLE
Update DeclarativeValidation feature gates for v1.36

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
@@ -9,6 +9,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.33"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 Enables declarative validation of in-tree Kubernetes APIs. When enabled, APIs with declarative validation rules
 (defined using IDL tags in the Go code) will have both the generated declarative validation code
@@ -17,6 +21,6 @@ The results are compared, and any discrepancies are reported via the `declarativ
 Only the hand-written validation result is returned to the user (eg: actually validates in the request path).
 The original hand-written validation are still the authoritative validations
 when this is enabled but this can be changed if the
-[DeclarativeValidationTakeover feature gate](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover/)
+[DeclarativeValidationBeta feature gate](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/)
 is enabled in addition to this gate.
 This feature gate only operates on the `kube-apiserver` component.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta.md
@@ -1,0 +1,26 @@
+---
+title: DeclarativeValidationBeta
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.36"
+---
+This feature gate acts as the Global Safety Switch for Beta-stage validation rules (`+k8s:beta`).
+It allows cluster admins to disable enforcement for validations in the Beta stage if
+regressions are found, forcing them back to Shadow mode.
+
+In Shadow mode, declarative validation is executed and mismatches against handwritten
+validation are logged as metrics, but failures do not reject requests.
+Handwritten validation remains authoritative and enforced.
+
+Enforcement logic for resources using `WithDeclarativeEnforcement()`:
+- Standard tags (no prefix): Always Enforced (Bypasses this gate).
+- Beta tags (`+k8s:beta`): Enforced when this gate is enabled (default), otherwise Shadowed.
+- Alpha tags (`+k8s:alpha`): Always Shadowed.
+
+This gate has no effect if the master `DeclarativeValidation` feature gate is disabled.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
@@ -9,7 +9,13 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.33"
+    toVersion: "1.35"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.36"
 ---
+Deprecated: in favor of [DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/).
+
 When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation/)
 feature gate, declarative validation errors are returned directly to the caller,
 replacing hand-written validation errors for rules that have declarative implementations.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR updates the documentation for the `DeclarativeValidation` feature gates to reflect their latest status in Kubernetes v1.36:

   - **`DeclarativeValidation`**: Promoted to stable (GA) in v1.36.
   - **`DeclarativeValidationBeta`**: Added this new feature gate, introduced in v1.36 to act as a Global Safety Switch for Beta-stage validation rules (`+k8s:beta`).
   - **`DeclarativeValidationTakeover`**: Marked as deprecated in v1.36 in favor of `DeclarativeValidationBeta`.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
Ref: https://github.com/kubernetes/enhancements/issues/5073
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #