### PR TITLE
Clarify kubelet filesystem layouts in storage docs

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -112,39 +112,44 @@ eviction signals (`<identifier>.inodesFree` or `<identifier>.available`):
     and more. For example, `nodefs` contains `/var/lib/kubelet`.
 
 1. `imagefs`: An optional filesystem that container runtimes can use to store
-   container images (which are the read-only layers) and container writable
-   layers.
+   container images (which are the read-only layers). If there is no separate
+   `containerfs`, the image filesystem also stores container writable layers.
 
-1. `containerfs`: An optional filesystem that container runtime can use to
-   store the writeable layers. Similar to the main filesystem (see `nodefs`),
-   it's used to store local disk volumes, emptyDir volumes not backed by memory,
-   log storage, and ephemeral storage, except for the container images. When
-   `containerfs` is used, the `imagefs` filesystem can be split to only store
-   images (read-only layers) and nothing else.
+1. `containerfs`: An optional filesystem that container runtimes can use to
+   store container writable layers. When `containerfs` is used, the `imagefs`
+   filesystem can be split to only store images (read-only layers) and nothing
+   else.
+
+These identifiers describe the filesystems as the kubelet observes them. They do
+not always mean three different mount points: in common layouts, two or all
+three identifiers can refer to the same underlying filesystem.
 
 {{<note>}}
 {{< feature-state feature_gate_name="KubeletSeparateDiskGC" >}}
-The _split image filesystem_ feature, which enables support for the `containerfs`
-filesystem, adds several new eviction signals, thresholds and metrics. To use
-`containerfs`, the Kubernetes release v{{< skew currentVersion >}} requires the
-`KubeletSeparateDiskGC` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-to be enabled. Currently, only CRI-O (v1.29 or higher) offers the `containerfs`
-filesystem support.
+The _split image filesystem_ feature adds new eviction signals, thresholds, and
+metrics for `containerfs`. To use `containerfs`, the Kubernetes release
+v{{< skew currentVersion >}} requires the `KubeletSeparateDiskGC`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to
+be enabled. For Kubernetes v{{< skew currentVersion >}}, only CRI-O (v1.29 or
+higher) offers `containerfs` filesystem support.
 {{</note>}}
 
-As such, kubelet generally allows three options for container filesystems:
+The kubelet supports three common layouts for container filesystems:
 
 - Everything is on the single `nodefs`, also referred to as "rootfs" or
-  simply "root", and there is no dedicated image filesystem.
+  simply "root". In this layout, `nodefs`, `imagefs`, and `containerfs`
+  all refer to the same underlying filesystem.
 
-- Container storage (see `nodefs`) is on a dedicated disk, and `imagefs`
-  (writable and read-only layers) is separate from the root filesystem.
-  This is often referred to as "split disk" (or "separate disk") filesystem.
-
-- Container filesystem `containerfs` (same as `nodefs` plus writable
-  layers) is on root and the container images (read-only layers) are
-  stored on separate `imagefs`. This is often referred to as "split image"
+- Container runtime storage is on a dedicated disk, separate from the root
+  filesystem. In this layout, `imagefs` and `containerfs` refer to the same
+  underlying filesystem, which stores both image layers and container writable
+  layers. This is often referred to as "split disk" (or "separate disk")
   filesystem.
+
+- Container writable layers are on `nodefs`, and the container images
+  (read-only layers) are stored on a separate `imagefs`. In this layout,
+  `containerfs` and `nodefs` refer to the same underlying filesystem. This is
+  often referred to as a "split image" filesystem.
 
 The kubelet will attempt to auto-discover these filesystems with their current
 configuration directly from the underlying container runtime and will ignore
@@ -235,15 +240,15 @@ inherit their default values instead of 0.
 The `containerfs.available` and `containerfs.inodesFree` (Linux nodes) default
 eviction thresholds will be set as follows:
 
-- If a single filesystem is used for everything, then `containerfs` thresholds
-  are set the same as `nodefs`.
+- If `containerfs` and `nodefs` refer to the same underlying filesystem, then
+  `containerfs` thresholds are set the same as `nodefs`.
 
-- If separate filesystems are configured for both images and containers,
-  then `containerfs` thresholds are set the same as `imagefs`.
+- If `containerfs` and `imagefs` refer to the same underlying filesystem, then
+  `containerfs` thresholds are set the same as `imagefs`.
 
-Setting custom overrides for thresholds related to `containersfs` is currently
-not supported, and a warning will be issued if an attempt to do so is made; any
-provided custom values will, as such, be ignored.
+Setting custom overrides for thresholds related to `containerfs` is not
+supported, and a warning will be issued if an attempt to do so is made; any
+provided custom values will be ignored.
 
 ## Eviction monitoring interval
 
@@ -380,7 +385,7 @@ The kubelet sorts pods differently based on whether the node has a dedicated
 - If `imagefs` triggers evictions, the kubelet sorts pods based on the
   writable layer usage of all containers.
 
-#### With `imagesfs` and `containerfs` (`imagefs` and `containerfs` have been split) {#with-containersfs}
+#### With `imagefs` and `containerfs` (`imagefs` and `containerfs` have been split) {#with-containersfs}
 
 - If `containerfs` triggers evictions, the kubelet sorts pods based on
   `containerfs` usage (`local volumes + logs and a writable layer of all containers`).

--- a/content/en/docs/concepts/storage/ephemeral-storage.md
+++ b/content/en/docs/concepts/storage/ephemeral-storage.md
@@ -39,13 +39,12 @@ of ephemeral local storage a Pod can consume.
 
 ## Configurations for local ephemeral storage {#configurations}
 
-Kubernetes supports two ways to configure local ephemeral storage on a node:
+Kubernetes supports the following ways to configure local ephemeral storage on a
+node:
 {{< tabs name="local_storage_configurations" >}}
 {{% tab name="Single filesystem" %}}
 In this configuration, you place all different kinds of ephemeral local data
 (`emptyDir` volumes, writeable layers, container images, logs) into one filesystem.
-The most effective way to configure the kubelet means dedicating this filesystem
-to Kubernetes (kubelet) data.
 
 The kubelet also writes
 [node-level container logs](/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)
@@ -61,30 +60,43 @@ and the kubelet is designed with that layout in mind.
 Your node can have as many other filesystems, not used for Kubernetes,
 as you like.
 {{% /tab %}}
-{{% tab name="Two filesystems" %}}
-You have a filesystem on the node that you're using for ephemeral data that
-comes from running Pods: logs, and `emptyDir` volumes. You can use this filesystem
-for other data (for example: system logs not related to Kubernetes); it can even
-be the root filesystem.
+{{% tab name="Runtime filesystem" %}}
+You use one filesystem on the node for ephemeral data from running Pods, such as
+logs and `emptyDir` volumes. You can also use this filesystem for other data,
+such as system logs that are not related to Kubernetes; it can even be the root
+filesystem.
 
 The kubelet also writes
 [node-level container logs](/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)
 into the first filesystem, and treats these similarly to ephemeral local storage.
 
 You also use a separate filesystem, backed by a different logical storage device.
-In this configuration, the directory where you tell the kubelet to place
-container image layers and writeable layers is on this second filesystem.
+In this configuration, the container runtime stores both container image layers
+and writeable layers on this second filesystem. Configure this storage location
+in your container runtime, not in the kubelet.
 
 The first filesystem does not hold any image layers or writeable layers.
 
 Your node can have as many other filesystems, not used for Kubernetes,
 as you like.
 {{% /tab %}}
+{{% tab name="Split image filesystem" %}}
+In this configuration, container image layers are on a separate filesystem, and
+container writeable layers are on the same filesystem as the kubelet's ephemeral
+data, such as logs and `emptyDir` volumes.
+
+This layout requires support for the `containerfs` eviction signals. For details
+about the feature gate and the container runtimes that support this layout, see
+[node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#filesystem-signals).
+{{% /tab %}}
 {{< /tabs >}}
 
-The kubelet can measure how much local storage it is using. It does this provided
-that you have set up the node using one of the supported configurations for local
-ephemeral storage.
+The [node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#filesystem-signals)
+page refers to these observed filesystems as `nodefs`, `imagefs`, and
+`containerfs`. Those names do not always mean separate mount points.
+
+The kubelet can measure local storage use when you set up the node using one of
+the supported configurations for local ephemeral storage.
 
 If you have a different configuration, then the kubelet does not apply resource
 limits for ephemeral local storage.
@@ -95,7 +107,10 @@ than as local ephemeral storage.
 {{< /note >}}
 
 {{< note >}}
-The kubelet will only track the root filesystem for ephemeral storage. OS layouts that mount a separate disk to `/var/lib/kubelet` or `/var/lib/containers` will not report ephemeral storage correctly.
+The kubelet can only track ephemeral storage on the filesystems it observes
+through the supported layouts. If you mount extra filesystems under paths such as
+`/var/lib/kubelet`, `/var/log`, or the container runtime storage directory
+outside those layouts, the kubelet might not report ephemeral storage correctly.
 {{< /note >}}
 
 ## Setting requests and limits for local ephemeral storage {#requests-limits}


### PR DESCRIPTION
## Summary

Fixes #23915.

This PR aligns the kubelet filesystem layout explanations across:

- `content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md`
- `content/en/docs/concepts/storage/ephemeral-storage.md`

It:

- clarifies how `nodefs`, `imagefs`, and `containerfs` map to underlying filesystems
- describes the supported filesystem layouts in terms that match kubelet eviction behavior
- updates local ephemeral storage docs to cover the split image filesystem layout
- fixes terminology mistakes such as `imagesfs` and `containersfs`

## Why

The current docs mix older two-filesystem wording with newer `nodefs` / `imagefs` / `containerfs` terminology. That makes it hard to tell which filesystems the kubelet actually tracks and when two identifiers refer to the same underlying filesystem.

## Impact

Readers diagnosing disk pressure or local ephemeral storage accounting should have a clearer path from the storage docs to the eviction docs, without needing to infer the layout from code or KEPs.

## Validation

- `git diff --check`
- `hugo --cleanDestinationDir --environment development --renderSegments en` with `hugo_extended_0.133.0`
