### PR TITLE
[zh-cn] Change H3 headings to H2 to match English source - Part 2

### DIFF
--- a/content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -214,7 +214,7 @@ server. The signed ConfigMap can be authenticated by the shared token.
 Enable ConfigMap signing by enabling the `bootstrapsigner` controller on the
 Controller Manager.
 -->
-### ConfigMap 签名  {#configmap-signing}
+## ConfigMap 签名  {#configmap-signing}
 
 除了身份认证，令牌还可以用于签名 ConfigMap。
 这一用法发生在集群启动过程的早期，在客户端信任 API 服务器之前。

--- a/content/zh-cn/docs/reference/debug-cluster/flow-control.md
+++ b/content/zh-cn/docs/reference/debug-cluster/flow-control.md
@@ -56,7 +56,7 @@ PriorityLevelConfigurations.
 With the `APIPriorityAndFairness` feature enabled, the `kube-apiserver`
 serves the following additional paths at its HTTP(S) ports.
 -->
-### 调试端点    {#debug-endpoints}
+## 调试端点    {#debug-endpoints}
 
 启用 APF 特性后，`kube-apiserver` 会在其 HTTP/HTTPS 端口额外提供以下路径：
 
@@ -234,7 +234,7 @@ to access `/debug/api_priority_and_fairness/` by specifying `nonResourceURLs`.
 At `-v=3` or more verbosity, the API server outputs an httplog line for every
 request in the API server log, and it includes the following attributes.
 -->
-### 调试日志生成行为  {#debug-logging}
+## 调试日志生成行为  {#debug-logging}
 
 在 `-v=3` 或更详细的情况下，API 服务器会为在 API 服务日志中为每个请求输出一行 httplog，
 其中包括以下属性：
@@ -274,7 +274,7 @@ For client using `klog`, use verbosity `-v=8` or higher to view these headers.
 - `X-Kubernetes-PF-PriorityLevel-UID` holds the UID of the
   PriorityLevelConfiguration object associated with that FlowSchema.
 -->
-### 响应头  {#response-headers}
+## 响应头  {#response-headers}
 
 APF 将以下两个头添加到每个 HTTP 响应消息中。
 这些信息不会出现在审计日志中，但可以从客户端查看。

--- a/content/zh-cn/docs/reference/node/node-status.md
+++ b/content/zh-cn/docs/reference/node/node-status.md
@@ -62,7 +62,7 @@ kubectl describe node <节点名称>
 
 The usage of these fields varies depending on your cloud provider or bare metal configuration.
 -->
-### 地址   {#addresses}
+## 地址   {#addresses}
 
 这些字段的用法取决于你的云服务商或者物理机配置。
 
@@ -82,7 +82,7 @@ The usage of these fields varies depending on your cloud provider or bare metal 
 
 The `conditions` field describes the status of all `Running` nodes. Examples of conditions include:
 -->
-### 状况   {#condition}
+## 状况   {#condition}
 
 `conditions` 字段描述了所有 `Running` 节点的状况。状况的示例包括：
 
@@ -178,7 +178,7 @@ for more details.
 Describes the resources available on the node: CPU, memory, and the maximum
 number of pods that can be scheduled onto the node.
 -->
-### 容量（Capacity）与可分配（Allocatable）     {#capacity}
+## 容量（Capacity）与可分配（Allocatable）     {#capacity}
 
 这两个值描述节点上的可用资源：CPU、内存和可以调度到节点上的 Pod 的个数上限。
 
@@ -207,7 +207,7 @@ operating system the node uses.
 The kubelet gathers this information from the node and publishes it into
 the Kubernetes API.
 -->
-### 信息（Info） {#info}
+## 信息（Info） {#info}
 
 Info 指的是节点的一般信息，如内核版本、Kubernetes 版本（`kubelet` 和 `kube-proxy` 版本）、
 容器运行时详细信息，以及节点使用的操作系统。

--- a/content/zh-cn/docs/reference/using-api/deprecation-policy.md
+++ b/content/zh-cn/docs/reference/using-api/deprecation-policy.md
@@ -766,7 +766,7 @@ this impacts removal of a metric during a Kubernetes release. These classes
 are determined by the perceived importance of the metric. The rules for
 deprecating and removing a metric are as follows:
 -->
-### 弃用度量值    {#deprecating-a-metric}
+## 弃用度量值    {#deprecating-a-metric}
 
 Kubernetes 控制平面的每个组件都公开度量值（通常是 `/metrics` 端点），它们通常由集群管理员使用。
 并不是所有的度量值都是同样重要的：一些度量值通常用作 SLIs 或被使用来确定 SLOs，这些往往比较重要。


### PR DESCRIPTION
Part of #55612

This PR updates zh-cn localized headings that currently use H3 (`###`) to H2 (`##`) where the current English source uses H2.

This PR handles the first batch of the H2 → H3 mismatch cases from #55612.

Per the zh-cn localization guide, this PR avoids partial updates: each touched file was checked with `./scripts/lsync.sh`, and all changed files are already in sync with their English sources. Therefore, the heading-level correction is the only required update for these files.

### Verification

For each changed file, I compared the current zh-cn heading level with the corresponding English source file.

I also ran `./scripts/lsync.sh` on every changed file:

```bash
./scripts/lsync.sh content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
./scripts/lsync.sh content/zh-cn/docs/reference/debug-cluster/flow-control.md
./scripts/lsync.sh content/zh-cn/docs/reference/node/node-status.md
./scripts/lsync.sh content/zh-cn/docs/reference/using-api/deprecation-policy.md
```