### PR TITLE
Add guidance for running multiple schedulers simultaneously

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/_index.md
+++ b/content/en/docs/concepts/scheduling-eviction/_index.md
@@ -15,6 +15,7 @@ of terminating one or more Pods on Nodes.
 ## Scheduling
 
 * [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/)
+* [Running Multiple Schedulers](/docs/concepts/scheduling-eviction/running-multiple-schedulers/)
 * [Assigning Pods to Nodes](/docs/concepts/scheduling-eviction/assign-pod-node/)
 * [Pod Overhead](/docs/concepts/scheduling-eviction/pod-overhead/)
 * [Pod Topology Spread Constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)

--- a/content/en/docs/concepts/scheduling-eviction/running-multiple-schedulers.md
+++ b/content/en/docs/concepts/scheduling-eviction/running-multiple-schedulers.md
@@ -1,0 +1,41 @@
+---
+title: Running multiple schedulers
+content_type: concept
+weight: 10
+---
+
+<!-- overview -->
+
+Kubernetes allows you to run multiple schedulers within a single cluster.
+
+This page describes the general principles of running multiple schedulers in a cluster, assuming that at least one of these schedulers is the default `kube-scheduler`. If you are only running custom or third-party schedulers, refer to their specific documentation.
+
+<!-- body -->
+
+## Deployment strategies
+
+When running multiple schedulers, you must decide how they interact with each other and the cluster's nodes. There are three common deployment scenarios:
+
+### High availability (Standby replicas)
+
+If you want to run a single logical scheduler (such as `kube-scheduler`) but ensure it remains available if a failure occurs, you should run multiple replicas of the scheduler and enable **leader election**.
+
+When leader election is enabled, only one replica (the leader) is active and schedules Pods, while the others remain in standby mode. If the active leader fails, one of the standby replicas automatically wins the leader election and takes over the scheduling work.
+
+For details on how to configure this, see [Enable leader election](/docs/tasks/extend-kubernetes/configure-multiple-schedulers/#enable-leader-election).
+
+### Multiple scheduler profiles or instances
+
+If you want to use different configurations or scheduling rules for different workloads, you can either configure a single `kube-scheduler` instance with multiple scheduling profiles, or run several separate instances of `kube-scheduler`.
+
+* **Multiple profiles in one instance:** A single `kube-scheduler` process can run multiple profiles (each with a unique scheduler name). Because these profiles run in the same process and share the same scheduling queue and cache, they do not make conflicting scheduling decisions. You can still use [node affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile) if you want to isolate workloads by directing each profile to a specific node pool.
+* **Multiple separate instances:** If you run several separate `kube-scheduler` processes (deployments), they do not coordinate with each other and might make conflicting scheduling decisions (such as overcommitting a node's resources). To prevent this, each scheduler instance must target a disjoint set of nodes using [node affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
+
+### Mixing kube-scheduler with custom schedulers
+
+If you run `kube-scheduler` alongside custom or third-party schedulers, run the schedulers on disjoint pools of nodes to avoid resource conflicts. Depending on how your custom scheduler is designed, it might support running in an active-active configuration, or it might require its own leader election mechanism. Always check the documentation for your custom scheduler.
+
+## {{% heading "whatsnext" %}}
+
+* Read about [Configuring Multiple Schedulers](/docs/tasks/extend-kubernetes/configure-multiple-schedulers/).
+* Learn about [Assigning Pods to Nodes](/docs/concepts/scheduling-eviction/assign-pod-node/).

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -97,9 +97,7 @@ detailed description of other customizable `kube-scheduler` configurations.
 ## Run the second scheduler in the cluster
 
 {{< caution >}}
-Avoid running multiple separate schedulers that simultaneously schedule pods on the same set of nodes.
-
-Instead, either [enable leader election](#enable-leader-election), or use multiple scheduling profiles with each profile assigned to a different node pool via [node affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
+Before you deploy multiple schedulers or scheduling profiles, see [Running multiple schedulers](/docs/concepts/scheduling-eviction/running-multiple-schedulers/) to understand the different deployment strategies and how to avoid resource scheduling conflicts.
 {{< /caution >}}
 
 In order to run your scheduler in a Kubernetes cluster, create the deployment

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -119,6 +119,10 @@ my-scheduler-lnf4s-4744f                       1/1       Running   0          2m
 You should see a "Running" my-scheduler pod, in addition to the default kube-scheduler
 pod in this list.
 
+It is NOT recommended to run multiple separate schedulers that will simultaneously schedule pods on the same set of nodes.
+The recommended approach is either to enable leader election, or to use multiple scheduling profiles, each assigned to a different
+node pool using [NodeAffinity plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
+
 ### Enable leader election
 
 To run multiple-scheduler with leader election enabled, you must do the following:

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -96,6 +96,12 @@ detailed description of other customizable `kube-scheduler` configurations.
 
 ## Run the second scheduler in the cluster
 
+{{< caution >}}
+Avoid running multiple separate schedulers that simultaneously schedule pods on the same set of nodes.
+
+Instead, either [enable leader election](#enable-leader-election), or use multiple scheduling profiles with each profile assigned to a different node pool via [node affinity](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
+{{< /caution >}}
+
 In order to run your scheduler in a Kubernetes cluster, create the deployment
 specified in the config above in a Kubernetes cluster:
 
@@ -118,10 +124,6 @@ my-scheduler-lnf4s-4744f                       1/1       Running   0          2m
 
 You should see a "Running" my-scheduler pod, in addition to the default kube-scheduler
 pod in this list.
-
-It is NOT recommended to run multiple separate schedulers that will simultaneously schedule pods on the same set of nodes.
-The recommended approach is either to enable leader election, or to use multiple scheduling profiles, each assigned to a different
-node pool using [NodeAffinity plugin](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
 
 ### Enable leader election
 

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -121,7 +121,7 @@ pod in this list.
 
 It is NOT recommended to run multiple separate schedulers that will simultaneously schedule pods on the same set of nodes.
 The recommended approach is either to enable leader election, or to use multiple scheduling profiles, each assigned to a different
-node pool using [NodeAffinity plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
+node pool using [NodeAffinity plugin](/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-per-scheduling-profile).
 
 ### Enable leader election
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR adds a short message about recommendations when running multiple schedulers on a cluster.

I want to include this in the docs, since there have been some issue reports (e.g. https://github.com/kubernetes/kubernetes/issues/136782, https://github.com/kubernetes/kubernetes/issues/130429, https://github.com/kubernetes/kubernetes/issues/93505) related to running multiple schedulers simultaneously against the same set of nodes. When addressing one of these issues I searched kubernetes docs for clear recommendations, but I could not find them anywhere. This recommendation (use leader election or split cluster into node pools) can be found in one of the issues linked above, but not in the official docs.
I hope that adding this message helps some users to avoid problems and improves the overall user experience.

### Issue
Related issues:
https://github.com/kubernetes/kubernetes/issues/136782
https://github.com/kubernetes/kubernetes/issues/130429
https://github.com/kubernetes/kubernetes/issues/93505

