### PR TITLE
Update MaxUnavailableStatefulSet default to false in 1.35

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MaxUnavailableStatefulSet.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MaxUnavailableStatefulSet.md
@@ -11,7 +11,7 @@ stages:
     fromVersion: "1.24"
     toVersion: "1.34"
   - stage: beta
-    defaultValue: true
+    defaultValue: false
     fromVersion: "1.35"
 ---
 Enables setting the `maxUnavailable` field for the


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

The `MaxUnavailableStatefulSet` feature gate has been disabled by default starting from `v1.35.4` due to a regression that broke StatefulSet Parallel pod management. This PR updates the docs to reflect the new default.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

- Upstream PR: kubernetes/kubernetes#137904
- Cherry-pick to release-1.35: kubernetes/kubernetes#137926
- Related issue: kubernetes/kubernetes#137409

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: # N/A