### PR TITLE
Move probe concept pages to new concepts/workloads/pods/probes.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-condition.md
+++ b/content/en/docs/concepts/workloads/pods/pod-condition.md
@@ -57,7 +57,7 @@ As a Pod progresses through its lifecycle, the kubelet sets the following condit
 1. `PodScheduled`: the Pod has been scheduled to a node.
 1. `PodReadyToStartContainers`: the Pod sandbox has been successfully created and networking configured. The sandbox and network are set up by the {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}} and {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin.
 1. `Initialized`: all [init containers](/docs/concepts/workloads/pods/init-containers/) have completed successfully. For a Pod without init containers, this is set to `True` before sandbox creation.
-1. `ContainersReady`: all containers in the Pod are ready. A container's readiness is determined by its [readiness probe](/docs/concepts/configuration/liveness-readiness-startup-probes/), if configured.
+1. `ContainersReady`: all containers in the Pod are ready. A container's readiness is determined by its [readiness probe](/docs/concepts/workloads/pods/probes/#readiness-probe), if configured.
 1. `Ready`: the Pod is able to serve requests and should be added to the load balancing pools of all matching [Services](/docs/concepts/services-networking/service/). Pods that are not `Ready` are removed from Service endpoints.
 
 {{< note >}}
@@ -250,5 +250,5 @@ the kubelet sets the Pod's `Ready` condition to `status: "False"` with `reason: 
 
 - Learn about the [Pod Lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/).
 - Learn about [Disruptions](/docs/concepts/workloads/pods/disruptions/).
-- Learn about [container probes](/docs/concepts/configuration/liveness-readiness-startup-probes/) and how they affect Pod readiness.
+- Learn about [container probes](/docs/concepts/workloads/pods/probes/) and how they affect Pod readiness.
 - Learn how to [resize Pod resources in-place](/docs/tasks/configure-pod-container/resize-container-resources/).

--- a/content/en/docs/concepts/workloads/pods/probes.md
+++ b/content/en/docs/concepts/workloads/pods/probes.md
@@ -1,7 +1,7 @@
 ---
 title: Liveness, Readiness, and Startup Probes
 content_type: concept
-weight: 40
+weight: 65
 math: true
 ---
 

--- a/content/en/docs/reference/using-api/health-checks.md
+++ b/content/en/docs/reference/using-api/health-checks.md
@@ -21,7 +21,7 @@ For a graceful shutdown you can specify the `--shutdown-delay-duration` [flag](/
 Machines that check the `healthz`/`livez`/`readyz` of the API server should rely on the HTTP status code.
 A status code `200` indicates the API server is `healthy`/`live`/`ready`, depending on the called endpoint.
 
-These endpoints align with how Kubernetes [HTTP probes](/docs/concepts/configuration/liveness-readiness-startup-probes/) function:
+These endpoints align with how Kubernetes [HTTP probes](/docs/concepts/workloads/pods/probes/#http-probes) function:
 
 * **livez**: Use this to determine if the API server should be restarted. If `/livez` returns a failure status code (such as 500), the API server is likely in a non-recoverable state, such as a deadlock, and requires a restart.
 * **readyz**: Use this to determine if the API server is ready to accept traffic. If `/readyz` returns a failure status code, it indicates the server is still initializing or temporarily unable to serve requests (for example, waiting for etcd to be available), and traffic should be routed away from it.

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -10,7 +10,7 @@ This page shows how to configure liveness, readiness and startup probes for
 containers.
 
 For more information about probes, see
-[Liveness, Readiness and Startup Probes](/docs/concepts/configuration/liveness-readiness-startup-probes).
+[Liveness, Readiness and Startup Probes](/docs/concepts/workloads/pods/probes).
 
 ## {{% heading "prerequisites" %}}
 
@@ -337,7 +337,7 @@ for it, and that containers are restarted when they fail.
 ## {{% heading "whatsnext" %}}
 
 * Learn more about
-  [Liveness, Readiness and Startup Probes](/docs/concepts/configuration/liveness-readiness-startup-probes/).
+  [Liveness, Readiness and Startup Probes](/docs/concepts/workloads/pods/probes/).
 * For the full specification of probe-related fields, see the API reference:
   [Pod](/docs/reference/kubernetes-api/workload-resources/pod-v1/),
   [Container](/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container),

--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -84,6 +84,7 @@
 /id/docs/concepts/configuration/assign-pod-node/     /id/docs/concepts/scheduling-eviction/assign-pod-node/ 301
 /docs/concepts/configuration/container-command-arg/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
 /docs/concepts/configuration/container-command-args/     /docs/tasks/inject-data-application/define-command-argument-container/     301
+/docs/concepts/configuration/liveness-readiness-startup-probes/     /docs/concepts/workloads/pods/probes/ 301
 /docs/concepts/configuration/manage-compute-resources-container/ /docs/concepts/configuration/manage-resources-containers/ 301
 /docs/concepts/configuration/resource-bin-packing/      /docs/concepts/scheduling-eviction/resource-bin-packing/ 301
 /id/docs/concepts/configuration/resource-bin-packing/      /id/docs/concepts/scheduling-eviction/resource-bin-packing/ 301


### PR DESCRIPTION
### Description

Move the Liveness, Readiness, and Startup Probes concept page from `concepts/configuration/liveness-readiness-startup-probes` to `concepts/workloads/pods/probes. Also added a redirect to keep existing URLs working.

### Issue

Closes: #55374