### PR TITLE
doc: link distributed systems concept to CNCF glossary

### DIFF
--- a/content/en/docs/concepts/workloads/_index.md
+++ b/content/en/docs/concepts/workloads/_index.md
@@ -63,7 +63,7 @@ additional behaviors. Using a
 [custom resource definition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/),
 you can add in a third-party workload resource if you want a specific behavior that's not part
 of Kubernetes' core. For example, if you wanted to run a group of Pods for your application but
-stop work unless _all_ the Pods are available (perhaps for some high-throughput distributed task),
+stop work unless _all_ the Pods are available (perhaps for some high-throughput [distributed task](https://glossary.cncf.io/distributed-systems/)),
 then you can implement or install an extension that does provide that feature.
 
 ## Workload placement
@@ -103,4 +103,3 @@ for applications:
 Once your application is running, you might want to make it available on the internet as
 a [Service](/docs/concepts/services-networking/service/) or, for web application only,
 using an [Ingress](/docs/concepts/services-networking/ingress).
-


### PR DESCRIPTION
### Description

This PR selectively links the broad cloud-native concept 'distributed task' to its baseline, beginner-friendly definition on the official CNCF Cloud Native Glossary website.

By providing this external hyperlink on the Workloads overview page, new users can easily access foundational definitions without cluttering the core Kubernetes concept documentation.

### What this PR changes
- Modifies `content/en/docs/concepts/workloads/_index.md`
- Updates the phrase `distributed task` to link directly to `https://glossary.cncf.io/distributed-systems/`

### Issue

Contributes to #39792