### PR TITLE
Clarify that an Ingress controller is required

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -33,6 +33,8 @@ This means that:
   or updates made to it.
 {{< /note >}}
 
+To use Ingress, you must have an Ingress controller installed and running in your cluster.
+
 <!-- body -->
 
 


### PR DESCRIPTION
- Added a minimal working Ingress example
- Clarified usage for local clusters such as Minikube and K3d
- Improved readability for beginners

Tested on a local K3d cluster.