### PR TITLE
Add patch release information to release series pages

### DIFF
--- a/content/en/releases/_content.gotmpl
+++ b/content/en/releases/_content.gotmpl
@@ -45,13 +45,15 @@
     {{ end }}
   {{ end }}
 
-  {{ $releaseInfo := dict 
+  {{ $releaseInfo := dict
     "releaseDate" .releaseDate
     "endOfLifeDate" .endOfLifeDate
     "maintenanceModeStartDate" .maintenanceModeStartDate
     "status" $status
     "latestPatchVersion" $latestPatchVersion
     "latestReleaseDate" $latestReleaseDate
+    "patchReleases" .previousPatches
+    "nextPatch" .next
   }}
   {{ $allReleases = merge $allReleases (dict $version $releaseInfo) }}
 {{ end }}
@@ -61,15 +63,15 @@
 {{ range $version, $info := $allReleases }}
   {{ $minorVersionPath := $version }}
   {{ $title := T "kubernetes" }}
-  
+
   {{ $parts := split $version "." }}
   {{ $major := int (index $parts 0) }}
   {{ $minor := int (index $parts 1) }}
 
-  {{/* 
+  {{/*
     Calculate the previous minor version (e.g., X.5 -> X.4).
-    NOTE: This logic assumes the major version stays constant. 
-    If Kubernetes releases a major version (e.g., 2.0), this will need to be updated 
+    NOTE: This logic assumes the major version stays constant.
+    If Kubernetes releases a major version (e.g., 2.0), this will need to be updated
     to handle major version transitions (e.g., 2.0 -> 1.Y).
   */}}
   {{ $previousMinorVersion := printf "%d.%d" $major (sub $minor 1) }}
@@ -90,6 +92,8 @@
       "maintenanceModeStartDate" (index $info "maintenanceModeStartDate")
       "latestPatchVersion" (index $info "latestPatchVersion")
       "latestReleaseDate" (index $info "latestReleaseDate")
+      "patchReleases" (index $info "patchReleases")
+      "nextPatch" (index $info "nextPatch")
       "isLatestVersion" (eq $version $latestSupportedVersion)
       "previousMinorVersion" $previousMinorVersion
       "toc_hide" true

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -662,6 +662,13 @@ other = "Release Information"
 [release_minor_version]
 other = "Minor Version"
 
+[release_patch_releases_heading]
+one = "Patch Release"
+other = "Patch Releases"
+
+[release_upcoming_patch_heading]
+other = "Upcoming Patch"
+
 [release_info_next_patch]
 other = "Next patch release is **%s**."
 

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -64,6 +64,52 @@
     {{ end }}
   </dl>
 
+  {{ with .Params.patchReleases }}
+  <h2>{{ T "release_patch_releases_heading" (len .) }}</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>{{ T "patch_release" }}</th>
+        <th>{{ T "release_cherry_pick_deadline" }}</th>
+        <th>{{ T "release_target_date" }}</th>
+        <th>{{ T "release_note" }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range . }}
+      <tr>
+        <td>{{ .release }}</td>
+        <td>{{ with .cherryPickDeadline }}{{ . }}{{ end }}</td>
+        <td>{{ .targetDate }}</td>
+        <td>{{ with .note }}{{ . | markdownify }}{{ end }}</td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ end }}
+
+  {{ with .Params.nextPatch }}
+  <h2>{{ T "release_upcoming_patch_heading" }}</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>{{ T "patch_release" }}</th>
+        <th>{{ T "release_cherry_pick_deadline" }}</th>
+        <th>{{ T "release_target_date" }}</th>
+        <th>{{ T "release_note" }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{ .release }}</td>
+        <td>{{ .cherryPickDeadline }}</td>
+        <td>{{ .targetDate }}</td>
+        <td>{{ with .note }}{{ . | markdownify }}{{ end }}</td>
+      </tr>
+    </tbody>
+  </table>
+  {{ end }}
+
   <h2>{{ T "release_links" }}</h2>
   <ul>
     {{ if .Params.status | in (slice "supported" "maintenance") }}


### PR DESCRIPTION
### Description

Add Patch Releases and Upcoming Patch sections to release-series pages with detailed information from  `data/releases/schedule.yaml`. EOL releases are not considered.

### Issue

Closes: #55598 

Previews:
v1.36: https://deploy-preview-55601--kubernetes-io-main-staging.netlify.app/releases/1.36/
v1.35: https://deploy-preview-55601--kubernetes-io-main-staging.netlify.app/releases/1.35/
v1.34: https://deploy-preview-55601--kubernetes-io-main-staging.netlify.app/releases/1.34/

No patch details:
v1.32: https://deploy-preview-55601--kubernetes-io-main-staging.netlify.app/releases/1.32/
