### PR TITLE
Update persistent-volumes.md with CSI driver note

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -685,9 +685,9 @@ are specified as ReadWriteOncePod, the volume is constrained and can be mounted 
 | VsphereVolume        | &#x2713;               | -                     | - (works when Pods are collocated) | - |
 | PortworxVolume       | &#x2713;               | -                     | &#x2713;      | -                  | - |
 
-{{< note >}} 
+{{<note>}} 
 The table above reflects in-tree plugin capabilities only. Some CSI drivers for FC and iSCSI support ReadWriteMany with `volumeMode: Block` (for example, for KubeVirt live migration). Refer to your CSI driver's documentation for details. 
-{{< /note >}}
+{{</note>}}
 
 ### Class
 

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -685,6 +685,10 @@ are specified as ReadWriteOncePod, the volume is constrained and can be mounted 
 | VsphereVolume        | &#x2713;               | -                     | - (works when Pods are collocated) | - |
 | PortworxVolume       | &#x2713;               | -                     | &#x2713;      | -                  | - |
 
+{{< note >}} 
+The table above reflects in-tree plugin capabilities only. Some CSI drivers for FC and iSCSI support ReadWriteMany with `volumeMode: Block` (for example, for KubeVirt live migration). Refer to your CSI driver's documentation for details. 
+{{< /note >}}
+
 ### Class
 
 A PV can have a class, which is specified by setting the


### PR DESCRIPTION
This PR updates the Access Modes table to reflect that FC and iSCSI can support ReadWriteMany (RWX) when used with volumeMode: Block and a compatible CSI driver.

Adds a note clarifying this behavior and distinguishing it from legacy in-tree plugin limitations.

Closes #55237