### PR TITLE
Fix broken links in v1.36 release blog post

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
@@ -369,7 +369,7 @@ This work was done across several KEPs (including [#5004](https://kep.k8s.io/500
 
 In Kubernetes v1.36, the `ComponentStatusz` feature gate for core Kubernetes components graduates to beta,
 providing a `/statusz` endpoint (enabled by default) that surfaces real‑time build and version details for each component.
-This low‑overhead [z-page](docs/reference/instrumentation/zpages/) exposes information like start time, uptime, Go version, binary version,
+This low‑overhead [z-page](/docs/reference/instrumentation/zpages/) exposes information like start time, uptime, Go version, binary version,
 emulation version, and minimum compatibility version, so operators and developers can quickly see exactly
 what is running without digging through logs or configs.
 
@@ -567,7 +567,7 @@ Kubernetes v1.36 includes a couple of deprecations.
 
 With this release, the `externalIPs` field in Service `spec` is deprecated. This means the functionality exists, but will no longer function in a **future** version of Kubernetes. You should plan to migrate if you currently rely on that field.
 This field has been a known security headache for years,
-enabling man-in-the-middle attacks on your cluster traffic, as documented in [CVE-2020-8554](https:/github.com/kubernetes/kubernetes/issues/97076).
+enabling man-in-the-middle attacks on your cluster traffic, as documented in [CVE-2020-8554](https://github.com/kubernetes/kubernetes/issues/97076).
 From Kubernetes v1.36 and onwards, you will see deprecation warnings when using it, with full removal planned for v1.43.
 
 If your Services still lean on `externalIPs`, consider using LoadBalancer services for cloud-managed ingress,


### PR DESCRIPTION
Fix a missing leading slash in the z-page documentation link and a missing slash in the CVE-2020-8554 URL.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

- Fix missing leading `/` in z-page documentation link (`docs/reference/...` → `/docs/reference/...`), which would resolve incorrectly from the blog post URL
- Fix malformed CVE-2020-8554 URL (`https:/github.com/...` → `https://github.com/...`), resulting in a broken link


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #