### PR TITLE
Update hugo timeout to 300s from 180s

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -20,7 +20,7 @@ disableKinds = ["taxonomy"]
 
 ignoreFiles = [ "(?:^|/)OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
-timeout = "180s"
+timeout = "300s"
 
 # Enable Git variables like commit, lastmod
 enableGitInfo = true


### PR DESCRIPTION
Many Netlify builds have been failing recently after a 3 min timeout. 
This PR increases the timeout setting from 180s to 300s (5 min)
