### PR TITLE
Fix syntax error in CRI-O drop-in file on Switching to EventedPLEG page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/switch-to-evented-pleg.md
+++ b/content/en/docs/tasks/administer-cluster/switch-to-evented-pleg.md
@@ -76,7 +76,7 @@ The polling based approach is referred to as _generic PLEG_.
 
    ```toml
    [crio.runtime]
-   enable_pod_events: true
+   enable_pod_events = true
    ```
    {{% /tab %}}
    {{< /tabs >}}


### PR DESCRIPTION
### Description

Fixes a syntax error in the CRI-O drop-in configuration example for enabling the EventedPLEG feature.

The current documentation suggests the following configuration:

```toml
[crio.runtime]
enable_pod_events: true
```

However, this results in a CRI-O configuration parsing error:

```text
unable to decode configuration ... expected '.' or '=', but got ':' instead
```

CRI-O configuration uses TOML syntax, where key-value assignments must use `=` instead of `:`.

This PR updates the example to:

```toml
[crio.runtime]
enable_pod_events = true
```

This ensures the configuration is valid and prevents runtime errors when users attempt to enable EventedPLEG.

This change applies to both English and zh-cn translations.

### Issue

Closes: #55670 