### PR TITLE
Add Spanish training index page for Kubernetes certification and courses

### DIFF
--- a/content/es/training/_index.html
+++ b/content/es/training/_index.html
@@ -171,7 +171,7 @@ menu:
   <div class="main-section two-thirds-centered">
     <div>
       <h2>Socios de capacitación de Kubernetes</h2>
-      <p>Nuestra red de Socios de capacitación de Kubernetes proporciona servicios de capacitación para Kubernetes y proyectos nativos de la nube.</p>
+      <p>Nuestra red de Kubernetes Training Partners proporciona servicios de capacitación para Kubernetes y proyectos nativos de la nube.</p>
     </div>
   </div>
   <div class="main-section landscape-section">

--- a/content/es/training/_index.html
+++ b/content/es/training/_index.html
@@ -63,7 +63,7 @@ menu:
           <h5>
             <b>Introducción a las Tecnologías de Infraestructura en la Nube</b>
           </h5>
-          <p>Aprende los fundamentos de la construcción y gestión de tecnologías en la nube directamente de The Linux Foundation, líder en código abierto.</p>
+          <p>Aprende los fundamentos de la construcción y gestión de tecnologías en la nube directamente de la Linux Foundation, líder en código abierto.</p>
           <br>
           <a href="https://www.edx.org/course/introduction-to-cloud-infrastructure-technologies" target="_blank" class="button">Ir al curso</a>
         </div>

--- a/content/es/training/_index.html
+++ b/content/es/training/_index.html
@@ -112,7 +112,7 @@ menu:
           <b>Kubernetes and Cloud Native Security Associate (KCSA)</b>
         </h5>
         <p>El KCSA es una certificación pre-profesional diseñada para candidatos interesados en avanzar al nivel profesional a través de una comprensión demostrada de los conocimientos y habilidades fundamentales de las tecnologías de seguridad en el ecosistema nativo de la nube.</p>
-        <p>Un KCSA certificado confirmará la comprensión de la configuración de seguridad base de los clústeres de Kubernetes para cumplir con los objetivos de cumplimiento.</p>
+        <p>Un certificado KCSA confirmará la comprensión de la configuración de seguridad básica de los clústeres de Kubernetes para cumplir con los objetivos de cumplimiento.</p>
         <br>
         <a href="https://training.linuxfoundation.org/certification/kubernetes-and-cloud-native-security-associate-kcsa/" target="_blank" class="button">Ir a la Certificación</a>
     </div>

--- a/content/es/training/_index.html
+++ b/content/es/training/_index.html
@@ -155,7 +155,7 @@ menu:
     <div class="call-to-action" id="cta-kubestronaut">
       <div class="cta-text">
         <h2>Programa Kubestronaut: Eleva tu experiencia en Kubernetes</h2>
-        <p> El Programa Kubestronaut de la CNCF celebra y reconoce a líderes comunitarios excepcionales que han demostrado un profundo compromiso con el dominio de Kubernetes. Esta prestigiosa iniciativa destaca a individuos que han invertido constantemente en su educación continua y han alcanzado los más altos niveles de competencia. Para obtener el estimado título de Kubestronaut, los individuos deben obtener y mantener con éxito las cinco certificaciones de Kubernetes de la CNCF: Certified Kubernetes Administrator (CKA), Certified Kubernetes Application Developer (CKAD), Certified Kubernetes Security Specialist (CKS), Kubernetes and Cloud Native Associate (KCNA), y Kubernetes and Cloud Native Security Associate (KCSA). </p>
+        <p> El Programa Kubestronaut de la CNCF celebra y reconoce a líderes comunitarios excepcionales que han demostrado un profundo compromiso con el dominio de Kubernetes. Esta prestigiosa iniciativa destaca a individuos que han invertido constantemente en su educación continua y han alcanzado los más altos niveles de competencia. Para obtener el anhelado título de Kubestronaut, los individuos deben obtener y mantener con éxito las cinco certificaciones de Kubernetes de la CNCF: Certified Kubernetes Administrator (CKA), Certified Kubernetes Application Developer (CKAD), Certified Kubernetes Security Specialist (CKS), Kubernetes and Cloud Native Associate (KCNA), y Kubernetes and Cloud Native Security Associate (KCSA). </p>
       </div>
       <div class="cta-img-container">
         <div class="logo-certification cta-image" id="logo-kubestronaut">

