### PR TITLE
[fr] : Removal of turnker and windows folders that do not exist in th…

### DIFF
--- a/content/fr/docs/setup/production-environment/turnkey/_index.md
+++ b/content/fr/docs/setup/production-environment/turnkey/_index.md
@@ -1,4 +1,0 @@
----
-title: Solutions Cloud clés en main
-weight: 40
----

--- a/content/fr/docs/setup/production-environment/windows/_index.md
+++ b/content/fr/docs/setup/production-environment/windows/_index.md
@@ -1,4 +1,0 @@
----
-title: Windows dans Kubernetes
-weight: 65
----


### PR DESCRIPTION
### What this PR does

- Removes obsolete `turnkey` and `windows` folders from the French documentation
- Aligns the French documentation structure with the English version

### Why this PR is needed

These folders don't exist in the English source and are outdated in the French documentation.

### Issue

Part of French localization sync effort.
#55608