### PR TITLE
[vi] Add Vietnamese translation for glossary certificate

### DIFF
--- a/content/vi/docs/reference/glossary/certificate.md
+++ b/content/vi/docs/reference/glossary/certificate.md
@@ -1,0 +1,16 @@
+---
+title: Certificate
+id: certificate
+full_link: /docs/tasks/tls/managing-tls-in-a-cluster/
+short_description: >
+  Một tệp được bảo mật bằng mật mã dùng để xác thực quyền truy cập vào Kubernetes cluster.
+
+aka: 
+tags:
+- security
+---
+ Một tệp được bảo mật bằng mật mã dùng để xác thực quyền truy cập vào Kubernetes cluster.
+
+<!--more--> 
+
+Certificate cho phép các ứng dụng trong Kubernetes cluster truy cập Kubernetes API một cách an toàn. Certificate xác nhận rằng client được phép truy cập API.


### PR DESCRIPTION
## Description

Add Vietnamese translation for glossary certificate
(https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/certificate.md)

## Issue

Closes: #
