### PR TITLE
Fix Mermaid initialization on Firefox

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,6 +6,13 @@
 {{/* future Docsy versions move this to partials/mermaid.html */}}
 {{- if .Page.Store.Get "hasmermaid" -}}
 <script src="https://cdn.jsdelivr.net/npm/mermaid@9.2.2/dist/mermaid.min.js" integrity="sha512-IX+bU+wShHqfqaMHLMrtwi4nK6W/Z+QdZoL4kPNtRxI2wCLyHPMAdl3a43Fv1Foqv4AP+aiW6hg1dcrTt3xc+Q==" crossorigin="anonymous"></script>
+<script>
+  // Avoid rendering failures caused by hidden mermaid rendering (on Firefox in particular)
+  document.documentElement.classList.remove('no-js');
+  mermaid.initialize({
+    startOnLoad: true
+  });
+</script>
 {{- end }}
 
 {{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem -}}


### PR DESCRIPTION
Mermaid diagrams in the documentation don't render properly in the latest version of Firefox:

<img width="1291" height="313" alt="image" src="https://github.com/user-attachments/assets/eb8b1847-2fbc-47a9-9691-5069852efea5" />

This was fixed by using Codex with the following prompt:

> This is a git checkout of the source of the Kubernetes website.
> 
> There's a Mermaid rendering bug in this website. It occurs only in Firefox
> 
> * The source page is: `content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md`
> * The rendered as HTML is in: `index1.html`
> 
> When viewing this page live online, all Mermaid diagrams don't show up properly, they're mostly invisible. When viewing this page locally from a file (in the same browser sessions), the diagrams _are_ rendered correctly (still using the same Mermaid JS source from the CDN). All the page styles don't render properly of course when viewed locally this way.
> 
> As an example, take the first diagram under "one topology spread constraint". I obtained the rendered HTML as from the DOM after rendering by the Mermaid script.
> * The file `mm2` contains the DOM snippet when viewing the page online, where it doesn't work
> * The file `mm1` contains the DOM snippet when viewing the page locally from disk, where the diagram does work
> 
> Fix the bug or suggest an approach for fixing this bug.

Closes #49053