### PR TITLE
fix: improve sentence completeness and tone in components overview

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -23,11 +23,11 @@ This page provides a high-level overview of the essential components that make u
 ## Core Components
 
 A Kubernetes cluster consists of a control plane and one or more worker nodes.
-Here's a brief overview of the main components:
+The following is a brief overview of the main components:
 
 ### Control Plane Components
 
-Manage the overall state of the cluster:
+Control plane components manage the overall state of the cluster:
 
 [kube-apiserver](/docs/concepts/architecture/#kube-apiserver)
 : The core component server that exposes the Kubernetes HTTP API.
@@ -46,7 +46,7 @@ Manage the overall state of the cluster:
 
 ### Node Components
 
-Run on every node, maintaining running pods and providing the Kubernetes runtime environment:
+Node components run on every node, maintaining running pods and providing the Kubernetes runtime environment:
 
 [kubelet](/docs/concepts/architecture/#kubelet)
 : Ensures that Pods are running, including their containers.


### PR DESCRIPTION
## What this PR does

Fixes three writing issues in content/en/docs/concepts/overview/components.md:

1. Replaced informal contraction "Here's" with formal "The following is"
2. Fixed incomplete sentence "Manage the overall state of the cluster" 
   → "Control plane components manage the overall state of the cluster"
3. Fixed incomplete sentence "Run on every node..." 
   → "Node components run on every node..."

## Why

The original sentences were either using informal contractions inconsistent 
with the rest of the document, or were sentence fragments missing a subject. 
Technical documentation should use complete, formal sentences throughout.

## How to verify

Read lines 26, 30, and 49 of 
content/en/docs/concepts/overview/components.md