### PR TITLE
Bump builder image for local preview image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   machineType: 'E2_HIGHCPU_8'
 steps:
     # It's fine to bump the tag to a recent version, as needed
-  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220830-45cbff55bc"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491"
     entrypoint: 'bash'
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
When we build a container image for use with `make container-serve` local previewing, use a more recent builder image.

(the old one had disappeared)

---

To see the problem that this PR aims to fix, visit https://testgrid.k8s.io/sig-docs-website#post-website-push-image-k8s-website-hugo