### PR TITLE
Update style guide for enhancement graduation phases casing style

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -115,6 +115,14 @@ events are recorded with an associated "stage". | events are recorded with an as
 The copy is called a "fork". | The copy is called a "fork."
 {{< /table >}}
 
+### Use start case for enhancement graduation phases
+
+{{< table caption = "Do and Don't - Use start case for enhancement graduation phases" >}}
+Do | Don't
+:--| :-----
+Dynamic Resource Allocation (DRA) is Beta. | Dynamic Resource Allocation (DRA) is beta.
+{{< /table >}}
+
 ## Inline code formatting
 
 ### Use code style for inline code, commands {#code-style-inline-code}


### PR DESCRIPTION
PR adds casing style for enhancement graduation phase
Casing style used is start case but since enhancement graduation phases are one word there are other options like title case, upper camel case, pascal case

Aligns style guide with PR https://github.com/kubernetes/community/pull/8939