### PR TITLE
Follow-on fixes for style guide nits in pod lifecycle docs

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -29,14 +29,12 @@ plane marks the Pods for removal after a timeout period.
 
 ## Pod lifetime
 
-Whilst a Pod is running, the kubelet is able to restart containers to handle
+While a Pod is running, the kubelet is able to restart containers to handle
 some kind of faults. Within a Pod, Kubernetes tracks different container
 [states](#container-states) and determines what action to take to make the Pod
 healthy again. This is done in a [polling
 loop](/docs/reference/node/kubelet-sync-loop/) that periodically reconciles the
 desired state (a Pod spec) with the actual state of the running containers.
-Because of this polling mechanism, the status seen in the API (like `kubectl get
-pod`) might have a slight delay compared to the instant reality on the node.
 
 In the Kubernetes API, Pods have both a specification and an actual status. The
 status for a Pod object consists of a set of [Pod conditions](#pod-conditions).

--- a/content/en/docs/reference/node/kubelet-sync-loop.md
+++ b/content/en/docs/reference/node/kubelet-sync-loop.md
@@ -9,22 +9,22 @@ primary "node agent" that creates and watches Pods on each node. The `kubelet`
 runs a sync loop that periodically reconciles the desired state (a Pod spec)
 with the actual state of the running containers.
 
-1.  **Sync Loop**: The Sync Loop queues work (aggregated from many sources) for
+1.  _Sync Loop_: The Sync Loop queues work (aggregated from many sources) for
     the Pods assigned to its node (where `nodeName` matches the node). Over the
     course of each loop, subprocesses called pod workers will attempt to
     reconcile the desired state of these Pods against the current state of the
     running containers.
-2. **Sync Pod**: The majority of the `kubelet` logic is stored in a suite of
-   functions within the `podSyncer` interface, including the `SyncPod` function
-   and its variants (like `SyncTerminatingPod` and `SyncTerminatedPod`). During
-   each Sync Loop, a relevant `podSyncer` function will be executed for each Pod
-   in an attempt to drive its state on the node toward the desired state.
-3. **{{< glossary_tooltip term_id="cri" text="Container Runtime Interface" >}}
-   (CRI)**: To actually run the containers, the `kubelet` uses the CRI to talk
+2.  _Sync Pod_: The majority of the `kubelet` logic is stored in a suite of
+    functions within the `podSyncer` interface, including the `SyncPod` function
+    and its variants (like `SyncTerminatingPod` and `SyncTerminatedPod`). During
+    each Sync Loop, a relevant `podSyncer` function will be executed for each Pod
+    in an attempt to drive its state on the node toward the desired state.
+3.  _{{< glossary_tooltip term_id="cri" text="Container Runtime Interface" >}}
+    (CRI)_: To actually run the containers, the `kubelet` uses the CRI to talk
     to a container runtime (like containerd or CRI-O). The `kubelet` acts as the
     client, instructing the runtime to create a "pod sandbox" and then
     create/start the individual containers defined in the Pod spec.
-4.  **PLEG (Pod Lifecycle Event Generator)**: The `kubelet` needs to know when
+4.  _PLEG (Pod Lifecycle Event Generator)_: The `kubelet` needs to know when
     containers start, stop, or fail. It relies on a component called PLEG to
     periodically poll the runtime for the standard state of all containers. PLEG
     generates events that wake up the Sync Loop to update the Pod status.


### PR DESCRIPTION
### Description

Addresses leftover nits that I missed from PR https://github.com/kubernetes/website/pull/54177, specifically [these](https://github.com/kubernetes/website/pull/54177/changes/BASE..45f9e22ab859205c51af07a50277eb29cef2b57c) (sorry @aman4433!)

### Issue

No issue

/cc @aman4433