### PR TITLE
Rename EnableWorkloadWithJob feature gate references to WorkloadWithJob

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -315,9 +315,9 @@ or completed for the same index will be deleted by the Job controller once they 
 
 ## Integrate with Workload APIs
 
-{{< feature-state feature_gate_name="EnableWorkloadWithJob" >}}
+{{< feature-state feature_gate_name="WorkloadWithJob" >}}
 
-When the [`EnableWorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/) feature gate is enabled,
+When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/) feature gate is enabled,
 the Job controller automatically creates
 [Workload](/docs/concepts/workloads/workload-api/) and
 [PodGroup](/docs/reference/kubernetes-api/workload-resources/workload-v1alpha1/) objects
@@ -1186,7 +1186,7 @@ Use cases for elastic Indexed Jobs include batch workloads which require
 scaling an indexed Job, such as MPI, Horovod, Ray, and PyTorch training jobs.
 
 {{< note >}}
-When the [`EnableWorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/)
+When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/)
 feature gate is enabled and a Job matches the
 [gang scheduling criteria](#integrate-with-workload-apis),
 updates to `.spec.parallelism` are rejected because the `Workload`'s `minCount` field

--- a/content/en/docs/concepts/workloads/workload-api/_index.md
+++ b/content/en/docs/concepts/workloads/workload-api/_index.md
@@ -81,10 +81,10 @@ This data is not used to schedule or manage the Workload.
 
 ## Gang scheduling with Jobs
 
-{{< feature-state feature_gate_name="EnableWorkloadWithJob" >}}
+{{< feature-state feature_gate_name="WorkloadWithJob" >}}
 
 When the
-[`EnableWorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/)
+[`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/)
 feature gate is enabled, the
 [Job](/docs/concepts/workloads/controllers/job/) controller automatically
 creates Workload and PodGroup objects for parallel indexed Jobs where

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
@@ -1,5 +1,5 @@
 ---
-title: EnableWorkloadWithJob
+title: WorkloadWithJob
 content_type: feature_gate
 _build:
   list: never


### PR DESCRIPTION
the docs referenced a feature gate named `EnableWorkloadWithJob`, but the gate is defined as `WorkloadWithJob` in k/k ([pkg/features/kube_features.go#L2141-L2143](https://github.com/kubernetes/kubernetes/blob/745e271a9cb9a105ac688761baa31df5474dd9fe/pkg/features/kube_features.go#L2141-L2143)).

renames the feature-gate description file and updates the three remaining references on the Job and Workload API pages. no non-English content touched (localization is handled separately).

Fixes #55476