### PR TITLE
fix: correct typos and update stale kubectl --validate advice in debug-pods

### DIFF
--- a/content/en/docs/concepts/cluster-administration/node-autoscaling.md
+++ b/content/en/docs/concepts/cluster-administration/node-autoscaling.md
@@ -207,7 +207,7 @@ Main differences between Cluster Autoscaler and Karpenter:
   them to new versions).
 * Cluster Autoscaler doesn't support auto-provisioning, the Node groups it can provision from have
   to be pre-configured. Karpenter supports auto-provisioning, so the user only has to configure a
-  set of constraints for the provisioned Nodes, instead of fully configuring homogenous groups.
+  set of constraints for the provisioned Nodes, instead of fully configuring homogeneous groups.
 * Cluster Autoscaler provides cloud provider integrations directly, which means that they're a part
   of the Kubernetes project. For Karpenter, the Kubernetes project publishes Karpenter as a library
   that cloud providers can integrate with to build a Node autoscaler.

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/pod-certificate-request-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/pod-certificate-request-v1beta1.md
@@ -90,7 +90,7 @@ PodCertificateRequestSpec describes the certificate request.  All fields are imm
 
   proofOfPossession proves that the requesting kubelet holds the private key corresponding to pkixPublicKey.
   
-  It is contructed by signing the ASCII bytes of the pod's UID using `pkixPublicKey`.
+  It is constructed by signing the ASCII bytes of the pod's UID using `pkixPublicKey`.
   
   kube-apiserver validates the proof of possession during creation of the PodCertificateRequest.
   

--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -187,7 +187,7 @@ CustomResourceDefinitionSpec describes how a user wants their resource to appear
 
     - **versions.selectableFields.jsonPath** (string), required
 
-      jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metdata fields. Required.
+      jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metadata fields. Required.
 
   - **versions.subresources** (CustomResourceSubresources)
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/device-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/device-class-v1.md
@@ -66,7 +66,7 @@ DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and h
 
   *Atomic: will be replaced during a merge*
   
-  Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.
+  Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.
   
   They are passed to the driver, but are not considered while allocating the claim.
 

--- a/content/en/docs/tasks/debug/debug-application/debug-pods.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-pods.md
@@ -113,16 +113,12 @@ For example, if you misspelled `command` as `commnd` then the pod will be create
 will not use the command line you intended it to use.
 
 The first thing to do is to delete your pod and try creating it again with the `--validate` option.
-For example, run `kubectl apply --validate -f mypod.yaml`.
+For example, run `kubectl apply --validate=strict -f mypod.yaml`.
 If you misspelled `command` as `commnd` then will give an error like this:
 
 ```shell
-I0805 10:43:25.129850   46757 schema.go:126] unknown field: commnd
-I0805 10:43:25.129973   46757 schema.go:129] this may be a false alarm, see https://github.com/kubernetes/kubernetes/issues/6842
-pods/mypod
+error: error validating "mypod.yaml": error validating data: ValidationError(Pod.spec.containers[0]): unknown field "commnd" in io.k8s.api.core.v1.Container
 ```
-
-<!-- TODO: Now that #11914 is merged, this advice may need to be updated -->
 
 The next thing to check is whether the pod on the apiserver
 matches the pod you meant to create (e.g. in a yaml file on your local machine).


### PR DESCRIPTION
This PR makes two types of improvement, identified and fixed via Claude and codespell:

**Content update (debug-pods.md)**
The "My pod is running but not doing what I told it to do" section contained stale advice about `kubectl apply --validate`, so I've:
- updated `--validate` to `--validate=strict`, reflecting that kubectl now defaults to server-side field validation (GA since Kubernetes 1.27)
- replaced the old client-side `schema.go` error output with the current server-side validation error format
- removed a stale TODO comment referencing kubernetes/kubernetes#11914, which was merged years ago

**Typo fixes (4 files)**
- `node-autoscaling.md`: homogenous → homogeneous
- `pod-certificate-request-v1beta1.md`: contructed → constructed
- `custom-resource-definition-v1.md`: metdata → metadata
- `device-class-v1.md`: classses → classes