### PR TITLE
Fix navbar hover state on scroll

### DIFF
--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -63,7 +63,16 @@
   background: white !important;
   box-shadow: 0 1px 2px $medium-grey;
 
-  .navbar-nav .nav-link, #hamburger {
+  .navbar-nav .nav-link {
+    color: $dark-grey;
+
+    &:hover,
+    &:focus {
+      color: $primary;
+    }
+  }
+
+  #hamburger {
     color: $dark-grey;
 
     &:hover,

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -66,7 +66,8 @@
   .navbar-nav .nav-link, #hamburger {
     color: $dark-grey;
 
-    &:hover:focus {
+    &:hover,
+    &:focus {
       color: $medium-grey;
     }
   }


### PR DESCRIPTION
### What changed

- Update the scrolled navbar state so navbar links and the hamburger use the visible medium gray color on both hover and focus.

### Why

When the homepage navbar switches to `.navbar-bg-onscroll`, the base link color becomes dark gray. The previous selector only applied the hover color when an element was both hovered and focused, so plain hover could fall back to the dark navbar hover styling and become hard to read against the white scrolled navbar.

Fixes #54938

### Validation

- `git diff --check`

## AI disclosure

This PR was assisted by Codex / AI tooling

I completed the overall direction and implementation plan myself. The initial code were made by an AI agent, then I reviewed and modified the remaining issues. The changes were reviewed again by the AI agent, followed by another review from me with additional feedback. A later revision was made by a sub-agent

The final PR description and commit content were drafted with AI assistance and reviewed by me. I reviewed all submitted changes and take responsibility for the final result