### PR TITLE
fix: remove duplicate 'The' in Kubernetes API link on overview page

### DIFF
--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -179,7 +179,7 @@ Containers have become popular because they provide extra benefits, such as:
 ## {{% heading "whatsnext" %}}
 
 * Take a look at the [Kubernetes Components](/docs/concepts/overview/components/)
-* Take a look at the [The Kubernetes API](/docs/concepts/overview/kubernetes-api/)
+* Take a look at the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * Take a look at [kubectl](/docs/concepts/overview/kubectl/) - the primary CLI for Kubernetes
 * Take a look at the [Cluster Architecture](/docs/concepts/architecture/)
 * Ready to [Get Started](/docs/setup/)?

--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -71,7 +71,7 @@ Kubernetes provides you with:
 * **Horizontal scaling**
   Scale your application up and down with a simple command, with a UI, or automatically based on CPU usage.
 * **IPv4/IPv6 dual-stack**
-  Allocation of IPv4 and IPv6 addresses to Pods and Services
+  Allocation of IPv4 and IPv6 addresses to Pods and Services.
 * **Designed for extensibility**
   Add features to your Kubernetes cluster without changing upstream source code.
 
@@ -180,6 +180,6 @@ Containers have become popular because they provide extra benefits, such as:
 
 * Take a look at the [Kubernetes Components](/docs/concepts/overview/components/)
 * Take a look at the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
-* Take a look at [kubectl](/docs/concepts/overview/kubectl/) - the primary CLI for Kubernetes
+* Take a look at the [kubectl](/docs/concepts/overview/kubectl/): the primary CLI for Kubernetes
 * Take a look at the [Cluster Architecture](/docs/concepts/architecture/)
 * Ready to [Get Started](/docs/setup/)?

--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -180,6 +180,6 @@ Containers have become popular because they provide extra benefits, such as:
 
 * Take a look at the [Kubernetes Components](/docs/concepts/overview/components/)
 * Take a look at the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
-* Take a look at the [kubectl](/docs/concepts/overview/kubectl/): the primary CLI for Kubernetes
+* Take a look at [kubectl](/docs/concepts/overview/kubectl/): the primary CLI for Kubernetes
 * Take a look at the [Cluster Architecture](/docs/concepts/architecture/)
 * Ready to [Get Started](/docs/setup/)?


### PR DESCRIPTION
## What this PR does

Three consistency fixes in content/en/docs/concepts/overview/_index.md:

1. Removed duplicate "The" in the Kubernetes API link
   Before: Take a look at the [The Kubernetes API](...)
   After:  Take a look at the [Kubernetes API](...)

2. Added missing "the" and fixed separator in kubectl line
   Before: Take a look at [kubectl](...) - the primary CLI
   After:  Take a look at the [kubectl](...): the primary CLI

3. Added missing period at end of IPv4/IPv6 dual-stack description
   Before: Allocation of IPv4 and IPv6 addresses to Pods and Services
   After:  Allocation of IPv4 and IPv6 addresses to Pods and Services.

## Why
All three fixes improve consistency with the surrounding content.

## How to verify
Read lines 74, 182, and 183 of
content/en/docs/concepts/overview/_index.md