### PR TITLE
[zh-cn] Sync reference pages and fix heading levels

### DIFF
--- a/content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
@@ -113,7 +113,7 @@ admission time.
 你可以使用这三个准入控制器来定制准入时的集群行为。
 
 <!--
-## Admission control phases
+### Admission control phases
 
 The admission control process proceeds in two phases. In the first phase,
 mutating admission controllers are run. In the second phase, validating
@@ -123,7 +123,7 @@ both.
 If any of the controllers in either phase reject the request, the entire
 request is rejected immediately and an error is returned to the end-user.
 -->
-## 准入控制阶段   {#admission-control-phases}
+### 准入控制阶段   {#admission-control-phases}
 
 准入控制过程分为两个阶段。第一阶段，运行变更准入控制器。第二阶段，运行验证准入控制器。
 再次提醒，某些控制器既是变更准入控制器又是验证准入控制器。

--- a/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
+++ b/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
@@ -578,10 +578,12 @@ Example: `resource.kubernetes.io/pod-claim-name: "my-pod-claim"`
 
 Used on: ResourceClaim
 
-This annotation is assigned to generated ResourceClaims. 
+This annotation is assigned to generated ResourceClaims.
 Its value corresponds to the name of the resource claim in the `.spec` of any Pod(s) for which the ResourceClaim was created.
-This annotation is an internal implementation detail of [dynamic resource allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/).
-You should not need to read or modify the value of this annotation.
+Within [dynamic resource allocation](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/), the
+discoverable device metadata feature uses this annotation to map a generated ResourceClaim
+back to the Pod claim name (`pod.spec.resourceClaims[].name`) for template-based claims.
+Kubernetes manages this annotation, so you should not modify it.
 -->
 ### resource.kubernetes.io/pod-claim-name {#resource-kubernetes-io-pod-claim-name}
 
@@ -593,8 +595,10 @@ You should not need to read or modify the value of this annotation.
 
 该注解被赋予自动生成的 ResourceClaim。
 注解的值对应于触发 ResourceClaim 创建的 Pod 在 `.spec` 中的资源声明名称。
-此注解是[动态资源分配](/zh-cn/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)的内部实现细节。
-你不需要读取或修改此注解的值。
+在[动态资源分配](/zh-cn/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)中，
+可发现设备元数据特性使用此注解将生成的 ResourceClaim 映射回基于模板的资源申领的
+Pod 申领名称（`pod.spec.resourceClaims[].name`）。
+Kubernetes 管理此注解，因此你不应修改它。
 
 <!--
 ### cluster-autoscaler.kubernetes.io/safe-to-evict
@@ -5407,7 +5411,7 @@ pod can be reached if the [JobSet](https://jobset.sigs.k8s.io) spec defines the 
 <!--
 ## Annotations used for audit
 -->
-## 用于审计的注解    {#annonations-used-for-audit}
+## 用于审计的注解    {#annotations-used-for-audit}
 
 <!-- sorted by annotation -->
 <!--
@@ -5438,7 +5442,7 @@ See more details on [Audit Annotations](/docs/reference/labels-annotations-taint
 <!--
 ### kubeadm.alpha.kubernetes.io/cri-socket (deprecated) {#kubeadm-alpha-kubernetes-io-cri-socket}
 -->
-## kubeadm.alpha.kubernetes.io/cri-socket (已弃用) {#kubeadm-alpha-kubernetes-io-cri-socket}
+### kubeadm.alpha.kubernetes.io/cri-socket (已弃用) {#kubeadm-alpha-kubernetes-io-cri-socket}
 
 <!--
 Type: Annotation

--- a/content/zh-cn/docs/reference/using-api/server-side-apply.md
+++ b/content/zh-cn/docs/reference/using-api/server-side-apply.md
@@ -269,14 +269,14 @@ You should avoid updating it manually.
 {{< /caution >}}
 
 <!--
-## Conflicts
+### Conflicts
 
 A _conflict_ is a special status error that occurs when an `Apply` operation tries
 to change a field that another manager also claims to manage. This prevents an
 applier from unintentionally overwriting the value set by another user. When
 this occurs, the applier has 3 options to resolve the conflicts:
 -->
-## 冲突 {#conflicts}
+### 冲突 {#conflicts}
 
 **冲突**是一种特定的错误状态，
 发生在执行 `Apply` 改变一个字段，而恰巧该字段被其他用户声明过主权时。
@@ -335,7 +335,7 @@ For other updates, the API server infers a field manager identity from the
 When you use the `kubectl` tool to perform a Server-Side Apply operation, `kubectl`
 sets the manager identity to `"kubectl"` by default.
 -->
-## 字段管理器 {#managers}
+### 字段管理器 {#managers}
 
 管理器识别出正在修改对象的工作流程（在冲突时尤其有用）,
 并且可以作为修改请求的一部分，通过
@@ -566,7 +566,7 @@ comments and code authors need not repeat them as field tags).
 By default, Server-Side Apply treats custom resources as unstructured data. All
 keys are treated the same as struct fields, and all lists are considered atomic.
 -->
-### 自定义资源和服务器端应用  {#custom-resources-and-server-side-apply}
+## 自定义资源和服务器端应用  {#custom-resources-and-server-side-apply}
 
 默认情况下，服务器端应用将自定义资源视为无结构的数据。
 所有键被视为 struct 数据类型的字段，所有列表都被视为 atomic 形式。


### PR DESCRIPTION
Part of #55612

This PR updates three zh-cn `docs/reference` pages to align their heading levels with the current English source.

These files were included in the heading-level mismatch work tracked by #55612 because some zh-cn headings used H2 (`##`) where the English source uses H3 (`###`). While preparing the heading fixes, I also found one file with a pending upstream content update, so this PR includes that sync to avoid a partial zh-cn update.

Changes include:

- `content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md`
  - Change `Admission control phases` / `准入控制阶段` from H2 (`##`) to H3 (`###`).

- `content/zh-cn/docs/reference/labels-annotations-taints/_index.md`
  - Sync the updated `resource.kubernetes.io/pod-claim-name` annotation paragraph.
  - Change `kubeadm.alpha.kubernetes.io/cri-socket` from H2 (`##`) to H3 (`###`).
  - Fix the anchor typo `{#annonations-used-for-audit}` to `{#annotations-used-for-audit}`.

- `content/zh-cn/docs/reference/using-api/server-side-apply.md`
  - Change `Conflicts` / `冲突` from H2 (`##`) to H3 (`###`.
  - Change `字段管理器 {#managers}` from H2 (`##`) to H3 (`###`).
  - Change `自定义资源和服务器端应用` from H3 (`###`) to H2 (`##`) to match the English source.