### PR TITLE
layouts: generate Netlify redirects from page aliases frontmatter

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -25,8 +25,13 @@
       {{- $parentDir := path.Dir (strings.TrimSuffix "/" $page.RelPermalink) -}}
       {{- $alias = printf "%s/%s/" $parentDir (strings.TrimSuffix "/" $alias) -}}
     {{- end -}}
+    {{- /* Guard: warn if alias crosses locale boundary */ -}}
+    {{- $pageLocale := index (split (strings.TrimPrefix "/" $page.RelPermalink) "/") 0 -}}
+    {{- $aliasLocale := index (split (strings.TrimPrefix "/" $alias) "/") 0 -}}
+    {{- if ne $pageLocale $aliasLocale -}}
+      {{- warnf "alias %q on page %q crosses locale boundary (%q → %q) — skipping" $alias $page.RelPermalink $aliasLocale $pageLocale -}}
     {{- /* Guard: warn if alias conflicts with a real page */ -}}
-    {{- if in $allPagePermalinks $alias -}}
+    {{- else if in $allPagePermalinks $alias -}}
       {{- warnf "alias %q on page %q conflicts with an existing page permalink — skipping" $alias $page.RelPermalink -}}
     {{- else }}
 {{ $alias }}    {{ $page.RelPermalink }}    301

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -10,8 +10,30 @@
 # Dynamic latest API redirect - automatically points to current latest version
 /docs/reference/generated/kubernetes-api/latest/     /docs/reference/generated/kubernetes-api/{{ $latest }}/ 307
 /docs/reference/generated/kubernetes-api/latest/*   /docs/reference/generated/kubernetes-api/{{ $latest }}/:splat 307
+{{- end }}
+
+# Redirects generated from page aliases frontmatter
+{{ $allPagePermalinks := slice -}}
+{{- range .Site.RegularPages -}}
+  {{- $allPagePermalinks = $allPagePermalinks | append .RelPermalink -}}
 {{- end -}}
+{{- range .Site.Pages -}}
+  {{- $page := . -}}
+  {{- range $page.Aliases -}}
+    {{- $alias := . -}}
+    {{- if not (hasPrefix $alias "/") -}}
+      {{- $parentDir := path.Dir (strings.TrimSuffix "/" $page.RelPermalink) -}}
+      {{- $alias = printf "%s/%s/" $parentDir (strings.TrimSuffix "/" $alias) -}}
+    {{- end -}}
+    {{- /* Guard: warn if alias conflicts with a real page */ -}}
+    {{- if in $allPagePermalinks $alias -}}
+      {{- warnf "alias %q on page %q conflicts with an existing page permalink — skipping" $alias $page.RelPermalink -}}
+    {{- else }}
+{{ $alias }}    {{ $page.RelPermalink }}    301
+    {{- end -}}
+  {{- end -}}
+{{- end }}
 
 # Include all existing static redirects
-{{- $staticRedirects := readFile "static/_redirects.base" -}}
-{{ $staticRedirects }}
+{{ $staticRedirects := readFile "static/_redirects.base" -}}
+{{- $staticRedirects }}


### PR DESCRIPTION
## What this does

Updates `layouts/index.redirects` to auto-generate Netlify server-side redirects from the `aliases` field in page frontmatter, fixing #53396.

Before this change, every redirect had to be manually added to `static/_redirects.base`. After this change, content authors can declare:

\`\`\`yaml
aliases:
- /old-url/
\`\`\`

...and the redirect is automatically emitted into the generated `_redirects` file at build time.

## How it works

- First pass: collects all `.Site.RegularPages` permalinks into a slice for conflict detection
- Second pass: iterates all `.Site.Pages`, reads each page's `aliases` frontmatter
- Relative aliases are resolved against the page's parent directory using `path.Dir` (matching Hugo's own alias resolution behavior)
- A `warnf` guard catches any alias that conflicts with an existing real page permalink and skips it
- Valid aliases emit: `<alias>    <page.RelPermalink>    301`

## Testing

Built and verified locally:
- English aliases (`/rbac/`, `/cve/`, `/cves/`, `/security/`, `master-node-communication`, `/dockershim`) all appear correctly in the generated `_redirects`
- Relative alias `master-node-communication` resolves to the correct sibling path (`/docs/concepts/architecture/master-node-communication/`) not as a child of the page
- No conflict warnings produced during build
- Localized aliases (`/zh-cn/rbac/`, `/ru/security/`, etc.) are present in their respective content files and will appear in the production build (which renders all language segments, unlike local dev which uses `--renderSegments en`)
- Existing static redirects in `_redirects.base` are unaffected

Fixes #53396