### PR TITLE
Update latest patch releases for v1.33.11, v1.34.7, and v1.35.4

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -15,11 +15,11 @@ schedules:
   releaseDate: "2026-04-22"
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
-  next:
-    cherryPickDeadline: "2026-04-10"
+  next: {}
+  previousPatches:
+  - cherryPickDeadline: "2026-04-10"
     release: 1.35.4
     targetDate: "2026-04-14"
-  previousPatches:
   - cherryPickDeadline: "2026-03-13"
     release: 1.35.3
     targetDate: "2026-03-19"
@@ -37,11 +37,11 @@ schedules:
   releaseDate: "2025-12-17"
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
-  next:
-    cherryPickDeadline: "2026-04-10"
+  next: {}
+  previousPatches:
+  - cherryPickDeadline: "2026-04-10"
     release: 1.34.7
     targetDate: "2026-04-14"
-  previousPatches:
   - cherryPickDeadline: "2026-03-13"
     release: 1.34.6
     targetDate: "2026-03-19"
@@ -71,11 +71,11 @@ schedules:
   releaseDate: "2025-08-27"
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
-  next:
-    cherryPickDeadline: "2026-04-10"
+  next: {}
+  previousPatches:
+  - cherryPickDeadline: "2026-04-10"
     release: 1.33.11
     targetDate: "2026-04-14"
-  previousPatches:
   - cherryPickDeadline: "2026-03-13"
     release: 1.33.10
     targetDate: "2026-03-19"


### PR DESCRIPTION
All three patch releases were released on 2026-04-14 but were not
moved from next: to previousPatches in schedule.yaml , causing the
release pages to show stale patch versions as latest

Releases confirmed at -
- https://github.com/kubernetes/kubernetes/releases/tag/v1.35.4
- https://github.com/kubernetes/kubernetes/releases/tag/v1.34.7
- https://github.com/kubernetes/kubernetes/releases/tag/v1.33.11

Closes: #55542