### PR TITLE
Move PodGroup DRA docs from Workload to PodGroup

### DIFF
--- a/content/en/docs/concepts/workloads/podgroup-api/_index.md
+++ b/content/en/docs/concepts/workloads/podgroup-api/_index.md
@@ -58,6 +58,41 @@ spec:
       podGroupTemplateName: worker
 ```
 
+### Requesting DRA devices for a PodGroup
+
+{{< feature-state feature_gate_name="DRAWorkloadResourceClaims" >}}
+
+{{< glossary_tooltip text="Devices" term_id="device" >}} available through
+{{< glossary_tooltip text="Dynamic Resource Allocation (DRA)" term_id="dra" >}}
+can be requested by a PodGroup through its `spec.resourceClaims` field:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: training-group
+  namespace: some-ns
+spec:
+  ...
+  resourceClaims:
+  - name: pg-claim
+    resourceClaimName: my-pg-claim
+  - name: pg-claim-template
+    resourceClaimTemplateName: my-pg-template
+```
+
+{{< glossary_tooltip text="ResourceClaims" term_id="resourceclaim" >}}
+associated with PodGroups can be shared by all Pods belonging to the group. With
+only a reference to the PodGroup in the ResourceClaim's `status.reservedFor`
+instead of each individual Pod, any number of Pods in the same PodGroup can
+share a ResourceClaim. ResourceClaims can also be generated from
+{{< glossary_tooltip text="ResourceClaimTemplates" term_id="resourceclaimtemplate" >}}
+for each PodGroup, allowing the devices allocated to each generated
+ResourceClaim to be shared by the Pods in each PodGroup.
+
+For more details and a more complete example, see the
+[DRA documentation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#workload-resource-claims).
+
 ### Status
 
 The scheduler updates `status.conditions` to report whether the group has been

--- a/content/en/docs/concepts/workloads/workload-api/_index.md
+++ b/content/en/docs/concepts/workloads/workload-api/_index.md
@@ -79,41 +79,6 @@ The `controllerRef` field links the Workload back to the specific high-level obj
 such as a [Job](/docs/concepts/workloads/controllers/job/) or a custom CRD. This is useful for observability and tooling.
 This data is not used to schedule or manage the Workload.
 
-### Requesting DRA devices for a PodGroup
-
-{{< feature-state feature_gate_name="DRAWorkloadResourceClaims" >}}
-
-{{< glossary_tooltip text="Devices" term_id="device" >}} available through
-{{< glossary_tooltip text="Dynamic Resource Allocation (DRA)" term_id="dra" >}}
-can be requested by a PodGroup through its `spec.resourceClaims` field:
-
-```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
-kind: PodGroup
-metadata:
-  name: training-group
-  namespace: some-ns
-spec:
-  ...
-  resourceClaims:
-  - name: pg-claim
-    resourceClaimName: my-pg-claim
-  - name: pg-claim-template
-    resourceClaimTemplateName: my-pg-template
-```
-
-{{< glossary_tooltip text="ResourceClaims" term_id="resourceclaim" >}}
-associated with PodGroups can be shared by all Pods belonging to the group. With
-only a reference to the PodGroup in the ResourceClaim's `status.reservedFor`
-instead of each individual Pod, any number of Pods in the same PodGroup can
-share a ResourceClaim. ResourceClaims can also be generated from
-{{< glossary_tooltip text="ResourceClaimTemplates" term_id="resourceclaimtemplate" >}}
-for each PodGroup, allowing the devices allocated to each generated
-ResourceClaim to be shared by the Pods in each PodGroup.
-
-For more details and a more complete example, see the
-[DRA documentation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#workload-resource-claims).
-
 ## Gang scheduling with Jobs
 
 {{< feature-state feature_gate_name="EnableWorkloadWithJob" >}}

--- a/content/en/docs/reference/glossary/podgroup.md
+++ b/content/en/docs/reference/glossary/podgroup.md
@@ -1,7 +1,7 @@
 ---
 title: PodGroup
 id: podgroup
-full_link: /docs/concepts/workloads/workload-api/#pod-groups
+full_link: /docs/concepts/workloads/podgroup-api/
 short_description: >
   A PodGroup represents a set of Pods with common scheduling policy and constraints.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This PR moves one section of the docs and updates one link added by #54596 based on the structure introduced by #54490. No other changes to the content are made here. I also cannot find any links to the nmoved section that would need to be updated.

I was thinking that merging #54596 would have caused a conflict with #54490 and [suggested making this change there](https://github.com/kubernetes/website/pull/54490#discussion_r3059091639), but it didn't cause any conflicts and this change didn't make it in before the PR merged.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #