### PR TITLE
Clarify front-proxy certificate dependency on aggregation layer

### DIFF
--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -57,8 +57,9 @@ In this scenario, there are two approaches for certificate usage:
   `kubelet-client.key` are created.
 
 {{< note >}}
-`front-proxy` certificates are required only if you run kube-proxy to support
-[an extension API server](/docs/tasks/extend-kubernetes/setup-extension-api-server/).
+`front-proxy` certificates are required only when using the
+[aggregation layer](/docs/tasks/extend-kubernetes/configure-aggregation-layer/)
+to enable an [extension (aggregated) API server](/docs/tasks/extend-kubernetes/setup-extension-api-server/).
 {{< /note >}}
 
 etcd also implements mutual TLS to authenticate clients and peers.


### PR DESCRIPTION
Closes #55622.

The note in the "Kubelet's server and client certificates" section currently reads:

> `front-proxy` certificates are required only if you run kube-proxy to support an extension API server.

That conflates two unrelated components. `kube-proxy` is the node-level Service networking dataplane and is not involved in extension API server delivery. The mechanism that actually requires the front-proxy CA is the apiserver aggregation layer, which proxies aggregated API requests on behalf of clients using the front-proxy client certificate.

I rewrote the note to point at the aggregation layer task page (the same link already appears in this file at line 41 under "Optional client certificate for the front-proxy") while preserving the existing extension API server reference.

```release-note
NONE
```

/sig docs
/kind documentation
/language en
