### PR TITLE
Introduce kubectl and cluster context in install prerequisites

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -6,12 +6,12 @@ content_type: task
 weight: 10
 ---
 
-## {{% heading "prerequisites" %}}
-
 `kubectl` is the command-line tool you use to interact with a Kubernetes
 {{< glossary_tooltip text="cluster" term_id="cluster" >}}. If you don't yet
 have a cluster, see [Learn Kubernetes basics](/docs/tutorials/kubernetes-basics/)
 or one of the [Setup](/docs/setup/) guides.
+
+## {{% heading "prerequisites" %}}
 
 You must use a kubectl version that is within one minor version difference of
 your cluster. For example, a v{{< skew currentVersion >}} client can communicate

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -8,6 +8,11 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
+`kubectl` is the command-line tool you use to interact with a Kubernetes
+{{< glossary_tooltip text="cluster" term_id="cluster" >}}. If you don't yet
+have a cluster, see [Learn Kubernetes basics](/docs/tutorials/kubernetes-basics/)
+or one of the [Setup](/docs/setup/) guides.
+
 You must use a kubectl version that is within one minor version difference of
 your cluster. For example, a v{{< skew currentVersion >}} client can communicate
 with v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersionAddMinor 0 >}},

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -6,6 +6,11 @@ content_type: task
 weight: 10
 ---
 
+`kubectl` is the command-line tool you use to interact with a Kubernetes
+{{< glossary_tooltip text="cluster" term_id="cluster" >}}. If you don't yet
+have a cluster, see [Learn Kubernetes basics](/docs/tutorials/kubernetes-basics/)
+or one of the [Setup](/docs/setup/) guides.
+
 ## {{% heading "prerequisites" %}}
 
 You must use a kubectl version that is within one minor version difference of

--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -6,6 +6,11 @@ content_type: task
 weight: 10
 ---
 
+`kubectl` is the command-line tool you use to interact with a Kubernetes
+{{< glossary_tooltip text="cluster" term_id="cluster" >}}. If you don't yet
+have a cluster, see [Learn Kubernetes basics](/docs/tutorials/kubernetes-basics/)
+or one of the [Setup](/docs/setup/) guides.
+
 ## {{% heading "prerequisites" %}}
 
 You must use a kubectl version that is within one minor version difference of


### PR DESCRIPTION
The prerequisites section jumped straight into the version-skew rule between kubectl and a cluster, which assumes the reader already knows what kubectl and a cluster are. Add a one-sentence introduction with a glossary link to cluster and pointers to Learn Kubernetes basics and the Setup guides for readers who do not yet have one.

https://github.com/kubernetes/website/issues/54771