### PR TITLE
Add simple Ingress example for local environments

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -647,3 +647,24 @@ You can expose a Service in multiple ways that don't directly involve the Ingres
 * Learn about the [Ingress](/docs/reference/kubernetes-api/service-resources/ingress-v1/) API
 * Learn about [Ingress controllers](/docs/concepts/services-networking/ingress-controllers/)
 
+### Simple Ingress Example
+
+The following example defines a basic Ingress resource:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: simple-ingress
+spec:
+  rules:
+  - host: my-app.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 80


### PR DESCRIPTION
Add simple Ingress example for local environments

- Added a minimal working Ingress example
- Clarified usage for local clusters such as Minikube and K3d
- Improved readability for beginners

Tested on a local K3d cluster.
