### PR TITLE
Recommend referencing cloud native glossary

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -545,6 +545,21 @@ Write hyperlinks that give you context for the content they link to. For example
 Write Markdown-style links: `[link text](URL)`. For example: `[Hugo shortcodes](/docs/contribute/style/hugo-shortcodes/#table-captions)` and the output is [Hugo shortcodes](/docs/contribute/style/hugo-shortcodes/#table-captions). | Write HTML-style links: `<a href="/media/examples/link-element-example.css" target="_blank">Visit our tutorial!</a>`, or create links that open in new tabs or windows. For example: `[example website](https://example.com){target="_blank"}`
 {{< /table >}}
 
+### Linking to the Cloud Native Glossary
+
+The [CNCF Cloud Native Glossary](https://glossary.cncf.io/) defines
+cloud native terms in plain language, with little assumed context. Where
+a term in the Kubernetes documentation has a corresponding Cloud Native Glossary entry,
+linking to it helps newer readers without disrupting more experienced ones.
+
+{{< table caption = "Do and Don't - Linking to the Cloud Native Glossary" >}}
+Do | Don't
+:--| :-----
+Link to the Cloud Native Glossary on the first occurrence of a term per page. | Link every occurrence of a term throughout the page.
+Link when the glossary entry adds useful context beyond what the Kubernetes documentation provides. | Link when the glossary definition duplicates or conflicts with Kubernetes-specific explanations.
+Add a "Further reading" reference in a glossary entry's `longDescription` pointing to the Cloud Native Glossary equivalent. | Replace the Kubernetes Glossary definition with a link to the Cloud Native Glossary.
+{{< /table >}}
+
 ### Lists
 
 Group items in a list that are related to each other and need to appear in a specific

--- a/content/en/docs/reference/glossary/cncf.md
+++ b/content/en/docs/reference/glossary/cncf.md
@@ -9,7 +9,7 @@ aka:
 tags:
 - community
 ---
- The Cloud Native Computing Foundation (CNCF) builds sustainable ecosystems and
+ The [Cloud Native](https://glossary.cncf.io/) Computing Foundation (CNCF) builds sustainable ecosystems and
  fosters a community around [projects](https://www.cncf.io/projects/) that
  orchestrate containers as part of a microservices architecture.
 

--- a/content/en/docs/reference/glossary/cncf.md
+++ b/content/en/docs/reference/glossary/cncf.md
@@ -9,7 +9,7 @@ aka:
 tags:
 - community
 ---
- The [Cloud Native](https://glossary.cncf.io/) Computing Foundation (CNCF) builds sustainable ecosystems and
+ The Cloud Native Computing Foundation (CNCF) builds sustainable ecosystems and
  fosters a community around [projects](https://www.cncf.io/projects/) that
  orchestrate containers as part of a microservices architecture.
 
@@ -20,3 +20,5 @@ Kubernetes is a CNCF project.
 The CNCF is a sub-foundation of [the Linux Foundation](https://www.linuxfoundation.org/).
 Its mission is to make cloud native computing ubiquitous.
 
+The CNCF also maintains the [Cloud Native Glossary](https://glossary.cncf.io/),
+a reference for cloud native terminology aimed at anyone new to the field.


### PR DESCRIPTION
This PR adds guidance to the documentation style guide on linking to the CNCF Cloud Native Glossary to improve accessibility for new users.

**What this PR does**

- Adds a new section to the Documentation Style Guide describing when and how to link to the Cloud Native Glossary
- Provides do/don’t examples to guide contributors on appropriate usage

**Why this is needed**

Kubernetes documentation includes many cloud native terms that may be unfamiliar to new users.

The CNCF Cloud Native Glossary offers simple, beginner-friendly definitions. Providing guidance on when to link to it helps improve accessibility while maintaining readability.

Fixes #39792