### PR TITLE
Add CLI tool reference links

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -43,6 +43,7 @@ client libraries:
 * [kubectl](/docs/reference/kubectl/) - Main CLI tool for running commands and managing Kubernetes clusters.
   * [JSONPath](/docs/reference/kubectl/jsonpath/) - Syntax guide for using [JSONPath expressions](https://goessner.net/articles/JsonPath/) with kubectl.
 * [kubeadm](/docs/reference/setup-tools/kubeadm/) - CLI tool to easily provision a secure Kubernetes cluster.
+* [CLI tool references](/docs/reference/cli-tool-references/) - Reference pages for kubectl, Kustomize, and Helm.
 
 ## Components
 

--- a/content/en/docs/reference/cli-tool-references.md
+++ b/content/en/docs/reference/cli-tool-references.md
@@ -1,0 +1,50 @@
+---
+title: CLI tool references
+content_type: reference
+weight: 115
+---
+
+<!-- overview -->
+
+This page lists reference material for command-line tools that you can use to
+manage Kubernetes resources and configuration.
+
+<!-- body -->
+
+## kubectl
+
+[`kubectl`](/docs/reference/kubectl/) is the primary command-line tool for
+communicating with a Kubernetes cluster.
+
+* [kubectl Quick Reference](/docs/reference/kubectl/quick-reference/) lists
+  commonly used `kubectl` commands and flags.
+* [kubectl command reference](/docs/reference/kubectl/generated/) lists
+  `kubectl` commands, subcommands, and options. Use the quick reference for
+  task-oriented examples.
+* [kubectl usage conventions](/docs/reference/kubectl/conventions/) describes
+  conventions for using `kubectl` in reusable scripts.
+* [JSONPath support](/docs/reference/kubectl/jsonpath/) describes how to use
+  JSONPath expressions with `kubectl` output.
+
+## Kustomize
+
+Kustomize lets you customize Kubernetes object configuration through a
+`kustomization.yaml` file. You can use Kustomize through `kubectl`.
+
+* [Declarative Management of Kubernetes Objects Using Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/)
+  explains how to compose and customize resources with a kustomization file.
+* [kubectl kustomize](/docs/reference/kubectl/generated/kubectl_kustomize/)
+  describes the command that builds a kustomization target from a directory or URL.
+
+## Helm
+
+[Helm](https://helm.sh/) is a package manager for Kubernetes. Helm is maintained
+outside the Kubernetes project, and the Helm project publishes its own reference
+documentation.
+
+* [Helm Cheat Sheet](https://helm.sh/docs/intro/cheatsheet/) lists common Helm
+  commands.
+* [Using Helm](https://helm.sh/docs/intro/using_helm/) explains Helm concepts and
+  common workflows.
+* [Helm command reference](https://helm.sh/docs/helm/) lists Helm commands,
+  subcommands, and options.

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -22,6 +22,8 @@ files by setting the `KUBECONFIG` environment variable or by setting the
 This overview covers `kubectl` syntax, describes the command operations, and provides common examples.
 For details about each command, including all the supported flags and subcommands, see the
 [kubectl](/docs/reference/kubectl/generated/kubectl/) reference documentation.
+The generated command reference focuses on command syntax and options. For task-oriented
+examples, start with the [kubectl Quick Reference](/docs/reference/kubectl/quick-reference/).
 
 For a overview, see [The kubectl command-line tool](/docs/concepts/overview/kubectl/).
 For installation instructions, see [Installing kubectl](/docs/tasks/tools/#kubectl);


### PR DESCRIPTION
Added a compact reference page that links to official kubectl, Kustomize, and Helm reference material.\n\nThis also updates the kubectl overview to clarify that the generated command reference focuses on syntax and options, and that task-oriented examples live in the kubectl Quick Reference.\n\nThe generated kubectl reference itself was not manually edited.\n\nPreviewed locally with:\n- git diff --check\n\nA full Hugo build was not run because Hugo is not installed in this environment.