### PR TITLE
Update Indonesian CVE aliases

### DIFF
--- a/content/id/docs/reference/issues-security/issues.md
+++ b/content/id/docs/reference/issues-security/issues.md
@@ -1,7 +1,7 @@
 ---
 title: Pelacak Isu Kubernetes
 weight: 10
-aliases: [/cve/,/cves/]
+aliases: [/id/cve/,/id/cves/]
 ---
 
 Untuk melaporkan isu keamanan, silakan ikuti [proses pengungkapan keamanan Kubernetes](/docs/reference/issues-security/security/#report-a-vulnerability).


### PR DESCRIPTION

### Description
Update the Indonesian security issues page aliases to use `/id/...` paths so the localized redirects resolve correctly.
### Issue
xref: #55045