### PR TITLE
Add image volume type to Restricted Pod Security Standard

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -370,6 +370,7 @@ fail validation.
 					<li><code>spec.volumes[*].downwardAPI</code></li>
 					<li><code>spec.volumes[*].emptyDir</code></li>
 					<li><code>spec.volumes[*].ephemeral</code></li>
+					<li><code>spec.volumes[*].image</code></li>
 					<li><code>spec.volumes[*].persistentVolumeClaim</code></li>
 					<li><code>spec.volumes[*].projected</code></li>
 					<li><code>spec.volumes[*].secret</code></li>


### PR DESCRIPTION
## Summary
Add `spec.volumes[*].image` to the Restricted Pod Security Standard's allowed volume types list. OCI image volumes have been permitted by the Pod Security admission controller since v1.33 (kubernetes/kubernetes#130394), and are beta / enabled by default in v1.35, so they should appear in the docs alongside the other allowed volume source types.

## Issue
Fixes #55370 (triaged/accepted, SIG Auth).

## Changes
- `content/en/docs/concepts/security/pod-security-standards.md`: add `<li><code>spec.volumes[*].image</code></li>` to the Restricted policy's allowed volume types list, inserted alphabetically between `ephemeral` and `persistentVolumeClaim`.

Context from the issue thread:

> I'm in favor of including image volumes in the set of volume types allowed by pod security restricted/baseline levels […]
> — @liggitt

> Actually, it looks like the code added support for the image volume in 1.33+ in kubernetes/kubernetes#130394
> The docs do need updating
> — @liggitt

## Testing
- Docs-only change, single `<li>` added; rendered HTML list order preserved.