### PR TITLE
[ko] update outdated links and fix typo

### DIFF
--- a/content/ko/docs/contribute/advanced.md
+++ b/content/ko/docs/contribute/advanced.md
@@ -119,7 +119,7 @@ SIG Docs의 공동 의장 역할을 할 수 있다.
 쿠버네티스 멤버가 공동 의장이 되려면 다음의 요구 사항을 충족해야 한다.
 
 - SIG Docs 워크플로와 툴링을 이해한다(git, Hugo, 현지화, 블로그 하위 프로젝트).
-- [k/org의 팀](https://github.com/kubernetes/org/blob/master/config/kubernetes/sig-docs/teams.yaml),
+- [k/org의 팀](https://github.com/kubernetes/org/blob/main/config/kubernetes/sig-docs/teams.yaml),
   [k/community의 프로세스](https://github.com/kubernetes/community/tree/main/sig-docs),
   [k/test-infra](https://github.com/kubernetes/test-infra/)의 플러그인 및
   [SIG 아키텍처](https://github.com/kubernetes/community/tree/main/sig-architecture)의

--- a/content/ko/docs/contribute/advanced.md
+++ b/content/ko/docs/contribute/advanced.md
@@ -120,13 +120,13 @@ SIG Docs의 공동 의장 역할을 할 수 있다.
 
 - SIG Docs 워크플로와 툴링을 이해한다(git, Hugo, 현지화, 블로그 하위 프로젝트).
 - [k/org의 팀](https://github.com/kubernetes/org/blob/master/config/kubernetes/sig-docs/teams.yaml),
-  [k/community의 프로세스](https://github.com/kubernetes/community/tree/master/sig-docs),
+  [k/community의 프로세스](https://github.com/kubernetes/community/tree/main/sig-docs),
   [k/test-infra](https://github.com/kubernetes/test-infra/)의 플러그인 및
-  [SIG 아키텍처](https://github.com/kubernetes/community/tree/master/sig-architecture)의
+  [SIG 아키텍처](https://github.com/kubernetes/community/tree/main/sig-architecture)의
   역할을 포함하여 다른 쿠버네티스 SIG와 리포지터리가 SIG Docs 워크플로에 미치는
   영향을 이해한다.
   추가로, [쿠버네티스 문서 릴리스 프로세스](/ko/docs/contribute/advanced/#쿠버네티스-릴리스를-위한-문서-조정)가 어떻게 동작하는지 이해한다.
-- SIG Docs 커뮤니티에 이해 직접적으로 또는 lazy consensus(특정 기간 내에 아무런 의견이 없으면 통과)를 통해 승인된다.
+- SIG Docs 커뮤니티에 의해 직접적으로 또는 lazy consensus(특정 기간 내에 아무런 의견이 없으면 통과)를 통해 승인된다.
 - 최소 6개월 동안 일주일에 5시간 이상(대부분 더)을 역할에 책임진다.
 
 ### 책임
@@ -147,7 +147,7 @@ SIG Docs의 공동 의장 역할을 할 수 있다.
 
 효과적으로 회의를 예약하고 진행하기 위해, 이 지침은 수행할 작업, 수행 방법과 이유를 보여준다.
 
-**[커뮤니티 행동 강령](https://github.com/cncf/foundation/blob/master/code-of-conduct-languages/ko.md)을 지킨다**.
+**[커뮤니티 행동 강령](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ko.md)을 지킨다**.
 
 - 정중함을 유지하고, 포괄적인 언어로, 정중하고 포괄적인 토론을 한다.
 
@@ -178,7 +178,7 @@ SIG Docs의 공동 의장 역할을 할 수 있다.
 
 **줌(Zoom)을 효과적으로 사용한다**.
 
-- [쿠버네티스에 대한 줌 가이드라인](https://github.com/kubernetes/community/blob/master/communication/zoom-guidelines.md)에 익숙해진다.
+- [쿠버네티스에 대한 줌 가이드라인](https://github.com/kubernetes/community/blob/main/communication/zoom-guidelines.md)에 익숙해진다.
 - 호스트 키를 입력하여 로그인할 때 호스트 역할을 선택한다.
 
 <img src="/images/docs/contribute/claim-host.png" width="75%" alt="줌에서 호스트 역할 신청" />
@@ -193,4 +193,4 @@ SIG Docs의 공동 의장 역할을 할 수 있다.
 
 ### SIG 공동 의장 임기 해제 (명예직)
 
-참고: [k/community/sig-docs/offboarding.md](https://github.com/kubernetes/community/blob/master/sig-docs/offboarding.md)
+참고: [k/community/sig-docs/offboarding.md](https://github.com/kubernetes/community/blob/main/sig-docs/offboarding.md)


### PR DESCRIPTION
### Description

This PR updates outdated GitHub links from `master` to `main` and fixes a typo in the Korean advanced contribution guide.

### Issue

Fixes #53264