### PR TITLE
List explicit apiserver flags at end of openssl certificate section

### DIFF
--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -155,7 +155,13 @@ manually through [`easyrsa`](https://github.com/OpenVPN/easy-rsa), [`openssl`](h
    openssl x509  -noout -text -in ./server.crt
    ```
 
-Finally, add the same parameters into the API server start parameters.
+1. Add the following parameters to the API server start parameters:
+
+   ```shell
+   --client-ca-file=/yourdirectory/ca.crt
+   --tls-cert-file=/yourdirectory/server.crt
+   --tls-private-key-file=/yourdirectory/server.key
+   ```
 
 ### cfssl
 

--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -155,7 +155,7 @@ manually through [`easyrsa`](https://github.com/OpenVPN/easy-rsa), [`openssl`](h
    openssl x509  -noout -text -in ./server.crt
    ```
 
-1. Add the following parameters to the API server start parameters:
+1. Fill in and add the following parameters into the API server start parameters:
 
    ```shell
    --client-ca-file=/yourdirectory/ca.crt


### PR DESCRIPTION
Closes #55501.

/sig docs
/kind documentation
/language en

The openssl section of `tasks/administer-cluster/certificates` ends with the line "Finally, add the same parameters into the API server start parameters." The reporter on #55501 pointed out that there is no obvious anchor for what "the same parameters" refers to: the easyrsa section a few hundred lines earlier lists `--client-ca-file`, `--tls-cert-file`, and `--tls-private-key-file` as a numbered step, and the openssl branch only alludes to it in prose. This patch replaces the prose line with a numbered step that includes the same shell block, so the openssl reader sees the explicit flag list inline.