### PR TITLE
Fix typos in docs

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/storage-version.md
+++ b/content/en/docs/concepts/overview/working-with-objects/storage-version.md
@@ -148,7 +148,7 @@ it can be used as a storage version.
 Multiple storage versions for a single resource can pose problems for cluster
 administrators. A cluster administrator may not remove old versions of an API
 for CRDs which may be unsupported until they are sure that all objects are no
-longer using the storege version associated with it. With a large number of
+longer using the storage version associated with it. With a large number of
 objects and an opaque view into which ones are new and which ones still are
 backed by old storage versions, it makes it difficult to tell when a version can
 be safely removed. If a version is removed prematurely, it can mean being unable

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -1151,7 +1151,7 @@ When the kubelet restarts, the container statuses are managed differently based 
   the containers `ready` value, after a kubelet restart, to be false.
 
   This legacy behavior was the default for a long time, but caused issue for people using Kubernetes,
-  especially in large scale deployments. Althought the feature gate allows reverting to this legacy
+  especially in large scale deployments. Although the feature gate allows reverting to this legacy
   behavior temporarily, the Kubernetes project recommends that you file a bug report if you encounter problems.
   The `ChangeContainerStatusOnKubeletRestart`
   [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#ChangeContainerStatusOnKubeletRestart)

--- a/content/en/docs/tasks/configure-pod-container/configure-runasusername.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-runasusername.md
@@ -113,7 +113,7 @@ In order to use this feature, the value set in the `runAsUserName` field must be
 
 Examples of acceptable values for the `runAsUserName` field: `ContainerAdministrator`, `ContainerUser`, `NT AUTHORITY\NETWORK SERVICE`, `NT AUTHORITY\LOCAL SERVICE`.
 
-For more information about these limtations, check [here](https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and) and [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/new-localuser?view=powershell-5.1).
+For more information about these limitations, check [here](https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and) and [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/new-localuser?view=powershell-5.1).
 
 
 


### PR DESCRIPTION
### Description

Fix three typos across three docs, found using Claude and CodeSpell:

- `configure-runasusername.md`: "limtations" → "limitations"
- `storage-version.md`: "storege" → "storage"  
- `pod-lifecycle.md`: "Althought" → "Although"

### Issue

Closes: #N/A