### PR TITLE
[fa] Remove kubeweekly shortcode from homepage

### DIFF
--- a/content/fa/_index.html
+++ b/content/fa/_index.html
@@ -58,5 +58,3 @@ sitemap:
 {{< blocks/kubernetes-features >}}
 
 {{< blocks/case-studies >}}
-
-{{< kubeweekly id="kubeweekly" >}}


### PR DESCRIPTION
## Summary

- Remove the deprecated `{{< kubeweekly >}}` shortcode call from the Farsi homepage
- The KubeWeekly signup form has already been removed from main
- The RTL overflow issue reported in [#55093 (comment)](https://github.com/kubernetes/website/pull/55093#issuecomment-4190454143) resolves on its own once dev-1.33-fa.1 merges into main, as the legacy layout files causing it no longer exist there