### PR TITLE
Allow search engines to crawl API reference

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -6,8 +6,4 @@ Disallow: /v1.1/
 Disallow: /404/
 Disallow: /404.html
 
-Allow: /docs/reference/kubernetes-api/api-index/
-Allow: /docs/reference/kubernetes-api/labels-annotations-taints/
-Disallow: /docs/reference/kubernetes-api/
-
 SITEMAP: {{ "sitemap.xml" | absLangURL }}


### PR DESCRIPTION
Allow web crawlers to take a look at https://kubernetes.io/docs/reference/kubernetes-api/

We recently merged https://github.com/kubernetes/website/pull/55758
Given that, I feel like our reference is easily done enough that we should allow this crawling.

/area web-development