### PR TITLE
Fix documentation fragment anchor offsets

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -1,5 +1,31 @@
 /* DOCUMENTATION */
 
+$docs-fragment-anchor-offset: 5rem;
+
+.td-offset-anchor {
+  display: block;
+  scroll-margin-top: $docs-fragment-anchor-offset;
+}
+
+body .td-offset-anchor:target {
+  position: static;
+  top: auto;
+  visibility: hidden;
+}
+
+.td-content {
+  :is(h1, h2, h3, h4, h5, h6)[id] {
+    scroll-margin-top: $docs-fragment-anchor-offset;
+  }
+
+  :is(h1, h2, h3, h4, h5, h6)[id]::before {
+    content: none;
+    display: none;
+    height: 0;
+    margin-top: 0;
+  }
+}
+
 .td-content .tab-content .highlight {
   margin: 0;
 }
@@ -342,8 +368,7 @@ body.glossary {
 
     .term-anchor {
       display: block;
-      position: relative;
-      top: -4rem; // adjust scrolling to target
+      scroll-margin-top: $docs-fragment-anchor-offset;
       visibility: hidden;
     }
 


### PR DESCRIPTION
## Summary

- replace the Docsy heading pseudo-element anchor offset in documentation content with `scroll-margin-top`
- apply the same fragment offset to narrow viewports and documentation block anchors
- update glossary anchors to use `scroll-margin-top` instead of a relative `top` offset

## Why

#29909 reports that fragment links can place documentation headings underneath the fixed top navigation, especially on narrow viewports. #51923 reports that the old invisible heading `::before` offset can overlap nearby controls, such as code block scrollbars.

This keeps the fix scoped to Kubernetes documentation styles while the site is still on the current Docsy version. It also supersedes the stale closed PR #51954.

Fixes #29909
Fixes #51923
Related: #32695, #51954

cc @alikhere, since #51923 is still assigned there and #51954 was the earlier stale attempt.

## Validation

- `git diff --check`
- inspected the Docsy SCSS import order and selector specificity against the existing `h2[id]::before` rules
- reviewed the changed SCSS for docs, block anchors, glossary anchors, and case study override interactions

Not run locally: full Hugo build. This worktree does not have `hugo` or `node_modules` installed; the Netlify preview should provide the full rendered-site validation.

### AI disclosure

This PR was assisted by Codex. I reviewed the generated changes, verified the diff, and take responsibility for the final result.