### PR TITLE
Make the kubectl describe pod describe only the affected pod

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.md
@@ -173,10 +173,17 @@ kubectl get pods
 
 Notice that some of the Pods have a status of `ImagePullBackOff`.
 
-To get more insight into the problem, run the `describe pods` subcommand:
+To get more insight into the problem, first create an environment variable called `AFFECTED_POD` that has the name of the affected pod:
 
 ```shell
-kubectl describe pods
+export AFFECTED_POD="$(kubectl get pods --field-selector status.phase=Pending -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"
+echo "AFFECTED POD=$AFFECTED_POD"
+```
+
+Then, run the `describe pod` subcommand to explore the affected pod:
+
+```shell
+kubectl describe pod $AFFECTED_POD
 ```
 
 In the `Events` section of the output for the affected Pods, notice that the `v10`


### PR DESCRIPTION
### Description
kubectl describe pods doesn't bring up events
kubectl describe pod $AFFECTED_POD will bring up events

The current documentation instructs to use describe pods, which gives a brief summary of all pods. This makes it hard to look for Events, which aren't listed anyway.

The proposed modification is based on the previous steps that cause only one pod to enter the Pending state ImagePullBackOff, which means it can be retrieved using status.phase=Pending. 

### Issue
This pull request doesn't resolve any open issue that I could find.