### PR TITLE
Fix broken 1.33 docs site build (hard code use of Google Search)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -43,17 +43,8 @@
 <link rel="stylesheet" href="{{ "css/prism.css" | relURL }}"/>
 {{ end -}}
 
-{{ template "algolia/head" . -}}
-
 {{ partial "hooks/head-end.html" . -}}
 
-{{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
 {{ if hugo.IsProduction -}}
-  {{ if (hasPrefix .Site.GoogleAnalytics "G-") -}}
-    {{ template "_internal/google_analytics.html" . }}
-  {{ end -}}
-{{ end -}}
-
-{{ define "algolia/head" -}}
-{{/* Algolia section skipped */ -}}
+  {{ template "_internal/google_analytics.html" . }}
 {{ end -}}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,6 +1,3 @@
-{{ with .Site.Params.algolia_docsearch }}
-<!-- scripts for algolia docsearch -->
-{{ end }}
 {{/* copy-and-paste helper for codenew shortcode */}}
 {{- if or (.HasShortcode "code_sample") (.HasShortcode "code") (.HasShortcode "codenew") -}}
   {{- $toastrJs := resources.Get "js/toastr-2.1.4.min.js" | minify | fingerprint -}}


### PR DESCRIPTION
Fix a bug where the site didn't build, by making production builds use Google Search unconditionally.

This **doesn't** stop use of PageFind; it's about not using Docsy's code to detect if Google Search should be active.

/area web-development