### PR TITLE
Clarify Ephemeral Containers RBAC

### DIFF
--- a/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
+++ b/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
@@ -76,13 +76,12 @@ you can view processes in other containers.
 
 Adding an ephemeral container to a running Pod uses the Pod's
 `ephemeralcontainers` subresource rather than being writable via `pod.spec`.
-This is a deliberate design choice: admission plugins and security policies
-that predate this API may not be aware of ephemeral containers, and treating
+This is a deliberate design choice. Older admission plugins and security policies don't always recognize ephemeral containers, and treating
 ephemeral container creation as a distinct API surface lets cluster
 administrators make an explicit decision about who may add containers to
 already-running Pods.
 
-For the same reason, the `pods/ephemeralcontainers` subresource is **not**
+For the same reason, the `pods/ephemeralcontainers` subresource is *not*
 included in the default `admin` and `edit`
 [user-facing ClusterRoles](/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 To allow users to add ephemeral containers (for example, by running

--- a/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
+++ b/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
@@ -72,6 +72,26 @@ When using ephemeral containers, it's helpful to enable [process namespace
 sharing](/docs/tasks/configure-pod-container/share-process-namespace/) so
 you can view processes in other containers.
 
+## Access control {#access-control}
+
+Adding an ephemeral container to a running Pod uses the Pod's
+`ephemeralcontainers` subresource rather than being writable via `pod.spec`.
+This is a deliberate design choice: admission plugins and security policies
+that predate this API may not be aware of ephemeral containers, and treating
+ephemeral container creation as a distinct API surface lets cluster
+administrators make an explicit decision about who may add containers to
+already-running Pods.
+
+For the same reason, the `pods/ephemeralcontainers` subresource is **not**
+included in the default `admin` and `edit`
+[user-facing ClusterRoles](/docs/reference/access-authn-authz/rbac/#user-facing-roles).
+To allow users to add ephemeral containers (for example, by running
+[`kubectl debug`](/docs/reference/kubectl/generated/kubectl_debug/)),
+cluster administrators must grant the `patch` (and typically `update`) verb
+on `pods/ephemeralcontainers` explicitly. See
+[Debug Running Pods: Permissions for ephemeral containers](/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container-permissions)
+for recommended approaches.
+
 ## {{% heading "whatsnext" %}}
 
 * Learn how to [debug pods using ephemeral containers](/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container).

--- a/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
+++ b/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
@@ -81,7 +81,7 @@ ephemeral container creation as a distinct API surface lets cluster
 administrators make an explicit decision about who may add containers to
 already-running Pods.
 
-For the same reason, the `pods/ephemeralcontainers` subresource is *not*
+For the same reason, the `pods/ephemeralcontainers` subresource is **not**
 included in the default `admin` and `edit`
 [user-facing ClusterRoles](/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 To allow users to add ephemeral containers (for example, by running

--- a/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
+++ b/content/en/docs/concepts/workloads/pods/ephemeral-containers.md
@@ -76,7 +76,7 @@ you can view processes in other containers.
 
 Adding an ephemeral container to a running Pod uses the Pod's
 `ephemeralcontainers` subresource rather than being writable via `pod.spec`.
-This is a deliberate design choice. Older admission plugins and security policies don't always recognize ephemeral containers, and treating
+This is a deliberate design choice. Some admission plugins and security policies don't recognize ephemeral containers, and treating
 ephemeral container creation as a distinct API surface lets cluster
 administrators make an explicit decision about who may add containers to
 already-running Pods.

--- a/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -386,6 +386,74 @@ because a container has crashed or a container image doesn't include debugging
 utilities, such as with [distroless images](
 https://github.com/GoogleContainerTools/distroless).
 
+### Permissions for ephemeral containers {#ephemeral-container-permissions}
+
+Adding an ephemeral container to a running Pod uses the Pod's
+`ephemeralcontainers` subresource. At the API level this is a `PATCH` (or
+`UPDATE`) request on `pods/ephemeralcontainers`, which is governed by its own
+RBAC verbs and is **not** granted by `patch` on `pods`.
+
+The `pods/ephemeralcontainers` subresource is intentionally not part of the
+default `admin` and `edit`
+[user-facing ClusterRoles](/docs/reference/access-authn-authz/rbac/#user-facing-roles).
+For background on why, see
+[Ephemeral Containers: Access control](/docs/concepts/workloads/pods/ephemeral-containers/#access-control).
+
+If you run `kubectl debug` to add an ephemeral container without the required
+permission, you will see an error similar to:
+
+```
+Error from server (Forbidden): pods "example" is forbidden: User "alice" cannot
+patch resource "pods/ephemeralcontainers" in API group "" in the namespace "example-ns"
+```
+
+Cluster administrators can grant this permission in one of two ways.
+
+To extend the built-in `edit` and `admin` ClusterRoles cluster-wide, create an
+aggregated ClusterRole labeled for
+[ClusterRole aggregation](/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).
+The `aggregate-to-edit` label is sufficient because the default `edit`
+ClusterRole itself aggregates into `admin`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-ephemeralcontainers-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch", "update"]
+```
+
+To grant the permission only to specific users or groups (for example, a
+dedicated debugging or SRE group), create a narrower ClusterRole and bind it
+directly:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: debug-ephemeralcontainers
+rules:
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch", "update"]
+```
+
+{{< note >}}
+Ephemeral containers are evaluated by [Pod Security admission](/docs/concepts/security/pod-security-admission/)
+against the same [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
+as regular containers. When granting permission to add ephemeral containers to
+Pods governed by the `baseline` or `restricted` policy, choose a matching
+[debugging profile](#debugging-profiles) such as `--profile=baseline` or
+`--profile=restricted`. Any validating admission webhooks in your cluster that
+were written before this API existed may also need to be updated to evaluate
+the `ephemeralContainers` field in a Pod's spec.
+{{< /note >}}
+
 ### Example debugging using ephemeral containers {#ephemeral-container-example}
 
 You can use the `kubectl debug` command to add ephemeral containers to a

--- a/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -452,8 +452,8 @@ Pods governed by the `baseline` or `restricted` policy, choose a matching
 `--profile=restricted` with `kubectl debug`.
 
 Any admission webhooks or admission policies in your cluster, that do not evaluate
-the `ephemeralContainers` field, may also need updating to evaluate the `ephemeralContainers`
-field in a Pod's spec.
+the `ephemeralContainers` field, may also need updating to intercept the
+`pods/ephemeralcontainers` resource and evaluate the `ephemeralContainers` field in a Pod's spec.
 {{< /note >}}
 
 ### Example debugging using ephemeral containers {#ephemeral-container-example}

--- a/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -391,7 +391,7 @@ https://github.com/GoogleContainerTools/distroless).
 Adding an ephemeral container to a running Pod uses the Pod's
 `ephemeralcontainers` subresource. At the API level this is a `PATCH` (or
 `UPDATE`) request on `pods/ephemeralcontainers`, which is governed by its own
-RBAC verbs and is **not** granted by `patch` on `pods`.
+RBAC verbs and is *not* granted by `patch` on `pods`.
 
 The `pods/ephemeralcontainers` subresource is intentionally not part of the
 default `admin` and `edit`
@@ -449,9 +449,7 @@ against the same [Pod Security Standards](/docs/concepts/security/pod-security-s
 as regular containers. When granting permission to add ephemeral containers to
 Pods governed by the `baseline` or `restricted` policy, choose a matching
 [debugging profile](#debugging-profiles) such as `--profile=baseline` or
-`--profile=restricted`. Any validating admission webhooks in your cluster that
-were written before this API existed may also need to be updated to evaluate
-the `ephemeralContainers` field in a Pod's spec.
+`--profile=restricted` with `kubectl debug`. Any validating admission webhooks in your cluster that do not evaluate the ephemeralContainers field may also need updating to evaluate the `ephemeralContainers` field in a Pod's spec.
 {{< /note >}}
 
 ### Example debugging using ephemeral containers {#ephemeral-container-example}

--- a/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -388,10 +388,10 @@ https://github.com/GoogleContainerTools/distroless).
 
 ### Permissions for ephemeral containers {#ephemeral-container-permissions}
 
-Adding an ephemeral container to a running Pod uses the Pod's
-`ephemeralcontainers` subresource. At the API level this is a `PATCH` (or
-`UPDATE`) request on `pods/ephemeralcontainers`, which is governed by its own
-RBAC verbs and is *not* granted by `patch` on `pods`.
+For security reasons, adding an ephemeral container to a running Pod uses the Pod's
+`ephemeralcontainers` subresource. At the API level this is an
+**update** request on `pods/ephemeralcontainers`. Just being authorized to **patch**
+a Pod does not allow users to add ephemeral containers to that Pod.
 
 The `pods/ephemeralcontainers` subresource is intentionally not part of the
 default `admin` and `edit`
@@ -407,7 +407,7 @@ Error from server (Forbidden): pods "example" is forbidden: User "alice" cannot
 patch resource "pods/ephemeralcontainers" in API group "" in the namespace "example-ns"
 ```
 
-Cluster administrators can grant this permission in one of two ways.
+If you're managing cluster access and your cluster uses [Kubernetes RBAC](/docs/reference/access-authn-authz/rbac/), you can grant this permission in one of two ways.
 
 To extend the built-in `edit` and `admin` ClusterRoles cluster-wide, create an
 aggregated ClusterRole labeled for
@@ -449,7 +449,11 @@ against the same [Pod Security Standards](/docs/concepts/security/pod-security-s
 as regular containers. When granting permission to add ephemeral containers to
 Pods governed by the `baseline` or `restricted` policy, choose a matching
 [debugging profile](#debugging-profiles) such as `--profile=baseline` or
-`--profile=restricted` with `kubectl debug`. Any validating admission webhooks in your cluster that do not evaluate the ephemeralContainers field may also need updating to evaluate the `ephemeralContainers` field in a Pod's spec.
+`--profile=restricted` with `kubectl debug`.
+
+Any admission webhooks or admission policies in your cluster, that do not evaluate
+the `ephemeralContainers` field, may also need updating to evaluate the `ephemeralContainers`
+field in a Pod's spec.
 {{< /note >}}
 
 ### Example debugging using ephemeral containers {#ephemeral-container-example}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Ephemeral Containers API is not included in the default RBAC for historic and security reasons. This PR provides clarification on Ephemeral Containers RBAC, mostly based on @liggitt's advice across various issues/PRs on `kubectl debug` feature.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #