### PR TITLE
[zh-cn] Sync job-v1.md translation

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -7,18 +7,8 @@ content_type: "api_reference"
 description: "Job 表示单个任务的配置。"
 title: "Job"
 weight: 10
----
-<!--
-api_metadata:
-apiVersion: "batch/v1"
-import: "k8s.io/api/batch/v1"
-kind: "Job"
-content_type: "api_reference"
-description: "Job represents the configuration of a single job."
-title: "Job"
-weight: 10
 auto_generated: true
--->
+---
 
 `apiVersion: batch/v1`
 


### PR DESCRIPTION
Sync Chinese translation for content/zh-cn/docs/reference/kubernetes-api/workload-resources/job-v1.md

Fixes:
- Add missing `auto_generated: true` to frontmatter
- Remove duplicate EN frontmatter from HTML comment

Following the pattern of kubernetes/website#55562