### PR TITLE
Clarify CEL field and map key checks

### DIFF
--- a/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
+++ b/content/en/docs/reference/access-authn-authz/validating-admission-policy.md
@@ -200,7 +200,8 @@ For the use cases requiring parameter configuration, we recommend to add a param
 #### Optional parameters
 
 It can be convenient to be able to have optional parameters as part of a parameter resource, and
-only validate them if present. CEL provides `has()`, which checks if the key passed to it exists.
+only validate them if present. CEL provides the `has()` macro, which checks whether a field
+is present before a CEL expression accesses the field's value.
 CEL also implements Boolean short-circuiting. If the first half of a logical OR evaluates to true,
 it won’t evaluate the other half (since the result of the entire OR will be true regardless). 
 
@@ -208,7 +209,7 @@ Combining the two, we can provide a way to validate optional parameters:
 
 `!has(params.optionalNumber) || (params.optionalNumber >= 5 && params.optionalNumber <= 10)`
 
-Here, we first check that the optional parameter is present with `!has(params.optionalNumber)`. 
+Here, we first check whether the optional parameter is absent with `!has(params.optionalNumber)`.
 
 - If `optionalNumber` hasn’t been defined, then the expression short-circuits since
   `!has(params.optionalNumber)` will evaluate to true. 
@@ -216,6 +217,10 @@ Here, we first check that the optional parameter is present with `!has(params.op
   evaluated, and optionalNumber will be checked to ensure that it contains a value between 5 and
   10 inclusive.
 
+Use `has()` to check field presence. To check whether a map contains a key, use the `in`
+operator instead. For example,
+`has(object.metadata.labels) && 'example.com/environment' in object.metadata.labels` checks that
+the `metadata.labels` field is present and that the map contains the `example.com/environment` key.
 
 #### Per-namespace Parameters
 
@@ -360,7 +365,7 @@ Concatenation on arrays with x-kubernetes-list-type use the semantics of the lis
 | `object.minReplicas <= object.replicas && object.replicas <= object.maxReplicas`             | Validate that the three fields defining replicas are ordered appropriately        |
 | `'Available' in object.stateCounts`                                                          | Validate that an entry with the 'Available' key exists in a map                   |
 | `(size(object.list1) == 0) != (size(object.list2) == 0)`                                     | Validate that one of two lists is non-empty, but not both                         |
-| <code>!('MY_KEY' in object.map1) &#124;&#124; object['MY_KEY'].matches('^[a-zA-Z]*$')</code> | Validate the value of a map for a specific key, if it is in the map               |
+| <code>!('MY_KEY' in object.map1) &#124;&#124; object.map1['MY_KEY'].matches('^[a-zA-Z]*$')</code> | Validate the value of a map for a specific key, if it is in the map        |
 | `object.envars.filter(e, e.name == 'MY_ENV').all(e, e.value.matches('^[a-zA-Z]*$')`          | Validate the 'value' field of a listMap entry where key field 'name' is 'MY_ENV'  |
 | `has(object.expired) && object.created + object.ttl < object.expired`                        | Validate that 'expired' date is after a 'create' date plus a 'ttl' duration       |
 | `object.health.startsWith('ok')`                                                             | Validate a 'health' string field has the prefix 'ok'                              |

--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -1124,13 +1124,25 @@ because the `namex` field is not defined. However, `object.namex` would pass
 type checking even when the `namex` field is not defined for the resource kinds
 that `object` refers to, because `object` is dynamically typed.
 
-The `has()` macro in CEL may be used in CEL expressions to check if a field of a
-dynamically typed variable is accessible before attempting to access the field's
-value. For example:
+The `has()` macro in CEL may be used in CEL expressions to check whether a field
+of a dynamically typed variable is present before attempting to access the
+field's value. For example:
 
 ```cel
 has(object.namex) ? object.namex == 'special' : request.name == 'special'
 ```
+
+Use `has()` to check field presence. Do not use `has()` to check whether a map
+contains a key. For example, do not write
+`has(object.metadata.labels['example.com/environment'])`. For map key checks,
+use the `in` operator instead. For example:
+
+```cel
+has(object.metadata.labels) && 'example.com/environment' in object.metadata.labels
+```
+
+This expression checks that `metadata.labels` is present before checking whether
+the map contains the `example.com/environment` key.
 
 ## Type system integration
 


### PR DESCRIPTION
Fixes #41392
Refs #47525

Clarify that CEL `has()` is used for field presence checks, while map key membership should be checked with the `in` operator.

This updates both the ValidatingAdmissionPolicy page and the CEL reference page with an example for checking a labels map key.

Validation:
- `git show --check --stat --oneline HEAD`
- Strict local review of the patch against #41392