### PR TITLE
[zh-cn]Add WorkloadAwarePreemption extend-websockets-to-kubelet cdi podgroup

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/WorkloadAwarePreemption.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/WorkloadAwarePreemption.md
@@ -1,0 +1,22 @@
+---
+title: WorkloadAwarePreemption
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.36"
+---
+
+<!--
+Enables the support for [Workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).
+
+When enabled, if a PodGroup fails to schedule, the scheduler will use a workload-aware preemption
+algorithm to select victims to preempt instead of the default pod preemption algorithm.
+-->
+启用对[工作负载感知抢占](/zh-cn/docs/concepts/scheduling-eviction/workload-aware-preemption/)的支持。
+
+启用后，如果 PodGroup 调度失败，调度器将使用工作负载感知抢占算法来选择要抢占的牺牲品，而不是默认的 Pod 抢占算法。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/extend-websockets-to-kubelet.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/extend-websockets-to-kubelet.md
@@ -1,0 +1,27 @@
+---
+title: ExtendWebSocketsToKubelet
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.36"
+---
+
+<!--
+When ExtendWebSocketsToKubelet is enabled and a kubelet node advertises support,
+exec/attach/portforward streams are proxied directly to the kubelet rather than
+being translated or tunneled at the API server. Critically, the same
+stream translation and tunneling handlers used at the API server are now set up
+identically at the kubelet — the logic is simply moved closer to the container
+runtime. This feature depends on NodeDeclaredFeatures graduating to beta so that
+kubelet capability advertisement is reliable in production clusters.
+-->
+当 ExtendWebSocketsToKubelet 启用且 kubelet 节点通告支持时，
+exec/attach/portforward 流量直接代理到 kubelet，而不是在 API 服务器处转换或隧道传输。
+关键在于，API 服务器使用的相同流转换和隧道处理程序现在在 kubelet
+中也以相同的方式设置 —— 逻辑只是更靠近容器运行时。
+此特性依赖于 NodeDeclaredFeatures 升级到 Beta，以便 kubelet 能力通告在生产集群中可靠。

--- a/content/zh-cn/docs/reference/glossary/cdi.md
+++ b/content/zh-cn/docs/reference/glossary/cdi.md
@@ -1,0 +1,31 @@
+---
+title: 容器设备接口（CDI）
+id: cdi
+full_link: /zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
+short_description: >
+  一种 CNCF 规范，用于描述容器运行时在创建容器时应用的设备配置。
+
+aka:
+tags:
+- extension
+---
+
+<!--
+The Container Device Interface (CDI) is a specification for how to configure
+devices inside containers. Kubernetes uses CDI together with device plugins and
+with Dynamic Resource Allocation so that workloads receive device setup such as
+bind mounts or environment variables from the runtime.
+-->
+容器设备接口（CDI）是一种规范，用于配置容器内部的设备。
+Kubernetes 使用 CDI 以及设备插件和动态资源分配，
+以便工作负载可以从运行时接收设备设置，例如绑定挂载或环境变量。
+
+<!--more-->
+
+<!--
+* [Device Plugins](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+* [Container Device Interface](https://github.com/cncf-tags/container-device-interface)
+  specification repository
+-->
+* [设备插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+* [容器设备接口](https://github.com/cncf-tags/container-device-interface)规范仓库

--- a/content/zh-cn/docs/reference/glossary/podgroup.md
+++ b/content/zh-cn/docs/reference/glossary/podgroup.md
@@ -1,0 +1,23 @@
+---
+title: PodGroup
+id: podgroup
+full_link: /zh-cn/docs/concepts/workloads/podgroup-api/
+short_description: >
+  PodGroup 表示一组具有共同调度策略和约束的 Pod。
+
+aka:
+tags:
+- core-object
+- workload
+---
+
+<!--
+A PodGroup is a runtime object that represents a group of Pods scheduled
+together as a single unit. While the
+[Workload API](/docs/concepts/workloads/workload-api/) defines scheduling policy
+templates, PodGroups are the runtime counterparts that carry both the policy and
+the scheduling status for a specific instance of that group.
+-->
+PodGroup 是一个运行时对象，代表作为单个单元一起调度的一组 Pod。
+虽然 [Workload API](/zh-cn/docs/concepts/workloads/workload-api/) 定义了调度策略模板，
+但 PodGroup 是运行时对应物，承载该组特定实例的策略和调度状态。


### PR DESCRIPTION
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/WorkloadAwarePreemption.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/extend-websockets-to-kubelet.md
content/zh-cn/docs/reference/glossary/cdi.md
content/zh-cn/docs/reference/glossary/podgroup.md