### PR TITLE
[zh-cn] Change H3 headings to H2 to match English source - Part 1

### DIFF
--- a/content/zh-cn/docs/concepts/architecture/nodes.md
+++ b/content/zh-cn/docs/concepts/architecture/nodes.md
@@ -517,7 +517,7 @@ Nodes that [self register](#self-registration-of-nodes) report their capacity du
 registration. If you [manually](#manual-node-administration) add a Node, then
 you need to set the node's capacity information when you add it.
 -->
-### 资源容量跟踪   {#node-capacity}
+## 资源容量跟踪   {#node-capacity}
 
 Node 对象会跟踪节点上资源的容量（例如可用内存和 CPU 数量）。
 通过[自注册](#self-registration-of-nodes)机制生成的 Node 对象会在注册期间报告自身容量。

--- a/content/zh-cn/docs/concepts/cluster-administration/logging.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/logging.md
@@ -279,7 +279,7 @@ after 10 MiB, running `kubectl logs` returns at most 10MiB of data.
 There are two types of system components: those that typically run in a container,
 and those components directly involved in running containers. For example:
 -->
-### 系统组件日志   {#system-component-logs}
+## 系统组件日志   {#system-component-logs}
 
 系统组件有两种类型：通常在容器中运行的组件和直接参与容器运行的组件。例如：
 

--- a/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -901,7 +901,7 @@ kubelet 可以根据其 `restartPolicy` 重新启动它。
 
 The following sections describe good practices for eviction configuration.
 -->
-### 良好实践 {#node-pressure-eviction-good-practices}
+## 良好实践 {#node-pressure-eviction-good-practices}
 
 以下各小节阐述驱逐配置的好的做法。
 

--- a/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
@@ -145,7 +145,7 @@ Services, this resolves to the set of IPs of all of the Pods selected by the Ser
 Clients are expected to consume the set or else use standard round-robin
 selection from the set.
 -->
-### Service
+## Service
 
 #### A/AAAA 记录 {#a-aaaa-records}
 

--- a/content/zh-cn/docs/concepts/storage/storage-classes.md
+++ b/content/zh-cn/docs/concepts/storage/storage-classes.md
@@ -91,7 +91,7 @@ For instructions on setting the default StorageClass, see
 When a PVC does not specify a `storageClassName`, the default StorageClass is
 used.
 -->
-### 默认 StorageClass  {#default-storageclass}
+## 默认 StorageClass  {#default-storageclass}
 
 你可以将某个 StorageClass 标记为集群的默认存储类。
 关于如何设置默认的 StorageClass，
@@ -167,7 +167,7 @@ of the associated PVC to `""`.
 Each StorageClass has a provisioner that determines what volume plugin is used
 for provisioning PVs. This field must be specified.
 -->
-### 存储制备器  {#provisioner}
+## 存储制备器  {#provisioner}
 
 每个 StorageClass 都有一个制备器（Provisioner），用来决定使用哪个卷插件制备 PV。
 该字段必须指定。

--- a/content/zh-cn/docs/concepts/workloads/pods/_index.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/_index.md
@@ -616,7 +616,7 @@ This behavior applies to:
 Pods enable data sharing and communication among their constituent
 containers.
 -->
-### 资源共享和通信 {#resource-sharing-and-communication}
+## 资源共享和通信 {#resource-sharing-and-communication}
 
 Pod 使它的成员容器间能够进行数据共享和通信。
 
@@ -843,7 +843,7 @@ The `spec` of a static Pod cannot refer to other API objects
 {{< /note >}}
 
 <!--
-### Pods manage multiple containers  {#how-pods-manage-multiple-containers}
+## Pods with multiple containers {#how-pods-manage-multiple-containers}
 
 Pods are designed to support multiple cooperating processes (as containers) that form
 a cohesive unit of service. The containers in a Pod are automatically co-located and
@@ -851,7 +851,7 @@ co-scheduled on the same physical or virtual machine in the cluster. The contain
 can share resources and dependencies, communicate with one another, and coordinate
 when and how they are terminated.
 -->
-### Pod 管理多个容器   {#how-pods-manage-multiple-containers}
+## 包含多个容器的 Pod   {#how-pods-manage-multiple-containers}
 
 Pod 被设计成支持构造内聚的服务单元的多个协作进程（形式为容器）。
 Pod 中的容器被自动并置到集群中的同一物理机或虚拟机上，并可以一起进行调度。
@@ -920,16 +920,17 @@ that provide auxiliary services to the main application Pod (for example: a serv
 <!--
 Enabled by default, the `SidecarContainers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 allows you to specify `restartPolicy: Always` for init containers.
-Setting the `Always` restart policy ensures that the init containers where you set it are
+Setting the `Always` restart policy ensures that the containers where you set it are
 treated as _sidecars_ that are kept running during the entire lifetime of the Pod.
-See [Sidecar containers and restartPolicy](/docs/concepts/workloads/pods/init-containers/#sidecar-containers-and-restartpolicy)
-for more details.
+Containers that you explicitly define as sidecar containers
+start up before the main application Pod and remain running until the Pod is
+shut down.
 -->
 启用 `SidecarContainers` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)（默认启用）允许你为
 Init 容器指定 `restartPolicy: Always`。
-设置重启策略为 `Always` 会确保设置的 Init 容器被视为**边车**，
+设置重启策略为 `Always` 会确保设置的容器被视为**边车**，
 并在 Pod 的整个生命周期内保持运行。
-更多细节参阅[边车容器和重启策略](/zh-cn/docs/concepts/workloads/pods/init-containers/#sidecar-containers-and-restartpolicy)。
+你显式定义为边车容器的容器会在主应用 Pod 之前启动，并保持运行直至 Pod 关闭。
 
 <!--
 ## Container probes


### PR DESCRIPTION
Part of #55612

This PR updates zh-cn localized headings that currently use H3 (`###`) to H2 (`##`) where the current English source uses H2.

This PR handles the first batch of the H2 → H3 mismatch cases from #55612.

Per the zh-cn localization guide, this PR avoids partial updates: each touched file was checked with `./scripts/lsync.sh`, and all changed files are already in sync with their English sources. Therefore, the heading-level correction is the only required update for these files.

### Verification

For each changed file, I compared the current zh-cn heading level with the corresponding English source file.

I also ran `./scripts/lsync.sh` on every changed file:

```bash
./scripts/lsync.sh content/zh-cn/docs/concepts/architecture/nodes.md
./scripts/lsync.sh content/zh-cn/docs/concepts/cluster-administration/logging.md
./scripts/lsync.sh content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
./scripts/lsync.sh content/zh-cn/docs/concepts/services-networking/dns-pod-service.md
./scripts/lsync.sh content/zh-cn/docs/concepts/storage/storage-classes.md
./scripts/lsync.sh content/zh-cn/docs/concepts/workloads/pods/_index.md
```