### PR TITLE
Update the patch releases for the releases earlier than v1.36

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -190,25 +190,25 @@ url = "https://kubernetes.io"
 
 [[params.versions]]
 version = "v1.35"
-githubbranch = "v1.35.0"
+githubbranch = "v1.35.3"
 docsbranch = "release-1.35"
 url = "https://v1-35.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.34"
-githubbranch = "v1.34.0"
+githubbranch = "v1.34.6"
 docsbranch = "release-1.34"
 url = "https://v1-34.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.33"
-githubbranch = "v1.33.4"
+githubbranch = "v1.33.10"
 docsbranch = "release-1.33"
 url = "https://v1-33.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.32"
-githubbranch = "v1.32.8"
+githubbranch = "v1.32.13"
 docsbranch = "release-1.32"
 url = "https://v1-32.docs.kubernetes.io"
 


### PR DESCRIPTION
This PR updates patch releases to the correct versions in the hugo.toml for the releases prior to v1.36 release.