### PR TITLE
Add best practices section for ConfigMap usage in production

### DIFF
--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -719,6 +719,26 @@ Once all the deployments have migrated to use the new immutable ConfigMap, it is
 ```shell
 kubectl delete configmap company-name-20150801
 ```
+## Best practices for using ConfigMaps in production
+
+When using ConfigMaps in real-world environments, consider the following best practices:
+
+- **Avoid using ConfigMaps for sensitive data**  
+  ConfigMaps are not encrypted. Use Secrets for storing sensitive information such as passwords or API keys.
+
+- **Prefer immutable ConfigMaps when possible**  
+  Immutable ConfigMaps improve performance and prevent accidental updates in production systems.
+
+- **Trigger rollouts for environment variable updates**  
+  When ConfigMaps are consumed as environment variables, updates require a Pod restart or rollout to take effect.
+
+- **Use versioned ConfigMaps**  
+  Instead of modifying existing ConfigMaps, create new versions (e.g., `app-config-v2`) and update your Deployments gradually.
+
+- **Monitor configuration drift**  
+  Ensure that all Pods are running with the expected configuration, especially after updates.
+
+These practices help improve reliability, security, and maintainability in Kubernetes-based applications
 
 ## Summary
 
@@ -745,19 +765,3 @@ kubectl delete service configmap-service configmap-sidecar-service
 kubectl delete configmap sport fruits color company-name-20240312
 
 kubectl delete configmap company-name-20150801 # In case it was not handled during the task execution
-
-
-Real-world example: Using ConfigMap for database configuration
-
-In real-world applications, ConfigMaps are often used to store configuration such as database connection details.
-
-For example:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: app-config
-data:
-  DB_HOSTP: mongodb-service
-  DB_PORT: "27017"```

--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -729,7 +729,7 @@ When using ConfigMaps, the following characteristics may be relevant:
 
 - When ConfigMaps are consumed as environment variables, updates are not reflected in running Pods automatically. A Pod restart or rollout is required for changes to take effect.
 
-- Some deployment workflows use versioned ConfigMaps to manage configuration changes across different application versions.
+- Some deployment workflows may use versioned ConfigMaps to manage configuration changes across application versions.
 
 ## Summary
 

--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -719,7 +719,7 @@ Once all the deployments have migrated to use the new immutable ConfigMap, it is
 ```shell
 kubectl delete configmap company-name-20150801
 ```
-## Best practices for using ConfigMaps in production
+## Good practices for using ConfigMaps
 
 When using ConfigMaps in real-world environments, consider the following best practices:
 

--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -723,13 +723,13 @@ kubectl delete configmap company-name-20150801
 
 When using ConfigMaps, the following characteristics may be relevant:
 
-- ConfigMaps are not encrypted. They are typically used for non-sensitive configuration data, while sensitive data is handled using Secrets.
+- ConfigMaps are not encrypted. They are typically used for non-sensitive configuration data, while sensitive data is handled using [Secrets](/docs/concepts/configuration/secret/).
 
-- Immutable ConfigMaps cannot be updated after creation. This behavior prevents changes to the stored data once the ConfigMap is created.
+- By default, ConfigMaps are mutable. However, they can be created as immutable, in which case they cannot be updated after creation. This behavior prevents changes to the stored data once the ConfigMap is created. See [Immutable ConfigMaps](/docs/concepts/configuration/configmap/#configmap-immutable) for more details.
 
 - When ConfigMaps are consumed as environment variables, updates are not reflected in running Pods automatically. A Pod restart or rollout is required for changes to take effect.
 
-- Some deployment workflows may use versioned ConfigMaps to manage configuration changes across application versions.
+- When ConfigMaps are mounted as volumes, updates are eventually reflected in running Pods by the kubelet, typically within a short sync period. See [Mounted ConfigMaps are updated automatically](/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically) for more details.
 
 ## Summary
 

--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -719,26 +719,17 @@ Once all the deployments have migrated to use the new immutable ConfigMap, it is
 ```shell
 kubectl delete configmap company-name-20150801
 ```
-## Good practices for using ConfigMaps
+## Considerations when using ConfigMaps
 
-When using ConfigMaps in real-world environments, consider the following best practices:
+When using ConfigMaps, the following characteristics may be relevant:
 
-- **Avoid using ConfigMaps for sensitive data**  
-  ConfigMaps are not encrypted. Use Secrets for storing sensitive information such as passwords or API keys.
+- ConfigMaps are not encrypted. They are typically used for non-sensitive configuration data, while sensitive data is handled using Secrets.
 
-- **Prefer immutable ConfigMaps when possible**  
-  Immutable ConfigMaps improve performance and prevent accidental updates in production systems.
+- Immutable ConfigMaps cannot be updated after creation. This behavior prevents changes to the stored data once the ConfigMap is created.
 
-- **Trigger rollouts for environment variable updates**  
-  When ConfigMaps are consumed as environment variables, updates require a Pod restart or rollout to take effect.
+- When ConfigMaps are consumed as environment variables, updates are not reflected in running Pods automatically. A Pod restart or rollout is required for changes to take effect.
 
-- **Use versioned ConfigMaps**  
-  Instead of modifying existing ConfigMaps, create new versions (e.g., `app-config-v2`) and update your Deployments gradually.
-
-- **Monitor configuration drift**  
-  Ensure that all Pods are running with the expected configuration, especially after updates.
-
-These practices help improve reliability, security, and maintainability in Kubernetes-based applications
+- Some deployment workflows use versioned ConfigMaps to manage configuration changes across different application versions.
 
 ## Summary
 

--- a/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
+++ b/content/en/docs/tutorials/configuration/updating-configuration-via-a-configmap.md
@@ -745,4 +745,19 @@ kubectl delete service configmap-service configmap-sidecar-service
 kubectl delete configmap sport fruits color company-name-20240312
 
 kubectl delete configmap company-name-20150801 # In case it was not handled during the task execution
-```
+
+
+Real-world example: Using ConfigMap for database configuration
+
+In real-world applications, ConfigMaps are often used to store configuration such as database connection details.
+
+For example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  DB_HOSTP: mongodb-service
+  DB_PORT: "27017"```


### PR DESCRIPTION
This PR adds a best practices section for using ConfigMaps in production environments.

The goal is to provide practical guidance beyond the tutorial examples, helping users apply ConfigMaps effectively in real-world scenarios.