### PR TITLE
Rework mobile navigation with Bootstrap 5 offcanvas

### DIFF
--- a/assets/icons/book.svg
+++ b/assets/icons/book.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" focusable="false">
+  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.4" d="M4.5 7.5c2.9-1.3 5.8-1.5 9-0.7v15.7c-3-0.8-5.9-0.5-9 0.9zM25.5 7.5c-2.9-1.3-5.8-1.5-9-0.7v15.7c3-0.8 5.9-0.5 9 0.9zM15 6.8v16.3"/>
+</svg>

--- a/assets/js/legacy-script.js
+++ b/assets/js/legacy-script.js
@@ -8,22 +8,6 @@
 // globals
 var body;
 
-//helper functions
-function booleanAttributeValue(element, attribute, defaultValue){
-    // returns true if an attribute is present with no value
-    // e.g. booleanAttributeValue(element, 'data-modal', false);
-    if (element.hasAttribute(attribute)) {
-        var value = element.getAttribute(attribute);
-        if (value === '' || value === 'true') {
-            return true;
-        } else if (value === 'false') {
-            return false;
-        }
-    }
-
-    return defaultValue;
-}
-
 function classOnCondition(element, className, condition) {
     if (condition)
         $(element).addClass(className);
@@ -52,36 +36,25 @@ function newDOMElement(tag, className, id){
     return el;
 }
 
-function px(n){
-    return n + 'px';
-}
-
 var kub = (function () {
-    var HEADER_HEIGHT;
-    var html, header, mainNav, quickstartButton, hero, encyclopedia, footer, headlineWrapper;
+    var html, quickstartButton, hero, encyclopedia, footer, headlineWrapper;
 
     $(document).ready(function () {
         html = $('html');
         body = $('body');
-        header = $('header');
-        mainNav = $('#mainNav');
         quickstartButton = $('#quickstartButton');
         hero = $('#hero');
         encyclopedia = $('#encyclopedia');
         footer = $('footer');
         headlineWrapper = $('#headlineWrapper');
-        HEADER_HEIGHT = header.outerHeight();
 
         resetTheView();
-
         window.addEventListener('resize', resetTheView);
         window.addEventListener('scroll', resetTheView);
-        window.addEventListener('keydown', handleKeystrokes);
 
         document.onunload = function(){
             window.removeEventListener('resize', resetTheView);
             window.removeEventListener('scroll', resetTheView);
-            window.removeEventListener('keydown', handleKeystrokes);
         };
 
         setInterval(setFooterType, 10);
@@ -118,12 +91,6 @@ var kub = (function () {
     }
 
     function resetTheView() {
-        if (html.hasClass('open-nav')) {
-            toggleMenu();
-        } else {
-            HEADER_HEIGHT = header.outerHeight();
-        }
-
         if (html.hasClass('open-toc')) {
             toggleToc();
         }
@@ -141,35 +108,6 @@ var kub = (function () {
         var quickstartBottom = quickstartButton[0].getBoundingClientRect().bottom;
 
         classOnCondition(html[0], 'y-enough', Y > quickstartBottom);
-    }
-
-    function toggleMenu() {
-        // Clickable for Bootstrap "lg" and narrower
-        if (window.innerWidth < 992) {
-            pushmenu.show('primary');
-        }
-
-        else {
-            var newHeight = HEADER_HEIGHT;
-
-            if (!html.hasClass('open-nav')) {
-                newHeight = mainNav.outerHeight();
-            }
-
-            header.css({height: px(newHeight)});
-            html.toggleClass('open-nav');
-        }
-    }
-
-    function handleKeystrokes(e) {
-        switch (e.which) {
-            case 27: {
-                if (html.hasClass('open-nav')) {
-                    toggleMenu();
-                }
-                break;
-            }
-        }
     }
 
     function showVideo() {
@@ -213,7 +151,6 @@ var kub = (function () {
 
     return {
         toggleToc: toggleToc,
-        toggleMenu: toggleMenu,
         showVideo: showVideo
     };
 })();
@@ -365,134 +302,6 @@ var kub = (function () {
     }
 })();
 
-
-var pushmenu = (function(){
-    var allPushMenus = {};
-
-    $(document).ready(function(){
-        $('[data-auto-burger]').each(function(){
-            var container = this;
-            var id = container.getAttribute('data-auto-burger');
-
-            var autoBurger = document.getElementById(id) || newDOMElement('div', 'pi-pushmenu', id);
-            var ul = autoBurger.querySelector('ul') || newDOMElement('ul');
-
-            $(container).find('a[href], button').each(function () {
-                if (!booleanAttributeValue(this, 'data-auto-burger-exclude', false)) {
-                    var clone = this.cloneNode(true);
-                    clone.id = '';
-
-                    if (clone.tagName == "BUTTON") {
-                        var aTag = newDOMElement('a');
-                        aTag.href = '';
-                        aTag.innerHTML = clone.innerHTML;
-                        aTag.onclick = clone.onclick;
-                        // Preserve data-* attributes (e.g. data-bs-theme-value) so cloned controls can be identified.
-                        for (var i = 0; i < clone.attributes.length; i++) {
-                            var attr = clone.attributes[i];
-                            if (attr.name.indexOf('data-') === 0) {
-                                aTag.setAttribute(attr.name, attr.value);
-                            }
-                        }
-                        clone = aTag;
-                    }
-                    var li = newDOMElement('li');
-                    li.appendChild(clone);
-                    ul.appendChild(li);
-                }
-            });
-
-            autoBurger.appendChild(ul);
-            body.append(autoBurger);
-        });
-
-        $(".pi-pushmenu").each(function(){
-            allPushMenus[this.id] = PushMenu(this);
-        });
-
-        // Cloned theme buttons lose Docsy's addEventListener bindings; forward clicks to the original.
-        // Capture-phase listener runs before sled.onclick's stopPropagation kills the bubble.
-        document.addEventListener('click', function (e) {
-            var target = e.target.closest('.pi-pushmenu [data-bs-theme-value]');
-            if (!target) return;
-            e.preventDefault();
-            var theme = target.getAttribute('data-bs-theme-value');
-            var original = document.querySelector('#bd-theme ~ ul [data-bs-theme-value="' + theme + '"]');
-            if (original) {
-                original.click();
-            }
-            var pushmenuEl = target.closest('.pi-pushmenu');
-            if (pushmenuEl) {
-                pushmenuEl.classList.remove('on');
-                setTimeout(function () { pushmenuEl.style.display = 'none'; }, 300);
-            }
-        }, true);
-    });
-
-    function show(objId) {
-        allPushMenus[objId].expose();
-    }
-
-    function PushMenu(el) {
-        var html = document.querySelector('html');
-
-        var overlay = newDOMElement('div', 'overlay');
-        var content = newDOMElement('div', 'content');
-        content.appendChild(el.querySelector('*'));
-
-        var side = el.getAttribute("data-side") || "right";
-
-        var sled = newDOMElement('div', 'sled');
-        $(sled).css(side, 0);
-
-        sled.appendChild(content);
-
-        var closeButton = newDOMElement('button', 'btn fa fa-times');
-        closeButton.onclick = closeMe;
-
-        sled.appendChild(closeButton);
-
-        overlay.appendChild(sled);
-        el.innerHTML = '';
-        el.appendChild(overlay);
-
-        sled.onclick = function(e){
-            e.stopPropagation();
-        };
-
-        overlay.onclick = closeMe;
-
-        window.addEventListener('resize', closeMe);
-
-        function closeMe(e) {
-            if (e.target == sled) return;
-
-            $(el).removeClass('on');
-            setTimeout(function(){
-                $(el).css({display: 'none'});
-            }, 300);
-        }
-
-        function exposeMe(){
-            $(el).css({
-                display: 'block',
-                zIndex: highestZ()
-            });
-
-            setTimeout(function(){
-                $(el).addClass('on');
-            }, 10);
-        }
-
-        return {
-            expose: exposeMe
-        };
-    }
-
-    return {
-        show: show
-    };
-})();
 
 $(function() {
     // If vendor strip doesn't exist add className

--- a/assets/js/mobile-navigation.js
+++ b/assets/js/mobile-navigation.js
@@ -1,0 +1,45 @@
+;(() => {
+  'use strict'
+
+  const setupGlobalNavBreakpointGuard = () => {
+    const offcanvasElement = document.getElementById('k8s-mobile-main-nav')
+
+    if (!offcanvasElement || !window.matchMedia || !window.bootstrap || !window.bootstrap.Offcanvas) {
+      return
+    }
+
+    // Bootstrap closes responsive offcanvases at their static breakpoint, but the
+    // global drawer uses the base `.offcanvas` class and needs an explicit guard.
+    // Read Bootstrap's emitted `lg` value to stay aligned with `d-lg-none`.
+    const bootstrapLgBreakpoint = getComputedStyle(document.documentElement)
+      .getPropertyValue('--bs-breakpoint-lg')
+      .trim()
+
+    if (!bootstrapLgBreakpoint) {
+      return
+    }
+
+    const breakpointQuery = window.matchMedia(`(min-width: ${bootstrapLgBreakpoint})`)
+
+    const hideOffcanvas = () => {
+      if (!breakpointQuery.matches) {
+        return
+      }
+
+      const offcanvas = window.bootstrap.Offcanvas.getInstance(offcanvasElement)
+      if (offcanvas) {
+        offcanvas.hide()
+      }
+    }
+
+    hideOffcanvas()
+
+    if (breakpointQuery.addEventListener) {
+      breakpointQuery.addEventListener('change', hideOffcanvas)
+    } else {
+      breakpointQuery.addListener(hideOffcanvas)
+    }
+  }
+
+  window.addEventListener('DOMContentLoaded', setupGlobalNavBreakpointGuard)
+})()

--- a/assets/js/mobile-theme-selector.js
+++ b/assets/js/mobile-theme-selector.js
@@ -1,0 +1,66 @@
+;(() => {
+  'use strict'
+
+  // Docsy manages the desktop theme selector as the source of truth. The mobile
+  // drawer delegates changes to it and mirrors its active and pressed state.
+  const setupMobileThemeSelector = () => {
+    const mobileThemeControls = document.querySelectorAll('[data-k8s-theme-value]')
+
+    if (!mobileThemeControls.length) {
+      return
+    }
+
+    // Read Docsy's stored preference so `auto` remains distinct from the resolved
+    // light or dark value in `data-bs-theme`.
+    const getCurrentTheme = () => {
+      try {
+        const storedTheme = window.localStorage.getItem('td-color-theme')
+        if (storedTheme) {
+          return storedTheme
+        }
+      } catch (error) {
+        // Fall back to the system preference when storage cannot be read.
+      }
+
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+    }
+
+    const syncMobileThemeControls = theme => {
+      for (const control of mobileThemeControls) {
+        const isActive = control.getAttribute('data-k8s-theme-value') === theme
+        control.classList.toggle('active', isActive)
+        control.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+      }
+    }
+
+    const mobileNav = document.getElementById('k8s-mobile-main-nav')
+    if (mobileNav) {
+      mobileNav.addEventListener('show.bs.offcanvas', () => {
+        syncMobileThemeControls(getCurrentTheme())
+      })
+    }
+
+    for (const control of mobileThemeControls) {
+      control.addEventListener('click', () => {
+        const theme = control.getAttribute('data-k8s-theme-value')
+        const docsyThemeControl = document.querySelector(`[data-bs-theme-value="${theme}"]`)
+
+        if (!docsyThemeControl) {
+          return
+        }
+
+        // Delegate persistence and theme changes to Docsy, then restore focus because
+        // Docsy moves it to the desktop theme trigger.
+        docsyThemeControl.click()
+        syncMobileThemeControls(theme)
+        window.setTimeout(() => control.focus(), 0)
+      })
+    }
+
+    syncMobileThemeControls(getCurrentTheme())
+  }
+
+  window.addEventListener('DOMContentLoaded', setupMobileThemeSelector)
+})()

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -302,32 +302,6 @@ footer .row > .order-2 { flex: 0 0 66.6667%; max-width: 66.6667%; }
 footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
-/* SIDE-DRAWER MENU */
-
-.pi-pushmenu .sled {
-  .content ul {
-    padding: 0;
-
-    li {
-      &:first-child {
-        display: none;
-      }
-
-      a.nav-link {
-        padding: 0;
-      }
-    }
-  }
-  .push-menu-close-button {
-    background: transparent;
-    border: none;
-
-    &:focus {
-      outline: none;
-    }
-  }
-}
-
 // Home page dark-mode
 [data-bs-theme="dark"] {
   body.cid-home {

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -36,27 +36,39 @@
     }
   }
 
-  #hamburger {
+
+  .td-navbar-mobile-menu-toggle {
     color: $navbar-dark-color;
 
-    &:hover:focus {
+    &:hover {
       color: $navbar-dark-hover-color;
     }
-    margin-right: 0.4rem;
-    margin-left: 0.4rem;
+    margin-inline: 0.4rem;
 
     position: absolute;
     top: 0.75rem;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     font-size: xx-large;
 
-    // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the hamburger button
+    // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the mobile menu button.
     &:focus,
     &:active {
-      box-shadow: none !important;
+      box-shadow: none;
     }
 
-    transition: all 0.75s;
+    &:focus:not(:focus-visible) {
+      outline: 0;
+    }
+
+    &:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: .2rem;
+    }
+
+    transition:
+      color .3s ease,
+      opacity .75s ease,
+      visibility .75s ease;
     opacity: 0;
     overflow: hidden;
     visibility: hidden;
@@ -67,8 +79,8 @@
     }
   }
 
-/* Centers logo without offset horizontally and vertically in the navbar on small / mobile viewports */
-@include media-breakpoint-down(sm) {
+/* Centers logo without offset horizontally and vertically below the desktop nav breakpoint */
+@include media-breakpoint-down(md) {
   .navbar-brand__logo {
     position: absolute;
     left: 50%;
@@ -83,7 +95,8 @@
   background: var(--bs-body-bg) !important;
   box-shadow: 0 1px 2px var(--bs-border-color);
 
-  .navbar-nav .nav-link, #hamburger {
+  .navbar-nav .nav-link,
+  .td-navbar-mobile-menu-toggle {
     color: var(--bs-body-color);
 
     &:hover, &:focus {
@@ -135,7 +148,7 @@
 .td-light-dark-menu .td-locked-theme__label {
   position: absolute;
   top: 100%;
-  right: 0;
+  inset-inline-end: 0;
   margin-top: 0.25rem;
   padding: 0.25rem 0.5rem;
   background: var(--bs-body-bg);
@@ -157,97 +170,97 @@
 
 /* Small/Mobile viewport nav menu */
 
-.pi-pushmenu {
-  display: none;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  transition: opacity 0.3s;
+.td-navbar-mobile-offcanvas {
+  --bs-offcanvas-width: min(400px, 100vw);
+  --bs-offcanvas-padding-x: 0;
+  --bs-offcanvas-padding-y: 0;
+  --bs-offcanvas-bg: var(--bs-body-bg);
 
-  &.on {
-    opacity: 1;
-
-    .sled {
-      width: 400px;
-      max-width: 100vw;
-    }
+  .offcanvas-header {
+    justify-content: flex-end;
+    min-height: 4rem;
+    padding: .75rem 1rem;
   }
 
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
+  .offcanvas-body {
+    // Leave room for Bootstrap's focus ring so it is not clipped at the drawer edges.
+    padding: var(--bs-focus-ring-width);
+  }
+
+  .td-navbar-mobile-nav {
+    margin: 0;
+    padding: 0;
+  }
+
+  .nav-item {
+    border-bottom: 1px solid var(--bs-border-color);
+  }
+
+  .nav-link,
+  .td-navbar-mobile-group-toggle,
+  .td-navbar-mobile-group-item {
+    align-items: center;
+    color: $primary;
+    display: flex;
+    font-size: 1.25rem;
+    min-height: 2.75rem;
+    padding-block: 0;
+    padding-inline: 1.25rem 3.75rem;
     width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.4);
   }
 
-  .sled {
-    position: absolute;
-    top: 0;
-    width: 0;
-    height: 100%;
-    background-color: var(--bs-body-bg);
-    overflow: auto;
-    transition: 0.3s;
+  .nav-link,
+  .td-navbar-mobile-group-toggle {
+    background: transparent;
+    border: 0;
+    text-align: start;
+  }
 
-    .content ul {
-      padding: 0;
-      margin-top: 25px;
+  .nav-link.active,
+  .nav-link .active {
+    font-weight: 600;
+  }
 
-      li {
-        position: relative;
-        display: block;
-        width: 100%;
-        min-height: 2.75rem;
-        padding: 0 60px 0 20px;
-        border-bottom: 1px solid var(--bs-border-color);
+  .td-navbar-mobile-group-toggle {
+    justify-content: space-between;
 
-        // Hides the logo that will be in the list
-        &:first-child {
-          display: none;
-        }
-
-        a {
-          display: inline-block;
-          width: 100%;
-          height: 2.75rem;
-          line-height: 2.75rem;
-          font-size: 1.25rem;
-          color: $primary;
-
-          .nav-link {
-            padding: 0;
-          }
-        }
-      }
+    .fas {
+      font-size: .875rem;
+      transition: transform .2s ease-in-out;
     }
 
-    button {
-      position: absolute;
-      top: 0;
-      right: 0;
-      font-size: xx-large;
+    &[aria-expanded="true"] .fas {
+      transform: rotate(180deg);
+    }
+  }
 
-      &:focus,
-      &:active {
-        box-shadow: none !important;
-      }
+  .td-navbar-mobile-group-menu {
+    .td-navbar-mobile-group-menu-inner {
+      padding: .25rem 0 .75rem;
     }
 
-    // Theme-switcher icons lose Docsy's .td-light-dark-menu wrapper during auto-burger cloning.
+    .td-navbar-mobile-group-item {
+      font-size: 1rem;
+      min-height: 2.25rem;
+      padding-inline-start: 2rem;
+      text-decoration: none;
+    }
+
     .bi {
       width: 1em;
       height: 1em;
       vertical-align: -.125em;
       fill: currentcolor;
     }
+  }
 
-    // Hide the cloned dropdown toggle itself; Light/Dark/Auto rows below already cover the choice.
-    .content ul li:has(> a > svg.theme-icon-active) {
-      display: none;
+  button.td-navbar-mobile-group-item {
+    background: transparent;
+    border: 0;
+    text-align: start;
+
+    &[aria-pressed="true"] {
+      font-weight: 600;
     }
   }
 }

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -36,6 +36,65 @@
     }
   }
 
+  .td-navbar-mobile-page-toggle {
+    align-items: center;
+    border: 0;
+    color: $navbar-dark-color;
+    display: flex;
+    height: 2.75rem;
+    justify-content: center;
+    inset-inline-start: 0.75rem;
+    margin-inline: 0.4rem;
+    opacity: 0;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    top: 0.75rem;
+    transition:
+      color .3s ease,
+      opacity .75s ease,
+      visibility .75s ease;
+    visibility: hidden;
+    width: 2.75rem;
+
+    &:hover {
+      color: $navbar-dark-hover-color;
+    }
+
+    .td-navbar-mobile-page-toggle-icon {
+      align-items: center;
+      display: flex;
+      height: 2em;
+      justify-content: center;
+      width: 1.7em;
+
+      svg {
+        display: block;
+        height: 1.6em;
+        width: 1.6em;
+      }
+    }
+
+    // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the mobile menu button.
+    &:focus,
+    &:active {
+      box-shadow: none;
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: 0;
+    }
+
+    &:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: .2rem;
+    }
+
+    @include media-breakpoint-down(lg) {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
 
   .td-navbar-mobile-menu-toggle {
     color: $navbar-dark-color;
@@ -96,6 +155,7 @@
   box-shadow: 0 1px 2px var(--bs-border-color);
 
   .navbar-nav .nav-link,
+  .td-navbar-mobile-page-toggle,
   .td-navbar-mobile-menu-toggle {
     color: var(--bs-body-color);
 
@@ -261,6 +321,81 @@
 
     &[aria-pressed="true"] {
       font-weight: 600;
+    }
+  }
+}
+
+.td-navbar-mobile-page-offcanvas {
+  --bs-offcanvas-width: min(400px, 100vw);
+  --bs-offcanvas-padding-x: 0;
+  --bs-offcanvas-padding-y: 0;
+  --bs-offcanvas-bg: var(--bs-body-bg);
+
+  // Docsy uses an undefined Bootstrap background variable at md and above;
+  // keep the responsive drawer opaque until it becomes the persistent sidebar.
+  background-color: var(--bs-offcanvas-bg);
+
+  @include media-breakpoint-down(md) {
+    // Docsy adds this inset at md and above; extend it through smaller drawers.
+    padding-top: 4rem;
+  }
+
+  @include media-breakpoint-up(lg) {
+    // Bootstrap sets `.offcanvas-lg` to `background-color: transparent !important`
+    // at lg and above, so this override also requires `!important` to restore the
+    // persistent Docsy sidebar background.
+    background-color: var(--bs-tertiary-bg) !important;
+  }
+
+  @include media-breakpoint-down(lg) {
+    .offcanvas-header {
+      justify-content: space-between;
+      min-height: 4rem;
+      padding: .75rem 1rem;
+    }
+
+    .offcanvas-body {
+      padding: 0 1.25rem 1rem;
+    }
+
+    .td-sidebar__inner {
+      height: auto;
+      position: static;
+    }
+
+    .td-sidebar__search {
+      background: var(--bs-body-bg);
+      margin-inline: -1.25rem;
+      padding: .25rem 1.25rem 1rem;
+      position: sticky;
+      top: 0;
+      z-index: 2;
+    }
+
+    .td-sidebar__toggle {
+      display: none;
+    }
+
+    // The language row uses Bootstrap's `.d-block`, which sets `display` with
+    // `!important`; this declaration must match it to hide the row below lg.
+    .td-sidebar-nav > .nav-item.dropdown {
+      display: none !important;
+    }
+
+    .td-search-box {
+      width: 100%;
+    }
+
+    .td-sidebar-nav {
+      display: block;
+      margin-inline: 0;
+      max-height: none;
+      overflow: visible;
+      padding-inline-end: 0;
+    }
+
+    .td-sidebar-nav > .td-sidebar-nav__section {
+      padding-inline-start: 0;
     }
   }
 }

--- a/assets/scss/_k8s_sidebar-tree.scss
+++ b/assets/scss/_k8s_sidebar-tree.scss
@@ -8,14 +8,129 @@
   }
 }
 
-// Hidden in dropdowns, visible when cloned into the mobile push menu
-.dropdown-menu .lang-pushmenu-only {
-  display: none;
-}
-
 .td-sidebar-link__page {
   &#m-docs-test {
     display: none;
+  }
+}
+
+nav.foldable-nav {
+  &#td-section-nav {
+    position: relative;
+
+    label {
+      margin-bottom: 0;
+      width: 100%;
+    }
+
+    .td-sidebar-nav__section-toggle {
+      background: transparent;
+      border: 0;
+      color: inherit;
+      cursor: pointer;
+      font: inherit;
+      padding-block: 0;
+      padding-inline-end: 0;
+      text-align: start;
+      width: 100%;
+
+      &:focus-visible {
+        outline: 2px solid $primary;
+        outline-offset: .125rem;
+      }
+    }
+
+    .ul-1 > li,
+    .with-child,
+    .without-child {
+      padding-inline-start: 0;
+    }
+
+    .with-child ul {
+      margin-inline-start: .75rem;
+    }
+
+    .ul-1 .with-child,
+    .ul-1 .without-child {
+      margin-block: .18rem;
+    }
+
+    .ul-1 .with-child > label,
+    .ul-1 .with-child > .td-sidebar-nav__section-toggle,
+    .ul-1 .without-child > label {
+      align-items: center;
+      display: flex;
+      min-height: 2.5rem;
+      padding-inline-start: 2.75rem;
+      position: relative;
+    }
+
+    .ul-1 .with-child > label::before {
+      align-items: center;
+      background: transparent;
+      border: 1px solid var(--bs-border-color);
+      border-radius: 50%;
+      box-sizing: border-box;
+      display: inline-flex;
+      height: 2.25rem;
+      justify-content: center;
+      inset-inline-start: 0;
+      padding: 0;
+      top: .125rem;
+      transition:
+        background-color .15s ease,
+        border-color .15s ease,
+        color .15s ease,
+        transform .2s ease;
+      width: 2.25rem;
+    }
+
+    .ul-1 .with-child > .td-sidebar-nav__section-toggle > .td-sidebar-nav__section-toggle-icon {
+      align-items: center;
+      background: transparent;
+      border: 1px solid var(--bs-border-color);
+      border-radius: 50%;
+      box-sizing: border-box;
+      display: inline-flex;
+      height: 2.25rem;
+      justify-content: center;
+      inset-inline-start: 0;
+      position: absolute;
+      top: .125rem;
+      transition:
+        background-color .15s ease,
+        border-color .15s ease,
+        color .15s ease,
+        transform .2s ease;
+      width: 2.25rem;
+    }
+
+    .ul-1 .with-child > label:hover::before,
+    .ul-1 .with-child > label:focus-within::before {
+      border-color: $primary;
+      color: $primary;
+    }
+
+    .ul-1 .with-child > .td-sidebar-nav__section-toggle:hover > .td-sidebar-nav__section-toggle-icon,
+    .ul-1 .with-child > .td-sidebar-nav__section-toggle:focus-visible > .td-sidebar-nav__section-toggle-icon {
+      border-color: $primary;
+      color: $primary;
+    }
+
+    // Highlight and rotate the disclosure control when its section is expanded.
+    .ul-1 .with-child > input:checked ~ label::before {
+      background: rgba($primary, .1);
+      border-color: $primary;
+      color: $primary;
+      transform: rotate(90deg);
+    }
+
+    .ul-1 .with-child > .td-sidebar-nav__section-toggle[aria-expanded="true"] > .td-sidebar-nav__section-toggle-icon {
+      background: rgba($primary, .1);
+      border-color: $primary;
+      color: $primary;
+      transform: rotate(90deg);
+    }
   }
 }
 

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -744,8 +744,20 @@ other = "Synopsis"
 [tab_default]
 other = "Tab {{ . }}"
 
+[theme_auto]
+other = "Auto"
+
+[theme_dark]
+other = "Dark"
+
+[theme_light]
+other = "Light"
+
 [theme_locked_notice]
 other = "Theme fixed for this page"
+
+[theme_menu]
+other = "Theme"
 
 [thirdparty_message]
 other = """This section links to third party projects that provide functionality required by Kubernetes. The Kubernetes project authors aren't responsible for these projects, which are listed alphabetically. To add a project to this list, read the <a href="/docs/contribute/style/content-guide/#third-party-content">content guide</a> before submitting a change. <a href="#third-party-content-disclaimer">More information.</a>"""
@@ -771,8 +783,17 @@ other = "Copied to clipboard: "
 [translated_by]
 other = "Translated By"
 
+[ui_close_navigation]
+other = "Close navigation"
+
+[ui_navigation]
+other = "Navigation"
+
 [ui_search]
 other = "Search this site"
+
+[ui_toggle_navigation]
+other = "Toggle navigation"
 
 [version_check_mustbe]
 other = "Your Kubernetes server must be version "

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -729,6 +729,9 @@ other = "RSS"
 [seealso_heading]
 other = "See Also"
 
+[sidebar_navigation]
+other = "Section navigation"
+
 [sidebar_toggle_nav]
 other = "Toggle section navigation"
 

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -24,10 +24,13 @@
     <div class="container-fluid td-outer">
       <div class="td-main">
         <div class="row flex-xl-nowrap">
-          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
-            {{ partial "blog/sidebar.html" . }}
+          <aside class="offcanvas-lg offcanvas-start col-lg-3 col-xl-2 td-sidebar d-print-none td-navbar-mobile-page-offcanvas" tabindex="-1" id="k8s-mobile-page-nav" aria-labelledby="k8s-mobile-page-nav-label">
+            {{ partialCached "page-navigation-offcanvas-header.html" . .Language.Lang }}
+            <div class="offcanvas-body d-block w-100">
+              {{ partial "blog/sidebar.html" . }}
+            </div>
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main"
+          <main class="col-12 col-lg-9 col-xl-8 ps-lg-5 pe-md-4" role="main"
               {{ if .IsPage }}data-pagefind-body data-pagefind-meta="date:{{  $.Date.Format "2006-01-02" }}"{{ end }}
             ><!-- inside main element -->
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -13,8 +13,11 @@
     <div class="container-fluid td-outer">
       <div class="td-main">
         <div class="row flex-xl-nowrap">
-          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
-            {{ partial "sidebar.html" . }}
+          <aside class="offcanvas-lg offcanvas-start col-lg-3 col-xl-2 td-sidebar d-print-none td-navbar-mobile-page-offcanvas" tabindex="-1" id="k8s-mobile-page-nav" aria-labelledby="k8s-mobile-page-nav-label">
+            {{ partialCached "page-navigation-offcanvas-header.html" . .Language.Lang }}
+            <div class="offcanvas-body d-block w-100">
+              {{ partial "sidebar.html" . }}
+            </div>
           </aside>
           <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
             {{/* Partial "docs/api-reference-links" determines API reference links for 'partial/page-meta-links.html' */}}
@@ -22,7 +25,7 @@
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 ps-md-5" {{ if ne .Params.cid "docsHome" }}data-pagefind-body{{ end }}{{ if (and .IsPage .Params.description ) }} data-pagefind-meta="description:{{ .Params.description }}"{{ end }}>
+          <main class="col-12 col-lg-9 col-xl-8 ps-lg-5" {{ if ne .Params.cid "docsHome" }}data-pagefind-body{{ end }}{{ if (and .IsPage .Params.description ) }} data-pagefind-meta="description:{{ .Params.description }}"{{ end }}>
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "deprecation_warning" . }}
               {{ partial "version-banner.html" . }}

--- a/layouts/partials/blog-sidebar-tree.html
+++ b/layouts/partials/blog-sidebar-tree.html
@@ -50,15 +50,19 @@ sidebar-tree in use elsewhere on the site. */}}
     {{ $year := .Key }}
     {{ $mid := printf "m-%s-%s" ($s.RelPermalink | anchorize) ($year) -}}
     {{ $active := and (not $shouldDelayActive) (in .Pages $p) -}}
+    {{ $foldable := and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1) -}}
+    {{ $postsID := printf "%s-posts" $mid -}}
     <li class="td-sidebar-nav__section-title td-sidebar-nav__section with-child{{ if $active }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
-      {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
-      <input type="checkbox" id="{{ $mid }}-check"{{ if $active}} checked{{ end }}/>
-      <label for="{{ $mid }}-check"><span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $year }}</span></label>
+      {{ if $foldable -}}
+      <button class="td-sidebar-nav__section-toggle{{ if not $active }} collapsed{{ end }}" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $postsID }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}" aria-controls="{{ $postsID }}">
+        <span class="td-sidebar-nav__section-toggle-icon fas fa-caret-right" aria-hidden="true"></span>
+        <span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $year }}</span>
+      </button>
       {{ else -}}
       {{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $year }}</span>
       {{- end }}
       {{- $ulNr := 2 }}
-      <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
+      <ul{{ if $foldable }} id="{{ $postsID }}"{{ end }} class="ul-{{ $ulNr }}{{ if $foldable }} collapse{{ if $active }} show{{ end }}{{ else if (gt $ulNr 1) }} foldable{{ end }}">
         {{ range .Pages -}}
         {{ $mid := printf "m-%s" (.RelPermalink | anchorize) -}}
         {{ $active := and (not $shouldDelayActive) (eq . $p) -}}

--- a/layouts/partials/blog/sidebar.html
+++ b/layouts/partials/blog/sidebar.html
@@ -12,6 +12,8 @@
     $("#td-section-nav #{{ $mid }}").parents("li").addClass("active-path");
     $("#td-section-nav li.active-path").addClass("show");
     $("#td-section-nav li.active-path").children("input").prop('checked', true);
+    $("#td-section-nav li.active-path").children(".td-sidebar-nav__section-toggle").removeClass("collapsed").attr("aria-expanded", "true");
+    $("#td-section-nav li.active-path").children("ul.collapse").addClass("show");
     $("#td-section-nav #{{ $mid }}-li").siblings("li").addClass("show");
     $("#td-section-nav #{{ $mid }}-li").children("ul").children("li").addClass("show");
     $("#td-sidebar-menu").toggleClass("d-none");

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -5,32 +5,24 @@
      if possible, simplified to align with the default upstream configuration.
      See: https://github.com/google/docsy/pull/2303
      Related PR: https://github.com/kubernetes/website/pull/53804 -->
-{{ $currentLang := .Language.Lang }}
-{{ $translationMap := dict }}
-{{ range .Translations }}
-  {{ $translationMap = merge $translationMap (dict .Language.Lang .) }}
-{{ end }}
-{{ $homeMap := dict }}
-{{ range .Site.Home.Translations }}
-  {{ $homeMap = merge $homeMap (dict .Language.Lang .) }}
-{{ end }}
+{{ $languageOptions := partial "navbar-language-options.html" . }}
 <div class="dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {{ .Language.LanguageName }}
   </a>
   <ul class="dropdown-menu dropdown-menu-end">
     {{ range site.Languages }}
-        {{- if ne .Lang $currentLang -}}
-            {{- with index $translationMap .Lang -}}
+        {{- if ne .Lang $languageOptions.currentLang -}}
+            {{- with index $languageOptions.translationMap .Lang -}}
                 <li><a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
             {{- end }}
         {{- end }}
     {{- end }} 
     {{ range site.Languages }}
-        {{- if and (ne .Lang $currentLang) (not (index $translationMap .Lang)) }}
+        {{- if and (ne .Lang $languageOptions.currentLang) (not (index $languageOptions.translationMap .Lang)) }}
             <li>
                 <span class="dropdown-item text-muted" title="{{ T "page_not_available_in_language" (dict "Language" .LanguageName) }}">
-                    {{ with index $homeMap .Lang }}
+                    {{ with index $languageOptions.homeMap .Lang }}
                         {{ .Language.LanguageName }}
                         <a href="{{ .RelPermalink }}" class="ms-1" data-auto-burger-exclude><i class="fas fa-home fa-xs"></i></a>
                     {{- end }}

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -5,34 +5,26 @@
      if possible, simplified to align with the default upstream configuration.
      See: https://github.com/google/docsy/pull/2303
      Related PR: https://github.com/kubernetes/website/pull/53804 -->
-{{ $currentLang := .Language.Lang }}
-{{ $translationMap := dict }}
-{{ range .Translations }}
-  {{ $translationMap = merge $translationMap (dict .Language.Lang .) }}
-{{ end }}
-{{ $homeMap := dict }}
-{{ range .Site.Home.Translations }}
-  {{ $homeMap = merge $homeMap (dict .Language.Lang .) }}
-{{ end }}
+{{ $languageOptions := partial "navbar-language-options.html" . }}
 <div class="dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {{ .Language.LanguageName }}
   </a>
   <ul class="dropdown-menu dropdown-menu-end">
     {{ range site.Languages }}
-        {{- if ne .Lang $currentLang -}}
-            {{- with index $translationMap .Lang -}}
+        {{- if ne .Lang $languageOptions.currentLang -}}
+            {{- with index $languageOptions.translationMap .Lang -}}
                 <li><a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
             {{- end }}
         {{- end }}
     {{- end }} 
     {{ range site.Languages }}
-        {{- if and (ne .Lang $currentLang) (not (index $translationMap .Lang)) }}
+        {{- if and (ne .Lang $languageOptions.currentLang) (not (index $languageOptions.translationMap .Lang)) }}
             <li>
                 <span class="dropdown-item text-muted" title="{{ T "page_not_available_in_language" (dict "Language" .LanguageName) }}">
-                    {{ with index $homeMap .Lang }}
+                    {{ with index $languageOptions.homeMap .Lang }}
                         {{ .Language.LanguageName }}
-                        <a href="{{ .RelPermalink }}" class="ms-1" data-auto-burger-exclude><i class="fas fa-home fa-xs"></i></a>
+                        <a href="{{ .RelPermalink }}" class="ms-1"><i class="fas fa-home fa-xs"></i></a>
                     {{- end }}
                 </span>
             </li>

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -24,7 +24,7 @@
                 <span class="dropdown-item text-muted" title="{{ T "page_not_available_in_language" (dict "Language" .LanguageName) }}">
                     {{ with index $languageOptions.homeMap .Lang }}
                         {{ .Language.LanguageName }}
-                        <a href="{{ .RelPermalink }}" class="ms-1" data-auto-burger-exclude><i class="fas fa-home fa-xs"></i></a>
+                        <a href="{{ .RelPermalink }}" class="ms-1"><i class="fas fa-home fa-xs"></i></a>
                     {{- end }}
                 </span>
             </li>

--- a/layouts/partials/navbar-language-options.html
+++ b/layouts/partials/navbar-language-options.html
@@ -1,0 +1,17 @@
+{{/*
+  Build page-specific lookups shared by all language selector renderers.
+*/}}
+{{- $page := . -}}
+{{- $translationMap := dict -}}
+{{- range .Translations -}}
+  {{- $translationMap = merge $translationMap (dict .Language.Lang .) -}}
+{{- end -}}
+{{- $homeMap := dict -}}
+{{- range .Site.Home.Translations -}}
+  {{- $homeMap = merge $homeMap (dict .Language.Lang .) -}}
+{{- end -}}
+{{- return (dict
+  "currentLang" $page.Language.Lang
+  "translationMap" $translationMap
+  "homeMap" $homeMap
+) -}}

--- a/layouts/partials/navbar-mobile-lang-selector.html
+++ b/layouts/partials/navbar-mobile-lang-selector.html
@@ -1,0 +1,30 @@
+{{- if gt (len .Site.Home.Translations) 0 -}}
+  {{- $languageOptions := partial "navbar-language-options.html" . -}}
+  <li class="nav-item td-navbar-mobile-group">
+    <button class="nav-link td-navbar-mobile-group-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#k8s-mobile-main-nav-languages" aria-expanded="false" aria-controls="k8s-mobile-main-nav-languages">
+      <span>{{ .Language.LanguageName }}</span>
+      <i class="fas fa-chevron-down" aria-hidden="true"></i>
+    </button>
+    <div id="k8s-mobile-main-nav-languages" class="collapse td-navbar-mobile-group-menu">
+      <div class="td-navbar-mobile-group-menu-inner">
+        {{- range site.Languages }}
+          {{- if ne .Lang $languageOptions.currentLang }}
+            {{- with index $languageOptions.translationMap .Lang }}
+              <a class="td-navbar-mobile-group-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- range site.Languages }}
+          {{- if and (ne .Lang $languageOptions.currentLang) (not (index $languageOptions.translationMap .Lang)) }}
+            {{- with index $languageOptions.homeMap .Lang }}
+              <span class="td-navbar-mobile-group-item text-muted" title="{{ T "page_not_available_in_language" (dict "Language" .Language.LanguageName) }}">
+                {{ .Language.LanguageName }}
+                <a href="{{ .RelPermalink }}" class="ms-1"><i class="fas fa-home fa-xs" aria-hidden="true"></i><span class="visually-hidden">{{ .Language.LanguageName }}</span></a>
+              </span>
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      </div>
+    </div>
+  </li>
+{{- end }}

--- a/layouts/partials/navbar-mobile-offcanvas.html
+++ b/layouts/partials/navbar-mobile-offcanvas.html
@@ -1,0 +1,32 @@
+<div class="offcanvas offcanvas-end d-lg-none d-print-none td-navbar-mobile-offcanvas" tabindex="-1" id="k8s-mobile-main-nav" aria-labelledby="k8s-mobile-main-nav-label">
+  <div class="offcanvas-header">
+    <h2 class="offcanvas-title visually-hidden" id="k8s-mobile-main-nav-label">{{ T "ui_navigation" }}</h2>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="{{ T "ui_close_navigation" }}"></button>
+  </div>
+  <div class="offcanvas-body">
+    <nav aria-label="{{ T "ui_navigation" }}">
+      <ul class="navbar-nav td-navbar-mobile-nav">
+        {{- $page := . }}
+        {{- range .Site.Menus.main }}
+        <li class="nav-item">
+          {{- $active := or ($page.IsMenuCurrent "main" .) ($page.HasMenuCurrent "main" .) }}
+          {{- with .Page }}
+            {{- $active = or $active ($page.IsDescendant .) }}
+          {{- end }}
+          {{- $pre := .Pre }}
+          {{- $post := .Post }}
+          {{- $url := urls.Parse .URL }}
+          {{- $baseurl := urls.Parse $page.Site.Params.Baseurl }}
+          <a class="nav-link{{ if $active }} active{{ end }}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre }}{{ $pre }}{{ end }}<span{{ if $active }} class="active"{{ end }}>{{ .Title }}</span>{{ with .Post }}{{ $post }}{{ end }}</a>
+        </li>
+        {{- end }}
+        {{/* Keep uncached because version_menu_pagelinks can make version links page-relative. */}}
+        {{- partial "navbar-mobile-version-selector.html" . }}
+        {{/* Language availability and fallback URLs depend on the current page. */}}
+        {{- partial "navbar-mobile-lang-selector.html" . }}
+        {{/* Theme output varies by language and the page's theme lock. */}}
+        {{- partialCached "navbar-mobile-theme-selector.html" . .Language.Lang (.Params.theme_lock | default "unlocked") }}
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/layouts/partials/navbar-mobile-offcanvas.html
+++ b/layouts/partials/navbar-mobile-offcanvas.html
@@ -1,0 +1,31 @@
+<div class="offcanvas offcanvas-end d-lg-none d-print-none td-navbar-mobile-offcanvas" tabindex="-1" id="k8s-mobile-main-nav" aria-labelledby="k8s-mobile-main-nav-label">
+  <div class="offcanvas-header">
+    <h2 class="offcanvas-title visually-hidden" id="k8s-mobile-main-nav-label">{{ T "ui_navigation" }}</h2>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="{{ T "ui_close_navigation" }}"></button>
+  </div>
+  <div class="offcanvas-body">
+    <nav aria-label="{{ T "ui_navigation" }}">
+      <ul class="navbar-nav td-navbar-mobile-nav">
+        {{- $page := . }}
+        {{- range .Site.Menus.main }}
+        <li class="nav-item">
+          {{- $active := or ($page.IsMenuCurrent "main" .) ($page.HasMenuCurrent "main" .) }}
+          {{- with .Page }}
+            {{- $active = or $active ($page.IsDescendant .) }}
+          {{- end }}
+          {{- $pre := .Pre }}
+          {{- $post := .Post }}
+          {{- $url := urls.Parse .URL }}
+          {{- $baseurl := urls.Parse $page.Site.Params.Baseurl }}
+          <a class="nav-link{{ if $active }} active{{ end }}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre }}{{ $pre }}{{ end }}<span{{ if $active }} class="active"{{ end }}>{{ .Title }}</span>{{ with .Post }}{{ $post }}{{ end }}</a>
+        </li>
+        {{- end }}
+        {{- partial "navbar-mobile-version-selector.html" . }}
+        {{/* Language availability and fallback URLs depend on the current page. */}}
+        {{- partial "navbar-mobile-lang-selector.html" . }}
+        {{/* Theme output varies by language and the page's theme lock. */}}
+        {{- partialCached "navbar-mobile-theme-selector.html" . .Language.Lang (.Params.theme_lock | default "unlocked") }}
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/layouts/partials/navbar-mobile-theme-selector.html
+++ b/layouts/partials/navbar-mobile-theme-selector.html
@@ -1,0 +1,32 @@
+{{- if .Site.Params.ui.showLightDarkModeMenu -}}
+  {{- with .Params.theme_lock }}
+    <li class="nav-item">
+      <span class="td-navbar-mobile-group-item text-muted" title="{{ T "theme_locked_notice" }}">
+        {{ T "theme_locked_notice" }}
+      </span>
+    </li>
+  {{- else }}
+    <li class="nav-item td-navbar-mobile-group">
+      <button class="nav-link td-navbar-mobile-group-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#k8s-mobile-main-nav-theme" aria-expanded="false" aria-controls="k8s-mobile-main-nav-theme">
+        <span>{{ T "theme_menu" }}</span>
+        <i class="fas fa-chevron-down" aria-hidden="true"></i>
+      </button>
+      <div id="k8s-mobile-main-nav-theme" class="collapse td-navbar-mobile-group-menu">
+        <div class="td-navbar-mobile-group-menu-inner">
+          <button type="button" class="td-navbar-mobile-group-item" data-k8s-theme-value="light" aria-pressed="false">
+            <svg class="bi me-2" aria-hidden="true"><use href="#sun-fill"></use></svg>
+            {{ T "theme_light" }}
+          </button>
+          <button type="button" class="td-navbar-mobile-group-item" data-k8s-theme-value="dark" aria-pressed="false">
+            <svg class="bi me-2" aria-hidden="true"><use href="#moon-stars-fill"></use></svg>
+            {{ T "theme_dark" }}
+          </button>
+          <button type="button" class="td-navbar-mobile-group-item" data-k8s-theme-value="auto" aria-pressed="false">
+            <svg class="bi me-2" aria-hidden="true"><use href="#circle-half"></use></svg>
+            {{ T "theme_auto" }}
+          </button>
+        </div>
+      </div>
+    </li>
+  {{- end }}
+{{- end }}

--- a/layouts/partials/navbar-mobile-version-selector.html
+++ b/layouts/partials/navbar-mobile-version-selector.html
@@ -1,0 +1,20 @@
+{{- if .Site.Params.versions -}}
+  {{- $versionPath := "" -}}
+  {{- if .Site.Params.version_menu_pagelinks -}}
+    {{- $versionPath = .Page.RelPermalink -}}
+  {{- end -}}
+  <li class="nav-item td-navbar-mobile-group">
+    <button class="nav-link td-navbar-mobile-group-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#k8s-mobile-main-nav-versions" aria-expanded="false" aria-controls="k8s-mobile-main-nav-versions">
+      <span>{{ T "version_menu" }}</span>
+      <i class="fas fa-chevron-down" aria-hidden="true"></i>
+    </button>
+    <div id="k8s-mobile-main-nav-versions" class="collapse td-navbar-mobile-group-menu">
+      <div class="td-navbar-mobile-group-menu-inner">
+        <a class="td-navbar-mobile-group-item" href="{{ "releases" | relLangURL }}">{{ i18n "release_information_navbar" . }}</a>
+        {{- range .Site.Params.versions }}
+        <a class="td-navbar-mobile-group-item" href="{{ .url }}{{ $versionPath }}">{{ .version }}</a>
+        {{- end }}
+      </div>
+    </div>
+  </li>
+{{- end }}

--- a/layouts/partials/navbar-mobile-version-selector.html
+++ b/layouts/partials/navbar-mobile-version-selector.html
@@ -1,0 +1,20 @@
+{{- if .Site.Params.versions -}}
+  {{- $versionPath := "" -}}
+  {{- if .Site.Params.version_menu_pagelinks -}}
+    {{- $versionPath = .Page.RelPermalink -}}
+  {{- end -}}
+  {{- $options := partialCached "navbar-version-options.html" . .Language.Lang $versionPath -}}
+  <li class="nav-item td-navbar-mobile-group">
+    <button class="nav-link td-navbar-mobile-group-toggle collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#k8s-mobile-main-nav-versions" aria-expanded="false" aria-controls="k8s-mobile-main-nav-versions">
+      <span>{{ T "version_menu" }}</span>
+      <i class="fas fa-chevron-down" aria-hidden="true"></i>
+    </button>
+    <div id="k8s-mobile-main-nav-versions" class="collapse td-navbar-mobile-group-menu">
+      <div class="td-navbar-mobile-group-menu-inner">
+        {{- range $options }}
+        <a class="td-navbar-mobile-group-item" href="{{ .url }}">{{ .label }}</a>
+        {{- end }}
+      </div>
+    </div>
+  </li>
+{{- end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -4,7 +4,7 @@
 -}}
 
 <nav class="js-navbar-scroll navbar navbar-expand
-            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark" data-auto-burger="primary">
+            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
@@ -20,7 +20,7 @@
     </span>
     {{- /**/ -}}
   </a>
-  <div class="td-navbar-nav-scroll d-none d-md-block ms-xl-auto" id="main_navbar">
+  <div class="td-navbar-nav-scroll d-none d-lg-block ms-xl-auto" id="main_navbar">
     {{- /* In Docsy, the mt-2 class is used but that causes issues. This should be re-visited after 0.7 migration */ -}}
     <ul class="navbar-nav mt-lg-0">
     {{ $p := . }}
@@ -78,9 +78,13 @@
   <div class="navbar-nav d-none k8s-1500-block">
     {{ partial "search-input.html" . }}
   </div>
-  {{- /*
-    The menu overlay is added to the DOM and shown/hidden all by JS.
-    We should explore a Hugo way of doing this.
-  */ -}}
-  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" data-auto-burger-exclude></button>
+  <button
+    class="btn td-navbar-mobile-menu-toggle fas fa-bars d-lg-none"
+    type="button"
+    data-bs-toggle="offcanvas"
+    data-bs-target="#k8s-mobile-main-nav"
+    aria-controls="k8s-mobile-main-nav"
+    aria-label="{{ T "ui_toggle_navigation" }}">
+  </button>
 </nav>
+{{ partial "navbar-mobile-offcanvas.html" . }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -2,9 +2,25 @@
     (.HasShortcode "blocks/cover")
     (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
+{{ $showPageDrawer := partial "page-navigation-enabled.html" . -}}
 
 <nav class="js-navbar-scroll navbar navbar-expand
             {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark">
+  {{- if $showPageDrawer -}}
+  <button
+    class="btn td-navbar-mobile-page-toggle d-lg-none"
+    type="button"
+    data-bs-toggle="offcanvas"
+    data-bs-target="#k8s-mobile-page-nav"
+    aria-controls="k8s-mobile-page-nav"
+    aria-label="{{ T "sidebar_toggle_nav" }}">
+    <span class="td-navbar-mobile-page-toggle-icon" aria-hidden="true">
+      {{- with resources.Get "icons/book.svg" -}}
+        {{- (. | minify).Content | safeHTML -}}
+      {{- end -}}
+    </span>
+  </button>
+  {{- end -}}
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">

--- a/layouts/partials/page-navigation-enabled.html
+++ b/layouts/partials/page-navigation-enabled.html
@@ -1,0 +1,5 @@
+{{/*
+  Keep this predicate aligned with the docs and blog HTML base templates,
+  which render #k8s-mobile-page-nav.
+*/}}
+{{- return (or (eq .Type "docs") (eq .Type "blog")) -}}

--- a/layouts/partials/page-navigation-offcanvas-header.html
+++ b/layouts/partials/page-navigation-offcanvas-header.html
@@ -1,0 +1,8 @@
+{{/*
+  This partial is cached by language. If its output gains another dependency,
+  add that value to each partialCached call's variants.
+*/}}
+<div class="offcanvas-header">
+  <h2 class="offcanvas-title h5" id="k8s-mobile-page-nav-label">{{ T "sidebar_navigation" }}</h2>
+  <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#k8s-mobile-page-nav" aria-label="{{ T "ui_close_navigation" }}"></button>
+</div>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -33,9 +33,12 @@
 {{ else if .Site.Params.customSearch }}
 {{ $jsSearch = resources.Get "js/custom-search.js" }}
 {{ end }}
-{{ $jsArray := slice $jsBs $jsBase $jsNav $jsSearch -}}
+{{ $jsMobileNavigation := resources.Get "js/mobile-navigation.js" -}}
+{{ $jsArray := slice $jsBs $jsBase $jsNav $jsSearch $jsMobileNavigation -}}
 {{ if .Site.Params.ui.showLightDarkModeMenu -}}
   {{ $jsArray = $jsArray | append (resources.Get "js/dark-mode.js") -}}
+  {{/* Load the mobile theme bridge after Docsy's theme script. */ -}}
+  {{ $jsArray = $jsArray | append (resources.Get "js/mobile-theme-selector.js") -}}
 {{ end -}}
 {{ $js := $jsArray | resources.Concat "js/main.js" -}}
 {{ if hugo.IsProduction -}}


### PR DESCRIPTION
## Description

This PR reworks mobile navigation around Bootstrap 5 Offcanvas following the Docsy 0.11 upgrade.

Below the `lg` breakpoint, the global menu uses a right-side offcanvas and docs and blog section navigation uses a left-side offcanvas. At `lg` and above, the standard navbar and persistent page sidebar are displayed. The page drawer and desktop sidebar use the same `<aside>` and navigation tree.

The goals are:

1. Make mobile documentation navigation easier to access, with distinct global and section-navigation controls, sticky search, and clear disclosure targets.
2. Reduce maintenance of drawer lifecycle and accessibility behavior by relying on Bootstrap for visibility, backdrops, dismissal, and focus management instead of a custom pushmenu implementation.
3. Keep mobile and desktop page navigation synchronized without rendering duplicate sidebar trees.

This implements the Bootstrap direction discussed in #54635 and supersedes the earlier approach in #55189.

Closes #22021.
Addresses #53998.

## What's changed

- Uses Bootstrap Offcanvas for drawer lifecycle behavior instead of a custom pushmenu implementation.
- Provides a right-side global navigation offcanvas below `lg`.
- Shows the global hamburger below `lg` and the desktop navbar at `lg` and above.
- Renders Versions, Languages, and Theme as collapsed groups in the global drawer.
- Provides a left-side page-navigation offcanvas for docs and blog pages below `lg`.
- Uses the existing docs and blog sidebar `<aside>` for both the drawer and persistent desktop sidebar.
- Keeps sidebar search sticky at the top of the page drawer while the section tree scrolls.
- Uses an opened-book icon to distinguish the page-navigation trigger from the global hamburger.
- Uses Bootstrap color variables so both drawers follow light and dark themes.
- Uses logical CSS properties for RTL layouts.
- Provides localized drawer labels, close controls, focus management, and pressed-state synchronization for theme choices.
- Provides larger circular sidebar disclosure targets with visible hover, focus, and expanded states.
- Uses real buttons with `aria-expanded` for collapsible blog year sections.
- Organizes the global drawer, selector groups, and page-drawer controls into focused Hugo partials.
- Reuses shared cached version options and page-specific language lookups across the desktop and mobile selectors.
- Keeps global breakpoint handling and mobile theme synchronization in separate JavaScript assets.

## Implementation notes

The docs and blog base templates render their sidebar `<aside>` with Bootstrap's `.offcanvas-lg` and `.offcanvas-start` classes. Below `lg`, Bootstrap presents that element as a drawer. At `lg` and above, the same element is the persistent sidebar.

This produces one navigation tree with one set of IDs, active states, and sidebar partials. No second tree is rendered or cloned.

The global drawer is rendered by `navbar-mobile-offcanvas.html`. Its Versions, Languages, and Theme groups use dedicated selector partials. `navbar-language-options.html` builds the page-specific language lookup maps shared by the desktop and mobile language selectors.

The desktop and mobile version selectors share version-link data from `navbar-version-options.html`. The options are cached by language and resolved version path so `version_menu_pagelinks` remains correct.

`page-navigation-enabled.html` determines whether the page-navigation trigger is available. `page-navigation-offcanvas-header.html` provides the shared localized header for the docs and blog drawers.

Page-dependent navigation and language output is uncached. Version options are cached by language and resolved version path. The mobile Theme partial is cached by language and page theme-lock state. The shared page-drawer header is cached by language.

`mobile-navigation.js` reads Bootstrap's emitted `lg` breakpoint and closes the global drawer when desktop navigation takes over. `mobile-theme-selector.js` delegates theme application and persistence to Docsy and synchronizes the mobile controls with that state.

## AI assistance

I used LLM-based tools to support scoping, architecture exploration, code generation, and review. I directed the implementation, selected the final single-tree responsive offcanvas architecture, reviewed every resulting change, and manually validated the behavior. I understand and take responsibility for the complete diff.

I personally read and evaluate every review comment and decide the substance of each response. I use LLM-based tools to help draft and refine the wording, then personally review and submit every response. I understand and take responsibility for every statement I make in review.