### PR TITLE
[vi] Add Vietnamese translation for glossary platform-developer

### DIFF
--- a/content/vi/docs/reference/glossary/platform-developer.md
+++ b/content/vi/docs/reference/glossary/platform-developer.md
@@ -1,0 +1,21 @@
+---
+title: Nhà phát triển nền tảng
+id: platform-developer
+full_link: 
+short_description: >
+  Người tùy chỉnh nền tảng Kubernetes để phù hợp với nhu cầu của dự án.
+
+aka: 
+tags:
+- user-type
+---
+ Người tùy chỉnh nền tảng Kubernetes để phù hợp với nhu cầu của dự án.
+
+<!--more--> 
+
+Nhà phát triển nền tảng có thể, ví dụ, sử dụng [Custom Resource](/docs/concepts/extend-kubernetes/api-extension/custom-resources/) hoặc
+[mở rộng Kubernetes API với aggregation layer](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)
+để thêm chức năng cho phiên bản Kubernetes của họ, đặc biệt cho ứng dụng của họ.
+Một số nhà phát triển nền tảng cũng là {{< glossary_tooltip text="người đóng góp" term_id="contributor" >}} và
+phát triển các extension được đóng góp cho cộng đồng Kubernetes.
+Những người khác phát triển các extension mã nguồn đóng thương mại hoặc dành riêng cho tổ chức.


### PR DESCRIPTION
## Description

Add Vietnamese translation for glossary platform-developer
(https://github.com/kubernetes/website/blob/main/content/en/docs/reference/glossary/platform-developer.md)

## Issue

Closes: #
