### PR TITLE
Correct release date in Blogpost for Gateway API v1.5 release

### DIFF
--- a/content/en/blog/_posts/2026/gateway-api-v1-5/index.md
+++ b/content/en/blog/_posts/2026/gateway-api-v1-5/index.md
@@ -14,17 +14,17 @@ authors: >
 ![Gateway API logo](gateway-api-logo.svg)
 
 The Kubernetes SIG Network community presents the release of Gateway API (v1.5)!
-Released on March 14, 2026, version 1.5 is our biggest release yet, and concentrates on moving existing Experimental features to Standard (Stable).
+Released on February 27, 2026, version 1.5 is our biggest release yet, and concentrates on moving existing Experimental features to Standard (Stable).
 
-The Gateway API [v1.5.1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1) patch release is already available
+The Gateway API [v1.5.1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1) patch release is already available.
 
 The Gateway API v1.5 brings six widely-requested feature promotions to the Standard channel (Gateway API's GA release channel):
 * ListenerSet
-* TLSRoute promoted to Stable
+* TLSRoute
 * HTTPRoute CORS Filter
 * Client Certificate Validation
 * Certificate Selection for Gateway TLS Origination
-* ReferenceGrant promoted to Stable
+* ReferenceGrant
 
 Special thanks for [Gateway API Contributors](https://github.com/kubernetes-sigs/gateway-api/blob/a811d174a406553006bbb9a3594b49380cb9069e/CHANGELOG/1.5-TEAM.md) for their efforts on this release.
 

--- a/content/en/blog/_posts/2026/gateway-api-v1-5/index.md
+++ b/content/en/blog/_posts/2026/gateway-api-v1-5/index.md
@@ -468,3 +468,5 @@ The maintainers would like to thank **everyone** who's contributed to Gateway
 API, whether in the form of commits to the repo, discussion, ideas, or general
 support. We could never have made this kind of progress without the support of
 this dedicated and active community.
+
+_This article was edited in April 2026 to correct the release date for Gateway API 1.5.0._


### PR DESCRIPTION
### Description

The date mentioned in the paragraph about 1.5 was the date of the release of 1.5.1. This is fixed in the present PR. Additionally:
 * A missing full stop is added at the end of the sentence.
 * The phrase "promoted to Standard" in bullet points is removed because it already appears in the introductory sentence.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #