### PR TITLE
[ko] Sync docs landing page cards with en docs

### DIFF
--- a/content/ko/docs/home/_index.md
+++ b/content/ko/docs/home/_index.md
@@ -14,51 +14,53 @@ menu:
     title: "문서"
     weight: 10
 description: >
-  쿠버네티스는 컨테이너화된 애플리케이션의 배포, 확장 및 관리를 자동화하기 위한 오픈소스 컨테이너 오케스트레이션 엔진이다. 오픈소스 프로젝트는 Cloud Native Computing Foundation에서 주관한다.
+  쿠버네티스는 컨테이너화된 애플리케이션의 배포, 확장 및 관리를 자동화하기 위한 오픈소스 컨테이너 오케스트레이션 엔진이다. 본 오픈소스 프로젝트는 Cloud Native Computing Foundation이 주관한다.
 overview: >
-  쿠버네티스는 배포, 스케일링, 그리고 컨테이너화된 애플리케이션의 관리를 자동화 해주는 오픈 소스 컨테이너 오케스트레이션 엔진이다. 본 오픈 소스 프로젝트는 Cloud Native Computing Foundation(<a href="https://www.cncf.io/about">CNCF</a>)가 주관한다.
+  쿠버네티스는 컨테이너화된 애플리케이션의 배포, 확장 및 관리를 자동화하기 위한 오픈소스 컨테이너 오케스트레이션 엔진이다. 본 오픈소스 프로젝트는 Cloud Native Computing Foundation(<a href="https://www.cncf.io/about">CNCF</a>)이 주관한다.
 cards:
 - name: concepts
   title: "쿠버네티스 이해하기"
   description: "쿠버네티스와 쿠버네티스의 기본 개념을 배운다."
   button: "개념 살펴보기"
-  button_path: "/ko/docs/concepts"
+  button_path: "/docs/concepts"
 - name: tutorials
   title: "쿠버네티스 사용해보기"
   description: "쿠버네티스에 애플리케이션을 배포하는 방법을 튜토리얼을 따라하며 배운다."
   button: "튜토리얼 보기"
-  button_path: "/ko/docs/tutorials"
+  button_path: "/docs/tutorials"
 - name: setup
   title: "K8s 클러스터 구축하기"
   description: "보유한 자원과 요구에 맞게 동작하는 쿠버네티스를 구축한다."
   button: "쿠버네티스 구축하기"
-  button_path: "/ko/docs/setup"
+  button_path: "/docs/setup"
 - name: tasks
   title: "쿠버네티스 사용법 배우기"
   description: "일반적인 태스크와 이를 수행하는 방법을 여러 단계로 구성된 짧은 시퀀스를 통해 살펴본다."
   button: "태스크 보기"
-  button_path: "/ko/docs/tasks"
+  button_path: "/docs/tasks"
+- name: reference
+  title: 레퍼런스 정보 찾기
+  description: 용어, 커맨드 라인 구문, API 자원 종류, 그리고 설치 툴 문서를 살펴본다.
+  button: 레퍼런스 보기
+  button_path: /docs/reference
+- name: contribute
+  title: 쿠버네티스에 기여하기
+  description: 쿠버네티스를 더 나아지게 만드는 것을 어떻게 도울 수 있는지 알아본다.
+  button: 기여 방법 보기
+  button_path: "/docs/contribute"
 - name: training
   title: "교육"
   description: "공인 쿠버네티스 인증을 획득하고 클라우드 네이티브 프로젝트를 성공적으로 수행하세요!"
   button: "교육 보기"
   button_path: "/training"
-- name: reference
-  title: 레퍼런스 정보 찾기
-  description: 용어, 커맨드 라인 구문, API 자원 종류, 그리고 설치 툴 문서를 살펴본다.
-  button: 레퍼런스 보기
-  button_path: "/ko/docs/reference"
-- name: contribute
-  title: 문서에 기여하기
-  description: 이 프로젝트가 처음인 사람이든, 오래 활동한 사람이든 상관없이 누구나 기여할 수 있다.
-  button: 문서에 기여하기
-  button_path: "/ko/docs/contribute"
-- name: release-notes
-  title: K8s 릴리스 노트
-  description: 쿠버네티스를 설치하거나 최신의 버전으로 업그레이드하는 경우, 현재 릴리스 노트를 참고한다.
+- name: Download
+  title: 쿠버네티스 다운로드
+  description: 쿠버네티스를 설치하거나 최신 버전으로 업그레이드한다.
   button: "쿠버네티스 다운로드"
   button_path: "/releases/download"
 - name: about
   title: 문서에 대하여
   description: 이 웹사이트는 현재 버전과 이전 4개 버전의 쿠버네티스 문서를 포함한다.
+  button: "사용 가능한 버전 보기"
+  button_path: "/docs/home/supported-doc-versions"
 ---


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Syncs `_index.md` with the en docs.
removes `/ko` link prefixes, reorders cards, updates the contribute card, replaces release-notes with Download, and adds `button`/`button_path` to about.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #