### PR TITLE
[zh-cn] Change H2 headings to H3 to match English source

### DIFF
--- a/content/zh-cn/blog/_posts/2022/forensic-container-checkpointing/index.md
+++ b/content/zh-cn/blog/_posts/2022/forensic-container-checkpointing/index.md
@@ -96,7 +96,7 @@ The runtime must also support container checkpointing:
 <!-- 
 ### Usage example with CRI-O
  -->
-## CRI-O 的使用示例
+### CRI-O 的使用示例
 
 <!-- 
 To use forensic container checkpointing in combination with CRI-O, the runtime

--- a/content/zh-cn/blog/_posts/2023/gateway-api-ga/index.md
+++ b/content/zh-cn/blog/_posts/2023/gateway-api-ga/index.md
@@ -107,7 +107,7 @@ channel. These include HTTPRoute timeouts, TLS config from Gateways to backends,
 WebSocket support, Gateway infrastructure labels, and more. Stay tuned for a
 follow up blog post that will cover each of these new features in detail.
 -->
-## 实验（Experimental）通道
+### 实验（Experimental）通道
 
 此发行版本中包含的大部分更改都限于实验通道。这些更改包括 HTTPRoute
 超时、用于 Gateway 访问后端的 TLS 配置、WebSocket 支持、Gateway 基础设施的标签等等。
@@ -119,7 +119,7 @@ For a full list of the changes included in this release, please refer to the
 [v1.0.0 release
 notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0).
 -->
-## 其他内容
+### 其他内容
 
 有关此版本中包含的所有更改的完整列表，请参阅
 [v1.0.0 版本说明](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0)。

--- a/content/zh-cn/blog/_posts/2024/consistent-read-from-cache.md
+++ b/content/zh-cn/blog/_posts/2024/consistent-read-from-cache.md
@@ -158,7 +158,7 @@ Our journey doesn't end here. Kubernetes community is actively exploring
 pagination support in the watch cache, which will unlock even more performance
 optimizations in the future.
 -->
-## 下一步是什么？   {#whats-next}
+### 下一步是什么？   {#whats-next}
 
 随着基于缓存的一致性读特性晋升至 Beta 版，该特性已默认启用，为所有使用受支持 etcd
 版本的 Kubernetes 用户提供了无缝的性能提升。

--- a/content/zh-cn/docs/concepts/cluster-administration/node-shutdown.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/node-shutdown.md
@@ -45,7 +45,7 @@ kubelet 会尝试检测节点系统关闭事件并终止在节点上运行的所
 <!--
 ### Enabling graceful node shutdown
 -->
-## 启用节点体面关闭 {#enabling-graceful-node-shutdown}
+### 启用节点体面关闭 {#enabling-graceful-node-shutdown}
 
 {{< tabs name="graceful_shutdown_os" >}}
 {{% tab name="Linux" %}}
@@ -126,7 +126,7 @@ thus not activating the graceful node shutdown functionality.
 To activate the feature, both options should be configured appropriately and
 set to non-zero values.
 -->
-## 配置节点体面关闭
+### 配置节点体面关闭
 
 注意，默认情况下，下面描述的两个配置选项，`shutdownGracePeriod` 和
 `shutdownGracePeriodCriticalPods` 都是被设置为 0 的，因此不会激活节点体面关闭特性。

--- a/content/zh-cn/docs/concepts/configuration/liveness-readiness-startup-probes.md
+++ b/content/zh-cn/docs/concepts/configuration/liveness-readiness-startup-probes.md
@@ -38,7 +38,7 @@ Kubernetes 允许你定义**探针**来持续监控 Pod 中容器的健康状况
 
 A startup probe verifies whether the application within a container is started. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.
 -->
-## 启动探针   {#startup-probe}
+### 启动探针   {#startup-probe}
 
 启动探针检查容器内的应用是否已启动。
 启动探针可以用于对慢启动容器进行存活性检测，避免它们在启动运行之前就被 kubelet 杀掉。
@@ -62,7 +62,7 @@ This type of probe is only executed at startup, unlike liveness and readiness pr
 
 Liveness probes determine when to restart a container. For example, liveness probes could catch a deadlock when an application is running, but unable to make progress.
 -->
-## 存活探针   {#liveness-probe}
+### 存活探针   {#liveness-probe}
 
 存活探针决定何时重启容器。
 例如，当应用在运行但无法取得进展时，存活探针可以捕获这类死锁。
