### PR TITLE
docs: clarify RestartAllContainersOnContainerExits dependency

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RestartAllContainersOnContainerExits.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RestartAllContainersOnContainerExits.md
@@ -17,6 +17,6 @@ stages:
 Enables the ability to specify
 `RestartAllContainers` as an action in container `restartPolicyRules`. When a container's exit matches a rule with this action, the entire Pod is terminated and restarted in-place.
 
-In Kubernetes 1.35, `RestartAllContainersOnContainerExits` depends on `NodeDeclaredFeatures`. Because `NodeDeclaredFeatures` is disabled by default in Kubernetes 1.35, kubelet startup can fail if only `RestartAllContainersOnContainerExits` is enabled.
+`RestartAllContainersOnContainerExits` depends on both the `ContainerRestartRules` and `NodeDeclaredFeatures` feature gates. If the dependent feature gates are not enabled, kubelet startup can fail.
 
 See [Restart All Containers](/docs/concepts/workloads/pods/pod-lifecycle/#restart-all-containers) for more details.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RestartAllContainersOnContainerExits.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RestartAllContainersOnContainerExits.md
@@ -16,4 +16,7 @@ stages:
 ---
 Enables the ability to specify
 `RestartAllContainers` as an action in container `restartPolicyRules`. When a container's exit matches a rule with this action, the entire Pod is terminated and restarted in-place.
+
+In Kubernetes 1.35, `RestartAllContainersOnContainerExits` depends on `NodeDeclaredFeatures`. Because `NodeDeclaredFeatures` is disabled by default in Kubernetes 1.35, kubelet startup can fail if only `RestartAllContainersOnContainerExits` is enabled.
+
 See [Restart All Containers](/docs/concepts/workloads/pods/pod-lifecycle/#restart-all-containers) for more details.


### PR DESCRIPTION
### Description

This PR clarifies a dependency between feature gates in Kubernetes 1.35.
Enabling `RestartAllContainersOnContainerExits` without also enabling
`NodeDeclaredFeatures` can cause kubelet startup failures.
This dependency exists in code and is reflected in runtime behavior, but is not documented at the feature gate action point.

### Issue

Closes: #55580
