### PR TITLE
Document HugepageAwareEviction feature gate

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -98,6 +98,13 @@ reproduces the same set of steps that the kubelet performs to calculate
 file-backed memory on the inactive LRU list) from its calculation, as it assumes that
 memory is reclaimable under pressure.
 
+{{< note >}}
+When the `HugepageAwareEviction` feature gate is enabled, the kubelet subtracts
+hugepage capacity from `memory.available` so the eviction signal reflects actual
+regular-memory availability. See the [Feature Gates](/docs/reference/command-line-tools-reference/feature-gates/)
+page for more details.
+{{< /note >}}
+
 On Windows nodes, the value for `memory.available` is derived from the node's global
 memory commit levels (queried through the [`GetPerformanceInfo()`](https://learn.microsoft.com/windows/win32/api/psapi/nf-psapi-getperformanceinfo)
 system call) by subtracting the node's global [`CommitTotal`](https://learn.microsoft.com/windows/win32/api/psapi/ns-psapi-performance_information) from the node's [`CommitLimit`](https://learn.microsoft.com/windows/win32/api/psapi/ns-psapi-performance_information). Please note that `CommitLimit` can change if the node's page-file size changes!

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/HugepageAwareEviction.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/HugepageAwareEviction.md
@@ -1,0 +1,16 @@
+---
+title: HugepageAwareEviction
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.36"
+
+---
+Enable the kubelet to subtract hugepage capacity from `memory.available`
+so the eviction signal reflects actual regular-memory availability.
+See [Node Pressure Eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/) for more details.


### PR DESCRIPTION
This PR adds documentation for the HugepageAwareEviction feature gate.

## Changes

1. **feature-gates.md**: Added entry for HugepageAwareEviction feature gate
2. **out-of-resource.md**: Added note explaining how hugepage capacity is subtracted from memory.available when the feature gate is enabled

## Background

The HugepageAwareEviction feature gate enables the kubelet to subtract hugepage capacity from `memory.available` so the eviction signal reflects actual regular-memory availability. This ensures more accurate eviction decisions when hugepages are in use.

Fixes #55286