@@ -84,7 +84,7 @@ Liveness probes do not wait for readiness probes to succeed. If you want to wait
 
 Readiness probes determine when a container is ready to accept traffic. This is useful when waiting for an application to perform time-consuming initial tasks that depend on its backing services; for example: establishing network connections, loading files, and warming caches. Readiness probes can also be useful later in the container’s lifecycle, for example, when recovering from temporary faults or overloads.
 -->
-## 就绪探针   {#readiness-probe}
+### 就绪探针   {#readiness-probe}
 
 就绪探针决定容器何时准备好接受流量。
 这种探针在等待应用执行耗时的初始任务时非常有用；

--- a/content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
@@ -348,7 +348,7 @@ but this isn't useful to specify: you must always assign whole numbers of bytes,
 
 Here are some examples of memory quantities that represent roughly the same value:
 -->
-## 内存资源单位      {#meaning-of-memory}
+### 内存资源单位      {#meaning-of-memory}
 
 `memory` 的限制和请求以字节为单位。你可以使用普通的整数，
 或者带有以下[数量](/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity/)后缀的定点数字来表示内存：

--- a/content/zh-cn/docs/concepts/overview/components.md
+++ b/content/zh-cn/docs/concepts/overview/components.md
@@ -66,7 +66,7 @@ Manage the overall state of the cluster:
 [cloud-controller-manager](/docs/concepts/architecture/#cloud-controller-manager) (optional)
 : Integrates with underlying cloud provider(s).
 -->
-## 控制平面组件    {#control-plane-components}
+### 控制平面组件    {#control-plane-components}
 
 这些控制平面组件（Control Plane Component）管理集群的整体状态：
 
@@ -100,7 +100,7 @@ Run on every node, maintaining running pods and providing the Kubernetes runtime
 : Software responsible for running containers. Read
   [Container Runtimes](/docs/setup/production-environment/container-runtimes/) to learn more.
 -->
-## Node 组件  {#node-components}
+### Node 组件  {#node-components}
 
 在每个节点上运行，维护运行的 Pod 并提供 Kubernetes 运行时环境：
 

--- a/content/zh-cn/docs/concepts/policy/resource-quotas.md
+++ b/content/zh-cn/docs/concepts/policy/resource-quotas.md
@@ -293,7 +293,7 @@ that can be requested in a given namespace.
 In addition, you can limit consumption of storage resources based on associated
 [StorageClass](/docs/concepts/storage/storage-classes/).
 -->
-## 存储的配额  {#quota-for-storage}
+### 存储的配额  {#quota-for-storage}
 
 你可以对给定命名空间下可以请求的[存储卷](/zh-cn/docs/concepts/storage/persistent-volumes/)总量进行限制。
 

--- a/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -91,7 +91,7 @@ nodes or groups of nodes. You can use this functionality to ensure that specific
 Pods only run on nodes with certain isolation, security, or regulatory
 properties.
 -->
-## 节点隔离/限制  {#node-isolation-restriction}
+### 节点隔离/限制  {#node-isolation-restriction}
 
 通过为节点添加标签，你可以准备让 Pod 调度到特定节点或节点组上。
 你可以使用这个功能来确保特定的 Pod 只能运行在具有一定隔离性、安全性或监管属性的节点上。

--- a/content/zh-cn/docs/concepts/storage/persistent-volumes.md
+++ b/content/zh-cn/docs/concepts/storage/persistent-volumes.md
@@ -2128,7 +2128,7 @@ Volume populators are {{< glossary_tooltip text="controllers" term_id="controlle
 create non-empty volumes, where the contents of the volume are determined by a Custom Resource.
 Users create a populated volume by referring to a Custom Resource using the `dataSourceRef` field:
 -->
-## 使用卷填充器   {#using-volume-populators}
+### 使用卷填充器   {#using-volume-populators}
 
 卷填充器是能创建非空卷的{{< glossary_tooltip text="控制器" term_id="controller" >}}，
 其卷的内容通过一个自定义资源决定。

--- a/content/zh-cn/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/cron-jobs.md
@@ -345,7 +345,7 @@ For another way to clean up Jobs automatically, see
 <!-- 
 ### Time zones
 -->
-## 时区    {#time-zones}
+### 时区    {#time-zones}
 
 {{< feature-state for_k8s_version="v1.27" state="stable" >}}
 

--- a/content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
@@ -123,7 +123,7 @@ both.
 If any of the controllers in either phase reject the request, the entire
 request is rejected immediately and an error is returned to the end-user.
 -->
-## 准入控制阶段   {#admission-control-phases}
+### 准入控制阶段   {#admission-control-phases}
 
 准入控制过程分为两个阶段。第一阶段，运行变更准入控制器。第二阶段，运行验证准入控制器。
 再次提醒，某些控制器既是变更准入控制器又是验证准入控制器。

--- a/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
+++ b/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
@@ -5438,7 +5438,7 @@ See more details on [Audit Annotations](/docs/reference/labels-annotations-taint
 <!--
 ### kubeadm.alpha.kubernetes.io/cri-socket (deprecated) {#kubeadm-alpha-kubernetes-io-cri-socket}
 -->
-## kubeadm.alpha.kubernetes.io/cri-socket (已弃用) {#kubeadm-alpha-kubernetes-io-cri-socket}
+### kubeadm.alpha.kubernetes.io/cri-socket (已弃用) {#kubeadm-alpha-kubernetes-io-cri-socket}
 
 <!--
 Type: Annotation

--- a/content/zh-cn/docs/reference/using-api/server-side-apply.md
+++ b/content/zh-cn/docs/reference/using-api/server-side-apply.md
@@ -276,7 +276,7 @@ to change a field that another manager also claims to manage. This prevents an
 applier from unintentionally overwriting the value set by another user. When
 this occurs, the applier has 3 options to resolve the conflicts:
 -->
-## 冲突 {#conflicts}
+### 冲突 {#conflicts}
 
 **冲突**是一种特定的错误状态，
 发生在执行 `Apply` 改变一个字段，而恰巧该字段被其他用户声明过主权时。
@@ -335,7 +335,7 @@ For other updates, the API server infers a field manager identity from the
 When you use the `kubectl` tool to perform a Server-Side Apply operation, `kubectl`
 sets the manager identity to `"kubectl"` by default.
 -->
-## 字段管理器 {#managers}
+### 字段管理器 {#managers}
 
 管理器识别出正在修改对象的工作流程（在冲突时尤其有用）,
 并且可以作为修改请求的一部分，通过

--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -162,7 +162,7 @@ controllerManager:
 <!--
 ### Scheduler flags
 -->
-## Scheduler 参数   {#scheduler-flags}
+### Scheduler 参数   {#scheduler-flags}
 
 <!--
 For details, see the [reference documentation for kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/).

--- a/content/zh-cn/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -69,7 +69,7 @@ For deploying in production, advanced hardware configuration is required.
 Before deploying etcd in production, see
 [resource requirement reference](https://etcd.io/docs/current/op-guide/hardware/#example-hardware-configurations).
 -->
-## etcd 资源需求    {#resource-requirements-for-etcd}
+### etcd 资源需求    {#resource-requirements-for-etcd}
 
 使用有限的资源运行 etcd 只适合测试目的。在生产环境中部署 etcd，你需要有先进的硬件配置。
 在生产中部署 etcd 之前，请查阅[所需资源参考文档](https://etcd.io/docs/current/op-guide/hardware/#example-hardware-configurations)。

--- a/content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
@@ -763,7 +763,7 @@ so that you're relying on KMS encryption.
 <!--
 ## Write an encryption configuration file
 -->
-## 编辑加密配置文件   {#write-an-encryption-configuration-file}
+### 编辑加密配置文件   {#write-an-encryption-configuration-file}
 
 {{< caution >}}
 <!--

--- a/content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -138,7 +138,7 @@ secret/db-user-pass created
 <!--
 ### Verify the Secret {#verify-the-secret}
 -->
-## 验证 Secret  {#verify-the-secret}
+### 验证 Secret  {#verify-the-secret}
 
 <!--
 Check that the Secret was created:

--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
@@ -804,7 +804,7 @@ often good enough for the application to load the token on a schedule
 <!--
 ## Service Account Issuer Discovery
 -->
-## 发现服务账号分发者 {#service-account-issuer-discovery}
+### 发现服务账号分发者 {#service-account-issuer-discovery}
 
 {{< feature-state for_k8s_version="v1.21" state="stable" >}}
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/extended-resource.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/extended-resource.md
@@ -193,7 +193,7 @@ kubectl delete pod extended-resource-demo-2
 * [Assign Memory Resources to Containers and Pods](/docs/tasks/configure-pod-container/assign-memory-resource/)
 * [Assign CPU Resources to Containers and Pods](/docs/tasks/configure-pod-container/assign-cpu-resource/)
 -->
-## 应用开发者参考
+### 应用开发者参考
 
 * [为容器和 Pod 分配内存资源](/zh-cn/docs/tasks/configure-pod-container/assign-memory-resource/)
 * [为容器和 Pod 分配 CPU 资源](/zh-cn/docs/tasks/configure-pod-container/assign-cpu-resource/)

--- a/content/zh-cn/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/zh-cn/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -517,7 +517,7 @@ https://github.com/GoogleContainerTools/distroless).
 You can use the `kubectl debug` command to add ephemeral containers to a
 running Pod. First, create a pod for the example:
 -->
-## 使用临时容器来调试的例子 {#ephemeral-container-example}
+### 使用临时容器来调试的例子 {#ephemeral-container-example}
 
 你可以使用 `kubectl debug` 命令来给正在运行中的 Pod 增加一个临时容器。
 首先，像示例一样创建一个 Pod：

--- a/content/zh-cn/docs/tasks/debug/debug-cluster/windows.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/windows.md
@@ -246,7 +246,7 @@ content_type: concept
    tries to assign a new pod subnet to the node. Users should remove the old pod
    subnet configuration files in the following paths:
 -->
-## Flannel 故障排查 {#troubleshooting-network}
+### Flannel 故障排查 {#troubleshooting-network}
 
 1. 使用 Flannel 时，我的节点在重新加入集群后出现问题
 

--- a/content/zh-cn/docs/tasks/job/pod-failure-policy.md
+++ b/content/zh-cn/docs/tasks/job/pod-failure-policy.md
@@ -74,7 +74,7 @@ With the following example, you can learn how to use Pod failure policy to
 avoid unnecessary Pod restarts when a Pod failure indicates a non-retriable
 software bug.
 -->
-## 使用 Pod 失效策略以避免不必要的 Pod 重试  {#using-pod-failure-policy-to-avoid-unecessary-pod-retries}
+### 使用 Pod 失效策略以避免不必要的 Pod 重试  {#using-pod-failure-policy-to-avoid-unecessary-pod-retries}
 
 借用以下示例，你可以学习在 Pod 失效表明有一个不可重试的软件漏洞时如何使用
 Pod 失效策略来避免不必要的 Pod 重启。

--- a/content/zh-cn/docs/tutorials/services/source-ip.md
+++ b/content/zh-cn/docs/tutorials/services/source-ip.md
@@ -29,7 +29,7 @@ of Services, and how you can toggle this behavior according to your needs.
 
 This document makes use of the following terms:
 -->
-## 术语表  {#terminology}
+### 术语表  {#terminology}
 
 本文使用了下列术语：
 
@@ -75,7 +75,7 @@ the target localization.
 <!-- 
 ### Prerequisites
 -->
-## 先决条件  {#prerequisites}
+### 先决条件  {#prerequisites}
 
 {{< include "task-tutorial-prereqs.md" >}}
 


### PR DESCRIPTION
Part of #55612 

This PR updates zh-cn localized headings that currently use H2 (`##`) to H3 (`###`) where the current English source uses H3.

This PR only handles the H3 → H2 portion of #55612

### Verification

For each changed file, I compared the current zh-cn heading level with the corresponding English source file. This PR only changes zh-cn headings from H2 (`##`) to H3 (`###`) where the English source uses H3 (`###`).

| # | Path (`content/zh-cn/...` ↔ `content/en/...`) | zh-cn heading after this PR | EN heading verified |
|---|---|---|---|
| 1 | `blog/_posts/2022/forensic-container-checkpointing/index.md` | `### CRI-O 的使用示例` | `### Usage example with CRI-O` |
| 2 | `blog/_posts/2023/gateway-api-ga/index.md` | `### 实验（Experimental）通道` | `### Experimental channel` |
| 3 | `blog/_posts/2023/gateway-api-ga/index.md` | `### 其他内容` | `### Everything else` |
| 4 | `blog/_posts/2024/consistent-read-from-cache.md` | `### 下一步是什么？ {#whats-next}` | `### What's next?` |
| 5 | `docs/concepts/cluster-administration/node-shutdown.md` | `### 启用节点体面关闭 {#enabling-graceful-node-shutdown}` | `### Enabling graceful node shutdown` |
| 6 | `docs/concepts/cluster-administration/node-shutdown.md` | `### 配置节点体面关闭` | `### Configuring graceful node shutdown` |
| 7 | `docs/concepts/configuration/liveness-readiness-startup-probes.md` | `### 启动探针 {#startup-probe}` | `### Startup probe {#startup-probe}` |
| 8 | `docs/concepts/configuration/liveness-readiness-startup-probes.md` | `### 存活探针 {#liveness-probe}` | `### Liveness probe {#liveness-probe}` |
| 9 | `docs/concepts/configuration/liveness-readiness-startup-probes.md` | `### 就绪探针 {#readiness-probe}` | `### Readiness probe {#readiness-probe}` |
| 10 | `docs/concepts/configuration/manage-resources-containers.md` | `### 内存资源单位 {#meaning-of-memory}` | `### Memory resource units {#meaning-of-memory}` |
| 11 | `docs/concepts/overview/components.md` | `### 控制平面组件 {#control-plane-components}` | `### Control Plane Components` |
| 12 | `docs/concepts/overview/components.md` | `### Node 组件 {#node-components}` | `### Node Components` |
| 13 | `docs/concepts/policy/resource-quotas.md` | `### 存储的配额 {#quota-for-storage}` | `### Quota for storage` |
| 14 | `docs/concepts/scheduling-eviction/assign-pod-node.md` | `### 节点隔离/限制 {#node-isolation-restriction}` | `### Node isolation/restriction` |
| 15 | `docs/concepts/storage/persistent-volumes.md` | `### 使用卷填充器 {#using-volume-populators}` | `### Using volume populators` |
| 16 | `docs/concepts/workloads/controllers/cron-jobs.md` | `### 时区 {#time-zones}` | `### Time zones` |
| 17 | `docs/reference/access-authn-authz/admission-controllers.md` | `### 准入控制阶段 {#admission-control-phases}` | `### Admission control phases` |
| 18 | `docs/reference/labels-annotations-taints/_index.md` | `### kubeadm.alpha.kubernetes.io/cri-socket (已弃用) {#kubeadm-alpha-kubernetes-io-cri-socket}` | `### kubeadm.alpha.kubernetes.io/cri-socket (deprecated) {#kubeadm-alpha-kubernetes-io-cri-socket}` |
| 19 | `docs/reference/using-api/server-side-apply.md` | `### 冲突 {#conflicts}` | `### Conflicts` |
| 20 | `docs/reference/using-api/server-side-apply.md` | `### 字段管理器 {#managers}` | `### Field managers {#managers}` |
| 21 | `docs/setup/production-environment/tools/kubeadm/control-plane-flags.md` | `### Scheduler 参数 {#scheduler-flags}` | `### Scheduler flags` |
| 22 | `docs/tasks/administer-cluster/configure-upgrade-etcd.md` | `### etcd 资源需求 {#resource-requirements-for-etcd}` | `### Resource requirements for etcd` |
| 23 | `docs/tasks/administer-cluster/encrypt-data.md` | `### 编辑加密配置文件 {#write-an-encryption-configuration-file}` | `### Write an encryption configuration file` |
| 24 | `docs/tasks/configmap-secret/managing-secret-using-kubectl.md` | `### 验证 Secret {#verify-the-secret}` | `### Verify the Secret {#verify-the-secret}` |
| 25 | `docs/tasks/configure-pod-container/configure-service-account.md` | `### 发现服务账号分发者 {#service-account-issuer-discovery}` | `### Service account issuer discovery` |
| 26 | `docs/tasks/configure-pod-container/extended-resource.md` | `### 应用开发者参考` | `### For application developers` |
| 27 | `docs/tasks/debug/debug-application/debug-running-pod.md` | `### 使用临时容器来调试的例子 {#ephemeral-container-example}` | `### Example debugging using ephemeral containers {#ephemeral-container-example}` |
| 28 | `docs/tasks/debug/debug-cluster/windows.md` | `### Flannel 故障排查 {#troubleshooting-network}` | `### Flannel troubleshooting` |
| 29 | `docs/tasks/job/pod-failure-policy.md` | `### 使用 Pod 失效策略以避免不必要的 Pod 重试 {#using-pod-failure-policy-to-avoid-unecessary-pod-retries}` | `### Using Pod failure policy to avoid unnecessary Pod retries {#pod-failure-policy-failjob}` |
| 30 | `docs/tutorials/services/source-ip.md` | `### 术语表 {#terminology}` | `### Terminology` |
| 31 | `docs/tutorials/services/source-ip.md` | `### 先决条件 {#prerequisites}` | `### Prerequisites` |