### PR TITLE
docs: remove future auto rollback statement from Deployment docs

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -1322,8 +1322,7 @@ spec:
 to wait for your Deployment to progress before the system reports back that the Deployment has
 [failed progressing](#failed-deployment) - surfaced as a condition with `type: Progressing`, `status: "False"`.
 and `reason: ProgressDeadlineExceeded` in the status of the resource. The Deployment controller will keep
-retrying the Deployment. This defaults to 600. In the future, once automatic rollback will be implemented, the Deployment
-controller will roll back a Deployment as soon as it observes such a condition.
+retrying the Deployment. This defaults to 600.
 
 If specified, this field needs to be greater than `.spec.minReadySeconds`.
 


### PR DESCRIPTION
### Description

Remove the stale forward-looking statement about automatic rollback from the `progressDeadlineSeconds` section of the Deployment documentation. Kubernetes has never implemented native automatic rollback and there are no plans to do so. The sentence implied a planned feature that does not exist, which is misleading to readers.
### Issue

Closes: #55312
