### PR TITLE
fix: improve sortable table accessibility and column sort behavior

### DIFF
--- a/assets/js/sortable-table.js
+++ b/assets/js/sortable-table.js
@@ -1,30 +1,66 @@
+// Tables with class .sortable-table: headers sort tbody by click or Enter/Space.
+// Changing column sorts ascending first; same column toggles asc/desc. Updates aria-sort.
+
 document.addEventListener("DOMContentLoaded", function () {
-    const tables = document.querySelectorAll(".sortable-table");
-    tables.forEach((table) => {
-      const headers = table.querySelectorAll("thead th");
-      headers.forEach((th, index) => {
-        th.style.cursor = "pointer";
-        th.addEventListener("click", () => sortTable(table, index));
+  const tables = document.querySelectorAll(".sortable-table");
+  tables.forEach((table) => {
+    const headers = table.querySelectorAll("thead th");
+    headers.forEach((th, index) => {
+      th.setAttribute("tabindex", "0");
+      th.setAttribute("role", "columnheader");
+      th.setAttribute("aria-sort", "none");
+      th.style.cursor = "pointer";
+
+      th.addEventListener("click", () => sortTable(table, index, th));
+
+      th.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          sortTable(table, index, th);
+        }
       });
     });
   });
+});
 
-  function sortTable(table, column) {
-    const rows = Array.from(table.querySelectorAll("tbody tr"));
-    let sortOrder = table.getAttribute("data-sort-order") || "asc";
-    
-    rows.sort((a, b) => {
-      const aValue = a.querySelectorAll("td")[column].innerText;
-      const bValue = b.querySelectorAll("td")[column].innerText;
-      if (sortOrder === "asc") {
-        return aValue.localeCompare(bValue, undefined, { numeric: true, sensitivity: "base" });
-      } else {
-        return bValue.localeCompare(aValue, undefined, { numeric: true, sensitivity: "base" });
-      }
-    });
+// Sorts rows by column; clickedTh receives the aria-sort state for accessibility.
+function sortTable(table, column, clickedTh) {
+  const rows = Array.from(table.querySelectorAll("tbody tr"));
 
-    rows.forEach((row) => table.querySelector("tbody").appendChild(row));
-    
-    sortOrder = (sortOrder === "asc") ? "desc" : "asc";
-    table.setAttribute("data-sort-order", sortOrder);
+  const tbody = table.querySelector("tbody");
+
+  let sortOrder = table.getAttribute("data-sort-order") || "asc";
+  const currentCol = table.getAttribute("data-sort-col");
+
+  // Different column clicked: start with ascending sort.
+  if (currentCol !== String(column)) {
+    sortOrder = "asc";
   }
+
+  rows.sort((a, b) => {
+    // textContent + trim: stable strings for collation.
+    const aValue = a.querySelectorAll("td")[column].textContent.trim();
+    const bValue = b.querySelectorAll("td")[column].textContent.trim();
+    if (sortOrder === "asc") {
+      return aValue.localeCompare(bValue, undefined, { numeric: true, sensitivity: "base" });
+    } else {
+      return bValue.localeCompare(aValue, undefined, { numeric: true, sensitivity: "base" });
+    }
+  });
+
+  rows.forEach((row) => tbody.appendChild(row));
+
+  // Clear sort state on every header so only the active column has aria-sort set.
+  const allHeaders = table.querySelectorAll("thead th");
+  allHeaders.forEach((th) => {
+    th.setAttribute("aria-sort", "none");
+    th.removeAttribute("data-sort-dir");
+  });
+
+  const newOrder = (sortOrder === "asc") ? "desc" : "asc";
+  clickedTh.setAttribute("aria-sort", sortOrder === "asc" ? "ascending" : "descending");
+  clickedTh.setAttribute("data-sort-dir", sortOrder);
+
+  table.setAttribute("data-sort-order", newOrder);
+  table.setAttribute("data-sort-col", String(column));
+}


### PR DESCRIPTION
### Description

This PR improves `assets/js/sortable-table.js` for `.sortable-table` pages.

Previously, sorting was click-only with no usable sort state for assistive technologies, and **`data-sort-order` applied globally to the table**. After sorting one column descending, activating **another** column could continue in descending order instead of behaving like typical data tables (new column sorts **ascending** first).

The update adds **keyboard** support (**Enter** and **Space** on headers), makes headers **focusable**, and refreshes **`aria-sort`** (`none`, then `ascending` / `descending` on the active column only). It tracks **`data-sort-col`** so a **different** column always starts **ascending**; toggling applies when the **same** column is activated again.

Sorting uses **`textContent` with trimming** instead of **`innerText`**, for more predictable collation. The **`tbody`** reference is reused when re-appending sorted rows.

**Changes made**

- Fixed **multi-column UX** by resetting to ascending when the sorted column changes (`data-sort-col` + conditional sort direction).
- Improved **accessibility**: focusable headers, **Enter** / **Space**, and **`aria-sort`** on headers (inactive columns set to `none`).
- Prefer **`textContent.trim()`** over **`innerText`** for stable string comparisons.
- Small **DOM clarity**: reuse a single **`tbody`** when moving rows.
