### PR TITLE
feat: Add universal copy button to markdown code blocks

### DIFF
--- a/assets/js/click-to-copy.js
+++ b/assets/js/click-to-copy.js
@@ -1,0 +1,79 @@
+let codeListings = document.querySelectorAll('.highlight > pre');
+
+for (let index = 0; index < codeListings.length; index++)
+{
+  const preElement = codeListings[index];
+  const highlightContainer = preElement.parentElement;
+
+  // Skip blocks that are already managed by custom shortcodes. 
+  // (K8s uses .code-sample and .includecode)
+  if (preElement.closest('.includecode') || preElement.closest('.code-sample')) {
+    continue;
+  }
+
+  const codeSample = preElement.querySelector('code');
+  if (!codeSample) continue;
+
+  // Create a top bar to hold the button
+  const topBar = document.createElement("div");
+  topBar.className = "generic-copy-bar";
+  topBar.style.display = "flex";
+  topBar.style.justifyContent = "flex-end";
+  topBar.style.alignItems = "center";
+  topBar.style.padding = "4px 8px";
+  topBar.style.backgroundColor = "rgba(0,0,0,0.05)"; // slight darker than code block bg
+  topBar.style.borderBottom = "1px solid rgba(0,0,0,0.1)";
+  topBar.style.borderTopLeftRadius = "4px";
+  topBar.style.borderTopRightRadius = "4px";
+
+  // Create the text-based copy button
+  const copyButton = document.createElement("button");
+  copyButton.setAttribute('type', 'button');
+  copyButton.textContent = "Copy";
+  copyButton.className = "generic-copy-btn";
+  copyButton.style.cursor = "pointer";
+  copyButton.style.border = "none";
+  copyButton.style.background = "transparent";
+  copyButton.style.fontWeight = "600";
+  copyButton.style.fontSize = "12px";
+  copyButton.style.color = "inherit";
+  copyButton.style.opacity = "0.7";
+  copyButton.style.padding = "4px";
+
+  copyButton.addEventListener('mouseenter', () => copyButton.style.opacity = "1");
+  copyButton.addEventListener('mouseleave', () => copyButton.style.opacity = "0.7");
+
+  copyButton.addEventListener('click', () =>
+  {
+    // Write code directly to clipboard
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(codeSample.textContent);
+    }
+    
+    // Visual feedback on the button itself
+    const originalText = copyButton.textContent;
+    copyButton.textContent = "Copied";
+    copyButton.style.color = "#28a745"; // Success green text
+    copyButton.style.opacity = "1";
+    
+    setTimeout(() => {
+        copyButton.textContent = originalText;
+        copyButton.style.color = "inherit";
+        copyButton.style.opacity = "0.7";
+    }, 2000);
+  });
+
+  topBar.appendChild(copyButton);
+
+  // Reset margins/padding if necessary so the bar sits flush
+  highlightContainer.style.position = 'relative';
+  
+  // Remove top margin/padding on the `pre` so it seamlessly attaches to our new top bar
+  const computedPreStyles = window.getComputedStyle(preElement);
+  if (computedPreStyles.marginTop) preElement.style.marginTop = '0';
+  if (computedPreStyles.borderTopLeftRadius) preElement.style.borderTopLeftRadius = '0';
+  if (computedPreStyles.borderTopRightRadius) preElement.style.borderTopRightRadius = '0';
+  
+  // Insert the top bar before the <pre> block
+  highlightContainer.insertBefore(topBar, preElement);
+}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -33,7 +33,7 @@
 </script>
 
 {{/* copy-and-paste helper for codenew shortcode */}}
-{{- if or (.HasShortcode "code_sample") (.HasShortcode "code") (.HasShortcode "codenew") -}}
+{{- if or (.HasShortcode "code_sample") (.HasShortcode "code") (.HasShortcode "codenew") (findRE "<pre>" .Content 1) -}}
   {{- $toastrJs := resources.Get "js/toastr-2.1.4.min.js" | minify | fingerprint -}}
   {{- if hugo.IsProduction -}}
     <script async src="{{ $toastrJs.RelPermalink }}"></script>
@@ -42,10 +42,12 @@
   {{- end -}}
 
 <script type="text/javascript">
-function copyCode(elem) {
-  if (document.getElementById(elem)) {
+function copyCode(elem, actualNode) {
+  var targetNode = actualNode || document.getElementById(elem);
+  var elemName = elem ? (typeof elem === 'string' ? elem : "") : "";
+  if (targetNode) {
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(document.getElementById(elem).textContent).then(
+      navigator.clipboard.writeText(targetNode.textContent).then(
         function () {
           toastr.options = {
             closeButton: true,
@@ -55,7 +57,7 @@ function copyCode(elem) {
             preventDuplicates: true,   
             newestOnTop: true          
           };
-          toastr.success("{{i18n "toast_success_copycode"}}" + elem, "{{i18n "success_copy_to_clipboard"}}");
+          toastr.success("{{i18n "toast_success_copycode"}}" + elemName, "{{i18n "success_copy_to_clipboard"}}");
         },
         function () {
           toastr.options = {
@@ -66,7 +68,7 @@ function copyCode(elem) {
             preventDuplicates: true,  
             newestOnTop: true         
           };
-          toastr.error("{{i18n "toast_failure_copycode"}}" + elem, "{{i18n "error_copy_to_clipboard"}}");
+          toastr.error("{{i18n "toast_failure_copycode"}}" + elemName, "{{i18n "error_copy_to_clipboard"}}");
         }
       );
     } else {

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -45,7 +45,7 @@
 
 {{ if .Site.Params.prism_syntax_highlighting -}}
   <script src='{{ "js/prism.js" | relURL }}'></script>
-{{ else if false -}}
+{{ else -}}
   {{ $c2cJS := resources.Get "js/click-to-copy.js" -}}
   {{ if hugo.IsProduction -}}
     {{ $c2cJS = $c2cJS | minify | fingerprint -}}


### PR DESCRIPTION
### Description
While studying for the CKA exam, I was reading through the Kubernetes docs and found it a bit annoying that I had to manually highlight and copy code from the standard code blocks. Some blocks had a copy button (using the custom shortcodes), but many did not.
I thought adding a universal copy button would really help ease the experience for everyone reading the docs!

**What this does:**
- Automatically adds a small "Copy" button to the top of all normal Markdown code blocks.
- When you click it, the text changes to "Copied" in green so you know it worked.
- It is smart enough to skip code blocks that already have their own copy buttons (so there's no double button issue).
- It looks clean, adapts to the text color, and doesn't overlap or hide the code itself.

### Issue
Closes: # [Issue Number]