### PR TITLE
docs: add `image` volume type to Restricted Pod Security Standard

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -370,6 +370,7 @@ fail validation.
 					<li><code>spec.volumes[*].downwardAPI</code></li>
 					<li><code>spec.volumes[*].emptyDir</code></li>
 					<li><code>spec.volumes[*].ephemeral</code></li>
+					<li><code>spec.volumes[*].image</code></li>
 					<li><code>spec.volumes[*].persistentVolumeClaim</code></li>
 					<li><code>spec.volumes[*].projected</code></li>
 					<li><code>spec.volumes[*].secret</code></li>


### PR DESCRIPTION
Add `image` volume type to the list of allowed volumes in the **Restricted** Pod Security Standard.

This aligns the documentation with the code change introduced in:
- kubernetes/kubernetes#130394 (merged in 1.33+)

Addresses kubernetes/website#55370

/sig auth
/kind documentation