### PR TITLE
blog(zh-cn): set dates and undraft two 2026 blog posts for v1.36

### DIFF
--- a/content/zh-cn/blog/_posts/2026/inplace-pod-level-resources-beta.md
+++ b/content/zh-cn/blog/_posts/2026/inplace-pod-level-resources-beta.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.36：Pod 级别资源的原地垂直扩缩容升级至 Beta 版本"
-draft: true
+date: 2026-04-30T10:35:00-08:00
 slug: kubernetes-v1-36-inplace-pod-level-resources-beta
 author: Narang Dixita Sohanlal (Google)
 translator: >
@@ -10,7 +10,7 @@ translator: >
 <!--
 layout: blog
 title: "Kubernetes v1.36: In-Place Vertical Scaling for Pod-Level Resources Graduates to Beta"
-draft: true
+date: 2026-04-30T10:35:00-08:00
 slug: kubernetes-v1-36-inplace-pod-level-resources-beta
 author: Narang Dixita Sohanlal (Google)
 -->

--- a/content/zh-cn/blog/_posts/2026/volume-group-snapshot-ga.md
+++ b/content/zh-cn/blog/_posts/2026/volume-group-snapshot-ga.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.36：卷组快照进入正式发布阶段"
-date: 2026-04-22T10:30:00-08:00
-draft: true
+date: 2026-05-08T10:35:00-08:00
 slug: kubernetes-v1-36-volume-group-snapshot-ga
 author: >
    Xing Yang (VMware by Broadcom)
@@ -12,8 +11,7 @@ translator: >
 <!--
 layout: blog
 title: "Kubernetes v1.36: Moving Volume Group Snapshots to GA"
-date: 2026-04-22T10:30:00-08:00
-draft: true
+date: 2026-05-08T10:35:00-08:00
 slug: kubernetes-v1-36-volume-group-snapshot-ga
 author: >
    Xing Yang (VMware by Broadcom)


### PR DESCRIPTION
### Description

https://kubernetes.io/blog/2026/04/30/kubernetes-v1-36-inplace-pod-level-resources-beta/ has been published.

For kubernetes-v1-36-volume-group-snapshot-ga, it is marked that it will be published in May 8th.

https://github.com/kubernetes/website/blob/2d524996b52c5f37ed3c214ea4d9ba49ad4a79f0/content/en/blog/_posts/2026/volume-group-snapshot-ga.md?plain=1#L2-L7

### Issue

Closes: None