### PR TITLE
[fr] Preserve English heading anchors in localized docs

### DIFF
--- a/content/fr/docs/concepts/architecture/cloud-controller.md
+++ b/content/fr/docs/concepts/architecture/cloud-controller.md
@@ -35,7 +35,7 @@ Vous pouvez également exécuter le gestionnaire du contrôleur de cloud en tant
 de le faire partie du plan de contrôle.
 {{< /note >}}
 
-## Fonctions du gestionnaire du contrôleur de cloud {#fonctions-du-ccm}
+## Fonctions du gestionnaire du contrôleur de cloud {#functions-of-the-ccm}
 
 Les contrôleurs à l'intérieur du gestionnaire du contrôleur de cloud comprennent :
 
@@ -79,7 +79,7 @@ lorsque vous déclarez une ressource Service qui les nécessite.
 Cette section détaille l'accès requis par le gestionnaire du contrôleur de cloud
 sur divers objets API pour effectuer ses opérations.
 
-### Contrôleur de nœud {#autorisation-contrôleur-de-nœud}
+### Contrôleur de nœud {#authorization-node-controller}
 
 Le contrôleur de nœud ne fonctionne qu'avec les objets Nœud. Il nécessite un accès complet
 pour lire et modifier les objets Nœud.
@@ -94,7 +94,7 @@ pour lire et modifier les objets Nœud.
 - watch
 - delete
 
-### Contrôleur de route {#autorisation-contrôleur-de-route}
+### Contrôleur de route {#authorization-route-controller}
 
 Le contrôleur de route écoute la création d'objets Nœud et configure
 les routes de manière appropriée. Il nécessite un accès Get aux objets Nœud.
@@ -103,7 +103,7 @@ les routes de manière appropriée. Il nécessite un accès Get aux objets Nœud
 
 - get
 
