### PR TITLE
Republish CCM metric article

### DIFF
--- a/content/en/blog/_posts/2026/ccm-metric-route-sync-total.md
+++ b/content/en/blog/_posts/2026/ccm-metric-route-sync-total.md
@@ -1,11 +1,17 @@
 ---
 layout: blog
 title: "Kubernetes v1.36: New Metric for Route Sync in the Cloud Controller Manager"
-date: 2026-02-26
+date: 2026-05-15T10:35:00-08:00
 slug: ccm-new-metric-route-sync-total
 author: >
   [Lukas Metzner](https://github.com/lukasmetzner) (Hetzner)
+aliases:
+  - /blog/2026/02/26/ccm-new-metric-route-sync-total
+  - /blog/2026/02/26/ccm-new-metric-route-sync-total/
 ---
+
+_This article was originally published with the wrong date. It was later republished, dated the 15th of
+May 2026._
 
 Kubernetes v1.36 introduces a new alpha counter metric `route_controller_route_sync_total`
 to the Cloud Controller Manager (CCM) route controller implementation at


### PR DESCRIPTION
The article was accidentally published with the wrong date, many weeks before the v1.36 release actually happened. This PR fixes that up.

Here's the article's original URL:
- https://kubernetes.io/blog/2026/02/26/ccm-new-metric-route-sync-total/ 
  - _(and a [preview](https://deploy-preview-55722--kubernetes-io-main-staging.netlify.app/blog/2026/02/26/ccm-new-metric-route-sync-total/) of the redirect)_

Here's the new URL:
- https://kubernetes.io/blog/2026/05/15/ccm-new-metric-route-sync-total/
  - _(and a [preview](https://deploy-preview-55722--kubernetes-io-main-staging.netlify.app/blog/2026/05/15/ccm-new-metric-route-sync-total/) of the new page)_

Because it's a change that will instantly go live, we should hold this and unhold it on the new publication date, ie 2026-05-15T10:35:00-08:00

/area blog