### PR TITLE
Clarify nodes/proxy access to privileged kubelet APIs

### DIFF
--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -146,6 +146,10 @@ This access bypasses audit logging and admission control, so care should be take
 granting any rights to this resource.
 These APIs can be exercised via websocket HTTP `GET` requests, which only requires authorization of the **get** verb.
 This means that **get** permission on `nodes/proxy` is not a read-only permission.
+For example, permission to **get** `nodes/proxy` provides access to privileged kubelet
+APIs that can retrieve container logs or execute and attach to pod processes,
+even when a caller does not have the equivalent permissions through the
+Kubernetes API.
 
 See [Kubelet authentication/authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/#get-nodes-proxy-warning)
 for more information.


### PR DESCRIPTION
This PR clarifies the existing warning about the nodes/proxy subresource.

It adds a short example explaining that permission to get nodes/proxy provides access to privileged kubelet APIs that can retrieve container logs or execute and attach to pod processes, even when the caller does not have the equivalent permissions through the Kubernetes API.

This is documentation-only and does not change behavior.

This supersedes #55828, which was closed after the branch temporarily picked up an incorrect large diff. The branch has now been reset and the diff is limited to the intended documentation change.