### PR TITLE
[zh-cn] change H3 headings to H2 to match English source - part 4

### DIFF
--- a/content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
@@ -348,7 +348,7 @@ Python 客户端可以像 kubectl CLI 一样使用相同的
 When accessing the API from a pod, locating and authenticating
 to the API server are somewhat different.
 -->
-### 从 Pod 中访问 API   {#accessing-the-api-from-a-pod}
+## 从 Pod 中访问 API   {#accessing-the-api-from-a-pod}
 
 当你从 Pod 中访问 API 时，定位和验证 API 服务器会有些许不同。
 

--- a/content/zh-cn/docs/tasks/access-application-cluster/connecting-frontend-backend.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/connecting-frontend-backend.md
@@ -61,7 +61,7 @@ require a supported environment. If your environment does not support this, you 
 The backend is a simple hello greeter microservice. Here is the configuration
 file for the backend Deployment:
 -->
-### 使用部署对象（Deployment）创建后端   {#creating-the-backend-using-a-deployment}
+## 使用 Deployment 创建后端   {#creating-the-backend-using-a-deployment}
 
 后端是一个简单的 hello 欢迎微服务应用。这是后端应用的 Deployment 配置文件：
 
@@ -136,7 +136,7 @@ the Pods that it routes traffic to.
 
 First, explore the Service configuration file:
 -->
-### 创建 `hello` Service 对象   {#creating-the-hello-service-object}
+## 创建 `hello` Service 对象   {#creating-the-hello-service-object}
 
 将请求从前端发送到后端的关键是后端 Service。Service 创建一个固定 IP 和 DNS 解析名入口，
 使得后端微服务总是可达。Service 使用
@@ -185,7 +185,7 @@ configuration file.
 The Pods in the frontend Deployment run a nginx image that is configured
 to proxy requests to the `hello` backend Service. Here is the nginx configuration file:
 -->
-### 创建前端   {#creating-the-frontend}
+## 创建前端   {#creating-the-frontend}
 
 现在你已经有了运行中的后端应用，你可以创建一个可在集群外部访问的前端，并通过代理
 前端的请求连接到后端。
@@ -256,7 +256,7 @@ so that you can change the configuration more easily.
 Once you've created a Service of type LoadBalancer, you can use this
 command to find the external IP:
 -->
-### 与前端 Service 交互   {#interact-with-the-frontend-service}
+## 与前端 Service 交互   {#interact-with-the-frontend-service}
 
 一旦你创建了 LoadBalancer 类型的 Service，你可以使用这条命令查看外部 IP：
 
@@ -299,7 +299,7 @@ cluster.
 The frontend and backend are now connected. You can hit the endpoint
 by using the curl command on the external IP of your frontend Service.
 -->
-### 通过前端发送流量   {#send-traffic-through-the-frontend}
+## 通过前端发送流量   {#send-traffic-through-the-frontend}
 
 前端和后端已经完成连接了。你可以使用 curl 命令通过你的前端 Service 的外部
 IP 访问服务端点。

--- a/content/zh-cn/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/kms-provider.md
@@ -91,7 +91,7 @@ you have selected.  Kubernetes recommends using KMS v2.
 <!--
 ## KMS encryption and per-object encryption keys
 -->
-### KMS 加密和为每个对象加密的密钥    {#kms-encryption-and-perobject-encryption-keys}
+## KMS 加密和为每个对象加密的密钥    {#kms-encryption-and-perobject-encryption-keys}
 
 <!--
 The KMS encryption provider uses an envelope encryption scheme to encrypt data in etcd.

--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -1338,7 +1338,7 @@ Pod 可以从使用 `data` 或 `binaryData` 的 ConfigMap 中加载数据。
 <!--
 ## Optional ConfigMaps
 -->
-### 可选的 ConfigMap {#optional-configmaps}
+## 可选的 ConfigMap {#optional-configmaps}
 
 <!--
 You can mark a reference to a ConfigMap as _optional_ in a Pod specification.
@@ -1427,7 +1427,7 @@ spec:
 <!--
 ## Restrictions
 -->
-### 限制   {#restrictions}
+## 限制   {#restrictions}
 
 <!--
 - You must create the `ConfigMap` object before you reference it in a Pod

--- a/content/zh-cn/docs/tasks/debug/debug-application/debug-service.md
+++ b/content/zh-cn/docs/tasks/debug/debug-application/debug-service.md
@@ -520,7 +520,7 @@ Assuming you have confirmed that DNS works, the next thing to test is whether yo
 Service works by its IP address.  From a Pod in your cluster, access the
 Service's IP (from `kubectl get` above).
 -->
-### Service 能够通过 IP 访问么？   {#does-the-service-work-by-ip}
+## Service 能够通过 IP 访问么？   {#does-the-service-work-by-ip}
 
 假设你已经确认 DNS 工作正常，那么接下来要测试的是你的 Service 能否通过它的 IP 正常访问。
 从集群中的一个 Pod，尝试访问 Service 的 IP（从上面的 `kubectl get` 命令获取）。

--- a/content/zh-cn/docs/tasks/run-application/access-api-from-pod.md
+++ b/content/zh-cn/docs/tasks/run-application/access-api-from-pod.md
@@ -28,7 +28,7 @@ This guide demonstrates how to access the Kubernetes API from within a pod.
 When accessing the API from within a Pod, locating and authenticating
 to the API server are slightly different to the external client case.
 -->
-### 从 Pod 中访问 API   {#accessing-the-api-from-within-a-pod}
+## 从 Pod 中访问 API   {#accessing-the-api-from-within-a-pod}
 
 从 Pod 内部访问 API 时，定位 API 服务器和向服务器认证身份的操作与外部客户端场景不同。
 


### PR DESCRIPTION
Part of #55612

This PR updates zh-cn localized headings that currently use H3 (`###`) to H2 (`##`) where the current English source uses H2.

This PR handles the first batch of the H2 → H3 mismatch cases from #55612.

Per the zh-cn localization guide, this PR avoids partial updates: each touched file was checked with `./scripts/lsync.sh`, and all changed files are already in sync with their English sources. Therefore, the heading-level correction is the only required update for these files.

### Verification

For each changed file, I compared the current zh-cn heading level with the corresponding English source file.

I also ran `./scripts/lsync.sh` on every changed file:

```bash
./scripts/lsync.sh content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
./scripts/lsync.sh content/zh-cn/docs/tasks/access-application-cluster/connecting-frontend-backend.md
./scripts/lsync.sh content/zh-cn/docs/tasks/administer-cluster/kms-provider.md
./scripts/lsync.sh content/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap.md
./scripts/lsync.sh content/zh-cn/docs/tasks/debug/debug-application/debug-service.md
./scripts/lsync.sh content/zh-cn/docs/tasks/run-application/access-api-from-pod.md
```