### PR TITLE
Fix badge color on release pages

### DIFF
--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -50,11 +50,11 @@
     <dt>{{ T "release_status" }}</dt>
     <dd>
       {{ if eq .Params.status "supported" }}
-      <span class="badge badge-success">{{ T "release_actively_supported" }}</span>
+      <span class="badge text-bg-primary">{{ T "release_actively_supported" }}</span>
       {{ else if eq .Params.status "maintenance" }}
-      <span class="badge badge-warning">{{ T "release_maintenance_mode" }}</span>
+      <span class="badge text-bg-secondary">{{ T "release_maintenance_mode" }}</span>
       {{ else }}
-      <span class="badge badge-danger">{{ T "release_end_of_life" }}</span>
+      <span class="badge text-bg-danger">{{ T "release_end_of_life" }}</span>
       {{ end }}
     </dd>
 


### PR DESCRIPTION
**Description**

After the Docsy 0.7 upgrade, the release status badges on release series pages stopped rendering correctly because Bootstrap was bumped from 4.x to 5.x, and the badge usage differs between versions:

Bootstrap 4.5: https://getbootstrap.com/docs/4.5/components/badge/
Bootstrap 5.3: https://getbootstrap.com/docs/5.3/components/badge/

Updated the class names in layouts/docs/release-series.html to the Bootstrap 5 equivalents.

Issue
Closes: #55825

Current:
https://kubernetes.io/releases/1.36/

Preview:
https://deploy-preview-55826--kubernetes-io-main-staging.netlify.app/releases/1.36/
https://deploy-preview-55826--kubernetes-io-main-staging.netlify.app/releases/1.33/
https://deploy-preview-55826--kubernetes-io-main-staging.netlify.app/releases/1.20/