### PR TITLE
Add note to increase terminationGracePeriodSeconds for long PreStop hook

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -95,6 +95,13 @@ takes 10 seconds to stop normally after receiving the signal, then the Container
 before it can stop normally, since `terminationGracePeriodSeconds` is less than the total time
 (55+10) it takes for these two things to happen.
 
+{{< note >}}
+If your `PreStop` hook needs longer to run, increase
+`terminationGracePeriodSeconds` so that it covers both the hook's
+worst-case execution time and the container's normal shutdown duration.
+Otherwise, the container is killed before either step can finish.
+{{< /note >}}
+
 If either a `PostStart` or `PreStop` hook fails,
 it kills the Container.
 


### PR DESCRIPTION
Make the recommendation explicit: when a PreStop hook is expected to run for a long time, set terminationGracePeriodSeconds high enough to cover both the hook execution and the container's shutdown duration.

https://github.com/kubernetes/website/issues/55092
