### PR TITLE
[fr] : Update kubeadm production environment documentation

### DIFF
--- a/content/fr/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -87,3 +87,253 @@ scheduler:
 ```
 
 
+---
+reviewers:
+- sig-cluster-lifecycle
+title: Personnalisation des composants avec l’API kubeadm
+content_type: concept
+weight: 40
+---
+
+<!-- aperçu -->
+
+Cette page explique comment personnaliser les composants déployés par kubeadm. Pour les composants du plan de contrôle,
+vous pouvez utiliser des flags dans la structure `ClusterConfiguration` ou des patches par nœud. Pour le kubelet
+et kube-proxy, vous pouvez utiliser respectivement `KubeletConfiguration` et `KubeProxyConfiguration`.
+
+Toutes ces options sont accessibles via l’API de configuration kubeadm.
+Pour plus de détails sur chaque champ de configuration, consultez nos
+[pages de référence de l’API](/docs/reference/config-api/kubeadm-config.v1beta4/).
+
+{{< note >}}
+Pour reconfigurer un cluster déjà créé, voir
+[Reconfiguration d’un cluster kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure).
+{{< /note >}}
+
+<!-- corps -->
+
+## Personnaliser le plan de contrôle avec des flags dans `ClusterConfiguration`
+
+L’objet `ClusterConfiguration` de kubeadm permet aux utilisateurs de remplacer les flags par défaut
+passés aux composants du plan de contrôle tels que l’APIServer, le ControllerManager, le Scheduler et etcd.
+Les composants sont définis à l’aide des structures suivantes :
+
+- `apiServer`
+- `controllerManager`
+- `scheduler`
+- `etcd`
+
+Ces structures contiennent un champ commun `extraArgs`, composé de paires `nom` / `valeur`.
+
+Pour remplacer un flag d’un composant du plan de contrôle :
+
+1. Ajouter les `extraArgs` appropriés à votre configuration.
+2. Ajouter les flags dans le champ `extraArgs`.
+3. Exécuter `kubeadm init` avec `--config <VOTRE FICHIER YAML>`.
+
+{{< note >}}
+Vous pouvez générer un objet `ClusterConfiguration` avec les valeurs par défaut en exécutant `kubeadm config print init-defaults`
+et en enregistrant la sortie dans un fichier de votre choix.
+{{< /note >}}
+
+{{< note >}}
+L’objet `ClusterConfiguration` est actuellement global dans les clusters kubeadm. Cela signifie que tous les flags ajoutés
+s’appliquent à toutes les instances d’un même composant sur différents nœuds. Pour appliquer une configuration individuelle
+par composant sur différents nœuds, vous pouvez utiliser des [patches](#patches).
+{{< /note >}}
+
+{{< note >}}
+Les flags dupliqués (clés), ou le passage multiple du même flag `--foo`, ne sont actuellement pas supportés.
+Pour contourner cela, vous devez utiliser des [patches](#patches).
+{{< /note >}}
+
+### Flags de l’APIServer
+
+Pour plus de détails, voir la [documentation de référence de kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/).
+
+Exemple d’utilisation :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: v1.16.0
+apiServer:
+  extraArgs:
+  - name: "enable-admission-plugins"
+    value: "AlwaysPullImages,DefaultStorageClass"
+  - name: "audit-log-path"
+    value: "/home/johndoe/audit.log"
+```
+
+### Flags du ControllerManager
+
+Pour plus de détails, consultez la [documentation de référence de kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
+
+Exemple d’utilisation :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: v1.16.0
+controllerManager:
+  extraArgs:
+  - name: "cluster-signing-key-file"
+    value: "/home/johndoe/keys/ca.key"
+  - name: "deployment-controller-sync-period"
+    value: "50"
+```
+
+### Flags du Scheduler
+
+Pour plus de détails, consultez la [documentation de référence de kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/).
+
+Exemple d’utilisation :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: v1.16.0
+scheduler:
+  extraArgs:
+  - name: "config"
+    value: "/etc/kubernetes/scheduler-config.yaml"
+  extraVolumes:
+    - name: schedulerconfig
+      hostPath: /home/johndoe/schedconfig.yaml
+      mountPath: /etc/kubernetes/scheduler-config.yaml
+      readOnly: true
+      pathType: "File"
+```
+
+### Flags d’Etcd
+
+Pour plus de détails, consultez la [documentation du serveur etcd](https://etcd.io/docs/).
+
+Exemple d’utilisation :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+etcd:
+  local:
+    extraArgs:
+    - name: "election-timeout"
+      value: 1000
+```
+
+## Personnalisation avec des patches {#patches}
+
+{{< feature-state for_k8s_version="v1.22" state="beta" >}}
+
+Kubeadm vous permet de passer un répertoire contenant des fichiers de patchs à `InitConfiguration`,
+`JoinConfiguration` et `UpgradeConfiguration`, sur des nœuds individuels. Ces patchs peuvent être utilisés comme dernière étape de personnalisation avant que la configuration des composants ne soit écrite sur le disque.
+
+Vous pouvez transmettre ce fichier à `kubeadm init` avec `--config <VOTRE FICHIER DE CONFIGURATION YAML>` :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+patches:
+  directory: /home/user/somedir
+```
+
+{{< note >}}
+Pour `kubeadm init`, vous pouvez fournir un fichier contenant à la fois une `ClusterConfiguration` et une `InitConfiguration`
+séparées par `---`.
+{{< /note >}}
+
+Vous pouvez transmettre ce fichier à `kubeadm join` avec `--config <VOTRE FICHIER DE CONFIGURATION YAML>` :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+patches:
+  directory: /home/user/somedir
+```
+
+Si vous utilisez `kubeadm upgrade apply` et `kubeadm upgrade node` pour mettre à niveau vos nœuds kubeadm,
+vous devez à nouveau fournir les mêmes patches afin que la personnalisation soit conservée après la mise à niveau.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+apply:
+  patches:
+    directory: /home/user/somedir
+```
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+node:
+  patches:
+    directory: /home/user/somedir
+```
+
+Le répertoire doit contenir des fichiers nommés `target[suffix][+patchtype].extension`.  
+Par exemple : `kube-apiserver0+merge.yaml` ou simplement `etcd.json`.
+
+- `target` peut être l’un des suivants : `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `etcd`,
+  `kubeletconfiguration` et `corednsdeployment`.
+- `suffix` est une chaîne optionnelle qui peut être utilisée pour déterminer l’ordre d’application des patches
+  (ordre alphanumérique).
+- `patchtype` peut être `strategic`, `merge` ou `json`, et doit correspondre aux formats de patch
+  [pris en charge par kubectl](/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch).
+  Le `patchtype` par défaut est `strategic`.
+- `extension` doit être soit `json` soit `yaml`.
+
+## Personnalisation du kubelet {#kubelet}
+
+Pour personnaliser le kubelet, vous pouvez ajouter une [`KubeletConfiguration`](/docs/reference/config-api/kubelet-config.v1beta1/)
+à côté de `ClusterConfiguration` ou `InitConfiguration`, séparée par `---` dans le même fichier de configuration.
+Ce fichier peut ensuite être passé à `kubeadm init`, et kubeadm appliquera la même `KubeletConfiguration` de base
+à tous les nœuds du cluster.
+
+Pour appliquer une configuration spécifique à une instance au-dessus de la configuration de base `KubeletConfiguration`,
+vous pouvez utiliser la cible de patch [`kubeletconfiguration`](#patches).
+
+Sinon, vous pouvez utiliser les flags du kubelet comme surcharges en les passant dans le champ
+`nodeRegistration.kubeletExtraArgs`, pris en charge par `InitConfiguration` et `JoinConfiguration`.
+Certains flags du kubelet sont obsolètes, vérifiez leur statut dans la
+[documentation de référence du kubelet](/docs/reference/command-line-tools-reference/kubelet)
+avant de les utiliser.
+
+Pour plus de détails, voir [Configurer chaque kubelet du cluster avec kubeadm](/docs/setup/production-environment/tools/kubeadm/kubelet-integration).
+
+## Personnalisation de kube-proxy
+
+Pour personnaliser kube-proxy, vous pouvez passer une `KubeProxyConfiguration` à côté de `ClusterConfiguration`
+ou `InitConfiguration` à `kubeadm init`, séparée par `---`.
+
+Pour plus de détails, consultez les [pages de référence de l’API](/docs/reference/config-api/kubeadm-config.v1beta4/).
+
+{{< note >}}
+kubeadm déploie kube-proxy sous forme de {{< glossary_tooltip text="DaemonSet" term_id="daemonset" >}}, ce qui signifie
+que la `KubeProxyConfiguration` s’applique à toutes les instances de kube-proxy dans le cluster.
+{{< /note >}}
+
+## Personnalisation de CoreDNS
+
+kubeadm permet de personnaliser le Deployment CoreDNS via des patches appliqués à la cible
+[`corednsdeployment`](#patches).
+
+Les patches pour d’autres objets API liés à CoreDNS comme le
+{{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} `kube-system/coredns`
+ne sont pas encore pris en charge. Vous devez les modifier manuellement avec kubectl et recréer ensuite les
+{{< glossary_tooltip text="Pods" term_id="pod" >}} CoreDNS.
+
+Sinon, vous pouvez désactiver le déploiement CoreDNS de kubeadm en ajoutant l’option suivante
+dans votre `ClusterConfiguration` :
+
+```yaml
+dns:
+  disabled: true
+```
+
+De plus, en exécutant la commande suivante :
+
+```shell
+kubeadm init phase addon coredns --print-manifest --config my-config.yaml
+```
+
+vous pouvez obtenir le fichier manifeste que kubeadm créerait pour CoreDNS dans votre configuration.

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -1,121 +1,29 @@
 ---
-title: Personnalisation de la configuration du control plane avec kubeadm
-description: Personnalisation de la configuration du control plane avec kubeadm
-content_type: concept
-weight: 40
----
-
-<!-- overview -->
-
-{{< feature-state for_k8s_version="1.12" state="stable" >}}
-
-L'objet `ClusterConfiguration` de kubeadm expose le champ `extraArgs` qui peut
-remplacer les indicateurs par défaut transmis au control plane à des composants
-tels que l'APIServer, le ControllerManager et le Scheduler. Les composants sont
-définis à l'aide des champs suivants:
-
-- `apiServer`
-- `controllerManager`
-- `scheduler`
-
-Le champ `extraArgs` se compose de paires` clé: valeur`. Pour remplacer un indicateur
-pour un composant du control plane:
-
-1. Ajoutez les champs appropriés à votre configuration.
-2. Ajoutez les indicateurs à remplacer dans le champ.
-
-Pour plus de détails sur chaque champ de la configuration, vous pouvez accéder aux
-[pages de référence de l'API](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#ClusterConfiguration).
-
-
-
-<!-- body -->
-
-## Paramètres pour l'API Server
-
-Pour plus de détails, voir la  [documentation de référence pour kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/).
-
-Exemple d'utilisation:
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: ClusterConfiguration
-kubernetesVersion: v1.13.0
-metadata:
-  name: 1.13-sample
-apiServer:
-  extraArgs:
-    advertise-address: 192.168.0.103
-    anonymous-auth: false
-    enable-admission-plugins: AlwaysPullImages,DefaultStorageClass
-    audit-log-path: /home/johndoe/audit.log
-```
-
-## Paramètres pour le ControllerManager
-
-Pour plus de détails, voir la [documentation de référence pour kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
-
-Exemple d'utilisation:
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: ClusterConfiguration
-kubernetesVersion: v1.13.0
-metadata:
-  name: 1.13-sample
-controllerManager:
-  extraArgs:
-    cluster-signing-key-file: /home/johndoe/keys/ca.key
-    bind-address: 0.0.0.0
-    deployment-controller-sync-period: 50
-```
-
-## Paramètres pour le Scheduler
-
-Pour plus de détails, voir la [documentation de référence pour kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/).
-
-Example usage:
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: ClusterConfiguration
-kubernetesVersion: v1.13.0
-metadata:
-  name: 1.13-sample
-scheduler:
-  extraArgs:
-    bind-address: 0.0.0.0
-    config: /home/johndoe/schedconfig.yaml
-    kubeconfig: /home/johndoe/kubeconfig.yaml
-```
-
-
----
 reviewers:
 - sig-cluster-lifecycle
-title: Personnalisation des composants avec l’API kubeadm
+title: Personnaliser les composants avec l’API kubeadm
 content_type: concept
 weight: 40
 ---
 
 <!-- aperçu -->
 
-Cette page explique comment personnaliser les composants déployés par kubeadm. Pour les composants du plan de contrôle,
-vous pouvez utiliser des flags dans la structure `ClusterConfiguration` ou des patches par nœud. Pour le kubelet
-et kube-proxy, vous pouvez utiliser respectivement `KubeletConfiguration` et `KubeProxyConfiguration`.
+Cette page explique comment personnaliser les composants déployés par kubeadm. Pour les composants du plan de contrôle (control plane), vous pouvez utiliser des flags dans la structure `ClusterConfiguration` ou des patches par nœud. Pour le kubelet et kube-proxy, vous pouvez utiliser respectivement `KubeletConfiguration` et `KubeProxyConfiguration`.
 
-Toutes ces options sont accessibles via l’API de configuration kubeadm.
-Pour plus de détails sur chaque champ de configuration, consultez nos
-[pages de référence de l’API](/docs/reference/config-api/kubeadm-config.v1beta4/).
+Toutes ces options sont disponibles via l’API de configuration kubeadm.  
+Pour plus de détails sur chaque champ de la configuration, vous pouvez consulter nos pages de [référence API](/docs/reference/config-api/kubeadm-config.v1beta4/).
 
 {{< note >}}
-Pour reconfigurer un cluster déjà créé, voir
-[Reconfiguration d’un cluster kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure).
+Pour reconfigurer un cluster déjà créé, consultez
+[Reconfigurer un cluster kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure).
 {{< /note >}}
 
-<!-- corps -->
+<!-- body -->
 
 ## Personnaliser le plan de contrôle avec des flags dans `ClusterConfiguration`
 
-L’objet `ClusterConfiguration` de kubeadm permet aux utilisateurs de remplacer les flags par défaut
-passés aux composants du plan de contrôle tels que l’APIServer, le ControllerManager, le Scheduler et etcd.
+L’objet `ClusterConfiguration` de kubeadm expose un moyen pour les utilisateurs de remplacer les flags par défaut passés aux composants du plan de contrôle tels que l’APIServer, le ControllerManager, le Scheduler et etcd.
+
 Les composants sont définis à l’aide des structures suivantes :
 
 - `apiServer`
@@ -127,31 +35,29 @@ Ces structures contiennent un champ commun `extraArgs`, composé de paires `nom`
 
 Pour remplacer un flag d’un composant du plan de contrôle :
 
-1. Ajouter les `extraArgs` appropriés à votre configuration.
-2. Ajouter les flags dans le champ `extraArgs`.
-3. Exécuter `kubeadm init` avec `--config <VOTRE FICHIER YAML>`.
+1. Ajoutez les `extraArgs` appropriés à votre configuration.
+2. Ajoutez les flags dans le champ `extraArgs`.
+3. Exécutez `kubeadm init` avec `--config <VOTRE FICHIER YAML>`.
 
 {{< note >}}
-Vous pouvez générer un objet `ClusterConfiguration` avec les valeurs par défaut en exécutant `kubeadm config print init-defaults`
-et en enregistrant la sortie dans un fichier de votre choix.
+Vous pouvez générer un objet `ClusterConfiguration` avec des valeurs par défaut en exécutant
+`kubeadm config print init-defaults` et en enregistrant la sortie dans un fichier de votre choix.
 {{< /note >}}
 
 {{< note >}}
-L’objet `ClusterConfiguration` est actuellement global dans les clusters kubeadm. Cela signifie que tous les flags ajoutés
-s’appliquent à toutes les instances d’un même composant sur différents nœuds. Pour appliquer une configuration individuelle
-par composant sur différents nœuds, vous pouvez utiliser des [patches](#patches).
+L’objet `ClusterConfiguration` est actuellement global dans les clusters kubeadm. Cela signifie que tous les flags que vous ajoutez s’appliqueront à toutes les instances du même composant sur différents nœuds. Pour appliquer une configuration individuelle par composant sur différents nœuds, vous pouvez utiliser des [patches](#patches).
 {{< /note >}}
 
 {{< note >}}
-Les flags dupliqués (clés), ou le passage multiple du même flag `--foo`, ne sont actuellement pas supportés.
+Les flags dupliqués (clés identiques), ou le passage multiple du même flag `--foo`, ne sont actuellement pas pris en charge.  
 Pour contourner cela, vous devez utiliser des [patches](#patches).
 {{< /note >}}
 
-### Flags de l’APIServer
+## Paramètres pour l'API Server
 
-Pour plus de détails, voir la [documentation de référence de kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/).
+Pour plus de détails, voir la  [documentation de référence pour kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/).
 
-Exemple d’utilisation :
+Exemple d'utilisation:
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta4
@@ -165,11 +71,11 @@ apiServer:
     value: "/home/johndoe/audit.log"
 ```
 
-### Flags du ControllerManager
+## Paramètres pour le ControllerManager
 
-Pour plus de détails, consultez la [documentation de référence de kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
+Pour plus de détails, voir la [documentation de référence pour kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
 
-Exemple d’utilisation :
+Exemple d'utilisation:
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta4
@@ -183,11 +89,11 @@ controllerManager:
     value: "50"
 ```
 
-### Flags du Scheduler
+## Paramètres pour le Scheduler
 
-Pour plus de détails, consultez la [documentation de référence de kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/).
+Pour plus de détails, voir la [documentation de référence pour kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/).
 
-Exemple d’utilisation :
+Example usage:
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta4

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -1,216 +1,229 @@
 ---
-title: Création d'un Cluster à master unique avec kubeadm
-description: Création d'un Cluster à master unique avec kubeadm
+reviewers:
+- sig-cluster-lifecycle
+title: Création d’un cluster avec kubeadm
 content_type: task
 weight: 30
 ---
 
-<!-- overview -->
+<!-- aperçu -->
 
-<img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.png" align="right" width="150px">**kubeadm** vous aide à démarrer un cluster Kubernetes minimum,
-viable et conforme aux meilleures pratiques. Avec kubeadm, votre cluster
-doit passer les [tests de Conformité Kubernetes](https://kubernetes.io/blog/2017/10/software-conformance-certification).
- Kubeadm prend également en charge d'autres fonctions du cycle de vie, telles que les mises
- à niveau, la rétrogradation et la gestion des
- [bootstrap tokens](/docs/reference/access-authn-authz/bootstrap-tokens/).
+<img src="/images/kubeadm-stacked-color.png" align="right" width="150px"></img>
+Avec `kubeadm`, vous pouvez créer un cluster Kubernetes minimal viable conforme aux bonnes pratiques.
+En fait, vous pouvez utiliser `kubeadm` pour configurer un cluster qui réussit les
+[Kubernetes Conformance tests](/blog/2017/10/software-conformance-certification/).
+`kubeadm` prend également en charge d’autres fonctions du cycle de vie du cluster, telles que les
+[jetons d’amorçage (bootstrap tokens)](/docs/reference/access-authn-authz/bootstrap-tokens/) et les mises à niveau de cluster.
 
-Comme vous pouvez installer kubeadm sur différents types de machines (par exemple, un ordinateur
-portable, un serveur,
-Raspberry Pi, etc.), il est parfaitement adapté à l'intégration avec des systèmes d'approvisionnement
-comme Terraform ou Ansible.
+L’outil `kubeadm` est adapté si vous avez besoin de :
 
-La simplicité de kubeadm lui permet d'être utilisé dans une large gamme de cas d'utilisation:
+- Une manière simple de tester Kubernetes, éventuellement pour la première fois.
+- Un moyen pour les utilisateurs existants d’automatiser la création d’un cluster et de tester leurs applications.
+- Un composant de base dans d’autres outils d’écosystème et/ou installateurs ayant un périmètre plus large.
 
-- Les nouveaux utilisateurs peuvent commencer par kubeadm pour essayer Kubernetes pour la première
-fois.
-- Les utilisateurs familiarisés avec Kubernetes peuvent créer des clusters avec kubeadm et tester
-leurs applications.
-- Les projets plus importants peuvent inclure kubeadm en tant que brique de base dans un système
-plus complexe pouvant également inclure d'autres outils d'installation.
-
-Kubeadm est conçu pour être un moyen simple pour les nouveaux utilisateurs de commencer à essayer
-Kubernetes, pour la première fois éventuellement. C'est un moyen pour les utilisateurs avancés de
-tester leur application en même temps qu'un cluster facilement, et aussi être
-une brique de base dans un autre écosystème et/ou un outil d’installation avec une plus grand
-portée.
-
-Vous pouvez installer très facilement _kubeadm_ sur des systèmes d'exploitation prenant en charge
-l'installation des paquets deb ou rpm. Le SIG responsable de kubeadm,
-[SIG Cluster Lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle),
-fournit ces paquets pré-construits pour vous,
-mais vous pouvez également les construire à partir des sources pour d'autres systèmes d'exploitation.
-
-
-###  Maturité de kubeadm
-
-| Elément                   | Niveau de maturité |
-|---------------------------|--------------------|
-| Command line UX           | GA                 |
-| Implementation            | GA                 |
-| Config file API           | beta               |
-| CoreDNS                   | GA                 |
-| kubeadm alpha subcommands | alpha              |
-| High availability         | alpha              |
-| DynamicKubeletConfig      | alpha              |
-| Self-hosting              | alpha              |
-
-Les fonctionnalités globales de kubeadm sont **GA**. Quelques sous-fonctionnalités, comme
-la configuration, les API de fichiers sont toujours en cours de développement. L'implémentation de la création du cluster
-peut changer légèrement au fur et à mesure que l'outil évolue, mais la mise en œuvre globale devrait être assez stable.
-Toutes les commandes sous `kubeadm alpha` sont par définition prises en charge au niveau alpha.
-
-
-### Calendrier de support
-
-Les versions de Kubernetes sont généralement prises en charge pendant neuf mois et pendant cette
-période, une version de correctif peut être publiée à partir de la branche de publication si un bug grave ou un
-problème de sécurité est trouvé. Voici les dernières versions de Kubernetes et le calendrier de support
- qui s'applique également à `kubeadm`.
-
-| Version de Kubernetes | Date de sortie de la version | Fin de vie     |
-|-----------------------|------------------------------|----------------|
-| v1.6.x                | Mars 2017                    | Décembre 2017  |
-| v1.7.x                | Juin 2017                    | Mars 2018      |
-| v1.8.x                | Septembre 2017               | Juin 2018      |
-| v1.9.x                | Décembre 2017                | Septembre 2018 |
-| v1.10.x               | Mars 2018                    | Décembre 2018  |
-| v1.11.x               | Juin 2018                    | Mars 2019      |
-| v1.12.x               | Septembre 2018               | Juin 2019      |
-| v1.13.x               | Décembre 2018                | Septembre 2019 |
-
-
+Vous pouvez installer et utiliser `kubeadm` sur différentes machines : votre ordinateur portable, un ensemble
+de serveurs cloud, un Raspberry Pi, etc. Que vous déployiez dans le cloud ou sur site, vous pouvez intégrer
+`kubeadm` dans des systèmes de provisionnement tels qu’Ansible ou Terraform.
 
 ## {{% heading "prerequisites" %}}
 
+Pour suivre ce guide, vous avez besoin de :
 
-- Une ou plusieurs machines exécutant un système d'exploitation compatible deb/rpm, par exemple Ubuntu ou CentOS
-- 2 Go ou plus de RAM par machine. Si vous essayez moins cela laissera trop peu de place pour vos applications.
-- 2 processeurs ou plus sur le master
-- Connectivité réseau entre toutes les machines du cluster, qu'il soit public ou privé.
+- Une ou plusieurs machines exécutant un système Linux compatible deb/rpm ; par exemple : Ubuntu ou CentOS.
+- 2 Gio ou plus de RAM par machine — moins laisserait peu de place pour vos applications.
+- Au moins 2 CPU sur la machine utilisée comme nœud de plan de contrôle.
+- Une connectivité réseau complète entre toutes les machines du cluster. Vous pouvez utiliser un réseau public ou privé.
 
+Vous devez également utiliser une version de `kubeadm` capable de déployer la version
+de Kubernetes que vous souhaitez utiliser dans votre nouveau cluster.
 
+La [politique de support des versions et du décalage de versions de Kubernetes](/docs/setup/release/version-skew-policy/#supported-versions)
+s’applique à `kubeadm` ainsi qu’à Kubernetes dans son ensemble.
+Consultez cette politique pour connaître les versions de Kubernetes et de `kubeadm` prises en charge.
+Cette page est écrite pour Kubernetes {{< param "version" >}}.
 
-<!-- steps -->
+L’état global des fonctionnalités de `kubeadm` est en disponibilité générale (GA). Certaines sous-fonctionnalités sont encore en cours de développement.
+L’implémentation de la création de cluster peut légèrement évoluer au fil du temps, mais l’approche globale reste stable.
+
+{{< note >}}
+Toutes les commandes sous `kubeadm alpha` sont, par définition, prises en charge au niveau alpha.
+{{< /note >}}
+
+<!-- étapes -->
 
 ## Objectifs
 
-* Installer un cluster Kubernetes à master unique ou un
-[cluster à haute disponibilité](/fr/docs/setup/production-environment/tools/kubeadm/high-availability/)
-* Installez un réseau de pods sur le cluster afin que vos pods puissent se parler
+* Installer un cluster Kubernetes avec un seul nœud de plan de contrôle
+* Installer un réseau de Pods sur le cluster afin que vos Pods puissent communiquer entre eux
 
 ## Instructions
 
-### Installer kubeadm sur vos hôtes
+### Préparation des hôtes
 
-Voir ["Installation de kubeadm"](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
+#### Installation des composants
+
+Installez un {{< glossary_tooltip term_id="container-runtime" text="runtime de conteneur" >}}
+et kubeadm sur tous les hôtes. Pour les instructions détaillées et autres prérequis, voir
+[Installer kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
 
 {{< note >}}
-Si vous avez déjà installé kubeadm, lancez `apt-get update &&
-apt-get upgrade` ou `yum update` pour obtenir la dernière version de kubeadm.
+Si vous avez déjà installé kubeadm, consultez les deux premières étapes du document
+[Mise à niveau des nœuds Linux](/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes)
+pour savoir comment mettre kubeadm à jour.
 
-Lorsque vous effectuez une mise à niveau, la kubelet redémarre plusieurs fois au bout de quelques
-secondes car elle attend dans une boucle de blocage
-kubeadm pour lui dire quoi faire. Ce fonctionnement est normal.
-Une fois que vous avez initialisé votre master, la kubelet s'exécute normalement.
+Lors d’une mise à niveau, le kubelet redémarre toutes les quelques secondes en attendant dans une boucle de crash que
+kubeadm lui indique quoi faire. Ce comportement est attendu et normal.
+Après l’initialisation du plan de contrôle, le kubelet fonctionne normalement.
 {{< /note >}}
 
-### Initialiser votre master
+#### Configuration réseau
 
-Le master est la machine sur laquelle s'exécutent les composants du control plane, y compris
-etcd (la base de données du cluster) et l'API serveur (avec lequel la CLI kubectl communique).
+Comme les autres composants Kubernetes, kubeadm essaie de trouver une adresse IP utilisable sur les interfaces réseau
+associées à une passerelle par défaut sur l’hôte. Cette adresse IP est ensuite utilisée pour l’annonce et/ou l’écoute
+effectuée par un composant.
 
-1. Choisissez un add-on réseau pour les pods et vérifiez s’il nécessite des arguments à
- passer à l'initialisation de kubeadm. Selon le
-fournisseur tiers que vous choisissez, vous devrez peut-être définir le `--pod-network-cidr` sur
-une valeur spécifique au fournisseur. Voir [Installation d'un add-on réseau de pod](#pod-network).
-1. (Facultatif) Sauf indication contraire, kubeadm utilise l'interface réseau associée
-avec la passerelle par défaut pour annoncer l’IP du master. Pour utiliser une autre
-interface réseau, spécifiez l'option `--apiserver-advertise-address=<ip-address>`
-à `kubeadm init`. Pour déployer un cluster Kubernetes en utilisant l’adressage IPv6, vous devez
- spécifier une adresse IPv6, par exemple `--apiserver-advertise-address=fd00::101`
-1. (Optional) Lancez `kubeadm config images pull` avant de faire `kubeadm init` pour vérifier la
-connectivité aux registres gcr.io.
+Pour trouver cette adresse sur un hôte Linux, vous pouvez utiliser :
 
-Maintenant, lancez:
+```shell
+ip route show # Rechercher une ligne commençant par "default via"
+```
+
+{{< note >}}
+Si deux passerelles par défaut ou plus sont présentes sur l’hôte, un composant Kubernetes
+essaiera d’utiliser la première qu’il rencontre ayant une adresse IP unicast globale adaptée.
+Lors de ce choix, l’ordre exact des passerelles peut varier selon les systèmes d’exploitation
+et les versions du noyau.
+{{< /note >}}
+
+Les composants Kubernetes n’acceptent pas la sélection d’une interface réseau personnalisée
+comme option. Par conséquent, une adresse IP personnalisée doit être passée en argument à toutes
+les instances de composants nécessitant une telle configuration.
+
+{{< note >}}
+Si l’hôte ne possède pas de passerelle par défaut et qu’aucune adresse IP personnalisée n’est fournie
+à un composant Kubernetes, celui-ci peut se terminer avec une erreur.
+{{< /note >}}
+
+Pour configurer l’adresse d’annonce de l’API server sur les nœuds de plan de contrôle créés avec
+`init` et `join`, le flag `--apiserver-advertise-address` peut être utilisé.
+Idéalement, cette option peut être définie dans l’[API kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4)
+via `InitConfiguration.localAPIEndpoint` et `JoinConfiguration.controlPlane.localAPIEndpoint`.
+
+Pour les kubelets sur tous les nœuds, l’option `--node-ip` peut être passée dans
+`.nodeRegistration.kubeletExtraArgs` dans un fichier de configuration kubeadm
+(`InitConfiguration` ou `JoinConfiguration`).
+
+Pour le support dual-stack, voir :
+[Support dual-stack avec kubeadm](/docs/setup/production-environment/tools/kubeadm/dual-stack-support).
+
+Les adresses IP assignées aux composants du plan de contrôle font partie des champs SAN
+(subject alternative name) des certificats X.509. Modifier ces adresses IP nécessiterait
+de signer de nouveaux certificats et de redémarrer les composants concernés afin que les changements
+soient pris en compte. Voir
+[Régénération manuelle des certificats](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#manual-certificate-renewal)
+pour plus de détails.
+
+{{< warning >}}
+Le projet Kubernetes déconseille cette approche (configurer toutes les instances de composants
+avec des adresses IP personnalisées). Les mainteneurs recommandent plutôt de configurer le réseau
+de l’hôte afin que la passerelle par défaut soit celle détectée automatiquement et utilisée par Kubernetes.
+Sur les nœuds Linux, vous pouvez utiliser des commandes comme `ip route` pour configurer le réseau ;
+votre système d’exploitation peut également fournir des outils de gestion réseau plus avancés.
+Si la passerelle par défaut de votre nœud est une adresse IP publique, vous devez configurer un filtrage
+de paquets ou d’autres mesures de sécurité pour protéger les nœuds et le cluster.
+{{< /warning >}}
+
+### Préparation des images de conteneurs requises
+
+Cette étape est optionnelle et ne s’applique que si vous souhaitez que `kubeadm init` et `kubeadm join`
+ne téléchargent pas les images de conteneurs par défaut hébergées sur `registry.k8s.io`.
+
+Kubeadm fournit des commandes permettant de pré-télécharger les images nécessaires
+lors de la création d’un cluster sans connexion Internet sur les nœuds.
+Voir [Exécuter kubeadm sans connexion Internet](/docs/reference/setup-tools/kubeadm/kubeadm-init#without-internet-connection)
+pour plus de détails.
+
+Kubeadm permet également d’utiliser un registre d’images personnalisé pour les images requises.
+Voir [Utilisation d’images personnalisées](/docs/reference/setup-tools/kubeadm/kubeadm-init#custom-images)
+pour plus de détails.
+
+### Initialisation du nœud de plan de contrôle
+
+Le nœud de plan de contrôle est la machine où s’exécutent les composants du plan de contrôle, notamment
+{{< glossary_tooltip term_id="etcd" >}} (la base de données du cluster) et le
+{{< glossary_tooltip text="serveur API" term_id="kube-apiserver" >}},
+avec lequel l’outil en ligne de commande {{< glossary_tooltip text="kubectl" term_id="kubectl" >}}
+communique.
+
+1. (Recommandé) Si vous prévoyez de faire évoluer ce cluster kubeadm à nœud unique vers une
+   [haute disponibilité](/docs/setup/production-environment/tools/kubeadm/high-availability/),
+   vous devez spécifier `--control-plane-endpoint` pour définir un endpoint partagé pour tous les nœuds de plan de contrôle.
+   Cet endpoint peut être un nom DNS ou une adresse IP d’un load balancer.
+
+2. Choisissez un add-on de réseau de Pods et vérifiez s’il nécessite des arguments supplémentaires
+   à passer à `kubeadm init`. Selon le fournisseur tiers choisi, vous devrez peut-être définir
+   `--pod-network-cidr` avec une valeur spécifique. Voir
+   [Installation d’un add-on réseau de Pods](#pod-network).
+
+3. (Optionnel) `kubeadm` tente de détecter le runtime de conteneur via une liste de points de terminaison connus.
+   Pour utiliser un runtime différent ou s’il y en a plusieurs installés sur le nœud provisionné,
+   spécifiez l’argument `--cri-socket` à `kubeadm`. Voir
+   [Installation d’un runtime](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-runtime).
+
+Pour initialiser le nœud de plan de contrôle, exécutez :
 
 ```bash
 kubeadm init <args>
 ```
 
-### Plus d'information
+### Considérations sur `apiserver-advertise-address` et `ControlPlaneEndpoint`
 
-Pour plus d'informations sur les arguments de `kubeadm init`, voir le
-[guide de référence kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/).
+Alors que `--apiserver-advertise-address` peut être utilisé pour définir l’adresse annoncée par le serveur API de ce nœud de plan de contrôle spécifique,
+`--control-plane-endpoint` peut être utilisé pour définir un endpoint partagé pour tous les nœuds du plan de contrôle.
 
-Pour une liste complète des options de configuration, voir la
-[documentation du fichier de configuration](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+`--control-plane-endpoint` accepte à la fois des adresses IP et des noms DNS pouvant être résolus en adresses IP.
+Veuillez contacter votre administrateur réseau pour évaluer les solutions possibles concernant ce type de résolution.
 
-Pour personnaliser les composants du control plane, y compris l'affectation facultative d'IPv6
-à la sonde liveness, pour les composants du control plane et du serveur etcd, fournissez des arguments
-supplémentaires à chaque composant, comme indiqué dans les [arguments personnalisés](/docs/admin/kubeadm#custom-args).
+Voici un exemple de correspondance :
 
-Pour lancer encore une fois `kubeadm init`, vous devez d'abord [détruire le cluster](#tear-down).
+```
+192.168.0.102 cluster-endpoint
+```
 
-Si vous joignez un nœud avec une architecture différente par rapport à votre cluster, créez un
-Déploiement ou DaemonSet pour `kube-proxy` et` kube-dns` sur le nœud. C’est nécéssaire car les images Docker pour ces
- composants ne prennent actuellement pas en charge la multi-architecture.
+Dans cet exemple, `192.168.0.102` est l’adresse IP de ce nœud et `cluster-endpoint` est un nom DNS personnalisé qui pointe vers cette adresse IP.
+Cela vous permet de passer `--control-plane-endpoint=cluster-endpoint` à `kubeadm init` et d’utiliser le même nom DNS pour
+`kubeadm join`. Plus tard, vous pouvez modifier `cluster-endpoint` pour qu’il pointe vers l’adresse de votre load balancer dans un scénario
+de haute disponibilité.
+
+Transformer un cluster à un seul plan de contrôle créé sans `--control-plane-endpoint` en un cluster hautement disponible
+n’est pas pris en charge par kubeadm.
+
+### Plus d’informations
+
+Pour plus d’informations sur les arguments de `kubeadm init`, consultez le [guide de référence kubeadm](/docs/reference/setup-tools/kubeadm/).
+
+Pour configurer `kubeadm init` avec un fichier de configuration, voir
+[Utiliser kubeadm init avec un fichier de configuration](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+
+Pour personnaliser les composants du plan de contrôle, y compris l’ajout optionnel d’IPv6 pour les probes de liveness
+des composants du plan de contrôle et du serveur etcd, fournissez des arguments supplémentaires à chaque composant comme décrit dans
+[arguments personnalisés](/docs/setup/production-environment/tools/kubeadm/control-plane-flags/).
+
+Pour reconfigurer un cluster déjà créé, voir
+[Reconfiguration d’un cluster kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure).
+
+Pour relancer `kubeadm init`, vous devez d’abord [supprimer le cluster](#tear-down).
+
+Si vous ajoutez un nœud d’une architecture différente à votre cluster, assurez-vous que vos DaemonSets déployés
+prennent en charge les images de conteneurs pour cette architecture.
 
 `kubeadm init` exécute d’abord une série de vérifications préalables pour s’assurer que la machine
-est prête à exécuter Kubernetes. Ces vérifications préalables exposent des avertissements et se terminent
- en cas d'erreur. Ensuite `kubeadm init` télécharge et installe les composants du control plane du cluster.
-Cela peut prendre plusieurs minutes. l'output devrait ressembler à:
+est prête à exécuter Kubernetes. Ces vérifications affichent des avertissements et arrêtent l’exécution en cas d’erreur. Ensuite, `kubeadm init`
+télécharge et installe les composants du plan de contrôle du cluster. Cela peut prendre plusieurs minutes.
+Une fois terminé, vous devriez voir :
 
 ```none
-[init] Using Kubernetes version: vX.Y.Z
-[preflight] Running pre-flight checks
-[preflight] Pulling images required for setting up a Kubernetes cluster
-[preflight] This might take a minute or two, depending on the speed of your internet connection
-[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
-[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
-[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
-[kubelet-start] Activating the kubelet service
-[certs] Using certificateDir folder "/etc/kubernetes/pki"
-[certs] Generating "etcd/ca" certificate and key
-[certs] Generating "etcd/server" certificate and key
-[certs] etcd/server serving cert is signed for DNS names [kubeadm-master localhost] and IPs [10.138.0.4 127.0.0.1 ::1]
-[certs] Generating "etcd/healthcheck-client" certificate and key
-[certs] Generating "etcd/peer" certificate and key
-[certs] etcd/peer serving cert is signed for DNS names [kubeadm-master localhost] and IPs [10.138.0.4 127.0.0.1 ::1]
-[certs] Generating "apiserver-etcd-client" certificate and key
-[certs] Generating "ca" certificate and key
-[certs] Generating "apiserver" certificate and key
-[certs] apiserver serving cert is signed for DNS names [kubeadm-master kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local] and IPs [10.96.0.1 10.138.0.4]
-[certs] Generating "apiserver-kubelet-client" certificate and key
-[certs] Generating "front-proxy-ca" certificate and key
-[certs] Generating "front-proxy-client" certificate and key
-[certs] Generating "sa" key and public key
-[kubeconfig] Using kubeconfig folder "/etc/kubernetes"
-[kubeconfig] Writing "admin.conf" kubeconfig file
-[kubeconfig] Writing "kubelet.conf" kubeconfig file
-[kubeconfig] Writing "controller-manager.conf" kubeconfig file
-[kubeconfig] Writing "scheduler.conf" kubeconfig file
-[control-plane] Using manifest folder "/etc/kubernetes/manifests"
-[control-plane] Creating static Pod manifest for "kube-apiserver"
-[control-plane] Creating static Pod manifest for "kube-controller-manager"
-[control-plane] Creating static Pod manifest for "kube-scheduler"
-[etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
-[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests". This can take up to 4m0s
-[apiclient] All control plane components are healthy after 31.501735 seconds
-[uploadconfig] storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
-[kubelet] Creating a ConfigMap "kubelet-config-X.Y" in namespace kube-system with the configuration for the kubelets in the cluster
-[patchnode] Uploading the CRI Socket information "/var/run/dockershim.sock" to the Node API object "kubeadm-master" as an annotation
-[mark-control-plane] Marking the node kubeadm-master as control-plane by adding the label "node-role.kubernetes.io/master=''"
-[mark-control-plane] Marking the node kubeadm-master as control-plane by adding the taints [node-role.kubernetes.io/master:NoSchedule]
-[bootstrap-token] Using token: <token>
-[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles
-[bootstraptoken] configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials
-[bootstraptoken] configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token
-[bootstraptoken] configured RBAC rules to allow certificate rotation for all node client certificates in the cluster
-[bootstraptoken] creating the "cluster-info" ConfigMap in the "kube-public" namespace
-[addons] Applied essential addon: CoreDNS
-[addons] Applied essential addon: kube-proxy
-
-Your Kubernetes master has initialized successfully!
+Your Kubernetes control-plane has initialized successfully!
 
 To start using your cluster, you need to run the following as a regular user:
 
@@ -218,18 +231,17 @@ To start using your cluster, you need to run the following as a regular user:
   sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
   sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
-You should now deploy a pod network to the cluster.
+You should now deploy a Pod network to the cluster.
 Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
-  https://kubernetes.io/fr/docs/concepts/cluster-administration/addons/
+  /docs/concepts/cluster-administration/addons/
 
 You can now join any number of machines by running the following on each node
 as root:
 
-  kubeadm join <master-ip>:<master-port> --token <token> --discovery-token-ca-cert-hash sha256:<hash>
+  kubeadm join <control-plane-host>:<control-plane-port> --token <token> --discovery-token-ca-cert-hash sha256:<hash>
 ```
 
-Pour que kubectl fonctionne pour votre utilisateur non root, exécutez ces commandes, qui font
- également partie du resultat de la commande `kubeadm init`:
+Pour que kubectl fonctionne avec un utilisateur non root, exécutez les commandes suivantes, qui font également partie de la sortie de `kubeadm init` :
 
 ```bash
 mkdir -p $HOME/.kube
@@ -237,449 +249,351 @@ sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 ```
 
-Alternativement, si vous êtes `root`, vous pouvez exécuter:
+Sinon, si vous êtes l'utilisateur `root`, vous pouvez exécuter :
 
 ```bash
 export KUBECONFIG=/etc/kubernetes/admin.conf
 ```
 
-Faites un enregistrement du retour de la commande `kubeadm join` que `kubeadm init` génère. Vous avez
-besoin de cette commande pour [joindre des noeuds à votre cluster](#join-nodes).
+{{< warning >}}
+Le fichier kubeconfig `admin.conf` généré par `kubeadm init` contient un certificat avec
+`Subject: O = kubeadm:cluster-admins, CN = kubernetes-admin`. Le groupe `kubeadm:cluster-admins`
+est lié au ClusterRole intégré `cluster-admin`.
+Ne partagez pas le fichier `admin.conf` avec qui que ce soit.
 
-Le jeton est utilisé pour l'authentification mutuelle entre le master et les nœuds qui veulent le rejoindre.
-Le jeton est secret. Gardez-le en sécurité, parce que n'importe qui avec ce
-jeton peut ajouter des nœuds authentifiés à votre cluster. Ces jetons peuvent être listés,
-créés et supprimés avec la commande `kubeadm token`. Voir le
-[Guide de référence kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm-token/).
+`kubeadm init` génère également un fichier kubeconfig `super-admin.conf` qui contient un certificat avec
+`Subject: O = system:masters, CN = kubernetes-super-admin`.
+`system:masters` est un groupe super-utilisateur de type “break-glass” qui contourne la couche d’autorisation (par exemple RBAC).
+Ne partagez pas le fichier `super-admin.conf`. Il est recommandé de le déplacer vers un emplacement sécurisé.
 
-### Installation d'un add-on réseau {#pod-network}
+Voir
+[Générer des fichiers kubeconfig pour des utilisateurs supplémentaires](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs#kubeconfig-additional-users)
+pour savoir comment utiliser `kubeadm kubeconfig user` afin de générer des kubeconfig pour des utilisateurs additionnels.
+{{< /warning >}}
+
+Conservez une copie de la commande `kubeadm join` affichée par `kubeadm init`. Vous
+en aurez besoin pour [ajouter des nœuds à votre cluster](#join-nodes).
+
+Le token est utilisé pour l’authentification mutuelle entre le nœud du plan de contrôle et les nœuds rejoignant le cluster.
+Le token inclus ici est secret. Conservez-le en lieu sûr, car toute personne disposant de ce token peut ajouter
+des nœuds authentifiés à votre cluster. Ces tokens peuvent être listés, créés et supprimés avec la commande
+`kubeadm token`. Voir le [guide de référence kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm-token/).
+
+### Installation d’un add-on réseau de Pods {#pod-network}
 
 {{< caution >}}
-Cette section contient des informations importantes sur l’ordre d’installation et de déploiement. Lisez-la attentivement avant de continuer.
+Cette section contient des informations importantes sur la configuration réseau et
+l’ordre de déploiement.
+Lisez attentivement ces recommandations avant de continuer.
+
+**Vous devez déployer un add-on réseau de Pods basé sur
+{{< glossary_tooltip text="Container Network Interface" term_id="cni" >}}
+(CNI) afin que vos Pods puissent communiquer entre eux.
+Le DNS du cluster (CoreDNS) ne démarrera pas tant qu’un réseau n’est pas installé.**
+
+- Assurez-vous que votre réseau de Pods ne chevauche aucun réseau hôte :
+  des problèmes peuvent survenir en cas de chevauchement.
+  (Si vous détectez une collision entre le CIDR réseau de votre plugin et un réseau hôte,
+  choisissez un autre bloc CIDR et utilisez-le avec `--pod-network-cidr` lors de `kubeadm init`,
+  ainsi que dans la configuration YAML du plugin réseau.)
+
+- Par défaut, `kubeadm` configure votre cluster pour utiliser et appliquer
+  [RBAC](/docs/reference/access-authn-authz/rbac/) (contrôle d’accès basé sur les rôles).
+  Assurez-vous que votre plugin réseau de Pods supporte RBAC, ainsi que tous les manifestes utilisés pour le déployer.
+
+- Si vous souhaitez utiliser IPv6 (réseau dual-stack ou IPv6 uniquement),
+  assurez-vous que votre plugin réseau de Pods le supporte.
+  Le support IPv6 a été ajouté à CNI en [v0.6.0](https://github.com/containernetworking/cni/releases/tag/v0.6.0).
 {{< /caution >}}
 
-Vous devez installer un add-on réseau pour pod afin que vos pods puissent communiquer les uns
-avec les autres.
+{{< note >}}
+Kubeadm doit rester agnostique vis-à-vis de CNI et la validation des fournisseurs CNI est hors du périmètre des tests e2e actuels.
+Si vous rencontrez un problème lié à un plugin CNI, veuillez ouvrir un ticket dans son tracker respectif
+plutôt que dans les trackers kubeadm ou Kubernetes.
+{{< /note >}}
 
-**Le réseau doit être déployé avant toute application. De plus, CoreDNS ne démarrera pas avant
-l’installation d’un réseau.
-kubeadm ne prend en charge que les réseaux basés sur un CNI (et ne prend pas
-en charge kubenet).**
+Plusieurs projets externes fournissent des réseaux de Pods Kubernetes via CNI, certains prenant également en charge les
+[politiques réseau](/docs/concepts/services-networking/network-policies/).
 
-Plusieurs projets fournissent des réseaux de pod Kubernetes utilisant CNI, dont certains
-supportent les [network policies](/docs/concepts/services-networking/networkpolicies/).
-Allez voir la [page des add-ons](/docs/concepts/cluster-administration/addons/) pour une liste complète
-des add-ons réseau disponibles.
-- Le support IPv6 a été ajouté dans [CNI v0.6.0](https://github.com/containernetworking/cni/releases/tag/v0.6.0).
-- [CNI bridge](https://github.com/containernetworking/plugins/blob/master/plugins/main/bridge/README.md) et
-[local-ipam](https://github.com/containernetworking/plugins/blob/master/plugins/ipam/host-local/README.md)
-sont les seuls plug-ins de réseau IPv6 pris en charge dans Kubernetes version 1.9.
+Voir la liste des add-ons qui implémentent le
+[modèle réseau Kubernetes](/docs/concepts/cluster-administration/networking/#how-to-implement-the-kubernetes-network-model).
 
-Notez que kubeadm configure un cluster sécurisé par défaut et impose l’utilisation de
-[RBAC](/docs/reference/access-authn-authz/rbac/).
-Assurez-vous que votre manifeste de réseau prend en charge RBAC.
+Veuillez consulter la page [Installation des add-ons](/docs/concepts/cluster-administration/addons/#networking-and-network-policy)
+pour une liste non exhaustive des plugins réseau supportés par Kubernetes.
 
-Veuillez également à ce que votre réseau Pod ne se superpose à aucun des réseaux hôtes,
-car cela pourrait entraîner des problèmes.
-Si vous constatez une collision entre le réseau de pod de votre plug-in de réseau et certains
-de vos réseaux hôtes,
-vous devriez penser à un remplacement de CIDR approprié et l'utiliser lors de `kubeadm init` avec
- `--pod-network-cidr` et en remplacement du YAML de votre plugin réseau.
-Vous pouvez installer un add-on réseau de pod avec la commande suivante:
+Vous pouvez installer un add-on réseau de Pods avec la commande suivante sur le
+nœud du plan de contrôle ou sur un nœud disposant des identifiants kubeconfig :
 
 ```bash
 kubectl apply -f <add-on.yaml>
 ```
 
-Vous ne pouvez installer qu'un seul réseau de pod par cluster.
+{{< note >}}
+Seuls quelques plugins CNI prennent en charge Windows. Plus de détails et des instructions de configuration sont disponibles dans
+[Ajout de nœuds workers Windows](/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/#network-config).
+{{< /note >}}
 
-{{< tabs name="tabs-pod-install" >}}
-{{% tab name="Choisissez-en un..." %}}
-Sélectionnez l'un des onglets pour consulter les instructions d'installation du fournisseur
-de réseau de pods.{{% /tab %}}
+Vous ne pouvez installer qu’un seul réseau de Pods par cluster.
 
-{{% tab name="Calico" %}}
-Pour plus d'informations sur l'utilisation de Calico, voir
-[Guide de démarrage rapide de Calico sur Kubernetes](https://docs.projectcalico.org/latest/getting-started/kubernetes/),
-[Installation de Calico pour les netpols ( network policies ) et le réseau](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/calico), ainsi que d'autres resources liées à ce sujet.
+Une fois un réseau de Pods installé, vous pouvez vérifier qu’il fonctionne en contrôlant que le Pod CoreDNS est à l’état `Running`
+dans la sortie de `kubectl get pods --all-namespaces`.
+Une fois le Pod CoreDNS en cours d’exécution, vous pouvez continuer en ajoutant vos nœuds au cluster.
 
-Pour que Calico fonctionne correctement, vous devez passer `--pod-network-cidr = 192.168.0.0 / 16`
-à `kubeadm init` ou mettre à jour le fichier `calico.yml` pour qu'il corresponde à votre réseau de Pod.
-Notez que Calico fonctionne uniquement sur `amd64`, `arm64`, `ppc64le` et `s390x`.
+Si votre réseau ne fonctionne pas ou si CoreDNS n’est pas à l’état `Running`, consultez le
+[guide de dépannage](/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/)
+pour `kubeadm`.
 
-```shell
-kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
-```
+### Labels des nœuds gérés
 
-{{% /tab %}}
-{{% tab name="Canal" %}}
-Canal utilise Calico pour les netpols et Flannel pour la mise en réseau. Reportez-vous à la
-documentation Calico pour obtenir le [guide de démarrage officiel](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/flannel).
+Par défaut, kubeadm active le contrôleur d’admission
+[NodeRestriction](/docs/reference/access-authn-authz/admission-controllers/#noderestriction)
+qui limite les labels pouvant être appliqués automatiquement par les kubelets lors de l’enregistrement d’un nœud.
+La documentation du contrôleur d’admission décrit les labels autorisés avec l’option kubelet `--node-labels`.
 
-Pour que Canal fonctionne correctement, `--pod-network-cidr = 10.244.0.0 / 16` doit être passé à
-`kubeadm init`. Notez que Canal ne fonctionne que sur `amd64`.
+Le label `node-role.kubernetes.io/control-plane` fait partie des labels restreints et kubeadm l’applique manuellement
+à l’aide d’un client privilégié après la création d’un nœud. Pour faire cela manuellement, vous pouvez utiliser `kubectl label`
+et vous assurer d’utiliser un kubeconfig privilégié tel que celui géré par kubeadm : `/etc/kubernetes/admin.conf`.
 
-```shell
-kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/canal.yaml
-```
+### Isolation du nœud de plan de contrôle
 
-{{% /tab %}}
-
-{{% tab name="Cilium" %}}
-Pour plus d'informations sur l'utilisation de Cilium avec Kubernetes, voir
-[Guide d'installation de Kubernetes pour Cilium](https://docs.cilium.io/en/stable/kubernetes/).
-
-Ces commandes déploieront Cilium avec son propre etcd géré par l'opérateur etcd.
-
-Note: Si vous utilisez kubeadm dans un seul noeud, veuillez enlever sa marque (taint) pour que
-les pods etcd-operator puissent être déployés dans le nœud du control plane.
-
-```shell
-kubectl taint nodes <node-name> node-role.kubernetes.io/master:NoSchedule-
-```
-
-Pour déployer Cilium, il vous suffit de lancer:
-```shell
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.4/examples/kubernetes/1.13/cilium.yaml
-```
-
-Une fois que tous les pods Cilium sont marqués «READY», vous commencez à utiliser votre cluster.
-```shell
-$ kubectl get pods -n kube-system --selector=k8s-app=cilium
-NAME           READY   STATUS    RESTARTS   AGE
-cilium-drxkl   1/1     Running   0          18m
-```
-
-{{% /tab %}}
-{{% tab name="Flannel" %}}
-
-Pour que `flannel` fonctionne correctement, vous devez passer `--pod-network-cidr = 10.244.0.0 / 16` à `kubeadm init`.
-Paramétrez `/proc/sys/net/bridge/bridge-nf-call-iptables` à «1» en exécutant
- `sysctl net.bridge.bridge-nf-call-iptables = 1`
-passez le trafic IPv4 bridged à iptables. Ceci est nécessaire pour que certains plugins CNI
-fonctionnent, pour plus d'informations
-allez voir [ici](/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
-
-Notez que `flannel` fonctionne sur `amd64`, `arm`, `arm64`, `ppc64le` et `s390x` sous Linux.
-Windows (`amd64`) est annoncé comme supporté dans la v0.11.0 mais son utilisation n’est pas
-documentée.
-
-```shell
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml
-```
-Pour plus d’informations sur `flannel`, voir [le dépôt CoreOS sur GitHub](https://github.com/coreos/flannel).
-{{% /tab %}}
-
-{{% tab name="Kube-router" %}}
-Paramétrez `/proc/sys/net/bridge/bridge-nf-call-iptables` à «1» en exécutant
-`sysctl net.bridge.bridge-nf-call-iptables = 1`
-Cette commande indiquera de passer le trafic IPv4 bridgé à iptables.
-Ceci est nécessaire pour que certains plugins CNI fonctionnent, pour plus d'informations
-s'il vous plaît allez voir [ici](/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
-
-Kube-router s'appuie sur kube-controller-manager pour allouer le pod CIDR aux nœuds. Par conséquent,
-utilisez `kubeadm init` avec l'option `--pod-network-cidr`.
-
-Kube-router fournit un réseau de pod, une stratégie réseau et un proxy de service basé sur un
-IP Virtual Server (IPVS) / Linux Virtual Server (LVS) hautement performant.
-
-Pour plus d'informations sur la configuration du cluster Kubernetes avec Kube-router à l'aide de kubeadm,
-veuillez consulter le [guide d'installation](https://github.com/cloudnativelabs/kube-router/blob/master/docs/kubeadm.md).
-{{% /tab %}}
-
-{{% tab name="Romana" %}}
-Paramétrez `/proc/sys/net/bridge/bridge-nf-call-iptables` à `1` en exécutant
-`sysctl net.bridge.bridge-nf-call-iptables = 1`
-Cette commande indiquera de passer le trafic IPv4 bridged à iptables. Ceci est nécessaire pour que certains plugins CNI fonctionnent,
-pour plus d'informations
-veuillez consulter la documentation [ici](/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
-
-Le guide d'installation officiel de Romana est [ici](https://github.com/romana/romana/tree/master/containerize#using-kubeadm).
-
-Romana ne fonctionne que sur `amd64`.
-
-```shell
-kubectl apply -f https://raw.githubusercontent.com/romana/romana/master/containerize/specs/romana-kubeadm.yml
-```
-{{% /tab %}}
-
-{{% tab name="Weave Net" %}}
-Paramétrez `/proc/sys/net/bridge/bridge-nf-call-iptables` à «1» en exécutant `sysctl net.bridge.bridge-nf-call-iptables = 1`
-Cette commande indiquera de passer le trafic IPv4 bridged à iptables. Ceci est nécessaire pour que certains plugins CNI fonctionnent, pour plus d'informations
-s'il vous plaît allez voir [ici](/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
-
-Le guide de configuration officiel de Weave Net est [ici](https://www.weave.works/docs/net/latest/kube-addon/).
-
-Weave Net fonctionne sur `amd64`, `arm`, `arm64` et `ppc64le` sans aucune action supplémentaire requise.
-Weave Net paramètre le mode hairpin par défaut. Cela permet aux pods de se connecter via leur adresse IP de service
-s'ils ne connaissent pas leur Pod IP.
-
-```shell
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
-```
-{{% /tab %}}
-
-{{% tab name="JuniperContrail/TungstenFabric" %}}
-Fournit une solution SDN superposée, offrant un réseau multicouches, un réseau de cloud hybride,
-prise en charge simultanée des couches superposées, application de la stratégie réseau, isolation du réseau,
-chaînage de service et équilibrage de charge flexible.
-
-Il existe de nombreuses manières flexibles d’installer JuniperContrail / TungstenFabric CNI.
-
-Veuillez vous référer à ce guide de démarrage rapide: [TungstenFabric](https://tungstenfabric.github.io/website/)
-{{% /tab %}}
-{{< /tabs >}}
-
-
-Une fois qu'un réseau de pod a été installé, vous pouvez vérifier qu'il fonctionne en
-vérifiant que le pod CoreDNS est en cours d’exécution dans l'output de `kubectl get pods --all-namespaces`.
-Et une fois que le pod CoreDNS est opérationnel, vous pouvez continuer en joignant vos nœuds.
-
-Si votre réseau ne fonctionne pas ou si CoreDNS n'est pas en cours d'exécution, vérifiez
-notre [documentation de dépannage](/fr/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/).
-
-### Isolation des nœuds du control plane
-
-Par défaut, votre cluster ne déploie pas de pods sur le master pour des raisons de sécurité.
-Si vous souhaitez pouvoir déployer des pods sur le master, par exemple, pour un
-cluster Kubernetes mono-machine pour le développement, exécutez:
+Par défaut, votre cluster ne planifie pas de Pods sur les nœuds du plan de contrôle pour des raisons de sécurité.
+Si vous souhaitez autoriser l’exécution de Pods sur les nœuds du plan de contrôle, par exemple pour un cluster Kubernetes sur une seule machine,
+exécutez :
 
 ```bash
-kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 ```
 
-Avec un resultat ressemblant à quelque chose comme:
+Le résultat ressemblera à ceci :
 
 ```
 node "test-01" untainted
-taint "node-role.kubernetes.io/master:" not found
-taint "node-role.kubernetes.io/master:" not found
+...
 ```
 
-Cela supprimera la marque `node-role.kubernetes.io/master` de tous les nœuds qui
-l'ont, y compris du nœud master, ce qui signifie que le scheduler sera alors capable
-de déployer des pods partout.
+Cela supprimera le taint `node-role.kubernetes.io/control-plane:NoSchedule`
+sur tous les nœuds qui le possèdent, y compris les nœuds du plan de contrôle, ce qui permettra ensuite au planificateur (scheduler)
+de planifier des Pods sur tous les nœuds.
 
-### Faire rejoindre vos nœuds {#join-nodes}
+De plus, vous pouvez exécuter la commande suivante pour supprimer le label
+[`node.kubernetes.io/exclude-from-external-load-balancers`](/docs/reference/labels-annotations-taints/#node-kubernetes-io-exclude-from-external-load-balancers)
+du nœud du plan de contrôle, ce qui l’exclut de la liste des serveurs backend :
 
-Les nœuds sont ceux sur lesquels vos workloads (conteneurs, pods, etc.) sont exécutées.
- Pour ajouter de nouveaux nœuds à votre cluster, procédez comme suit pour chaque machine:
-
-* SSH vers la machine
-* Devenir root (par exemple, `sudo su-`)
-* Exécutez la commande qui a été récupérée sur l'output de `kubeadm init`. Par exemple:
-
-``` bash
-kubeadm join --token <token> <master-ip>:<master-port> --discovery-token-ca-cert-hash sha256:<hash>
+```bash
+kubectl label nodes --all node.kubernetes.io/exclude-from-external-load-balancers-
 ```
 
-Si vous n'avez pas le jeton, vous pouvez l'obtenir en exécutant la commande suivante sur le nœud master:
-``` bash
-kubeadm token list
-```
+### Ajout de nœuds de plan de contrôle supplémentaires
 
-L'output est similaire à ceci:
-``` console
-TOKEN                    TTL  EXPIRES              USAGES           DESCRIPTION            EXTRA GROUPS
-8ewj1p.9r9hcjoqgajrj4gi  23h  2018-06-12T02:51:28Z authentication,  The default bootstrap  system:
-                                                   signing          token generated by     bootstrappers:
-                                                                    'kubeadm init'.        kubeadm:
-                                                                                           default-node-token
-```
+Voir [Créer des clusters hautement disponibles avec kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/)
+pour les étapes permettant de créer un cluster kubeadm hautement disponible en ajoutant plusieurs nœuds de plan de contrôle.
 
-Par défaut, les jetons expirent après 24 heures. Si vous joignez un nœud au cluster après
-l’expiration du jeton actuel,
-vous pouvez créer un nouveau jeton en exécutant la commande suivante sur le nœud maître:
-``` bash
-kubeadm token create
-```
+### Ajout de nœuds workers {#join-nodes}
 
-L'output est similaire à ceci:
-``` console
-5didvk.d09sbcov8ph2amjw
-```
+Les nœuds workers sont ceux où s’exécutent vos workloads.
 
-Si vous n'avez pas la valeur `--discovery-token-ca-cert-hash`, vous pouvez l'obtenir en
-exécutant la suite de commande suivante sur le nœud master:
-``` bash
-openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | \
-   openssl dgst -sha256 -hex | sed 's/^.* //'
-```
+Les pages suivantes expliquent comment ajouter des nœuds workers Linux et Windows au cluster en utilisant
+la commande `kubeadm join` :
 
-L'output est similaire à ceci:
-``` console
-8cb2de97839780a412b93877f8507ad6c94f73add17d5d7058e91741c9d5ec78
-```
+* [Ajout de nœuds workers Linux](/docs/tasks/administer-cluster/kubeadm/adding-linux-nodes/)
+* [Ajout de nœuds workers Windows](/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/)
 
-{{< note >}}
-Pour spécifier un tuple IPv6 pour `<maître-ip>: <maître-port>`, l'adresse IPv6 doit être placée
-entre crochets, par exemple: `[fd00 :: 101]: 2073`.{{< /note >}}
+### (Optionnel) Contrôler votre cluster depuis des machines autres que le nœud de plan de contrôle
 
-Le resultat devrait ressembler à quelque chose comme:
-```
-[preflight] Running pre-flight checks
+Afin d’utiliser `kubectl` depuis une autre machine (par exemple un ordinateur portable) pour communiquer avec votre
+cluster, vous devez copier le fichier kubeconfig administrateur depuis votre nœud de plan de contrôle
+vers votre poste de travail comme ceci :
 
-... (log output of join workflow) ...
-
-Node join complete:
-* Certificate signing request sent to master and response
-  received.
-* Kubelet informed of new secure connection details.
-
-Run 'kubectl get nodes' on the master to see this machine join.
-```
-
-Quelques secondes plus tard, vous remarquerez ce nœud dans l'output de `kubectl get
-node`.
-
-### (Optionnel) Contrôler votre cluster à partir de machines autres que le master
-
-Afin d'utiliser kubectl sur une autre machine (par exemple, un ordinateur portable) pour communiquer avec votre
-cluster, vous devez copier le fichier administrateur kubeconfig de votre master
-sur votre poste de travail comme ceci:
-
-``` bash
-scp root@<master ip>:/etc/kubernetes/admin.conf .
+```bash
+scp root@<control-plane-host>:/etc/kubernetes/admin.conf .
 kubectl --kubeconfig ./admin.conf get nodes
 ```
 
 {{< note >}}
-L'exemple ci-dessus suppose que l'accès SSH est activé pour root. Si ce n'est pas le cas,
- vous pouvez copier le fichier `admin.conf` pour qu'il soit accessible à un autre utilisateur.
-et `scp` en utilisant cet autre utilisateur à la place.
+L’exemple ci-dessus suppose que l’accès SSH est activé pour l’utilisateur root. Si ce n’est pas le cas,
+vous pouvez copier le fichier `admin.conf` pour qu’il soit accessible par un autre utilisateur,
+puis utiliser `scp` avec cet autre utilisateur.
 
-Le fichier `admin.conf` donne à l'utilisateur _superuser_ des privilèges sur le cluster.
-Ce fichier doit être utilisé avec parcimonie. Pour les utilisateurs normaux, il est recommandé de
-générer une information d'identification unique pour laquelle vous ajoutez des privilèges à la liste blanche
- (whitelist).
-Vous pouvez faire ceci avec `kubeadm alpha kubeconfig utilisateur --nom-client <CN>`.
-Le resultat de cette commande génèrera un fichier KubeConfig qui sera envoyé sur STDOUT, que vous
-devrez enregistrer dans un fichier et donner à votre utilisateur. Après cela, créez la whitelist des
-privilèges en utilisant `kubectl create (cluster) rolebinding.`
+Le fichier `admin.conf` donne à l’utilisateur des privilèges _superutilisateur_ sur le cluster.
+Ce fichier doit être utilisé avec précaution. Pour les utilisateurs normaux, il est recommandé de générer
+des identifiants uniques auxquels vous accordez des permissions spécifiques. Vous pouvez le faire avec la commande
+`kubeadm kubeconfig user --client-name <CN>`.
+Cette commande affiche un fichier KubeConfig sur la sortie standard (STDOUT) que vous devez enregistrer dans un fichier
+et distribuer à l’utilisateur. Ensuite, accordez les privilèges avec `kubectl create (cluster)rolebinding`.
 {{< /note >}}
 
-### (Facultatif) Proxifier l'API Server vers localhost
+### (Optionnel) Proxy du serveur API vers localhost
 
-Si vous souhaitez vous connecter à l'API server à partir de l'éxterieur du cluster, vous pouvez utiliser
-`kubectl proxy`:
+Si vous souhaitez vous connecter au serveur API depuis l’extérieur du cluster, vous pouvez utiliser
+`kubectl proxy` :
 
 ```bash
-scp root@<master ip>:/etc/kubernetes/admin.conf .
+scp root@<control-plane-host>:/etc/kubernetes/admin.conf .
 kubectl --kubeconfig ./admin.conf proxy
 ```
 
-Vous pouvez maintenant accéder à l'API server localement à `http://localhost:8001/api/v1`
+Vous pouvez désormais accéder au serveur API localement à l’adresse `http://localhost:8001/api/v1`
 
-## Destruction {#tear-down}
+## Nettoyage {#tear-down}
 
-Pour annuler ce que kubeadm a fait, vous devez d’abord
+Si vous avez utilisé des serveurs jetables pour votre cluster de test, vous pouvez simplement les éteindre sans effectuer de nettoyage supplémentaire.
+Vous pouvez utiliser `kubectl config delete-cluster` pour supprimer vos références locales au cluster.
+
+Cependant, si vous souhaitez désactiver votre cluster de manière plus propre, vous devez d’abord
 [drainer le nœud](/docs/reference/generated/kubectl/kubectl-commands#drain)
-et assurez-vous que le nœud est vide avant de l'arrêter.
-En communiquant avec le master en utilisant les informations d'identification appropriées, exécutez:
+et vous assurer que le nœud est vide, puis désconfigurer le nœud.
+
+### Supprimer le nœud
+
+En vous connectant au nœud du plan de contrôle avec les identifiants appropriés, exécutez :
+
 ```bash
-kubectl drain <node name> --delete-local-data --force --ignore-daemonsets
-kubectl delete node <node name>
+kubectl drain <node name> --delete-emptydir-data --force --ignore-daemonsets
 ```
 
-Ensuite, sur le nœud en cours de suppression, réinitialisez l'état de tout ce qui concerne kubeadm:
+Avant de supprimer le nœud, réinitialisez l'état installé par `kubeadm` :
+
 ```bash
 kubeadm reset
 ```
 
-Le processus de réinitialisation ne réinitialise pas et ne nettoie pas les règles iptables ni les
-tables IPVS. Si vous souhaitez réinitialiser iptables, vous devez le faire manuellement:
+La procédure de réinitialisation ne supprime ni ne réinitialise les règles iptables ni les tables IPVS.
+Pour réinitialiser iptables, vous devez le faire manuellement.
+
 ```bash
 iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X
 ```
 
-Si vous souhaitez réinitialiser les tables IPVS, vous devez exécuter la commande suivante:
+Pour réinitialiser les tables IPVS, vous devez exécuter la commande suivante :
+
 ```bash
 ipvsadm -C
 ```
 
-Si vous souhaitez recommencer Il suffit de lancer `kubeadm init` ou `kubeadm join` avec les
-arguments appropriés.
-Plus d'options et d'informations sur la
-[`commande de réinitialisation de kubeadm`](/docs/reference/setup-tools/kubeadm/kubeadm-reset/).
+Supprimez maintenant le nœud :
 
-## Maintenir un cluster {#lifecycle}
+```bash
+kubectl delete node <node name>
+```
 
-Vous trouverez des instructions pour la maintenance des clusters kubeadm (mises à niveau,
-rétrogradation, etc.) [ici](/docs/tasks/administer-cluster/kubeadm)
+Si vous souhaitez recommencer, exécutez `kubeadm init` ou `kubeadm join` avec les arguments appropriés.
 
-## Explorer les autres add-ons {#other-addons}
+### Nettoyage du plan de contrôle
 
-Parcourez la [liste des add-ons](/docs/concepts/cluster-administration/addons/),
-y compris des outils pour la journalisation, la surveillance, la stratégie réseau, la visualisation
-et le contrôle de votre cluster Kubernetes.
+Vous pouvez utiliser `kubeadm reset` sur l’hôte du plan de contrôle pour effectuer un nettoyage au mieux des efforts.
 
-## Et après ? {#whats-next}
+Voir la documentation de référence [`kubeadm reset`](/docs/reference/setup-tools/kubeadm/kubeadm-reset/)
+pour plus d’informations sur cette sous-commande et ses options.
 
-* Vérifiez que votre cluster fonctionne correctement avec [Sonobuoy](https://github.com/heptio/sonobuoy)
-* En savoir plus sur l'utilisation avancée de kubeadm dans la
-[documentation de référence de kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm)
-* En savoir plus sur Kubernetes [concepts](/docs/concepts/) et [`kubectl`](/docs/user-guide/kubectl-overview/).
-* Configurez la rotation des logs. Vous pouvez utiliser **logrotate** pour cela. Lorsque vous utilisez Docker,
- vous pouvez spécifier des options de rotation des logs pour le démon Docker, par exemple
-  `--log-driver = fichier_json --log-opt = taille_max = 10m --log-opt = fichier_max = 5`.
-  Consultez [Configurer et dépanner le démon Docker](https://docs.docker.com/engine/admin/) pour plus de détails.
+## Politique de décalage de versions {#version-skew-policy}
 
-## Feedback {#feedback}
+Bien que kubeadm autorise un décalage de versions avec certains composants qu’il gère, il est recommandé de faire correspondre
+la version de kubeadm avec celles des composants du plan de contrôle, de kube-proxy et du kubelet.
 
-* Pour les bugs, visitez [kubeadm GitHub issue tracker](https://github.com/kubernetes/kubeadm/issues)
-* Pour le support, rendez vous sur le Channel Slack kubeadm:
-  [#kubeadm](https://kubernetes.slack.com/messages/kubeadm/)
-* Le Channel Slack: General SIG Cluster Lifecycle Development:
-  [#sig-cluster-lifecycle](https://kubernetes.slack.com/messages/sig-cluster-lifecycle/)
-* [SIG Cluster Lifecycle SIG information](#TODO)
-* SIG Cluster Lifecycle Mailing List:
-  [kubernetes-sig-cluster-lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
+### Décalage de kubeadm par rapport à la version de Kubernetes
 
-## Politique de compatibilité de versions {#version-skew-policy}
+kubeadm peut être utilisé avec des composants Kubernetes ayant la même version que kubeadm ou une version plus ancienne.
+La version de Kubernetes peut être spécifiée à kubeadm via le flag `--kubernetes-version` de `kubeadm init`
+ou via le champ `ClusterConfiguration.kubernetesVersion` lorsque vous utilisez `--config`.
 
-L'outil CLI kubeadm de la version vX.Y peut déployer des clusters avec un control
-plane de la version vX.Y ou vX. (Y-1).
-kubeadm CLI vX.Y peut également mettre à niveau un cluster existant créé par kubeadm
- de la version vX. (Y-1).
+Cette option contrôle les versions de kube-apiserver, kube-controller-manager, kube-scheduler et kube-proxy.
 
-Pour cette raison, nous ne pouvons pas voir plus loin, kubeadm CLI vX.Y peut ou pas être
-en mesure de déployer des clusters vX. (Y + 1).
+Exemple :
 
-Exemple: kubeadm v1.8 peut déployer des clusters v1.7 et v1.8 et mettre à niveau des
-clusters v1.7 créés par kubeadm vers
-v1.8.
+* kubeadm est en version {{< skew currentVersion >}}
+* `kubernetesVersion` doit être en {{< skew currentVersion >}} ou {{< skew currentVersionAddMinor -1 >}}
 
-Ces ressources fournissent plus d'informations sur le saut de version pris en
-charge entre les kubelets et le control plane, ainsi que sur d'autres composants Kubernetes:
+### Décalage de kubeadm par rapport au kubelet
 
-* [politique de compatibilité de versions](/docs/setup/version-skew-policy/) de Kubernetes
-* [Guide d'installation](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)
-spécifique à Kubeadm
+De manière similaire à la version de Kubernetes, kubeadm peut être utilisé avec une version de kubelet identique
+ou jusqu’à trois versions mineures plus anciennes.
 
-## kubeadm fonctionne sur plusieurs plates-formes {#multi-platform}
+Exemple :
 
-Les packages et fichiers binaires de kubeadm deb/rpm sont conçus pour amd64, arm (32 bits), arm64, ppc64le et s390x
-suite à la [multiplateforme proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multi-platform.md).
+* kubeadm est en version {{< skew currentVersion >}}
+* le kubelet sur l’hôte doit être en {{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}},
+  {{< skew currentVersionAddMinor -2 >}} ou {{< skew currentVersionAddMinor -3 >}}
 
-Les images de conteneur multiplatform pour le control plane et les addons sont également pris en charge depuis la v1.12.
+### Décalage de kubeadm par rapport à kubeadm
 
-Seuls certains fournisseurs de réseau proposent des solutions pour toutes les plateformes. Veuillez consulter la liste des
-fournisseurs de réseau ci-dessus ou la documentation de chaque fournisseur pour déterminer si le fournisseur
-prend en charge votre plate-forme.
+Il existe certaines limitations sur la manière dont les commandes kubeadm peuvent opérer sur des nœuds existants ou des clusters
+entièrement gérés par kubeadm.
+
+Si de nouveaux nœuds rejoignent le cluster, le binaire kubeadm utilisé pour `kubeadm join` doit correspondre
+à la dernière version de kubeadm utilisée pour créer le cluster avec `kubeadm init` ou pour mettre à jour
+ce même nœud avec `kubeadm upgrade`. Des règles similaires s’appliquent aux autres commandes kubeadm,
+à l’exception de `kubeadm upgrade`.
+
+Exemple pour `kubeadm join` :
+
+* kubeadm en version {{< skew currentVersion >}} a été utilisé pour créer un cluster avec `kubeadm init`
+* Les nœuds rejoignant le cluster doivent utiliser kubeadm en version {{< skew currentVersion >}}
+
+Les nœuds en cours de mise à jour doivent utiliser une version de kubeadm correspondant à la même version MINOR
+ou à une version MINOR supérieure à celle utilisée pour gérer le nœud.
+
+Exemple pour `kubeadm upgrade` :
+
+* kubeadm en version {{< skew currentVersionAddMinor -1 >}} a été utilisé pour créer ou mettre à jour le nœud
+* La version de kubeadm utilisée pour la mise à jour doit être en {{< skew currentVersionAddMinor -1 >}}
+  ou {{< skew currentVersion >}}
+
+Pour en savoir plus sur le décalage de versions entre les différents composants Kubernetes, voir la
+[politique de décalage de versions](/releases/version-skew-policy/).
 
 ## Limitations {#limitations}
 
-Remarque: kubeadm évolue continuellement et ces limitations seront résolues en temps voulu.
+### Résilience du cluster {#resilience}
 
-* Le cluster créé ici a un seul master, avec une seule base de données etcd. Cela signifie que
-si le master est irrécupérable, votre cluster peut perdre ses données et peut avoir besoin d'être recréé à
-partir de zéro. L'ajout du support HA (plusieurs serveurs etcd, plusieurs API servers, etc.)
-à kubeadm est encore en cours de developpement.
+Le cluster créé ici possède un seul nœud de plan de contrôle, avec une seule base de données etcd
+qui y est exécutée. Cela signifie que si le nœud du plan de contrôle tombe en panne, votre cluster peut perdre
+des données et devoir être recréé depuis zéro.
 
-   Contournement: régulièrement [sauvegarder etcd](https://etcd.io/docs/v3.5/op-guide/recovery/).
-le répertoire des données etcd configuré par kubeadm se trouve dans `/var/lib/etcd` sur le master.
+Solutions possibles :
 
-## Diagnostic {#troubleshooting}
+* Effectuer régulièrement des [sauvegardes etcd](https://etcd.io/docs/v3.5/op-guide/recovery/).
+  Le répertoire de données etcd configuré par kubeadm se trouve sur le nœud du plan de contrôle à `/var/lib/etcd`.
 
-Si vous rencontrez des difficultés avec kubeadm, veuillez consulter nos
- [troubleshooting docs](/fr/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/).
+* Utiliser plusieurs nœuds de plan de contrôle. Vous pouvez consulter
+  [Options de topologie hautement disponible](/docs/setup/production-environment/tools/kubeadm/ha-topology/)
+  pour choisir une topologie de cluster offrant une
+  [haute disponibilité](/docs/setup/production-environment/tools/kubeadm/high-availability/).
+
+### Compatibilité des plateformes {#multi-platform}
+
+Les packages deb/rpm et les binaires kubeadm sont construits pour amd64, arm (32 bits), arm64, ppc64le et s390x
+conformément à la [proposition multi-plateforme](https://git.k8s.io/design-proposals-archive/multi-platform.md).
+
+Les images de conteneurs multiplateformes pour le plan de contrôle et les add-ons sont également prises en charge depuis la version v1.12.
+
+Seuls certains fournisseurs réseau proposent des solutions pour toutes les plateformes. Veuillez consulter la liste des fournisseurs réseau
+ou leur documentation pour vérifier la compatibilité avec votre plateforme.
+
+## Dépannage {#troubleshooting}
+
+Si vous rencontrez des difficultés avec kubeadm, veuillez consulter la
+[documentation de dépannage](/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/).
+
+## {{% heading "whatsnext" %}}
+
+* Vérifiez que votre cluster fonctionne correctement avec [Sonobuoy](https://github.com/heptio/sonobuoy)
+* Consultez [Mise à niveau des clusters kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
+  pour mettre à jour votre cluster avec `kubeadm`
+* Apprenez l’utilisation avancée de `kubeadm` dans la [documentation de référence kubeadm](/docs/reference/setup-tools/kubeadm/)
+* Découvrez les [concepts Kubernetes](/docs/concepts/) et [`kubectl`](/docs/reference/kubectl/)
+* Consultez la page [Réseau du cluster](/docs/concepts/cluster-administration/networking/) pour une liste complète
+  des add-ons réseau de Pods
+* Consultez la [liste des add-ons](/docs/concepts/cluster-administration/addons/) pour explorer d’autres add-ons
+  (logs, monitoring, politiques réseau, visualisation et contrôle du cluster)
+* Configurez la gestion des logs des événements du cluster et des applications dans les Pods.
+  Voir [Architecture de logging](/docs/concepts/cluster-administration/logging/)
+
+### Feedback {#feedback}
+
+* Pour les bugs, visitez le [tracker GitHub kubeadm](https://github.com/kubernetes/kubeadm/issues)
+* Pour du support, rejoignez le canal Slack [#kubeadm](https://kubernetes.slack.com/messages/kubeadm/)
+* Canal Slack SIG Cluster Lifecycle : [#sig-cluster-lifecycle](https://kubernetes.slack.com/messages/sig-cluster-lifecycle/)
+* Informations SIG Cluster Lifecycle : https://github.com/kubernetes/community/tree/main/sig-cluster-lifecycle#readme
+* Liste de diffusion SIG Cluster Lifecycle :
+  https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle
+  

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -1,0 +1,193 @@
+---
+title: Support dual-stack avec kubeadm
+content_type: task
+weight: 100
+min-kubernetes-server-version: 1.21
+---
+
+<!-- aperçu -->
+
+{{< feature-state for_k8s_version="v1.23" state="stable" >}}
+
+Votre cluster Kubernetes inclut le support du [dual-stack](/docs/concepts/services-networking/dual-stack/),
+ce qui signifie que le réseau du cluster permet d’utiliser l’une ou l’autre famille d’adresses IP.
+Dans un cluster, le plan de contrôle peut attribuer à la fois une adresse IPv4 et une adresse IPv6 à un seul
+{{< glossary_tooltip text="Pod" term_id="pod" >}} ou à un {{< glossary_tooltip text="Service" term_id="service" >}}.
+
+<!-- corps -->
+
+## {{% heading "prerequisites" %}}
+
+Vous devez avoir installé l’outil {{< glossary_tooltip text="kubeadm" term_id="kubeadm" >}},
+en suivant les étapes de [Installation de kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
+
+Pour chaque serveur que vous souhaitez utiliser comme {{< glossary_tooltip text="nœud" term_id="node" >}},
+assurez-vous que le forwarding IPv6 est activé.
+
+### Activer le forwarding des paquets IPv6 {#prerequisite-ipv6-forwarding}
+
+Pour vérifier si le forwarding IPv6 est activé :
+
+```bash
+sysctl net.ipv6.conf.all.forwarding
+```
+
+Si la sortie est `net.ipv6.conf.all.forwarding = 1`, le transfert de paquets IPv6 est déjà activé.
+
+Sinon, il n'est pas encore activé.
+
+Pour activer manuellement le transfert de paquets IPv6 :
+
+```bash
+# sysctl params required by setup, params persist across reboots
+cat <<EOF | sudo tee -a /etc/sysctl.d/k8s.conf
+net.ipv6.conf.all.forwarding = 1
+EOF
+
+# Apply sysctl params without reboot
+sudo sysctl --system
+```
+
+Vous devez disposer d’une plage d’adresses IPv4 et IPv6 à utiliser. Les opérateurs de cluster utilisent généralement
+des plages d’adresses privées pour IPv4. Pour IPv6, un opérateur de cluster choisit généralement un bloc d’adresses unicast global
+dans `2000::/3`, en utilisant une plage attribuée à l’opérateur.
+Vous n’avez pas besoin de router les plages d’adresses IP du cluster vers Internet.
+
+La taille des allocations d’adresses IP doit être adaptée au nombre de Pods et de Services que vous prévoyez d’exécuter.
+
+{{< note >}}
+Si vous mettez à niveau un cluster existant avec la commande `kubeadm upgrade`,
+kubeadm ne prend pas en charge la modification de la plage d’adresses IP des Pods
+(“cluster CIDR”) ni de la plage d’adresses des Services (“Service CIDR”) du cluster.
+{{< /note >}}
+
+### Créer un cluster dual-stack
+
+Pour créer un cluster dual-stack avec `kubeadm init`, vous pouvez passer des arguments en ligne de commande
+similaires à l’exemple suivant :
+
+```shell
+# These address ranges are examples
+kubeadm init --pod-network-cidr=10.244.0.0/16,2001:db8:42:0::/56 --service-cidr=10.96.0.0/16,2001:db8:42:1::/112
+```
+
+Pour plus de clarté, voici un exemple de fichier de configuration kubeadm
+[configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/)
+`kubeadm-config.yaml` pour le nœud principal du plan de contrôle en dual-stack.
+
+```yaml
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+networking:
+  podSubnet: 10.244.0.0/16,2001:db8:42:0::/56
+  serviceSubnet: 10.96.0.0/16,2001:db8:42:1::/112
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: "10.100.0.1"
+  bindPort: 6443
+nodeRegistration:
+  kubeletExtraArgs:
+  - name: "node-ip"
+    value: "10.100.0.2,fd00:1:2:3::2"
+```
+
+`advertiseAddress` dans `InitConfiguration` spécifie l’adresse IP sur laquelle le serveur API annonce qu’il écoute.
+La valeur de `advertiseAddress` correspond au flag `--apiserver-advertise-address` de `kubeadm init`.
+
+Exécutez kubeadm pour initialiser le nœud du plan de contrôle en dual-stack :
+
+```shell
+kubeadm init --config=kubeadm-config.yaml
+```
+
+Les flags du kube-controller-manager `--node-cidr-mask-size-ipv4` et `--node-cidr-mask-size-ipv6`
+sont définis avec des valeurs par défaut. Voir
+[configurer le dual-stack IPv4/IPv6](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack).
+
+{{< note >}}
+Le flag `--apiserver-advertise-address` ne prend pas en charge le dual-stack.
+{{< /note >}}
+
+### Joindre un nœud à un cluster dual-stack
+
+Avant de joindre un nœud, assurez-vous que celui-ci dispose d’une interface réseau IPv6 routable et que le forwarding IPv6 est activé.
+
+Voici un exemple de fichier de configuration kubeadm
+[configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/)
+`kubeadm-config.yaml` pour ajouter un nœud worker au cluster.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: 10.100.0.1:6443
+    token: "clvldh.vjjwg16ucnhp94qr"
+    caCertHashes:
+    - "sha256:a4863cde706cfc580a439f842cc65d5ef112b7b2be31628513a9881cf0d9fe0e"
+    # change auth info above to match the actual token and CA certificate hash for your cluster
+nodeRegistration:
+  kubeletExtraArgs:
+  - name: "node-ip"
+    value: "10.100.0.2,fd00:1:2:3::3"
+```
+
+Voici également un exemple de fichier de configuration kubeadm
+[configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/)
+`kubeadm-config.yaml` pour ajouter un autre nœud de plan de contrôle au cluster.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+controlPlane:
+  localAPIEndpoint:
+    advertiseAddress: "10.100.0.2"
+    bindPort: 6443
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: 10.100.0.1:6443
+    token: "clvldh.vjjwg16ucnhp94qr"
+    caCertHashes:
+    - "sha256:a4863cde706cfc580a439f842cc65d5ef112b7b2be31628513a9881cf0d9fe0e"
+    # change auth info above to match the actual token and CA certificate hash for your cluster
+nodeRegistration:
+  kubeletExtraArgs:
+  - name: "node-ip"
+    value: "10.100.0.2,fd00:1:2:3::4"
+```
+
+`advertiseAddress` dans JoinConfiguration.controlPlane spécifie l'adresse IP sur laquelle
+le serveur API annoncera son écoute. La valeur de `advertiseAddress` correspond à
+l'option `--apiserver-advertise-address` de `kubeadm join`.
+
+```shell
+kubeadm join --config=kubeadm-config.yaml
+```
+
+### Créer un cluster mono-stack
+
+{{< note >}}
+Le support du dual-stack ne signifie pas que vous devez obligatoirement utiliser un adressage dual-stack.
+Vous pouvez déployer un cluster mono-stack avec la fonctionnalité de dual-stack réseau activée.
+{{< /note >}}
+
+Pour plus de clarté, voici un exemple de fichier de configuration kubeadm
+[configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/)
+`kubeadm-config.yaml` pour un nœud de plan de contrôle en mono-stack.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+networking:
+  podSubnet: 10.244.0.0/16
+  serviceSubnet: 10.96.0.0/16
+```
+
+## {{% heading "whatsnext" %}}
+
+* [Valider le dual-stack IPv4/IPv6](/docs/tasks/network/validate-dual-stack)
+* En savoir plus sur le réseau de cluster [Dual-stack](/docs/concepts/services-networking/dual-stack/)
+* Découvrir le format de configuration kubeadm [configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/)

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/ha-topology.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/ha-topology.md
@@ -1,82 +1,67 @@
 ---
-title: Options pour la topologie en haute disponibilité
-description: Topologie haute-disponibilité Kubernetes
+reviewers:
+- sig-cluster-lifecycle
+title: Options pour une topologie hautement disponible
 content_type: concept
 weight: 50
 ---
 
-<!-- overview -->
+<!-- aperçu -->
 
-Cette page explique les deux options de configuration de topologie de vos clusters Kubernetes
-pour la haute disponibilité.
+Cette page explique les deux options pour configurer la topologie de vos clusters Kubernetes hautement disponibles (HA).
 
-Vous pouvez configurer un cluster en haute disponibilité:
+Vous pouvez configurer un cluster HA :
 
-- Avec des nœuds du control plane empilés, les nœuds etcd étant co-localisés avec des nœuds du control plane
-- Avec des nœuds etcd externes, où etcd s'exécute sur des nœuds distincts du control plane
+- Avec des nœuds de plan de contrôle empilés (stacked), où les nœuds etcd sont co-localisés avec les nœuds du plan de contrôle
+- Avec des nœuds etcd externes, où etcd s’exécute sur des nœuds séparés des nœuds du plan de contrôle
 
-Vous devez examiner attentivement les avantages et les inconvénients de chaque topologie avant
-de configurer un cluster en haute disponibilité.
+Vous devez soigneusement comparer les avantages et inconvénients de chaque topologie avant de configurer un cluster HA.
 
+{{< note >}}
+kubeadm initialise le cluster etcd de manière statique. Consultez le
+[Guide de clustering etcd](https://github.com/etcd-io/etcd/blob/release-3.4/Documentation/op-guide/clustering.md#static)
+pour plus de détails.
+{{< /note >}}
 
-<!-- body -->
+<!-- corps -->
 
-## Topologie etcd empilée
+## Topologie etcd empilée (stacked)
 
-Un cluster HA empilé est une [topologie réseau](https://fr.wikipedia.org/wiki/Topologie_de_r%C3%A9seau)
-où le cluster de stockage de données distribuées est fourni par etcd et est superposé au
-cluster formé par les noeuds gérés par kubeadm qui exécute les composants du control plane.
+Un cluster HA empilé est une [topologie](https://en.wikipedia.org/wiki/Network_topology) dans laquelle le cluster de stockage distribué fourni par etcd est empilé sur le cluster formé par les nœuds gérés par kubeadm qui exécutent les composants du plan de contrôle.
 
-Chaque nœud du control plane exécute une instance de `kube-apiserver`, `kube-scheduler` et
-`kube-controller-manager`.
-Le `kube-apiserver` est exposé aux nœuds à l'aide d'un loadbalancer.
+Chaque nœud du plan de contrôle exécute une instance de `kube-apiserver`, `kube-scheduler` et `kube-controller-manager`.
+Le `kube-apiserver` est exposé aux nœuds workers via un load balancer.
 
-Chaque nœud du control plane crée un membre etcd local et ce membre etcd communique uniquement avec
-le `kube-apiserver` de ce noeud. Il en va de même pour le `kube-controller-manager` local
-et les instances de `kube-scheduler`.
+Chaque nœud du plan de contrôle crée un membre etcd local, et ce membre etcd communique uniquement avec le `kube-apiserver` de ce même nœud.
+Il en va de même pour les instances locales de `kube-controller-manager` et `kube-scheduler`.
 
-Cette topologie couple les control planes et les membres etcd sur les mêmes nœuds. C'est
-plus simple à mettre en place qu'un cluster avec des nœuds etcd externes et plus simple à
-gérer pour la réplication.
+Cette topologie couple les composants du plan de contrôle et les membres etcd sur les mêmes nœuds. Elle est plus simple à mettre en place qu’un cluster avec etcd externe, et plus simple à gérer pour la réplication.
 
-Cependant, un cluster empilé présente un risque d'échec du couplage. Si un noeud tombe en panne,
-un membre etcd et une instance du control plane sont perdus et la redondance est compromise. Vous
-pouvez atténuer ce risque en ajoutant plus de nœuds au control plane.
+Cependant, cette approche comporte un risque de couplage de défaillance. Si un nœud tombe, un membre etcd et une instance du plan de contrôle sont perdus, ce qui réduit la redondance.
+Vous pouvez atténuer ce risque en ajoutant davantage de nœuds de plan de contrôle.
 
-Par conséquent, vous devez exécuter au moins trois nœuds de control plane empilés pour un cluster
-en haute disponibilité.
+Il est donc recommandé d’exécuter au minimum trois nœuds de plan de contrôle empilés pour un cluster HA.
 
-C'est la topologie par défaut dans kubeadm. Un membre etcd local est créé automatiquement
-sur les noeuds du control plane en utilisant `kubeadm init` et `kubeadm join --experimental-control-plane`.
+C’est la topologie par défaut dans kubeadm. Un membre etcd local est créé automatiquement
+sur les nœuds du plan de contrôle lors de l’utilisation de `kubeadm init` et `kubeadm join --control-plane`.
 
-Schéma de la [Topologie etcd empilée](/images/kubeadm/kubeadm-ha-topology-stacked-etcd.svg)
+![Topologie etcd empilée](/images/kubeadm/kubeadm-ha-topology-stacked-etcd.svg)
 
 ## Topologie etcd externe
 
-Un cluster haute disponibilité avec un etcd externe est une
-[topologie réseau](https://fr.wikipedia.org/wiki/Topologie_de_r%C3%A9seau) où le cluster de stockage de données
-distribuées fourni par etcd est externe au cluster formé par les nœuds qui exécutent les composants
-du control plane.
+Un cluster HA avec etcd externe est une [topologie](https://en.wikipedia.org/wiki/Network_topology)
+dans laquelle le cluster de stockage distribué fourni par etcd est externe au cluster formé par les nœuds exécutant les composants du plan de contrôle.
 
-Comme la topologie etcd empilée, chaque nœud du control plane d'une topologie etcd externe exécute
-une instance de `kube-apiserver`, `kube-scheduler` et `kube-controller-manager`. Et le `kube-apiserver`
-est exposé aux nœuds workers à l’aide d’un load-balancer. Cependant, les membres etcd s'exécutent sur
-des hôtes distincts et chaque hôte etcd communique avec le `kube-apiserver` de chaque nœud du control plane.
+Comme dans la topologie empilée, chaque nœud du plan de contrôle exécute une instance de `kube-apiserver`, `kube-scheduler` et `kube-controller-manager`.
+Le `kube-apiserver` est exposé aux nœuds workers via un load balancer. Cependant, les membres etcd s’exécutent sur des hôtes séparés, et chaque hôte etcd communique avec le `kube-apiserver` de chaque nœud du plan de contrôle.
 
-Cette topologie dissocie le control plane et le membre etcd. Elle fournit donc une configuration HA où
-perdre une instance de control plane ou un membre etcd a moins d'impact et n'affecte pas la redondance du
-cluster autant que la topologie HA empilée.
+Cette topologie découple le plan de contrôle et etcd. Elle permet donc une meilleure résilience : la perte d’un nœud du plan de contrôle ou d’un membre etcd a moins d’impact sur la redondance du cluster.
 
-Cependant, cette topologie requiert le double du nombre d'hôtes de la topologie HA integrée.
-Un minimum de trois machines pour les nœuds du control plane et de trois machines
- pour les nœuds etcd est requis pour un cluster HA avec cette topologie.
+Cependant, cette topologie nécessite deux fois plus de machines que la topologie empilée.
+Un minimum de trois nœuds pour le plan de contrôle et trois nœuds pour etcd est requis pour un cluster HA avec cette topologie.
 
-Schéma de la [Topologie externe etcd](/images/kubeadm/kubeadm-ha-topology-external-etcd.svg)
-
-
+![Topologie etcd externe](/images/kubeadm/kubeadm-ha-topology-external-etcd.svg)
 
 ## {{% heading "whatsnext" %}}
 
-
-- [Configurer un cluster hautement disponible avec kubeadm](/fr/docs/setup/production-environment/tools/kubeadm/high-availability/)
-
+- [Configurer un cluster hautement disponible avec kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/)

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -1,348 +1,408 @@
 ---
+reviewers:
+- sig-cluster-lifecycle
 title: Création de clusters hautement disponibles avec kubeadm
-description: Cluster Kubernetes haute-disponibilité kubeadm
 content_type: task
 weight: 60
 ---
 
 <!-- overview -->
 
-Cette page explique deux approches différentes pour configurer un Kubernetes à haute disponibilité.
-cluster utilisant kubeadm:
+Cette page explique deux approches pour configurer un cluster Kubernetes hautement disponible
+(HA) à l’aide de kubeadm :
 
-- Avec des nœuds de control plane empilés. Cette approche nécessite moins d'infrastructure.
-Les membres etcd et les nœuds du control plane sont co-localisés.
-- Avec un cluster etcd externe cette approche nécessite plus d'infrastructure.
-Les nœuds du control plane et les membres etcd sont séparés.
+- Avec des nœuds de plan de contrôle empilés (stacked control plane). Cette approche nécessite moins d’infrastructure. Les membres etcd
+  et les nœuds de plan de contrôle sont co-localisés.
+- Avec un cluster etcd externe. Cette approche nécessite plus d’infrastructure. Les
+  nœuds de plan de contrôle et les membres etcd sont séparés.
 
-Avant de poursuivre, vous devez déterminer avec soin quelle approche répond le mieux
-aux besoins de vos applications et de l'environnement. [Cette comparaison](/fr/docs/setup/production-environment/tools/kubeadm/ha-topology/)
-décrit les avantages et les inconvénients de chacune.
+Avant de continuer, vous devez soigneusement choisir l’approche qui correspond le mieux aux besoins de vos applications
+et de votre environnement. La page Options de topologie hautement disponible décrit les avantages et inconvénients de chaque approche.
 
-Vos clusters doivent exécuter Kubernetes version 1.12 ou ultérieure. Vous devriez aussi savoir que
-la mise en place de clusters HA avec kubeadm est toujours expérimentale et sera simplifiée davantage
-dans les futures versions. Vous pouvez par exemple rencontrer des problèmes lors de la mise à niveau de vos clusters.
-Nous vous encourageons à essayer l’une ou l’autre approche et à nous faire part de vos commentaires dans
-[Suivi des problèmes Kubeadm](https://github.com/kubernetes/kubeadm/issues/new).
+Si vous rencontrez des problèmes lors de la configuration du cluster HA, veuillez les signaler
+dans le système de tickets kubeadm.
 
-Notez que la fonctionnalité alpha `HighAvailability` est obsolète dans la version 1.12 et supprimée dans la version 1.13
-
-Voir aussi [La documentation de mise à niveau HA](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-13).
+Voir également la documentation de mise à niveau.
 
 {{< caution >}}
-Cette page ne traite pas de l'exécution de votre cluster sur un fournisseur de cloud. Dans un
-environnement Cloud, les approches documentées ici ne fonctionnent ni avec des objets de type
-load balancer, ni avec des volumes persistants dynamiques.
+Cette page ne couvre pas les déploiements sur un fournisseur cloud. Dans un environnement cloud,
+aucune des approches décrites ici ne fonctionne correctement avec les objets Service de type LoadBalancer,
+ni avec les volumes persistants dynamiques.
 {{< /caution >}}
-
-
 
 ## {{% heading "prerequisites" %}}
 
+Les prérequis dépendent de la topologie choisie pour le plan de contrôle :
 
-Pour les deux méthodes, vous avez besoin de cette infrastructure:
+{{< tabs name="prerequisite_tabs" >}}
+{{% tab name="Stacked etcd" %}}
+<!--
+Note aux réviseurs : ces prérequis doivent correspondre au début de l’onglet externe etc.
+-->
 
-- Trois machines qui répondent aux pré-requis des [exigences de kubeadm](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin) pour les maîtres (masters)
-- Trois machines qui répondent aux pré-requis des [exigences de kubeadm](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin) pour les workers
-- Connectivité réseau complète entre toutes les machines du cluster (public ou réseau privé)
-- Privilèges sudo sur toutes les machines
-- Accès SSH d'une machine à tous les nœuds du cluster
-- `kubeadm` et une `kubelet` installés sur toutes les machines. `kubectl` est optionnel.
+Vous avez besoin de :
 
-Pour le cluster etcd externe uniquement, vous avez besoin également de:
+- Trois machines ou plus répondant aux [exigences minimales de kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin) pour
+  les nœuds du plan de contrôle. Avoir un nombre impair de nœuds de plan de contrôle peut aider
+  lors de l’élection du leader en cas de défaillance d’une machine ou d’une zone.
+  - incluant un {{< glossary_tooltip text="runtime de conteneurs" term_id="container-runtime" >}}, déjà installé et fonctionnel
+- Trois machines ou plus répondant aux [exigences minimales de kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin) pour les workers
+  - incluant un runtime de conteneurs, déjà installé et fonctionnel
+- Une connectivité réseau complète entre toutes les machines du cluster (réseau public ou privé)
+- Des privilèges superutilisateur sur toutes les machines via `sudo`
+  - Vous pouvez utiliser un autre outil ; ce guide utilise `sudo` dans les exemples.
+- Un accès SSH depuis une machine vers tous les nœuds du système
+- `kubeadm` et `kubelet` déjà installés sur toutes les machines.
 
-- Trois machines supplémentaires pour les membres etcd
+_Voir la [topologie etcd empilée](/docs/setup/production-environment/tools/kubeadm/ha-topology/#stacked-etcd-topology) pour le contexte._
 
-{{< note >}}
-Les exemples suivants utilisent Calico en tant que fournisseur de réseau de Pod. Si vous utilisez un autre
-CNI, pensez à remplacer les valeurs par défaut si nécessaire.
-{{< /note >}}
+{{% /tab %}}
+{{% tab name="External etcd" %}}
+<!--
+Note aux réviseurs : ces prérequis doivent correspondre au début de l’onglet externe etc.
+-->
 
+Vous avez besoin de :
 
+- Trois machines ou plus répondant aux [exigences minimales de kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin) pour
+  les nœuds du plan de contrôle. Avoir un nombre impair de nœuds de plan de contrôle peut aider
+  lors de l’élection du leader en cas de défaillance d’une machine ou d’une zone.
+  - incluant un {{< glossary_tooltip text="runtime de conteneurs" term_id="container-runtime" >}}, déjà configuré et fonctionnel
+- Trois machines ou plus répondant aux [exigences minimales de kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin) pour les workers
+  - incluant un runtime de conteneurs, déjà configuré et fonctionnel
+- Une connectivité réseau complète entre toutes les machines du cluster (réseau public ou privé)
+- Des privilèges superutilisateur sur toutes les machines via `sudo`
+  - Vous pouvez utiliser un autre outil ; ce guide utilise `sudo` dans les exemples.
+- Un accès SSH depuis une machine vers tous les nœuds du système
+- `kubeadm` et `kubelet` déjà installés sur toutes les machines.
 
-<!-- steps -->
+<!-- fin des prérequis communs -->
+
+Et vous avez également besoin de :
+
+- Trois machines supplémentaires ou plus, qui deviendront des membres du cluster etcd.
+  Avoir un nombre impair de membres dans le cluster etcd est une exigence pour obtenir un
+  quorum de vote optimal.
+  - Ces machines doivent également avoir `kubeadm` et `kubelet` installés.
+  - Ces machines nécessitent aussi un runtime de conteneurs, déjà configuré et fonctionnel.
+
+_Voir la [topologie etcd externe](/docs/setup/production-environment/tools/kubeadm/ha-topology/#external-etcd-topology) pour le contexte._
+{{% /tab %}}
+{{< /tabs >}}
+
+### Images de conteneurs
+
+Chaque hôte doit avoir accès en lecture et pouvoir récupérer les images depuis le registre d’images de conteneurs Kubernetes, `registry.k8s.io`. Si vous souhaitez déployer un cluster hautement disponible dont les hôtes n’ont pas accès pour télécharger les images, c’est possible. Vous devez alors vous assurer par d’autres moyens que les bonnes images de conteneurs sont déjà disponibles sur les hôtes concernés.
+
+### Interface en ligne de commande {#kubectl}
+
+Pour gérer Kubernetes une fois votre cluster configuré, vous devez
+[installer kubectl](/docs/tasks/tools/#kubectl) sur votre ordinateur. Il est également utile
+d’installer l’outil `kubectl` sur chaque nœud du plan de contrôle, car cela peut être
+utile pour le dépannage.
+
+<!-- étapes -->
 
 ## Premières étapes pour les deux méthodes
 
-{{< note >}}
-Toutes les commandes d'un control plane ou d'un noeud etcd doivent être
-éxecutées en tant que root.
-{{< /note >}}
-
-- Certains plugins réseau CNI tels que Calico nécessitent un CIDR tel que `192.168.0.0 / 16` et 
-certains comme Weave n'en ont pas besoin. Voir la
-[Documentation du CNI réseau](/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network).
-  Pour ajouter un CIDR de pod, définissez le champ `podSubnet: 192.168.0.0 / 16` sous
-  l'objet `networking` de` ClusterConfiguration`.
-
-### Créez un load balancer pour kube-apiserver
+### Création d’un load balancer pour kube-apiserver
 
 {{< note >}}
-Il existe de nombreuses configurations pour les équilibreurs de charge (load balancers).
-L'exemple suivant n'est qu'un exemple. Vos exigences pour votre cluster peuvent nécessiter une configuration différente.
+Il existe de nombreuses configurations possibles pour les load balancers. L’exemple suivant n’est qu’une
+option parmi d’autres. Les exigences de votre cluster peuvent nécessiter une configuration différente.
 {{< /note >}}
 
-1. Créez un load balancer kube-apiserver avec un nom résolu en DNS.
+1. Créer un load balancer pour le kube-apiserver avec un nom qui résout via DNS.
 
-    - Dans un environnement cloud, placez vos nœuds du control plane derrière un load balancer TCP.
-    Ce load balancer distribue le trafic à tous les nœuds du control plane sains dans sa liste.
-    La vérification de la bonne santé d'un apiserver est une vérification TCP sur le port que
-    kube-apiserver écoute (valeur par défaut: `6443`).
+   - Dans un environnement cloud, vous devez placer vos nœuds du plan de contrôle derrière un load balancer TCP. Ce load balancer distribue le trafic vers tous les nœuds du plan de contrôle en bonne santé présents dans sa liste de cibles. Le contrôle de santé (health check) pour l’API server est une vérification TCP sur le port utilisé par le kube-apiserver (valeur par défaut `:6443`).
 
-    - Il n'est pas recommandé d'utiliser une adresse IP directement dans un environnement cloud.
+   - Il n’est pas recommandé d’utiliser directement une adresse IP dans un environnement cloud.
 
-    - Le load balancer doit pouvoir communiquer avec tous les nœuds du control plane sur le
-    port apiserver. Il doit également autoriser le trafic entrant sur son réseau de port d'écoute.
+   - Le load balancer doit pouvoir communiquer avec tous les nœuds du plan de contrôle sur le port de l’API server. Il doit également autoriser le trafic entrant sur son port d’écoute.
 
-    - [HAProxy](http://www.haproxy.org/) peut être utilisé comme load balancer.
+   - Assurez-vous que l’adresse du load balancer correspond toujours à l’adresse définie dans le `ControlPlaneEndpoint` de kubeadm.
 
-    - Assurez-vous que l'adresse du load balancer correspond toujours à
-      l'adresse de `ControlPlaneEndpoint` de kubeadm.
+   - Consultez le guide [Options for Software Load Balancing](https://git.k8s.io/kubeadm/docs/ha-considerations.md#options-for-software-load-balancing) pour plus de détails.
 
-1. Ajoutez les premiers nœuds du control plane au load balancer et testez la connexion:
+1. Ajouter le premier nœud du plan de contrôle au load balancer, et tester la connexion :
 
-    ```sh
-    nc -v LOAD_BALANCER_IP PORT
-    ```
+   ```shell
+   nc -zv -w 2 <LOAD_BALANCER_IP> <PORT>
+   ```
 
-    - Une erreur `connection refused` est attendue car l'apiserver n'est pas encore en fonctionnement.
-     Cependant, un timeout signifie que le load balancer ne peut pas communiquer avec le nœud du
-     control plane. Si un timeout survient, reconfigurez le load balancer pour communiquer avec le nœud du control plane.
+   Une erreur de type connection refused est attendue car le serveur API n’est pas encore en cours d’exécution. En revanche, un timeout signifie que le load balancer ne peut pas communiquer avec le nœud du plan de contrôle. Si un timeout se produit, reconfigurez le load balancer afin qu’il puisse communiquer avec le nœud du plan de contrôle.
 
-1.  Ajouter les nœuds du control plane restants au groupe cible du load balancer.
+1. Ajouter les autres nœuds du plan de contrôle au groupe de cibles du load balancer.
 
-### Configurer SSH
+## Nœuds du plan de contrôle et etcd empilés (stacked)
 
-SSH est requis si vous souhaitez contrôler tous les nœuds à partir d'une seule machine.
+### Étapes pour le premier nœud du plan de contrôle
 
-1.  Activer ssh-agent sur votre machine ayant accès à tous les autres nœuds du cluster:
+1. Initialiser le plan de contrôle :
 
-    ```
-    eval $(ssh-agent)
-    ```
+   ```sh
+   sudo kubeadm init --control-plane-endpoint "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT" --upload-certs
+   ```
 
-1.  Ajoutez votre clé SSH à la session:
+   - Vous pouvez utiliser l’option `--kubernetes-version` pour définir la version de Kubernetes à utiliser.
+     Il est recommandé que les versions de kubeadm, kubelet, kubectl et Kubernetes soient identiques.
+   - L’option `--control-plane-endpoint` doit être définie avec l’adresse (ou le DNS) et le port du load balancer.
 
-    ```
-    ssh-add ~/.ssh/path_to_private_key
-    ```
+   - L’option `--upload-certs` est utilisée pour téléverser les certificats qui doivent être partagés
+     entre toutes les instances du plan de contrôle dans le cluster. Si vous préférez copier les certificats
+     manuellement entre les nœuds du plan de contrôle ou utiliser des outils d’automatisation, supprimez cette option et référez-vous à la section [Distribution manuelle des certificats](#manual-certs) ci-dessous.
 
-1.  SSH entre les nœuds pour vérifier que la connexion fonctionne correctement.
+   {{< note >}}
+   Les flags `--config` et `--certificate-key` de `kubeadm init` ne peuvent pas être utilisés ensemble.
+   Par conséquent, si vous souhaitez utiliser la [configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/),
+   vous devez ajouter le champ `certificateKey` aux emplacements appropriés
+   (dans `InitConfiguration` et `JoinConfiguration: controlPlane`).
+   {{< /note >}}
 
-    - Lorsque vous faites un SSH sur un noeud, assurez-vous d’ajouter l’option `-A`:
+   {{< note >}}
+   Certains plugins réseau CNI nécessitent une configuration supplémentaire, par exemple la définition du CIDR des pods, tandis que d’autres n’en ont pas besoin. 
+   Consultez la [documentation CNI](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network).
+   Pour ajouter un CIDR de pods, utilisez le flag `--pod-network-cidr`, ou si vous utilisez un fichier de configuration kubeadm, définissez le champ `podSubnet` dans l’objet `networking` de `ClusterConfiguration`.
+   {{< /note >}}
 
-        ```
-        ssh -A 10.0.0.7
-        ```
+   La sortie ressemble à :
 
-    - Lorsque vous utilisez sudo sur n’importe quel nœud, veillez à préserver l’environnement afin que le SSH forwarding fonctionne:
+   ```sh
+   ...
+   Vous pouvez maintenant joindre autant de nœuds du plan de contrôle que vous le souhaitez en exécutant la commande suivante sur chacun en tant que root :
+       kubeadm join 192.168.0.200:6443 --token 9vr73a.a8uxyaju799qwdjv --discovery-token-ca-cert-hash sha256:7c2e69131a36ae2a042a339b33381c6d0d43887e2de83720eff5359e26aec866 --control-plane --certificate-key f8902e114ef118304e561c3ecd4d0b543adc226b7a07f675f56564185ffe0c07
 
-        ```
-        sudo -E -s
-        ```
+   Veuillez noter que la certificate-key donne accès à des données sensibles du cluster, gardez-la secrète ! 
+   Par mesure de sécurité, les certificats téléversés seront supprimés au bout de deux heures. Si nécessaire, vous pouvez utiliser `kubeadm init phase upload-certs` pour recharger les certificats par la suite.
 
-## Control plane empilé et nœuds etcd
+   Ensuite, vous pouvez joindre autant de nœuds workers que vous le souhaitez en exécutant la commande suivante sur chacun en tant que root :
+       kubeadm join 192.168.0.200:6443 --token 9vr73a.a8uxyaju799qwdjv --discovery-token-ca-cert-hash sha256:7c2e69131a36ae2a042a339b33381c6d0d43887e2de83720eff5359e26aec866
+   ```
 
-### Étapes pour le premier nœud du control plane
+   - Copiez cette sortie dans un fichier texte. Vous en aurez besoin plus tard pour ajouter des nœuds du plan de contrôle et des nœuds workers au cluster.
+   - Lorsque l’option `--upload-certs` est utilisée avec `kubeadm init`, les certificats du plan de contrôle principal sont chiffrés et envoyés dans le Secret `kubeadm-certs`.
+   - Pour ré-envoyer les certificats et générer une nouvelle clé de déchiffrement, utilisez la commande suivante sur un nœud du plan de contrôle déjà joint au cluster :
 
-1.  Sur le premier nœud du control plane, créez un fichier de configuration appelé `kubeadm-config.yaml`:
+     ```sh
+     sudo kubeadm init phase upload-certs --upload-certs
+     ```
 
-        apiVersion: kubeadm.k8s.io/v1beta1
-        kind: ClusterConfiguration
-        kubernetesVersion: stable
-        apiServer:
-          certSANs:
-          - "LOAD_BALANCER_DNS"
-        controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
+   - Vous pouvez également spécifier une clé personnalisée `--certificate-key` lors de l’exécution de `init`, qui pourra ensuite être utilisée par `join`.
+     Pour générer une telle clé, vous pouvez utiliser la commande suivante :
 
-    - `kubernetesVersion` doit représenter la version de Kubernetes à utiliser. Cet exemple utilise `stable`.
-    - `controlPlaneEndpoint` doit correspondre à l'adresse ou au DNS et au port du load balancer.
-    - Il est recommandé que les versions de kubeadm, kubelet, kubectl et kubernetes correspondent.
+     ```sh
+     kubeadm certs certificate-key
+     ```
 
-1.  Assurez-vous que le nœud est dans un état sain:
+   La clé de certificat est une chaîne encodée en hexadécimal correspondant à une clé AES de 32 octets.
 
-    ```sh
-    sudo kubeadm init --config=kubeadm-config.yaml
-    ```
+   {{< note >}}
+   Le Secret `kubeadm-certs` ainsi que la clé de déchiffrement expirent après deux heures.
+   {{< /note >}}
 
-    Vous devriez voir quelque chose comme:
+   {{< caution >}}
+   Comme indiqué dans la sortie de la commande, la clé de certificat donne accès à des données sensibles du cluster. Gardez-la secrète !
+   {{< /caution >}}
 
-    ```sh
-    ...
-Vous pouvez à présent joindre n'importe quelle machine au cluster en lancant la commande suivante sur
-chaque nœeud en tant que root:
+1. Appliquez le plugin CNI de votre choix :
+   [Suivez ces instructions](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network) pour installer un fournisseur CNI. Assurez-vous que la configuration correspond au CIDR des Pods défini dans le fichier de configuration kubeadm (le cas échéant).
 
-    kubeadm join 192.168.0.200:6443 --token j04n3m.octy8zely83cy2ts --discovery-token-ca-cert-hash    sha256:84938d2a22203a8e56a787ec0c6ddad7bc7dbd52ebabc62fd5f4dbea72b14d1f
-    ```
+   {{< note >}}
+   Vous devez choisir un plugin réseau adapté à votre cas d’usage et l’installer avant de passer à l’étape suivante. 
+   Si ce n’est pas fait, vous ne pourrez pas démarrer correctement votre cluster.
+   {{< /note >}}
 
-1.  Copiez ce jeton dans un fichier texte. Vous en aurez besoin plus tard pour joindre
-d’autres nœuds du control plane au cluster.
+1. Tapez la commande suivante et observez le démarrage des Pods des composants du plan de contrôle :
 
-1.  Activez l'extension CNI Weave:
+   ```sh
+   kubectl get pod -n kube-system -w
+   ```
 
-    ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
-    ```
+### Étapes pour les autres nœuds du plan de contrôle
 
-1.  Tapez ce qui suit et observez les pods des composants démarrer:
+Pour chaque nœud de plan de contrôle supplémentaire, vous devez :
 
-    ```sh
-    kubectl get pod -n kube-system -w
-    ```
+1. Exécutez la commande de jointure qui vous a été fournie précédemment par la sortie de `kubeadm init` sur le premier nœud.
+   Elle devrait ressembler à ceci :
 
-    - Il est recommandé de ne joindre les nouveaux nœuds du control plane qu'après l'initialisation du premier nœud.
+   ```sh
+   sudo kubeadm join 192.168.0.200:6443 --token 9vr73a.a8uxyaju799qwdjv --discovery-token-ca-cert-hash sha256:7c2e69131a36ae2a042a339b33381c6d0d43887e2de83720eff5359e26aec866 --control-plane --certificate-key f8902e114ef118304e561c3ecd4d0b543adc226b7a07f675f56564185ffe0c07
+   ```
 
-1.  Copiez les fichiers de certificat du premier nœud du control plane dans les autres:
+   - L’option `--control-plane` indique à `kubeadm join` de créer un nouveau plan de contrôle.
+   - L’option `--certificate-key ...` permet de télécharger les certificats du plan de contrôle depuis le Secret `kubeadm-certs` du cluster, puis de les déchiffrer à l’aide de la clé fournie.
 
-    Dans l'exemple suivant, remplacez `CONTROL_PLANE_IPS` par les adresses IP des autres nœuds du control plane.
-    ```sh
-    USER=ubuntu # customizable
-    CONTROL_PLANE_IPS="10.0.0.7 10.0.0.8"
-    for host in ${CONTROL_PLANE_IPS}; do
-        scp /etc/kubernetes/pki/ca.crt "${USER}"@$host:
-        scp /etc/kubernetes/pki/ca.key "${USER}"@$host:
-        scp /etc/kubernetes/pki/sa.key "${USER}"@$host:
-        scp /etc/kubernetes/pki/sa.pub "${USER}"@$host:
-        scp /etc/kubernetes/pki/front-proxy-ca.crt "${USER}"@$host:
-        scp /etc/kubernetes/pki/front-proxy-ca.key "${USER}"@$host:
-        scp /etc/kubernetes/pki/etcd/ca.crt "${USER}"@$host:etcd-ca.crt
-        scp /etc/kubernetes/pki/etcd/ca.key "${USER}"@$host:etcd-ca.key
-        scp /etc/kubernetes/admin.conf "${USER}"@$host:
-    done
-    ```
+{{< note >}}
+Comme les nœuds du cluster sont généralement initialisés de manière séquentielle, il est probable que les pods CoreDNS s’exécutent tous sur le premier nœud du plan de contrôle. Pour assurer une meilleure disponibilité, veuillez rééquilibrer les pods CoreDNS avec la commande `kubectl -n kube-system rollout restart deployment coredns` après qu’au moins un nouveau nœud a été rejoint.
+{{< /note >}}
+
+## Nœuds etcd externes
+
+La configuration d’un cluster avec des nœuds etcd externes est similaire à celle du mode stacked etcd,
+à l’exception du fait que vous devez d’abord configurer etcd, puis fournir les informations etcd
+dans le fichier de configuration kubeadm.
+
+### Mise en place du cluster etcd
+
+1. Suivez ces [instructions](/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/) pour configurer le cluster etcd.
+
+1. Configurez SSH comme décrit [ici](#manual-certs).
+
+1. Copiez les fichiers suivants depuis n’importe quel nœud etcd du cluster vers le premier nœud du plan de contrôle :
+
+   ```sh
+   export CONTROL_PLANE="ubuntu@10.0.0.7"
+   scp /etc/kubernetes/pki/etcd/ca.crt "${CONTROL_PLANE}":
+   scp /etc/kubernetes/pki/apiserver-etcd-client.crt "${CONTROL_PLANE}":
+   scp /etc/kubernetes/pki/apiserver-etcd-client.key "${CONTROL_PLANE}":
+   ```
+
+   - Replace the value of `CONTROL_PLANE` with the `user@host` of the first control-plane node.
+
+### Configuration du premier nœud du plan de contrôle
+
+1. Créez un fichier nommé `kubeadm-config.yaml` avec le contenu suivant :
+
+   ```yaml
+   ---
+   apiVersion: kubeadm.k8s.io/v1beta4
+   kind: ClusterConfiguration
+   kubernetesVersion: stable
+   controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT" # change this (see below)
+   etcd:
+     external:
+       endpoints:
+         - https://ETCD_0_IP:2379 # change ETCD_0_IP appropriately
+         - https://ETCD_1_IP:2379 # change ETCD_1_IP appropriately
+         - https://ETCD_2_IP:2379 # change ETCD_2_IP appropriately
+       caFile: /etc/kubernetes/pki/etcd/ca.crt
+       certFile: /etc/kubernetes/pki/apiserver-etcd-client.crt
+       keyFile: /etc/kubernetes/pki/apiserver-etcd-client.key
+   ```
+
+{{< note >}}
+La différence entre etcd empilé (stacked etcd) et etcd externe ici est que la configuration etcd externe nécessite
+un fichier de configuration avec les endpoints etcd sous l’objet `external` de `etcd`.
+Dans le cas de la topologie etcd empilée, cela est géré automatiquement.
+{{< /note >}}
+
+- Remplacez les variables suivantes dans le modèle de configuration avec les valeurs appropriées de votre cluster :
+
+  - `LOAD_BALANCER_DNS`
+  - `LOAD_BALANCER_PORT`
+  - `ETCD_0_IP`
+  - `ETCD_1_IP`
+  - `ETCD_2_IP`
+
+Les étapes suivantes sont similaires à la configuration etcd empilée :
+
+1. Exécutez `sudo kubeadm init --config kubeadm-config.yaml --upload-certs` sur ce nœud.
+
+1. Enregistrez les commandes de jointure affichées dans un fichier texte pour une utilisation ultérieure.
+
+1. Appliquez le plugin réseau CNI de votre choix.
+
+{{< note >}}
+Vous devez choisir un plugin réseau adapté à votre cas d’usage et le déployer avant de passer à l’étape suivante.
+Sinon, vous ne pourrez pas démarrer correctement votre cluster.
+{{< /note >}}
+
+### Étapes pour les autres nœuds du plan de contrôle
+
+Les étapes sont les mêmes que pour la configuration etcd empilée :
+
+- Assurez-vous que le premier nœud du plan de contrôle est entièrement initialisé.
+- Joignez chaque nœud de plan de contrôle avec la commande de jointure que vous avez enregistrée dans un fichier texte. Il est recommandé de les joindre un par un.
+- N’oubliez pas que la clé de déchiffrement `--certificate-key` expire par défaut après deux heures.
+
+## Tâches courantes après le démarrage du plan de contrôle
+
+### Ajouter des workers
+
+Les nœuds worker peuvent être ajoutés au cluster avec la commande que vous avez précédemment enregistrée lors de la sortie de `kubeadm init` :
+
+```sh
+sudo kubeadm join 192.168.0.200:6443 --token 9vr73a.a8uxyaju799qwdjv --discovery-token-ca-cert-hash sha256:7c2e69131a36ae2a042a339b33381c6d0d43887e2de83720eff5359e26aec866
+```
+
+## Distribution manuelle des certificats {#manual-certs}
+
+Si vous choisissez de ne pas utiliser `kubeadm init` avec le flag `--upload-certs`, cela signifie que
+vous devrez copier manuellement les certificats depuis le nœud principal du plan de contrôle vers les
+nœuds du plan de contrôle qui rejoignent le cluster.
+
+Il existe plusieurs façons de faire cela. L’exemple suivant utilise `ssh` et `scp` :
+
+SSH est requis si vous souhaitez contrôler tous les nœuds depuis une seule machine.
+
+1. Activez `ssh-agent` sur votre machine principale qui a accès à tous les autres nœuds du système :
+
+   ```shell
+   eval $(ssh-agent)
+   ```
+
+1. Ajoutez votre identité SSH à la session :
+
+   ```shell
+   ssh-add ~/.ssh/path_to_private_key
+   ```
+
+1. Effectuez une connexion SSH entre les nœuds pour vérifier que la connexion fonctionne correctement.
+
+   - Lorsque vous vous connectez en SSH à un nœud, ajoutez l’option `-A`. Cette option permet au nœud sur lequel vous êtes connecté via SSH d’accéder à l’agent SSH de votre PC. Envisagez des méthodes alternatives si vous ne faites pas entièrement confiance à la sécurité de votre session utilisateur sur le nœud.
+
+     ```shell
+     ssh -A 10.0.0.7
+     ```
+
+   - Lorsque vous utilisez `sudo` sur un nœud, assurez-vous de préserver l’environnement afin que la redirection SSH (SSH forwarding) fonctionne :
+
+     ```shell
+     sudo -E -s
+     ```
+
+1. Après avoir configuré SSH sur tous les nœuds, vous devez exécuter le script suivant sur le premier
+   nœud du plan de contrôle après avoir exécuté `kubeadm init`. Ce script va copier les certificats depuis
+   le premier nœud du plan de contrôle vers les autres nœuds du plan de contrôle :
+
+   Dans l’exemple suivant, remplacez `CONTROL_PLANE_IPS` par les adresses IP des
+   autres nœuds du plan de contrôle.
+
+   ```sh
+   USER=ubuntu # customizable
+   CONTROL_PLANE_IPS="10.0.0.7 10.0.0.8"
+   for host in ${CONTROL_PLANE_IPS}; do
+       scp /etc/kubernetes/pki/ca.crt "${USER}"@$host:
+       scp /etc/kubernetes/pki/ca.key "${USER}"@$host:
+       scp /etc/kubernetes/pki/sa.key "${USER}"@$host:
+       scp /etc/kubernetes/pki/sa.pub "${USER}"@$host:
+       scp /etc/kubernetes/pki/front-proxy-ca.crt "${USER}"@$host:
+       scp /etc/kubernetes/pki/front-proxy-ca.key "${USER}"@$host:
+       scp /etc/kubernetes/pki/etcd/ca.crt "${USER}"@$host:etcd-ca.crt
+       # Skip the next line if you are using external etcd
+       scp /etc/kubernetes/pki/etcd/ca.key "${USER}"@$host:etcd-ca.key
+   done
+   ```
 
 {{< caution >}}
-N'utilisez que les certificats de la liste ci-dessus. kubeadm se chargera de générer le reste des certificats avec les SANs requis pour les instances du control plane qui se joignent.
-Si vous copiez tous les certificats par erreur, la création de noeuds supplémentaires pourrait
- échouer en raison d'un manque de SANs requis.
+Copiez uniquement les certificats listés ci-dessus. kubeadm se chargera de générer le reste des certificats
+avec les SAN (Subject Alternative Name) requis pour les instances de plan de contrôle qui rejoignent le cluster. Si vous copiez tous les certificats par erreur,
+la création de nouveaux nœuds peut échouer en raison de l’absence des SAN requis.
 {{< /caution >}}
 
-### Étapes pour le reste des nœuds du control plane
+1. Ensuite, sur chaque nœud du plan de contrôle qui rejoint le cluster, vous devez exécuter le script suivant avant d’exécuter `kubeadm join`.
+   Ce script déplacera les certificats précédemment copiés depuis le répertoire home vers `/etc/kubernetes/pki` :
 
-1. Déplacer les fichiers créés à l'étape précédente où `scp` était utilisé:
-
-    ```sh
-    USER=ubuntu # customizable
-    mkdir -p /etc/kubernetes/pki/etcd
-    mv /home/${USER}/ca.crt /etc/kubernetes/pki/
-    mv /home/${USER}/ca.key /etc/kubernetes/pki/
-    mv /home/${USER}/sa.pub /etc/kubernetes/pki/
-    mv /home/${USER}/sa.key /etc/kubernetes/pki/
-    mv /home/${USER}/front-proxy-ca.crt /etc/kubernetes/pki/
-    mv /home/${USER}/front-proxy-ca.key /etc/kubernetes/pki/
-    mv /home/${USER}/etcd-ca.crt /etc/kubernetes/pki/etcd/ca.crt
-    mv /home/${USER}/etcd-ca.key /etc/kubernetes/pki/etcd/ca.key
-    mv /home/${USER}/admin.conf /etc/kubernetes/admin.conf
-    ```
-
-    Ce processus écrit tous les fichiers demandés dans le dossier `/etc/kubernetes`.
-
-1.  Lancez `kubeadm join` sur ce nœud en utilisant la commande de join qui vous avait été précédemment
-donnée par` kubeadm init` sur le premier noeud. Ça devrait ressembler a quelque chose
- comme ça:
-
-    ```sh
-    sudo kubeadm join 192.168.0.200:6443 --token j04n3m.octy8zely83cy2ts --discovery-token-ca-cert-hash sha256:84938d2a22203a8e56a787ec0c6ddad7bc7dbd52ebabc62fd5f4dbea72b14d1f --experimental-control-plane
-    ```
-
-    - Remarquez l'ajout de l'option `--experimental-control-plane`. Ce paramètre automatise l'adhésion au
-    control plane du cluster.
-
-1.  Tapez ce qui suit et observez les pods des composants démarrer:
-
-    ```sh
-    kubectl get pod -n kube-system -w
-    ```
-
-1.  Répétez ces étapes pour le reste des nœuds du control plane.
-
-## Noeuds etcd externes
-
-### Configurer le cluster etcd
-
-- Suivez ces [instructions](/fr/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)
-  pour configurer le cluster etcd.
-
-### Configurer le premier nœud du control plane
-
-1. Copiez les fichiers suivants de n’importe quel nœud du cluster etcd vers ce nœud.:
-
-    ```sh
-    export CONTROL_PLANE="ubuntu@10.0.0.7"
-    +scp /etc/kubernetes/pki/etcd/ca.crt "${CONTROL_PLANE}":
-    +scp /etc/kubernetes/pki/apiserver-etcd-client.crt "${CONTROL_PLANE}":
-    +scp /etc/kubernetes/pki/apiserver-etcd-client.key "${CONTROL_PLANE}":
-    ```
-
-    - Remplacez la valeur de `CONTROL_PLANE` par l'`utilisateur@hostname` de cette machine.
-
-1.  Créez un fichier YAML appelé `kubeadm-config.yaml` avec le contenu suivant:
-
-        apiVersion: kubeadm.k8s.io/v1beta1
-        kind: ClusterConfiguration
-        kubernetesVersion: stable
-        apiServer:
-          certSANs:
-          - "LOAD_BALANCER_DNS"
-        controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
-        etcd:
-            external:
-                endpoints:
-                - https://ETCD_0_IP:2379
-                - https://ETCD_1_IP:2379
-                - https://ETCD_2_IP:2379
-                caFile: /etc/kubernetes/pki/etcd/ca.crt
-                certFile: /etc/kubernetes/pki/apiserver-etcd-client.crt
-                keyFile: /etc/kubernetes/pki/apiserver-etcd-client.key
-
-    - La différence entre etcd empilé et externe, c’est que nous utilisons le champ `external`
-     pour `etcd` dans la configuration de kubeadm. Dans le cas de la topologie etcd empilée,
-     c'est géré automatiquement.
-
-    - Remplacez les variables suivantes dans le modèle (template) par les valeurs appropriées
-     pour votre cluster:
-
-        - `LOAD_BALANCER_DNS`
-        - `LOAD_BALANCER_PORT`
-        - `ETCD_0_IP`
-        - `ETCD_1_IP`
-        - `ETCD_2_IP`
-
-1.  Lancez `kubeadm init --config kubeadm-config.yaml` sur ce nœud.
-
-1.  Ecrivez le résultat de la commande de join dans un fichier texte pour une utilisation ultérieure.
-
-1.  Appliquer le plugin CNI Weave:
-
-    ```sh
-    kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
-    ```
-
-### Étapes pour le reste des nœuds du control plane
-
-Pour ajouter le reste des nœuds du control plane, suivez [ces instructions](#étapes-pour-le-reste-des-nœuds-du-control-plane).
-Les étapes sont les mêmes que pour la configuration etcd empilée, à l’exception du fait qu'un membre
- etcd local n'est pas créé.
-
-Pour résumer:
-
-- Assurez-vous que le premier nœud du control plane soit complètement initialisé.
-- Copier les certificats entre le premier nœud du control plane et les autres nœuds du control plane.
-- Joignez chaque nœud du control plane à l'aide de la commande de join que vous avez enregistrée dans
- un fichier texte, puis ajoutez l'option `--experimental-control-plane`.
-
-## Tâches courantes après l'amorçage du control plane
-
-### Installer un réseau de pod
-
-[Suivez ces instructions](/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network) afin
- d'installer le réseau de pod. Assurez-vous que cela correspond au pod CIDR que vous avez fourni
- dans le fichier de configuration principal.
-
-### Installer les workers
-
-Chaque nœud worker peut maintenant être joint au cluster avec la commande renvoyée à partir du resultat
- de n’importe quelle commande `kubeadm init`. L'option `--experimental-control-plane` ne doit pas
- être ajouté aux nœuds workers.
-
-
+   ```sh
+   USER=ubuntu # customizable
+   mkdir -p /etc/kubernetes/pki/etcd
+   mv /home/${USER}/ca.crt /etc/kubernetes/pki/
+   mv /home/${USER}/ca.key /etc/kubernetes/pki/
+   mv /home/${USER}/sa.pub /etc/kubernetes/pki/
+   mv /home/${USER}/sa.key /etc/kubernetes/pki/
+   mv /home/${USER}/front-proxy-ca.crt /etc/kubernetes/pki/
+   mv /home/${USER}/front-proxy-ca.key /etc/kubernetes/pki/
+   mv /home/${USER}/etcd-ca.crt /etc/kubernetes/pki/etcd/ca.crt
+   # Skip the next line if you are using external etcd
+   mv /home/${USER}/etcd-ca.key /etc/kubernetes/pki/etcd/ca.key
+   ```      

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -1,61 +1,49 @@
 ---
-title: Configuration des kubelet de votre cluster avec kubeadm
-description: Configuration kubelet Kubernetes cluster kubeadm
+reviewers:
+- sig-cluster-lifecycle
+title: Configuration de chaque kubelet dans votre cluster avec kubeadm
 content_type: concept
 weight: 80
 ---
 
-<!-- overview -->
+<!-- vue d’ensemble -->
 
-{{< feature-state for_k8s_version="1.11" state="stable" >}}
+{{% dockershim-removal %}}
 
-Le cycle de vie de l’outil CLI kubeadm est découplé de celui de la
-[kubelet](/docs/reference/command-line-tools-reference/kubelet), qui est un démon qui s'éxécute
-sur chaque noeud du cluster Kubernetes. L'outil CLI de kubeadm est exécuté par l'utilisateur lorsque
- Kubernetes est initialisé ou mis à niveau, alors que la kubelet est toujours exécutée en arrière-plan.
+{{< feature-state for_k8s_version="v1.11" state="stable" >}}
 
-Comme la kubelet est un démon, elle doit être maintenue par une sorte d'init système ou un gestionnaire
- de service. Lorsque la kubelet est installée à l'aide de DEB ou de RPM,
-systemd est configuré pour gérer la kubelet. Vous pouvez utiliser un gestionnaire différent à la place,
- mais vous devez le configurer manuellement.
+Le cycle de vie de l’outil CLI kubeadm est découplé du
+[kubelet](/docs/reference/command-line-tools-reference/kubelet), qui est un daemon s’exécutant
+sur chaque nœud au sein du cluster Kubernetes. L’outil CLI kubeadm est exécuté par l’utilisateur lors de l’initialisation ou de la mise à niveau de Kubernetes, tandis que le kubelet fonctionne en permanence en arrière-plan.
 
-Certains détails de configuration de la kubelet doivent être identiques pour
-toutes les kubelets du cluster, tandis que d’autres aspects de la configuration
-doivent être définis par nœud, pour tenir compte des différentes caractéristiques
-d’une machine donnée, telles que le système d’exploitation, le stockage et la
-mise en réseau. Vous pouvez gérer la configuration manuellement de vos kubelets,
-mais [kubeadm fournit maintenant un type d’API `KubeletConfiguration` pour la gestion centralisée de vos configurations de kubelets](#configure-kubelets-using-kubeadm).
+Étant donné que le kubelet est un daemon, il doit être géré par un système d’initialisation (init system) ou un gestionnaire de services. Lorsque le kubelet est installé via des paquets DEB ou RPM, systemd est configuré pour gérer le kubelet. Vous pouvez utiliser un autre gestionnaire de services, mais vous devrez le configurer manuellement.
 
+Certaines configurations du kubelet doivent être identiques sur tous les kubelets du cluster, tandis que d’autres doivent être définies individuellement pour chaque kubelet afin de s’adapter aux caractéristiques spécifiques d’une machine (comme le système d’exploitation, le stockage et le réseau). Vous pouvez gérer la configuration des kubelets manuellement, mais kubeadm fournit désormais un type d’API `KubeletConfiguration` pour
+[centraliser la gestion des configurations du kubelet](#configure-kubelets-using-kubeadm).
 
+<!-- contenu principal -->
 
-<!-- body -->
+## Modèles de configuration du kubelet
 
-## Patterns de configuration des Kubelets
+Les sections suivantes décrivent des modèles de configuration du kubelet simplifiés grâce à kubeadm, plutôt que de gérer manuellement la configuration de chaque nœud.
 
-Les sections suivantes décrivent les modèles de configuration de kubelet simplifiés en
-utilisant kubeadm, plutôt que de gérer manuellement la configuration des kubelets pour chaque nœud.
+### Propagation de la configuration au niveau du cluster vers chaque kubelet
 
-### Propagation de la configuration niveau cluster à chaque kubelet {#propagating-cluster-level-configuration-to-each-kubelet}
+Vous pouvez fournir au kubelet des valeurs par défaut utilisées par les commandes `kubeadm init` et `kubeadm join`.
+Parmi les exemples intéressants, on peut citer l’utilisation d’un runtime de conteneurs différent ou la définition du sous-réseau par défaut utilisé par les services.
 
-Vous pouvez fournir à la kubelet les valeurs par défaut à utiliser par les commandes `kubeadm init` et
- `kubeadm join`. Des exemples intéressants incluent l’utilisation d’un runtime CRI différent ou la
- définition du sous-réseau par défaut utilisé par les services.
-
-Si vous souhaitez que vos services utilisent le sous-réseau `10.96.0.0 / 12` par défaut pour les
- services, vous pouvez passer le paramètre `--service-cidr` à kubeadm:
+Si vous souhaitez que vos services utilisent le sous-réseau `10.96.0.0/12` par défaut, vous pouvez passer le paramètre `--service-cidr` à kubeadm :
 
 ```bash
 kubeadm init --service-cidr 10.96.0.0/12
 ```
 
-Les adresses IP virtuelles pour les services sont maintenant attribuées à partir de ce sous-réseau.
-Vous devez également définir l'adresse DNS utilisée par la kubelet, en utilisant l'option
- `--cluster-dns`. Ce paramètre doit être le même pour chaque kubelet sur chaque master et worker
-du cluster. La kubelet fournit un objet API structuré versionné qui peut configurer la plupart des
- paramètres dans la kubelet et pousser cette configuration à chaque exécution de la kubelet dans
- le cluster. Cet objet s'appelle la **ComponentConfig** de la kubelet.
-La ComponentConfig permet à l’utilisateur de spécifier des options tels que les adresses IP DNS du
-cluster exprimées en une liste de valeurs pour une clé formatée en CamelCased, illustrée par l'exemple suivant:
+Les adresses IP virtuelles des services sont désormais allouées à partir de ce sous-réseau. Vous devez également définir l’adresse DNS utilisée par le kubelet, à l’aide de l’option `--cluster-dns`. Ce paramètre doit être identique pour tous les kubelets de tous les nœuds du plan de contrôle et des nœuds du cluster.
+
+Le kubelet fournit un objet d’API structuré et versionné permettant de configurer la plupart de ses paramètres et de diffuser cette configuration à chaque kubelet en cours d’exécution dans le cluster. Cet objet est appelé
+[`KubeletConfiguration`](/docs/reference/config-api/kubelet-config.v1beta1/).
+
+Le `KubeletConfiguration` permet à l’utilisateur de spécifier des options telles que les adresses IP du DNS du cluster, exprimées sous forme de liste de valeurs associées à une clé en camelCase, comme illustré dans l’exemple suivant :
 
 ```yaml
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -64,114 +52,127 @@ clusterDNS:
 - 10.96.0.10
 ```
 
-Pour plus de détails sur ComponentConfig, jetez un œil à [cette section](#configure-kubelets-using-kubeadm).
+Pour plus de détails sur le `KubeletConfiguration`, consultez [cette section](#configure-kubelets-using-kubeadm).
 
-### Fournir des détails de configuration spécifiques à l'instance {#providing-instance-specific-configuration-details}
+### Fournir des configurations spécifiques à une instance
 
-Certaines machines nécessitent des configurations de kubelet spécifiques, en raison de la différences de
-matériel, de système d’exploitation, réseau ou d’autres paramètres spécifiques à l’hôte. La liste suivante
- fournit quelques exemples.
+Certains hôtes nécessitent des configurations kubelet spécifiques en raison de différences de matériel, de système d’exploitation, de réseau ou d’autres paramètres propres à chaque machine. La liste suivante fournit quelques exemples :
 
-- Le chemin d'accès au fichier de résolution DNS, tel que spécifié par l'option de configuration
-de la kubelet `--resolv-conf`, peut différer selon les systèmes d'exploitation ou selon que vous utilisez
- ou non `systemd-resolved`. Si ce chemin est incorrect, la résolution DNS échouera sur le nœud
- dont la kubelet est configuré de manière incorrecte.
+- Le chemin du fichier de résolution DNS, spécifié par l’option `--resolv-conf` du kubelet, peut varier selon les systèmes d’exploitation ou selon l’utilisation de `systemd-resolved`. Si ce chemin est incorrect, la résolution DNS échouera sur le nœud dont le kubelet est mal configuré.
 
-- L'objet API de nœud `.metadata.name` est défini par défaut sur le hostname de la machine,
-sauf si vous utilisez un fournisseur de cloud. Vous pouvez utiliser l’indicateur `--hostname-override`
- pour remplacer le comportement par défaut si vous devez spécifier un nom de nœud différent du hostname
-  de la machine.
+- L’objet Node API `.metadata.name` est défini par défaut avec le nom d’hôte de la machine, sauf si vous utilisez un fournisseur cloud. Vous pouvez utiliser l’option `--hostname-override` pour remplacer ce comportement si vous devez définir un nom de nœud différent du nom d’hôte de la machine.
 
-- Actuellement, la kubelet ne peut pas détecter automatiquement le driver cgroup utilisé par le
-runtime CRI, mais la valeur de `--cgroup-driver` doit correspondre au driver cgroup
-utilisé par le runtime CRI pour garantir la santé de la kubelet.
+- Actuellement, le kubelet ne peut pas détecter automatiquement le driver cgroup utilisé par le runtime de conteneurs, mais la valeur de `--cgroup-driver` doit correspondre à celle utilisée par le runtime pour garantir le bon fonctionnement du kubelet.
 
-- En fonction du runtime du CRI utilisé par votre cluster, vous devrez peut-être spécifier des
-options différentes pour la kubelet. Par exemple, lorsque vous utilisez Docker,
-vous devez spécifier des options telles que
-`--network-plugin = cni`, mais si vous utilisez un environnement d’exécution externe, vous devez spécifier
-`--container-runtime = remote` et spécifier le CRI endpoint en utilisant l'option
-`--container-runtime-path-endpoint = <chemin>`.
+- Pour spécifier le runtime de conteneurs, vous devez définir son endpoint avec l’option `--container-runtime-endpoint=<path>`.
 
-Vous pouvez spécifier ces options en modifiant la configuration d’une kubelet individuelle dans
-votre gestionnaire de service, tel que systemd.
+La méthode recommandée pour appliquer ce type de configuration spécifique à une instance consiste à utiliser les
+[patchs `KubeletConfiguration`](/docs/setup/production-environment/tools/kubeadm/control-plane-flags#patches).
 
-## Configurer les kubelets en utilisant kubeadm {#configure-kubelets-using-kubeadm}
+## Configurer les kubelets avec kubeadm
 
-Il est possible de configurer la kubelet que kubeadm va démarrer si un objet API personnalisé
-`KubeletConfiguration` est passé en paramètre via un fichier de configuration comme
-`kubeadm ... --config some-config-file.yaml`.
+Il est possible de configurer le kubelet que kubeadm va démarrer si un objet API personnalisé
+[`KubeletConfiguration`](/docs/reference/config-api/kubelet-config.v1beta1/)
+est fourni via un fichier de configuration comme suit : `kubeadm ... --config some-config-file.yaml`.
 
-En appelant `kubeadm config print-default --api-objects KubeletConfiguration` vous
-pouvez voir toutes les valeurs par défaut pour cette structure.
+En exécutant `kubeadm config print init-defaults --component-configs KubeletConfiguration`, vous pouvez
+voir toutes les valeurs par défaut de cette structure.
 
-Regardez aussi la [référence API pour le composant ComponentConfig des kubelets](https://godoc.org/k8s.io/kubernetes/pkg/kubelet/apis/config#KubeletConfiguration)
-pour plus d'informations sur les champs individuels.
+Il est également possible d’appliquer des patchs spécifiques à une instance par-dessus la configuration de base `KubeletConfiguration`.
+Consultez [Personnaliser le kubelet](/docs/setup/production-environment/tools/kubeadm/control-plane-flags#customizing-the-kubelet)
+pour plus de détails.
 
-### Workflow lors de l'utilisation de `kubeadm init`
+### Workflow lors de l’utilisation de `kubeadm init`
 
-Lorsque vous appelez `kubeadm init`, la configuration de la kubelet est organisée sur le disque
-sur `/var/lib/kubelet/config.yaml`, et également chargé sur une ConfigMap du cluster. La ConfigMap
- est nommé `kubelet-config-1.X`, où `.X` est la version mineure de la version de Kubernetes
- que vous êtes en train d'initialiser. Un fichier de configuration de kubelet est également écrit dans
-`/etc/kubernetes/kubelet.conf` avec la configuration de base à l'échelle du cluster pour tous les
-kubelets du cluster. Ce fichier de configuration pointe vers les certificats clients permettant aux
-kubelets de communiquer avec l'API server. Ceci répond au besoin de
-[propager la configuration niveau cluster à chaque kubelet](#propagating-cluster-level-configuration-to-each-kubelet).
+Lorsque vous exécutez `kubeadm init`, la configuration du kubelet est sérialisée sur le disque
+dans `/var/lib/kubelet/config.yaml`, et également téléversée dans une ConfigMap `kubelet-config`
+dans le namespace `kube-system` du cluster.
 
-Pour répondre au besoin de
-[fournir des détails de configuration spécifiques à l'instance de kubelet](#providing-instance-specific-configuration-details),
-kubeadm écrit un fichier d'environnement dans `/var/lib/kubelet/kubeadm-flags.env`, qui contient une liste
-d'options à passer à la kubelet quand elle démarre. Les options sont représentées dans le fichier comme ceci:
+En outre, l’outil kubeadm détecte le socket CRI sur le nœud et écrit ses détails
+(y compris le chemin du socket) dans une configuration locale `/var/lib/kubelet/instance-config.yaml`.
+
+Un fichier de configuration kubelet est également écrit dans `/etc/kubernetes/kubelet.conf`,
+contenant la configuration de base commune à tous les kubelets du cluster. Ce fichier de configuration
+pointe vers les certificats clients permettant au kubelet de communiquer avec le serveur API. Cela
+répond au besoin de
+[propager la configuration au niveau du cluster vers chaque kubelet](#propagating-cluster-level-configuration-to-each-kubelet).
+
+Pour répondre au second modèle de
+[fourniture de paramètres spécifiques à une instance](#providing-instance-specific-configuration-details),
+kubeadm écrit un fichier d’environnement dans `/var/lib/kubelet/kubeadm-flags.env`, qui contient une liste de
+paramètres à passer au kubelet lors de son démarrage. Les flags sont présentés dans ce fichier comme suit :
 
 ```bash
 KUBELET_KUBEADM_ARGS="--flag1=value1 --flag2=value2 ..."
 ```
 
-Outre les indicateurs utilisés lors du démarrage de la kubelet, le fichier contient également des
-informations dynamiques comme des paramètres tels que le driver cgroup et s'il faut utiliser un autre
-socket de runtime CRI (`--cri-socket`).
+En plus des options utilisées lors du démarrage du kubelet, ce fichier contient également des paramètres dynamiques
+tels que le driver cgroup.
 
-Après avoir rassemblé ces deux fichiers sur le disque, kubeadm tente d’exécuter ces deux commandes,
- si vous utilisez systemd:
-
-```bash
-systemctl daemon-reload && systemctl restart kubelet
-```
-
-Si le rechargement et le redémarrage réussissent, le workflow normal de `kubeadm init` continue.
-
-### Workflow en utilisant `kubeadm join`
-
-Lorsque vous exécutez `kubeadm join`, kubeadm utilise les informations d'identification du bootstrap
-token pour faire un bootstrap TLS, qui récupère les informations d’identité nécessaires pour télécharger le
-`kubelet-config-1.X` ConfigMap puis l'écrit dans `/var/lib/kubelet/config.yaml`. Le fichier d’environnement
-dynamique est généré exactement de la même manière que `kubeadm init`.
-
-Ensuite, `kubeadm` exécute les deux commandes suivantes pour charger la nouvelle configuration dans la kubelet:
+Après avoir écrit ces deux fichiers sur le disque, kubeadm tente d’exécuter les deux
+commandes suivantes si vous utilisez systemd :
 
 ```bash
 systemctl daemon-reload && systemctl restart kubelet
 ```
 
-Après le chargement de la nouvelle configuration par la kubelet, kubeadm écrit le fichier KubeConfig
-`/etc/kubernetes/bootstrap-kubelet.conf`, qui contient un certificat de CA et un jeton Bootstrap.
- Ceux-ci sont utilisés par la kubelet pour effectuer le TLS Bootstrap et obtenir une information
- d'identification unique, qui est stocké dans `/etc/kubernetes/kubelet.conf`. Quand ce fichier est
- écrit, la kubelet a terminé l'exécution du bootstrap TLS.
+Si le rechargement et le redémarrage réussissent, le flux normal de `kubeadm init` continue.
 
-##  Le fichier kubelet généré pour systemd {#the-kubelet-drop-in-file-for-systemd}
+### Workflow lors de l’utilisation de `kubeadm join`
 
-Le fichier de configuration installé par le package DEB ou RPM de kubeadm est écrit dans
-`/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` et est utilisé par systemd.
+Lorsque vous exécutez `kubeadm join`, kubeadm utilise le jeton de bootstrap (Bootstrap Token) pour effectuer
+un bootstrap TLS, qui récupère les identifiants nécessaires pour télécharger la ConfigMap
+`kubelet-config`, puis l’écrit dans `/var/lib/kubelet/config.yaml`.
+
+En outre, l’outil kubeadm détecte le socket CRI sur le nœud et écrit ses détails
+(y compris le chemin du socket) dans une configuration locale `/var/lib/kubelet/instance-config.yaml`.
+
+Le fichier d’environnement dynamique est généré exactement de la même manière que pour `kubeadm init`.
+
+Ensuite, `kubeadm` exécute les deux commandes suivantes pour charger la nouvelle configuration dans le kubelet :
+
+```bash
+systemctl daemon-reload && systemctl restart kubelet
+```
+
+Après que le kubelet a chargé la nouvelle configuration, kubeadm écrit le fichier KubeConfig
+`/etc/kubernetes/bootstrap-kubelet.conf`, qui contient un certificat CA et un Bootstrap Token.
+Ces éléments sont utilisés par le kubelet pour effectuer le bootstrap TLS et obtenir une
+identité unique, qui est ensuite stockée dans `/etc/kubernetes/kubelet.conf`.
+
+Une fois que le fichier `/etc/kubernetes/kubelet.conf` est écrit, le kubelet a terminé le bootstrap TLS.
+Kubeadm supprime le fichier `/etc/kubernetes/bootstrap-kubelet.conf` après la fin de ce processus.
+
+## Le fichier drop-in du kubelet pour systemd
+
+`kubeadm` fournit la configuration indiquant comment systemd doit exécuter le kubelet.
+Notez que la commande kubeadm ne modifie jamais ce fichier drop-in.
+
+Ce fichier de configuration installé par le
+[paquet kubeadm](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf)
+est écrit dans `/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf` et est utilisé par systemd.
+Il complète le fichier de base
+[`kubelet.service`](https://github.com/kubernetes/release/blob/cd53840/cmd/krel/templates/latest/kubelet/kubelet.service).
+
+Si vous souhaitez aller plus loin et le surcharger, vous pouvez créer le répertoire
+`/etc/systemd/system/kubelet.service.d/` (et non `/usr/lib/systemd/system/kubelet.service.d/`)
+et y placer vos propres personnalisations. Par exemple, vous pouvez ajouter un fichier local
+`/etc/systemd/system/kubelet.service.d/local-overrides.conf` pour remplacer les paramètres de l’unité
+configurés par kubeadm.
+
+Voici ce que vous trouverez probablement dans `/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf` :
+
+{{< note >}}
+Le contenu ci-dessous est uniquement un exemple. Si vous ne souhaitez pas utiliser un gestionnaire de paquets,
+suivez le guide décrit dans la section ([Sans gestionnaire de paquets](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#k8s-install-2)).
+{{< /note >}}
 
 ```none
 [Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf
---kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
-# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating
-the KUBELET_KUBEADM_ARGS variable dynamically
+# This is a file that "kubeadm init" and "kubeadm join" generate at runtime, populating
+# the KUBELET_KUBEADM_ARGS variable dynamically
 EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably,
 # the user should use the .NodeRegistration.KubeletExtraArgs object in the configuration files instead.
@@ -181,29 +182,40 @@ ExecStart=
 ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
 ```
 
-Ce fichier spécifie les emplacements par défaut pour tous les fichiers gérés par kubeadm pour la kubelet.
+```none
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# Ceci est un fichier que "kubeadm init" et "kubeadm join" génèrent au moment de l’exécution,
+# en remplissant dynamiquement la variable KUBELET_KUBEADM_ARGS
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# Ceci est un fichier que l’utilisateur peut utiliser pour des surcharges des arguments du kubelet en dernier recours.
+# Idéalement, l’utilisateur devrait utiliser l’objet .NodeRegistration.KubeletExtraArgs dans les fichiers de configuration à la place.
+# KUBELET_EXTRA_ARGS doit être lu depuis ce fichier.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+```
 
-- Le fichier KubeConfig à utiliser pour le TLS Bootstrap est `/etc/kubernetes/bootstrap-kubelet.conf`,
-  mais il n'est utilisé que si `/etc/kubernetes/kubelet.conf` n'existe pas.
-- Le fichier KubeConfig avec l’identité unique de la kubelet est `/etc/kubernetes/kubelet.conf`.
-- Le fichier contenant le ComponentConfig de la kubelet est `/var/lib/kubelet/config.yaml`.
-- Le fichier d'environnement dynamique qui contient `KUBELET_KUBEADM_ARGS` est sourcé à partir de
- `/var/lib/kubelet/kubeadm-flags.env`.
-- Le fichier qui peut contenir les paramètres surchargés par l'utilisateur avec `KUBELET_EXTRA_ARGS`
- provient de `/etc/default/kubelet` (pour les  DEBs), ou `/etc/sysconfig/kubelet` (pour les RPMs)
- `KUBELET_EXTRA_ARGS` est le dernier de la chaîne d'options et a la priorité la plus élevée en cas
- de conflit de paramètres.
+Ce fichier spécifie les emplacements par défaut de tous les fichiers gérés par kubeadm pour le kubelet.
 
-## Fichiers binaires de Kubernetes et contenu du package
+- Le fichier KubeConfig utilisé pour le TLS Bootstrap est `/etc/kubernetes/bootstrap-kubelet.conf`,
+  mais il n’est utilisé que si `/etc/kubernetes/kubelet.conf` n’existe pas.
+- Le fichier KubeConfig contenant l’identité unique du kubelet est `/etc/kubernetes/kubelet.conf`.
+- Le fichier contenant le ComponentConfig du kubelet est `/var/lib/kubelet/config.yaml`.
+- Le fichier d’environnement dynamique contenant `KUBELET_KUBEADM_ARGS` est chargé depuis `/var/lib/kubelet/kubeadm-flags.env`.
+- Le fichier pouvant contenir des options définies par l’utilisateur via `KUBELET_EXTRA_ARGS` est chargé depuis
+  `/etc/default/kubelet` (pour les paquets DEB), ou `/etc/sysconfig/kubelet` (pour les RPM). `KUBELET_EXTRA_ARGS`
+  est en dernier dans la chaîne des paramètres et a la plus haute priorité en cas de conflit.
 
-Les packages DEB et RPM fournis avec les versions de Kubernetes sont les suivants:
+## Binaires Kubernetes et contenu des paquets
 
-| Nom du paquet    | Description                                                                                                                                    |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| `kubeadm`        | Installe l'outil CLI `/usr/bin/kubeadm` et [le fichier instantané de kubelet](#the-kubelet-drop-in-file-for-systemd) pour la kubelet.          |
-| `kubelet`        | Installe `/usr/bin/kubelet`.                                                                                                                   |
-| `kubectl`        | Installe `/usr/bin/kubectl`.                                                                                                                   |
-| `kubernetes-cni` | Installe les binaires officiels du CNI dans le repertoire `/opt/cni/bin`.                                                                      |
-| `cri-tools`      | Installe `/usr/bin/crictl` à partir de [https://github.com/kubernetes-incubator/cri-tools](https://github.com/kubernetes-incubator/cri-tools). |
+Les paquets DEB et RPM fournis avec les versions de Kubernetes sont :
 
-
+| Nom du paquet | Description |
+|--------------|-------------|
+| `kubeadm`    | Installe l’outil CLI `/usr/bin/kubeadm` et le [fichier drop-in du kubelet](#the-kubelet-drop-in-file-for-systemd). |
+| `kubelet`    | Installe le binaire `/usr/bin/kubelet`. |
+| `kubectl`    | Installe le binaire `/usr/bin/kubectl`. |
+| `cri-tools`  | Installe le binaire `/usr/bin/crictl` depuis le dépôt [cri-tools](https://github.com/kubernetes-sigs/cri-tools). |
+| `kubernetes-cni` | Installe les binaires `/opt/cni/bin` depuis le dépôt [plugins](https://github.com/containernetworking/plugins). |

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -1,264 +1,302 @@
 ---
-title: Configurer un cluster etcd en haute disponibilité avec kubeadm
-description: Configuration d'un cluster etcd en haute disponibilité avec kubeadm
+reviewers:
+- sig-cluster-lifecycle
+title: Mise en place d’un cluster etcd haute disponibilité avec kubeadm
 content_type: task
 weight: 70
 ---
 
-<!-- overview -->
-
-Par défaut, Kubeadm exécute un cluster etcd mono nœud dans un pod statique géré
-par la kubelet sur le nœud du plan de contrôle (control plane). Ce n'est pas une configuration haute disponibilité puisque le cluster etcd ne contient qu'un seul membre et ne peut donc supporter
-qu'aucun membre ne devienne indisponible. Cette page vous accompagne dans le processus de création
-d'un cluster etcd à trois membres en haute disponibilité, pouvant être utilisé en tant que cluster externe lors de l’utilisation de kubeadm pour configurer un cluster kubernetes.
+<!-- vue d’ensemble -->
 
 
+Par défaut, kubeadm exécute une instance locale d’etcd sur chaque nœud du plan de contrôle.
+Il est également possible de considérer le cluster etcd comme externe et de provisionner
+des instances etcd sur des hôtes séparés. Les différences entre ces deux approches sont détaillées dans la page
+[Options pour une topologie hautement disponible](/docs/setup/production-environment/tools/kubeadm/ha-topology).
+
+Cette tâche décrit le processus de création d’un cluster etcd externe haute disponibilité composé de trois membres,
+qui peut être utilisé par kubeadm lors de la création du cluster.
 
 ## {{% heading "prerequisites" %}}
 
+- Trois hôtes capables de communiquer entre eux via les ports TCP 2379 et 2380. Ce document utilise ces ports par défaut, mais ils peuvent être configurés via le fichier de configuration kubeadm.
+- Chaque hôte doit disposer de systemd et d’un shell compatible bash.
+- Chaque hôte doit [avoir un runtime de conteneurs, kubelet et kubeadm installés](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
+- Chaque hôte doit pouvoir accéder au registre d’images Kubernetes (`registry.k8s.io`) ou lister/télécharger l’image etcd requise avec
+  `kubeadm config images list/pull`. Ce guide configure les instances etcd en tant que
+  [pods statiques](/docs/tasks/configure-pod-container/static-pod/) gérés par kubelet.
+- Une infrastructure permettant de copier des fichiers entre les hôtes. Par exemple, `ssh` et `scp` peuvent être utilisés.
 
-* Trois machines pouvant communiquer entre elles via les ports 2379 et 2380. Cette 
-methode utilise ces ports par défaut. Cependant, ils sont configurables via 
-le fichier de configuration kubeadm.
-* Chaque hôte doit avoir [docker, kubelet et kubeadm installés][toolbox].
-* Certains paquets pour copier des fichiers entre les hôtes. Par exemple, `ssh` et` scp`.
+<!-- étapes -->
 
-[toolbox]: /fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
+## Configuration du cluster
 
-
-
-<!-- steps -->
-
-## Mise en place du cluster
-
-L’approche générale consiste à générer tous les certificats sur un nœud et à ne distribuer que
-les fichiers *nécessaires* aux autres nœuds.
+L’approche générale consiste à générer tous les certificats sur un seul nœud, puis à distribuer uniquement les fichiers _nécessaires_ aux autres nœuds.
 
 {{< note >}}
-kubeadm contient tout ce qui est nécessaire pour générer les certificats décrits ci-dessous;
- aucun autre outil de chiffrement n'est requis pour cet exemple.
+kubeadm inclut toute la mécanique cryptographique nécessaire pour générer les certificats décrits ci-dessous ; aucun autre outil cryptographique n’est requis pour cet exemple.
 {{< /note >}}
 
+{{< note >}}
+Les exemples ci-dessous utilisent des adresses IPv4, mais vous pouvez également configurer kubeadm, kubelet et etcd pour utiliser des adresses IPv6. Le mode dual-stack est pris en charge par certaines options Kubernetes, mais pas par etcd. Pour plus de détails sur le support dual-stack dans Kubernetes, consultez [Support dual-stack avec kubeadm](/docs/setup/production-environment/tools/kubeadm/dual-stack-support/).
+{{< /note >}}
 
-1. Configurez la kubelet pour qu'elle soit un gestionnaire de service pour etcd.
+1. Configurer le kubelet pour qu’il serve de gestionnaire de service pour etcd.
 
-    Etant donné qu'etcd a été créé en premier, vous devez remplacer la priorité de service en
-    créant un nouveau fichier unit qui a une priorité plus élevée que le fichier unit de la kubelet fourni
-    par kubeadm.
+   {{< note >}}Vous devez effectuer cette étape sur chaque hôte où etcd doit être exécuté.{{< /note >}}
+
+   Comme etcd a été créé en premier, vous devez remplacer la priorité du service en créant un nouveau fichier d’unité
+   ayant une priorité plus élevée que le fichier d’unité kubelet fourni par kubeadm.
+
+   ```sh
+   cat << EOF > /etc/systemd/system/kubelet.service.d/kubelet.conf
+   # Replace "systemd" with the cgroup driver of your container runtime. The default value in the kubelet is "cgroupfs".
+   # Replace the value of "containerRuntimeEndpoint" for a different container runtime if needed.
+   #
+   apiVersion: kubelet.config.k8s.io/v1beta1
+   kind: KubeletConfiguration
+   authentication:
+     anonymous:
+       enabled: false
+     webhook:
+       enabled: false
+   authorization:
+     mode: AlwaysAllow
+   cgroupDriver: systemd
+   address: 127.0.0.1
+   containerRuntimeEndpoint: unix:///var/run/containerd/containerd.sock
+   staticPodPath: /etc/kubernetes/manifests
+   EOF
+
+   cat << EOF > /etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
+   [Service]
+   ExecStart=
+   ExecStart=/usr/bin/kubelet --config=/etc/systemd/system/kubelet.service.d/kubelet.conf
+   Restart=always
+   EOF
+
+   systemctl daemon-reload
+   systemctl restart kubelet
+   ```
+
+   Vérifiez l’état du kubelet pour vous assurer qu’il est en cours d’exécution.
+
+   ```sh
+   systemctl status kubelet
+   ```
+1. Créez les fichiers de configuration pour kubeadm.
+
+   Générez un fichier de configuration kubeadm pour chaque hôte qui exécutera un membre etcd
+   en utilisant le script suivant.
+
+   ```sh
+   # Update HOST0, HOST1 and HOST2 with the IPs of your hosts
+   export HOST0=10.0.0.6
+   export HOST1=10.0.0.7
+   export HOST2=10.0.0.8
+
+   # Update NAME0, NAME1 and NAME2 with the hostnames of your hosts
+   export NAME0="infra0"
+   export NAME1="infra1"
+   export NAME2="infra2"
+
+   # Create temp directories to store files that will end up on other hosts
+   mkdir -p /tmp/${HOST0}/ /tmp/${HOST1}/ /tmp/${HOST2}/
+
+   HOSTS=(${HOST0} ${HOST1} ${HOST2})
+   NAMES=(${NAME0} ${NAME1} ${NAME2})
+
+   for i in "${!HOSTS[@]}"; do
+   HOST=${HOSTS[$i]}
+   NAME=${NAMES[$i]}
+   cat << EOF > /tmp/${HOST}/kubeadmcfg.yaml
+   ---
+   apiVersion: "kubeadm.k8s.io/v1beta4"
+   kind: InitConfiguration
+   nodeRegistration:
+       name: ${NAME}
+   localAPIEndpoint:
+       advertiseAddress: ${HOST}
+   ---
+   apiVersion: "kubeadm.k8s.io/v1beta4"
+   kind: ClusterConfiguration
+   etcd:
+       local:
+           serverCertSANs:
+           - "${HOST}"
+           peerCertSANs:
+           - "${HOST}"
+           extraArgs:
+           - name: initial-cluster
+             value: ${NAMES[0]}=https://${HOSTS[0]}:2380,${NAMES[1]}=https://${HOSTS[1]}:2380,${NAMES[2]}=https://${HOSTS[2]}:2380
+           - name: initial-cluster-state
+             value: new
+           - name: name
+             value: ${NAME}
+           - name: listen-peer-urls
+             value: https://${HOST}:2380
+           - name: listen-client-urls
+             value: https://${HOST}:2379
+           - name: advertise-client-urls
+             value: https://${HOST}:2379
+           - name: initial-advertise-peer-urls
+             value: https://${HOST}:2380
+   EOF
+   done
+   ```
+
+1. Générez l’autorité de certification (CA).
+
+   Si vous possédez déjà une CA, la seule action consiste à copier les fichiers `crt` et `key` de la CA vers :
+   `/etc/kubernetes/pki/etcd/ca.crt` et `/etc/kubernetes/pki/etcd/ca.key`. Une fois ces fichiers copiés,
+   passez à l’étape suivante, « Créer des certificats pour chaque membre ».
+
+   Si vous ne possédez pas encore de CA, exécutez cette commande sur `$HOST0` (où vous avez généré les fichiers de configuration kubeadm).
+
+   ```
+   kubeadm init phase certs etcd-ca
+   ```
+
+   Cela crée deux fichiers :
+
+   - `/etc/kubernetes/pki/etcd/ca.crt`
+   - `/etc/kubernetes/pki/etcd/ca.key`
+
+1. Créer des certificats pour chaque membre.
+
+   ```sh
+   kubeadm init phase certs etcd-server --config=/tmp/${HOST2}/kubeadmcfg.yaml
+   kubeadm init phase certs etcd-peer --config=/tmp/${HOST2}/kubeadmcfg.yaml
+   kubeadm init phase certs etcd-healthcheck-client --config=/tmp/${HOST2}/kubeadmcfg.yaml
+   kubeadm init phase certs apiserver-etcd-client --config=/tmp/${HOST2}/kubeadmcfg.yaml
+   cp -R /etc/kubernetes/pki /tmp/${HOST2}/
+   # cleanup non-reusable certificates
+   find /etc/kubernetes/pki -not -name ca.crt -not -name ca.key -type f -delete
+
+   kubeadm init phase certs etcd-server --config=/tmp/${HOST1}/kubeadmcfg.yaml
+   kubeadm init phase certs etcd-peer --config=/tmp/${HOST1}/kubeadmcfg.yaml
+   kubeadm init phase certs etcd-healthcheck-client --config=/tmp/${HOST1}/kubeadmcfg.yaml
+   kubeadm init phase certs apiserver-etcd-client --config=/tmp/${HOST1}/kubeadmcfg.yaml
+   cp -R /etc/kubernetes/pki /tmp/${HOST1}/
+   find /etc/kubernetes/pki -not -name ca.crt -not -name ca.key -type f -delete
+
+   kubeadm init phase certs etcd-server --config=/tmp/${HOST0}/kubeadmcfg.yaml
+   kubeadm init phase certs etcd-peer --config=/tmp/${HOST0}/kubeadmcfg.yaml
+   kubeadm init phase certs etcd-healthcheck-client --config=/tmp/${HOST0}/kubeadmcfg.yaml
+   kubeadm init phase certs apiserver-etcd-client --config=/tmp/${HOST0}/kubeadmcfg.yaml
+   # No need to move the certs because they are for HOST0
+
+   # clean up certs that should not be copied off this host
+   find /tmp/${HOST2} -name ca.key -type f -delete
+   find /tmp/${HOST1} -name ca.key -type f -delete
+   ```
+
+1. Copiez les certificats et les fichiers de configuration kubeadm.
+
+   Les certificats ont été générés et doivent maintenant être déplacés vers leurs
+   hôtes respectifs.
+
+   ```sh
+   USER=ubuntu
+   HOST=${HOST1}
+   scp -r /tmp/${HOST}/* ${USER}@${HOST}:
+   ssh ${USER}@${HOST}
+   USER@HOST $ sudo -Es
+   root@HOST $ chown -R root:root pki
+   root@HOST $ mv pki /etc/kubernetes/
+   ```
+
+1. Assurez-vous que tous les fichiers attendus existent.
+
+   La liste complète des fichiers requis sur `$HOST0` est la suivante :
+
+   ```
+   /tmp/${HOST0}
+   └── kubeadmcfg.yaml
+   ---
+   /etc/kubernetes/pki
+   ├── apiserver-etcd-client.crt
+   ├── apiserver-etcd-client.key
+   └── etcd
+       ├── ca.crt
+       ├── ca.key
+       ├── healthcheck-client.crt
+       ├── healthcheck-client.key
+       ├── peer.crt
+       ├── peer.key
+       ├── server.crt
+       └── server.key
+   ```
+
+   Sur `$HOST1` :
+
+   ```
+   $HOME
+   └── kubeadmcfg.yaml
+   ---
+   /etc/kubernetes/pki
+   ├── apiserver-etcd-client.crt
+   ├── apiserver-etcd-client.key
+   └── etcd
+       ├── ca.crt
+       ├── healthcheck-client.crt
+       ├── healthcheck-client.key
+       ├── peer.crt
+       ├── peer.key
+       ├── server.crt
+       └── server.key
+   ```
+
+    Sur `$HOST2` :
+
+    ```
+   $HOME
+   └── kubeadmcfg.yaml
+   ---
+   /etc/kubernetes/pki
+   ├── apiserver-etcd-client.crt
+   ├── apiserver-etcd-client.key
+   └── etcd
+       ├── ca.crt
+       ├── healthcheck-client.crt
+       ├── healthcheck-client.key
+       ├── peer.crt
+       ├── peer.key
+       ├── server.crt
+       └── server.key
+   ```
+
+1. Créez les manifests de pods statiques.
+
+   Maintenant que les certificats et les fichiers de configuration sont en place, il est temps de créer les manifests. Sur chaque hôte, exécutez la commande `kubeadm` pour générer un manifest statique pour etcd.
+
+   ```sh
+   root@HOST0 $ kubeadm init phase etcd local --config=/tmp/${HOST0}/kubeadmcfg.yaml
+   root@HOST1 $ kubeadm init phase etcd local --config=$HOME/kubeadmcfg.yaml
+   root@HOST2 $ kubeadm init phase etcd local --config=$HOME/kubeadmcfg.yaml
+   ```
+
+1. Optionnel : Vérifiez l’état de santé du cluster.
+
+   Si `etcdctl` n’est pas disponible, vous pouvez exécuter cet outil dans une image de conteneur.
+   Vous pouvez le faire directement avec votre runtime de conteneurs en utilisant un outil tel que
+   `crictl run`, et non via Kubernetes.
 
     ```sh
-    cat << EOF > /etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests
-    Restart=always
-    EOF
-
-    systemctl daemon-reload
-    systemctl restart kubelet
-    ```
-
-1. Créez des fichiers de configuration pour kubeadm.
-
-    Générez un fichier de configuration kubeadm pour chaque machine qui éxécutera un membre etcd
-    en utilisant le script suivant.
-
-    ```sh
-    # Update HOST0, HOST1, and HOST2 with the IPs or resolvable names of your hosts
-    export HOST0=10.0.0.6
-    export HOST1=10.0.0.7
-    export HOST2=10.0.0.8
-
-    # Create temp directories to store files that will end up on other hosts.
-    mkdir -p /tmp/${HOST0}/ /tmp/${HOST1}/ /tmp/${HOST2}/
-
-    ETCDHOSTS=(${HOST0} ${HOST1} ${HOST2})
-    NAMES=("infra0" "infra1" "infra2")
-
-    for i in "${!ETCDHOSTS[@]}"; do
-    HOST=${ETCDHOSTS[$i]}
-    NAME=${NAMES[$i]}
-    cat << EOF > /tmp/${HOST}/kubeadmcfg.yaml
-    apiVersion: "kubeadm.k8s.io/v1beta1"
-    kind: ClusterConfiguration
-    etcd:
-        local:
-            serverCertSANs:
-            - "${HOST}"
-            peerCertSANs:
-            - "${HOST}"
-            extraArgs:
-                initial-cluster: ${NAMES[0]}=https://${ETCDHOSTS[0]}:2380,${NAMES[1]}=https://${ETCDHOSTS[1]}:2380,${NAMES[2]}=https://${ETCDHOSTS[2]}:2380
-                initial-cluster-state: new
-                name: ${NAME}
-                listen-peer-urls: https://${HOST}:2380
-                listen-client-urls: https://${HOST}:2379
-                advertise-client-urls: https://${HOST}:2379
-                initial-advertise-peer-urls: https://${HOST}:2380
-    EOF
-    done
-    ```
-
-1. Générer l'autorité de certification
-
-    Si vous avez déjà une autorité de certification, alors la seule action qui est faite copie
-	 les fichiers `crt` et `key` de la CA dans `/etc/kubernetes/pki/etcd/ca.crt` et
-	 `/etc/kubernetes/pki/etcd/ca.key`. Une fois ces fichiers copiés,
-    passez à l'étape suivante, "Créer des certificats pour chaque membre".
-
-    Si vous ne possédez pas déjà de CA, exécutez cette commande sur `$HOST0` (où vous
-    avez généré les fichiers de configuration pour kubeadm).
-
-    ```
-    kubeadm init phase certs etcd-ca
-    ```
-
-    Cela crée deux fichiers
-
-    - `/etc/kubernetes/pki/etcd/ca.crt`
-    - `/etc/kubernetes/pki/etcd/ca.key`
-
-1. Créer des certificats pour chaque membre
-
-    ```sh
-    kubeadm init phase certs etcd-server --config=/tmp/${HOST2}/kubeadmcfg.yaml
-    kubeadm init phase certs etcd-peer --config=/tmp/${HOST2}/kubeadmcfg.yaml
-    kubeadm init phase certs etcd-healthcheck-client --config=/tmp/${HOST2}/kubeadmcfg.yaml
-    kubeadm init phase certs apiserver-etcd-client --config=/tmp/${HOST2}/kubeadmcfg.yaml
-    cp -R /etc/kubernetes/pki /tmp/${HOST2}/
-    # cleanup non-reusable certificates
-    find /etc/kubernetes/pki -not -name ca.crt -not -name ca.key -type f -delete
-
-    kubeadm init phase certs etcd-server --config=/tmp/${HOST1}/kubeadmcfg.yaml
-    kubeadm init phase certs etcd-peer --config=/tmp/${HOST1}/kubeadmcfg.yaml
-    kubeadm init phase certs etcd-healthcheck-client --config=/tmp/${HOST1}/kubeadmcfg.yaml
-    kubeadm init phase certs apiserver-etcd-client --config=/tmp/${HOST1}/kubeadmcfg.yaml
-    cp -R /etc/kubernetes/pki /tmp/${HOST1}/
-    find /etc/kubernetes/pki -not -name ca.crt -not -name ca.key -type f -delete
-
-    kubeadm init phase certs etcd-server --config=/tmp/${HOST0}/kubeadmcfg.yaml
-    kubeadm init phase certs etcd-peer --config=/tmp/${HOST0}/kubeadmcfg.yaml
-    kubeadm init phase certs etcd-healthcheck-client --config=/tmp/${HOST0}/kubeadmcfg.yaml
-    kubeadm init phase certs apiserver-etcd-client --config=/tmp/${HOST0}/kubeadmcfg.yaml
-    # No need to move the certs because they are for HOST0
-
-    # clean up certs that should not be copied off this host
-    find /tmp/${HOST2} -name ca.key -type f -delete
-    find /tmp/${HOST1} -name ca.key -type f -delete
-    ```
-
-1. Copier les certificats et les configurations kubeadm
-
-    Les certificats ont été générés et doivent maintenant être déplacés vers leur
-    hôtes respectifs.
-
-     ```sh
-     USER=ubuntu
-     HOST=${HOST1}
-     scp -r /tmp/${HOST}/* ${USER}@${HOST}:
-     ssh ${USER}@${HOST}
-     USER@HOST $ sudo -Es
-     root@HOST $ chown -R root:root pki
-     root@HOST $ mv pki /etc/kubernetes/
-     ```
-
-1. S'assurer que tous les fichiers attendus existent
-
-    La liste complète des fichiers requis sur `$HOST0` est la suivante:
-
-    ```
-    /tmp/${HOST0}
-    └── kubeadmcfg.yaml
-    ---
-    /etc/kubernetes/pki
-    ├── apiserver-etcd-client.crt
-    ├── apiserver-etcd-client.key
-    └── etcd
-        ├── ca.crt
-        ├── ca.key
-        ├── healthcheck-client.crt
-        ├── healthcheck-client.key
-        ├── peer.crt
-        ├── peer.key
-        ├── server.crt
-        └── server.key
-    ```
-
-    Sur `$HOST1`:
-
-    ```
-    $HOME
-    └── kubeadmcfg.yaml
-    ---
-    /etc/kubernetes/pki
-    ├── apiserver-etcd-client.crt
-    ├── apiserver-etcd-client.key
-    └── etcd
-        ├── ca.crt
-        ├── healthcheck-client.crt
-        ├── healthcheck-client.key
-        ├── peer.crt
-        ├── peer.key
-        ├── server.crt
-        └── server.key
-    ```
-
-    Sur `$HOST2`:
-
-    ```
-    $HOME
-    └── kubeadmcfg.yaml
-    ---
-    /etc/kubernetes/pki
-    ├── apiserver-etcd-client.crt
-    ├── apiserver-etcd-client.key
-    └── etcd
-        ├── ca.crt
-        ├── healthcheck-client.crt
-        ├── healthcheck-client.key
-        ├── peer.crt
-        ├── peer.key
-        ├── server.crt
-        └── server.key
-    ```
-
-1. Créer les manifestes de pod statiques
-
-    Maintenant que les certificats et les configurations sont en place, il est temps de créer les
-    manifestes. Sur chaque hôte, exécutez la commande `kubeadm` pour générer un manifeste statique
-    pour etcd.
-
-    ```sh
-    root@HOST0 $ kubeadm init phase etcd local --config=/tmp/${HOST0}/kubeadmcfg.yaml
-    root@HOST1 $ kubeadm init phase etcd local --config=$HOME/kubeadmcfg.yaml
-    root@HOST2 $ kubeadm init phase etcd local --config=$HOME/kubeadmcfg.yaml
-    ```
-
-1. Facultatif: Vérifiez la santé du cluster
-
-    ```sh
-    docker run --rm -it \
-    --net host \
-    -v /etc/kubernetes:/etc/kubernetes quay.io/coreos/etcd:${ETCD_TAG} etcdctl \
-    --cert-file /etc/kubernetes/pki/etcd/peer.crt \
-    --key-file /etc/kubernetes/pki/etcd/peer.key \
-    --ca-file /etc/kubernetes/pki/etcd/ca.crt \
-    --endpoints https://${HOST0}:2379 cluster-health
+    ETCDCTL_API=3 etcdctl \
+    --cert /etc/kubernetes/pki/etcd/peer.crt \
+    --key /etc/kubernetes/pki/etcd/peer.key \
+    --cacert /etc/kubernetes/pki/etcd/ca.crt \
+    --endpoints https://${HOST0}:2379 endpoint health
     ...
-    cluster is healthy
+    https://[HOST0 IP]:2379 is healthy: successfully committed proposal: took = 16.283339ms
+    https://[HOST1 IP]:2379 is healthy: successfully committed proposal: took = 19.44402ms
+    https://[HOST2 IP]:2379 is healthy: successfully committed proposal: took = 35.926451ms
     ```
-    - Configurez `${ETCD_TAG}` avec la version de votre image etcd. Par exemple `v3.2.24`.
-    - Configurez `${HOST0}` avec l'adresse IP de l'hôte que vous testez.
 
-
+    - Définissez `${HOST0}` avec l’adresse IP de l’hôte que vous testez.
 
 ## {{% heading "whatsnext" %}}
 
-
-Une fois que vous avez un cluster de 3 membres etcd qui fonctionne, vous pouvez continuer à
- configurer un control plane hautement disponible utilisant la
-[méthode etcd externe avec kubeadm](/fr/docs/setup/production-environment/tools/kubeadm/high-availability/).
-
-
-
-
+Une fois que vous disposez d’un cluster etcd avec 3 membres fonctionnels, vous pouvez continuer à mettre en place un plan de contrôle haute disponibilité en utilisant la
+[méthode etcd externe avec kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/).

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -424,15 +424,6 @@ controllerManager:
     value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 ```
 
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta4
-kind: JoinConfiguration
-nodeRegistration:
-  kubeletExtraArgs:
-  - name: "volume-plugin-dir"
-    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
-```
-
 Sur les nœuds qui rejoignent le cluster :
 
 ```yaml

--- a/content/fr/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -1,8 +1,7 @@
 ---
-title: Dépanner kubeadm
-description: Diagnostic pannes kubeadm debug
+title: Dépannage de kubeadm
 content_type: concept
-weight: 90
+weight: 20
 ---
 
 <!-- overview -->
@@ -21,19 +20,60 @@ Si votre problème ne figure pas dans la liste ci-dessous, procédez comme suit:
   suivez le modèle ( template ) d'issue
 
 - Si vous ne savez pas comment fonctionne kubeadm, vous pouvez demander sur [Slack](http://slack.k8s.io/)
-dans le canal #kubeadm, ou posez une questions sur
+dans le canal #kubeadm, ou posez une questions sur 
 [StackOverflow](https://stackoverflow.com/questions/tagged/kubernetes). Merci d'ajouter les tags pertinents
 comme `#kubernetes` et `#kubeadm`, ainsi on pourra vous aider.
 
-
-
 <!-- body -->
+
+## Impossible de joindre un nœud v1.18 à un cluster v1.17 en raison d’un RBAC manquant
+
+Dans la version v1.18, kubeadm a ajouté une protection empêchant l’ajout d’un nœud au cluster si un nœud portant le même nom existe déjà.
+Cela a nécessité l’ajout de règles RBAC permettant à l’utilisateur bootstrap-token de faire une requête GET sur un objet Node.
+
+Cependant, cela provoque un problème : une commande `kubeadm join` depuis la version v1.18 ne peut pas rejoindre un cluster créé avec kubeadm v1.17.
+
+Pour contourner ce problème, vous avez deux options :
+
+Exécutez `kubeadm init phase bootstrap-token` sur un nœud du plan de contrôle avec kubeadm v1.18.
+Notez que cela active également les autres permissions liées au bootstrap-token.
+
+ou
+
+Appliquez manuellement le contrôle d'accès basé sur les rôles (RBAC) suivant à l'aide de la commande `kubectl apply -f ...` :
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeadm:get-nodes
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:get-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeadm:get-nodes
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:bootstrappers:kubeadm:default-node-token
+```
 
 ## `ebtables` ou un exécutable similaire introuvable lors de l'installation
 
 Si vous voyez les warnings suivants lors de l'exécution `kubeadm init`
 
-```sh
+```console
 [preflight] WARNING: ebtables not found in system path
 [preflight] WARNING: ethtool not found in system path
 ```
@@ -48,40 +88,25 @@ pouvez l'installer avec les commandes suivantes:
 
 Si vous remarquez que `kubeadm init` se bloque après la ligne suivante:
 
-```sh
+```console
 [apiclient] Created API client, waiting for the control plane to become ready
 ```
 
-Cela peut être causé par un certain nombre de problèmes. Les plus communs sont:
+Cela peut être causé par un certain nombre de problèmes. Les plus courants sont :
 
-- problèmes de connexion réseau. Vérifiez que votre machine dispose d'une connectivité réseau
-complète avant de continuer.
-- la configuration du driver cgroup par défaut pour la kubelet diffère de celle utilisée par Docker.
-  Vérifiez le fichier journal du système (par exemple, `/var/log/message`) ou examinez le résultat
-de `journalctl -u kubelet`. Si vous voyez quelque chose comme ce qui suit:
+- des problèmes de connexion réseau. Vérifiez que votre machine dispose d’une connectivité réseau complète avant de continuer.
+- le pilote cgroup du runtime de conteneur est différent de celui du kubelet. Pour comprendre comment le configurer correctement, consultez [Configurer un pilote cgroup](/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/).
+- les conteneurs du plan de contrôle sont en boucle de redémarrage (crashloop) ou bloqués. Vous pouvez le vérifier en exécutant `docker ps` et en inspectant chaque conteneur avec `docker logs`. Pour d’autres runtimes de conteneurs, voir [Déboguer les nœuds Kubernetes avec crictl](/docs/tasks/debug/debug-cluster/crictl/).
 
-  ```shell
-  error: failed to run Kubelet: failed to create kubelet:
-  misconfiguration: kubelet cgroup driver: "systemd" is different from docker cgroup driver: "cgroupfs"
-  ```
+## kubeadm se bloque lors de la suppression de conteneurs gérés
 
-  Il existe deux méthodes courantes pour résoudre le problème du driver cgroup:
+Cela peut se produire si le runtime de conteneurs s’arrête et ne supprime aucun conteneur géré par Kubernetes :
 
- 1. Installez à nouveau Docker en suivant les instructions
-  [ici](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-docker).
- 1. Changez manuellement la configuration de la kubelet pour correspondre au driver Docker cgroup, vous pouvez vous référer à
-    [Configurez le driver de cgroupe utilisé par la kubelet sur le Nœud Master](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-master-node)
-    pour des instruction détaillées.
-
-- Les conteneurs Docker du control plane sont en crashloop ou suspendus. Vous pouvez le vérifier en lançant `docker ps` et étudier chaque conteneur en exécutant `docker logs`.
-
-## kubeadm bloque lors de la suppression de conteneurs gérés
-
-Les événements suivants peuvent se produire si Docker s'arrête et ne supprime pas les conteneurs gérés
-par Kubernetes:
-
-```bash
+```shell
 sudo kubeadm reset
+```
+
+```console
 [preflight] Running pre-flight checks
 [reset] Stopping the kubelet service
 [reset] Unmounting mounted directories in "/var/lib/kubelet"
@@ -89,18 +114,9 @@ sudo kubeadm reset
 (block)
 ```
 
-Une solution possible consiste à redémarrer le service Docker, puis à réexécuter `kubeadm reset`:
-
-```bash
-sudo systemctl restart docker.service
-sudo kubeadm reset
-```
-
-L'inspection des journaux de Docker peut également être utile:
-
-```sh
-journalctl -ul docker
-```
+Une solution possible consiste à redémarrer le runtime de conteneurs, puis à relancer `kubeadm reset`.
+Vous pouvez également utiliser `crictl` pour déboguer l’état du runtime de conteneurs. Voir
+[Déboguer les nœuds Kubernetes avec crictl](/docs/tasks/debug/debug-cluster/crictl/).
 
 ## Pods dans l'état `RunContainerError`, `CrashLoopBackOff` ou `Error`
 
@@ -114,40 +130,30 @@ Juste après `kubeadm init`, il ne devrait pas y avoir de pods dans ces états.
   il est très probable que la solution Pod Network que vous avez installée est en quelque sorte
 endommagée. Vous devrez peut-être lui accorder plus de privilèges RBAC ou utiliser une version
 plus récente. S'il vous plaît créez une issue dans le dépôt du fournisseur de réseau de Pod.
-- Si vous installez une version de Docker antérieure à 1.12.1, supprimez l'option `MountFlags = slave`
-  lors du démarrage de `dockerd` avec `systemd` et redémarrez `docker`. Vous pouvez voir les options
-de montage dans `/usr/lib/systemd/system/docker.service`.
-  Les options de montage peuvent interférer avec les volumes montés par Kubernetes et mettre les
-  pods dans l'état `CrashLoopBackOff`. L'erreur se produit lorsque Kubernetes ne trouve pas les fichiers
-`var/run/secrets/kubernetes.io/serviceaccount`.
 
-## `coredns` (ou `kube-dns`) est bloqué dans l'état `Pending`
+## `coredns` est bloqué à l’état `Pending`
 
-Ceci est **prévu** et fait partie du design. kubeadm est agnostique vis-à-vis du fournisseur
+Ceci est **prévu** et fait partie du design. kubeadm est indépendant du fournisseur
 de réseau, ainsi l'administrateur devrait [installer la solution réseau pod](/docs/concepts/cluster-administration/addons/)
-de choix. Vous devez installer un réseau de pods avant que CoreDNS ne soit complètement déployé.
+de son choix. Vous devez installer un réseau de pods avant que CoreDNS ne soit complètement déployé.
 D'où l' état `Pending` avant la mise en place du réseau.
 
 ## Les services `HostPort` ne fonctionnent pas
 
 Les fonctionnalités `HostPort` et `HostIP` sont disponibles en fonction de votre fournisseur
-de réseau de pod. Veuillez contacter l’auteur de la solution de réseau de Pod pour savoir si
-Les fonctionnalités `HostPort` et `HostIP` sont disponibles.
+de réseau de pod. Veuillez contacter l’auteur de l’add-on réseau pour savoir si ces fonctionnalités sont prises en charge.
 
-Les fournisseurs de CNI Calico, Canal, et Flannel supportent HostPort.
+Les fournisseurs de CNI Calico, Canal, et Flannel sont validés pour supporter `HostPort`.
 
-Pour plus d'informations, voir la [CNI portmap documentation](https://github.com/containernetworking/plugins/blob/master/plugins/meta/portmap/README.md).
+Pour plus d'informations, voir la [documentation CNI portmap](https://github.com/containernetworking/plugins/blob/master/plugins/meta/portmap/README.md).
 
-Si votre fournisseur de réseau ne prend pas en charge le plug-in portmap CNI, vous devrez peut-être utiliser le
-[NodePort feature of services](/docs/concepts/services-networking/service/#nodeport) ou utiliser `HostNetwork=true`.
+Si votre fournisseur de réseau ne prend pas en charge le plug-in portmap CNI, vous devrez peut-être utiliser la
+[fonction NodePort des services](/docs/concepts/services-networking/service/#nodeport) ou utiliser `HostNetwork=true`.
 
 ## Les pods ne sont pas accessibles via leur IP de service
 
 - De nombreux add-ons réseau ne permettent pas encore
-[hairpin mode](/docs/tasks/debug-application-cluster/debug-service/#a-pod-cannot-reach-itself-via-service-ip)
-  qui permet aux pods d’accéder à eux-mêmes via leur IP de service. Ceci est un problème lié
-  au [CNI](https://github.com/containernetworking/cni/issues/476). S'il vous plaît contacter
-  le fournisseur d'add-on réseau afin d'obtenir des informations en matière de prise en charge du mode hairpin.
+[mode hairpin](/docs/tasks/debug-application-cluster/debug-service/#a-pod-cannot-reach-itself-via-service-ip), qui permet aux pods d’accéder à eux-mêmes via leur IP de service. Ceci est un problème lié au [CNI](https://github.com/containernetworking/cni/issues/476). S'il vous plaît contacter le fournisseur d'add-on réseau afin d'obtenir des informations en matière de prise en charge du mode hairpin.
 
 - Si vous utilisez VirtualBox (directement ou via Vagrant), vous devrez vous assurez que
 `hostname -i` renvoie une adresse IP routable. Par défaut la première interface est connectée
@@ -166,17 +172,59 @@ Unable to connect to the server: x509: certificate signed by unknown authority (
 
 - Vérifiez que le fichier `$HOME/.kube/config` contient un certificat valide, et 
 re-générer un certificat si nécessaire. Les certificats dans un fichier kubeconfig 
-sont encodés en base64. La commande `base64 -d` peut être utilisée pour décoder le certificat 
-et `openssl x509 -text -noout` peut être utilisé pour afficher les informations du certificat.
-- Une autre solution consiste à écraser le `kubeconfig` existant pour l'utilisateur" admin ":
+sont encodés en base64. La commande `base64 --decode` permet de décoder le certificat et la commande `openssl x509 -text -noout` permet d'afficher les informations du certificat.
+
+- Désactivez la variable d’environnement `KUBECONFIG` en utilisant :
 
   ```sh
-  mv  $HOME/.kube $HOME/.kube.bak
+  unset KUBECONFIG
+  ```
+
+  Ou définissez-la vers l’emplacement par défaut de `KUBECONFIG` :
+
+  ```sh
+  export KUBECONFIG=/etc/kubernetes/admin.conf
+  ```
+
+- Une autre solution consiste à écraser le `kubeconfig` existant pour l'utilisateur " admin ":
+
+  ```sh
+  mv $HOME/.kube $HOME/.kube.bak
+  mkdir $HOME/.kube
   sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
   sudo chown $(id -u):$(id -g) $HOME/.kube/config
   ```
 
-## Carte réseau par défaut lors de l'utilisation de flannel comme réseau de pod dans Vagrant
+## Échec de la rotation du certificat client kubelet {#kubelet-client-cert}
+
+Par défaut, kubeadm configure le kubelet avec une rotation automatique des certificats clients en utilisant le lien symbolique `/var/lib/kubelet/pki/kubelet-client-current.pem` défini dans `/etc/kubernetes/kubelet.conf`.
+
+Si ce processus de rotation échoue, vous pouvez voir des erreurs telles que `x509: certificate has expired or is not yet valid` dans les logs du kube-apiserver. Pour corriger ce problème, vous devez suivre les étapes suivantes :
+
+1. Sauvegardez puis supprimez `/etc/kubernetes/kubelet.conf` et `/var/lib/kubelet/pki/kubelet-client*` sur le nœud concerné.
+1. Depuis un nœud du plan de contrôle fonctionnel du cluster qui possède `/etc/kubernetes/pki/ca.key`, exécutez :
+  `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`.
+  `$NODE` doit être défini comme le nom du nœud défaillant existant dans le cluster.
+Modifiez ensuite manuellement le fichier `kubelet.conf` généré afin d’ajuster le nom du cluster et le point de terminaison du serveur,
+ou passez l’option `kubeconfig user --config` (voir [Générer des fichiers kubeconfig pour des utilisateurs supplémentaires](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubeconfig-additional-users)).
+
+Si votre cluster ne dispose pas de `ca.key`, vous devez signer les certificats intégrés dans `kubelet.conf` de manière externe.
+
+1. Copiez ce fichier `kubelet.conf` généré vers `/etc/kubernetes/kubelet.conf` sur le nœud défaillant.
+2. Redémarrez le kubelet (`systemctl restart kubelet`) sur le nœud défaillant et attendez que
+   `/var/lib/kubelet/pki/kubelet-client-current.pem` soit recréé.
+3. Modifiez manuellement `kubelet.conf` pour pointer vers les certificats client kubelet renouvelés, en remplaçant
+   `client-certificate-data` et `client-key-data` par :
+
+   ```yaml
+   client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
+   client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
+   ```   
+
+1. Redémarrez le kubelet.
+1. Assurez-vous que le nœud passe à l’état `Ready`.
+
+## Interface réseau (NIC) par défaut lors de l’utilisation de flannel comme réseau de pods dans Vagrant
 
 L'erreur suivante peut indiquer que quelque chose n'allait pas dans le réseau de pod:
 
@@ -185,23 +233,21 @@ Error from server (NotFound): the server could not find the requested resource
 ```
 
 - Si vous utilisez flannel comme réseau de pod dans Vagrant, vous devrez spécifier le
-nom d'interface par défaut pour flannel.
+nom d'interface réseau par défaut pour flannel.
 
   Vagrant attribue généralement deux interfaces à tous les ordinateurs virtuels. La
 première, pour laquel tous les hôtes se voient attribuer l’adresse IP `10.0.2.15`,
-est pour le trafic externe qui est NATé.
+est utilisée pour le trafic externe via NAT.
 
   Cela peut entraîner des problèmes avec Flannel, qui utilise par défaut la première
-interface sur un hôte. Ceci conduit au fait que tous les hôtes pensent qu'ils ont la
-même adresse IP publique. Pour éviter cela, passez l'option `--iface eth1` sur Flannel
-pour que la deuxième interface soit choisie.
+interface sur un hôte. Cela conduit tous les hôtes à penser qu’ils ont la même adresse IP publique. Pour éviter cela, passez l'option `--iface eth1` sur Flannel pour que la deuxième interface soit choisie.
 
 ## IP non publique utilisée pour les conteneurs
 
 Dans certaines situations, les commandes `kubectl logs` et `kubectl run` peuvent
 renvoyer les erreurs suivantes dans un cluster par ailleurs fonctionnel:
 
-```sh
+```console
 Error from server: Get https://10.19.0.41:10250/containerLogs/default/mysql-ddc65b868-glc5m/mysql:
 dial tcp 10.19.0.41:10250: getsockopt: no route to host
 ```
@@ -224,9 +270,10 @@ dernière comme `InternalIP` du noeud au lieu du public.
   La solution consiste à indiquer à la `kubelet` l'adresse IP à utiliser avec` --node-ip`. Lors de
   l'utilisation de Digital Ocean, il peut être public (assigné à `eth0`) ou privé (assigné à` eth1`)
   si vous voulez utiliser le réseau privé optionnel. la
-  [la section `KubeletExtraArgs` de kubeadm `NodeRegistrationOptions` structure](https://github.com/kubernetes/kubernetes/blob/release-1.13/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go) peut être utilisé pour cela.
+  [`NodeRegistrationOptions` structure](/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-NodeRegistrationOptions)
+  peut être utilisée pour cela.
 
-  Puis redémarrer la `kubelet`:
+  Puis redémarrer `kubelet`:
 
   ```sh
   systemctl daemon-reload
@@ -238,9 +285,11 @@ dernière comme `InternalIP` du noeud au lieu du public.
 Si vous avez des nœuds qui exécutent SELinux avec une version plus ancienne de Docker, vous risquez
 de rencontrer un problème ou les pods de `coredns` ne démarrent pas. Pour résoudre ce problème, vous pouvez essayer l'une des options suivantes:
 
-- Mise à niveau vers une [nouvelle version de Docker](/fr/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-docker).
-- [Désactiver SELinux](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux).
-- Modifiez le déploiement de `coredns` pour définir` allowPrivilegeEscalation` à `true`:
+- Mettez à niveau vers une [version plus récente de Docker](/docs/setup/production-environment/container-runtimes/#docker).
+
+- [Désactivez SELinux](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux).
+
+- Modifiez le déploiement `coredns` pour définir `allowPrivilegeEscalation` sur `true` :
 
 ```bash
 kubectl -n kube-system get deployment coredns -o yaml | \
@@ -283,4 +332,231 @@ sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/dock
 yum install docker-ce-18.06.1.ce-3.el7.x86_64
 ```
 
+## Impossible de passer une liste de valeurs séparées par des virgules dans l’argument `--component-extra-args`
 
+Les options de `kubeadm init` telles que `--component-extra-args` permettent de passer des arguments personnalisés à un composant du plan de contrôle, comme le kube-apiserver. Cependant, ce mécanisme est limité en raison du type utilisé pour l’analyse des valeurs (`mapStringString`).
+
+Si vous essayez de passer un argument acceptant plusieurs valeurs séparées par des virgules, comme :
+
+`--apiserver-extra-args "enable-admission-plugins=LimitRanger,NamespaceExists"`
+
+cela échouera avec l’erreur :
+
+`flag: malformed pair, expect string=string`
+
+Cela se produit car la liste d’arguments pour `--apiserver-extra-args` attend des paires `clé=valeur`, et dans ce cas `NamespaceExists` est interprété comme une clé sans valeur.
+
+Vous pouvez également essayer de séparer les paires `clé=valeur` comme ceci :
+
+`--apiserver-extra-args "enable-admission-plugins=LimitRanger,enable-admission-plugins=NamespaceExists"`
+
+mais cela aura pour effet que la clé `enable-admission-plugins` ne conservera que la valeur `NamespaceExists`.
+
+Une solution de contournement connue consiste à utiliser le [fichier de configuration kubeadm](/docs/reference/config-api/kubeadm-config.v1beta4/).
+
+## kube-proxy programmé avant l’initialisation du nœud par le cloud-controller-manager
+
+Dans les scénarios avec fournisseur cloud, kube-proxy peut être programmé sur de nouveaux nœuds worker avant que le cloud-controller-manager n’ait initialisé les adresses du nœud. Cela empêche kube-proxy de récupérer correctement l’adresse IP du nœud et entraîne des effets secondaires sur la gestion du load balancing par le proxy.
+
+L’erreur suivante peut apparaître dans les Pods kube-proxy :
+
+```
+server.go:610] Failed to retrieve node IP: host IP unknown; known addresses: []
+proxier.go:340] invalid nodeIP, initializing kube-proxy with 127.0.0.1 as nodeIP
+```
+
+Une solution connue consiste à patcher le DaemonSet kube-proxy afin de permettre sa planification sur les nœuds du plan de contrôle, indépendamment de leurs conditions, tout en l’empêchant de s’exécuter sur les autres nœuds jusqu’à ce que leurs conditions de protection initiales disparaissent :
+
+```
+kubectl -n kube-system patch ds kube-proxy -p='{
+  "spec": {
+    "template": {
+      "spec": {
+        "tolerations": [
+          {
+            "key": "CriticalAddonsOnly",
+            "operator": "Exists"
+          },
+          {
+            "effect": "NoSchedule",
+            "key": "node-role.kubernetes.io/control-plane"
+          }
+        ]
+      }
+    }
+  }
+}'
+```
+
+Le ticket de suivi de ce problème se trouve [ici](https://github.com/kubernetes/kubeadm/issues/1027).
+
+## `/usr` monté en lecture seule sur les nœuds {#usr-mounted-read-only}
+
+Sur des distributions Linux comme Fedora CoreOS ou Flatcar Container Linux, le répertoire `/usr` est monté en système de fichiers en lecture seule.
+Pour le [support des flex-volumes](https://github.com/kubernetes/community/blob/ab55d85/contributors/devel/sig-storage/flexvolume.md),
+les composants Kubernetes comme le kubelet et le kube-controller-manager utilisent par défaut le chemin
+`/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, mais le répertoire des flex-volumes _doit être accessible en écriture_
+pour que la fonctionnalité fonctionne.
+
+{{< note >}}
+FlexVolume est déprécié depuis la version Kubernetes v1.23.
+{{< /note >}}
+
+Pour contourner ce problème, vous pouvez configurer le répertoire flex-volume via le fichier de configuration kubeadm :
+
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/).
+
+Sur le nœud du plan de contrôle principal (créé avec `kubeadm init`), passez le fichier suivant avec `--config` :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+  - name: "volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+controllerManager:
+  extraArgs:
+  - name: "flex-volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+```
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+  - name: "volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+```
+
+Sur les nœuds qui rejoignent le cluster :
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+  - name: "volume-plugin-dir"
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+```
+
+Sinon, vous pouvez modifier `/etc/fstab` pour rendre le montage `/usr` accessible en écriture, mais veuillez noter que cela modifie un principe de conception de la distribution Linux.
+
+## `kubeadm upgrade plan` affiche l’erreur `context deadline exceeded`
+
+Ce message d’erreur apparaît lors de la mise à niveau d’un cluster Kubernetes avec `kubeadm` dans le cas où un etcd externe est utilisé.
+Ce n’est pas un bug critique et cela se produit parce que les anciennes versions de kubeadm effectuent une vérification de version sur le cluster etcd externe.
+Vous pouvez continuer avec `kubeadm upgrade apply ...`.
+
+Ce problème est corrigé à partir de la version 1.19.
+
+## `kubeadm reset` démonte `/var/lib/kubelet`
+
+Si `/var/lib/kubelet` est monté, l’exécution de `kubeadm reset` le démontera effectivement.
+
+Pour contourner ce problème, remontez le répertoire `/var/lib/kubelet` après avoir exécuté `kubeadm reset`.
+
+Il s’agit d’une régression introduite dans kubeadm 1.15. Le problème est corrigé en version 1.20.
+
+## Impossible d’utiliser metrics-server de manière sécurisée dans un cluster kubeadm
+
+Dans un cluster kubeadm, le [metrics-server](https://github.com/kubernetes-sigs/metrics-server)
+peut être utilisé de manière non sécurisée en passant l’option `--kubelet-insecure-tls`. Cela n’est pas recommandé pour les clusters de production.
+
+Si vous souhaitez utiliser TLS entre metrics-server et le kubelet, un problème se pose,
+car kubeadm déploie un certificat auto-signé pour le kubelet. Cela peut provoquer les erreurs suivantes du côté de metrics-server :
+
+```
+x509: certificate signed by unknown authority
+x509: certificate is valid for IP-foo not IP-bar
+```
+
+Voir [Activer les certificats de service kubelet signés](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs)
+pour comprendre comment configurer les kubelets dans un cluster kubeadm afin d’obtenir des certificats de service correctement signés.
+
+Voir également [Comment exécuter metrics-server de manière sécurisée](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md#how-to-run-metrics-server-securely).
+
+## Échec de la mise à niveau dû à un hash etcd qui ne change pas
+
+Applicable uniquement lors de la mise à niveau d’un nœud du plan de contrôle avec un binaire kubeadm v1.28.3 ou ultérieur,
+lorsque le nœud est actuellement géré par kubeadm en version v1.28.0, v1.28.1 ou v1.28.2.
+
+Voici le message d’erreur que vous pouvez rencontrer :
+
+```
+[upgrade/etcd] Failed to upgrade etcd: couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced: static Pod hash for component etcd on Node kinder-upgrade-control-plane-1 did not change after 5m0s: timed out waiting for the condition
+[upgrade/etcd] Waiting for previous etcd to become available
+I0907 10:10:09.109104    3704 etcd.go:588] [etcd] attempting to see if all cluster endpoints ([https://172.17.0.6:2379/ https://172.17.0.4:2379/ https://172.17.0.3:2379/]) are available 1/10
+[upgrade/etcd] Etcd was rolled back and is now available
+static Pod hash for component etcd on Node kinder-upgrade-control-plane-1 did not change after 5m0s: timed out waiting for the condition
+couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced
+k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade.rollbackOldManifests
+	cmd/kubeadm/app/phases/upgrade/staticpods.go:525
+k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade.upgradeComponent
+	cmd/kubeadm/app/phases/upgrade/staticpods.go:254
+k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade.performEtcdStaticPodUpgrade
+	cmd/kubeadm/app/phases/upgrade/staticpods.go:338
+...
+```
+
+La raison de cet échec est que les versions concernées génèrent un fichier de manifeste etcd avec des valeurs par défaut non souhaitées dans le PodSpec. Cela entraîne une différence lors de la comparaison du manifeste, et kubeadm s’attend alors à un changement du hash du Pod, mais le kubelet ne met jamais ce hash à jour.
+
+Il existe deux façons de contourner ce problème si vous le rencontrez dans votre cluster :
+
+- La mise à niveau d’etcd peut être ignorée entre les versions affectées et v1.28.3 (ou ultérieure) en utilisant :
+
+  ```shell
+  kubeadm upgrade {apply|node} [version] --etcd-upgrade=false
+  ```
+
+Cette méthode n’est pas recommandée dans le cas où une nouvelle version d’etcd aurait été introduite par une version corrective ultérieure de v1.28.
+
+- Avant la mise à niveau, corrigez le manifeste du pod statique etcd afin de supprimer les attributs par défaut problématiques :
+
+```patch
+  diff --git a/etc/kubernetes/manifests/etcd_defaults.yaml b/etc/kubernetes/manifests/etcd_origin.yaml
+  index d807ccbe0aa..46b35f00e15 100644
+  --- a/etc/kubernetes/manifests/etcd_defaults.yaml
+  +++ b/etc/kubernetes/manifests/etcd_origin.yaml
+  @@ -43,7 +43,6 @@ spec:
+          scheme: HTTP
+        initialDelaySeconds: 10
+        periodSeconds: 10
+  -      successThreshold: 1
+        timeoutSeconds: 15
+      name: etcd
+      resources:
+  @@ -59,26 +58,18 @@ spec:
+          scheme: HTTP
+        initialDelaySeconds: 10
+        periodSeconds: 10
+  -      successThreshold: 1
+        timeoutSeconds: 15
+  -    terminationMessagePath: /dev/termination-log
+  -    terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /var/lib/etcd
+        name: etcd-data
+      - mountPath: /etc/kubernetes/pki/etcd
+        name: etcd-certs
+  -  dnsPolicy: ClusterFirst
+  -  enableServiceLinks: true
+    hostNetwork: true
+    priority: 2000001000
+    priorityClassName: system-node-critical
+  -  restartPolicy: Always
+  -  schedulerName: default-scheduler
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  -  terminationGracePeriodSeconds: 30
+    volumes:
+    - hostPath:
+        path: /etc/kubernetes/pki/etcd
+  ```
+
+Vous trouverez plus d’informations dans le [ticket de suivi](https://github.com/kubernetes/kubeadm/issues/2927) de ce bug.  


### PR DESCRIPTION
## Description

This PR updates multiple outdated French documentation pages under the kubeadm production environment section.

Changes include:
- Updating several kubeadm setup and troubleshooting pages that were outdated (_**some last updated several years ago**_)
- Improving consistency and modernizing content structure
- Adding a new page for dual-stack support (`dual-stack-support.md`)
- Minor fixes and clarifications across HA-related and kubelet integration documentation

## Files changed

- control-plane-flags.md
- create-cluster-kubeadm.md
- ha-topology.md
- high-availability.md
- kubelet-integration.md
- setup-ha-etcd-with-kubeadm.md
- troubleshooting-kubeadm.md
- + new: dual-stack-support.md

## Notes

- This is part of a documentation refresh effort for the kubeadm production environment section.
- Each file is independent and can be reviewed separately.
- No functional changes, only documentation updates and additions.
#55608 