### PR TITLE
Fix typo in Kubernetes v1.36 blog post

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
@@ -325,7 +325,7 @@ This work was done as a part of [KEP #3104](https://kep.k8s.io/3104) led by SIG 
 ### Mutable container resources when Job is suspended
 
 In Kubernetes v1.36, the `MutablePodResourcesForSuspendedJobs` feature graduates to beta and is enabled by default.
-This update This update relaxes Job validation to allow updates to container CPU, memory,
+This update relaxes Job validation to allow updates to container CPU, memory,
 GPU, and extended resource requests and limits while a Job is suspended.
 
 This capability allows queue controllers and operators to adjust batch workload requirements based on


### PR DESCRIPTION
### Description

In the section "Mutable container resources when Job is suspended" the words "This update" were duplicated by accident.

### Issue

None opened (It's a small fix)