### PR TITLE
Add developowl to sig-docs-ko-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -144,6 +144,7 @@ aliases:
     - Okabe-Junya
     - t-inu
   sig-docs-ko-owners: # Admins for Korean content
+    - developowl
     - gochist
     - ianychoi
     - jihoon-seo


### PR DESCRIPTION
Added myself to sig-docs-ko-owners.

[[Requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-2)]

Reviewer of the codebase for at least 3 months - I have been a ko-reviewer since [Jan 26, 2026](https://github.com/kubernetes/website/pull/54119).

- Primary reviewer for at least 10 substantial PRs to the codebase - [is:pr assignee:developowl](https://github.com/kubernetes/website/pulls?q=is%3Apr+assignee%3Adevelopowl)

- Reviewed or merged at least 30 PRs to the codebase

  - Reviewed: [is:pr reviewed-by: developowl](https://github.com/kubernetes/website/pulls?q=is%3Apr+reviewed-by%3Adevelopowl)
  - Merged: [is:pr is:merged author: developowl](https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Amerged+author%3Adevelopowl+)

/cc @kubernetes/sig-docs-ko-owners 🥝