### PR TITLE
[vi] Add Vietnamese translation for glossary approver

### DIFF
--- a/content/vi/docs/reference/glossary/approver.md
+++ b/content/vi/docs/reference/glossary/approver.md
@@ -1,0 +1,16 @@
+---
+title: Người phê duyệt
+id: approver
+full_link: 
+short_description: >
+  Người có thể review và phê duyệt các đóng góp mã nguồn cho Kubernetes.
+
+aka: 
+tags:
+- community
+---
+ Người có thể review và phê duyệt các đóng góp mã nguồn cho Kubernetes.
+
+<!--more--> 
+
+Trong khi việc review mã nguồn tập trung vào chất lượng và tính chính xác của code, thì việc phê duyệt tập trung vào sự chấp nhận tổng thể của một đóng góp. Sự chấp nhận tổng thể bao gồm tính tương thích ngược/tiến, tuân thủ các quy ước API và flag, các vấn đề tinh tế về hiệu suất và tính chính xác, tương tác với các phần khác của hệ thống, và nhiều yếu tố khác. Quyền phê duyệt được giới hạn trong một phần của codebase. Người phê duyệt trước đây được gọi là maintainer.


### PR DESCRIPTION
## Description

Add Vietnamese translation for glossary approver
(https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/approver.md)

## Issue

Closes: #
