### PR TITLE
Fix dismissable announcement banner; default-on with opt-out

### DIFF
--- a/assets/js/banner-dismiss.js
+++ b/assets/js/banner-dismiss.js
@@ -1,11 +1,13 @@
 $(document).ready(function() {
-  function setCookie(name, value, days) {
+  function setCookie(name, value, days, expiresAtUnix) {
     let expires = "";
-    let date = new Date(); // Create a new Date object
-    let dateToSecond = 24 * 60 * 60 * 1000;
+    let dayInMs = 24 * 60 * 60 * 1000;
 
-    if (days) {
-      date.setTime(date.getTime() + days * dateToSecond); // Modify the existing Date object
+    if (expiresAtUnix) {
+      expires = "; expires=" + new Date(expiresAtUnix * 1000).toUTCString();
+    } else if (days) {
+      let date = new Date();
+      date.setTime(date.getTime() + days * dayInMs);
       expires = "; expires=" + date.toUTCString();
     }
 
@@ -47,7 +49,8 @@ $(document).ready(function() {
     button.removeAttribute('style');
     button.addEventListener('click', function() {
       setCookie(tokenName, "true",
-      button.getAttribute('data-ttl')); // Set a cookie with time to live parameter
+        button.getAttribute('data-ttl'),
+        button.getAttribute('data-expires-at'));
       announcement.remove();
     });
   }

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -21,6 +21,15 @@
 #      Message *one*.
 #      [Hyperlink](https://en.wikipedia.org/wiki/Hyperlink).
 #    # message is required. You can use Markdown.
+#    dismissParameters:
+#      dismissible: true
+#      showDismissedAnnouncementAfterDays: 7
+#    # dismissParameters is optional. By default banners are sticky.
+#    # Set dismissible: true to render a dismiss button; clicking it
+#    # sets a cookie that hides the banner. If
+#    # showDismissedAnnouncementAfterDays is omitted, the cookie lives
+#    # until the banner's endTime (so dismissing hides it for the rest
+#    # of the banner's scheduled run).
 #  - name: Sample 2
 #    startTime: 2020-01-01T00:00:00
 #    endTime: 2021-04-01T00:00:00

--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -25,8 +25,13 @@
         {{ end }}
         <p>{{ .message | markdownify }}</p>
         {{- if eq .dismissParameters.dismissible true -}}
-        <button  id="banner-dismiss" class="button" style="display: none;" data-ttl={{ .dismiss_params.showDismissedAnnouncementAfterDays }}>{{ T "banner_acknowledgement" }}</button> <!-- Only JS enabled users will see this button -->
-        {{- end -}}      
+          {{- $ttlDays := .dismissParameters.showDismissedAnnouncementAfterDays -}}
+          {{- if $ttlDays -}}
+        <button id="banner-dismiss" class="button" style="display: none;" data-ttl="{{ $ttlDays }}">{{ T "banner_acknowledgement" }}</button> <!-- Only JS enabled users will see this button -->
+          {{- else -}}
+        <button id="banner-dismiss" class="button" style="display: none;" data-expires-at="{{ (time .endTime).Unix }}">{{ T "banner_acknowledgement" }}</button> <!-- Default: cookie expires at the banner's endTime. Only JS enabled users will see this button -->
+          {{- end -}}
+        {{- end -}}
       </div>
     </aside>
   </div>


### PR DESCRIPTION
The dismiss button has never rendered since #44435 , `layouts/partials/announcement.html` reads `.dismissParameters.dismissible` for the condition but `.dismiss_params.showDismissedAnnouncementAfterDays` for the TTL (mismatched key paths), and no banner has opted in.

- Aligns both reads to `.dismissParameters`.
- Defaults banners to dismissable with a 7-day cookie TTL.
- Opt-out via `dismissParameters.dismissible: false` for sticky/critical notices.


Part: #55816 