### PR TITLE
[zh-cn] Change H2 headings to H3 to match English source - part 3 (tasks)

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -69,7 +69,7 @@ For deploying in production, advanced hardware configuration is required.
 Before deploying etcd in production, see
 [resource requirement reference](https://etcd.io/docs/current/op-guide/hardware/#example-hardware-configurations).
 -->
-## etcd 资源需求    {#resource-requirements-for-etcd}
+### etcd 资源需求    {#resource-requirements-for-etcd}
 
 使用有限的资源运行 etcd 只适合测试目的。在生产环境中部署 etcd，你需要有先进的硬件配置。
 在生产中部署 etcd 之前，请查阅[所需资源参考文档](https://etcd.io/docs/current/op-guide/hardware/#example-hardware-configurations)。

--- a/content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
@@ -761,9 +761,9 @@ so that you're relying on KMS encryption.
 请在主机之间使用非对称加密，或更改你正在使用的方法，以便依赖 KMS 加密。
 
 <!--
-## Write an encryption configuration file
+### Write an encryption configuration file
 -->
-## 编辑加密配置文件   {#write-an-encryption-configuration-file}
+### 编辑加密配置文件   {#write-an-encryption-configuration-file}
 
 {{< caution >}}
 <!--

--- a/content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -138,7 +138,7 @@ secret/db-user-pass created
 <!--
 ### Verify the Secret {#verify-the-secret}
 -->
-## 验证 Secret  {#verify-the-secret}
+### 验证 Secret  {#verify-the-secret}
 
 <!--
 Check that the Secret was created:

--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
@@ -802,9 +802,9 @@ often good enough for the application to load the token on a schedule
 重新加载就足够了，不必跟踪令牌的实际过期时间。
 
 <!--
-## Service Account Issuer Discovery
+### Service account issuer discovery
 -->
-## 发现服务账号分发者 {#service-account-issuer-discovery}
+### 发现服务账号分发者 {#service-account-issuer-discovery}
 
 {{< feature-state for_k8s_version="v1.21" state="stable" >}}
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/extended-resource.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/extended-resource.md
@@ -193,7 +193,7 @@ kubectl delete pod extended-resource-demo-2
 * [Assign Memory Resources to Containers and Pods](/docs/tasks/configure-pod-container/assign-memory-resource/)
 * [Assign CPU Resources to Containers and Pods](/docs/tasks/configure-pod-container/assign-cpu-resource/)
 -->
-## 应用开发者参考
+### 应用开发者参考
 
 * [为容器和 Pod 分配内存资源](/zh-cn/docs/tasks/configure-pod-container/assign-memory-resource/)
 * [为容器和 Pod 分配 CPU 资源](/zh-cn/docs/tasks/configure-pod-container/assign-cpu-resource/)

--- a/content/zh-cn/docs/tasks/debug/debug-application/debug-running-pod.md
+++ b/content/zh-cn/docs/tasks/debug/debug-application/debug-running-pod.md
@@ -442,7 +442,7 @@ If your container has previously crashed, you can access the previous container'
 如果你的容器之前崩溃过，你可以通过下面命令访问之前容器的崩溃日志：
 
 ```shell
-kubectl logs --previous ${POD_NAME} -c ${CONTAINER_NAME} --previous
+kubectl logs ${POD_NAME} -c ${CONTAINER_NAME} --previous
 ```
 
 <!--
@@ -517,7 +517,7 @@ https://github.com/GoogleContainerTools/distroless).
 You can use the `kubectl debug` command to add ephemeral containers to a
 running Pod. First, create a pod for the example:
 -->
-## 使用临时容器来调试的例子 {#ephemeral-container-example}
+### 使用临时容器来调试的例子 {#ephemeral-container-example}
 
 你可以使用 `kubectl debug` 命令来给正在运行中的 Pod 增加一个临时容器。
 首先，像示例一样创建一个 Pod：

--- a/content/zh-cn/docs/tasks/debug/debug-cluster/windows.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/windows.md
@@ -246,7 +246,7 @@ content_type: concept
    tries to assign a new pod subnet to the node. Users should remove the old pod
    subnet configuration files in the following paths:
 -->
-## Flannel 故障排查 {#troubleshooting-network}
+### Flannel 故障排查 {#flannel-troubleshooting}
 
 1. 使用 Flannel 时，我的节点在重新加入集群后出现问题
 

--- a/content/zh-cn/docs/tasks/job/pod-failure-policy.md
+++ b/content/zh-cn/docs/tasks/job/pod-failure-policy.md
@@ -74,7 +74,7 @@ With the following example, you can learn how to use Pod failure policy to
 avoid unnecessary Pod restarts when a Pod failure indicates a non-retriable
 software bug.
 -->
-## 使用 Pod 失效策略以避免不必要的 Pod 重试  {#using-pod-failure-policy-to-avoid-unecessary-pod-retries}
+### 使用 Pod 失效策略以避免不必要的 Pod 重试  {#pod-failure-policy-failjob}
 
 借用以下示例，你可以学习在 Pod 失效表明有一个不可重试的软件漏洞时如何使用
 Pod 失效策略来避免不必要的 Pod 重启。


### PR DESCRIPTION
Part of #55612

This PR updates zh-cn localized headings that currently use H2 (`##`) to H3 (`###`) where the current English source uses H3.

This PR handles the docs/tasks batch of the H3 → H2 mismatch cases from #55612.

Per the zh-cn localization guide, this PR avoids partial updates: each touched file was checked with `./scripts/lsync.sh`. All touched files already report as in sync with their English sources, so the main required update is the heading-level correction.

While checking the touched files, I also found one stale command in `debug-running-pod.md`: the zh-cn page had a duplicated `--previous` flag in a `kubectl logs` command. Since this is a copy-pasteable command bug in a file already touched by this PR, I fixed it here as well.

Changes include:

- Update 8 zh-cn headings from H2 (`##`) to H3 (`###`) to match the current English source.
- Fix the duplicated `--previous` flag in `debug-running-pod.md`.

### Verification

For each changed file, I compared the current zh-cn heading level with the corresponding English source file.

I also ran `./scripts/lsync.sh` on every changed file:

```bash
./scripts/lsync.sh content/zh-cn/docs/tasks/administer-cluster/configure-upgrade-etcd.md
./scripts/lsync.sh content/zh-cn/docs/tasks/administer-cluster/encrypt-data.md
./scripts/lsync.sh content/zh-cn/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
./scripts/lsync.sh content/zh-cn/docs/tasks/configure-pod-container/configure-service-account.md
./scripts/lsync.sh content/zh-cn/docs/tasks/configure-pod-container/extended-resource.md
./scripts/lsync.sh content/zh-cn/docs/tasks/debug/debug-application/debug-running-pod.md
./scripts/lsync.sh content/zh-cn/docs/tasks/debug/debug-cluster/windows.md
./scripts/lsync.sh content/zh-cn/docs/tasks/job/pod-failure-policy.md
```