### PR TITLE
Publish blog post on user namespaces in Kubernetes

### DIFF
--- a/content/zh-cn/blog/_posts/2026/user-namespaces-goes-ga.md
+++ b/content/zh-cn/blog/_posts/2026/user-namespaces-goes-ga.md
@@ -1,9 +1,8 @@
 ---
 layout: blog
 title: "Kubernetes v1.36：用户命名空间终于正式可用"
-date: 2026-04-22
+date: 2026-04-23T10:35:00-08:00
 slug: userns-ga
-draft: true
 author: >
   Rodrigo Campos Catelin (Amutable),
   Giuseppe Scrivano (Red Hat)
@@ -13,9 +12,8 @@ translator: >
 <!--
 layout: blog
 title: "User Namespaces in Kubernetes: Finally GA"
-date: 2026-04-22
+date: 2026-04-23T10:35:00-08:00
 slug: userns-ga
-draft: true
 author: >
   Rodrigo Campos Catelin (Amutable),
   Giuseppe Scrivano (Red Hat)


### PR DESCRIPTION
Updated the publication date and removed draft status for the blog post.

### Description

My local branch is not update-to-date.
In https://github.com/kubernetes/website/pull/55552, I forget to update the draft:true and blog release date.

### Issue

Sync https://github.com/kubernetes/website/pull/55475

Closes: None