### PR TITLE
docs: fix duplicate "the" in custom-resources storage sentence

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -266,7 +266,7 @@ Installing an Aggregated API server always involves running a new Deployment.
 Custom resources consume storage space in the same way that ConfigMaps do. Creating too many
 custom resources may overload your API server's storage space.
 
-Custom resources are placed into storage based upon the the current storage
+Custom resources are placed into storage based upon the current storage
 version of the resource, defined in the CRD spec. Any update to a custom
 resource will use the currently defined storage version to store the resource.
 All other versions either need to have all the fields of that version or define


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `the` in the [Custom Resources concept docs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) — `placed into storage based upon the the current storage` → `placed into storage based upon the current storage`.

## Why

Cleaner read on the published docs page.

## How verified

Single-word edit, no structural change. Re-read the paragraph after the change to confirm it still parses.

## Maintainer note

Feel free to close if not worth the review cycle. Commit is signed off per DCO.