-### Contrôleur de service {#autorisation-contrôleur-de-service}
+### Contrôleur de service {#authorization-service-controller}
 
 Le contrôleur de service surveille les événements de création, de mise à jour et de suppression des objets Service, puis
 configure les Endpoints pour ces Services de manière appropriée (pour les EndpointSlices, le
@@ -123,7 +123,7 @@ Pour configurer les ressources Endpoints pour les Services, il nécessite un acc
 - patch
 - update
 
-### Autres {#autorisation-divers}
+### Autres {#authorization-miscellaneous}
 
 La mise en œuvre du cœur du gestionnaire du contrôleur de cloud nécessite un accès pour créer des objets Event
 et pour assurer un fonctionnement sécurisé, il nécessite un accès pour créer des comptes de service.

--- a/content/fr/docs/concepts/cluster-administration/logging.md
+++ b/content/fr/docs/concepts/cluster-administration/logging.md
@@ -43,7 +43,7 @@ l'extérieur du cluster. Même sans avoir l'intention de journaliser les
 évènements au niveau du cluster, il est intéressant de savoir comment les
 journaux sont conservés et gérés au niveau d'un nœud.
 
-## Journalisation simple d'évènements dans Kubernetes
+## Journalisation simple d'évènements dans Kubernetes {#basic-logging-in-kubernetes}
 
 Dans cette section, on va utiliser un exemple simple de journalisation
 d'évènements avec le flux de sortie standard. Cette démonstration utilise un

--- a/content/fr/docs/concepts/overview/_index.md
+++ b/content/fr/docs/concepts/overview/_index.md
@@ -8,7 +8,7 @@ card:
   name: concepts
   weight: 10
   anchors:
-  - anchor: "#pourquoi-vous-avez-besoin-de-kubernetes-et-ce-quil-peut-faire"
+  - anchor: "#why-you-need-kubernetes-and-what-can-it-do"
     title: Pourquoi Kubernetes ?
 no_list: true
 ---
@@ -21,7 +21,7 @@ Cette page est une vue d'ensemble de Kubernetes.
 
 Le nom Kubernetes provient du grec, signifiant timonier ou pilote. K8s comme abréviation résulte du comptage des huit lettres entre le "K" et le "s". Google a open-sourcé le projet Kubernetes en 2014. Kubernetes combine [plus de 15 ans d'expérience de Google](/blog/2015/04/borg-predecessor-to-kubernetes/) dans l'exécution de charges de travail en production à grande échelle avec les meilleures idées et pratiques de la communauté.
 
-## Pourquoi vous avez besoin de Kubernetes et ce qu'il peut faire {#pourquoi-vous-avez-besoin-de-kubernetes-et-ce-quil-peut-faire}
+## Pourquoi vous avez besoin de Kubernetes et ce qu'il peut faire {#why-you-need-kubernetes-and-what-can-it-do}
 
 Les conteneurs sont un bon moyen de regrouper et d'exécuter vos applications. Dans un environnement de production, vous devez gérer les conteneurs qui exécutent les applications et vous assurer qu'il n'y a pas de temps d'arrêt. Par exemple, si un conteneur tombe en panne, un autre conteneur doit démarrer. Ne serait-il pas plus facile si ce comportement était géré par un système ?
 
@@ -64,7 +64,7 @@ Kubernetes :
 * Ne fournit ni n'adopte de systèmes complets de configuration, de maintenance, de gestion ou d'auto-guérison des machines.
 * De plus, Kubernetes n'est pas un simple système d'orchestration. En fait, il élimine le besoin d'orchestration. La définition technique de l'orchestration est l'exécution d'un workflow défini : d'abord faire A, puis B, puis C. En revanche, Kubernetes comprend un ensemble de processus de contrôle indépendants et composables qui conduisent continuellement l'état actuel vers l'état souhaité fourni. Peu importe comment vous passez de A à C. Le contrôle centralisé n'est pas non plus requis. Cela se traduit par un système plus facile à utiliser et plus puissant, robuste, résilient et extensible.
 
-## Contexte historique de Kubernetes {#retour-dans-le-temps}
+## Contexte historique de Kubernetes {#going-back-in-time}
 
 Jetons un coup d'œil à pourquoi Kubernetes est si utile en remontant dans le temps.
 

--- a/content/fr/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/fr/docs/tasks/configure-pod-container/configure-service-account.md
@@ -63,7 +63,7 @@ spec:
 
 La spéc de Pod a prépondérance par rapport au compte de service si les deux spécifient la valeur `automountServiceAccountToken`.
 
-## Utiliser plusieurs comptes de services.
+## Utiliser plusieurs comptes de services. {#use-multiple-service-accounts}
 
 Chaque Namespace possède une ressource ServiceAccount par défaut appelée `default`.
 Vous pouvez lister cette ressource et toutes les autres ressources de ServiceAccount dans le Namespace avec cette commande :


### PR DESCRIPTION
Part of #55635

This PR fixes French localized heading anchors so they preserve the explicit anchors used by the English source.

The changes were verified against the current English source files. This PR only updates heading anchors and one related front matter card link; it does not change translated heading text.

### Verification

For each changed heading, I compared the French heading anchor with the corresponding English source heading anchor.

| # | Path (`content/fr/...` ↔ `content/en/...`) | French heading | Anchor change | EN anchor verified |
|---|---|---|---|---|
| 1 | `docs/concepts/architecture/cloud-controller.md` | `Fonctions du gestionnaire du contrôleur de cloud` | `{#fonctions-du-ccm}` → `{#functions-of-the-ccm}` | `{#functions-of-the-ccm}` |
| 2 | `docs/concepts/architecture/cloud-controller.md` | `Contrôleur de nœud` | `{#autorisation-contrôleur-de-nœud}` → `{#authorization-node-controller}` | `{#authorization-node-controller}` |
| 3 | `docs/concepts/architecture/cloud-controller.md` | `Contrôleur de route` | `{#autorisation-contrôleur-de-route}` → `{#authorization-route-controller}` | `{#authorization-route-controller}` |
| 4 | `docs/concepts/architecture/cloud-controller.md` | `Contrôleur de service` | `{#autorisation-contrôleur-de-service}` → `{#authorization-service-controller}` | `{#authorization-service-controller}` |
| 5 | `docs/concepts/architecture/cloud-controller.md` | `Autres` | `{#autorisation-divers}` → `{#authorization-miscellaneous}` | `{#authorization-miscellaneous}` |
| 6 | `docs/concepts/cluster-administration/logging.md` | `Journalisation simple d'évènements dans Kubernetes` | Added `{#basic-logging-in-kubernetes}` | `{#basic-logging-in-kubernetes}` |
| 7 | `docs/concepts/overview/_index.md` | `Pourquoi vous avez besoin de Kubernetes et ce qu'il peut faire` | `{#pourquoi-vous-avez-besoin-de-kubernetes-et-ce-qu-il-peut-faire}` → `{#why-you-need-kubernetes-and-what-can-it-do}` | `{#why-you-need-kubernetes-and-what-can-it-do}` |
| 8 | `docs/concepts/overview/_index.md` | `Contexte historique de Kubernetes` | `{#retour-dans-le-temps}` → `{#going-back-in-time}` | `{#going-back-in-time}` |
| 9 | `docs/tasks/configure-pod-container/configure-service-account.md` | `Utiliser plusieurs comptes de services.` | Added `{#use-multiple-service-accounts}` | `{#use-multiple-service-accounts}` |

### Additional note

In `content/fr/docs/concepts/overview/_index.md`, this PR also updates the related front matter card anchor from `#pourquoi-vous-avez-besoin-de-kubernetes-et-ce-qu-il-peut-faire` to `#why-you-need-kubernetes-and-what-can-it-do`, so the card link continues to point to the updated heading anchor.