### PR TITLE
fix: correctly return cookie value in banner-dismiss.js

### DIFF
--- a/assets/js/banner-dismiss.js
+++ b/assets/js/banner-dismiss.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+$(document).ready(function() {
   function setCookie(name, value, days) {
     let expires = "";
     let date = new Date(); // Create a new Date object
@@ -12,18 +12,17 @@ $(document).ready(function () {
     document.cookie = name + "=" + value + expires + "; path=/";
   }
 
-  //Problem: getCookie() always returns "true" if the cookie name is found, regardless of the 
-  // cookie's actual value. This breaks any logic that checks cookie value.
+  // Returns the decoded cookie value if found, otherwise undefined.
   function getCookie(name) {
     let matches = document.cookie.match(new RegExp(
       "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
     ));
-    return matches ? decodeURIComponent(matches[1]) : undefined; //Fixed the return value to return the actual cookie value instead of just "true"
+    return matches ? decodeURIComponent(matches[1]) : undefined; 
   }
 
   function getTokenName() {
     let announcement_name_rewritten = announcement.getAttribute('data-announcement-name').replace(/\s/g, '_');
-    let token = 'announcement_ack_' + announcement_name_rewritten; // Generate the unique token for this announcement
+    let token = 'announcement_ack_'+announcement_name_rewritten; // Generate the unique token for this announcement
     return token;
   }
 
@@ -33,8 +32,8 @@ $(document).ready(function () {
     let announcement_name_rewritten = announcement.getAttribute('data-announcement-name').replace(/\s/g, '_');
     let tokenName = getTokenName();
     let acknowledged = getCookie(tokenName);
-    if (acknowledged) {  // truthy check is sufficient
-      announcement.remove();
+    if (acknowledged) {  
+      announcement.remove(); // Remove the announcement if the cookie is set
     }
     else {
       announcement.classList.add('display-announcement') // Display the announcement if the cookie is not set
@@ -46,9 +45,9 @@ $(document).ready(function () {
   if (button) {
     let tokenName = getTokenName();
     button.removeAttribute('style');
-    button.addEventListener('click', function () {
+    button.addEventListener('click', function() {
       setCookie(tokenName, "true",
-        button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
+      button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
       announcement.remove();
     });
   }

--- a/assets/js/banner-dismiss.js
+++ b/assets/js/banner-dismiss.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
     let matches = document.cookie.match(new RegExp(
       "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
     ));
-    return matches ? decodeURIComponent(matches[1]) : undefined; 
+    return matches ? decodeURIComponent(matches[1]) : undefined;
   }
 
   function getTokenName() {

--- a/assets/js/banner-dismiss.js
+++ b/assets/js/banner-dismiss.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).ready(function () {
   function setCookie(name, value, days) {
     let expires = "";
     let date = new Date(); // Create a new Date object
@@ -12,16 +12,18 @@ $(document).ready(function() {
     document.cookie = name + "=" + value + expires + "; path=/";
   }
 
+  //Problem: getCookie() always returns "true" if the cookie name is found, regardless of the 
+  // cookie's actual value. This breaks any logic that checks cookie value.
   function getCookie(name) {
     let matches = document.cookie.match(new RegExp(
       "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
     ));
-    return matches ? "true" : undefined;
+    return matches ? decodeURIComponent(matches[1]) : undefined; //Fixed the return value to return the actual cookie value instead of just "true"
   }
 
   function getTokenName() {
     let announcement_name_rewritten = announcement.getAttribute('data-announcement-name').replace(/\s/g, '_');
-    let token = 'announcement_ack_'+announcement_name_rewritten; // Generate the unique token for this announcement
+    let token = 'announcement_ack_' + announcement_name_rewritten; // Generate the unique token for this announcement
     return token;
   }
 
@@ -31,8 +33,8 @@ $(document).ready(function() {
     let announcement_name_rewritten = announcement.getAttribute('data-announcement-name').replace(/\s/g, '_');
     let tokenName = getTokenName();
     let acknowledged = getCookie(tokenName);
-    if (acknowledged === "true") {
-      announcement.remove(); // Remove the announcement if the cookie is set
+    if (acknowledged) {  // truthy check is sufficient
+      announcement.remove();
     }
     else {
       announcement.classList.add('display-announcement') // Display the announcement if the cookie is not set
@@ -44,9 +46,9 @@ $(document).ready(function() {
   if (button) {
     let tokenName = getTokenName();
     button.removeAttribute('style');
-    button.addEventListener('click', function() {
+    button.addEventListener('click', function () {
       setCookie(tokenName, "true",
-      button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
+        button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
       announcement.remove();
     });
   }

--- a/assets/js/banner-dismiss.js
+++ b/assets/js/banner-dismiss.js
@@ -32,7 +32,7 @@ $(document).ready(function() {
     let announcement_name_rewritten = announcement.getAttribute('data-announcement-name').replace(/\s/g, '_');
     let tokenName = getTokenName();
     let acknowledged = getCookie(tokenName);
-    if (acknowledged) {  
+    if (acknowledged) {
       announcement.remove(); // Remove the announcement if the cookie is set
     }
     else {


### PR DESCRIPTION
### Description

This PR fixes the `getCookie()` function in `assets/js/banner-dismiss.js`.

Previously, the function returned `"true"` whenever the cookie existed, regardless of the cookie's actual stored value. This caused incorrect behavior for any logic depending on the real cookie value.

The fix updates `getCookie()` to return the decoded cookie value using `decodeURIComponent(matches[1])`.

Additionally, the redundant check:

```js
acknowledged === "true"
```

has been simplified to a truthy check after fixing `getCookie()`:

```js
if (acknowledged) {
  announcement.remove();
}
```

This makes the logic cleaner, more reliable, and future-proof.

### Changes Made

* Fixed `getCookie()` to return the actual cookie value.
* Replaced hardcoded `"true"` return behavior.
* Simplified acknowledgment condition check.
* Improved maintainability and correctness of banner dismissal logic.