### PR TITLE
Use glossary tooltip shortcode for containers on Nodes concept page

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -13,7 +13,7 @@ weight: 10
 <!-- overview -->
 
 Kubernetes runs your {{< glossary_tooltip text="workload" term_id="workload" >}}
-by placing containers into Pods to run on _Nodes_.
+by placing {{< glossary_tooltip text="containers" term_id="container" >}} into Pods to run on _Nodes_.
 A node may be a virtual or physical machine, depending on the cluster. Each node
 is managed by the
 {{< glossary_tooltip text="control plane" term_id="control-plane" >}}


### PR DESCRIPTION

### Description

This pull request adds a missing glossary link on the Nodes concept page (nodes.md). The first instance of the term "containers" on line 16 has been wrapped using the {{< glossary_tooltip >}} shortcode to link it directly to the glossary.
This update targets a standalone content page and does not conflict with the open changes in PR #55287.

### Issue
Contributes to #39792