### PR TITLE
Make probes section on Pod lifecycle page lighter

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -786,148 +786,61 @@ to automatically manage Pod resource recommendations and updates.
 
 ## Container probes
 
-A _probe_ is a diagnostic performed periodically by the [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
-on a container. To perform a diagnostic, the kubelet either executes code within the container,
-or makes a network request.
+Kubernetes lets you define _probes_ to continuously monitor the health
+of containers in a Pod. A probe is a diagnostic performed periodically
+by the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} on a container.
+To perform a diagnostic, the kubelet either executes code within
+the container or makes a network request.
 
-### Check mechanisms {#probe-check-methods}
-
-There are four different ways to check a container using a probe.
-Each probe must define exactly one of these four mechanisms:
-
-`exec`
-: Executes a specified command inside the container. The diagnostic
-  is considered successful if the command exits with a status code of 0.
-
-`grpc`
-: Performs a remote procedure call using [gRPC](https://grpc.io/).
-  The target should implement
-  [gRPC health checks](https://grpc.io/grpc/core/md_doc_health-checking.html).
-  The diagnostic is considered successful if the `status`
-  of the response is `SERVING`.  
-
-`httpGet`
-: Performs an HTTP `GET` request against the Pod's IP
-  address on a specified port and path. The diagnostic is
-  considered successful if the response has a status code
-  greater than or equal to 200 and less than 400. See
-  [Configure Probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes)
-  for more information on how the kubelet follows redirects.
-
-`tcpSocket`
-: Performs a TCP check against the Pod's IP address on
-  a specified port. The diagnostic is considered successful if
-  the port is open. If the remote system (the container) closes
-  the connection immediately after it opens, this counts as healthy.
-
-{{< caution >}}
-Unlike the other mechanisms, `exec` probe's implementation involves
-the creation/forking of multiple processes each time when executed.
-As a result, in case of the clusters having higher pod densities,
-lower intervals of `initialDelaySeconds`, `periodSeconds`,
-configuring any probe with exec mechanism might introduce an overhead on the cpu usage of the node.
-In such scenarios, consider using the alternative probe mechanisms to avoid the overhead.
-{{< /caution >}}
-
-### Probe outcome
-
-Each probe has one of three results:
-
-`Success`
-: The container passed the diagnostic.
-
-`Failure`
-: The container failed the diagnostic.
-
-`Unknown`
-: The diagnostic failed (no action should be taken, and the kubelet
-  will make further checks).
-
-### Types of probe
+Based on the probe results, Kubernetes can restart unhealthy containers
+or stop sending traffic to containers that are not ready.
 
 The kubelet can optionally perform and react to three kinds of probes on running
-containers:
+containers, each serving a different purpose. For probe mechanisms (`exec`,
+`grpc`, `httpGet`, `tcpSocket`), configuration fields, and detailed usage
+guidance, see [Liveness, Readiness, and Startup Probes](/docs/concepts/workloads/pods/probes/).
 
-`livenessProbe`
-: Indicates whether the container is running. If
-  the liveness probe fails, the kubelet kills the container, and the container
-  is subjected to its [restart policy](#restart-policy). If a container does not
-  provide a liveness probe, the default state is `Success`.
+### Startup probe
 
-`readinessProbe`
-: Indicates whether the container is ready to respond to requests.
-  If the readiness probe fails, the {{< glossary_tooltip term_id="endpoint-slice" text="EndpointSlice" >}}
-  controller removes the Pod's IP address from the EndpointSlices of all Services that match the Pod.
-  The default state of readiness before the initial delay is `Failure`. If a container does
-  not provide a readiness probe, the default state is `Success`.
+Startup probes verify whether the application within a container is started.
+If a startup probe is configured, Kubernetes does not execute liveness or
+readiness probes until the startup probe succeeds, allowing the application
+time to finish its initialization.
 
-`startupProbe`
-: Indicates whether the application within the container is started.
-  All other probes are disabled if a startup probe is provided, until it succeeds.
-  If the startup probe fails, the kubelet kills the container, and the container
-  is subjected to its [restart policy](#restart-policy). If a container does not
-  provide a startup probe, the default state is `Success`.
+This type of probe is only executed at startup, unlike liveness and readiness
+probes, which are run periodically.
 
-For more information about how to set up a liveness, readiness, or startup probe,
-see [Configure Liveness, Readiness and Startup Probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+If the startup probe fails, the kubelet kills the container, and the container
+is subjected to its [restart policy](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy).
 
-#### When should you use a liveness probe?
+### Liveness probe
 
-If the process in your container is able to crash on its own whenever it
-encounters an issue or becomes unhealthy, you do not necessarily need a liveness
-probe; the kubelet will automatically perform the correct action in accordance
-with the Pod's `restartPolicy`.
+Liveness probes determine when to restart a container.
+For example, liveness probes could catch a deadlock, where an application is
+running, but unable to make progress. Restarting a container in such a state
+can help to make the application more available despite bugs.
 
-If you'd like your container to be killed and restarted if a probe fails, then
-specify a liveness probe, and specify a `restartPolicy` of Always or OnFailure.
+If a container fails its liveness probe more times than the configured tolerance,
+the kubelet restarts that container.
+Liveness probes do not wait for readiness probes to succeed. If you want to
+wait before executing a liveness probe, you can either define
+`initialDelaySeconds` or use a startup probe.
 
-#### When should you use a readiness probe?
+### Readiness probe
 
-If you'd like to start sending traffic to a Pod only when a probe succeeds,
-specify a readiness probe. In this case, the readiness probe might be the same
-as the liveness probe, but the existence of the readiness probe in the spec means
-that the Pod will start without receiving any traffic and only start receiving
-traffic after the probe starts succeeding.
+Readiness probes determine when a container is ready to accept traffic.
+This is useful when waiting for an application to perform time-consuming initial
+tasks, such as establishing network connections, loading files, and warming
+caches.
+Readiness probes can also be useful later in the container's lifecycle,
+for example, when recovering from temporary faults or overloads.
 
-If you want your container to be able to take itself down for maintenance, you
-can specify a readiness probe that checks an endpoint specific to readiness that
-is different from the liveness probe.
+If the readiness probe returns a failed state, the
+{{< glossary_tooltip text="EndpointSlice" term_id="endpoint-slice" >}}
+controller removes the Pod's IP address from the EndpointSlices of all Services
+that match the Pod.
 
-If your app has a strict dependency on back-end services, you can implement both
-a liveness and a readiness probe. The liveness probe passes when the app itself
-is healthy, but the readiness probe additionally checks that each required
-back-end service is available. This helps you avoid directing traffic to Pods
-that can only respond with error messages.
-
-If your container needs to work on loading large data, configuration files, or
-migrations during startup, you can use a
-[startup probe](#when-should-you-use-a-startup-probe). However, if you want to
-detect the difference between an app that has failed and an app that is still
-processing its startup data, you might prefer a readiness probe.
-
-{{< note >}}
-If you want to be able to drain requests when the Pod is deleted, you do not
-necessarily need a readiness probe; when the Pod is deleted, the corresponding endpoint
-in the `EndpointSlice` will update its [conditions](/docs/concepts/services-networking/endpoint-slices/#conditions):
-the endpoint `ready` condition will be set to `false`, so load balancers
-will not use the Pod for regular traffic. See [Pod termination](#pod-termination)
-for more information about how the kubelet handles Pod deletion.
-{{< /note >}}
-
-#### When should you use a startup probe?
-
-Startup probes are useful for Pods that have containers that take a long time to
-come into service. Rather than set a long liveness interval, you can configure
-a separate configuration for probing the container as it starts up, allowing
-a time longer than the liveness interval would allow.
-
-<!-- ensure front matter contains math: true -->
-If your container usually starts in more than
-\\( initialDelaySeconds + failureThreshold \times  periodSeconds \\), you should specify a
-startup probe that checks the same endpoint as the liveness probe. The default for
-`periodSeconds` is 10s. You should then set its `failureThreshold` high enough to
-allow the container to start, without changing the default values of the liveness
-probe. This helps to protect against deadlocks.
+Readiness probes run on the container during its whole lifecycle.
 
 ## Termination of Pods {#pod-termination}
 


### PR DESCRIPTION
### Description

Since the probes page covers probe details, this PR slims down the probes section on the Pod lifecycle page to keep only the basic information.

### Issue

Part of #55251

Preview: https://deploy-preview-55863--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/pods/pod-lifecycle/#container-probes