--- a/content/es/training/_index.html
+++ b/content/es/training/_index.html
@@ -1,0 +1,180 @@
+---
+title: Capacitación
+bigheader: Capacitación y Certificación de Kubernetes
+abstract: Programas de capacitación, certificaciones y socios.
+layout: basic
+cid: training
+class: training
+body_class: training
+# Once all localizations have migrated, we can drop the training_styles_migrated
+# field and simplify the CSS code.
+training_styles_migrated: true
+menu:
+  main:
+    weight: 30
+---
+
+<section class="call-to-action">
+  <div class="main-section">
+    <div class="call-to-action" id="cta-certification">
+      <div class="cta-text">
+        <h2>Construye tu carrera en la nube nativa</h2>
+        <p>Kubernetes es el núcleo del movimiento de la nube nativa. Los programas de capacitación y las certificaciones de la Linux Foundation y nuestros socios de capacitación te permiten invertir en tu carrera, aprender Kubernetes y hacer que tus proyectos de nube nativa sean exitosos.</p>
+      </div>
+      <div class="cta-img-container">
+        <div class="logo-certification cta-image" id="logo-kcnf">
+          <img src="/images/training/kubernetes-kcnf-white.svg" />
+        </div>
+        <div class="logo-certification cta-image" id="logo-kcsa">
+          <img src="/images/training/kubernetes-cksa-white.svg" />
+        </div>
+        <div class="logo-certification cta-image" id="logo-cka">
+          <img src="/images/training/kubernetes-cka-white.svg"/>
+        </div>
+        <div class="logo-certification cta-image" id="logo-ckad">
+          <img src="/images/training/kubernetes-ckad-white.svg"/>
+        </div>
+        <div class="logo-certification cta-image" id="logo-cks">
+          <img src="/images/training/kubernetes-cks-white.svg"/>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="main-section padded">
+    <div>
+      <h2>Toma un curso gratuito en edX</h2>
+    </div>
+    <div class="col-container">
+      <div class="col-nav">
+        <div>
+          <h5>
+            <b>Introducción a Kubernetes <br> &nbsp;</b>
+          </h5>
+          <p>¿Quieres aprender Kubernetes? Obtén una introducción profunda a este potente sistema para gestionar aplicaciones contenerizadas.</p>
+          <br>
+          <a href="https://www.edx.org/course/introduction-to-kubernetes" target="_blank" class="button">Ir al curso</a>
+        </div>
+      </div>
+      <div class="col-nav">
+        <div>
+          <h5>
+            <b>Introducción a las Tecnologías de Infraestructura en la Nube</b>
+          </h5>
+          <p>Aprende los fundamentos de la construcción y gestión de tecnologías en la nube directamente de The Linux Foundation, líder en código abierto.</p>
+          <br>
+          <a href="https://www.edx.org/course/introduction-to-cloud-infrastructure-technologies" target="_blank" class="button">Ir al curso</a>
+        </div>
+      </div>
+      <div class="col-nav">
+        <div>
+          <h5>
+            <b>Introducción a Linux</b>
+          </h5>
+          <p>¿Nunca aprendiste Linux? ¿Quieres un repaso? Desarrolla un buen conocimiento práctico de Linux utilizando tanto la interfaz gráfica como la línea de comandos en las principales familias de distribuciones de Linux.</p>
+          <br>
+          <a href="https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">Ir al curso</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="padded lighter-gray-bg">
+  <div class="main-section two-thirds-centered">
+    <div>
+      <h2>Aprende con la Linux Foundation</h2>
+      <p>La Linux Foundation ofrece cursos dirigidos por instructores y a tu propio ritmo para todos los aspectos del desarrollo de aplicaciones y el ciclo de vida de las operaciones de Kubernetes.</p>
+      <br/><br/>
+      <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">Ver cursos</a>
+    </div>
+  </div>
+</div>
+
+<section id="get-certified">
+  <div class="main-section padded">
+    <h2>Obtén la Certificación de Kubernetes</h2>
+    <div class="col-container">
+      <div class="col-nav">
+        <h5>
+          <b>Kubernetes and Cloud Native Associate (KCNA)</b>
+        </h5>
+        <p>El examen Kubernetes and Cloud Native Associate (KCNA) demuestra el conocimiento y las habilidades fundamentales de un usuario en Kubernetes y el ecosistema nativo de la nube en general.</p>
+        <p>Un KCNA certificado confirmará el conocimiento conceptual de todo el ecosistema nativo de la nube, centrándose particularmente en Kubernetes.</p>
+        <br>
+        <a href="https://training.linuxfoundation.org/certification/kubernetes-cloud-native-associate/" target="_blank" class="button">Ir a la Certificación</a>
+      </div>
+      <div class="col-nav">
+
+        <h5>
+          <b>Kubernetes and Cloud Native Security Associate (KCSA)</b>
+        </h5>
+        <p>El KCSA es una certificación pre-profesional diseñada para candidatos interesados en avanzar al nivel profesional a través de una comprensión demostrada de los conocimientos y habilidades fundamentales de las tecnologías de seguridad en el ecosistema nativo de la nube.</p>
+        <p>Un KCSA certificado confirmará la comprensión de la configuración de seguridad base de los clústeres de Kubernetes para cumplir con los objetivos de cumplimiento.</p>
+        <br>
+        <a href="https://training.linuxfoundation.org/certification/kubernetes-and-cloud-native-security-associate-kcsa/" target="_blank" class="button">Ir a la Certificación</a>
+    </div>
+      <div class="col-nav">
+          <h5>
+            <b>Certified Kubernetes Application Developer (CKAD)</b>
+          </h5>
+          <p>El examen Certified Kubernetes Application Developer certifica que los usuarios pueden diseñar, construir, configurar y exponer aplicaciones nativas de la nube para Kubernetes.</p>
+          <p>Un CKAD puede definir recursos de aplicación y usar primitivas básicas para construir, monitorear y solucionar problemas de aplicaciones y herramientas escalables en Kubernetes.</p>
+          <br>
+          <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/" target="_blank" class="button">Ir a la Certificación</a>
+      </div>
+      <div class="col-nav">
+          <h5>
+            <b>Certified Kubernetes Administrator (CKA)</b>
+          </h5>
+
+          <p>El programa Certified Kubernetes Administrator (CKA) asegura que los CKA tienen las habilidades, el conocimiento y la competencia para desempeñar las responsabilidades de los administradores de Kubernetes.</p>
+          <p>Un administrador de Kubernetes certificado ha demostrado la capacidad de realizar la instalación básica, así como de configurar y gestionar clústeres de Kubernetes de nivel de producción.</p>
+          <br>
+          <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Ir a la Certificación</a>
+      </div>
+      <div class="col-nav">
+          <h5>
+            <b>Certified Kubernetes Security Specialist (CKS)</b>
+          </h5>
+
+          <p>El programa Certified Kubernetes Security Specialist asegura que el titular se siente cómodo y competente con una amplia gama de mejores prácticas. La certificación CKS cubre habilidades para asegurar aplicaciones basadas en contenedores y plataformas Kubernetes durante la construcción, implementación y tiempo de ejecución.</p>
+          <p><em>Los candidatos para CKS deben poseer una certificación Certified Kubernetes Administrator (CKA) actual para demostrar que poseen suficiente experiencia en Kubernetes antes de presentarse al CKS.</em></p>
+          <br>
+          <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/" target="_blank" class="button">Ir a la Certificación</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section class="call-to-action">
+  <div class="main-section">
+    <div class="call-to-action" id="cta-kubestronaut">
+      <div class="cta-text">
+        <h2>Programa Kubestronaut: Eleva tu experiencia en Kubernetes</h2>
+        <p> El Programa Kubestronaut de la CNCF celebra y reconoce a líderes comunitarios excepcionales que han demostrado un profundo compromiso con el dominio de Kubernetes. Esta prestigiosa iniciativa destaca a individuos que han invertido constantemente en su educación continua y han alcanzado los más altos niveles de competencia. Para obtener el estimado título de Kubestronaut, los individuos deben obtener y mantener con éxito las cinco certificaciones de Kubernetes de la CNCF: Certified Kubernetes Administrator (CKA), Certified Kubernetes Application Developer (CKAD), Certified Kubernetes Security Specialist (CKS), Kubernetes and Cloud Native Associate (KCNA), y Kubernetes and Cloud Native Security Associate (KCSA). </p>
+      </div>
+      <div class="cta-img-container">
+        <div class="logo-certification cta-image" id="logo-kubestronaut">
+          <img src="/images/training/kubestronaut-stacked-color.svg" />
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<div class="padded lighter-gray-bg">
+  <div class="main-section two-thirds-centered">
+    <div>
+      <h2>Socios de capacitación de Kubernetes</h2>
+      <p>Nuestra red de Socios de capacitación de Kubernetes proporciona servicios de capacitación para Kubernetes y proyectos nativos de la nube.</p>
+    </div>
+  </div>
+  <div class="main-section landscape-section">
+    {{< cncf-landscape helpers=false category="special--kubernetes-and-cloud-native-training-partner" >}}
+  </div>
+</div>


### PR DESCRIPTION
This pull request creates the Spanish translation for the `content/en/training/_index.html` file,
  located at `content/es/training/_index.html`. This provides the training section of the website in
  Spanish.