### PR TITLE
Syntax fixup for EventedPLEG CRI-O drop-in file

### DIFF
--- a/content/en/docs/tasks/administer-cluster/switch-to-evented-pleg.md
+++ b/content/en/docs/tasks/administer-cluster/switch-to-evented-pleg.md
@@ -76,7 +76,7 @@ The polling based approach is referred to as _generic PLEG_.
 
    ```toml
    [crio.runtime]
-   enable_pod_events: true
+   enable_pod_events = true
    ```
    {{% /tab %}}
    {{< /tabs >}}

--- a/content/zh-cn/docs/tasks/administer-cluster/switch-to-evented-pleg.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/switch-to-evented-pleg.md
@@ -140,7 +140,7 @@ The polling based approach is referred to as _generic PLEG_.
 
    ```toml
    [crio.runtime]
-   enable_pod_events: true
+   enable_pod_events = true
    ```
 
    {{% /tab %}}


### PR DESCRIPTION
### Description

This resolves an "unable to decode configuration ... expected '.' or '=', but got ':' instead" error when running `crio config`.