### PR TITLE
Update Release Schedule for months following May 2026

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,7 +7,11 @@ schedules:
 - endOfLifeDate: "2027-06-28"
   maintenanceModeStartDate: "2027-04-28"
   next:
-    cherryPickDeadline: "2026-05-08"
+    cherryPickDeadline: "2026-06-05"
+    release: 1.36.2
+    targetDate: "2026-06-09"
+  previousPatches:
+  - cherryPickDeadline: "2026-05-08"
     release: 1.36.1
     targetDate: "2026-05-13"
   release: "1.36"
@@ -15,10 +19,13 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-05-08"
+    cherryPickDeadline: "2026-06-05"
+    release: 1.35.6
+    targetDate: "2026-06-09"
+  previousPatches:
+  - cherryPickDeadline: "2026-05-08"
     release: 1.35.5
     targetDate: "2026-05-12"
-  previousPatches:
   - cherryPickDeadline: "2026-04-10"
     release: 1.35.4
     targetDate: "2026-04-14"
@@ -40,10 +47,13 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2026-05-08"
+    cherryPickDeadline: "2026-06-05"
+    release: 1.34.9
+    targetDate: "2026-06-09"
+  previousPatches:
+  - cherryPickDeadline: "2026-05-08"
     release: 1.34.8
     targetDate: "2026-05-12"
-  previousPatches:
   - cherryPickDeadline: "2026-04-10"
     release: 1.34.7
     targetDate: "2026-04-14"
@@ -75,10 +85,13 @@ schedules:
 - endOfLifeDate: "2026-06-28"
   maintenanceModeStartDate: "2026-04-28"
   next:
-    cherryPickDeadline: "2026-05-08"
+    cherryPickDeadline: "2026-06-05"
+    release: 1.33.13
+    targetDate: "2026-06-09"
+  previousPatches:
+  - cherryPickDeadline: "2026-05-08"
     release: 1.33.12
     targetDate: "2026-05-12"
-  previousPatches:
   - cherryPickDeadline: "2026-04-10"
     release: 1.33.11
     targetDate: "2026-04-14"
@@ -120,9 +133,9 @@ schedules:
   release: "1.33"
   releaseDate: "2025-04-23"
 upcoming_releases:
-- cherryPickDeadline: "2026-05-08"
-  targetDate: "2026-05-12"
 - cherryPickDeadline: "2026-06-05"
   targetDate: "2026-06-09"
 - cherryPickDeadline: "2026-07-10"
   targetDate: "2026-07-14"
+- cherryPickDeadline: "2026-08-07"
+  targetDate: "2026-08-11"


### PR DESCRIPTION
### Description

Update the patch release schedule for months following May 2026

### Issue

Part of:
https://github.com/kubernetes/sig-release/issues/3010
https://github.com/kubernetes/sig-release/issues/3011
https://github.com/kubernetes/sig-release/issues/3012
https://github.com/kubernetes/sig-release/issues/3013

cc: @kubernetes/release-managers 