### PR TITLE
Update Config API reference for v1.36.0

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-admission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-admission.v1.md
@@ -60,7 +60,7 @@ auto_generated: true
 <tbody>
     
   
-<tr><td><code>uid</code> <B>[Required]</B><br/>
+<tr><td><code>uid</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
 </td>
 <td>
@@ -70,14 +70,14 @@ The UID is meant to track the round trip (request/response) between the KAS and 
 It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
 </td>
 </tr>
-<tr><td><code>kind</code> <B>[Required]</B><br/>
+<tr><td><code>kind</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#GroupVersionKind"><code>meta/v1.GroupVersionKind</code></a>
 </td>
 <td>
    <p>kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)</p>
 </td>
 </tr>
-<tr><td><code>resource</code> <B>[Required]</B><br/>
+<tr><td><code>resource</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#GroupVersionResource"><code>meta/v1.GroupVersionResource</code></a>
 </td>
 <td>
@@ -143,7 +143,7 @@ rely on the server to generate the name.  If that is the case, this field will c
    <p>namespace is the namespace associated with the request (if any).</p>
 </td>
 </tr>
-<tr><td><code>operation</code> <B>[Required]</B><br/>
+<tr><td><code>operation</code><br/>
 <a href="#admission-k8s-io-v1-Operation"><code>Operation</code></a>
 </td>
 <td>
@@ -151,8 +151,8 @@ rely on the server to generate the name.  If that is the case, this field will c
 requested. e.g. a patch can result in either a CREATE or UPDATE Operation.</p>
 </td>
 </tr>
-<tr><td><code>userInfo</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
+<tr><td><code>userInfo</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
    <p>userInfo is information about the requesting user</p>
@@ -210,7 +210,7 @@ Operation might be a CREATE, in which case the Options will a
 <tbody>
     
   
-<tr><td><code>uid</code> <B>[Required]</B><br/>
+<tr><td><code>uid</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
 </td>
 <td>
@@ -218,7 +218,7 @@ Operation might be a CREATE, in which case the Options will a
 This must be copied over from the corresponding AdmissionRequest.</p>
 </td>
 </tr>
-<tr><td><code>allowed</code> <B>[Required]</B><br/>
+<tr><td><code>allowed</code><br/>
 <code>bool</code>
 </td>
 <td>
@@ -226,7 +226,7 @@ This must be copied over from the corresponding AdmissionRequest.</p>
 </td>
 </tr>
 <tr><td><code>status</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#status-v1-meta"><code>meta/v1.Status</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#status-v1-meta"><code>meta/v1.Status</code></a>
 </td>
 <td>
    <p>status is the result contains extra details into why an admission request was denied.

--- a/content/en/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-audit.v1.md
@@ -71,14 +71,14 @@ For non-resource requests, this is the lower-cased HTTP method.</p>
 </td>
 </tr>
 <tr><td><code>user</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
    <p>Authenticated user information.</p>
 </td>
 </tr>
 <tr><td><code>impersonatedUser</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
    <p>Impersonated user information.</p>
@@ -123,7 +123,7 @@ Does not apply for List-type requests, or non-resource requests.</p>
 </td>
 </tr>
 <tr><td><code>responseStatus</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#status-v1-meta"><code>meta/v1.Status</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#status-v1-meta"><code>meta/v1.Status</code></a>
 </td>
 <td>
    <p>The response status, populated even when the ResponseObject is not a Status type.
@@ -151,14 +151,14 @@ at Response Level.</p>
 </td>
 </tr>
 <tr><td><code>requestReceivedTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
 </td>
 <td>
    <p>Time the request reached the apiserver.</p>
 </td>
 </tr>
 <tr><td><code>stageTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
 </td>
 <td>
    <p>Time the request reached current audit stage.</p>
@@ -195,7 +195,7 @@ should be short. Annotations are included in the Metadata level.</p>
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>
@@ -230,7 +230,7 @@ categories are logged.</p>
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
    <p>ObjectMeta is included for interoperability with API infrastructure.</p>
@@ -285,7 +285,7 @@ in a rule will override the global default.</p>
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>
@@ -345,7 +345,8 @@ the ImpersonatedUser associated with this audit event.  It is only set when cons
 </td>
 <td>
    <p>Group is the name of the API group that contains the resources.
-The empty string represents the core API group.</p>
+The empty string represents the core API group.
+<code>*</code> matches all groups</p>
 </td>
 </tr>
 <tr><td><code>resources</code><br/>

--- a/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
@@ -1018,6 +1018,13 @@ Must be absent/empty if TCPTransport.URL is prefixed with http://
 Must be configured if TCPTransport.URL is prefixed with https://</p>
 </td>
 </tr>
