### PR TITLE
Add (automatic) hyperlinks from API reference pages to concept docs that reference them

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -41,6 +41,46 @@ div.feature-state-notice {
   max-width: 80%;
 }
 
+div.api-reference-header-note {
+  background-color: $api-infobox-shown;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1em;
+
+  font-size: 1.1em;
+
+  details > summary, details[open] > summary { 
+    color: $black;
+    font-size: 1rem;
+    margin: 0;
+  }
+  
+  ul {
+    list-style-type: none;
+    > li {
+      margin-top: 1rem;
+
+      div:has(> a) {
+        font-size: 1.4em;
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+      }
+      .concept-page-toc ol > li {
+        list-style: "";
+      }
+    }
+  }
+}
+
+div.api-reference-header-note:not(:has(details[open])) {
+  background-color: $api-infobox;
+}
+
+div.api-reference-header-note.empty {
+  visibility: hidden;
+}
+
+
 .includecode .highlight {
   margin-top: 0;
   margin-bottom: 0;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -19,6 +19,10 @@ $navbar-dark-active-color: $primary;
 $feature: #daeaf9;
 $feature-inset: #eeeeee;
 
+// API infobox colors
+$api-infobox: hsl(209, 0%, 92%);
+$api-infobox-shown: hsl(209, 72%, 92%);
+
 // metrics reference colors
 $metric-labels-varying: #efefef;
 $metric-labels-varying-border: #e2e2e2;

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -6,6 +6,10 @@
 [api_reference_title]
 other = "API reference"
 
+[api_reference_page_related_concepts]
+one = "Concept documentation for {{ .title }}"
+other = "Related concept pages"
+
 [auto_generated_edit_notice]
 other = "(auto-generated page)"
 

--- a/layouts/docs/content.html
+++ b/layouts/docs/content.html
@@ -11,6 +11,9 @@
     {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
       {{ partial "reading-time.html" . }}
     {{ end }}
+    {{- if (eq .Params.content_type "api_reference") -}}
+    {{ partial "docs/api-reference-header-note.html" . }}
+    {{- end -}}
   </header>
   {{ .Content }}
   {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) }}

--- a/layouts/partials/docs/api-reference-header-note.html
+++ b/layouts/partials/docs/api-reference-header-note.html
@@ -1,0 +1,45 @@
+{{- $referenceApiVersion := .Params.api_metadata.apiVersion -}} {{- $referenceApiType := .Params.api_metadata.kind -}}
+{{- $allInboundConceptPages := partialCached "docs/api-reference-hyperlink-map.gotemplate" (.Site.GetPage "section" "docs/concepts" ) -}}
+{{- $thisPageInboundConceptPages := slice -}}
+{{- range $index, $page := $allInboundConceptPages -}}
+  {{- $matched := false -}}
+  {{- range $page.Params.api_metadata -}}
+    {{- if (and (eq .apiVersion $referenceApiVersion) (eq .kind $referenceApiType )) -}}
+      {{- $thisPageInboundConceptPages = $thisPageInboundConceptPages | append $page -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $pageUrl := slice -}}
+
+<div class="api-reference-header-note{{ if eq (len $thisPageInboundConceptPages) 0 }} empty{{ end }}">
+  {{- if gt (len $thisPageInboundConceptPages) 0 -}}
+  <details open>
+   <summary>{{ T "api_reference_page_related_concepts" (dict "count" (len $thisPageInboundConceptPages) "title" .Title) }}</summary>
+   <ul class="concept-page-list">
+     {{- range $thisPageInboundConceptPages -}}
+     <li>
+       <div><a href="{{ .RelPermalink }}">{{ .Title}}</a></div>
+       {{- $pageUrl = .RelPermalink -}}
+       {{- with .Description -}}
+       <p class="concept-page-description">{{ . }}</p>
+       {{- end -}}
+       <div class="concept-page-toc">
+        {{- with .Fragments -}}
+          <ol>
+          {{- range .Headings -}}
+            {{- range .Headings -}}
+              {{- if eq .Level 2 -}}
+              <li><a href="{{ $pageUrl }}#{{ .ID }}">{{ .Title }}</a></li>
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+          </ol>
+        {{- end -}}
+       </div>
+     </li> 
+     {{- end -}}
+   </ul>
+  </details>
+  {{- end -}}
+</div>

--- a/layouts/partials/docs/api-reference-hyperlink-map.gotemplate
+++ b/layouts/partials/docs/api-reference-hyperlink-map.gotemplate
@@ -1,0 +1,29 @@
+{{- $base := . -}}
+{{- $sectionsForBase := $base.Sections -}}
+
+
+{{- $regularPagesWithApiReferenceLinks := where $base.RegularPages "Params.api_metadata" "ne" nil -}}
+
+{{- $sectionsWithApiReferenceFrontMatter := slice -}}
+{{- range $sectionsForBase.ByWeight -}}
+   {{- if and .IsSection (.Page.Params.api_metadata) -}}
+     {{- $sectionsWithApiReferenceFrontMatter = $sectionsWithApiReferenceFrontMatter | collections.Append . -}}
+   {{- end -}}
+{{- end -}}
+
+{{- $childPagesWithApiReferenceFrontMatter := slice -}}
+{{- $specificMatchedChildren := slice -}}
+{{- range $sectionsForBase.ByWeight -}}
+  {{ $specificMatchedChildren = partial "docs/api-reference-hyperlink-map.gotemplate" .Page }}
+  {{ $childPagesWithApiReferenceFrontMatter = $childPagesWithApiReferenceFrontMatter | collections.Append $specificMatchedChildren }}
+{{- end -}}
+
+
+{{- $pagesWithApiReferenceFrontMatter := slice -}}
+{{- range $sectionsWithApiReferenceFrontMatter -}}
+  {{- $pagesWithApiReferenceFrontMatter = $pagesWithApiReferenceFrontMatter | collections.Append .Page -}}
+{{- end -}}
+{{- $pagesWithApiReferenceFrontMatter = $pagesWithApiReferenceFrontMatter | collections.Append $childPagesWithApiReferenceFrontMatter -}}
+{{- $pagesWithApiReferenceFrontMatter = $pagesWithApiReferenceFrontMatter | collections.Append $regularPagesWithApiReferenceLinks -}}
+
+{{- return $pagesWithApiReferenceFrontMatter -}}


### PR DESCRIPTION
- Discover all the concept pages that reference an API
- Render back links, from the API reference page to each referring concept page
  If there are multiple referring pages, handle that.

## Comparison

### Before

https://k8s.io/docs/reference/kubernetes-api/apps/deployment-v1/

<img width="204" height="161" alt="Screenshot showing the Deployment API reference before the change. There is no blue-background infobox." src="https://github.com/user-attachments/assets/7bf2f9da-f576-47ca-bb81-95256893ebcc" />


### After

https://deploy-preview-55864--kubernetes-io-main-staging.netlify.app/docs/reference/kubernetes-api/apps/deployment-v1/

<img width="204" height="161" alt="Screenshot showing the Deployment API reference after the change. There is now a blue-background infobox." src="https://github.com/user-attachments/assets/8fb43689-fd08-4c68-8ca4-e663388431ef" />


/area web-development