### PR TITLE
Improve kubectl description for better clarity

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -6,7 +6,7 @@ weight: 30
 
 ## {{% heading "synopsis" %}}
 
-kubectl controls the Kubernetes cluster manager.
+kubectl is a command-line tool used to interact with a Kubernetes cluster. It allows users to deploy applications, inspect and manage cluster resources such as pods, services, and deployments.
 
 Find more information in [Command line tool](/docs/reference/kubectl/) (`kubectl`).
 


### PR DESCRIPTION
### What I did
- Improved the description of kubectl in the documentation

### Why
- The previous description was vague and not beginner-friendly
- Added more clarity about its purpose and usage