### PR TITLE
Update release schedule for April 2026 patches

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -10,16 +10,18 @@ schedules:
     cherryPickDeadline: "2026-05-08"
     release: 1.36.1
     targetDate: "2026-05-13"
-  previousPatches: []
   release: "1.36"
   releaseDate: "2026-04-22"
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-04-10"
+    cherryPickDeadline: "2026-05-08"
+    release: 1.35.5
+    targetDate: "2026-05-12"
+  previousPatches:
+  - cherryPickDeadline: "2026-04-10"
     release: 1.35.4
     targetDate: "2026-04-14"
-  previousPatches:
   - cherryPickDeadline: "2026-03-13"
     release: 1.35.3
     targetDate: "2026-03-19"
@@ -38,10 +40,13 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2026-04-10"
+    cherryPickDeadline: "2026-05-08"
+    release: 1.34.8
+    targetDate: "2026-05-12"
+  previousPatches:
+  - cherryPickDeadline: "2026-04-10"
     release: 1.34.7
     targetDate: "2026-04-14"
-  previousPatches:
   - cherryPickDeadline: "2026-03-13"
     release: 1.34.6
     targetDate: "2026-03-19"
@@ -65,17 +70,18 @@ schedules:
   - cherryPickDeadline: "2025-09-05"
     release: 1.34.1
     targetDate: "2025-09-09"
-  - release: 1.34.0
-    targetDate: "2025-08-27"
   release: "1.34"
   releaseDate: "2025-08-27"
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2026-04-10"
+    cherryPickDeadline: "2026-05-08"
+    release: 1.33.12
+    targetDate: "2026-05-12"
+  previousPatches:
+  - cherryPickDeadline: "2026-04-10"
     release: 1.33.11
     targetDate: "2026-04-14"
-  previousPatches:
   - cherryPickDeadline: "2026-03-13"
     release: 1.33.10
     targetDate: "2026-03-19"
@@ -114,9 +120,9 @@ schedules:
   release: "1.33"
   releaseDate: "2025-04-23"
 upcoming_releases:
-- cherryPickDeadline: "2026-04-10"
-  targetDate: "2026-04-14"
 - cherryPickDeadline: "2026-05-08"
   targetDate: "2026-05-12"
 - cherryPickDeadline: "2026-06-05"
   targetDate: "2026-06-09"
+- cherryPickDeadline: "2026-07-10"
+  targetDate: "2026-07-14"


### PR DESCRIPTION
- Promotes 1.33.11, 1.34.7, and 1.35.4 from `next` into `previousPatches` (April 2026 patch releases shipped on schedule).
- Sets `next` to 1.33.12 / 1.34.8 / 1.35.5 with the May 2026 cherry-pick deadlines.
- Refreshes `upcoming_releases` (drops the April row, adds July).
- Removes a stray `1.34.0` entry from 1.34's `previousPatches`. The `.0` of a minor isn't a patch and the other minors (1.33, 1.35, 1.36) follow the convention of starting `previousPatches` at `.1`. `schedule-builder` does not produce `.0` entries.

Generated by running `schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml` (per the file header), then manually removing the `1.34.0` block.

Closes #55542 