### PR TITLE
[zh-cn] Sync node shutdown and manage-resources-containers pages

### DIFF
--- a/content/zh-cn/docs/concepts/cluster-administration/node-shutdown.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/node-shutdown.md
@@ -21,6 +21,33 @@ either **graceful** or **non-graceful**.
 也可能因断电或其他某些外部原因被意外关闭。如果节点在关闭之前未被排空，则节点关闭可能会导致工作负载失败。
 节点可以**体面关闭**或**非体面关闭**。
 
+{{< caution >}}
+<!--
+The `unattended-upgrades` package from Debian conflicts with node graceful shutdown in
+its normal configuration.
+If you use the default configuration of `unattended-upgrades`, which customizes the server shutdown
+grace period, then the kubelet fails to obtain the necessary lock to handle shutdown events properly.
+
+This happens if the `shutdownGracePeriod` value is greater than 30 seconds.
+To avoid this, you can suppress part of the `unattended-upgrades` configuration,
+by making `/etc/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf` be a symbolic link
+to `/dev/null`.
+
+For more details, refer to the
+[`logind.conf` documentation](https://www.freedesktop.org/software/systemd/man/latest/logind.conf.html).
+-->
+Debian 的 `unattended-upgrades` 软件包在其默认配置下会与节点体面关闭功能冲突。
+如果你使用 `unattended-upgrades` 的默认配置（该配置会自定义服务器关机宽限期），
+则 kubelet 将无法获取处理关闭事件所需的锁。
+
+当 `shutdownGracePeriod` 值大于 30 秒时会发生此问题。
+为避免这种情况，你可以通过将 `/etc/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf`
+设置为指向 `/dev/null` 的符号链接，来抑制 `unattended-upgrades` 的部分配置。
+
+更多详细信息，请参阅
+[`logind.conf` 文档](https://www.freedesktop.org/software/systemd/man/latest/logind.conf.html)。
+{{< /caution >}}
+
 <!-- body -->
 
 <!-- 
@@ -45,7 +72,7 @@ kubelet 会尝试检测节点系统关闭事件并终止在节点上运行的所
 <!--
 ### Enabling graceful node shutdown
 -->
-## 启用节点体面关闭 {#enabling-graceful-node-shutdown}
+### 启用节点体面关闭 {#enabling-graceful-node-shutdown}
 
 {{< tabs name="graceful_shutdown_os" >}}
 {{% tab name="Linux" %}}
@@ -126,7 +153,7 @@ thus not activating the graceful node shutdown functionality.
 To activate the feature, both options should be configured appropriately and
 set to non-zero values.
 -->
-## 配置节点体面关闭
+### 配置节点体面关闭 {#configuring-graceful-node-shutdown}
 
 注意，默认情况下，下面描述的两个配置选项，`shutdownGracePeriod` 和
 `shutdownGracePeriodCriticalPods` 都是被设置为 0 的，因此不会激活节点体面关闭特性。

--- a/content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/zh-cn/docs/concepts/configuration/manage-resources-containers.md
@@ -107,15 +107,12 @@ its `memory` limit, but if it does, it may get killed.
 
 {{< note >}}
 <!--
-There is an alpha feature `MemoryQoS` which attempts to add more preemptive
-limit enforcement for memory (as opposed to reactive enforcement by the OOM
-killer). However, this effort is
-[stalled](https://github.com/kubernetes/enhancements/tree/a47155b340/keps/sig-node/2570-memory-qos#latest-update-stalled)
-due to a potential livelock situation a memory hungry container process can cause.
+There is an alpha feature `MemoryQoS` which adds memory throttling and optional
+tiered memory reservation on Linux nodes using cgroup v2. For details, see
+[Memory QoS with cgroup v2](/docs/concepts/workloads/pods/pod-qos/#memory-qos-with-cgroup-v2).
 -->
-你可以使用一个 Alpha 特性 `MemoryQoS` 来尝试为内存添加执行更多的抢占限制
-（这与 OOM Killer 的被动执行相反）。然而，由于可能会因内存饥饿容器进程造成活锁情形，
-所以这一特性现在处于[停滞状态](https://github.com/kubernetes/enhancements/tree/a47155b340/keps/sig-node/2570-memory-qos#latest-update-stalled)。
+有一个 Alpha 特性 `MemoryQoS`，它在使用 cgroup v2 的 Linux 节点上添加内存节流以及可选的分层内存预留功能。
+详细信息参阅[使用 cgroup v2 的内存 QoS](/zh-cn/docs/concepts/workloads/pods/pod-qos/#memory-qos-with-cgroup-v2)。
 {{< /note >}}
 
 {{< note >}}
@@ -348,7 +345,7 @@ but this isn't useful to specify: you must always assign whole numbers of bytes,
 
 Here are some examples of memory quantities that represent roughly the same value:
 -->
-## 内存资源单位      {#meaning-of-memory}
+### 内存资源单位      {#meaning-of-memory}
 
 `memory` 的限制和请求以字节为单位。你可以使用普通的整数，
 或者带有以下[数量](/zh-cn/docs/reference/kubernetes-api/common-definitions/quantity/)后缀的定点数字来表示内存：


### PR DESCRIPTION
Part of #55612

This PR fully synchronizes three zh-cn `docs/concepts` pages with the current English source while fixing H2/H3 heading-level mismatches.

These files were included in the heading-level mismatch work tracked by #55612 because some zh-cn headings used H2 (`##`) where the English source uses H3 (`###`).

While preparing the heading fixes, I found that these files also had pending upstream content updates. To avoid partial zh-cn updates, this PR includes the required sync work together with the heading-level corrections.

Changes include:

- `content/zh-cn/docs/concepts/cluster-administration/node-shutdown.md`
  - Add the new caution block about Debian `unattended-upgrades` and graceful node shutdown.
  - Change affected zh-cn headings from H2 (`##`) to H3 (`###`) to match the English source.
  - Add the missing `{#configuring-graceful-node-shutdown}` anchor.

- `content/zh-cn/docs/concepts/configuration/manage-resources-containers.md`
  - Update the MemoryQoS content to match the current English source.
  - Change the affected zh-cn heading from H2 (`##`) to H3 (`###`).

- `content/zh-cn/docs/concepts/storage/persistent-volumes.md`
  - Add the new `Unused PVC tracking` section, including the feature-state shortcode, condition descriptions, and note.
  - Change the affected zh-cn heading from H2 (`##`) to H3 (`###`).