+<tr><td><code>tlsServerName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>tlsServerName is used to check server certificate. If tlsServerName is empty, the hostname used to contact the server is used.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
@@ -951,6 +951,13 @@ Must be absent/empty if TCPTransport.URL is prefixed with http://
 Must be configured if TCPTransport.URL is prefixed with https://</p>
 </td>
 </tr>
+<tr><td><code>tlsServerName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>tlsServerName is used to check server certificate. If tlsServerName is empty, the hostname used to contact the server is used.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/content/en/docs/reference/config-api/apiserver-webhookadmission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-webhookadmission.v1.md
@@ -35,6 +35,19 @@ auto_generated: true
    <p>KubeConfigFile is the path to the kubeconfig file.</p>
 </td>
 </tr>
+<tr><td><code>staticManifestsDir</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>StaticManifestsDir is the path to a directory containing static webhook
+configurations to be loaded at startup. Files with extensions .yaml,
+.yml, and .json are read. Only admissionregistration.k8s.io/v1
+ValidatingWebhookConfiguration and MutatingWebhookConfiguration
+resources are supported.
+Using this field requires the ManifestBasedAdmissionControlConfig
+feature gate to be enabled.</p>
+</td>
+</tr>
 </tbody>
 </table>
   

--- a/content/en/docs/reference/config-api/client-authentication.v1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1.md
@@ -205,7 +205,7 @@ itself should at least be protected via file permissions.</p>
     
   
 <tr><td><code>expirationTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>ExpirationTimestamp indicates a time when the provided credentials expire.</p>

--- a/content/en/docs/reference/config-api/client-authentication.v1beta1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1beta1.md
@@ -205,7 +205,7 @@ itself should at least be protected via file permissions.</p>
     
   
 <tr><td><code>expirationTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>ExpirationTimestamp indicates a time when the provided credentials expire.</p>

--- a/content/en/docs/reference/config-api/imagepolicy.v1alpha1.md
+++ b/content/en/docs/reference/config-api/imagepolicy.v1alpha1.md
@@ -28,14 +28,14 @@ auto_generated: true
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
    <p>Standard object's metadata.
 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata</p>
 Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#imagepolicy-k8s-io-v1alpha1-ImageReviewSpec"><code>ImageReviewSpec</code></a>
 </td>
 <td>
@@ -136,7 +136,7 @@ It is up to each webhook backend to determine how to interpret these annotations
 <tbody>
     
   
-<tr><td><code>allowed</code> <B>[Required]</B><br/>
+<tr><td><code>allowed</code><br/>
 <code>bool</code>
 </td>
 <td>

--- a/content/en/docs/reference/config-api/kube-controller-manager-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kube-controller-manager-config.v1alpha1.md
@@ -220,6 +220,15 @@ during leader election cycles.</p>
 concurrently synchronizing nodes</p>
 </td>
 </tr>
+<tr><td><code>ConcurrentNodeStatusUpdates</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>ConcurrentNodeStatusUpdates is the number of workers
+concurrently updating node statuses.
+If unspecified or 0, ConcurrentNodeSyncs is used instead</p>
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -921,6 +930,13 @@ ValidatingAdmissionPolicyStatusController related features.</p>
 </td>
 <td>
    <p>DeviceTaintEvictionControllerConfiguration contains elements configuring the device taint eviction controller.</p>
+</td>
+</tr>
+<tr><td><code>ResourceClaimController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceClaimControllerConfiguration"><code>ResourceClaimControllerConfiguration</code></a>
+</td>
+<td>
+   <p>ResourceClaimControllerConfiguration contains elements configuring the resource claim controller.</p>
 </td>
 </tr>
 </tbody>
@@ -1918,6 +1934,34 @@ CPU (and network) load.</p>
    <p>concurrentRCSyncs is the number of replication controllers that are
 allowed to sync concurrently. Larger number = more responsive replica
 management, but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceClaimControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceClaimControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ResourceClaimControllerConfiguration contains elements configuring the resource claim controller.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>ConcurrentSyncs is the number of operations (deleting a pod, updating a ResourcClaim status, etc.)
+that will be done concurrently. Larger number = processing, but more CPU (and network) load.</p>
+<p>The default is 50.</p>
 </td>
 </tr>
 </tbody>

--- a/content/en/docs/reference/config-api/kube-scheduler-config.v1.md
+++ b/content/en/docs/reference/config-api/kube-scheduler-config.v1.md
@@ -482,7 +482,7 @@ Defaults to false.</p>
     
   
 <tr><td><code>addedAffinity</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
 </td>
 <td>
    <p>AddedAffinity is applied to all Pods additionally to the NodeAffinity
