### PR TITLE
Enable dismiss on KubeCon India 2026 banner

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -327,6 +327,8 @@ announcements:
 - name: KubeCon 2026 India
   startTime: 2026-05-18T00:00:00
   endTime: 2026-06-19T18:00:00
+  dismissParameters:
+    dismissible: true
   style: >-
     background: linear-gradient(90deg, #eeb32d 0%, #f5d4a1 100%);
     color: #000000;


### PR DESCRIPTION
Depends on #55820.

Enables the dismiss button on the active KubeCon India 2026 banner by setting `dismissParameters.dismissible: true`. 

With #55820's default behavior, the cookie expires at the banner's `endTime` (2026-06-19), so dismissing it hides it for the rest of the scheduled run.

Closes #55816.