### PR TITLE
Add 1.36 to release schedule for 1.36 release

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -4,6 +4,15 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 schedules:
+- endOfLifeDate: "2027-06-28"
+  maintenanceModeStartDate: "2027-04-28"
+  next:
+    cherryPickDeadline: "2026-05-08"
+    release: 1.36.1
+    targetDate: "2026-05-13"
+  previousPatches: []
+  release: "1.36"
+  releaseDate: "2026-04-20"
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:


### PR DESCRIPTION
This PR adds 1.36 to the releases schedule for the 1.36.0 release.

/milestone 1.36
cc @rytswd @katcosgrove @fsmunoz @kubernetes/release-managers 