### PR TITLE
Fix documentation fragment anchor offsets

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -1,5 +1,31 @@
 /* DOCUMENTATION */
 
+$docs-fragment-anchor-offset: 5rem;
+
+.td-offset-anchor {
+  display: block;
+  scroll-margin-top: $docs-fragment-anchor-offset;
+}
+
+body .td-offset-anchor:target {
+  position: static;
+  top: auto;
+  visibility: hidden;
+}
+
+.td-content {
+  :is(h1, h2, h3, h4, h5, h6)[id] {
+    scroll-margin-top: $docs-fragment-anchor-offset;
+  }
+
+  :is(h1, h2, h3, h4, h5, h6)[id]::before {
+    content: none;
+    display: none;
+    height: 0;
+    margin-top: 0;
+  }
+}
+
 .td-content .tab-content .highlight {
   margin: 0;
 }
@@ -342,8 +368,7 @@ body.glossary {
 
     .term-anchor {
       display: block;
-      position: relative;
-      top: -4rem; // adjust scrolling to target
+      scroll-margin-top: $docs-fragment-anchor-offset;
       visibility: hidden;
     }
 


### PR DESCRIPTION
This PR is a fresh replacement for #55703. The previous PR went through a somewhat messy revision process, so I opened this one from a clean branch.

The change is based on the issues and related previous PRs:
- Fixes #29909
- Fixes #51923
- Related: #32695, #51954, #55703

## Validation

- `git diff --check`

Not run locally: full Hugo build. This worktree does not have `hugo` or `node_modules` installed.

## AI disclosure
I planned this change myself. The code was written with AI assistance, then reviewed again by me before submission.