### PR TITLE
Fix broken Gateway API spec link

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -278,5 +278,5 @@ you quickly start working with Gateway API.
 Make sure to review the documentation of your selected implementation to understand any caveats.
 {{< /note >}}
 
-Refer to the [API specification](https://gateway-api.sigs.k8s.io/reference/spec/) for additional
+Refer to the [API specification](https://gateway-api.sigs.k8s.io/references/spec/) for additional
 details of all Gateway API kinds.


### PR DESCRIPTION
### Description
Fixes a broken Gateway API specs link in the Gateway docs page. The previous URL returned HTTP 404 and has been updated to the correct working reference URL.

### Issue
Closes: #55880