### PR TITLE
Updates v1.34 hugo.toml for release v1.36

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://kubernetes.io"
+baseURL = "https://v1-34.docs.kubernetes.io/"
 title = "Kubernetes"
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
@@ -139,10 +139,10 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.35"
+latest = "v1.36"
 
 version = "v1.34"
-githubbranch = "1.34.2"
+githubbranch = "1.34.6"
 docsbranch = "release-1.34"
 # Should be changed to Docsy provided `archived_version` in the future.
 deprecated = true
@@ -182,34 +182,34 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.35"
-githubbranch = "v1.35.0"
+version = "v1.36"
+githubbranch = "v1.36.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
+version = "v1.35"
+githubbranch = "v1.35.3"
+docsbranch = "release-1.35"
+url = "https://v1-35.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.34"
-githubbranch = "v1.34.2"
+githubbranch = "v1.34.6"
 docsbranch = "release-1.34"
 url = "https://v1-34.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.33"
-githubbranch = "v1.33.6"
+githubbranch = "v1.33.10"
 docsbranch = "release-1.33"
 url = "https://v1-33.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.32"
-githubbranch = "v1.32.10"
+githubbranch = "v1.32.13"
 docsbranch = "release-1.32"
 url = "https://v1-32.docs.kubernetes.io"
-
-[[params.versions]]
-version = "v1.31"
-githubbranch = "v1.31.14"
-docsbranch = "release-1.31"
-url = "https://v1-31.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
This PR updates the hugo.toml for v1.34 ahead of the v1.36 release.

/hold for v1.36 release day