### PR TITLE
Use feature-state shortcode for externalIPs deprecation

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -1025,11 +1025,11 @@ to learn more.
 
 ## External IPs
 
-{{< caution >}}
-The `externalIPs` feature is deprecated as of Kubernetes v1.36, and all users should begin
-migrating away from it.
-Consider using an external load balancer controller or a Gateway API implementation instead.
-{{< /caution >}}
+{{< feature-state for_k8s_version="v1.36" state="deprecated" >}}
+
+All users should begin migrating away from `externalIPs`.
+Consider using an external load balancer controller or a Gateway API
+implementation instead.
 
 If there are external IPs that route to one or more cluster nodes, Kubernetes Services
 can be exposed on those `externalIPs`. When network traffic arrives into the cluster, with


### PR DESCRIPTION
switches the existing `caution` note in the External IPs section to the `feature-state` shortcode, matching the pattern already used for Endpoints (line 312 in the same file) and ~10 other field deprecations across the docs. kept the migration advice (external LB controller / Gateway API) as body prose since the shortcode only emits the standard deprecation banner.

Fixes #55473