### PR TITLE
Improve kubectl introduction for clarity

### DIFF
--- a/content/en/docs/reference/kubectl/introduction.md
+++ b/content/en/docs/reference/kubectl/introduction.md
@@ -4,7 +4,7 @@ content_type: concept
 weight: 1
 ---
 
-kubectl is a command-line tool for interacting with Kubernetes clusters.
+kubectl is a command-line tool for interacting with Kubernetes clusters, using the Kubernetes API.
 Use it to deploy applications, inspect resources, and manage workloads.
 
 While this Book is focused on using kubectl to declaratively manage applications in Kubernetes, it

--- a/content/en/docs/reference/kubectl/introduction.md
+++ b/content/en/docs/reference/kubectl/introduction.md
@@ -4,7 +4,8 @@ content_type: concept
 weight: 1
 ---
 
-kubectl is the Kubernetes cli version of a swiss army knife, and can do many things.
+kubectl is a command-line tool for interacting with Kubernetes clusters.
+Use it to deploy applications, inspect resources, and manage workloads.
 
 While this Book is focused on using kubectl to declaratively manage applications in Kubernetes, it
 also covers other kubectl functions.

--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -6,7 +6,7 @@ weight: 30
 
 ## {{% heading "synopsis" %}}
 
-kubectl controls the Kubernetes cluster manager.
+{{< glossary_definition term_id="kubectl" length="short" >}}
 
 Find more information in [Command line tool](/docs/reference/kubectl/) (`kubectl`).
 


### PR DESCRIPTION
### What I did
- Replaced informal wording with a clearer and more professional description

### Why
- Improves readability and helps users better understand kubectl's purpose