### PR TITLE
[zh-cn]sync pods/_index AtomicFIFO CRIListStreaming ControllerManagerReleaseLeaderElectionLockOnExit

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/pods/_index.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/_index.md
@@ -293,25 +293,28 @@ Here are some examples of workload resources that manage one or more Pods:
 * {{< glossary_tooltip text="DaemonSet" term_id="daemonset" >}}
 
 <!--
-### Specifying a Workload reference
+### Specifying a scheduling group
 -->
-### 指定工作负载引用
+### 指定调度组
+
+{{< feature-state feature_gate_name="GenericWorkload" >}}
 
 <!--
 By default, Kubernetes schedules every Pod individually. However, some tightly-coupled applications
 need a group of Pods to be scheduled simultaneously to function correctly.
 
-You can link a Pod to a [Workload](/docs/concepts/workloads/workload-api/) object
-using a [Workload reference](/docs/concepts/workloads/pods/workload-reference/).
-This tells the `kube-scheduler` that the Pod is part of a specific group,
-enabling it to make coordinated placement decisions for the entire group at once.
+You can link a Pod to a [PodGroup](/docs/concepts/workloads/podgroup-api/) using the
+[scheduling group](/docs/concepts/workloads/pods/scheduling-group/) field
+(`spec.schedulingGroup`). This tells the `kube-scheduler` that the `Pod` belongs to a specific
+group, enabling it to apply group-level coordinated placement decisions for the entire group at once.
 -->
 默认情况下，Kubernetes 会单独调度每一个 Pod。
 然而，一些紧密耦合的应用程序需要一组 Pod 能够同时被调度，才能正确运行。
 
-你可以使用[工作负载引用](/zh-cn/docs/concepts/workloads/pods/workload-reference/)将一个
-Pod 链接到一个[工作负载](/zh-cn/docs/concepts/workloads/workload-api/)对象。
-这会告诉 `kube-scheduler` 该 Pod 是特定组的一部分，使其能够为整个组做出协调一致的放置决策。
+你可以使用[调度组](/zh-cn/docs/concepts/workloads/pods/scheduling-group/)字段
+（`spec.schedulingGroup`）将 Pod 链接到 [PodGroup](/zh-cn/docs/concepts/workloads/podgroup-api/)。
+这会告诉 `kube-scheduler` 该 `Pod` 属于特定组，
+使其能够为整个组应用组级协调放置决策。
 
 <!--
 ### Pod templates
@@ -558,18 +561,19 @@ directly in the `status` or is an indirect result of a running process.
 
 For status fields where the allocated spec is directly reflected, the `observedGeneration` will
 be associated with the current `metadata.generation` (Generation N).
-
-This behavior applies to:
-
-- **Resize Status**: The status of a resource resize operation.
-- **Allocated Resources**: The resources allocated to the Pod after a resize.
-- **Ephemeral Containers**: When a new ephemeral container is added, and it is in `Waiting` state.
 -->
 #### 直接状态更新
 
 对于那些直接反映分配的 spec 的状态字段，`observedGeneration`
 将与当前的 `metadata.generation`（第 N 代）相关联。
 
+<!--
+This behavior applies to:
+
+- **Resize Status**: The status of a resource resize operation.
+- **Allocated Resources**: The resources allocated to the Pod after a resize.
+- **Ephemeral Containers**: When a new ephemeral container is added, and it is in `Waiting` state.
+-->
 此行为适用于：
 
 - **扩缩状态**：资源扩缩操作的状态。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/AtomicFIFO.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/AtomicFIFO.md
@@ -1,0 +1,26 @@
+---
+title: AtomicFIFO
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.36"
+
+---
+
+<!--
+A client-go implementation of a FIFO queue that uses atomic operations to ensure events that come in
+batches, such as those from a ListAndWatch call, are processed in a single chunk. This is in contrast to
+the previous implementation which would process these events one by one, potentially causing the internal
+cache to become temporarily inconsistent with the API server. This feature gate can be toggled in the
+kube-controller-manager and any client-go based controller.
+-->
+一个 client-go 实现的 FIFO 队列，使用原子操作确保批量传入的事件（例如来自
+ListAndWatch 调用的事件）作为单个块处理。
+这与之前的实现形成对比，之前的实现会逐个处理这些事件，可能导致内部缓存与 API 服务器暂时不一致。
+此特性门控可以在 kube-controller-manager 和任何基于 client-go 的控制器中切换。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/CRIListStreaming.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/CRIListStreaming.md
@@ -1,0 +1,27 @@
+---
+title: CRIListStreaming
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.36"
+---
+
+<!--
+Enable streaming RPCs for CRI list operations (`ListContainers`,
+`ListPodSandbox`, `ListImages`). When enabled, the kubelet uses server-side
+streaming RPCs (e.g., `StreamContainers`, `StreamPodSandboxes`) that allow the
+container runtime to divide results across multiple response messages,
+bypassing the 16 MiB gRPC message size limit. This allows listing containers
+on nodes with thousands of containers without failures. If the container
+runtime does not support streaming RPCs, the kubelet falls back to unary RPCs.
+-->
+为 CRI 列表操作（`ListContainers`、`ListPodSandbox`、`ListImages`）启用流式 RPC。
+启用后，kubelet 使用服务器端流式 RPC（例如 `StreamContainers`、`StreamPodSandboxes`），
+允许容器运行时将结果分散到多个响应消息中，绕过 16 MiB 的 gRPC 消息大小限制。
+这允许在具有数千个容器的节点上列出容器而不会失败。
+如果容器运行时不支持流式 RPC，kubelet 会回退到一元 RPC。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
@@ -1,0 +1,21 @@
+---
+title: ControllerManagerReleaseLeaderElectionLockOnExit
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.36"
+---
+
+<!--
+Enables the `kube-controller-manager` to actively release its leader election lock
+during leader transitions, rather than waiting for the lock's TTL to expire.
+This allows a new leader to be elected more quickly.
+-->
+启用 `kube-controller-manager` 在领导者转换期间主动释放其领导者选举锁，
+而不是等待锁的 TTL 过期。
+这允许更快地选举新的领导者。


### PR DESCRIPTION
```
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/AtomicFIFO.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/CRIListStreaming.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
content/zh-cn/docs/concepts/workloads/pods/_index.md
```