### PR TITLE
docs: add ClusterRole aggregation risks to RBAC good practices

### DIFF
--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -194,6 +194,27 @@ for a more permissive policy than intended by the administrators.
 For clusters where NetworkPolicy is used, users may be set labels that indirectly allow
 access to services that an administrator did not intend to allow.
 
+### ClusterRole aggregation
+
+{{< glossary_tooltip text="ClusterRole" term_id="role" >}} aggregation allows the control
+plane to dynamically merge rules from multiple ClusterRoles into a single one
+using label selectors (see [Aggregated ClusterRoles](/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)).
+
+This mechanism can become a privilege escalation vector: any user or workload that can
+create or update a ClusterRole carrying an aggregation label — for example
+`rbac.authorization.k8s.io/aggregate-to-admin: "true"` — silently merges its rules into
+the `admin` default ClusterRole, granting cluster-wide access without any explicit
+RoleBinding change.
+
+To reduce this risk:
+
+- Audit existing ClusterRoles for unexpected aggregation labels. You can list them with:
+  `kubectl get clusterroles -o json | jq -r '.items[] | select(.metadata.labels | keys[] | startswith("rbac.authorization.k8s.io/aggregate-")) | .metadata.name'`
+- Restrict `create` and `update` permissions on ClusterRole objects to trusted
+  administrators only.
+- Periodically review aggregated ClusterRoles to ensure that the merged rule set
+  matches the intended access model.
+
 ## Kubernetes RBAC - denial of service risks {#denial-of-service-risks}
 
 ### Object creation denial-of-service {#object-creation-dos}


### PR DESCRIPTION
## Description

Adds a new subsection under **Privilege escalation risks** in the RBAC good practices page, documenting how ClusterRole aggregation can silently escalate privileges when misconfigured aggregation labels are applied to ClusterRoles.

The section covers:
- How ClusterRole aggregation works via label selectors (with link to reference docs)
- The security risk: any user/workload that can create a ClusterRole with aggregation labels (e.g. `rbac.authorization.k8s.io/aggregate-to-admin: "true"`) can silently merge rules into default roles like `admin`
- Three mitigation recommendations: audit, restrict write access to ClusterRole objects, periodic review

## Related issue

Fixes #55254

## Changes

- `content/en/docs/concepts/security/rbac-good-practices.md`: added `### ClusterRole aggregation` subsection