### PR TITLE
Fix navbar hamburger menu overlap with logo on RTL layouts

### DIFF
--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -16,7 +16,7 @@
 
   .navbar-brand {
     @include media-breakpoint-down(sm) {
-      margin-left: auto;
+      margin-inline-start: auto;
     }
 
     svg {
@@ -37,7 +37,7 @@
       color: $navbar-dark-hover-color;
     }
 
-    margin-left: auto;
+    margin-inline-start: auto;
     font-size: xx-large;
 
     // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the hamburger button


### PR DESCRIPTION
Fixes the mobile hamburger menu positioning for RTL (right-to-left) languages such as Farsi. 
- Please note that main branch does not include Farsi localization works yet. 
- https://github.com/kubernetes/website/pull/55356 will enable the Farsi localization.

This PR is to support RTL languages that would be included to the main soon.

On viewports below 768px, the hamburger menu button overlaps with the centered Kubernetes logo because `margin-left: auto` does not correctly push the element to the opposite side in RTL layouts.

This PR replaces `margin-left: auto` with `margin-inline-start: auto` in two places in `assets/scss/_k8s_nav.scss`. The logical property automatically resolves to `margin-left` for LTR and `margin-right` for RTL, so existing LTR languages are unaffected.

### Changes

- `.navbar-brand` (mobile breakpoint): `margin-left: auto` → `margin-inline-start: auto`
- `#hamburger`: `margin-left: auto` → `margin-inline-start: auto`
