### PR TITLE
[pt-br] Update content/pt-br/community

### DIFF
--- a/content/pt-br/community/_index.html
+++ b/content/pt-br/community/_index.html
@@ -55,6 +55,9 @@ menu:
   <div class="community-nav-item">
     <a href="/releases"><i>Releases</i></a>
   </div>
+  <div class="community-nav-item">
+    <a href="/case-studies">Estudos de caso</a>
+  </div>
 </div>
 
 <div class="community-section" id="gallery">
@@ -83,9 +86,8 @@ menu:
     comunicação, contate o Comitê de Código de Conduta do Kubernetes através do
     e-mail <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
     Todos os relatos são mantidos em confidencialidade. Você pode ler
-    <a href="https://github.com/kubernetes/community/tree/master/committee-code-of-conduct">sobre o comitê</a>
-    no <a href="https://github.com/kubernetes/community">repositório da comunidade do Kubernetes</a>,
-    no GitHub.</p>
+    <a href="https://github.com/kubernetes/community/tree/main/committee-code-of-conduct">sobre o comitê</a>
+    no repositório da comunidade do Kubernetes, no GitHub.</p>
   <a href="/community/code-of-conduct/" class="community-cta-button">
     <span class="community-cta">Leia mais</span>
   </a>
@@ -139,12 +141,12 @@ menu:
         solução de problemas, e muito mais.</p>
     </div>
 
-    <div id="twitter" class="community-resource">
-      <a href="https://twitter.com/kubernetesio">
-        <img src="/images/community/twitter.png" alt="Twitter">
+    <div id="bluesky" class="community-resource">
+      <a href="https://bsky.app/profile/kubernetes.io">
+        <img src="/images/community/bluesky.png" alt="Bluesky">
       </a>
-      <a href="https://twitter.com/kubernetesio">Twitter&nbsp;&#9654;</a>
-      <p><em>#kubernetesio</em></p>
+      <a href="https://bsky.app/profile/kubernetes.io">Bluesky&nbsp;&#9654;</a>
+      <p><em>@kubernetes.io</em></p>
       <p>Anúncios em tempo real de postagens no blog, eventos, notícias e ideias.</p>
     </div>
 
@@ -173,7 +175,16 @@ menu:
       <p>Com mais de 170 canais, você vai encontrar um que atenda às suas necessidades.</p>
       <details><summary><em>Precisa de um convite?</em></summary>
         Visite <a href="https://slack.k8s.io/">https://slack.k8s.io/</a>
-        para obter um convite</details>
+        para obter um convite.</details>
+    </div>
+
+    <div id="twitter" class="community-resource">
+      <a href="https://x.com/kubernetesio">
+        <img src="/images/community/x-org.png" alt="X">
+      </a>
+      <a href="https://x.com/kubernetesio">𝕏&nbsp;&#9654;</a>
+      <p><em>@kubernetesio</em></p>
+      <p>Anúncios em tempo real de postagens no blog, eventos, notícias e ideias.</p>
     </div>
   </div>
 </div>
@@ -197,7 +208,5 @@ menu:
 
 <div class="community-section community-frame" id="news">
   <h2>Notícias Recentes</h2>
-  <div class="twittercol1">
-    <a class="twitter-timeline" data-tweet-limit="1" data-width="600" data-height="800" href="https://twitter.com/kubernetesio?ref_src=twsrc%5Etfw">Tuítes por kubernetesio</a>
-  </div>
+  {{< social-media-feed kind="bluesky" >}}
 </div>

--- a/content/pt-br/community/code-of-conduct.md
+++ b/content/pt-br/community/code-of-conduct.md
@@ -1,30 +1,25 @@
 ---
 title: Código de Conduta da Comunidade Kubernetes
-layout: basic
-cid: community
-community_styles_migrated: true
+body_class: code-of-conduct
+cid: code-of-conduct
 ---
 
-<div class="community-section" id="cncf-code-of-conduct-intro">
-<p>
-Kubernetes segue
-<a href="https://github.com/cncf/foundation/blob/main/code-of-conduct.md">CNCF Código de Conduta</a>.
-O texto do CNCF CoC é reproduzido abaixo, a partir de
-<a href="https://github.com/cncf/foundation/blob/fff715fb000ba4d7422684eca1d50d80676be254/code-of-conduct.md">commit fff715fb0</a>.
-Se você perceber que isso está desatualizado, por favor
-<a href="https://github.com/kubernetes/website/issues/new">crie uma issue</a>.
-</p>
-
-
-<p>
-Se você notar uma violação do Código de Conduta em um evento ou encontro, no
-Slack, ou em outro meio de comunicação, entre em contato com
-o <a href="https://git.k8s.io/community/committee-code-of-conduct">Comitê de Código de Conduta da Comunidade Kubernetes</a>. 
-Você pode nos contatar por e-mail em <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
-Seu anonimato será protegido.
-</p>
-</div>
+_O Kubernetes segue o
+[Código de Conduta da CNCF](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+O texto do CoC da CNCF é reproduzido abaixo, a partir do
+[commit 71412bb02](https://github.com/cncf/foundation/blob/71412bb029090d42ecbeadb39374a337bfb48a9c/code-of-conduct.md)._
 
 <div id="cncf-code-of-conduct">
-{{< include "/static/cncf-code-of-conduct.md" >}}
+{{< include "static/cncf-code-of-conduct.md" >}}
 </div>
+
+---
+
+Se você notar uma violação do Código de Conduta em um evento ou reunião, no
+Slack, ou em outro mecanismo de comunicação, entre em contato com
+o [Comitê de Código de Conduta do Kubernetes](https://git.k8s.io/community/committee-code-of-conduct).
+
+Você pode contatá-los por e-mail em [conduct@kubernetes.io](mailto:conduct@kubernetes.io).
+Seu anonimato será protegido.
+
+Se você perceber que esta página está desatualizada, por favor [crie uma issue](https://github.com/kubernetes/website/issues/new/choose).


### PR DESCRIPTION
### Description

This PR updates the Portuguese (pt-br) localization of the community pages (https://kubernetes.io/pt-br/community/) to bring them back in sync with the current English source.

Updated files:

- `content/pt-br/community/_index.html`
- `content/pt-br/community/code-of-conduct.md`

References:

- EN source: `content/en/community/_index.html`
- EN source: `content/en/community/code-of-conduct.md`

/cc @stormqueen1990 @edsoncelio

### Issue

Closes: #55902