### PR TITLE
Add release_announcement to frontmatter to 1.36 blog

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
@@ -4,6 +4,8 @@ title: "Kubernetes v1.36: ハル (Haru)"
 date: 2026-04-22
 evergreen: true
 slug: kubernetes-v1-36-release
+release_announcement:
+  minor_version: "1.36"
 author: >
   [Kubernetes v1.36 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-team.md)
 ---


### PR DESCRIPTION
After PR https://github.com/kubernetes/website/pull/54885 merged, this PR adds the release_announcement for 1.36 to the 1.36 release blog
/assign @sayanchowdhury 