### PR TITLE
Explain why drain skips DaemonSet pods

### DIFF
--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -89,6 +89,14 @@ the DaemonSet controller (part of the control plane) immediately replaces missin
 new equivalent Pods. The DaemonSet controller also creates Pods that ignore unschedulable
 taints, which allows the new Pods to launch onto a node that you are draining.
 
+DaemonSet Pods are typically node-local services such as networking, storage, or
+log collection that need to remain on the node for as long as the node itself is
+running. Because the DaemonSet controller pins each Pod to a specific node and
+ignores the unschedulable taint, evicting these Pods would only cause them to be
+recreated on the same node. `--ignore-daemonsets` skips them so that drain can
+complete; the Pods continue to run while you perform maintenance and are removed
+when the node is removed from the cluster.
+
 Once it returns (without giving an error), you can power down the node
 (or equivalently, if on a cloud platform, delete the virtual machine backing the node).
 If you leave the node in the cluster during the maintenance operation, you need to run


### PR DESCRIPTION
The page already showed how --ignore-daemonsets works mechanically, but did not explain why it is safe to skip these Pods. Add a short paragraph noting that DaemonSet Pods are node-local services that must keep running until the node itself is removed, and that the DaemonSet controller pins each Pod to a specific node.

https://github.com/kubernetes/website/issues/39816