@@ -581,7 +581,7 @@ The default strategy is LeastAllocated with an equal &quot;cpu&quot; and &quot;m
     
   
 <tr><td><code>defaultConstraints</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
 </td>
 <td>
    <p>DefaultConstraints defines topology spread constraints to be applied to
@@ -964,7 +964,7 @@ for that plugin.</p>
 - [PluginSet](#kubescheduler-config-k8s-io-v1-PluginSet)
 
 
-<p>Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.</p>
+<p>Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score and PlacementScore plugins.</p>
 
 
 <table class="table">
@@ -983,7 +983,7 @@ for that plugin.</p>
 <code>int32</code>
 </td>
 <td>
-   <p>Weight defines the weight of plugin, only used for Score plugins.</p>
+   <p>Weight defines the weight of plugin, only used for Score and PlacementScore plugins.</p>
 </td>
 </tr>
 </tbody>
@@ -1189,6 +1189,20 @@ set in both <code>multiPoint.Enabled</code> and <code>multiPoint.Disabled</code>
 including <code>multiPoint.Disabled = '*'</code> and <code>multiPoint.Enabled = pluginA</code> will still register that specific
 plugin through MultiPoint. This follows the same behavior as all other extension point configurations.</li>
 </ol>
+</td>
+</tr>
+<tr><td><code>placementGenerate</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   <p>PlacementGenerate is a list of plugins that should be invoked during pod group scheduling cycle when determining placements for a pod group.</p>
+</td>
+</tr>
+<tr><td><code>placementScore</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   <p>PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.</p>
 </td>
 </tr>
 </tbody>

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -309,7 +309,7 @@ for, so other administrators can know its purpose.</p>
 </td>
 </tr>
 <tr><td><code>expires</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
@@ -1043,7 +1043,7 @@ file from which to load cluster information.</p>
 </td>
 </tr>
 <tr><td><code>pathType</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
 </td>
 <td>
    <p><code>pathType</code> is the type of the <code>hostPath</code>.</p>
@@ -1269,7 +1269,7 @@ This information will be annotated to the Node API object, for later re-use.</p>
 </td>
 </tr>
 <tr><td><code>taints</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
    <p><code>taints</code> specifies the taints the Node API object should be registered with.
@@ -1301,7 +1301,7 @@ Value <code>all</code> ignores errors from all checks.</p>
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during kubeadm &quot;init&quot; and

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
@@ -408,7 +408,7 @@ for, so other administrators can know its purpose.</p>
 </td>
 </tr>
 <tr><td><code>expires</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
@@ -1262,7 +1262,7 @@ does not contain any other authentication information.</p>
     
   
 <tr><td><code>EnvVar</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvar-v1-core"><code>core/v1.EnvVar</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvar-v1-core"><code>core/v1.EnvVar</code></a>
 </td>
 <td>(Members of <code>EnvVar</code> are embedded into this type.)
    <span class="text-muted">No description provided.</span></td>
@@ -1446,7 +1446,7 @@ file from which to load cluster information.</p>
 </td>
 </tr>
 <tr><td><code>pathType</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
 </td>
 <td>
    <p><code>pathType</code> is the type of the <code>hostPath</code>.</p>
@@ -1683,7 +1683,7 @@ This information will be annotated to the Node API object, for later re-use.</p>
 </td>
 </tr>
 <tr><td><code>taints</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
    <p><code>taints</code> specifies the taints the Node API object should be registered with.
@@ -1716,7 +1716,7 @@ Value 'all' ignores errors from all checks.</p>
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during kubeadm <code>init</code> and
@@ -1993,7 +1993,7 @@ NOTE: This field is currently ignored for <code>kubeadm upgrade apply</code>, bu
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during <code>kubeadm upgrade apply</code> operations.
@@ -2108,7 +2108,7 @@ The list of phases can be obtained with the <code>kubeadm upgrade node phase --h
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during <code>kubeadm upgrade node</code> operations.

--- a/content/en/docs/reference/config-api/kubelet-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1alpha1.md
@@ -91,7 +91,7 @@ image represented by this record is being requested.</p>
     
   
 <tr><td><code>lastUpdatedTime</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>LastUpdatedTime is the time of the last update to this record</p>

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -427,7 +427,7 @@ image represented by this record is being requested.</p>
     
   
 <tr><td><code>lastUpdatedTime</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>LastUpdatedTime is the time of the last update to this record</p>
@@ -602,6 +602,20 @@ Default: &quot;&quot;</p>
    <p>tlsCipherSuites is the list of allowed cipher suites for the server.
 Note that TLS 1.3 ciphersuites are not configurable.
 Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Default: nil</p>
+</td>
+</tr>
+<tr><td><code>tlsCurvePreferences</code><br/>
+<code>[]int32</code>
+</td>
+<td>
+   <p>tlsCurvePreferences is the set of allowed key exchange mechanisms for the server,
+specified as numeric Go crypto/tls CurveID values.
+The supported values depend on the Go version used.
+See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version.
+The order of the list is ignored, and key exchange mechanisms are
+chosen by Go from this list using an internal preference order.
+If empty, the default Go curves will be used.
 Default: nil</p>
 </td>
 </tr>
@@ -865,6 +879,8 @@ Default: 40</p>
 <td>
    <p>imageMinimumGCAge is the minimum age for an unused image before it is
 garbage collected.
+The field value must be greater than 0.
+If unset or 0, defaults to 2m.
 Default: &quot;2m&quot;</p>
 </td>
 </tr>
@@ -1504,10 +1520,11 @@ Default: &quot;&quot;</p>
 <td>
    <p>This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
 This flag accepts a list of options. Acceptable options are <code>none</code>, <code>pods</code>,
-<code>system-reserved</code> and <code>kube-reserved</code>.
+<code>system-reserved</code>, <code>system-reserved-compressible</code>, <code>kube-reserved</code>, and <code>kube-reserved-compressible</code>.
 If <code>none</code> is specified, no other options may be specified.
-When <code>system-reserved</code> is in the list, systemReservedCgroup must be specified.
-When <code>kube-reserved</code> is in the list, kubeReservedCgroup must be specified.
+When a <code>system-reserved</code> option is in the list, systemReservedCgroup must be specified.
+When a <code>kube-reserved</code> option is in the list, kubeReservedCgroup must be specified.
+If a <code>compressible</code> option is specified, the corresponding non-compressible option may not be specified.
 This field is supported only when <code>cgroupsPerQOS</code> is set to true.
 Refer to <a href="https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable">Node Allocatable</a>
 for more information.
@@ -1706,8 +1723,21 @@ See https://kep.k8s.io/2570 for more details.
 Default: 0.9</p>
 </td>
 </tr>
+<tr><td><code>memoryReservationPolicy</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-MemoryReservationPolicy"><code>MemoryReservationPolicy</code></a>
+</td>
+<td>
+   <p>MemoryReservationPolicy controls how the kubelet applies cgroup v2 memory protection.
+&quot;None&quot; (default): The kubelet does not set memory.min for containers and pods,
+ensuring no hard memory is locked by the kernel.
+&quot;TieredReservation&quot;: The kubelet sets cgroup v2 memory.min for Guaranteed pods and memory.low for Burstable pods based on memory requests.
+Guaranteed memory is never reclaimed by the kernel; Burstable memory is preferentially retained but may be reclaimed under extreme pressure.
+See https://kep.k8s.io/2570 for more details.
+Default: None</p>
+</td>
+</tr>
 <tr><td><code>registerWithTaints</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
    <p>registerWithTaints are an array of taints to add to a node object when
@@ -1805,7 +1835,7 @@ It exists in the kubeletconfig API group because it is classified as a versioned
     
   
 <tr><td><code>source</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
 </td>
 <td>
    <p>source is the source that we are serializing.</p>
@@ -2336,13 +2366,27 @@ and groups corresponding to the Organization in the client certificate.</p>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>limits</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 </tbody>
 </table>
+
+## `MemoryReservationPolicy`     {#kubelet-config-k8s-io-v1beta1-MemoryReservationPolicy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+<p>MemoryReservationPolicy defines how the kubelet applies cgroup v2 memory protection.</p>
+
+
+
 
 ## `MemorySwapConfiguration`     {#kubelet-config-k8s-io-v1beta1-MemorySwapConfiguration}
     

--- a/content/en/docs/reference/config-api/kuberc.v1beta1.md
+++ b/content/en/docs/reference/config-api/kuberc.v1beta1.md
@@ -208,6 +208,18 @@ the plugin and the name in the allowlist entry using <code>exec.LookPath</code>.
 will be called on both, and the resulting strings must be equal. If
 either call to <code>exec.LookPath</code> results in an error, the <code>Name</code> check
 will be considered a failure.</p>
+<p>Deprecated: use Command instead.</p>
+</td>
+</tr>
+<tr><td><code>command</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Command matching is performed by first resolving the absolute path of both
+the plugin and the name in the allowlist entry using <code>exec.LookPath</code>. It
+will be called on both, and the resulting strings must be equal. If
+either call to <code>exec.LookPath</code> results in an error, the <code>Command</code> check
+will be considered a failure.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Regenerated Config API pages for Kubernetes v1.36.0. 

Generated via kubernetes-sigs/reference-docs genref.

/hold

depends on https://github.com/kubernetes-sigs/reference-docs/pull/439