### PR TITLE
Update health check endpoints output examples to match the command example

### DIFF
--- a/content/en/docs/reference/using-api/health-checks.md
+++ b/content/en/docs/reference/using-api/health-checks.md
@@ -34,7 +34,7 @@ For all endpoints, you can use the `verbose` parameter to print out the checks a
 This can be useful for a human operator to debug the current status of the API server, it is not intended to be consumed by a machine:
 
 ```shell
-curl -k https://localhost:6443/livez?verbose
+curl -k https://localhost:6443/readyz?verbose
 ```
 
 or from a remote host with authentication:
@@ -63,7 +63,7 @@ The output will look like this:
     [+]poststarthook/kube-apiserver-autoregistration ok
     [+]autoregister-completion ok
     [+]poststarthook/apiservice-openapi-controller ok
-    healthz check passed
+    readyz check passed
 
 The Kubernetes API server also supports to exclude specific checks.
 The query parameters can also be combined like in this example:
@@ -93,7 +93,7 @@ The output show that the `etcd` check is excluded:
     [+]autoregister-completion ok
     [+]poststarthook/apiservice-openapi-controller ok
     [+]shutdown ok
-    healthz check passed
+    readyz check passed
 
 ## Individual health checks
 


### PR DESCRIPTION
### Description

Aligning kubectl command, curl example and the output examples.

kubectl was using /readyz endpoint as example but 
the output example was showing /healthz output, 
and one of curl example was using /livez path example.

Align them to use the /readyz



