### PR TITLE
Add release info on available Kubernetes version page

### DIFF
--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -167,6 +167,9 @@ other = "Latest version"
 [docs_version_other_heading]
 other = "Older versions"
 
+[docs_version_release_information]
+other = "release information"
+
 [end_of_life]
 other = "End of Life:"
 

--- a/layouts/docs/supported-versions.html
+++ b/layouts/docs/supported-versions.html
@@ -30,6 +30,8 @@
         {{ if eq .version ( delimit $thisVersionArray "." ) }}
         {{ T "docs_version_current" }}
         {{ end }}
+        {{ $minor := strings.TrimPrefix "v" .version }}
+        – <a href="/releases/{{ $minor }}/">{{ T "docs_version_release_information" }}</a>
     </li>
     {{ end }}
     {{ if ne (index ($.Scratch.Get "version-class") 0) "placeholder" }}


### PR DESCRIPTION
### Description

Add a link to the corresponding release series page next to each version entry on the Available Documentation Versions page, providing an entry point to per-release information (release notes, announcement blog, etc.).

### Issue

Closes: #55526 

Preview: https://deploy-preview-55527--kubernetes-io-main-staging.netlify.app/docs/home/supported-doc-versions/