### PR TITLE
Add release codename in release pages

### DIFF
--- a/content/en/blog/_posts/2018/kubernetes-1-10-stabilizing-storage-security-networking.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-10-stabilizing-storage-security-networking.md
@@ -6,6 +6,8 @@ slug: kubernetes-1.10-stabilizing-storage-security-networking
 evergreen: true
 release_announcement:
   minor_version: "1.10"
+  themes:
+    - "Left Shark"
 author: >
   [Kubernetes v1.10 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.10/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-11-release-announcement.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-11-release-announcement.md
@@ -6,6 +6,8 @@ slug: kubernetes-1.11-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.11"
+  themes:
+    - "Eleventy-One: A Long-Expected Release"
 author: >
   [Kubernetes v1.11 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-12-release-announcement.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-12-release-announcement.md
@@ -6,6 +6,8 @@ evergreen: true
 slug: kubernetes-1-12-release-announcement
 release_announcement:
   minor_version: "1.12"
+  themes:
+    - "A next iteration in the evolving stable distributed system"
 author: >
   [Kubernetes v1.12 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)
 ---

--- a/content/en/blog/_posts/2018/kubernetes-1-13-release-announcement.md
+++ b/content/en/blog/_posts/2018/kubernetes-1-13-release-announcement.md
@@ -6,6 +6,8 @@ slug: kubernetes-1-13-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.13"
+  themes:
+    - "Angel Release"
 author: >
   [Kubernetes v1.13 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.13/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/1-14-release-announcement.md
+++ b/content/en/blog/_posts/2019/1-14-release-announcement.md
@@ -5,6 +5,8 @@ slug: kubernetes-1-14-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.14"
+  themes:
+    - "Caturnetes"
 author: >
   [Kubernetes v1.14 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.14/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/kubernetes-1-15-release-announcement.md
+++ b/content/en/blog/_posts/2019/kubernetes-1-15-release-announcement.md
@@ -6,6 +6,8 @@ slug: kubernetes-1-15-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.15"
+  themes:
+    - "The Persevering Release"
 author: >
   [Kubernetes 1.15 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.15/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/kubernetes-1-16-release-announcement.md
+++ b/content/en/blog/_posts/2019/kubernetes-1-16-release-announcement.md
@@ -5,6 +5,8 @@ date: 2019-09-18
 slug: kubernetes-1-16-release-announcement
 release_announcement:
   minor_version: "1.16"
+  themes:
+    - "Unlimited Breadsticks For All"
 author: >
   [Kubernetes 1.16 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.16/release_team.md)
 ---

--- a/content/en/blog/_posts/2019/kubernetes-1.17-release-announcement.md
+++ b/content/en/blog/_posts/2019/kubernetes-1.17-release-announcement.md
@@ -6,6 +6,9 @@ slug: kubernetes-1-17-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.17"
+  themes:
+    - "Stability"
+    - "The Chillest Release"
 author: >
   [Kubernetes 1.17 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.17/release_team.md)
 ---

--- a/content/en/blog/_posts/2020/kubernetes-1.18-release-announcement.md
+++ b/content/en/blog/_posts/2020/kubernetes-1.18-release-announcement.md
@@ -6,6 +6,9 @@ slug: kubernetes-1-18-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.18"
+  themes:
+    - "Fit & Finish"
+    - "A Bit Quarky"
 author: >
   [Kubernetes 1.18 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.18/release_team.md) 
 ---

--- a/content/en/blog/_posts/2020/kubernetes-release-1.19.md
+++ b/content/en/blog/_posts/2020/kubernetes-release-1.19.md
@@ -6,6 +6,8 @@ slug: kubernetes-release-1.19-accentuate-the-paw-sitive
 evergreen: true
 release_announcement:
   minor_version: "1.19"
+  themes:
+    - "Accentuate the Paw-sitive"
 author: >
   [Kubernetes 1.19 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.19/release_team.md)
 ---

--- a/content/en/blog/_posts/2020/kubernetes-release-1.20.md
+++ b/content/en/blog/_posts/2020/kubernetes-release-1.20.md
@@ -6,6 +6,8 @@ slug: kubernetes-1-20-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.20"
+  themes:
+    - "The Raddest Release"
 author: >
   [Kubernetes 1.20 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release_team.md)
 ---

--- a/content/en/blog/_posts/2021/kubernetes-release-1.21.md
+++ b/content/en/blog/_posts/2021/kubernetes-release-1.21.md
@@ -6,6 +6,8 @@ slug: kubernetes-1-21-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.21"
+  themes:
+    - "Power to the Community"
 author: >
   [Kubernetes 1.21 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md)
 ---

--- a/content/en/blog/_posts/2021/kubernetes-release-1.22.md
+++ b/content/en/blog/_posts/2021/kubernetes-release-1.22.md
@@ -6,6 +6,8 @@ slug: kubernetes-1-22-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.22"
+  themes:
+    - "Reaching New Peaks"
 author: >
   [Kubernetes 1.22 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.22/release-team.md)
 ---

--- a/content/en/blog/_posts/2021/kubernetes-release-1.23.md
+++ b/content/en/blog/_posts/2021/kubernetes-release-1.23.md
@@ -6,6 +6,8 @@ slug: kubernetes-1-23-release-announcement
 evergreen: true
 release_announcement:
   minor_version: "1.23"
+  themes:
+    - "The Next Frontier"
 author: >
   [Kubernetes 1.23 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/release-team.md)
 ---

--- a/content/en/blog/_posts/2022/kubernetes-1.25-blog.md
+++ b/content/en/blog/_posts/2022/kubernetes-1.25-blog.md
@@ -5,6 +5,8 @@ date: 2022-08-23
 slug: kubernetes-v1-25-release
 release_announcement:
   minor_version: "1.25"
+  themes:
+    - "Combiner"
 author: >
   [Kubernetes 1.25 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.25/release-team.md)
 ---

--- a/content/en/blog/_posts/2022/kubernetes-1.26-blog.md
+++ b/content/en/blog/_posts/2022/kubernetes-1.26-blog.md
@@ -5,6 +5,8 @@ date: 2022-12-09
 slug: kubernetes-v1-26-release
 release_announcement:
   minor_version: "1.26"
+  themes:
+    - "Electrifying"
 author: >
   [Kubernetes 1.26 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)
 ---

--- a/content/en/blog/_posts/2022/kubernetes-release-1.24.md
+++ b/content/en/blog/_posts/2022/kubernetes-release-1.24.md
@@ -5,6 +5,8 @@ date: 2022-05-03
 slug: kubernetes-1-24-release-announcement
 release_announcement:
   minor_version: "1.24"
+  themes:
+    - "Stargazer"
 author: >
   [Kubernetes 1.24 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)
 ---

--- a/content/en/blog/_posts/2023/kubernetes-1.27-release.md
+++ b/content/en/blog/_posts/2023/kubernetes-1.27-release.md
@@ -5,6 +5,8 @@ date: 2023-04-11
 slug: kubernetes-v1-27-release
 release_announcement:
   minor_version: "1.27"
+  themes:
+    - "Chill Vibes"
 author: >
    [Kubernetes v1.27 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.27/release-team.md)
 ---

--- a/content/en/blog/_posts/2023/kubernetes-1.28-blog.md
+++ b/content/en/blog/_posts/2023/kubernetes-1.28-blog.md
@@ -5,6 +5,8 @@ date: 2023-08-15T12:00:00+0000
 slug: kubernetes-v1-28-release
 release_announcement:
   minor_version: "1.28"
+  themes:
+    - "Planternetes"
 author: >
   [Kubernetes v1.28 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/release-team.md)
 ---

--- a/content/en/blog/_posts/2023/kubernetes-1.29.md
+++ b/content/en/blog/_posts/2023/kubernetes-1.29.md
@@ -5,6 +5,8 @@ date: 2023-12-13
 slug: kubernetes-v1-29-release
 release_announcement:
   minor_version: "1.29"
+  themes:
+    - "Mandala (The Universe)"
 author: >
  [Kubernetes v1.29 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release-team.md)
 ---

--- a/content/en/blog/_posts/2024/kubernetes-v1-30-release.md
+++ b/content/en/blog/_posts/2024/kubernetes-v1-30-release.md
@@ -5,6 +5,8 @@ date: 2024-04-17
 slug: kubernetes-v1-30-release
 release_announcement:
   minor_version: "1.30"
+  themes:
+    - "Uwubernetes"
 author: >
   [Kubernetes v1.30 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.30/release-team.md)
 ---

--- a/content/en/blog/_posts/2024/kubernetes-v1-31-release.md
+++ b/content/en/blog/_posts/2024/kubernetes-v1-31-release.md
@@ -5,6 +5,8 @@ date: 2024-08-13
 slug: kubernetes-v1-31-release
 release_announcement:
   minor_version: "1.31"
+  themes:
+    - "Elli"
 author: >
   [Kubernetes v1.31 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.31/release-team.md)
 ---

--- a/content/en/blog/_posts/2024/kubernetes-v1-32-release/index.md
+++ b/content/en/blog/_posts/2024/kubernetes-v1-32-release/index.md
@@ -5,6 +5,8 @@ date: 2024-12-11
 slug: kubernetes-v1-32-release
 release_announcement:
   minor_version: "1.32"
+  themes:
+    - "Penelope"
 author: >
   [Kubernetes v1.32 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.32/release-team.md)
 ---

--- a/content/en/blog/_posts/2025/kubernetes-v1-33-release/index.md
+++ b/content/en/blog/_posts/2025/kubernetes-v1-33-release/index.md
@@ -6,6 +6,8 @@ slug: kubernetes-v1-33-release
 evergreen: true
 release_announcement:
   minor_version: "1.33"
+  themes:
+    - "Octarine (The Color of Magic)"
 author: >
   [Kubernetes v1.33 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.33/release-team.md)
 ---

--- a/content/en/blog/_posts/2025/kubernetes-v1-34-release/index.md
+++ b/content/en/blog/_posts/2025/kubernetes-v1-34-release/index.md
@@ -6,6 +6,8 @@ evergreen: true
 slug: kubernetes-v1-34-release
 release_announcement:
   minor_version: "1.34"
+  themes:
+    - "Of Wind & Will (O' WaW)"
 author: >
   [Kubernetes v1.34 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.34/release-team.md)
 ---

--- a/content/en/blog/_posts/2025/kubernetes-v1-35-release/index.md
+++ b/content/en/blog/_posts/2025/kubernetes-v1-35-release/index.md
@@ -6,6 +6,8 @@ evergreen: true
 slug: kubernetes-v1-35-release
 release_announcement:
   minor_version: "1.35"
+  themes:
+    - "Timbernetes (The World Tree Release)"
 author: >
   [Kubernetes v1.35 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.35/release-team.md)
 ---

--- a/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md
@@ -4,10 +4,12 @@ title: "Kubernetes v1.36: ハル (Haru)"
 date: 2026-04-22
 evergreen: true
 slug: kubernetes-v1-36-release
-author: >
-  [Kubernetes v1.36 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-team.md)
 release_announcement:
   minor_version: "1.36"
+  themes:
+    - "ハル (Haru)"
+author: >
+  [Kubernetes v1.36 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-team.md)
 ---
 
 **Editors:** Chad M. Crowell, Kirti Goyal, Sophia Ugochukwu, Swathi Rao, Utkarsh Umre

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -1,44 +1,9 @@
 {{ define "main" }}
 
-{{/* Map minor version -> release blog URL and theme. Fall back to English when a
-     localized announcement post is missing for the current language. */}}
-{{ $releaseBlogMap := dict }}
-
-{{/* Seed with English entries first. */}}
-{{ $englishSite := index (where site.Sites "Language.Lang" "en") 0 }}
-{{ range where $englishSite.RegularPages "Section" "blog" }}
-  {{ $releaseAnnouncement := .Params.release_announcement }}
-  {{ if $releaseAnnouncement }}
-    {{ $version := $releaseAnnouncement.minor_version }}
-    {{ if $version }}
-      {{ $themes := $releaseAnnouncement.themes }}
-      {{ $primaryTheme := "" }}
-      {{ if and $themes (gt (len $themes) 0) }}
-        {{ $primaryTheme = index $themes 0 }}
-      {{ end }}
-      {{ $entry := dict "url" .RelPermalink "theme" $primaryTheme }}
-      {{ $releaseBlogMap = merge $releaseBlogMap (dict $version $entry) }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
-{{/* Override with current language entries when present. */}}
-{{ range where site.Pages "Section" "blog" }}
-  {{ $releaseAnnouncement := .Params.release_announcement }}
-  {{ if $releaseAnnouncement }}
-    {{ $version := $releaseAnnouncement.minor_version }}
-    {{ if $version }}
-      {{ $themes := $releaseAnnouncement.themes }}
-      {{ $primaryTheme := "" }}
-      {{ if and $themes (gt (len $themes) 0) }}
-        {{ $primaryTheme = index $themes 0 }}
-      {{ end }}
-      {{ $entry := dict "url" .RelPermalink "theme" $primaryTheme }}
-      {{ $releaseBlogMap = merge $releaseBlogMap (dict $version $entry) }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
+{{/* Map minor version -> release blog URL and theme for the current language,
+     falling back to English. Cached per language so the scan runs once per
+     language per build. */}}
+{{ $releaseBlogMap := partialCached "docs/release-announcement-map.html" . site.Language.Lang }}
 {{ $currentBlog := index $releaseBlogMap .Params.minorVersion }}
 
 <article class="td-content">

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -1,4 +1,46 @@
 {{ define "main" }}
+
+{{/* Map minor version -> release blog URL and theme. Fall back to English when a
+     localized announcement post is missing for the current language. */}}
+{{ $releaseBlogMap := dict }}
+
+{{/* Seed with English entries first. */}}
+{{ $englishSite := index (where site.Sites "Language.Lang" "en") 0 }}
+{{ range where $englishSite.RegularPages "Section" "blog" }}
+  {{ $releaseAnnouncement := .Params.release_announcement }}
+  {{ if $releaseAnnouncement }}
+    {{ $version := $releaseAnnouncement.minor_version }}
+    {{ if $version }}
+      {{ $themes := $releaseAnnouncement.themes }}
+      {{ $primaryTheme := "" }}
+      {{ if and $themes (gt (len $themes) 0) }}
+        {{ $primaryTheme = index $themes 0 }}
+      {{ end }}
+      {{ $entry := dict "url" .RelPermalink "theme" $primaryTheme }}
+      {{ $releaseBlogMap = merge $releaseBlogMap (dict $version $entry) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* Override with current language entries when present. */}}
+{{ range where site.Pages "Section" "blog" }}
+  {{ $releaseAnnouncement := .Params.release_announcement }}
+  {{ if $releaseAnnouncement }}
+    {{ $version := $releaseAnnouncement.minor_version }}
+    {{ if $version }}
+      {{ $themes := $releaseAnnouncement.themes }}
+      {{ $primaryTheme := "" }}
+      {{ if and $themes (gt (len $themes) 0) }}
+        {{ $primaryTheme = index $themes 0 }}
+      {{ end }}
+      {{ $entry := dict "url" .RelPermalink "theme" $primaryTheme }}
+      {{ $releaseBlogMap = merge $releaseBlogMap (dict $version $entry) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $currentBlog := index $releaseBlogMap .Params.minorVersion }}
+
 <article class="td-content">
   {{ if eq .Params.status "end-of-life" }}
   <div class="pageinfo pageinfo-warning">
@@ -25,7 +67,13 @@
   </div>
   {{ end }}
 
-  <h1>{{ .Title }}</h1>
+  <h1>
+    {{ .Title }}
+      {{ with $currentBlog }}
+        {{ with .theme }}: {{ . }}
+      {{ end }}
+    {{ end }}
+  </h1>
 
   <p>
     {{ T "release_series_page_intro"
@@ -156,24 +204,13 @@
         {{ T "release_github_tag" }} ({{ .Params.latestPatchVersion }})
       </a>
     </li>
-    {{/* Build release blog URL map by scanning all blog posts */}}
-    {{ $releaseBlogMap := dict }}
-    {{ range where site.Pages "Section" "blog" }}
-      {{ $releaseAnnouncement := .Params.release_announcement }}
-      {{ if $releaseAnnouncement }}
-        {{ $version := $releaseAnnouncement.minor_version }}
-        {{ if $version }}
-          {{ $releaseBlogMap = merge $releaseBlogMap (dict $version .RelPermalink) }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-    {{ with index $releaseBlogMap .Params.minorVersion }}
+    {{ with $currentBlog }}{{ with .url }}
       <li>
         <a href="{{ . }}">
           {{ T "release_announcement_blog" }}
         </a>
       </li>
-    {{ end }}
+    {{ end }}{{ end }}
   </ul>
 </article>
 {{ end }}

--- a/layouts/partials/docs/release-announcement-map.html
+++ b/layouts/partials/docs/release-announcement-map.html
@@ -1,0 +1,40 @@
+{{/*
+  Returns a map keyed by minor_version of release announcement blog posts for
+  the current site language. Scans the English blog once and prefers the
+  current-language translation (via Page.Translations) when its front matter
+  carries a matching release_announcement.minor_version.
+*/}}
+{{- $releaseBlogMap := dict -}}
+{{- $currentLang := site.Language.Lang -}}
+{{- $englishSite := index (where site.Sites "Language.Lang" "en") 0 -}}
+{{- range where $englishSite.RegularPages "Section" "blog" -}}
+  {{- $announcement := .Params.release_announcement -}}
+  {{- if $announcement -}}
+    {{- $version := $announcement.minor_version -}}
+    {{- if $version -}}
+      {{- $url := .RelPermalink -}}
+      {{- $themes := $announcement.themes -}}
+
+      {{- if ne $currentLang "en" -}}
+        {{- with where .Translations ".Lang" $currentLang -}}
+          {{- $localized := index . 0 -}}
+          {{- with $localized.Params.release_announcement -}}
+            {{- if eq .minor_version $version -}}
+              {{- $url = $localized.RelPermalink -}}
+              {{- $themes = .themes -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- /* Use the first theme as the primary theme if available. */ -}}
+      {{- $primaryTheme := "" -}}
+      {{- if and $themes (gt (len $themes) 0) -}}
+        {{- $primaryTheme = index $themes 0 -}}
+      {{- end -}}
+      {{- $entry := dict "url" $url "theme" $primaryTheme -}}
+      {{- $releaseBlogMap = merge $releaseBlogMap (dict $version $entry) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $releaseBlogMap -}}


### PR DESCRIPTION
### Description

Add `release_announcement.themes` to release series page front matter.
Themes are stored as an array because some releases have differing names between the SIG Release README (e.g. v1.18 "A Bit Quarky") and the blog announcement (e.g. v1.18 "Fit & Finish").

### Issue

Closes: #55500

Previews:
v1.36: https://deploy-preview-55596--kubernetes-io-main-staging.netlify.app/releases/1.36/
v1.36 (ja): https://deploy-preview-55596--kubernetes-io-main-staging.netlify.app/ja/releases/1.36/
v1.36 (bn): https://deploy-preview-55596--kubernetes-io-main-staging.netlify.app/bn/releases/1.36/
v1.36 (fr): https://deploy-preview-55596--kubernetes-io-main-staging.netlify.app/fr/releases/1.36/
v1.35: https://deploy-preview-55596--kubernetes-io-main-staging.netlify.app/releases/1.35/
v1.20: https://deploy-preview-55596--kubernetes-io-main-staging.netlify.app/releases/1.20/