### PR TITLE
Update resource metrics endpoint for kubelet in the documentation

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
@@ -47,7 +47,7 @@ usage statistics, then the kubelet can look up those statistics directly
 (using code from [cAdvisor](https://github.com/google/cadvisor)).
 No matter how those statistics arrive, the kubelet then exposes the aggregated pod
 resource usage statistics through the metrics-server Resource Metrics API.
-This API is served at `/metrics/resource/v1beta1` on the kubelet's authenticated and 
+This API is served at `/metrics/resource` on the kubelet's authenticated and 
 read-only ports. 
 
 ## Full metrics pipeline


### PR DESCRIPTION
The Kubelet is exposing resource metrics on `/metrics/resource` without versioning.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The documentation is mentioning `/metrics/resource/v1beta1` as the endpoint on the kubelet where metrics are exposed. But actually the resource metrics are on `/metrics/resource`.  So my proposal is just a small correction in the documentation.



### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #