### PR TITLE
Fix LimitPodHardAntiAffinityTopology documentation

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -488,8 +488,8 @@ In any case, the annotations are provided by the user and are not validated by K
 
 **Type**: Validating.
 
-This admission controller denies any pod that defines `AntiAffinity` topology key other than
-`kubernetes.io/hostname` in `requiredDuringSchedulingRequiredDuringExecution`.
+This admission controller denies any pod that defines an `AntiAffinity` topology key other than
+`kubernetes.io/hostname` in `requiredDuringSchedulingIgnoredDuringExecution`.
 
 This admission controller is disabled by default.
 


### PR DESCRIPTION
The admission controller documentation referenced requiredDuringSchedulingRequiredDuringExecution, which was never implemented in the Kubernetes API (kubernetes/kubernetes#96149). The actual field that the admission controller checks and that exists in the API is requiredDuringSchedulingIgnoredDuringExecution.

Closes: #55284