### PR TITLE
Specify that image volumes are not in scope for the ImagePolicyWebhook

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -466,6 +466,14 @@ To disallow access, the service would return:
 }
 ```
 
+{{< note >}}
+`ImageReview` objects will include all images in Pods intended to be executed as
+containers. This covers images specified as part of the containers,
+initContainers, or ephemeralContainers fields in a Pod specification. As a
+result, images included under image volumes are not in scope for the
+ImagePolicyWebhook.
+{{< /note >}}
+
 For further documentation refer to the
 [`imagepolicy.v1alpha1` API](/docs/reference/config-api/imagepolicy.v1alpha1/).
 


### PR DESCRIPTION
### Description

This PR specifies that image volumes are not in scope for the ImagePolicyWebhook. The SRC received a vulnerability report that image volumes are not covered by this admission controller, however, we have confirmed that this is the intended behavior. Only images which are intended to be run are in scope for the webhook (specifically images specified under the containers, initContainers, or ephemeralContainers fields in the Pod specification).

