### PR TITLE
Add visible sort indicators to sortable tables

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -172,6 +172,28 @@ table td.value-not-applicable {
   text-align: center;
 }
 
+/* Styles for sortable tables */
+.sortable-table thead th[aria-sort]::after {
+  content: "\2195";
+  display: inline-block;
+  margin-left: 0.35rem;
+  font-size: 0.85em;
+  line-height: 1;
+}
+
+.sortable-table thead th[aria-sort="ascending"]::after {
+  content: "\2191";
+}
+
+.sortable-table thead th[aria-sort="descending"]::after {
+  content: "\2193";
+}
+
+[dir="rtl"] .sortable-table thead th[aria-sort]::after {
+  margin-right: 0.35rem;
+  margin-left: 0;
+}
+
 // <details> shortcode
 
 details > summary {


### PR DESCRIPTION
## Summary
- Adds visible indicators to sortable table headers
- Shows ↕ for sortable columns, ↑ for ascending sort, and ↓ for descending sort
- Uses existing aria-sort state from sortable-table.js
- Adds RTL spacing support for localized pages

Fixes #55766

## Testing
- git diff --check

Could not run a full Hugo build locally because submodules were not initialized and Hugo/Docker are not installed in this environment.