### PR TITLE
docs: fix max-allowable-numa-nodes value type in description

### DIFF
--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -271,7 +271,8 @@ lack of data, using this policy option with Kubernetes {{< skew currentVersion >
 at your own risk.
 {{< /note >}}
 
-You can enable this option by adding `max-allowable-numa-nodes=true` to the Topology Manager policy options.
+You can set this option by adding `max-allowable-numa-nodes=<N>` to the Topology
+Manager policy options, where `<N>` is an integer value of 8 or greater.
 
 Setting a value of `max-allowable-numa-nodes` does not (in and of itself) affect the
 latency of pod admission, but binding a Pod to a (Kubernetes) node with many NUMA does have an impact.


### PR DESCRIPTION
The documentation incorrectly stated that `max-allowable-numa-nodes`
accepts a boolean value (`=true`). According to the kubelet source in
`pkg/kubelet/cm/topologymanager/policy_options.go`, this option accepts
an integer value. The kubelet errors if the value is less than 8 and
warns if it is greater than 8, compared against `defaultMaxAllowableNUMANodes`
which defaults to 8.

Fixes #55714

/sig node
/kind documentation