### PR TITLE
[zh-cn] Publish Declarative Validation blog and update author attribution

### DIFF
--- a/content/en/blog/_posts/2026/declarative-validation.md
+++ b/content/en/blog/_posts/2026/declarative-validation.md
@@ -4,7 +4,7 @@ title: "Kubernetes v1.36: Declarative Validation Graduates to GA"
 date: 2026-05-05T10:35:00-08:00
 slug: kubernetes-v1-36-declarative-validation-ga
 author: >
-  [Yongrui Lin](https://github.com/yongruilin)
+  [Yongrui Lin](https://github.com/yongruilin) (Google)
 ---
 
 In Kubernetes v1.36, **Declarative Validation** for Kubernetes native types has reached General Availability (GA).

--- a/content/zh-cn/blog/_posts/2026/declarative-validation.md
+++ b/content/zh-cn/blog/_posts/2026/declarative-validation.md
@@ -1,20 +1,17 @@
 ---
 layout: blog
 title: "Kubernetes v1.36：声明式验证正式发布"
-date: 2026-03-23T10:00:00-08:00
-draft: true
+date: 2026-05-05T10:35:00-08:00
 slug: kubernetes-v1-36-declarative-validation-ga
 author: >
   [Yongrui Lin](https://github.com/yongruilin) (Google)
-translator: >
 translator: >
   [Xin Li](https://github.com/my-git9) (DaoCloud)
 ---
 <!--
 layout: blog
 title: "Kubernetes v1.36: Declarative Validation Graduates to GA"
-date: 2026-03-23T10:00:00-08:00
-draft: true
+date: 2026-05-05T10:35:00-08:00
 slug: kubernetes-v1-36-declarative-validation-ga
 author: >
   [Yongrui Lin](https://github.com/yongruilin) (Google)

--- a/content/zh-cn/blog/_posts/2026/declarative-validation.md
+++ b/content/zh-cn/blog/_posts/2026/declarative-validation.md
@@ -5,7 +5,7 @@ date: 2026-03-23T10:00:00-08:00
 draft: true
 slug: kubernetes-v1-36-declarative-validation-ga
 author: >
-  [Yongrui Lin](https://github.com/yongruilin)
+  [Yongrui Lin](https://github.com/yongruilin) (Google)
 translator: >
 translator: >
   [Xin Li](https://github.com/my-git9) (DaoCloud)
@@ -17,7 +17,7 @@ date: 2026-03-23T10:00:00-08:00
 draft: true
 slug: kubernetes-v1-36-declarative-validation-ga
 author: >
-  [Yongrui Lin](https://github.com/yongruilin)
+  [Yongrui Lin](https://github.com/yongruilin) (Google)
 -->
 
 <!--

--- a/content/zh-cn/blog/_posts/2026/declarative-validation.md
+++ b/content/zh-cn/blog/_posts/2026/declarative-validation.md
@@ -79,7 +79,7 @@ These generated functions are then registered seamlessly with the API scheme. Th
 会解析 `+k8s:` 标签并自动生成相应的 Go 验证函数。
 
 这些生成的函数随后会无缝注册到 API 方案中。该生成器被设计为一个可扩展的框架，
-允许开发人员通过描述它们要解析的标签以及它们应该生成的 Go 逻辑来插入新的“验证器”。
+允许开发人员通过描述其要解析的标签以及应生成的 Go 逻辑来插入新的“验证器”。
 
 <!--
 ### A Comprehensive Suite of +k8s: Tags
@@ -131,14 +131,14 @@ One of the most substantial outcomes of this work is that validation ratcheting 
 
 With declarative validation, this safety mechanism is built-in. If a user updates an existing object, the validation framework compares the incoming object with the `oldObject`. If a specific field's value is semantically equivalent to its prior state (i.e., the user didn't change it), the new validation rule is bypassed. This "ambient ratcheting" means we can loosen or tighten validation immediately and in the least disruptive way possible.
 -->
-## 高级功能：“Ambient 机制”
+## 高级功能：“Ambient 棘轮机制”
 
 这项工作最重要的成果之一是，验证棘轮机制现在已成为 API 的标准组成部分。
 过去，如果我们需要加强验证，必须先编写手动棘轮代码，等待版本发布，然后再加强验证，以避免破坏现有对象。
 
 借助声明式验证，这种安全机制已内置。如果用户更新现有对象，验证框架会将传入的对象与 `oldObject` 进行比较。
 如果特定字段的值在语义上与其先前状态相同（即用户未对其进行更改），则新的验证规则将被忽略。
-这种 “Ambient 机制”意味着我们可以立即以尽可能减少干扰的方式放松或加强验证。
+这种“Ambient 棘轮机制”意味着我们可以立即以尽可能减少干扰的方式放松或加强验证。
 
 <!--
 ## Scaling API Reviews with `kube-api-linter`


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR updates the v1.36 Declarative Validation blog posts to include the suffix for  author attribution. It also publishes the Chinese version by updating metadata and refining the translation for technical consistency.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #