### PR TITLE
[zh-cn] Change H3 headings to H2 to match English source - Part 3

### DIFF
--- a/content/zh-cn/docs/contribute/localization.md
+++ b/content/zh-cn/docs/contribute/localization.md
@@ -868,7 +868,7 @@ when starting out and the localization is not yet live.
 
 To collaborate on a localization branch:
 -->
-### 分支策略 {#branch-strategy}
+## 分支策略 {#branch-strategy}
 
 因为本地化项目是高度协同的工作，
 特别是在刚开始本地化并且本地化尚未生效时，我们鼓励团队基于共享的本地化分支工作。
@@ -1006,6 +1006,6 @@ see ["fork and clone the repo"](#fork-and-clone-the-repo).
 
 SIG Docs welcomes upstream contributions and corrections to the English source.
 -->
-### 上游贡献 {#upstream-contributions}
+## 上游贡献 {#upstream-contributions}
 
 Sig Docs 欢迎对英文原文的上游贡献和修正。

--- a/content/zh-cn/docs/setup/best-practices/cluster-large.md
+++ b/content/zh-cn/docs/setup/best-practices/cluster-large.md
@@ -141,9 +141,9 @@ for details on configuring and managing etcd for a large cluster.
 [kubeadm 创建一个高可用 etcd 集群](/zh-cn/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/)。
 
 <!--
-### Addon Resources
+## Addon Resources
 -->
-### 插件资源   {#addon-resources}
+## 插件资源   {#addon-resources}
 
 <!--
 Kubernetes [resource limits](/docs/concepts/configuration/manage-resources-containers/)

--- a/content/zh-cn/docs/setup/production-environment/_index.md
+++ b/content/zh-cn/docs/setup/production-environment/_index.md
@@ -386,7 +386,7 @@ hundreds of people. In a learning environment or platform prototype, you might h
 administrative account for everything you do. In production, you will want
 more accounts with different levels of access to different namespaces.
 -->
-### 生产级用户环境   {#production-user-management}
+## 生产级用户环境   {#production-user-management}
 
 在生产环境中，情况可能不再是你或者一小组人在访问集群，而是几十上百人需要访问集群。
 在学习环境或者平台原型环境中，你可能具有一个可以执行任何操作的管理账号。


### PR DESCRIPTION
Part of #55612

This PR updates zh-cn localized headings that currently use H3 (`###`) to H2 (`##`) where the current English source uses H2.

This PR handles the first batch of the H2 → H3 mismatch cases from #55612.

Per the zh-cn localization guide, this PR avoids partial updates: each touched file was checked with `./scripts/lsync.sh`, and all changed files are already in sync with their English sources. Therefore, the heading-level correction is the only required update for these files.

### Verification

For each changed file, I compared the current zh-cn heading level with the corresponding English source file.

I also ran `./scripts/lsync.sh` on every changed file:

```bash
./scripts/lsync.sh content/zh-cn/docs/contribute/localization.md 
./scripts/lsync.sh content/zh-cn/docs/setup/best-practices/cluster-large.md 
./scripts/lsync.sh content/zh-cn/docs/setup/production-environment/_index.md
```