### PR TITLE
fix(docs): ensure PowerShell profile exists before kubectl completion setup

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
@@ -21,8 +21,12 @@ This command will regenerate the auto-completion script on every PowerShell star
 To add the generated script to your `$PROFILE` file, first ensure that the profile exists, then run the following commands in your PowerShell prompt:
 
 ```powershell
-if (!(Test-Path -Path $PROFILE)) {
-    New-Item -Type File -Path $PROFILE -Force
+if (!(Test-Path (Split-Path $PROFILE))) {
+    New-Item -Path (Split-Path $PROFILE) -ItemType Directory -Force
+}
+
+if (!(Test-Path $PROFILE)) {
+    New-Item -Path $PROFILE -ItemType File -Force
 }
 
 kubectl completion powershell >> $PROFILE

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-pwsh.md
@@ -18,9 +18,13 @@ kubectl completion powershell | Out-String | Invoke-Expression
 
 This command will regenerate the auto-completion script on every PowerShell start up. You can also add the generated script directly to your `$PROFILE` file.
 
-To add the generated script to your `$PROFILE` file, run the following line in your powershell prompt:
+To add the generated script to your `$PROFILE` file, first ensure that the profile exists, then run the following commands in your PowerShell prompt:
 
 ```powershell
+if (!(Test-Path -Path $PROFILE)) {
+    New-Item -Type File -Path $PROFILE -Force
+}
+
 kubectl completion powershell >> $PROFILE
 ```
 


### PR DESCRIPTION
This PR updates the PowerShell autocompletion setup instructions to ensure that the `$PROFILE` file exists before adding the generated kubectl completion script.

On fresh PowerShell installations, `$PROFILE` may not exist, which can cause the documented commands to fail.

### Issue

Closes: #55900
