### PR TITLE
Clarify hardcoded device plugins path in documentation

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -90,7 +90,9 @@ The general workflow of a device plugin includes the following steps:
    initialization and setup to make sure the devices are in a ready state.
 
 1. The plugin starts a gRPC service, with a Unix socket under the host path
-   `/var/lib/kubelet/device-plugins/`, that implements the following interfaces:
+   `/var/lib/kubelet/device-plugins/` (this path is hardcoded and is not
+   affected by the kubelet's `--root-dir` or any other configuration), that
+   implements the following interfaces:
 
    ```gRPC
    service DevicePlugin {
@@ -167,7 +169,7 @@ The general workflow of a device plugin includes the following steps:
 
 A device plugin is expected to detect kubelet restarts and re-register itself with the new
 kubelet instance. A new kubelet instance deletes all the existing Unix sockets under
-`/var/lib/kubelet/device-plugins` when it starts. A device plugin can monitor the deletion
+`/var/lib/kubelet/device-plugins` (the hardcoded path for device plugins) when it starts. A device plugin can monitor the deletion
 of its Unix socket and re-register itself upon such an event.
 
 ### Device plugin and unhealthy devices
@@ -204,7 +206,7 @@ an over-temperature event, the `allocatedResourcesStatus` field may be able to r
 You can deploy a device plugin as a DaemonSet, as a package for your node's operating system,
 or manually.
 
-The canonical directory `/var/lib/kubelet/device-plugins` requires privileged access,
+The canonical directory `/var/lib/kubelet/device-plugins` (which is hardcoded on the kubelet) requires privileged access,
 so a device plugin must run in a privileged security context.
 If you're deploying a device plugin as a DaemonSet, `/var/lib/kubelet/device-plugins`
 must be mounted as a {{< glossary_tooltip term_id="volume" >}}
@@ -389,26 +391,31 @@ affine. The NUMA cells are identified using a opaque integer ID, which value is 
 what device plugins report
 [when they register themselves to the kubelet](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-integration-with-the-topology-manager).
 
-The gRPC service is served over a unix socket at `/var/lib/kubelet/pod-resources/kubelet.sock`.
+The gRPC service is served over a unix socket at `pod-resources/kubelet.sock` within the
+kubelet's root directory (typically `/var/lib/kubelet/pod-resources/kubelet.sock`).
 Monitoring agents for device plugin resources can be deployed as a daemon, or as a DaemonSet.
-The canonical directory `/var/lib/kubelet/pod-resources` requires privileged access, so monitoring
+The canonical directory `pod-resources` within the kubelet root directory (typically
+`/var/lib/kubelet/pod-resources`) requires privileged access, so monitoring
 agents must run in a privileged security context. If a device monitoring agent is running as a
-DaemonSet, `/var/lib/kubelet/pod-resources` must be mounted as a
+DaemonSet, the `pod-resources` directory must be mounted as a
 {{< glossary_tooltip term_id="volume" >}} in the device monitoring agent's
 [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core).
 
 {{< note >}}
 
-When accessing the `/var/lib/kubelet/pod-resources/kubelet.sock` from DaemonSet
+When accessing the `pod-resources/kubelet.sock` from DaemonSet
 or any other app deployed as a container on the host, which is mounting socket as
-a volume, it is a good practice to mount directory `/var/lib/kubelet/pod-resources/`
-instead of the `/var/lib/kubelet/pod-resources/kubelet.sock`. This will ensure
-that after kubelet restart, container will be able to re-connect to this socket.
+a volume, it is a good practice to mount the `pod-resources` directory
+instead of the socket file itself. This will ensure
+that after kubelet restart, the container will be able to re-connect to this socket.
+
+On a typical Linux node, this means mounting `/var/lib/kubelet/pod-resources/`
+instead of `/var/lib/kubelet/pod-resources/kubelet.sock`.
 
 Container mounts are managed by inode referencing the socket or directory,
-depending on what was mounted. When kubelet restarts, socket is deleted
-and a new socket is created, while directory stays untouched.
-So the original inode for the socket become unusable. Inode to directory
+depending on what was mounted. When kubelet restarts, the socket is deleted
+and a new socket is created, while the directory stays untouched.
+So the original inode for the socket becomes unusable. The inode to the directory
 will continue working.
 
 {{< /note >}}

--- a/content/en/docs/reference/node/kubelet-files.md
+++ b/content/en/docs/reference/node/kubelet-files.md
@@ -87,6 +87,7 @@ Names of files:
 ### Checkpoint file for device manager {#device-manager-state}
 
 Device manager creates checkpoints in the same directory with socket files: `/var/lib/kubelet/device-plugins/`.
+This path is hardcoded and is not relative to the kubelet root directory.
 The name of a checkpoint file is `kubelet_internal_checkpoint` for
 [Device Manager](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-integration-with-the-topology-manager)
 
@@ -125,13 +126,15 @@ various [Device Plugins to register](/docs/concepts/extend-kubernetes/compute-st
 
 When a device plugin registers itself, it provides its socket path for the kubelet to connect.
 
-The device plugin socket should be in the directory `device-plugins` within the kubelet base
-directory. On a typical Linux node, this means `/var/lib/kubelet/device-plugins`.
+The device plugin socket must be in the directory `/var/lib/kubelet/device-plugins/`.
+This path is hardcoded and is not relative to the kubelet base directory (root directory).
+On Linux, this path is always `/var/lib/kubelet/device-plugins`.
 
 ### Pod resources API
 
 [Pod Resources API](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)
-will be exposed at the path `/var/lib/kubelet/pod-resources`.
+will be exposed at the path `pod-resources` within the kubelet base directory (root directory).
+On a typical Linux node, this means `/var/lib/kubelet/pod-resources`.
 
 ### DRA, CSI, and Device plugins
 


### PR DESCRIPTION
### Description

Update device-plugins.md and kubelet-files.md to clarify that the device plugins path (/var/lib/kubelet/device-plugins) is hardcoded and independent of the kubelet's root directory. Also clarify that the Pod Resources API path is relative to the root directory.

This is gemini generated with:

```
The path for device plugins is hardcoded in Kuberentes. Update these two pages:                                            
   https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation     
   https://kubernetes.io/docs/reference/node/kubelet-files/#device-plugins that mention this path to make it clear what path  
   is used and that it is not related to any other paths. Find other mentions of it and if needed in context, update them as  
   well. ONLY LOOK at files under @content/en and do NOT edit any other languages. You can use source code                    
   ~/src/k8s.io/kubernetes to consult on exact behavior    
```

And update:

```
why the change kept the note: "On a typical Linux node, this means mounting `/var/lib/kubelet/pod-resources/`              
   instead of `/var/lib/kubelet/pod-resources/kubelet.sock`.", what is typical Linux node means and since it is hardcoded,    
   are there non-typical option?  
```

I reviewed and LGTM

### Issue

Relates to https://github.com/kubernetes/kubernetes/issues/120626

