### PR TITLE
[zh-cn] change H2 headings to H3 to match English source - part 1 (blogpost)

### DIFF
--- a/content/zh-cn/blog/_posts/2022/forensic-container-checkpointing/index.md
+++ b/content/zh-cn/blog/_posts/2022/forensic-container-checkpointing/index.md
@@ -96,7 +96,7 @@ The runtime must also support container checkpointing:
 <!-- 
 ### Usage example with CRI-O
  -->
-## CRI-O 的使用示例
+### CRI-O 的使用示例
 
 <!-- 
 To use forensic container checkpointing in combination with CRI-O, the runtime
@@ -120,7 +120,7 @@ security implications are still under consideration.
 
 <!-- 
 Once containers and pods are running it is possible to create a checkpoint.
-[Checkpointing](https://kubernetes.io/docs/reference/node/kubelet-checkpoint-api/)
+[Checkpointing](/docs/reference/node/kubelet-checkpoint-api/)
 is currently only exposed on the **kubelet** level. To checkpoint a container,
 you can run `curl` on the node where that container is running, and trigger a
 checkpoint:
@@ -138,7 +138,7 @@ curl -X POST "https://localhost:10250/checkpoint/namespace/podId/container"
 
 <!-- 
 For a container named *counter* in a pod named *counters* in a namespace named
-*default* the *kubelet* API endpoint is reachable at:
+*default* the **kubelet** API endpoint is reachable at:
 
 ```shell
 curl -X POST "https://localhost:10250/checkpoint/default/counters/counter"
@@ -394,8 +394,8 @@ and without losing the state of the containers in that Pod.
 <!-- 
 You can reach SIG Node by several means:
 
-* Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+- Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
  -->
 你可以通过多种方式参与 SIG Node：
 

--- a/content/zh-cn/blog/_posts/2024/consistent-read-from-cache.md
+++ b/content/zh-cn/blog/_posts/2024/consistent-read-from-cache.md
@@ -158,7 +158,7 @@ Our journey doesn't end here. Kubernetes community is actively exploring
 pagination support in the watch cache, which will unlock even more performance
 optimizations in the future.
 -->
-## 下一步是什么？   {#whats-next}
+### 下一步是什么？   {#whats-next}
 
 随着基于缓存的一致性读特性晋升至 Beta 版，该特性已默认启用，为所有使用受支持 etcd
 版本的 Kubernetes 用户提供了无缝的性能提升。


### PR DESCRIPTION
Part of #55612

This PR updates zh-cn localized headings that currently use H2 (`##`) to H3 (`###`) where the current English source uses H3.

This PR handles Batch B1, the blog post batch, of the H3 → H2 mismatch cases from #55612.

Per the zh-cn localization guide, this PR avoids partial updates: both touched files were checked with `./scripts/lsync.sh` and are already in sync with their English sources. The rendered Chinese translation is otherwise unchanged.

Changes include:

- Change `## CRI-O 的使用示例` to H3 (`###`) to match English `### Usage example with CRI-O`.
- Change `## 下一步是什么？ {#whats-next}` to H3 (`###`) to match English `### What's next?`.
- Preserve the existing `{#whats-next}` anchor.
- Refresh a few embedded English source comments in `forensic-container-checkpointing/index.md` to match current English source formatting.

### Verification

I compared the changed zh-cn headings with the corresponding English source headings.

I also ran:

```bash
./scripts/lsync.sh content/zh-cn/blog/_posts/2022/forensic-container-checkpointing/index.md
./scripts/lsync.sh content/zh-cn/blog/_posts/2024/consistent-read-from-cache.md
```